### PR TITLE
feat(server): route update through the ORM v2 write path

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -22,6 +22,7 @@ import {
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
 import { buildMutationQueryBuilder } from 'src/engine/api/common/common-query-runners/utils/build-mutation-query-builder.util';
 import { buildMutationQueryBuilderV2 } from 'src/engine/api/common/common-query-runners/utils/build-mutation-query-builder-v2.util';
+import { updateDataIsSupportedByOrmV2 } from 'src/engine/api/common/common-query-runners/utils/update-data-is-supported-by-orm-v2.util';
 import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
 import { CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
@@ -420,21 +421,33 @@ export abstract class CommonBaseQueryRunnerService<
     filter,
     columnsToReturn,
     kind,
+    data,
   }: {
     queryRunnerContext: CommonExtendedQueryRunnerContext;
     filter: Partial<ObjectRecordFilter>;
     columnsToReturn: string[];
     kind: MutationKind;
+    data?: Partial<ObjectRecord>;
   }): Promise<ObjectRecord[]> {
     const {
       repository,
       flatObjectMetadata,
+      flatFieldMetadataMaps,
       commonQueryParser,
       featureFlagsMap,
     } = queryRunnerContext;
     const alias = flatObjectMetadata.nameSingular;
 
-    if (featureFlagsMap[FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED]) {
+    const ormV2CanHandle =
+      featureFlagsMap[FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED] &&
+      (kind !== 'update' ||
+        updateDataIsSupportedByOrmV2({
+          data: data ?? {},
+          flatObjectMetadata,
+          flatFieldMetadataMaps,
+        }));
+
+    if (ormV2CanHandle) {
       const writeRepository = this.getWriteRepository(queryRunnerContext);
 
       const { selectQueryBuilder, rowLevelPermissionsApplied } =
@@ -450,6 +463,7 @@ export abstract class CommonBaseQueryRunnerService<
         rowLevelPermissionsApplied,
         kind,
         columnsToReturn,
+        data,
       });
     }
 
@@ -459,6 +473,16 @@ export abstract class CommonBaseQueryRunnerService<
       filter,
       commonQueryParser,
     });
+
+    if (kind === 'update') {
+      const result = await queryBuilder
+        .update()
+        .set(data ?? {})
+        .returning(columnsToReturn)
+        .execute();
+
+      return result.generatedMaps as ObjectRecord[];
+    }
 
     const mutationQueryBuilder =
       kind === 'soft-delete'

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-update-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-update-many-query-runner.service.ts
@@ -11,7 +11,6 @@ import {
   CommonQueryRunnerExceptionCode,
 } from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
-import { buildMutationQueryBuilder } from 'src/engine/api/common/common-query-runners/utils/build-mutation-query-builder.util';
 import { CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
 import {
@@ -40,22 +39,13 @@ export class CommonUpdateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     queryRunnerContext: CommonExtendedQueryRunnerContext,
   ): Promise<ObjectRecord[]> {
     const {
-      repository,
       authContext,
       rolePermissionConfig,
       workspaceDataSource,
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,
       flatObjectMetadata,
-      commonQueryParser,
     } = queryRunnerContext;
-
-    const queryBuilder = buildMutationQueryBuilder({
-      repository,
-      alias: flatObjectMetadata.nameSingular,
-      filter: args.filter,
-      commonQueryParser,
-    });
 
     const columnsToReturn = buildColumnsToReturn({
       select: args.selectedFieldsResult.select,
@@ -65,13 +55,13 @@ export class CommonUpdateManyQueryRunnerService extends CommonBaseQueryRunnerSer
       flatFieldMetadataMaps,
     });
 
-    const updatedObjectRecords = await queryBuilder
-      .update()
-      .set(args.data)
-      .returning(columnsToReturn)
-      .execute();
-
-    const updatedRecords = updatedObjectRecords.generatedMaps as ObjectRecord[];
+    const updatedRecords = await this.runFilteredMutation({
+      queryRunnerContext,
+      filter: args.filter,
+      columnsToReturn,
+      kind: 'update',
+      data: args.data,
+    });
 
     if (isDefined(args.selectedFieldsResult.relations)) {
       await this.processNestedRelationsHelper.processNestedRelations({

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/__tests__/update-data-is-supported-by-orm-v2.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/__tests__/update-data-is-supported-by-orm-v2.util.spec.ts
@@ -1,0 +1,84 @@
+import { FieldMetadataType, type ObjectRecord } from 'twenty-shared/types';
+
+import { updateDataIsSupportedByOrmV2 } from 'src/engine/api/common/common-query-runners/utils/update-data-is-supported-by-orm-v2.util';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
+
+jest.mock(
+  'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util',
+);
+jest.mock(
+  'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util',
+);
+
+const fieldTypeById: Record<string, FieldMetadataType> = {
+  'field-jobTitle': FieldMetadataType.TEXT,
+  'field-name': FieldMetadataType.FULL_NAME,
+  'field-company': FieldMetadataType.RELATION,
+  'field-owner': FieldMetadataType.MORPH_RELATION,
+  'field-attachments': FieldMetadataType.FILES,
+};
+
+beforeEach(() => {
+  jest.mocked(buildFieldMapsFromFlatObjectMetadata).mockReturnValue({
+    fieldIdByName: {
+      jobTitle: 'field-jobTitle',
+      name: 'field-name',
+      company: 'field-company',
+      owner: 'field-owner',
+      attachments: 'field-attachments',
+    },
+    fieldIdByJoinColumnName: { companyId: 'field-company' },
+  });
+
+  jest
+    .mocked(findFlatEntityByIdInFlatEntityMaps)
+    .mockImplementation(({ flatEntityId }) =>
+      flatEntityId !== undefined && flatEntityId in fieldTypeById
+        ? ({ type: fieldTypeById[flatEntityId] } as never)
+        : undefined,
+    );
+});
+
+const callWith = (data: Partial<ObjectRecord>) =>
+  updateDataIsSupportedByOrmV2({
+    data,
+    flatObjectMetadata: {} as never,
+    flatFieldMetadataMaps: {} as never,
+  });
+
+describe('updateDataIsSupportedByOrmV2', () => {
+  it('should return true for empty data', () => {
+    expect(callWith({})).toBe(true);
+  });
+
+  it('should return true for scalar and composite fields', () => {
+    expect(callWith({ jobTitle: 'Tech Lead', name: { firstName: 'A' } })).toBe(
+      true,
+    );
+  });
+
+  it('should return false when a relation field is set', () => {
+    expect(callWith({ company: { connect: { where: { id: 'x' } } } })).toBe(
+      false,
+    );
+  });
+
+  it('should return false when a morph relation field is set', () => {
+    expect(callWith({ owner: { connect: { where: { id: 'x' } } } })).toBe(
+      false,
+    );
+  });
+
+  it('should return false when a files field is set', () => {
+    expect(callWith({ attachments: [] })).toBe(false);
+  });
+
+  it('should resolve a relation set through its join column name', () => {
+    expect(callWith({ companyId: 'company-id' })).toBe(false);
+  });
+
+  it('should return false for an unknown field', () => {
+    expect(callWith({ doesNotExist: 'x' })).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/update-data-is-supported-by-orm-v2.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/update-data-is-supported-by-orm-v2.util.ts
@@ -1,0 +1,42 @@
+import { FieldMetadataType, type ObjectRecord } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+
+export const updateDataIsSupportedByOrmV2 = ({
+  data,
+  flatObjectMetadata,
+  flatFieldMetadataMaps,
+}: {
+  data: Partial<ObjectRecord>;
+  flatObjectMetadata: FlatObjectMetadata;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+}): boolean => {
+  const { fieldIdByName, fieldIdByJoinColumnName } =
+    buildFieldMapsFromFlatObjectMetadata(
+      flatFieldMetadataMaps,
+      flatObjectMetadata,
+    );
+
+  return Object.keys(data).every((fieldName) => {
+    const fieldMetadata = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId:
+        fieldIdByName[fieldName] ?? fieldIdByJoinColumnName[fieldName],
+      flatEntityMaps: flatFieldMetadataMaps,
+    });
+
+    if (!isDefined(fieldMetadata)) {
+      return false;
+    }
+
+    return (
+      fieldMetadata.type !== FieldMetadataType.RELATION &&
+      fieldMetadata.type !== FieldMetadataType.MORPH_RELATION &&
+      fieldMetadata.type !== FieldMetadataType.FILES
+    );
+  });
+};

--- a/packages/twenty-server/src/engine/twenty-orm-v2/README.md
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/README.md
@@ -120,7 +120,7 @@ table-shape builder cannot represent. `GroupByWithRecordsV2Service` builds the i
 subquery with the v2 builder and runs the composed outer query through
 `repository.executeRaw`; the runner flag-branches between it and the v1 service.
 
-## Writes: delete, destroy and restore route through v2
+## Writes: delete, destroy, restore and (most) update route through v2
 
 `WorkspaceMutationQueryBuilderV2` generates `UPDATE` / `DELETE` / soft-delete / restore
 statements with `RETURNING`, reusing the same primitives as the select builder
@@ -129,16 +129,24 @@ generator. The select builder morphs into it: `.update()` / `.delete()` / `.soft
 / `.restore()` carry the current where clauses and parameters into the mutation, matching
 the TypeORM surface the mutation runners already call.
 
-`deleteMany`, `destroyMany` and `restoreMany` (and their `...One` delegates) flag-branch to
-this path. Each runner builds the filtered v2 select builder with
-`buildMutationQueryBuilderV2` (which rewrites a relation-traversal filter into an
-`id IN (subquery)` predicate, RLS inside the subquery) and hands it to
-`WorkspaceRepositoryV2.runMutation`, which owns the choreography the v1 mutation builders
-own: apply the row-level predicate, validate the write with the matching operation type,
-snapshot the affected rows before and after through a permission-bypassing all-columns
-select, run the statement, and emit the `DELETED` / `RESTORED` / `DESTROYED` batch event
-through the shared `formatTwentyOrmEventToDatabaseBatchEvent`. `getWriteRepository` on the
-base runner pins the primary and counts `orm-v2/write-path-used`.
+`deleteMany`, `destroyMany`, `restoreMany` and `updateMany` (and their `...One` delegates)
+flag-branch to this path through the shared `runFilteredMutation` on the base runner. Each
+builds the filtered v2 select builder with `buildMutationQueryBuilderV2` (which rewrites a
+relation-traversal filter into an `id IN (subquery)` predicate, RLS inside the subquery)
+and hands it to `WorkspaceRepositoryV2.runMutation`, which owns the choreography the v1
+mutation builders own: apply the row-level predicate, validate the write with the matching
+operation type, snapshot the affected rows before and after through a permission-bypassing
+all-columns select, run the statement, and emit the batch event(s) through the shared
+`formatTwentyOrmEventToDatabaseBatchEvent` — `DELETED` / `RESTORED` / `DESTROYED` for the
+soft ones, `UPDATED` then `UPSERTED` for update. `getWriteRepository` on the base runner
+pins the primary and counts `orm-v2/write-path-used`.
+
+Update flattens its input with the shared `formatData` (composite fields to columns) and
+validates the field-level write permission over the resulting column set. It carves back
+to v1 for one case: data that sets a relation (`{connect}` / `{disconnect}`) or a files
+field, because that input is resolved by `RelationNestedQueries` / `FilesFieldSync`, which
+are coupled to the TypeORM builder and not yet reproduced here. `updateDataIsSupportedByOrmV2`
+makes that call; both branches match their v1 counterpart byte for byte.
 
 Deliberate choices, the SQL ones asserted by exact-SQL unit tests:
 
@@ -161,13 +169,15 @@ Deliberate choices, the SQL ones asserted by exact-SQL unit tests:
   user-input error the read path already produces (v2 refuses to render a to-many join),
   rather than the row-multiplying join v1 would emit.
 
-Update, insert and upsert still keep `repository` (v1).
+Insert and upsert still keep `repository` (v1), as does update with relation/files input.
 
 ## Not covered yet
 
-- Update, insert and upsert. `UPDATE ... SET` from caller data, `INSERT` and
-  `ON CONFLICT` still go through v1, which is where composite flattening of the input and
-  the column defaults / conflict-target derivation live.
+- Insert and upsert. `INSERT` and `ON CONFLICT` still go through v1, which is where the
+  column defaults and conflict-target derivation live.
+- Relation connect/disconnect and files-field input on writes, resolved by
+  `RelationNestedQueries` / `FilesFieldSync`. Update carves these back to v1; create and
+  upsert stay on v1 entirely until this input machinery has a v2 form.
 - `find` / `findOne` / `findBy` and the rest of the repository surface used by
   `src/modules`.
 - Transactions and DDL.

--- a/packages/twenty-server/src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception.ts
@@ -1,3 +1,5 @@
+import { type MessageDescriptor } from '@lingui/core';
+
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
 import { CustomException } from 'src/utils/custom-exception';
 
@@ -11,10 +13,15 @@ export enum TwentyOrmV2ExceptionCode {
   UNSUPPORTED_OPERATION = 'UNSUPPORTED_OPERATION',
   MISSING_ALIAS = 'MISSING_ALIAS',
   INVALID_QUERY = 'INVALID_QUERY',
+  TOO_MANY_RECORDS_TO_UPDATE = 'TOO_MANY_RECORDS_TO_UPDATE',
 }
 
 export class TwentyOrmV2Exception extends CustomException<TwentyOrmV2ExceptionCode> {
-  constructor(message: string, code: TwentyOrmV2ExceptionCode) {
-    super(message, code, { userFriendlyMessage: STANDARD_ERROR_MESSAGE });
+  constructor(
+    message: string,
+    code: TwentyOrmV2ExceptionCode,
+    userFriendlyMessage: MessageDescriptor = STANDARD_ERROR_MESSAGE,
+  ) {
+    super(message, code, { userFriendlyMessage });
   }
 }

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -1,3 +1,5 @@
+import { msg } from '@lingui/core/macro';
+import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
 import {
   type ObjectRecord,
   type ObjectsPermissions,
@@ -9,15 +11,30 @@ import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/wo
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { validateOperationIsPermittedOrThrow } from 'src/engine/twenty-orm/repository/permissions.utils';
 import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
+import { formatData } from 'src/engine/twenty-orm/utils/format-data.util';
 import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
 import { formatTwentyOrmEventToDatabaseBatchEvent } from 'src/engine/twenty-orm/utils/format-twenty-orm-event-to-database-batch-event.util';
 import { renderRowLevelPermissionFilterToSql } from 'src/engine/twenty-orm/utils/render-row-level-permission-filter-to-sql.util';
 import { resolveRowLevelPermissionRecordFilter } from 'src/engine/twenty-orm/utils/resolve-row-level-permission-record-filter.util';
+import {
+  TwentyOrmV2Exception,
+  TwentyOrmV2ExceptionCode,
+} from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
 import { type QueryExecutorV2 } from 'src/engine/twenty-orm-v2/executor/types/query-executor-v2.type';
 import { type MutationKind } from 'src/engine/twenty-orm-v2/sql/utils/build-mutation-statement.util';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { compileNamedParameters } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
+
+const MUTATION_EVENT_ACTIONS_BY_KIND: Record<
+  MutationKind,
+  DatabaseEventAction[]
+> = {
+  delete: [DatabaseEventAction.DESTROYED],
+  restore: [DatabaseEventAction.RESTORED],
+  'soft-delete': [DatabaseEventAction.DELETED],
+  update: [DatabaseEventAction.UPDATED, DatabaseEventAction.UPSERTED],
+};
 
 type WorkspaceRepositoryV2Options = {
   tableShape: WorkspaceTableShape;
@@ -88,17 +105,32 @@ export class WorkspaceRepositoryV2 {
     rowLevelPermissionsApplied,
     kind,
     columnsToReturn,
+    data,
   }: {
     selectQueryBuilder: WorkspaceSelectQueryBuilderV2;
     rowLevelPermissionsApplied: boolean;
     kind: MutationKind;
     columnsToReturn: string[];
+    data?: Partial<ObjectRecord>;
   }): Promise<ObjectRecord[]> {
     if (!rowLevelPermissionsApplied) {
       this.applyRowLevelPermissionPredicates(selectQueryBuilder);
     }
 
-    this.validateWriteIsPermitted({ operationType: kind, columnsToReturn });
+    const setColumns =
+      kind === 'update' && isDefined(data)
+        ? formatData(
+            data,
+            this.options.flatObjectMetadata,
+            this.options.internalContext.flatFieldMetadataMaps,
+          )
+        : undefined;
+
+    this.validateWriteIsPermitted({
+      operationType: kind,
+      columnsToReturn,
+      updatedColumns: isDefined(setColumns) ? Object.keys(setColumns) : [],
+    });
 
     const eventSelectQueryBuilder =
       this.buildEventSnapshotQueryBuilder(selectQueryBuilder);
@@ -114,10 +146,19 @@ export class WorkspaceRepositoryV2 {
             noFormatting: true,
           });
 
+    if (kind === 'update' && recordsBefore.length > QUERY_MAX_RECORDS) {
+      throw new TwentyOrmV2Exception(
+        `Cannot update more than ${QUERY_MAX_RECORDS} records at once`,
+        TwentyOrmV2ExceptionCode.TOO_MANY_RECORDS_TO_UPDATE,
+        msg`You can only update up to ${QUERY_MAX_RECORDS} records at once.`,
+      );
+    }
+
     const mutationResult = await this.morphAndExecute({
       selectQueryBuilder,
       kind,
       columnsToReturn,
+      setColumns,
     });
 
     const recordsAfter =
@@ -136,11 +177,21 @@ export class WorkspaceRepositoryV2 {
     selectQueryBuilder,
     kind,
     columnsToReturn,
+    setColumns,
   }: {
     selectQueryBuilder: WorkspaceSelectQueryBuilderV2;
     kind: MutationKind;
     columnsToReturn: string[];
+    setColumns?: Record<string, unknown>;
   }): Promise<{ generatedMaps: ObjectRecord[] }> {
+    if (kind === 'update') {
+      return selectQueryBuilder
+        .update()
+        .set(setColumns ?? {})
+        .returning(columnsToReturn)
+        .execute();
+    }
+
     const mutationQueryBuilder =
       kind === 'soft-delete'
         ? selectQueryBuilder.softDelete()
@@ -172,9 +223,11 @@ export class WorkspaceRepositoryV2 {
   private validateWriteIsPermitted({
     operationType,
     columnsToReturn,
+    updatedColumns,
   }: {
     operationType: MutationKind;
     columnsToReturn: string[];
+    updatedColumns: string[];
   }): void {
     if (this.options.shouldBypassPermissionChecks) {
       return;
@@ -191,7 +244,7 @@ export class WorkspaceRepositoryV2 {
         this.options.internalContext.objectIdByNameSingular,
       selectedColumns: columnsToReturn,
       allFieldsSelected: false,
-      updatedColumns: [],
+      updatedColumns,
     });
   }
 
@@ -204,29 +257,30 @@ export class WorkspaceRepositoryV2 {
     recordsBefore: ObjectRecord[];
     recordsAfter?: ObjectRecord[];
   }): void {
-    const action =
-      kind === 'delete'
-        ? DatabaseEventAction.DESTROYED
-        : kind === 'restore'
-          ? DatabaseEventAction.RESTORED
-          : DatabaseEventAction.DELETED;
+    const actions = MUTATION_EVENT_ACTIONS_BY_KIND[kind];
 
-    const event = formatTwentyOrmEventToDatabaseBatchEvent({
-      action,
-      objectMetadataItem: this.options.flatObjectMetadata,
-      flatFieldMetadataMaps: this.options.internalContext.flatFieldMetadataMaps,
-      workspaceId: this.options.internalContext.workspaceId,
-      recordsBefore: this.formatResult<ObjectRecord[]>(recordsBefore),
-      recordsAfter: isDefined(recordsAfter)
-        ? this.formatResult<ObjectRecord[]>(recordsAfter)
-        : undefined,
-      authContext: this.options.authContext,
-    });
+    const formattedBefore = this.formatResult<ObjectRecord[]>(recordsBefore);
+    const formattedAfter = isDefined(recordsAfter)
+      ? this.formatResult<ObjectRecord[]>(recordsAfter)
+      : undefined;
 
-    if (isDefined(event)) {
-      this.options.internalContext.eventEmitterService.emitDatabaseBatchEvent(
-        event,
-      );
+    for (const action of actions) {
+      const event = formatTwentyOrmEventToDatabaseBatchEvent({
+        action,
+        objectMetadataItem: this.options.flatObjectMetadata,
+        flatFieldMetadataMaps:
+          this.options.internalContext.flatFieldMetadataMaps,
+        workspaceId: this.options.internalContext.workspaceId,
+        recordsBefore: formattedBefore,
+        recordsAfter: formattedAfter,
+        authContext: this.options.authContext,
+      });
+
+      if (isDefined(event)) {
+        this.options.internalContext.eventEmitterService.emitDatabaseBatchEvent(
+          event,
+        );
+      }
     }
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/utils/twenty-orm-v2-to-user-input-error.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/utils/twenty-orm-v2-to-user-input-error.util.ts
@@ -12,6 +12,7 @@ export const isTwentyOrmV2UserInputError = (
     case TwentyOrmV2ExceptionCode.UNKNOWN_COLUMN:
     case TwentyOrmV2ExceptionCode.UNKNOWN_RELATION:
     case TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION:
+    case TwentyOrmV2ExceptionCode.TOO_MANY_RECORDS_TO_UPDATE:
       return true;
     default:
       return false;


### PR DESCRIPTION
Stacked on #24131 (delete/destroy/restore through v2). Routes `updateMany` (and
`updateOne`, which delegates to it) through the ORM v2 write path.

Behind `IS_ORM_V2_READ_PATH_ENABLED` (the same flag). Flag off, nothing changes.

## Scope

`updateMany` joins the shared `runFilteredMutation` branch. On the v2 side,
`WorkspaceRepositoryV2.runMutation` gains the update kind: it flattens the input with the
shared `formatData` (composite fields to columns), validates the field-level write
permission over the resulting column set (`updatedColumns`), applies the `QUERY_MAX_RECORDS`
guard, runs `UPDATE ... SET ... RETURNING`, and emits `UPDATED` then `UPSERTED` with the
before/after snapshots — matching the v1 update builder.

**One carve-out.** Update data that sets a relation (`{connect}` / `{disconnect}`) or a
files field stays on v1, because that input is resolved by `RelationNestedQueries` /
`FilesFieldSync`, which are coupled to the TypeORM builder's `expressionMap` and not yet
reproduced for v2. `updateDataIsSupportedByOrmV2` makes the call per request; the v1 branch
is unchanged, so both paths match their v1 behaviour byte for byte. Scalar and composite
updates (the vast majority) go through v2.

## Deliberately not in this PR

The original plan bundled update + create + upsert here. Create and upsert turned out to
need materially more than update — a v2 `INSERT` / `ON CONFLICT` statement generator plus
the same relation/files input machinery on the *always* path (not just a carve-out), since
`dataArgProcessor` leaves connect/disconnect and files values unresolved for the builder to
handle. Landing those in the same PR would roughly triple the diff and put un-canaried
`INSERT` generation on the highest-traffic mutation. They are better as their own stacked
PRs, which I'll open next.

## Verification

- Ran locally both ways: the update permission suites (many + one), the field-level
  `update-permissions` suite, `mutate-by-relation-field` and `mutation-relation-filter-rls`,
  all green with the flag on and off (20 tests). Broader flag-on sweep of
  `object-records-permissions` + `merge-many` + the relation-mutation suites: 18 suites /
  71 tests green.
- 89 v2 builder unit tests still green. oxlint / oxfmt / typecheck clean. The
  update/delete/destroy/restore suites already ride the flagged CI shard via
  `object-records-permissions`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

