### PR TITLE
Open AI chat threads in a new tab with cmd/ctrl click

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/NavigationDrawerAiChatThreadItem.tsx
+++ b/packages/twenty-front/src/modules/ai/components/NavigationDrawerAiChatThreadItem.tsx
@@ -1,5 +1,7 @@
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
+import { AppPath } from 'twenty-shared/types';
+import { getAppPath, isValidUuid } from 'twenty-shared/utils';
 import { IconArchive, IconComment } from 'twenty-ui/icon';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
@@ -85,6 +87,9 @@ export const NavigationDrawerAiChatThreadItem = ({
     isDropdownOpenComponentState,
     itemMenuDropdownId,
   );
+  const threadPath = isValidUuid(thread.id)
+    ? getAppPath(AppPath.AiChat, { threadId: thread.id })
+    : undefined;
 
   if (isRenaming) {
     return (
@@ -105,6 +110,7 @@ export const NavigationDrawerAiChatThreadItem = ({
       label={displayLabel}
       Icon={ThreadIcon}
       active={isActive}
+      to={threadPath}
       onClick={() => onClick(thread)}
       variant={isArchived ? 'tertiary' : 'default'}
       alwaysShowRightOptions


### PR DESCRIPTION
AI chat items in the navigation drawer rendered as a div with an onClick, so a cmd/ctrl click opened the thread in place instead of a new tab. Passing `to` makes `NavigationDrawerItem` render a real link, and `useMouseDownNavigation` then leaves modifier clicks to the browser while plain clicks keep selecting the thread in place.

The admin panel chat tables already used `TableRow to=` and were checked to open a real new tab, so they are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

