### PR TITLE
fix(twenty-server): honor the identity provider's advertised id_token signing algorithm

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/sso/services/__tests__/sso.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/services/__tests__/sso.service.spec.ts
@@ -1,0 +1,81 @@
+/* @license Enterprise */
+
+import { Issuer } from 'openid-client';
+
+import {
+  IdentityProviderType,
+  SSOIdentityProviderStatus,
+  type WorkspaceSSOIdentityProviderEntity,
+} from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
+import { SSOService } from 'src/engine/core-modules/sso/services/sso.service';
+import { type OIDCConfiguration } from 'src/engine/core-modules/sso/types/SSOConfigurations.type';
+
+describe('SSOService.getOIDCClient', () => {
+  const buildSSOService = () => {
+    const twentyConfigService = {
+      get: jest.fn().mockReturnValue('https://twenty.example.com'),
+    };
+
+    const ssoService = new SSOService(
+      {} as never,
+      twentyConfigService as never,
+      {} as never,
+      {} as never,
+    );
+
+    return ssoService;
+  };
+
+  const buildOIDCIdentityProvider = (): WorkspaceSSOIdentityProviderEntity &
+    OIDCConfiguration =>
+    ({
+      id: 'identity-provider-id',
+      name: 'Test IdP',
+      status: SSOIdentityProviderStatus.Active,
+      type: IdentityProviderType.OIDC,
+      issuer: 'https://idp.example.com',
+      clientID: 'client-id',
+      clientSecret: 'client-secret',
+    }) as unknown as WorkspaceSSOIdentityProviderEntity & OIDCConfiguration;
+
+  const buildIssuer = (idTokenSigningAlgValuesSupported?: string[]): Issuer =>
+    new Issuer({
+      issuer: 'https://idp.example.com',
+      authorization_endpoint: 'https://idp.example.com/auth',
+      token_endpoint: 'https://idp.example.com/token',
+      jwks_uri: 'https://idp.example.com/jwks',
+      ...(idTokenSigningAlgValuesSupported && {
+        id_token_signing_alg_values_supported: idTokenSigningAlgValuesSupported,
+      }),
+    });
+
+  it('registers the client with the algorithm the identity provider actually signs id_tokens with', () => {
+    const ssoService = buildSSOService();
+    const identityProvider = buildOIDCIdentityProvider();
+    const issuer = buildIssuer(['ES384']);
+
+    const client = ssoService.getOIDCClient(identityProvider, issuer);
+
+    expect(client.metadata.id_token_signed_response_alg).toBe('ES384');
+  });
+
+  it('prefers RS256 when the identity provider supports it alongside other algorithms', () => {
+    const ssoService = buildSSOService();
+    const identityProvider = buildOIDCIdentityProvider();
+    const issuer = buildIssuer(['ES384', 'RS256']);
+
+    const client = ssoService.getOIDCClient(identityProvider, issuer);
+
+    expect(client.metadata.id_token_signed_response_alg).toBe('RS256');
+  });
+
+  it('falls back to the library default when the issuer does not publish supported algorithms', () => {
+    const ssoService = buildSSOService();
+    const identityProvider = buildOIDCIdentityProvider();
+    const issuer = buildIssuer();
+
+    const client = ssoService.getOIDCClient(identityProvider, issuer);
+
+    expect(client.metadata.id_token_signed_response_alg).toBe('RS256');
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/sso/services/sso.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/services/sso.service.ts
@@ -23,6 +23,7 @@ import {
   type SAMLConfiguration,
   type SSOConfiguration,
 } from 'src/engine/core-modules/sso/types/SSOConfigurations.type';
+import { resolveIdTokenSignedResponseAlg } from 'src/engine/core-modules/sso/utils/resolve-id-token-signed-response-alg.util';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
 @Injectable()
@@ -194,11 +195,18 @@ export class SSOService {
       );
     }
 
+    const idTokenSignedResponseAlg = resolveIdTokenSignedResponseAlg(
+      issuer.metadata,
+    );
+
     return new issuer.Client({
       client_id: identityProvider.clientID,
       client_secret: identityProvider.clientSecret,
       redirect_uris: [this.buildCallbackUrl(identityProvider)],
       response_types: [OIDCResponseType.CODE],
+      ...(idTokenSignedResponseAlg && {
+        id_token_signed_response_alg: idTokenSignedResponseAlg,
+      }),
     });
   }
 

--- a/packages/twenty-server/src/engine/core-modules/sso/utils/resolve-id-token-signed-response-alg.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/utils/resolve-id-token-signed-response-alg.util.ts
@@ -1,0 +1,48 @@
+/* @license Enterprise */
+
+// openid-client's `IssuerMetadata` type doesn't declare this field explicitly
+// (it falls through the `[key: string]: unknown` index signature), even
+// though `id_token_signing_alg_values_supported` is standard OIDC discovery
+// metadata (https://openid.net/specs/openid-connect-discovery-1_0.html).
+// The index signature here mirrors `IssuerMetadata`'s own so this type
+// stays structurally assignable from it.
+type IssuerMetadataWithSigningAlgs = {
+  id_token_signing_alg_values_supported?: unknown;
+  [key: string]: unknown;
+};
+
+/**
+ * Picks which `id_token_signed_response_alg` to register the OIDC client
+ * with, based on what the identity provider actually advertises.
+ *
+ * If we don't pass this explicitly, openid-client's `Client` constructor
+ * silently defaults it to 'RS256' regardless of what the issuer supports
+ * (this is a spec-mandated default, not something the library infers from
+ * discovery). Identity providers that sign id_tokens with anything else
+ * (Logto's ES384 default, for example) then fail every login with
+ * "unexpected JWT alg received", even though the algorithm they used is one
+ * they published support for.
+ *
+ * Returns undefined when the issuer didn't publish a usable list, in which
+ * case we fall back to leaving `id_token_signed_response_alg` unset (i.e.
+ * openid-client's own RS256 default), preserving today's behavior.
+ */
+export const resolveIdTokenSignedResponseAlg = (
+  issuerMetadata: IssuerMetadataWithSigningAlgs,
+): string | undefined => {
+  const supportedAlgs = issuerMetadata.id_token_signing_alg_values_supported;
+
+  if (!Array.isArray(supportedAlgs)) {
+    return undefined;
+  }
+
+  const stringAlgs = supportedAlgs.filter(
+    (alg): alg is string => typeof alg === 'string' && alg.length > 0,
+  );
+
+  if (stringAlgs.length === 0) {
+    return undefined;
+  }
+
+  return stringAlgs.includes('RS256') ? 'RS256' : stringAlgs[0];
+};


### PR DESCRIPTION
Fixes #22780.

`SSOService.getOIDCClient` constructs the `openid-client` `Client` without setting `id_token_signed_response_alg`:

```ts
return new issuer.Client({
  client_id: identityProvider.clientID,
  client_secret: identityProvider.clientSecret,
  redirect_uris: [this.buildCallbackUrl(identityProvider)],
  response_types: [OIDCResponseType.CODE],
});
```

When that field is omitted, `openid-client` doesn't look at what the issuer actually supports — it silently defaults to `RS256` (that's the OIDC dynamic client registration default, not something the library infers from discovery). I checked this empirically against the installed `openid-client` version: constructing a client against an issuer whose discovery document only advertises `id_token_signing_alg_values_supported: ['ES384']` still comes back with `metadata.id_token_signed_response_alg === 'RS256'` unless you pass the field explicitly.

So any identity provider that doesn't sign id_tokens with RS256 fails every login with `RPError: unexpected JWT alg received`, even though the algorithm it used is one it published support for. Logto is the example in the issue (its default is ES384), but this breaks any OIDC provider with a non-RS256 default.

`Issuer.discover()` (called in `oidc-auth.guard.ts` before `getOIDCClient` runs) already fetches and populates `issuer.metadata`, including the standard `id_token_signing_alg_values_supported` discovery field — the client just never reads it.

Fix: a small helper (`resolveIdTokenSignedResponseAlg`) picks an algorithm from what the issuer actually advertises — `RS256` if it's in the supported list (keeping today's behavior for the common case), otherwise the first algorithm the issuer supports. If the issuer doesn't publish the field at all, we pass nothing and keep relying on `openid-client`'s own default, so behavior for providers that don't advertise this is unchanged.

Verified with a new `SSOService.getOIDCClient` spec that builds a real `openid-client` `Issuer` (no network calls, just the in-memory metadata object) with `id_token_signing_alg_values_supported: ['ES384']` and asserts what the constructed client resolves to. Ran it against the unpatched code first — it fails with `Received: "RS256"`, reproducing the bug exactly. After the fix it resolves to `ES384`. Added two more cases: RS256 is still preferred when the issuer lists it alongside others, and behavior is unchanged (falls back to the library's RS256 default) when the issuer publishes no algorithm list at all.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

