### PR TITLE
ci: retry a storybook shard that aborts before running any story

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -122,7 +122,13 @@ jobs:
         run: |
           npx http-server packages/twenty-front/storybook-static --port 6006 --silent &
           timeout 30 bash -c 'until curl -sf http://localhost:6006 > /dev/null 2>&1; do sleep 1; done'
-          npx nx storybook:test twenty-front --configuration=${{ matrix.storybook_scope }} --shard=${{ matrix.shard }}/${{ env.SHARD_COUNTER }}
+          # A shard occasionally dies mid-import with "the iframe was reloaded",
+          # before a single story runs (Tests: no tests). vitest's retry only
+          # covers a story that ran and failed, so that abort takes the shard
+          # down on its own. Give the command one more go; a story that really
+          # fails still fails twice.
+          npx nx storybook:test twenty-front --configuration=${{ matrix.storybook_scope }} --shard=${{ matrix.shard }}/${{ env.SHARD_COUNTER }} \
+            || npx nx storybook:test twenty-front --configuration=${{ matrix.storybook_scope }} --shard=${{ matrix.shard }}/${{ env.SHARD_COUNTER }} --skip-nx-cache
       - name: Upload screenshots for visual regression
         if: always() && !cancelled() && matrix.storybook_scope != 'performance'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## What

Retries a storybook shard once when the command fails, to cover an abort that happens before any story runs.

## Why

`front-sb-test (3, pages)` fails on ~6% of pushes to `main` — 6 of the last 100 push runs, including yesterday and before any of this week's changes. It is **not a story failing**:

```
Error: Failed to run the test .../SettingsObjectNewFieldSelect.stories.tsx
Caused by: Error: The iframe for ".../SettingsObjectNewFieldSelect.stories.tsx" was reloaded
 Test Files  2 skipped (10)
      Tests  no tests
   Duration  52.64s (setup 42.39s, import 41.04s, tests 0ms)
```

Against a healthy run of the same shard:

| | healthy | failing |
|---|---|---|
| Test Files | 7 passed, 3 skipped (10) | 2 skipped (10) |
| setup | ~84s | ~42s |
| import | ~130s | ~41s |
| tests | 20–33s | **0ms** |

So the shard dies about halfway through importing its files, before a single story executes, and the blamed story differs between runs (`SettingsObjectDetail` one run, `SettingsObjectNewFieldSelect` the next) — which rules out any individual story.

`vitest.config.ts` already sets `retry: 2`, but that only covers a story that ran and failed. A file-level abort is an unhandled error, so it takes the whole shard down and nothing retries it.

## Changes

Run the shard command a second time if it fails, with `--skip-nx-cache` so the retry actually re-runs. A story that genuinely fails still fails on both attempts, so this doesn't hide real breakage — it only absorbs the pre-test abort. Green runs pay nothing.

## What this does not do

It doesn't explain *why* the iframe reloads. I checked every hard-navigation site in the front (`useAuth.clearSession`, `useImpersonationSession`, `ClientConfigProvider`, `SettingsClaimApplicationSection`) — none fires automatically while a settings story renders, so the usual "your test changed window.location" explanation doesn't fit. My read is resource pressure in the harness on the heaviest shard (10 story files, ~130s of import, on a 2-core runner also hosting `http-server` and Chromium), but a ~6% CI-only flake won't reproduce locally, so that stays a hypothesis. If the retry stops being enough, the next step is splitting `pages` into more shards.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

