### PR TITLE
Refresh the front component limitations doc

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
@@ -779,20 +779,18 @@ If one of these blocks you, [open an issue](https://github.com/twentyhq/twenty/i
 
 ### Layout and measurement
 
-Elements can measure themselves. The host measures your elements on the real page and mirrors the values into the sandbox, so reads are answered locally but can be up to one frame stale, and the very first read of an element that was never measured returns zeros. Write-then-measure in the same tick returns the stale value; re-read in a `requestAnimationFrame` callback or an effect.
+Elements can measure themselves: the host mirrors geometry into the sandbox, so reads are answered locally but can be up to one frame stale, and the first read of a never-measured element returns zeros. After writing, re-read in a `requestAnimationFrame` callback or an effect.
 
 | API | What happens |
 |-----|--------------|
-| `getBoundingClientRect()` | Works from the mirror: up to one frame stale, and a zero rect on the first read of a never-measured element |
-| `getClientRects()` | Throws |
-| `offsetWidth`, `clientWidth`, `scrollWidth`, `offsetTop`, ... | Work, with the same staleness (`0` on the first read); assigning `scrollTop` / `scrollLeft` is a no-op |
+| `getBoundingClientRect()`, `offsetWidth`, `clientWidth`, `scrollWidth`, `offsetTop`, ... | Work, from the mirror; assigning `scrollTop` / `scrollLeft` is a no-op |
+| `getClientRects()`, `window.matchMedia()` | Throws |
 | `window.innerWidth`, `innerHeight`, `devicePixelRatio`, `scrollX`, `scrollY` | Work, reporting the **browser viewport**; your widget's own size is `document.body.clientWidth` / `clientHeight` |
-| `window.getComputedStyle()` | Returns the element's inline styles only, never the host-computed cascade, so a value set by a stylesheet reads as empty |
-| `window.matchMedia()` | Throws |
+| `window.getComputedStyle()` | Returns the element's inline styles only, never the host-computed cascade |
 | `ResizeObserver`, `IntersectionObserver` | `ReferenceError` (`typeof` guards do work) |
-| `MutationObserver` | Works: `childList`, `attributes`, `characterData`, `subtree`, `attributeFilter`, old values, `disconnect()`, `takeRecords()` |
+| `MutationObserver` | Works, including `subtree`, `attributeFilter`, old values and `takeRecords()` |
 
-Measurement unblocks code that positions or sizes itself from `getBoundingClientRect`, but anything that *watches* for size changes through `ResizeObserver` (recharts `ResponsiveContainer`, Floating UI's `autoUpdate`) still does not work. Prefer CSS for layout anyway: your stylesheet reaches the real page, so flexbox, grid, `aspect-ratio`, `clamp()` and `@container` all behave normally, with no frame lag.
+Positioning from `getBoundingClientRect` now works, but anything watching size changes through `ResizeObserver` (recharts `ResponsiveContainer`, Floating UI's `autoUpdate`) still does not. Prefer CSS for layout anyway: your stylesheet reaches the real page, so flexbox, grid, `aspect-ratio`, `clamp()` and `@container` behave normally, with no frame lag.
 
 <Note>
 `requestAnimationFrame`, `fetch`, `setTimeout` and `queueMicrotask` work without the `window.` prefix. Only `window.requestAnimationFrame(...)` and friends throw.

--- a/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
@@ -806,7 +806,7 @@ A `ref` gives you a sandbox element, not an `HTMLElement`.
 |----------------|--------------|-------------|
 | `ref.current.focus()`, `.click()`, `.select()`, `.setSelectionRange()`, `.scrollIntoView()`, `video.play()` | Throws | Controlled components; read values from `event.target` |
 | `element.classList.add(...)` | Throws (`classList` is `undefined`) | Build the `className` string yourself |
-| `document.createTreeWalker()` | Throws | `querySelector()` / `querySelectorAll()`, `getElementById()` and `getElementsByClassName()`, which all work |
+| `document.createTreeWalker()` | Throws | `querySelector()` / `querySelectorAll()` and `getElementById()` work; `getElementsByClassName()` works too, but returns a static collection, not a live `HTMLCollection` |
 | `document.activeElement` | Always `undefined` | Track focus with `onFocus` / `onBlur` |
 | `<canvas>` | Renders nothing, no error | SVG, or draw offscreen and show an `<img src={dataUrl}>` |
 | `createPortal(node, document.body)` | Renders nothing, while `isConnected` reports success | Overlays inline with `position: absolute`, or pass the library your own container element |

--- a/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
@@ -773,24 +773,26 @@ To branch on the active scheme explicitly, read it with `useColorScheme()` from 
 
 ## Current limitations
 
-Front components are under active development. Rendering, styling and handling events works well. Anything that reaches *past* rendering (measuring an element, calling a DOM method on a ref, portaling outside your tree, touching browser storage) is missing or incomplete today, and most of it fails silently: no exception, and no TypeScript error either, since the scaffold is typed against the full browser DOM.
+Front components are under active development. Rendering, styling, handling events, measuring elements and browser storage work well. Anything that reaches *past* those (calling a DOM method on a ref, observing element resizes, portaling outside your tree) is missing or incomplete today, and most of it fails silently: no exception, and no TypeScript error either, since the scaffold is typed against the full browser DOM.
 
 If one of these blocks you, [open an issue](https://github.com/twentyhq/twenty/issues/new/choose) so it gets prioritized.
 
 ### Layout and measurement
 
-Nothing can measure itself yet.
+Elements can measure themselves. The host measures your elements on the real page and mirrors the values into the sandbox, so reads are answered locally but can be up to one frame stale, and the very first read of an element that was never measured returns zeros. Write-then-measure in the same tick returns the stale value; re-read in a `requestAnimationFrame` callback or an effect.
 
 | API | What happens |
 |-----|--------------|
-| `getBoundingClientRect()`, `getClientRects()` | Throws |
-| `offsetWidth`, `clientWidth`, `scrollWidth`, `offsetTop`, ... | Silently `undefined`, so `width ?? 0` yields `0` and `width > 600` is always false |
+| `getBoundingClientRect()` | Works from the mirror: up to one frame stale, and a zero rect on the first read of a never-measured element |
+| `getClientRects()` | Throws |
+| `offsetWidth`, `clientWidth`, `scrollWidth`, `offsetTop`, ... | Work, with the same staleness (`0` on the first read); assigning `scrollTop` / `scrollLeft` is a no-op |
+| `window.innerWidth`, `innerHeight`, `devicePixelRatio`, `scrollX`, `scrollY` | Work, reporting the **browser viewport**; your widget's own size is `document.body.clientWidth` / `clientHeight` |
+| `window.getComputedStyle()` | Returns the element's inline styles only, never the host-computed cascade, so a value set by a stylesheet reads as empty |
+| `window.matchMedia()` | Throws |
 | `ResizeObserver`, `IntersectionObserver` | `ReferenceError` (`typeof` guards do work) |
-| `window.matchMedia()`, `window.getComputedStyle()` | Throws |
-| `window.innerWidth`, `innerHeight`, `devicePixelRatio` | Silently `undefined` |
-| `new MutationObserver(fn)` | Constructs, then `.observe()` throws |
+| `MutationObserver` | Works: `childList`, `attributes`, `characterData`, `subtree`, `attributeFilter`, old values, `disconnect()`, `takeRecords()` |
 
-So recharts `ResponsiveContainer`, Floating UI / Popper, list virtualization and drag-to-resize do not work yet. Do layout in CSS instead: your stylesheet reaches the real page, so flexbox, grid, `aspect-ratio`, `clamp()` and `@container` all behave normally.
+Measurement unblocks code that positions or sizes itself from `getBoundingClientRect`, but anything that *watches* for size changes through `ResizeObserver` (recharts `ResponsiveContainer`, Floating UI's `autoUpdate`) still does not work. Prefer CSS for layout anyway: your stylesheet reaches the real page, so flexbox, grid, `aspect-ratio`, `clamp()` and `@container` all behave normally, with no frame lag.
 
 <Note>
 `requestAnimationFrame`, `fetch`, `setTimeout` and `queueMicrotask` work without the `window.` prefix. Only `window.requestAnimationFrame(...)` and friends throw.
@@ -804,7 +806,7 @@ A `ref` gives you a sandbox element, not an `HTMLElement`.
 |----------------|--------------|-------------|
 | `ref.current.focus()`, `.click()`, `.select()`, `.setSelectionRange()`, `.scrollIntoView()`, `video.play()` | Throws | Controlled components; read values from `event.target` |
 | `element.classList.add(...)` | Throws (`classList` is `undefined`) | Build the `className` string yourself |
-| `document.getElementById()`, `getElementsByClassName()`, `createTreeWalker()` | Throws | `querySelector()` / `querySelectorAll()`, which work |
+| `document.createTreeWalker()` | Throws | `querySelector()` / `querySelectorAll()`, `getElementById()` and `getElementsByClassName()`, which all work |
 | `document.activeElement` | Always `undefined` | Track focus with `onFocus` / `onBlur` |
 | `<canvas>` | Renders nothing, no error | SVG, or draw offscreen and show an `<img src={dataUrl}>` |
 | `createPortal(node, document.body)` | Renders nothing, while `isConnected` reports success | Overlays inline with `position: absolute`, or pass the library your own container element |


### PR DESCRIPTION
The limitations section of the front components doc predates the geometry mirror (#23264) and the MutationObserver polyfill (#23489), so it still documents measurement APIs as throwing or returning undefined.

Updates the tables to match the current sandbox: getBoundingClientRect and the offset/client/scroll getters work from the host-pushed mirror (up to one frame stale, zero on first read), window viewport values work, getComputedStyle returns inline styles, getElementById / getElementsByClassName work, and MutationObserver is fully implemented. Still-missing APIs (getClientRects, matchMedia, ResizeObserver, classList, ...) stay documented as such.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

