### PR TITLE
docs: keep JSX tags out of translatable prose so Crowdin can rebuild

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
@@ -806,22 +806,22 @@ A `ref` gives you a sandbox element, not an `HTMLElement`.
 | `element.classList.add(...)` | Throws (`classList` is `undefined`) | Build the `className` string yourself |
 | `document.getElementById()`, `getElementsByClassName()`, `createTreeWalker()` | Throws | `querySelector()` / `querySelectorAll()`, which work |
 | `document.activeElement` | Always `undefined` | Track focus with `onFocus` / `onBlur` |
-| `<canvas>` | Renders nothing, no error | SVG, or draw offscreen and show an `<img src={dataUrl}>` |
+| `canvas` | Renders nothing, no error | SVG, or draw offscreen and show the result in an `img` element |
 | `createPortal(node, document.body)` | Renders nothing, while `isConnected` reports success | Overlays inline with `position: absolute`, or pass the library your own container element |
 
 The portal gap is why Radix, Headless UI, MUI and react-select popovers render nothing by default. Most accept a container prop; point it at an element you rendered.
 
 ### Events
 
-Mouse, pointer, touch, drag, keyboard, focus, `input`/`change`/`submit`, `scroll`/`wheel`/`contextmenu` and `animationend`/`transitionend` cross to the host, plus a few per element: `load`/`error` on `<img>`, clipboard and composition on `<input>`/`<textarea>`, media on `<video>`/`<audio>`, `toggle` on `<details>`/`<dialog>`. Anything else (`onAuxClick`, `onSelect`, `onInvalid`, `onReset`, `onAnimationStart`, pointer capture, `onLoad` off `<img>`) is dropped without warning.
+Mouse, pointer, touch, drag, keyboard, focus, `input`/`change`/`submit`, `scroll`/`wheel`/`contextmenu` and `animationend`/`transitionend` cross to the host, plus a few per element: `load`/`error` on `img`, clipboard and composition on `input`/`textarea`, media on `video`/`audio`, `toggle` on `details`/`dialog`. Anything else (`onAuxClick`, `onSelect`, `onInvalid`, `onReset`, `onAnimationStart`, pointer capture, `onLoad` off `img`) is dropped without warning.
 
 `document.addEventListener()` and `window.addEventListener()` register without error and never fire, which is why a drag stops as soon as the pointer leaves the element it started on. `event.preventDefault()` does not cross either; form submission, `dragover`/`drop` and link clicks are already guarded for you.
 
 ### Attributes and styling
 
-Each element forwards its own properties to the host DOM (`href` on `<a>`, `src`/`alt` on `<img>`, `value`/`placeholder`/`disabled` on `<input>`, and so on), plus a common set on every element: `id`, `className`, `style`, `title`, `tabIndex`, `role`, `draggable` and any `aria-*` / `data-*` attribute (hyphenated, so `ariaLabel` is dropped). Anything outside that is silently discarded, so express custom state as `data-*`.
+Each element forwards its own properties to the host DOM (`href` on `a`, `src`/`alt` on `img`, `value`/`placeholder`/`disabled` on `input`, and so on), plus a common set on every element: `id`, `className`, `style`, `title`, `tabIndex`, `role`, `draggable` and any `aria-*` / `data-*` attribute (hyphenated, so `ariaLabel` is dropped). Anything outside that is silently discarded, so express custom state as `data-*`.
 
-Component CSS, whether from `import './styles.css'`, CSS-in-JS or a `<style>` element, is injected into the host page's `<head>` **unscoped**. So class names collide with Twenty's own (prefix them, and never write bare `div { ... }` selectors), and `@media` matches the browser window rather than your widget (use `@container` with your own `container-type`). Inline `style` props are unaffected.
+Component CSS, whether from `import './styles.css'`, CSS-in-JS or a `style` element, is injected into the host page's `head` **unscoped**. So class names collide with Twenty's own (prefix them, and never write bare `div { ... }` selectors), and `@media` matches the browser window rather than your widget (use `@container` with your own `container-type`). Inline `style` props are unaffected.
 
 ### Storage and network
 
@@ -835,7 +835,7 @@ Component CSS, whether from `import './styles.css'`, CSS-in-JS or a `<style>` el
 
 ### Other gaps
 
-- **File contents.** `<input type="file">` gives your handler file metadata only, not the bytes, so `FileReader` and uploads are not possible yet.
+- **File contents.** An `input` of type `file` gives your handler file metadata only, not the bytes, so `FileReader` and uploads are not possible yet.
 - **Drag-and-drop payloads.** Drag events fire, but `event.dataTransfer` is `undefined`.
 - **Node built-ins.** `fs`, `path` and `node:crypto` fail the build, so move that work into a [logic function](/developers/extend/apps/logic/logic-functions). Web Crypto, `fetch`, `TextEncoder` and `URL` are available.
-- **`<iframe>`** is always re-sandboxed without `allow-same-origin`, so an embed relying on its own session renders logged out. It has no `onLoad` either.
+- **`iframe`** is always re-sandboxed without `allow-same-origin`, so an embed relying on its own session renders logged out. It has no `onLoad` either.

--- a/packages/twenty-docs/developers/extend/apps/translations/overview.mdx
+++ b/packages/twenty-docs/developers/extend/apps/translations/overview.mdx
@@ -55,8 +55,8 @@ const Card = ({ count, name }: { count: number; name: string }) => {
 
 ### When to use which
 
-- **`<Trans>…</Trans>`** — static text in JSX. Use the `message` and `values`
-  props for interpolation (`<Trans message="Hi {name}" values={{ name }} />`);
+- **`Trans`** — static text in JSX. Use the `message` and `values` props for
+  interpolation, as in `Trans message="Hi {name}" values={{ name }}`;
   interpolating directly in the children is not statically extractable.
 - **`useTranslate().t`** — dynamic strings inside a component. Re-renders when the
   user switches language. Prefer this inside render.
@@ -85,7 +85,7 @@ twenty dev:translations-extract                  # collect strings into locales/
 twenty dev:translations-extract --locale fr-FR   # also scaffold a target locale
 ```
 
-Extraction collects both your manifest labels and the `t()`/`msg()`/`<Trans>`
+Extraction collects both your manifest labels and the `t()`/`msg()`/`Trans`
 strings from your front-component source into `locales/<locale>.json`, keyed by
 source string. Fill in the translations:
 
@@ -108,7 +108,7 @@ current user: manifest labels are resolved server-side, and front-component
 catalogs are baked into each component bundle. At runtime a component reads the
 locale from its execution context (the host's current language) and resolves
 each string against its catalog, falling back to the source when a translation
-is missing. Switching language in the host re-renders `<Trans>` and
+is missing. Switching language in the host re-renders `Trans` and
 `useTranslate().t` strings live.
 
 Because catalogs are compiled at build time, updating a translation means
@@ -120,6 +120,13 @@ continuous `twenty dev` watch shows source strings, so test localized output
 with a one-off build.
 </Note>
 
-`<Trans>` text children may span multiple lines — whitespace is collapsed the
-same way JSX collapses it, so `<Trans>Welcome\n  back</Trans>` and the extracted
-key both become `Welcome back`.
+`Trans` text children may span multiple lines — whitespace is collapsed the
+same way JSX collapses it, so both of these extract to the key `Welcome back`:
+
+```tsx
+<Trans>Welcome back</Trans>
+<Trans>
+  Welcome
+  back
+</Trans>
+```


### PR DESCRIPTION
## What

Keeps JSX/HTML tags out of translatable prose in the two docs pages that break the Crowdin build.

## Why

`Pull docs translations` has failed on **every scheduled run for two days** (10 today, 2 yesterday, zero successes), always for pt, ru and zh-CN. The `--verbose` output names the cause:

```
❌ The build has failed. Error message: An unknown error occurred while generating the resulting file.
File: /packages/twenty-docs/developers/extend/apps/layout/front-components.mdx.
Language: Portuguese.
Parsing error in string: SVG, ou desenhe
```

Three failures, one class — a translated string carrying an inline code span that holds a tag:

| language | file | string |
|---|---|---|
| Portuguese | `layout/front-components.mdx` | ``…show an `<img src={dataUrl}>` `` |
| Chinese Simplified | `layout/front-components.mdx` | the `Mouse, pointer, touch…` paragraph listing `` `<img>` ``, `` `<input>` ``, `` `<video>` `` |
| Russian | `translations/overview.mdx` | ``` `<Trans>` text children may span multiple lines ``` |

Crowdin's `mdx_v2` parser can't rebuild those once translated — the Russian error shows the tag coming back HTML-escaped (`Дети с текстом&lt;T`). `exclude_code_blocks: true` only covers fenced blocks, not inline spans.

One unbuildable string fails the entire language, so **every other translated page in pt, ru and zh-CN goes stale** because of these two files.

## Changes

Refer to elements by name in prose — `` `img` ``, `` `input` ``, `` `iframe` ``, `` `Trans` `` — instead of wrapping the tag form in a code span. The multi-line `Trans` example moves into a fenced `tsx` block, which is already excluded from translation and reads better than the previous `\n`-escaped one-liner:

```tsx
<Trans>Welcome back</Trans>
<Trans>
  Welcome
  back
</Trans>
```

Tags are still shown in full inside fenced code samples throughout both pages; only the prose changed. `npx nx lint twenty-docs` passes.

## Notes

- I first proposed adding these two files to `ignore` in the Crowdin config; fixing the source is better, since it keeps the pages translated.
- 5 similar spans remain in 4 other docs files. They aren't blocking a build today (the build stops at the first error), so I left them rather than widen the diff — worth cleaning up if one of them starts failing.
- The build runs against the sources Crowdin already holds, so this takes effect once `Push translations to Crowdin` re-uploads from `main` after merge; the first scheduled pull after that is the one to watch.
