### PR TITLE
ci: serialize the i18n workflows per branch

### DIFF
--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -28,7 +28,7 @@ on:
       - '.github/workflows/docs-i18n-pull.yaml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/docs-i18n-push.yaml
+++ b/.github/workflows/docs-i18n-push.yaml
@@ -15,7 +15,7 @@ on:
       - '.github/crowdin-docs.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -26,7 +26,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -11,7 +11,7 @@ on:
     branches: ['main']
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -26,7 +26,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/website-i18n-push.yaml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
## What

Groups the six i18n workflows by `github.ref` instead of `github.run_id`, so runs on a branch queue behind each other instead of running concurrently.

## Why

`Extract and upload translations` went red on `main` this morning ([run](https://github.com/twentyhq/twenty/actions/runs/31696154871/job/94434279330)):

```
To https://github.com/twentyhq/twenty
 ! [rejected]          HEAD -> i18n (fetch first)
error: failed to push some refs
```

The group is

```yaml
group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
```

and `github.head_ref` is only set for `pull_request` events. On a push to `main` it is empty, so the group falls back to `github.run_id` — unique per run. Every push to `main` starts its own concurrent run, they all check out the same bot branch, and whichever finishes second is rejected as non-fast-forward. Two pushes landed a minute apart (11:34 and 11:35) and the second run failed.

Using `github.ref` gives one group per branch. On `main`, `cancel-in-progress` is already false, so a second run queues rather than racing; GitHub keeps only the newest queued run, which is the right outcome here since each run extracts from the current tip.

Applied to all six workflows that push a shared bot branch (`i18n`, `i18n-docs`, `i18n-website`) — the push-triggered ones raced today, the scheduled ones carry the same latent bug.

## Note

This does not cover a run racing the Crowdin bot's own force-push of `i18n`, or an `i18n-pull` run racing `i18n-push` for the same branch (they have distinct workflow names, so distinct groups). Neither has shown up in the failure log; worth revisiting if it does.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

