### PR TITLE
fix(twenty-server): apply watched-fields filter to upserted database-event triggers

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/__tests__/transform-event-batch-to-event-payloads.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/__tests__/transform-event-batch-to-event-payloads.spec.ts
@@ -424,6 +424,97 @@ describe('transformEventBatchToEventPayloads', () => {
     });
   });
 
+  describe('upserted event operation', () => {
+    it('should filter upserted events to only those matching updatedFields, same as updated', () => {
+      const workspaceEventBatch = createMockWorkspaceEventBatch({
+        name: 'company.upserted',
+        events: [
+          createMockEvent({
+            recordId: 'record-1',
+            properties: { after: {}, updatedFields: ['gstin'] },
+          }),
+          createMockEvent({
+            recordId: 'record-2',
+            properties: { after: {}, updatedFields: ['gstStatus'] },
+          }),
+        ],
+      });
+      const logicFunctions = [
+        createMockLogicFunction({
+          databaseEventTriggerSettings: {
+            eventName: 'company.upserted',
+            updatedFields: ['gstin'],
+          },
+        }),
+      ];
+
+      const result = transformEventBatchToEventPayloads({
+        workspaceEventBatch,
+        logicFunctions,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(
+        result.map((r) => (r.payload as ObjectRecordEvent).recordId),
+      ).toEqual(['record-1']);
+    });
+
+    it('should return no upserted events when none match the updatedFields filter', () => {
+      const workspaceEventBatch = createMockWorkspaceEventBatch({
+        name: 'company.upserted',
+        events: [
+          createMockEvent({
+            recordId: 'record-1',
+            properties: { after: {}, updatedFields: ['gstStatus'] },
+          }),
+        ],
+      });
+      const logicFunctions = [
+        createMockLogicFunction({
+          databaseEventTriggerSettings: {
+            eventName: 'company.upserted',
+            updatedFields: ['gstin'],
+          },
+        }),
+      ];
+
+      const result = transformEventBatchToEventPayloads({
+        workspaceEventBatch,
+        logicFunctions,
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should include all upserted events when the trigger has no updatedFields filter', () => {
+      const workspaceEventBatch = createMockWorkspaceEventBatch({
+        name: 'company.upserted',
+        events: [
+          createMockEvent({
+            recordId: 'record-1',
+            properties: { after: {}, updatedFields: ['gstin'] },
+          }),
+          createMockEvent({
+            recordId: 'record-2',
+            properties: { after: {}, updatedFields: ['gstStatus'] },
+          }),
+        ],
+      });
+      const logicFunctions = [
+        createMockLogicFunction({
+          databaseEventTriggerSettings: { eventName: 'company.upserted' },
+        }),
+      ];
+
+      const result = transformEventBatchToEventPayloads({
+        workspaceEventBatch,
+        logicFunctions,
+      });
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
   describe('edge cases', () => {
     it('should return empty array when no logic functions provided', () => {
       const workspaceEventBatch = createMockWorkspaceEventBatch();

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/transform-event-batch-to-event-payloads.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/transform-event-batch-to-event-payloads.ts
@@ -53,7 +53,13 @@ const filterEventsByUpdatedFields = ({
   operation: string;
   triggerUpdatedFields?: string[];
 }): ObjectRecordEvent[] => {
-  if (operation !== 'updated') {
+  // Upserted events carry the same before/after-derived `updatedFields` as
+  // updated events (see formatTwentyOrmEventToDatabaseBatchEvent), so a
+  // trigger's watched-fields filter applies to both operations. Without
+  // this, an upserted trigger fires on every write regardless of which
+  // fields changed, which is surprising and can cause self-triggering
+  // loops when a logic function upserts back into the same record.
+  if (operation !== 'updated' && operation !== 'upserted') {
     return events;
   }
 


### PR DESCRIPTION
Fixes #22876.

`filterEventsByUpdatedFields` (the function that applies a logic function's `databaseEventTriggerSettings.updatedFields` watch-list) only checks the intersection when `operation === 'updated'`. For `upserted` events it short-circuits and returns every event untouched, so a database-event trigger with a watched-fields filter fires on every upsert regardless of which fields actually changed.

This isn't a theoretical gap: `formatTwentyOrmEventToDatabaseBatchEvent`'s `UPSERTED` branch computes `updatedFields` from a before/after diff exactly the same way the `UPDATED` branch does, and the "classic" workflow trigger listener (`workflow-database-event-trigger.listener.ts`) already treats `UPDATED` and `UPSERTED` identically when applying its own fields filter. The logic-function trigger path is the outlier — it has the data it needs (`event.properties.updatedFields`) but never uses it for this operation.

The practical failure mode is a self-triggering loop: a logic function watching `company.upserted` with `updatedFields: ['gstin']` that writes back other fields on the same record (e.g. enrichment results) re-emits `company.upserted`, and since the watch-list is silently ignored for upserts, the trigger fires again on its own write, forever, regardless of what changed.

I know this issue has had a few attempts before that didn't land — from what I can see on the closed PRs, they either patched the classic workflow listener (which already handles this correctly and isn't the code path this issue is about) or didn't establish that `upserted` triggers are actually reachable outside the Workflow UI. They are: `databaseEventTriggerSettings` is a plain `{ eventName, updatedFields }` pair configured via the app/logic-function manifest (`packages/twenty-shared/src/application/logicFunctionManifestType.ts`), so `eventName: '<object>.upserted'` with an `updatedFields` list is valid input today, independent of whether a "Workflow" is involved.

Fix: apply the same field-intersection check to `upserted` that already applies to `updated`.

Verified by adding regression coverage to the existing `transform-event-batch-to-event-payloads.spec.ts` (which already had thorough coverage for the `updated` path but none at all for `upserted`): an `upserted` batch with a configured `updatedFields` filter now only produces payloads for events whose diff touches a watched field. Ran the new tests against the unpatched function first to confirm they fail the way the bug predicts (all events pass through unfiltered), then confirmed they pass after the one-line fix. The existing 14 tests for `updated` are untouched and still pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

