### PR TITLE
Persist admin panel chat filters across navigation

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/chats/hooks/useAdminChatThreads.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/chats/hooks/useAdminChatThreads.ts
@@ -1,19 +1,19 @@
 import { useQuery } from '@apollo/client/react';
 import { t } from '@lingui/core/macro';
-import { useState } from 'react';
 import { useDebounce } from 'use-debounce';
 
 import { isDefined } from 'twenty-shared/utils';
 
 import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
-import { DEFAULT_ADMIN_CHATS_FILTER_STATE } from '@/settings/admin-panel/chats/constants/DefaultAdminChatsFilterState';
 import { SETTINGS_ADMIN_CHATS_TABLE_ID } from '@/settings/admin-panel/chats/constants/SettingsAdminChatsTableId';
-import { type AdminChatsFilterState } from '@/settings/admin-panel/chats/types/AdminChatsFilterState';
+import { adminChatsFilterState } from '@/settings/admin-panel/chats/states/adminChatsFilterState';
+import { adminChatsSearchQueryState } from '@/settings/admin-panel/chats/states/adminChatsSearchQueryState';
 import { getAdminChatsSortVariables } from '@/settings/admin-panel/chats/utils/getAdminChatsSortVariables';
 import { GET_ADMIN_CHAT_THREADS } from '@/settings/admin-panel/graphql/queries/getAdminChatThreads';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { sortedFieldByTableFamilyState } from '@/ui/layout/table/states/sortedFieldByTableFamilyState';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
+import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import {
   AdminChatThreadScope,
   type GetAdminChatThreadsQuery,
@@ -25,10 +25,12 @@ const PAGE_SIZE = 25;
 export const useAdminChatThreads = () => {
   const apolloAdminClient = useApolloAdminClient();
   const { enqueueErrorSnackBar } = useSnackBar();
-  const [searchQuery, setSearchQuery] = useState('');
-  const [debouncedSearchQuery] = useDebounce(searchQuery, 300);
-  const [filters, setFilters] = useState<AdminChatsFilterState>(
-    DEFAULT_ADMIN_CHATS_FILTER_STATE,
+  const [adminChatsSearchQuery, setAdminChatsSearchQuery] = useAtomState(
+    adminChatsSearchQueryState,
+  );
+  const [debouncedSearchQuery] = useDebounce(adminChatsSearchQuery, 300);
+  const [adminChatsFilter, setAdminChatsFilter] = useAtomState(
+    adminChatsFilterState,
   );
 
   const sortedFieldByTable = useAtomFamilyStateValue(
@@ -50,11 +52,11 @@ export const useAdminChatThreads = () => {
       limit: PAGE_SIZE,
       offset: 0,
       searchTerm: debouncedSearchQuery,
-      scope: filters.onboardingOnly
+      scope: adminChatsFilter.onboardingOnly
         ? AdminChatThreadScope.ONBOARDING
         : AdminChatThreadScope.ALL,
-      hasErrorOnly: filters.hasErrorOnly,
-      userNeverEngagedOnly: filters.userNeverEngagedOnly,
+      hasErrorOnly: adminChatsFilter.hasErrorOnly,
+      userNeverEngagedOnly: adminChatsFilter.userNeverEngagedOnly,
       sortBy,
       sortDirection,
     },
@@ -64,7 +66,8 @@ export const useAdminChatThreads = () => {
   const totalCount = data?.getAdminChatThreads.totalCount ?? 0;
   const hasMore = data?.getAdminChatThreads.hasMore ?? false;
 
-  const isShowMoreDisabled = loading || searchQuery !== debouncedSearchQuery;
+  const isShowMoreDisabled =
+    loading || adminChatsSearchQuery !== debouncedSearchQuery;
 
   const handleShowMore = async () => {
     if (isShowMoreDisabled) {
@@ -105,10 +108,10 @@ export const useAdminChatThreads = () => {
   };
 
   return {
-    searchQuery,
-    setSearchQuery,
-    filters,
-    setFilters,
+    searchQuery: adminChatsSearchQuery,
+    setSearchQuery: setAdminChatsSearchQuery,
+    filters: adminChatsFilter,
+    setFilters: setAdminChatsFilter,
     threads,
     totalCount,
     hasMore,

--- a/packages/twenty-front/src/modules/settings/admin-panel/chats/states/adminChatsFilterState.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/chats/states/adminChatsFilterState.ts
@@ -1,0 +1,8 @@
+import { DEFAULT_ADMIN_CHATS_FILTER_STATE } from '@/settings/admin-panel/chats/constants/DefaultAdminChatsFilterState';
+import { type AdminChatsFilterState } from '@/settings/admin-panel/chats/types/AdminChatsFilterState';
+import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
+
+export const adminChatsFilterState = createAtomState<AdminChatsFilterState>({
+  key: 'adminChatsFilterState',
+  defaultValue: DEFAULT_ADMIN_CHATS_FILTER_STATE,
+});

--- a/packages/twenty-front/src/modules/settings/admin-panel/chats/states/adminChatsSearchQueryState.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/chats/states/adminChatsSearchQueryState.ts
@@ -1,0 +1,6 @@
+import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
+
+export const adminChatsSearchQueryState = createAtomState<string>({
+  key: 'adminChatsSearchQueryState',
+  defaultValue: '',
+});


### PR DESCRIPTION
On the admin panel chats page, the filters and search query reset when opening a thread and navigating back, because they lived in component state that died on unmount.

Moves them to global Jotai atoms (same pattern as the config-variables admin page) so they survive navigation within the session.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

