### PR TITLE
Show pinned command menu actions as icons on mobile headers

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenu.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { RecordIndexCommandMenuDropdown } from '@/command-menu-item/components/RecordIndexCommandMenuDropdown';
 import { CommandMenuContextProvider } from '@/command-menu-item/contexts/CommandMenuContextProvider';
 import { PinnedCommandMenuItemButtons } from '@/command-menu-item/display/components/PinnedCommandMenuItemButtons';
@@ -25,7 +26,7 @@ export const RecordIndexCommandMenu = () => {
           <CommandMenuContextProvider
             isInSidePanel={false}
             displayType="button"
-            containerType="index-page-header"
+            containerType={CommandMenuItemContainerType.IndexPageHeader}
             isInPreviewMode={isLayoutCustomizationModeEnabled}
           >
             <PinnedCommandMenuItemButtons />
@@ -33,7 +34,7 @@ export const RecordIndexCommandMenu = () => {
           <CommandMenuContextProvider
             isInSidePanel={false}
             displayType="dropdownItem"
-            containerType="index-page-dropdown"
+            containerType={CommandMenuItemContainerType.IndexPageDropdown}
           >
             <RecordIndexCommandMenuDropdown />
           </CommandMenuContextProvider>

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenu.tsx
@@ -7,7 +7,6 @@ import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context
 import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { useIsMobile } from 'twenty-ui/utilities';
 
 export const RecordIndexCommandMenu = () => {
   const contextStoreCurrentObjectMetadataItemId = useAtomComponentStateValue(
@@ -15,7 +14,6 @@ export const RecordIndexCommandMenu = () => {
     MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
-  const isMobile = useIsMobile();
   const isLayoutCustomizationModeEnabled = useAtomStateValue(
     isLayoutCustomizationModeEnabledState,
   );
@@ -30,7 +28,7 @@ export const RecordIndexCommandMenu = () => {
             containerType="index-page-header"
             isInPreviewMode={isLayoutCustomizationModeEnabled}
           >
-            {!isMobile && <PinnedCommandMenuItemButtons />}
+            <PinnedCommandMenuItemButtons />
           </CommandMenuContextProvider>
           <CommandMenuContextProvider
             isInSidePanel={false}

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelCommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelCommandMenu.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { RecordPageSidePanelCommandMenuDropdown } from '@/command-menu-item/components/RecordPageSidePanelCommandMenuDropdown';
 import { CommandMenuContextProvider } from '@/command-menu-item/contexts/CommandMenuContextProvider';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
@@ -14,7 +15,9 @@ export const RecordPageSidePanelCommandMenu = () => {
         <CommandMenuContextProvider
           isInSidePanel={true}
           displayType="dropdownItem"
-          containerType="command-menu-show-page-dropdown"
+          containerType={
+            CommandMenuItemContainerType.CommandMenuShowPageDropdown
+          }
         >
           <RecordPageSidePanelCommandMenuDropdown />
         </CommandMenuContextProvider>

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelPinnedCommandMenuItems.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelPinnedCommandMenuItems.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { isDefined } from 'twenty-shared/utils';
 
 import { CommandMenuContextProvider } from '@/command-menu-item/contexts/CommandMenuContextProvider';
@@ -18,7 +19,7 @@ export const RecordPageSidePanelPinnedCommandMenuItems = () => {
     <CommandMenuContextProvider
       isInSidePanel={true}
       displayType="button"
-      containerType="side-panel-footer"
+      containerType={CommandMenuItemContainerType.SidePanelFooter}
     >
       <PinnedCommandMenuItemButtons />
     </CommandMenuContextProvider>

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordShowCommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordShowCommandMenu.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { CommandMenuContextProvider } from '@/command-menu-item/contexts/CommandMenuContextProvider';
 import { PinnedCommandMenuItemButtons } from '@/command-menu-item/display/components/PinnedCommandMenuItemButtons';
 import { CommandMenuItemEditButton } from '@/command-menu-item/edit/components/CommandMenuItemEditButton';
@@ -34,7 +35,7 @@ export const RecordShowCommandMenu = () => {
           <CommandMenuContextProvider
             isInSidePanel={false}
             displayType="button"
-            containerType="show-page-header"
+            containerType={CommandMenuItemContainerType.ShowPageHeader}
             isInPreviewMode={isLayoutCustomizationModeEnabled}
           >
             <PinnedCommandMenuItemButtons />

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordShowCommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordShowCommandMenu.tsx
@@ -7,7 +7,6 @@ import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/s
 import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { useIsMobile } from 'twenty-ui/utilities';
 
 export const RecordShowCommandMenu = () => {
   const contextStoreCurrentObjectMetadataItemId = useAtomComponentStateValue(
@@ -24,7 +23,6 @@ export const RecordShowCommandMenu = () => {
     contextStoreTargetedRecordsRule.mode === 'selection' &&
     contextStoreTargetedRecordsRule.selectedRecordIds.length === 1;
 
-  const isMobile = useIsMobile();
   const isLayoutCustomizationModeEnabled = useAtomStateValue(
     isLayoutCustomizationModeEnabledState,
   );
@@ -39,7 +37,7 @@ export const RecordShowCommandMenu = () => {
             containerType="show-page-header"
             isInPreviewMode={isLayoutCustomizationModeEnabled}
           >
-            {!isMobile && <PinnedCommandMenuItemButtons />}
+            <PinnedCommandMenuItemButtons />
           </CommandMenuContextProvider>
           <CommandMenuItemEditButton />
         </>

--- a/packages/twenty-front/src/modules/command-menu-item/components/StandalonePageCommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/StandalonePageCommandMenu.tsx
@@ -19,12 +19,10 @@ import {
   type CommandMenuContextApi,
 } from 'twenty-shared/types';
 import { evaluateConditionalAvailabilityExpression } from 'twenty-shared/utils';
-import { useIsMobile } from 'twenty-ui/utilities';
 import { CommandMenuItemAvailabilityType } from '~/generated-metadata/graphql';
 
 export const StandalonePageCommandMenu = () => {
   const store = useStore();
-  const isMobile = useIsMobile();
   const commandMenuItems = useAtomStateValue(commandMenuItemsSelector);
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
   const currentUserWorkspace = useAtomStateValue(currentUserWorkspaceState);
@@ -134,7 +132,7 @@ export const StandalonePageCommandMenu = () => {
         isInPreviewMode: false,
       }}
     >
-      {!isMobile && <PinnedCommandMenuItemButtons />}
+      <PinnedCommandMenuItemButtons />
       <CommandMenuItemEditButton />
     </CommandMenuContext.Provider>
   );

--- a/packages/twenty-front/src/modules/command-menu-item/components/StandalonePageCommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/StandalonePageCommandMenu.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
@@ -126,7 +127,7 @@ export const StandalonePageCommandMenu = () => {
     <CommandMenuContext.Provider
       value={{
         displayType: 'button',
-        containerType: 'standalone-page-header',
+        containerType: CommandMenuItemContainerType.StandalonePageHeader,
         commandMenuItems: filteredCommandMenuItems,
         commandMenuContextApi,
         isInPreviewMode: false,

--- a/packages/twenty-front/src/modules/command-menu-item/components/__stories__/RecordIndexCommandMenuDropdown.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/__stories__/RecordIndexCommandMenuDropdown.stories.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { Provider as JotaiProvider } from 'jotai';
 import { expect, within } from 'storybook/test';
@@ -42,7 +43,7 @@ const meta: Meta<typeof RecordIndexCommandMenuDropdown> = {
             <CommandMenuContext.Provider
               value={{
                 displayType: 'dropdownItem',
-                containerType: 'index-page-dropdown',
+                containerType: CommandMenuItemContainerType.IndexPageDropdown,
                 commandMenuItems: createMockCommandMenuItems(),
                 commandMenuContextApi: EMPTY_COMMAND_MENU_CONTEXT_API,
                 isInPreviewMode: false,

--- a/packages/twenty-front/src/modules/command-menu-item/components/__stories__/RecordShowSidePanelCommandMenuDropdown.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/__stories__/RecordShowSidePanelCommandMenuDropdown.stories.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { Provider as JotaiProvider } from 'jotai';
 import { userEvent, within } from 'storybook/test';
@@ -38,7 +39,8 @@ const meta: Meta<typeof RecordPageSidePanelCommandMenuDropdown> = {
               <CommandMenuContext.Provider
                 value={{
                   displayType: 'dropdownItem',
-                  containerType: 'command-menu-show-page-dropdown',
+                  containerType:
+                    CommandMenuItemContainerType.CommandMenuShowPageDropdown,
                   commandMenuItems: createMockCommandMenuItems(),
                   commandMenuContextApi: {
                     ...EMPTY_COMMAND_MENU_CONTEXT_API,

--- a/packages/twenty-front/src/modules/command-menu-item/contexts/CommandMenuContext.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/contexts/CommandMenuContext.ts
@@ -1,5 +1,5 @@
 import { EMPTY_COMMAND_MENU_CONTEXT_API } from '@/command-menu-item/constants/EmptyCommandMenuContextApi';
-import { type CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { createContext } from 'react';
 import { type CommandMenuContextApi } from 'twenty-shared/types';
 import { type CommandMenuItemFieldsFragment } from '~/generated-metadata/graphql';
@@ -13,7 +13,7 @@ export type CommandMenuContextType = {
 };
 
 export const CommandMenuContext = createContext<CommandMenuContextType>({
-  containerType: 'command-menu-list',
+  containerType: CommandMenuItemContainerType.CommandMenuList,
   displayType: 'button',
   commandMenuItems: [],
   commandMenuContextApi: EMPTY_COMMAND_MENU_CONTEXT_API,

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { CommandMenuItemRenderer } from '@/command-menu-item/display/components/CommandMenuItemRenderer';
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
 import { PinnedCommandMenuItemsInlineMeasurements } from '@/command-menu-item/display/components/PinnedCommandMenuItemsInlineMeasurements';
@@ -51,12 +52,14 @@ export const PinnedCommandMenuItemButtons = () => {
 
   // The footer keeps its label rightmost. Headers reverse the row so labels sit
   // left of the icons.
-  const isSidePanelFooter = containerType === 'side-panel-footer';
+  const isSidePanelFooter =
+    containerType === CommandMenuItemContainerType.SidePanelFooter;
 
   // A record header keeps its breadcrumb on mobile, so its actions stay icons
   // and leave the record name room. Index and standalone headers drop their
   // title there, which frees the width for one label.
-  const isRecordPageHeader = containerType === 'show-page-header';
+  const isRecordPageHeader =
+    containerType === CommandMenuItemContainerType.ShowPageHeader;
 
   const shouldLabelSingleCommandMenuItem =
     isSidePanelFooter || (isMobile && !isRecordPageHeader);

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -53,9 +53,13 @@ export const PinnedCommandMenuItemButtons = () => {
   // left of the icons.
   const isSidePanelFooter = containerType === 'side-panel-footer';
 
-  // Neither the footer nor a mobile header is wide enough to label every action,
-  // so both label a single one and render the rest as icons.
-  const shouldLabelSingleCommandMenuItem = isSidePanelFooter || isMobile;
+  // A record header keeps its breadcrumb on mobile, so its actions stay icons
+  // and leave the record name room. Index and standalone headers drop their
+  // title there, which frees the width for one label.
+  const isRecordPageHeader = containerType === 'show-page-header';
+
+  const shouldLabelSingleCommandMenuItem =
+    isSidePanelFooter || (isMobile && !isRecordPageHeader);
 
   const pinnedCommandMenuItems = useMemo(
     () => commandMenuItems.filter((item) => item.isPinned === true),
@@ -67,8 +71,9 @@ export const PinnedCommandMenuItemButtons = () => {
     : null;
 
   const shouldHideCommandMenuItemLabel = (commandMenuItemId: string) =>
-    shouldLabelSingleCommandMenuItem &&
-    commandMenuItemId !== labelledCommandMenuItemId;
+    (isMobile && isRecordPageHeader) ||
+    (shouldLabelSingleCommandMenuItem &&
+      commandMenuItemId !== labelledCommandMenuItemId);
 
   const {
     pinnedInlineCommandMenuItems,

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -10,6 +10,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { motion } from 'framer-motion';
 import { useContext, useMemo } from 'react';
 import { ThemeContext } from 'twenty-ui/theme-constants';
+import { useIsMobile } from 'twenty-ui/utilities';
 import {
   type CommandMenuItemFieldsFragment,
   EngineComponentKey,
@@ -46,23 +47,28 @@ const StyledItemsContainer = styled.div<{ shouldReverse: boolean }>`
 export const PinnedCommandMenuItemButtons = () => {
   const { theme } = useContext(ThemeContext);
   const { commandMenuItems, containerType } = useContext(CommandMenuContext);
+  const isMobile = useIsMobile();
 
-  // The footer is far narrower than a page header, so it labels a single action
-  // and keeps that label rightmost. Headers label every action and reverse the
-  // row so their labels sit left of the icons.
+  // The footer keeps its label rightmost. Headers reverse the row so labels sit
+  // left of the icons.
   const isSidePanelFooter = containerType === 'side-panel-footer';
+
+  // Neither the footer nor a mobile header is wide enough to label every action,
+  // so both label a single one and render the rest as icons.
+  const shouldLabelSingleCommandMenuItem = isSidePanelFooter || isMobile;
 
   const pinnedCommandMenuItems = useMemo(
     () => commandMenuItems.filter((item) => item.isPinned === true),
     [commandMenuItems],
   );
 
-  const labelledCommandMenuItemId = isSidePanelFooter
+  const labelledCommandMenuItemId = shouldLabelSingleCommandMenuItem
     ? getLabelledPinnedCommandMenuItemId(pinnedCommandMenuItems)
     : null;
 
   const shouldHideCommandMenuItemLabel = (commandMenuItemId: string) =>
-    isSidePanelFooter && commandMenuItemId !== labelledCommandMenuItemId;
+    shouldLabelSingleCommandMenuItem &&
+    commandMenuItemId !== labelledCommandMenuItemId;
 
   const {
     pinnedInlineCommandMenuItems,

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import {
   type Decorator,
   type Meta,
@@ -109,7 +110,7 @@ const createDecorator =
           <CommandMenuContext.Provider
             value={{
               displayType: 'listItem',
-              containerType: 'command-menu-list',
+              containerType: CommandMenuItemContainerType.CommandMenuList,
               commandMenuItems,
               commandMenuContextApi: EMPTY_COMMAND_MENU_CONTEXT_API,
               isInPreviewMode: false,

--- a/packages/twenty-front/src/modules/command-menu-item/hooks/__tests__/useCloseCommandMenu.test.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/hooks/__tests__/useCloseCommandMenu.test.tsx
@@ -1,6 +1,6 @@
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
 import { useCloseCommandMenu } from '@/command-menu-item/hooks/useCloseCommandMenu';
-import { type CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { act, renderHook } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import { ContextStorePageType } from 'twenty-shared/types';
@@ -86,7 +86,9 @@ beforeEach(() => {
 describe('useCloseCommandMenu', () => {
   describe('when containerType is command-menu-list', () => {
     it('should call closeSidePanelMenu by default', () => {
-      const wrapper = getWrapper({ containerType: 'command-menu-list' });
+      const wrapper = getWrapper({
+        containerType: CommandMenuItemContainerType.CommandMenuList,
+      });
 
       const { result } = renderHook(() => useCloseCommandMenu(), { wrapper });
 
@@ -99,7 +101,9 @@ describe('useCloseCommandMenu', () => {
     });
 
     it('should not call closeSidePanelMenu when closeSidePanelOnCommandMenuListExecution is false', () => {
-      const wrapper = getWrapper({ containerType: 'command-menu-list' });
+      const wrapper = getWrapper({
+        containerType: CommandMenuItemContainerType.CommandMenuList,
+      });
 
       const { result } = renderHook(
         () =>
@@ -118,7 +122,9 @@ describe('useCloseCommandMenu', () => {
     });
 
     it('should not call closeDropdown', () => {
-      const wrapper = getWrapper({ containerType: 'command-menu-list' });
+      const wrapper = getWrapper({
+        containerType: CommandMenuItemContainerType.CommandMenuList,
+      });
 
       const { result } = renderHook(() => useCloseCommandMenu(), { wrapper });
 
@@ -132,7 +138,9 @@ describe('useCloseCommandMenu', () => {
 
   describe('when containerType is index-page-dropdown', () => {
     it('should call closeDropdown with the correct dropdown id', () => {
-      const wrapper = getWrapper({ containerType: 'index-page-dropdown' });
+      const wrapper = getWrapper({
+        containerType: CommandMenuItemContainerType.IndexPageDropdown,
+      });
 
       const { result } = renderHook(() => useCloseCommandMenu(), { wrapper });
 
@@ -146,7 +154,9 @@ describe('useCloseCommandMenu', () => {
     });
 
     it('should not call closeSidePanelMenu', () => {
-      const wrapper = getWrapper({ containerType: 'index-page-dropdown' });
+      const wrapper = getWrapper({
+        containerType: CommandMenuItemContainerType.IndexPageDropdown,
+      });
 
       const { result } = renderHook(() => useCloseCommandMenu(), { wrapper });
 
@@ -161,7 +171,7 @@ describe('useCloseCommandMenu', () => {
   describe('when containerType is command-menu-show-page-dropdown', () => {
     it('should call closeDropdown with the correct dropdown id', () => {
       const wrapper = getWrapper({
-        containerType: 'command-menu-show-page-dropdown',
+        containerType: CommandMenuItemContainerType.CommandMenuShowPageDropdown,
       });
 
       const { result } = renderHook(() => useCloseCommandMenu(), { wrapper });
@@ -177,7 +187,7 @@ describe('useCloseCommandMenu', () => {
 
     it('should not call closeSidePanelMenu by default', () => {
       const wrapper = getWrapper({
-        containerType: 'command-menu-show-page-dropdown',
+        containerType: CommandMenuItemContainerType.CommandMenuShowPageDropdown,
       });
 
       const { result } = renderHook(() => useCloseCommandMenu(), { wrapper });
@@ -191,7 +201,7 @@ describe('useCloseCommandMenu', () => {
 
     it('should call closeSidePanelMenu when closeSidePanelOnShowPageOptionsExecution is true', () => {
       const wrapper = getWrapper({
-        containerType: 'command-menu-show-page-dropdown',
+        containerType: CommandMenuItemContainerType.CommandMenuShowPageDropdown,
       });
 
       const { result } = renderHook(
@@ -213,7 +223,7 @@ describe('useCloseCommandMenu', () => {
   describe('when isInSidePanel is true', () => {
     it('should use side panel dropdown id for closeDropdown', () => {
       const wrapper = getWrapper({
-        containerType: 'index-page-dropdown',
+        containerType: CommandMenuItemContainerType.IndexPageDropdown,
         isInSidePanel: true,
       });
 

--- a/packages/twenty-front/src/modules/command-menu-item/hooks/useCloseCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/hooks/useCloseCommandMenu.ts
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
 import { getCommandMenuDropdownIdFromCommandMenuId } from '@/command-menu-item/utils/getCommandMenuDropdownIdFromCommandMenuId';
 import { getSidePanelCommandMenuDropdownIdFromCommandMenuId } from '@/command-menu-item/utils/getSidePanelCommandMenuDropdownIdFromCommandMenuId';
@@ -31,7 +32,7 @@ export const useCloseCommandMenu = ({
     : getCommandMenuDropdownIdFromCommandMenuId(commandMenuId);
 
   const closeCommandMenu = () => {
-    if (containerType === 'command-menu-list') {
+    if (containerType === CommandMenuItemContainerType.CommandMenuList) {
       if (!closeSidePanelOnCommandMenuListExecution) {
         return;
       }
@@ -39,14 +40,15 @@ export const useCloseCommandMenu = ({
     }
 
     if (
-      containerType === 'index-page-dropdown' ||
-      containerType === 'command-menu-show-page-dropdown'
+      containerType === CommandMenuItemContainerType.IndexPageDropdown ||
+      containerType === CommandMenuItemContainerType.CommandMenuShowPageDropdown
     ) {
       closeDropdown(dropdownId);
     }
 
     if (
-      containerType === 'command-menu-show-page-dropdown' &&
+      containerType ===
+        CommandMenuItemContainerType.CommandMenuShowPageDropdown &&
       closeSidePanelOnShowPageOptionsExecution
     ) {
       closeSidePanelMenu();

--- a/packages/twenty-front/src/modules/command-menu-item/types/CommandMenuItemContainerType.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/types/CommandMenuItemContainerType.ts
@@ -1,8 +1,9 @@
-export type CommandMenuItemContainerType =
-  | 'command-menu-list'
-  | 'index-page-header'
-  | 'index-page-dropdown'
-  | 'show-page-header'
-  | 'standalone-page-header'
-  | 'command-menu-show-page-dropdown'
-  | 'side-panel-footer';
+export enum CommandMenuItemContainerType {
+  CommandMenuList = 'command-menu-list',
+  IndexPageHeader = 'index-page-header',
+  IndexPageDropdown = 'index-page-dropdown',
+  ShowPageHeader = 'show-page-header',
+  StandalonePageHeader = 'standalone-page-header',
+  CommandMenuShowPageDropdown = 'command-menu-show-page-dropdown',
+  SidePanelFooter = 'side-panel-footer',
+}

--- a/packages/twenty-front/src/modules/object-record/record-update-multiple/components/__stories__/UpdateMultipleRecordsContainer.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-update-multiple/components/__stories__/UpdateMultipleRecordsContainer.stories.tsx
@@ -1,5 +1,6 @@
 import { EMPTY_COMMAND_MENU_CONTEXT_API } from '@/command-menu-item/constants/EmptyCommandMenuContextApi';
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreNumberOfSelectedRecordsComponentState } from '@/context-store/states/contextStoreNumberOfSelectedRecordsComponentState';
 import { ApolloCoreClientContext } from '@/object-metadata/contexts/ApolloCoreClientContext';
@@ -79,7 +80,7 @@ const meta: Meta<typeof UpdateMultipleRecordsContainer> = {
         <CommandMenuContext.Provider
           value={{
             commandMenuItems: [],
-            containerType: 'index-page-dropdown',
+            containerType: CommandMenuItemContainerType.IndexPageDropdown,
             displayType: 'dropdownItem',
             commandMenuContextApi: EMPTY_COMMAND_MENU_CONTEXT_API,
             isInPreviewMode: false,

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelRouter.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelRouter.tsx
@@ -1,3 +1,4 @@
+import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { CommandMenuContextProvider } from '@/command-menu-item/contexts/CommandMenuContextProvider';
 import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
@@ -82,7 +83,7 @@ export const SidePanelRouter = () => {
           <CommandMenuContextProvider
             isInSidePanel={true}
             displayType="listItem"
-            containerType="command-menu-list"
+            containerType={CommandMenuItemContainerType.CommandMenuList}
           >
             <SidePanelSubPageRouter>
               {sidePanelPageComponent}


### PR DESCRIPTION
## Problem

The blue create button ("New Company" etc.) is invisible on mobile, so the only way to create a record is the command menu, which is painful on a phone.

Three page headers dropped their pinned action buttons entirely below the mobile breakpoint:

- `RecordIndexCommandMenu` — `{!isMobile && <PinnedCommandMenuItemButtons />}`
- `RecordShowCommandMenu` — same
- `StandalonePageCommandMenu` — same

Combined with `PageCardHeader` hiding the title on mobile, the record index header ended up nearly empty: a nav collapse button and the side panel toggle, with plenty of unused space.

## Change

Mobile headers now reuse the rule the side panel footer already follows: **label a single action, render the rest as icons.** How many labels a header can afford depends on whether it shows a title:

| Header | Mobile |
| --- | --- |
| Index, standalone | `PageCardHeader` drops the title, so one action keeps its label — the create action, so it stays a full blue "+ New Person" button |
| Record page | Keeps its breadcrumb, so actions stay icons and leave the record name room |

Everything needed already existed:

- `getLabelledPinnedCommandMenuItemId` picks which action keeps its label.
- `CommandMenuButton` already falls back to an `IconButton` with a tooltip when no label is shown, keeping the blue primary accent on create.
- `usePinnedCommandMenuItemsInlineLayout` already handles overflow when actions don't fit.

So the change is two conditions on the existing "label a single action" flag, plus deleting the three mobile gates. No new component, no new layout state.

Desktop is unchanged.

## Screenshots

People index and a company record page at 390x844.

## Notes

- `aria-label` is identical in labelled and icon-only modes (`Create new Person`), so `packages/twenty-e2e-testing/tests/create-record.spec.ts` keeps matching.
- Verified on a local instance at 390px and 320px (narrowest realistic phone): the index label still fits, clicking creates the record and navigates to it, the record page renders its four actions as icons with the title intact, the side panel command menu list does not repeat them, and both desktop headers are unchanged.
- Verified with `oxlint --type-aware`, `oxfmt --check`, `nx typecheck twenty-front`, and the `command-menu` jest suites (72 tests).
- Follow-up worth its own PR: "primary CTA" is implicit today — a hardcoded `EngineComponentKey` list in `PinnedCommandMenuItemButtons` plus a separate `isPrimaryCTA` flag on side panel footer widgets. Promoting it to a metadata property would unify the two, and would let overflow reserve a slot for the primary action by intent instead of by position.
