### PR TITLE
feat(server): ORM v2 workspace repository read-family methods

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -361,10 +361,6 @@ export abstract class CommonBaseQueryRunnerService<
       ? await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceReplica()
       : await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
 
-    // When the ORM v2 read path is enabled, the runners only read `repository`
-    // for a handful of lookups (create re-fetch, upsert existing, merge fetch),
-    // all of which the v2 repository serves. Building it here instead of the v1
-    // one avoids constructing the TypeORM EntityMetadata-backed repository.
     const repository = context.featureFlagsMap[
       FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED
     ]

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -67,7 +67,10 @@ import {
   PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
-import { RelationNestedQueries } from 'src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries';
+import {
+  type ConnectQueryRunner,
+  RelationNestedQueries,
+} from 'src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
@@ -518,7 +521,7 @@ export abstract class CommonBaseQueryRunnerService<
     queryRunnerContext: CommonExtendedQueryRunnerContext;
     writeRepository: WorkspaceRepositoryV2;
   }): Promise<Partial<ObjectRecord>[]> {
-    const { repository, flatObjectMetadata, flatFieldMetadataMaps } =
+    const { flatObjectMetadata, flatFieldMetadataMaps, rolePermissionConfig } =
       queryRunnerContext;
     const nameSingular = flatObjectMetadata.nameSingular;
 
@@ -533,11 +536,37 @@ export abstract class CommonBaseQueryRunnerService<
       return records;
     }
 
+    const workspaceDataSource = this.workspaceDataSourceV2Service.getDataSource(
+      {
+        useReplica: false,
+      },
+    );
+
+    const connectQueryRunner: ConnectQueryRunner = async ({
+      connectQueryConfig,
+      clause,
+      parameters,
+    }) => {
+      const targetObjectName = connectQueryConfig.targetObjectName;
+      const targetQueryBuilder = workspaceDataSource
+        .getRepository(targetObjectName, rolePermissionConfig)
+        .createQueryBuilder(targetObjectName);
+
+      targetQueryBuilder.select([]);
+      targetQueryBuilder.addSelect(`"${targetObjectName}"."id"`, 'id');
+
+      for (const [field] of connectQueryConfig.recordToConnectConditions[0]) {
+        targetQueryBuilder.addSelect(`"${targetObjectName}"."${field}"`, field);
+      }
+
+      return targetQueryBuilder.where(clause, parameters).getRawMany();
+    };
+
     const resolvedRecords =
       await relationNestedQueries.processRelationNestedQueries({
         entities: records,
         relationNestedConfig,
-        queryBuilder: repository.createQueryBuilder(nameSingular),
+        connectQueryRunner,
       });
 
     const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -361,10 +361,23 @@ export abstract class CommonBaseQueryRunnerService<
       ? await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceReplica()
       : await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
 
-    const repository = globalWorkspaceDataSource.getRepository(
-      queryRunnerContext.flatObjectMetadata.nameSingular,
-      rolePermissionConfig,
-    );
+    // When the ORM v2 read path is enabled, the runners only read `repository`
+    // for a handful of lookups (create re-fetch, upsert existing, merge fetch),
+    // all of which the v2 repository serves. Building it here instead of the v1
+    // one avoids constructing the TypeORM EntityMetadata-backed repository.
+    const repository = context.featureFlagsMap[
+      FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED
+    ]
+      ? (this.workspaceDataSourceV2Service
+          .getDataSource({ useReplica: this.isReadOnly })
+          .getRepository(
+            queryRunnerContext.flatObjectMetadata.nameSingular,
+            rolePermissionConfig,
+          ) as unknown as WorkspaceRepository<ObjectLiteral>)
+      : globalWorkspaceDataSource.getRepository(
+          queryRunnerContext.flatObjectMetadata.nameSingular,
+          rolePermissionConfig,
+        );
 
     return {
       ...queryRunnerContext,

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
@@ -4,7 +4,13 @@ import { msg } from '@lingui/core/macro';
 import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
 import { FeatureFlagKey, ObjectRecord } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { FindOptionsRelations, In, InsertResult, ObjectLiteral } from 'typeorm';
+import {
+  Brackets,
+  FindOptionsRelations,
+  In,
+  InsertResult,
+  ObjectLiteral,
+} from 'typeorm';
 
 import { CommonBaseQueryRunnerService } from 'src/engine/api/common/common-query-runners/common-base-query-runner.service';
 import { type ConflictingFieldGroup } from 'src/engine/api/common/common-query-runners/common-create-many-query-runner/types/conflicting-field-group.type';
@@ -302,6 +308,10 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
       flatFieldMetadataMaps,
       args,
       conflictingFieldGroups,
+      isOrmV2Enabled:
+        queryRunnerContext.featureFlagsMap[
+          FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED
+        ],
     });
 
     const { recordsToUpdate, recordsToInsert } = categorizeRecords(
@@ -392,12 +402,14 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     flatFieldMetadataMaps,
     args,
     conflictingFieldGroups,
+    isOrmV2Enabled,
   }: {
     repository: WorkspaceRepository<ObjectLiteral>;
     flatObjectMetadata: FlatObjectMetadata;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     args: CreateManyQueryArgs;
     conflictingFieldGroups: ConflictingFieldGroup[];
+    isOrmV2Enabled: boolean;
   }): Promise<PartialObjectRecordWithId[]> {
     const queryBuilder = repository.createQueryBuilder(
       flatObjectMetadata.nameSingular,
@@ -412,9 +424,26 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
       return [];
     }
 
-    whereConditions.forEach((condition) => {
-      queryBuilder.orWhere(condition);
-    });
+    if (isOrmV2Enabled) {
+      // Group the OR conditions so the v2 row-level-permission predicate, which
+      // is ANDed onto the query, applies to the whole disjunction rather than
+      // only the first branch.
+      queryBuilder.andWhere(
+        new Brackets((qb) => {
+          whereConditions.forEach((condition, index) => {
+            if (index === 0) {
+              qb.where(condition);
+            } else {
+              qb.orWhere(condition);
+            }
+          });
+        }),
+      );
+    } else {
+      whereConditions.forEach((condition) => {
+        queryBuilder.orWhere(condition);
+      });
+    }
 
     const restrictedFields =
       repository.objectRecordsPermissions?.[flatObjectMetadata.id]

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
@@ -425,9 +425,6 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     }
 
     if (isOrmV2Enabled) {
-      // Group the OR conditions so the v2 row-level-permission predicate, which
-      // is ANDed onto the query, applies to the whole disjunction rather than
-      // only the first branch.
       queryBuilder.andWhere(
         new Brackets((qb) => {
           whereConditions.forEach((condition, index) => {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
@@ -117,6 +117,24 @@ export class WorkspaceDataSourceV2 {
       );
     }
 
+    return this.buildRepositoryForObjectMetadataId({
+      objectMetadataId,
+      rolePermissionConfig,
+      executor,
+    });
+  }
+
+  // Relation loading needs sibling repositories that share the caller's executor
+  // (so a relation load stays on the same transaction) and role permissions.
+  private buildRepositoryForObjectMetadataId({
+    objectMetadataId,
+    rolePermissionConfig,
+    executor,
+  }: {
+    objectMetadataId: string;
+    rolePermissionConfig?: RolePermissionConfig;
+    executor: QueryExecutorV2;
+  }): WorkspaceRepositoryV2 {
     const flatObjectMetadata =
       this.getFlatObjectMetadataOrThrow(objectMetadataId);
 
@@ -138,6 +156,12 @@ export class WorkspaceDataSourceV2 {
         this.getTableShape(targetObjectMetadataId),
       flatObjectMetadataByObjectMetadataId: (targetObjectMetadataId) =>
         this.getFlatObjectMetadataOrThrow(targetObjectMetadataId),
+      getRepositoryForObjectMetadataId: (targetObjectMetadataId) =>
+        this.buildRepositoryForObjectMetadataId({
+          objectMetadataId: targetObjectMetadataId,
+          rolePermissionConfig,
+          executor,
+        }),
     });
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
@@ -124,8 +124,6 @@ export class WorkspaceDataSourceV2 {
     });
   }
 
-  // Relation loading needs sibling repositories that share the caller's executor
-  // (so a relation load stays on the same transaction) and role permissions.
   private buildRepositoryForObjectMetadataId({
     objectMetadataId,
     rolePermissionConfig,

--- a/packages/twenty-server/src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception.ts
@@ -14,6 +14,7 @@ export enum TwentyOrmV2ExceptionCode {
   MISSING_ALIAS = 'MISSING_ALIAS',
   INVALID_QUERY = 'INVALID_QUERY',
   TOO_MANY_RECORDS_TO_UPDATE = 'TOO_MANY_RECORDS_TO_UPDATE',
+  ENTITY_NOT_FOUND = 'ENTITY_NOT_FOUND',
 }
 
 export class TwentyOrmV2Exception extends CustomException<TwentyOrmV2ExceptionCode> {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-find-options.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-find-options.util.spec.ts
@@ -88,8 +88,6 @@ describe('applyFindOptionsToQueryBuilder', () => {
 
     const [text] = queryBuilder.getQueryAndParameters();
 
-    // The disjunction is grouped, then the soft-delete predicate is ANDed onto
-    // the whole group rather than only the first branch.
     expect(text).toContain(
       '((("person"."name" = $1) OR ("person"."name" = $2))) AND "person"."deletedAt" IS NULL',
     );

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-find-options.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-find-options.util.spec.ts
@@ -1,0 +1,133 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+import { In } from 'typeorm';
+
+import { TwentyOrmV2Exception } from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
+import { applyFindOptionsToQueryBuilder } from 'src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util';
+import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import { type WorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
+
+const SCHEMA_NAME = 'workspace_test';
+
+const buildColumn = (columnName: string) => ({
+  columnName,
+  fieldMetadataId: `field-${columnName}`,
+  fieldName: columnName,
+  fieldMetadataType: FieldMetadataType.TEXT,
+});
+
+const personTableShape: WorkspaceTableShape = {
+  objectMetadataId: 'person-object-id',
+  nameSingular: 'person',
+  schemaName: SCHEMA_NAME,
+  tableName: 'person',
+  columnShapeByColumnName: {
+    id: buildColumn('id'),
+    name: buildColumn('name'),
+    companyId: buildColumn('companyId'),
+    deletedAt: buildColumn('deletedAt'),
+  },
+  columnNames: ['id', 'name', 'companyId', 'deletedAt'],
+  relationShapeByFieldName: {},
+  hasDeletedAtColumn: true,
+};
+
+const buildQueryBuilder = () =>
+  new WorkspaceSelectQueryBuilderV2('person', {
+    tableShape: personTableShape,
+    executor: { execute: async () => [] },
+    objectRecordsPermissions: {},
+    tableShapeByObjectMetadataId: () => personTableShape,
+    onBeforeExecute: () => undefined,
+    formatResult: (records) => records as never,
+  });
+
+describe('applyFindOptionsToQueryBuilder', () => {
+  it('returns the query builder unchanged when no options are given', () => {
+    const queryBuilder = buildQueryBuilder();
+
+    expect(applyFindOptionsToQueryBuilder(queryBuilder)).toBe(queryBuilder);
+    expect(queryBuilder.getQuery()).toContain(
+      `FROM "${SCHEMA_NAME}"."person" AS "person" WHERE "person"."deletedAt" IS NULL`,
+    );
+  });
+
+  it('applies an equality where as an AND condition', () => {
+    const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+      where: { name: 'Twenty' },
+    });
+
+    const [text, values] = queryBuilder.getQueryAndParameters();
+
+    expect(text).toContain('"person"."name" = $1');
+    expect(text).toContain('"person"."deletedAt" IS NULL');
+    expect(values).toContain('Twenty');
+  });
+
+  it('applies an In operator as an IN clause', () => {
+    const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+      where: { id: In(['a', 'b']) },
+    });
+
+    const [text, values] = queryBuilder.getQueryAndParameters();
+
+    expect(text).toContain('"person"."id" IN ($1, $2)');
+    expect(values).toEqual(expect.arrayContaining(['a', 'b']));
+  });
+
+  it('renders a null where value as IS NULL', () => {
+    const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+      where: { companyId: null },
+    });
+
+    expect(queryBuilder.getQuery()).toContain('"person"."companyId" IS NULL');
+  });
+
+  it('treats a where array as an OR of AND-groups', () => {
+    const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+      where: [{ name: 'A' }, { name: 'B' }],
+    });
+
+    const [text] = queryBuilder.getQueryAndParameters();
+
+    expect(text).toContain('"person"."name" = $1');
+    expect(text).toContain('OR');
+    expect(text).toContain('"person"."name" = $2');
+  });
+
+  it('applies select, order, take and skip', () => {
+    const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+      select: { id: true, name: true },
+      order: { name: 'DESC' },
+      take: 10,
+      skip: 5,
+    });
+
+    const [text, values] = queryBuilder.getQueryAndParameters();
+
+    expect(text).toContain(
+      'SELECT "person"."id" AS "person_id", "person"."name" AS "person_name"',
+    );
+    expect(text).toContain('ORDER BY "person"."name" DESC');
+    expect(text).toContain('LIMIT $');
+    expect(text).toContain('OFFSET $');
+    expect(values).toEqual(expect.arrayContaining([10, 5]));
+  });
+
+  it('drops the soft-delete predicate when withDeleted is set', () => {
+    const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+      withDeleted: true,
+    });
+
+    expect(queryBuilder.getQuery()).not.toContain(
+      '"person"."deletedAt" IS NULL',
+    );
+  });
+
+  it('throws when relations are requested', () => {
+    expect(() =>
+      applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+        relations: { company: true },
+      }),
+    ).toThrow(TwentyOrmV2Exception);
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-find-options.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-find-options.util.spec.ts
@@ -1,7 +1,6 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 import { In } from 'typeorm';
 
-import { TwentyOrmV2Exception } from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
 import { applyFindOptionsToQueryBuilder } from 'src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
@@ -123,11 +122,13 @@ describe('applyFindOptionsToQueryBuilder', () => {
     );
   });
 
-  it('throws when relations are requested', () => {
-    expect(() =>
-      applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
-        relations: { company: true },
-      }),
-    ).toThrow(TwentyOrmV2Exception);
+  it('ignores relations in the base query (the repository loads them separately)', () => {
+    const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+      where: { id: 'x' },
+      relations: { company: true },
+    });
+
+    expect(queryBuilder.getQuery()).not.toContain('JOIN');
+    expect(queryBuilder.getQuery()).toContain('"person"."id" =');
   });
 });

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-find-options.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-find-options.util.spec.ts
@@ -81,16 +81,28 @@ describe('applyFindOptionsToQueryBuilder', () => {
     expect(queryBuilder.getQuery()).toContain('"person"."companyId" IS NULL');
   });
 
-  it('treats a where array as an OR of AND-groups', () => {
+  it('treats a where array as a bracketed OR so an ANDed predicate covers all branches', () => {
     const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
       where: [{ name: 'A' }, { name: 'B' }],
     });
 
     const [text] = queryBuilder.getQueryAndParameters();
 
-    expect(text).toContain('"person"."name" = $1');
-    expect(text).toContain('OR');
-    expect(text).toContain('"person"."name" = $2');
+    // The disjunction is grouped, then the soft-delete predicate is ANDed onto
+    // the whole group rather than only the first branch.
+    expect(text).toContain(
+      '((("person"."name" = $1) OR ("person"."name" = $2))) AND "person"."deletedAt" IS NULL',
+    );
+  });
+
+  it('normalizes an array select into the builder column map', () => {
+    const queryBuilder = applyFindOptionsToQueryBuilder(buildQueryBuilder(), {
+      select: ['id', 'name'],
+    });
+
+    expect(queryBuilder.getQuery()).toContain(
+      'SELECT "person"."id" AS "person_id", "person"."name" AS "person_name"',
+    );
   });
 
   it('applies select, order, take and skip', () => {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-mutation-criteria.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-mutation-criteria.util.spec.ts
@@ -1,0 +1,85 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { TwentyOrmV2Exception } from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
+import { applyMutationCriteriaToQueryBuilder } from 'src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util';
+import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import { type WorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
+
+const buildColumn = (columnName: string) => ({
+  columnName,
+  fieldMetadataId: `field-${columnName}`,
+  fieldName: columnName,
+  fieldMetadataType: FieldMetadataType.TEXT,
+});
+
+const personTableShape: WorkspaceTableShape = {
+  objectMetadataId: 'person-object-id',
+  nameSingular: 'person',
+  schemaName: 'workspace_test',
+  tableName: 'person',
+  columnShapeByColumnName: {
+    id: buildColumn('id'),
+    name: buildColumn('name'),
+    deletedAt: buildColumn('deletedAt'),
+  },
+  columnNames: ['id', 'name', 'deletedAt'],
+  relationShapeByFieldName: {},
+  hasDeletedAtColumn: true,
+};
+
+const buildQueryBuilder = () =>
+  new WorkspaceSelectQueryBuilderV2('person', {
+    tableShape: personTableShape,
+    executor: { execute: async () => [] },
+    objectRecordsPermissions: {},
+    tableShapeByObjectMetadataId: () => personTableShape,
+    onBeforeExecute: () => undefined,
+    formatResult: (records) => records as never,
+  });
+
+describe('applyMutationCriteriaToQueryBuilder', () => {
+  it('turns a bare id into an equality predicate', () => {
+    const [text, values] = applyMutationCriteriaToQueryBuilder(
+      buildQueryBuilder(),
+      'record-id',
+    ).getQueryAndParameters();
+
+    expect(text).toContain('"person"."id" = $1');
+    expect(values).toContain('record-id');
+  });
+
+  it('turns a list of ids into an IN predicate', () => {
+    const [text, values] = applyMutationCriteriaToQueryBuilder(
+      buildQueryBuilder(),
+      ['a', 'b'],
+    ).getQueryAndParameters();
+
+    expect(text).toContain('"person"."id" IN ($1, $2)');
+    expect(values).toEqual(expect.arrayContaining(['a', 'b']));
+  });
+
+  it('applies a where object', () => {
+    const [text, values] = applyMutationCriteriaToQueryBuilder(
+      buildQueryBuilder(),
+      { name: 'Twenty' },
+    ).getQueryAndParameters();
+
+    expect(text).toContain('"person"."name" = $1');
+    expect(values).toContain('Twenty');
+  });
+
+  it('treats a where array as an OR', () => {
+    const [text] = applyMutationCriteriaToQueryBuilder(buildQueryBuilder(), [
+      { name: 'A' },
+      { name: 'B' },
+    ]).getQueryAndParameters();
+
+    expect(text).toContain('OR');
+  });
+
+  it('throws on an empty criteria array', () => {
+    expect(() =>
+      applyMutationCriteriaToQueryBuilder(buildQueryBuilder(), []),
+    ).toThrow(TwentyOrmV2Exception);
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-mutation-criteria.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/__tests__/apply-mutation-criteria.util.spec.ts
@@ -68,18 +68,26 @@ describe('applyMutationCriteriaToQueryBuilder', () => {
     expect(values).toContain('Twenty');
   });
 
-  it('treats a where array as an OR', () => {
+  it('treats a where array as a bracketed OR', () => {
     const [text] = applyMutationCriteriaToQueryBuilder(buildQueryBuilder(), [
       { name: 'A' },
       { name: 'B' },
     ]).getQueryAndParameters();
 
-    expect(text).toContain('OR');
+    expect(text).toContain(
+      '((("person"."name" = $1) OR ("person"."name" = $2)))',
+    );
   });
 
   it('throws on an empty criteria array', () => {
     expect(() =>
       applyMutationCriteriaToQueryBuilder(buildQueryBuilder(), []),
+    ).toThrow(TwentyOrmV2Exception);
+  });
+
+  it('throws on an empty-string id criterion', () => {
+    expect(() =>
+      applyMutationCriteriaToQueryBuilder(buildQueryBuilder(), ''),
     ).toThrow(TwentyOrmV2Exception);
   });
 });

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
@@ -1,0 +1,80 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import {
+  TwentyOrmV2Exception,
+  TwentyOrmV2ExceptionCode,
+} from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
+import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import {
+  type FindOptionsSelectLike,
+  type ObjectWhereLike,
+  type OrderByConditionLike,
+} from 'src/engine/twenty-orm-v2/query-builder/types/query-builder-v2.type';
+
+export type FindOptionsV2 = {
+  where?: ObjectWhereLike | ObjectWhereLike[];
+  select?: FindOptionsSelectLike;
+  order?: OrderByConditionLike;
+  take?: number;
+  skip?: number;
+  withDeleted?: boolean;
+  relations?: unknown;
+};
+
+// A `where` array is an OR of AND-groups, matching TypeORM's find semantics.
+const applyWhere = (
+  queryBuilder: WorkspaceSelectQueryBuilderV2,
+  where: ObjectWhereLike | ObjectWhereLike[],
+): void => {
+  const clauses = Array.isArray(where) ? where : [where];
+
+  clauses.forEach((clause, index) => {
+    if (index === 0) {
+      queryBuilder.where(clause);
+    } else {
+      queryBuilder.orWhere(clause);
+    }
+  });
+};
+
+export const applyFindOptionsToQueryBuilder = (
+  queryBuilder: WorkspaceSelectQueryBuilderV2,
+  options?: FindOptionsV2,
+): WorkspaceSelectQueryBuilderV2 => {
+  if (!isDefined(options)) {
+    return queryBuilder;
+  }
+
+  if (isDefined(options.relations)) {
+    throw new TwentyOrmV2Exception(
+      'Loading relations through the ORM v2 find methods is not supported yet',
+      TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION,
+    );
+  }
+
+  if (options.withDeleted === true) {
+    queryBuilder.withDeleted();
+  }
+
+  if (isDefined(options.select)) {
+    queryBuilder.setFindOptions({ select: options.select });
+  }
+
+  if (isDefined(options.where)) {
+    applyWhere(queryBuilder, options.where);
+  }
+
+  if (isDefined(options.order)) {
+    queryBuilder.orderBy(options.order);
+  }
+
+  if (isDefined(options.take)) {
+    queryBuilder.limit(options.take);
+  }
+
+  if (isDefined(options.skip)) {
+    queryBuilder.offset(options.skip);
+  }
+
+  return queryBuilder;
+};

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
@@ -7,7 +7,9 @@ import {
   type OrderByConditionLike,
 } from 'src/engine/twenty-orm-v2/query-builder/types/query-builder-v2.type';
 
-export type FindOptionsRelationsV2 = Record<string, boolean | object>;
+export type FindOptionsRelationsV2 = {
+  [relationFieldName: string]: boolean | FindOptionsRelationsV2;
+};
 
 export type FindOptionsSelectV2 = FindOptionsSelectLike | string[];
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
@@ -1,15 +1,13 @@
 import { isDefined } from 'twenty-shared/utils';
 
-import {
-  TwentyOrmV2Exception,
-  TwentyOrmV2ExceptionCode,
-} from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
 import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import {
   type FindOptionsSelectLike,
   type ObjectWhereLike,
   type OrderByConditionLike,
 } from 'src/engine/twenty-orm-v2/query-builder/types/query-builder-v2.type';
+
+export type FindOptionsRelationsV2 = Record<string, boolean | object>;
 
 export type FindOptionsV2 = {
   where?: ObjectWhereLike | ObjectWhereLike[];
@@ -18,7 +16,7 @@ export type FindOptionsV2 = {
   take?: number;
   skip?: number;
   withDeleted?: boolean;
-  relations?: unknown;
+  relations?: FindOptionsRelationsV2;
 };
 
 // A `where` array is an OR of AND-groups, matching TypeORM's find semantics.
@@ -45,13 +43,8 @@ export const applyFindOptionsToQueryBuilder = (
     return queryBuilder;
   }
 
-  if (isDefined(options.relations)) {
-    throw new TwentyOrmV2Exception(
-      'Loading relations through the ORM v2 find methods is not supported yet',
-      TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION,
-    );
-  }
-
+  // `relations` are loaded by the repository after the base rows are fetched,
+  // never rendered into this base query.
   if (options.withDeleted === true) {
     queryBuilder.withDeleted();
   }

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
@@ -9,9 +9,11 @@ import {
 
 export type FindOptionsRelationsV2 = Record<string, boolean | object>;
 
+export type FindOptionsSelectV2 = FindOptionsSelectLike | string[];
+
 export type FindOptionsV2 = {
   where?: ObjectWhereLike | ObjectWhereLike[];
-  select?: FindOptionsSelectLike;
+  select?: FindOptionsSelectV2;
   order?: OrderByConditionLike;
   take?: number;
   skip?: number;
@@ -19,19 +21,41 @@ export type FindOptionsV2 = {
   relations?: FindOptionsRelationsV2;
 };
 
-// A `where` array is an OR of AND-groups, matching TypeORM's find semantics.
+const normalizeSelect = (select: FindOptionsSelectV2): FindOptionsSelectLike =>
+  Array.isArray(select)
+    ? Object.fromEntries(select.map((columnName) => [columnName, true]))
+    : select;
+
+// A `where` array is an OR of AND-groups, matching TypeORM's find semantics. It
+// is wrapped in a single bracketed group so a later ANDed predicate (e.g. the
+// row-level permission filter) applies to the whole disjunction, not just the
+// first branch.
 const applyWhere = (
   queryBuilder: WorkspaceSelectQueryBuilderV2,
   where: ObjectWhereLike | ObjectWhereLike[],
 ): void => {
-  const clauses = Array.isArray(where) ? where : [where];
+  if (!Array.isArray(where)) {
+    queryBuilder.where(where);
 
-  clauses.forEach((clause, index) => {
-    if (index === 0) {
-      queryBuilder.where(clause);
-    } else {
-      queryBuilder.orWhere(clause);
-    }
+    return;
+  }
+
+  if (where.length === 1) {
+    queryBuilder.where(where[0]);
+
+    return;
+  }
+
+  queryBuilder.where({
+    whereFactory: (nestedQueryBuilder) => {
+      where.forEach((clause, index) => {
+        if (index === 0) {
+          nestedQueryBuilder.where(clause);
+        } else {
+          nestedQueryBuilder.orWhere(clause);
+        }
+      });
+    },
   });
 };
 
@@ -45,12 +69,12 @@ export const applyFindOptionsToQueryBuilder = (
 
   // `relations` are loaded by the repository after the base rows are fetched,
   // never rendered into this base query.
-  if (options.withDeleted === true) {
+  if (options.withDeleted) {
     queryBuilder.withDeleted();
   }
 
   if (isDefined(options.select)) {
-    queryBuilder.setFindOptions({ select: options.select });
+    queryBuilder.setFindOptions({ select: normalizeSelect(options.select) });
   }
 
   if (isDefined(options.where)) {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util.ts
@@ -28,10 +28,6 @@ const normalizeSelect = (select: FindOptionsSelectV2): FindOptionsSelectLike =>
     ? Object.fromEntries(select.map((columnName) => [columnName, true]))
     : select;
 
-// A `where` array is an OR of AND-groups, matching TypeORM's find semantics. It
-// is wrapped in a single bracketed group so a later ANDed predicate (e.g. the
-// row-level permission filter) applies to the whole disjunction, not just the
-// first branch.
 const applyWhere = (
   queryBuilder: WorkspaceSelectQueryBuilderV2,
   where: ObjectWhereLike | ObjectWhereLike[],
@@ -69,8 +65,6 @@ export const applyFindOptionsToQueryBuilder = (
     return queryBuilder;
   }
 
-  // `relations` are loaded by the repository after the base rows are fetched,
-  // never rendered into this base query.
   if (options.withDeleted) {
     queryBuilder.withDeleted();
   }

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util.ts
@@ -19,8 +19,6 @@ const isPlainObject = (value: unknown): value is ObjectWhereLike =>
   value !== null &&
   Object.getPrototypeOf(value) === Object.prototype;
 
-// TypeORM mutation criteria are an id, a list of ids, a where object, or a list
-// of where objects (OR). Bare ids collapse to an `{ id }` predicate.
 export const applyMutationCriteriaToQueryBuilder = (
   queryBuilder: WorkspaceSelectQueryBuilderV2,
   criteria: MutationCriteria,
@@ -59,8 +57,6 @@ export const applyMutationCriteriaToQueryBuilder = (
       );
     }
 
-    // Bracket the OR group so a later ANDed permission predicate applies to the
-    // whole disjunction rather than only the first branch.
     queryBuilder.where({
       whereFactory: (nestedQueryBuilder) => {
         criteria.forEach((entry, index) => {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util.ts
@@ -1,0 +1,76 @@
+import { isDefined } from 'twenty-shared/utils';
+import { In } from 'typeorm';
+
+import {
+  TwentyOrmV2Exception,
+  TwentyOrmV2ExceptionCode,
+} from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
+import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import { type ObjectWhereLike } from 'src/engine/twenty-orm-v2/query-builder/types/query-builder-v2.type';
+
+export type MutationCriteria =
+  | string
+  | string[]
+  | ObjectWhereLike
+  | ObjectWhereLike[];
+
+const isPlainObject = (value: unknown): value is ObjectWhereLike =>
+  typeof value === 'object' &&
+  value !== null &&
+  Object.getPrototypeOf(value) === Object.prototype;
+
+// TypeORM mutation criteria are an id, a list of ids, a where object, or a list
+// of where objects (OR). Bare ids collapse to an `{ id }` predicate.
+export const applyMutationCriteriaToQueryBuilder = (
+  queryBuilder: WorkspaceSelectQueryBuilderV2,
+  criteria: MutationCriteria,
+): WorkspaceSelectQueryBuilderV2 => {
+  if (typeof criteria === 'string') {
+    queryBuilder.where({ id: criteria });
+
+    return queryBuilder;
+  }
+
+  if (Array.isArray(criteria)) {
+    if (criteria.length === 0) {
+      throw new TwentyOrmV2Exception(
+        'A mutation criteria array cannot be empty',
+        TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
+      );
+    }
+
+    if (criteria.every((entry) => typeof entry === 'string')) {
+      queryBuilder.where({ id: In(criteria) });
+
+      return queryBuilder;
+    }
+
+    criteria.forEach((entry, index) => {
+      if (!isPlainObject(entry)) {
+        throw new TwentyOrmV2Exception(
+          'A mutation criteria array must be all ids or all where objects',
+          TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
+        );
+      }
+
+      if (index === 0) {
+        queryBuilder.where(entry);
+      } else {
+        queryBuilder.orWhere(entry);
+      }
+    });
+
+    return queryBuilder;
+  }
+
+  if (isDefined(criteria) && isPlainObject(criteria)) {
+    queryBuilder.where(criteria);
+
+    return queryBuilder;
+  }
+
+  throw new TwentyOrmV2Exception(
+    'Unsupported mutation criteria',
+    TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
+  );
+};

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util.ts
@@ -26,6 +26,13 @@ export const applyMutationCriteriaToQueryBuilder = (
   criteria: MutationCriteria,
 ): WorkspaceSelectQueryBuilderV2 => {
   if (typeof criteria === 'string') {
+    if (criteria.length === 0) {
+      throw new TwentyOrmV2Exception(
+        'A mutation criteria id cannot be an empty string',
+        TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
+      );
+    }
+
     queryBuilder.where({ id: criteria });
 
     return queryBuilder;
@@ -45,19 +52,25 @@ export const applyMutationCriteriaToQueryBuilder = (
       return queryBuilder;
     }
 
-    criteria.forEach((entry, index) => {
-      if (!isPlainObject(entry)) {
-        throw new TwentyOrmV2Exception(
-          'A mutation criteria array must be all ids or all where objects',
-          TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
-        );
-      }
+    if (!criteria.every(isPlainObject)) {
+      throw new TwentyOrmV2Exception(
+        'A mutation criteria array must be all ids or all where objects',
+        TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
+      );
+    }
 
-      if (index === 0) {
-        queryBuilder.where(entry);
-      } else {
-        queryBuilder.orWhere(entry);
-      }
+    // Bracket the OR group so a later ANDed permission predicate applies to the
+    // whole disjunction rather than only the first branch.
+    queryBuilder.where({
+      whereFactory: (nestedQueryBuilder) => {
+        criteria.forEach((entry, index) => {
+          if (index === 0) {
+            nestedQueryBuilder.where(entry);
+          } else {
+            nestedQueryBuilder.orWhere(entry);
+          }
+        });
+      },
     });
 
     return queryBuilder;

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util.ts
@@ -1,4 +1,3 @@
-import { isDefined } from 'twenty-shared/utils';
 import { In } from 'typeorm';
 
 import {
@@ -72,14 +71,7 @@ export const applyMutationCriteriaToQueryBuilder = (
     return queryBuilder;
   }
 
-  if (isDefined(criteria) && isPlainObject(criteria)) {
-    queryBuilder.where(criteria);
+  queryBuilder.where(criteria);
 
-    return queryBuilder;
-  }
-
-  throw new TwentyOrmV2Exception(
-    'Unsupported mutation criteria',
-    TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
-  );
+  return queryBuilder;
 };

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/__tests__/attach-relations.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/__tests__/attach-relations.util.spec.ts
@@ -1,0 +1,80 @@
+import { type ObjectRecord } from 'twenty-shared/types';
+
+import {
+  attachToManyRelationToRecords,
+  attachToOneRelationToRecords,
+  collectForeignKeys,
+  collectRecordIds,
+} from 'src/engine/twenty-orm-v2/repository/utils/attach-relations.util';
+
+const asRecords = (records: Record<string, unknown>[]): ObjectRecord[] =>
+  records as ObjectRecord[];
+
+describe('attach-relations util', () => {
+  describe('collectForeignKeys', () => {
+    it('returns unique non-empty foreign keys', () => {
+      const records = asRecords([
+        { id: '1', companyId: 'c1' },
+        { id: '2', companyId: 'c1' },
+        { id: '3', companyId: 'c2' },
+        { id: '4', companyId: null },
+      ]);
+
+      expect(collectForeignKeys(records, 'companyId')).toEqual(['c1', 'c2']);
+    });
+  });
+
+  describe('collectRecordIds', () => {
+    it('returns unique ids', () => {
+      const records = asRecords([{ id: 'a' }, { id: 'a' }, { id: 'b' }]);
+
+      expect(collectRecordIds(records)).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('attachToOneRelationToRecords', () => {
+    it('attaches the matching target or null', () => {
+      const records = asRecords([
+        { id: '1', companyId: 'c1' },
+        { id: '2', companyId: 'c2' },
+        { id: '3', companyId: null },
+      ]);
+      const targets = asRecords([{ id: 'c1', name: 'Twenty' }]);
+
+      attachToOneRelationToRecords({
+        records,
+        fieldName: 'company',
+        joinColumnName: 'companyId',
+        targets,
+      });
+
+      expect(records[0].company).toEqual({ id: 'c1', name: 'Twenty' });
+      expect(records[1].company).toBeNull();
+      expect(records[2].company).toBeNull();
+    });
+  });
+
+  describe('attachToManyRelationToRecords', () => {
+    it('groups children under each parent and defaults to an empty array', () => {
+      const records = asRecords([{ id: 'c1' }, { id: 'c2' }]);
+      const children = asRecords([
+        { id: 'p1', companyId: 'c1' },
+        { id: 'p2', companyId: 'c1' },
+        { id: 'p3', companyId: 'cX' },
+      ]);
+
+      attachToManyRelationToRecords({
+        records,
+        fieldName: 'people',
+        inverseForeignKeyColumnName: 'companyId',
+        children,
+      });
+
+      expect(records[0].people).toEqual([
+        { id: 'p1', companyId: 'c1' },
+        { id: 'p2', companyId: 'c1' },
+      ]);
+      expect(records[1].people).toEqual([]);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/__tests__/resolve-save-and-upsert.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/__tests__/resolve-save-and-upsert.util.spec.ts
@@ -1,0 +1,63 @@
+import { type ObjectRecord } from 'twenty-shared/types';
+
+import {
+  buildConflictKey,
+  matchEntitiesForUpsert,
+  partitionEntitiesForSave,
+} from 'src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util';
+
+describe('resolve-save-and-upsert util', () => {
+  describe('partitionEntitiesForSave', () => {
+    it('updates entities with an existing id and inserts the rest', () => {
+      const entities = [
+        { id: 'existing', name: 'A' },
+        { id: 'missing', name: 'B' },
+        { name: 'C' },
+      ];
+
+      const { toUpdate, toInsert } = partitionEntitiesForSave(
+        entities,
+        new Set(['existing']),
+      );
+
+      expect(toUpdate).toEqual([{ id: 'existing', name: 'A' }]);
+      expect(toInsert).toEqual([{ id: 'missing', name: 'B' }, { name: 'C' }]);
+    });
+  });
+
+  describe('buildConflictKey', () => {
+    it('is stable across entities with the same conflict values', () => {
+      expect(
+        buildConflictKey({ email: 'a', tenant: 't' }, ['email', 'tenant']),
+      ).toBe(
+        buildConflictKey({ email: 'a', tenant: 't', other: 'x' }, [
+          'email',
+          'tenant',
+        ]),
+      );
+    });
+  });
+
+  describe('matchEntitiesForUpsert', () => {
+    it('routes matches to update by existing id and the rest to insert', () => {
+      const entities = [
+        { email: 'a@twenty.com', name: 'A' },
+        { email: 'b@twenty.com', name: 'B' },
+      ];
+      const existing = [
+        { id: 'existing-a', email: 'a@twenty.com' },
+      ] as ObjectRecord[];
+
+      const { toUpdate, toInsert } = matchEntitiesForUpsert(
+        entities,
+        existing,
+        ['email'],
+      );
+
+      expect(toUpdate).toEqual([
+        { id: 'existing-a', entity: { email: 'a@twenty.com', name: 'A' } },
+      ]);
+      expect(toInsert).toEqual([{ email: 'b@twenty.com', name: 'B' }]);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/__tests__/resolve-save-and-upsert.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/__tests__/resolve-save-and-upsert.util.spec.ts
@@ -59,5 +59,19 @@ describe('resolve-save-and-upsert util', () => {
       ]);
       expect(toInsert).toEqual([{ email: 'b@twenty.com', name: 'B' }]);
     });
+
+    it('routes entities with a null conflict value to insert (NULL never conflicts)', () => {
+      const entities = [{ email: null, name: 'A' }];
+      const existing = [{ id: 'existing', email: null }] as ObjectRecord[];
+
+      const { toUpdate, toInsert } = matchEntitiesForUpsert(
+        entities,
+        existing,
+        ['email'],
+      );
+
+      expect(toUpdate).toEqual([]);
+      expect(toInsert).toEqual([{ email: null, name: 'A' }]);
+    });
   });
 });

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/attach-relations.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/attach-relations.util.ts
@@ -14,7 +14,6 @@ export const collectRecordIds = (records: ObjectRecord[]): string[] => [
   ...new Set(records.map((record) => record.id).filter(isNonEmptyString)),
 ];
 
-// Mutates `records`, setting each `fieldName` to its matching target (or null).
 export const attachToOneRelationToRecords = ({
   records,
   fieldName,
@@ -37,8 +36,6 @@ export const attachToOneRelationToRecords = ({
   }
 };
 
-// Mutates `records`, grouping `children` by their inverse foreign key onto each
-// parent's `fieldName` (empty array when a parent has no children).
 export const attachToManyRelationToRecords = ({
   records,
   fieldName,

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/attach-relations.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/attach-relations.util.ts
@@ -1,0 +1,71 @@
+import { isNonEmptyString } from '@sniptt/guards';
+import { type ObjectRecord } from 'twenty-shared/types';
+
+export const collectForeignKeys = (
+  records: ObjectRecord[],
+  joinColumnName: string,
+): string[] => [
+  ...new Set(
+    records.map((record) => record[joinColumnName]).filter(isNonEmptyString),
+  ),
+];
+
+export const collectRecordIds = (records: ObjectRecord[]): string[] => [
+  ...new Set(records.map((record) => record.id).filter(isNonEmptyString)),
+];
+
+// Mutates `records`, setting each `fieldName` to its matching target (or null).
+export const attachToOneRelationToRecords = ({
+  records,
+  fieldName,
+  joinColumnName,
+  targets,
+}: {
+  records: ObjectRecord[];
+  fieldName: string;
+  joinColumnName: string;
+  targets: ObjectRecord[];
+}): void => {
+  const targetById = new Map(targets.map((target) => [target.id, target]));
+
+  for (const record of records) {
+    const foreignKey = record[joinColumnName];
+
+    record[fieldName] = isNonEmptyString(foreignKey)
+      ? (targetById.get(foreignKey) ?? null)
+      : null;
+  }
+};
+
+// Mutates `records`, grouping `children` by their inverse foreign key onto each
+// parent's `fieldName` (empty array when a parent has no children).
+export const attachToManyRelationToRecords = ({
+  records,
+  fieldName,
+  inverseForeignKeyColumnName,
+  children,
+}: {
+  records: ObjectRecord[];
+  fieldName: string;
+  inverseForeignKeyColumnName: string;
+  children: ObjectRecord[];
+}): void => {
+  const childrenByParentId = new Map<string, ObjectRecord[]>();
+
+  for (const child of children) {
+    const parentId = child[inverseForeignKeyColumnName];
+
+    if (!isNonEmptyString(parentId)) {
+      continue;
+    }
+
+    const siblings = childrenByParentId.get(parentId) ?? [];
+
+    siblings.push(child);
+    childrenByParentId.set(parentId, siblings);
+  }
+
+  for (const record of records) {
+    record[fieldName] = childrenByParentId.get(record.id) ?? [];
+  }
+};

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util.ts
@@ -7,7 +7,6 @@ export type SavePartition = {
   toInsert: Partial<ObjectRecord>[];
 };
 
-// `save` updates entities whose id already exists and inserts the rest.
 export const partitionEntitiesForSave = (
   entities: Partial<ObjectRecord>[],
   existingIds: Set<string>,
@@ -33,8 +32,6 @@ export const buildConflictKey = (
   conflictPaths: string[],
 ): string => JSON.stringify(conflictPaths.map((path) => entity[path] ?? null));
 
-// Postgres `ON CONFLICT` never treats a NULL conflict value as a conflict, so a
-// row with any nullish conflict value can only be inserted.
 const hasCompleteConflictKey = (
   record: Partial<ObjectRecord>,
   conflictPaths: string[],
@@ -45,8 +42,6 @@ export type UpsertPartition = {
   toInsert: Partial<ObjectRecord>[];
 };
 
-// `upsert` matches incoming entities to existing rows on the conflict columns,
-// updating matches by their existing id and inserting the rest.
 export const matchEntitiesForUpsert = (
   entities: Partial<ObjectRecord>[],
   existingRecords: ObjectRecord[],

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util.ts
@@ -1,0 +1,74 @@
+import { isNonEmptyString } from '@sniptt/guards';
+import { type ObjectRecord } from 'twenty-shared/types';
+
+export type SavePartition = {
+  toUpdate: Partial<ObjectRecord>[];
+  toInsert: Partial<ObjectRecord>[];
+};
+
+// `save` updates entities whose id already exists and inserts the rest.
+export const partitionEntitiesForSave = (
+  entities: Partial<ObjectRecord>[],
+  existingIds: Set<string>,
+): SavePartition => {
+  const toUpdate: Partial<ObjectRecord>[] = [];
+  const toInsert: Partial<ObjectRecord>[] = [];
+
+  for (const entity of entities) {
+    const id = entity.id;
+
+    if (isNonEmptyString(id) && existingIds.has(id)) {
+      toUpdate.push(entity);
+    } else {
+      toInsert.push(entity);
+    }
+  }
+
+  return { toUpdate, toInsert };
+};
+
+export const buildConflictKey = (
+  entity: Partial<ObjectRecord>,
+  conflictPaths: string[],
+): string => JSON.stringify(conflictPaths.map((path) => entity[path] ?? null));
+
+export type UpsertPartition = {
+  toUpdate: { id: string; entity: Partial<ObjectRecord> }[];
+  toInsert: Partial<ObjectRecord>[];
+};
+
+// `upsert` matches incoming entities to existing rows on the conflict columns,
+// updating matches by their existing id and inserting the rest.
+export const matchEntitiesForUpsert = (
+  entities: Partial<ObjectRecord>[],
+  existingRecords: ObjectRecord[],
+  conflictPaths: string[],
+): UpsertPartition => {
+  const existingIdByConflictKey = new Map<string, string>();
+
+  for (const existingRecord of existingRecords) {
+    if (isNonEmptyString(existingRecord.id)) {
+      existingIdByConflictKey.set(
+        buildConflictKey(existingRecord, conflictPaths),
+        existingRecord.id,
+      );
+    }
+  }
+
+  const toUpdate: { id: string; entity: Partial<ObjectRecord> }[] = [];
+  const toInsert: Partial<ObjectRecord>[] = [];
+
+  for (const entity of entities) {
+    const existingId = existingIdByConflictKey.get(
+      buildConflictKey(entity, conflictPaths),
+    );
+
+    if (isNonEmptyString(existingId)) {
+      toUpdate.push({ id: existingId, entity });
+    } else {
+      toInsert.push(entity);
+    }
+  }
+
+  return { toUpdate, toInsert };
+};

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util.ts
@@ -1,5 +1,6 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import { type ObjectRecord } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 
 export type SavePartition = {
   toUpdate: Partial<ObjectRecord>[];
@@ -32,6 +33,13 @@ export const buildConflictKey = (
   conflictPaths: string[],
 ): string => JSON.stringify(conflictPaths.map((path) => entity[path] ?? null));
 
+// Postgres `ON CONFLICT` never treats a NULL conflict value as a conflict, so a
+// row with any nullish conflict value can only be inserted.
+const hasCompleteConflictKey = (
+  record: Partial<ObjectRecord>,
+  conflictPaths: string[],
+): boolean => conflictPaths.every((path) => isDefined(record[path]));
+
 export type UpsertPartition = {
   toUpdate: { id: string; entity: Partial<ObjectRecord> }[];
   toInsert: Partial<ObjectRecord>[];
@@ -47,7 +55,10 @@ export const matchEntitiesForUpsert = (
   const existingIdByConflictKey = new Map<string, string>();
 
   for (const existingRecord of existingRecords) {
-    if (isNonEmptyString(existingRecord.id)) {
+    if (
+      isNonEmptyString(existingRecord.id) &&
+      hasCompleteConflictKey(existingRecord, conflictPaths)
+    ) {
       existingIdByConflictKey.set(
         buildConflictKey(existingRecord, conflictPaths),
         existingRecord.id,
@@ -59,9 +70,9 @@ export const matchEntitiesForUpsert = (
   const toInsert: Partial<ObjectRecord>[] = [];
 
   for (const entity of entities) {
-    const existingId = existingIdByConflictKey.get(
-      buildConflictKey(entity, conflictPaths),
-    );
+    const existingId = hasCompleteConflictKey(entity, conflictPaths)
+      ? existingIdByConflictKey.get(buildConflictKey(entity, conflictPaths))
+      : undefined;
 
     if (isNonEmptyString(existingId)) {
       toUpdate.push({ id: existingId, entity });

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -234,7 +234,10 @@ export class WorkspaceRepositoryV2 {
   async exists(options?: FindOptionsV2): Promise<boolean> {
     const queryBuilder = applyFindOptionsToQueryBuilder(
       this.createQueryBuilder(),
-      options,
+      {
+        where: options?.where,
+        withDeleted: options?.withDeleted,
+      },
     );
 
     queryBuilder.select(['id']);

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -155,7 +155,11 @@ export class WorkspaceRepositoryV2 {
     ).getMany<ObjectRecord>();
 
     if (isDefined(options?.relations)) {
-      await this.loadRelations(records, options.relations);
+      await this.loadRelations(
+        records,
+        options.relations,
+        options.withDeleted ?? false,
+      );
     }
 
     return records;
@@ -181,7 +185,11 @@ export class WorkspaceRepositoryV2 {
     ).getOne<ObjectRecord>();
 
     if (isDefined(record) && isDefined(options?.relations)) {
-      await this.loadRelations([record], options.relations);
+      await this.loadRelations(
+        [record],
+        options.relations,
+        options.withDeleted ?? false,
+      );
     }
 
     return record;
@@ -241,6 +249,7 @@ export class WorkspaceRepositoryV2 {
   private async loadRelations(
     records: ObjectRecord[],
     relations: FindOptionsRelationsV2,
+    withDeleted: boolean,
   ): Promise<void> {
     if (records.length === 0) {
       return;
@@ -261,10 +270,7 @@ export class WorkspaceRepositoryV2 {
         );
       }
 
-      const nestedRelations =
-        typeof nested === 'object'
-          ? (nested as FindOptionsRelationsV2)
-          : undefined;
+      const nestedRelations = typeof nested === 'object' ? nested : undefined;
       const targetRepository = this.options.getRepositoryForObjectMetadataId(
         relationShape.targetObjectMetadataId,
       );
@@ -284,6 +290,7 @@ export class WorkspaceRepositoryV2 {
           relationShape,
           targetRepository,
           nestedRelations,
+          withDeleted,
         });
       } else {
         throw new TwentyOrmV2Exception(
@@ -339,12 +346,14 @@ export class WorkspaceRepositoryV2 {
     relationShape,
     targetRepository,
     nestedRelations,
+    withDeleted,
   }: {
     records: ObjectRecord[];
     fieldName: string;
     relationShape: WorkspaceRelationShape;
     targetRepository: WorkspaceRepositoryV2;
     nestedRelations?: FindOptionsRelationsV2;
+    withDeleted: boolean;
   }): Promise<void> {
     const inverseForeignKeyColumnName =
       this.resolveInverseForeignKeyColumnName(relationShape);
@@ -356,6 +365,7 @@ export class WorkspaceRepositoryV2 {
         ? await targetRepository.find({
             where: { [inverseForeignKeyColumnName]: In(parentIds) },
             relations: nestedRelations,
+            withDeleted,
           })
         : [];
 
@@ -606,29 +616,35 @@ export class WorkspaceRepositoryV2 {
       conflictPaths,
     );
 
-    if (toUpdate.length > 0) {
-      await this.runBatchUpdate({
-        inputs: toUpdate.map((match) => ({
-          id: match.id,
-          data: match.entity,
-        })),
-        columnsToReturn: ['id'],
-      });
-    }
+    const emptyOutcome = { identifiers: [], generatedMaps: [], raw: [] };
+
+    const updateOutcome =
+      toUpdate.length > 0
+        ? await this.runBatchUpdate({
+            inputs: toUpdate.map((match) => ({
+              id: match.id,
+              data: match.entity,
+            })),
+            columnsToReturn: ['id'],
+          })
+        : emptyOutcome;
 
     const insertOutcome =
       toInsert.length > 0
         ? await this.runInsert({ records: toInsert, columnsToReturn: ['id'] })
-        : { identifiers: [], generatedMaps: [], raw: [] };
+        : emptyOutcome;
 
     const insertResult = new InsertResult();
 
     insertResult.identifiers = [
-      ...toUpdate.map((match) => ({ id: match.id })),
+      ...updateOutcome.identifiers,
       ...insertOutcome.identifiers,
     ];
-    insertResult.generatedMaps = insertOutcome.generatedMaps;
-    insertResult.raw = insertOutcome.raw;
+    insertResult.generatedMaps = [
+      ...updateOutcome.generatedMaps,
+      ...insertOutcome.generatedMaps,
+    ];
+    insertResult.raw = [...updateOutcome.raw, ...insertOutcome.raw];
 
     return insertResult;
   }

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -217,7 +217,14 @@ export class WorkspaceRepositoryV2 {
   }
 
   async exists(options?: FindOptionsV2): Promise<boolean> {
-    return (await this.count(options)) > 0;
+    const queryBuilder = applyFindOptionsToQueryBuilder(
+      this.createQueryBuilder(),
+      options,
+    );
+
+    queryBuilder.select(['id']);
+
+    return isDefined(await queryBuilder.getRawOne());
   }
 
   async existsBy(where: ObjectWhereLike | ObjectWhereLike[]): Promise<boolean> {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -47,6 +47,10 @@ import {
   collectForeignKeys,
   collectRecordIds,
 } from 'src/engine/twenty-orm-v2/repository/utils/attach-relations.util';
+import {
+  matchEntitiesForUpsert,
+  partitionEntitiesForSave,
+} from 'src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { compileNamedParameters } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
 import { serializeJsonbWriteValue } from 'src/engine/twenty-orm-v2/sql/utils/serialize-jsonb-write-value.util';
@@ -487,6 +491,153 @@ export class WorkspaceRepositoryV2 {
     updateResult.generatedMaps = records;
 
     return updateResult;
+  }
+
+  async save(
+    entityOrEntities: Partial<ObjectRecord> | Partial<ObjectRecord>[],
+  ): Promise<ObjectRecord[]> {
+    const entities = Array.isArray(entityOrEntities)
+      ? entityOrEntities
+      : [entityOrEntities];
+
+    this.assertNoNestedRelationObjects(entities);
+
+    if (entities.length === 0) {
+      return [];
+    }
+
+    const idsToCheck = entities
+      .map((entity) => entity.id)
+      .filter(isNonEmptyString);
+
+    const existingIds =
+      idsToCheck.length > 0
+        ? new Set(
+            (await this.findBy({ id: In(idsToCheck) })).map(
+              (record) => record.id,
+            ),
+          )
+        : new Set<string>();
+
+    const { toUpdate, toInsert } = partitionEntitiesForSave(
+      entities,
+      existingIds,
+    );
+
+    const updatedIds = toUpdate
+      .map((entity) => entity.id)
+      .filter(isNonEmptyString);
+
+    if (updatedIds.length > 0) {
+      await this.runBatchUpdate({
+        inputs: toUpdate.flatMap((entity) =>
+          isNonEmptyString(entity.id) ? [{ id: entity.id, data: entity }] : [],
+        ),
+        columnsToReturn: ['id'],
+      });
+    }
+
+    const insertedIds =
+      toInsert.length > 0
+        ? (
+            await this.runInsert({
+              records: toInsert,
+              columnsToReturn: ['id'],
+            })
+          ).identifiers.map((identifier) => identifier.id)
+        : [];
+
+    const savedIds = [...updatedIds, ...insertedIds];
+
+    return savedIds.length > 0
+      ? this.find({ where: { id: In(savedIds) } })
+      : [];
+  }
+
+  async upsert(
+    entityOrEntities: Partial<ObjectRecord> | Partial<ObjectRecord>[],
+    conflictPathsOrOptions: string[] | { conflictPaths: string[] },
+  ): Promise<InsertResult> {
+    const entities = Array.isArray(entityOrEntities)
+      ? entityOrEntities
+      : [entityOrEntities];
+
+    this.assertNoNestedRelationObjects(entities);
+
+    const conflictPaths = Array.isArray(conflictPathsOrOptions)
+      ? conflictPathsOrOptions
+      : conflictPathsOrOptions.conflictPaths;
+
+    if (conflictPaths.length === 0) {
+      throw new TwentyOrmV2Exception(
+        'upsert requires at least one conflict path',
+        TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
+      );
+    }
+
+    const conflictWhere = entities.map((entity) =>
+      Object.fromEntries(
+        conflictPaths.map((path) => [path, entity[path] ?? null]),
+      ),
+    );
+
+    const existingRecords =
+      entities.length > 0
+        ? await this.find({ where: conflictWhere, withDeleted: true })
+        : [];
+
+    const { toUpdate, toInsert } = matchEntitiesForUpsert(
+      entities,
+      existingRecords,
+      conflictPaths,
+    );
+
+    if (toUpdate.length > 0) {
+      await this.runBatchUpdate({
+        inputs: toUpdate.map((match) => ({
+          id: match.id,
+          data: match.entity,
+        })),
+        columnsToReturn: ['id'],
+      });
+    }
+
+    const insertOutcome =
+      toInsert.length > 0
+        ? await this.runInsert({ records: toInsert, columnsToReturn: ['id'] })
+        : { identifiers: [], generatedMaps: [], raw: [] };
+
+    const insertResult = new InsertResult();
+
+    insertResult.identifiers = [
+      ...toUpdate.map((match) => ({ id: match.id })),
+      ...insertOutcome.identifiers,
+    ];
+    insertResult.generatedMaps = insertOutcome.generatedMaps;
+    insertResult.raw = insertOutcome.raw;
+
+    return insertResult;
+  }
+
+  private assertNoNestedRelationObjects(
+    entities: Partial<ObjectRecord>[],
+  ): void {
+    for (const entity of entities) {
+      for (const key of Object.keys(entity)) {
+        const value = entity[key];
+
+        if (
+          isDefined(this.options.tableShape.relationShapeByFieldName[key]) &&
+          typeof value === 'object' &&
+          value !== null
+        ) {
+          throw new TwentyOrmV2Exception(
+            `Writing nested relation "${key}" through the ORM v2 repository is not supported yet`,
+            TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION,
+          );
+        }
+      }
+    }
   }
 
   async runInsert({

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -30,6 +30,11 @@ import {
   type InsertRowValue,
 } from 'src/engine/twenty-orm-v2/sql/utils/build-insert-statement.util';
 import { type MutationKind } from 'src/engine/twenty-orm-v2/sql/utils/build-mutation-statement.util';
+import {
+  applyFindOptionsToQueryBuilder,
+  type FindOptionsV2,
+} from 'src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util';
+import { type ObjectWhereLike } from 'src/engine/twenty-orm-v2/query-builder/types/query-builder-v2.type';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { compileNamedParameters } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
 import { serializeJsonbWriteValue } from 'src/engine/twenty-orm-v2/sql/utils/serialize-jsonb-write-value.util';
@@ -119,6 +124,70 @@ export class WorkspaceRepositoryV2 {
 
   getInternalContext(): WorkspaceInternalContext {
     return this.options.internalContext;
+  }
+
+  async find(options?: FindOptionsV2): Promise<ObjectRecord[]> {
+    return applyFindOptionsToQueryBuilder(
+      this.createQueryBuilder(),
+      options,
+    ).getMany<ObjectRecord>();
+  }
+
+  async findBy(
+    where: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<ObjectRecord[]> {
+    return this.find({ where });
+  }
+
+  async findOne(options?: FindOptionsV2): Promise<ObjectRecord | null> {
+    return applyFindOptionsToQueryBuilder(
+      this.createQueryBuilder(),
+      options,
+    ).getOne<ObjectRecord>();
+  }
+
+  async findOneBy(
+    where: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<ObjectRecord | null> {
+    return this.findOne({ where });
+  }
+
+  async findOneOrFail(options?: FindOptionsV2): Promise<ObjectRecord> {
+    const record = await this.findOne(options);
+
+    if (!isDefined(record)) {
+      throw new TwentyOrmV2Exception(
+        `No "${this.options.tableShape.nameSingular}" record matches the given criteria`,
+        TwentyOrmV2ExceptionCode.ENTITY_NOT_FOUND,
+      );
+    }
+
+    return record;
+  }
+
+  async findOneByOrFail(
+    where: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<ObjectRecord> {
+    return this.findOneOrFail({ where });
+  }
+
+  async count(options?: FindOptionsV2): Promise<number> {
+    return applyFindOptionsToQueryBuilder(
+      this.createQueryBuilder(),
+      options,
+    ).getCount();
+  }
+
+  async countBy(where: ObjectWhereLike | ObjectWhereLike[]): Promise<number> {
+    return this.count({ where });
+  }
+
+  async exists(options?: FindOptionsV2): Promise<boolean> {
+    return (await this.count(options)) > 0;
+  }
+
+  async existsBy(where: ObjectWhereLike | ObjectWhereLike[]): Promise<boolean> {
+    return this.exists({ where });
   }
 
   async runInsert({

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -168,6 +168,13 @@ export class WorkspaceRepositoryV2 {
   }
 
   async findOne(options?: FindOptionsV2): Promise<ObjectRecord | null> {
+    if (!isDefined(options?.where)) {
+      throw new TwentyOrmV2Exception(
+        'findOne requires a "where" condition',
+        TwentyOrmV2ExceptionCode.INVALID_PARAMETER,
+      );
+    }
+
     const record = await applyFindOptionsToQueryBuilder(
       this.createQueryBuilder(),
       options,

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -30,8 +30,10 @@ import {
   type InsertRowValue,
 } from 'src/engine/twenty-orm-v2/sql/utils/build-insert-statement.util';
 import { type MutationKind } from 'src/engine/twenty-orm-v2/sql/utils/build-mutation-statement.util';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import {
   applyFindOptionsToQueryBuilder,
+  type FindOptionsRelationsV2,
   type FindOptionsV2,
 } from 'src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util';
 import {
@@ -39,10 +41,19 @@ import {
   type MutationCriteria,
 } from 'src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util';
 import { type ObjectWhereLike } from 'src/engine/twenty-orm-v2/query-builder/types/query-builder-v2.type';
+import {
+  attachToManyRelationToRecords,
+  attachToOneRelationToRecords,
+  collectForeignKeys,
+  collectRecordIds,
+} from 'src/engine/twenty-orm-v2/repository/utils/attach-relations.util';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { compileNamedParameters } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
 import { serializeJsonbWriteValue } from 'src/engine/twenty-orm-v2/sql/utils/serialize-jsonb-write-value.util';
-import { type WorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
+import {
+  type WorkspaceRelationShape,
+  type WorkspaceTableShape,
+} from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
 
 const MUTATION_EVENT_ACTIONS_BY_KIND: Record<
   MutationKind,
@@ -68,6 +79,9 @@ type WorkspaceRepositoryV2Options = {
   flatObjectMetadataByObjectMetadataId: (
     objectMetadataId: string,
   ) => FlatObjectMetadata;
+  getRepositoryForObjectMetadataId: (
+    objectMetadataId: string,
+  ) => WorkspaceRepositoryV2;
 };
 
 export class WorkspaceRepositoryV2 {
@@ -131,10 +145,16 @@ export class WorkspaceRepositoryV2 {
   }
 
   async find(options?: FindOptionsV2): Promise<ObjectRecord[]> {
-    return applyFindOptionsToQueryBuilder(
+    const records = await applyFindOptionsToQueryBuilder(
       this.createQueryBuilder(),
       options,
     ).getMany<ObjectRecord>();
+
+    if (isDefined(options?.relations)) {
+      await this.loadRelations(records, options.relations);
+    }
+
+    return records;
   }
 
   async findBy(
@@ -144,10 +164,16 @@ export class WorkspaceRepositoryV2 {
   }
 
   async findOne(options?: FindOptionsV2): Promise<ObjectRecord | null> {
-    return applyFindOptionsToQueryBuilder(
+    const record = await applyFindOptionsToQueryBuilder(
       this.createQueryBuilder(),
       options,
     ).getOne<ObjectRecord>();
+
+    if (isDefined(record) && isDefined(options?.relations)) {
+      await this.loadRelations([record], options.relations);
+    }
+
+    return record;
   }
 
   async findOneBy(
@@ -192,6 +218,159 @@ export class WorkspaceRepositoryV2 {
 
   async existsBy(where: ObjectWhereLike | ObjectWhereLike[]): Promise<boolean> {
     return this.exists({ where });
+  }
+
+  private async loadRelations(
+    records: ObjectRecord[],
+    relations: FindOptionsRelationsV2,
+  ): Promise<void> {
+    if (records.length === 0) {
+      return;
+    }
+
+    for (const [fieldName, nested] of Object.entries(relations)) {
+      if (nested === false) {
+        continue;
+      }
+
+      const relationShape =
+        this.options.tableShape.relationShapeByFieldName[fieldName];
+
+      if (!isDefined(relationShape)) {
+        throw new TwentyOrmV2Exception(
+          `Relation "${fieldName}" does not exist on "${this.options.tableShape.nameSingular}"`,
+          TwentyOrmV2ExceptionCode.UNKNOWN_RELATION,
+        );
+      }
+
+      const nestedRelations =
+        typeof nested === 'object'
+          ? (nested as FindOptionsRelationsV2)
+          : undefined;
+      const targetRepository = this.options.getRepositoryForObjectMetadataId(
+        relationShape.targetObjectMetadataId,
+      );
+
+      if (relationShape.relationType === RelationType.MANY_TO_ONE) {
+        await this.attachToOneRelation({
+          records,
+          fieldName,
+          joinColumnName: relationShape.joinColumnName,
+          targetRepository,
+          nestedRelations,
+        });
+      } else if (relationShape.relationType === RelationType.ONE_TO_MANY) {
+        await this.attachToManyRelation({
+          records,
+          fieldName,
+          relationShape,
+          targetRepository,
+          nestedRelations,
+        });
+      } else {
+        throw new TwentyOrmV2Exception(
+          `Loading "${relationShape.relationType}" relations through find is not supported yet`,
+          TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION,
+        );
+      }
+    }
+  }
+
+  private async attachToOneRelation({
+    records,
+    fieldName,
+    joinColumnName,
+    targetRepository,
+    nestedRelations,
+  }: {
+    records: ObjectRecord[];
+    fieldName: string;
+    joinColumnName?: string;
+    targetRepository: WorkspaceRepositoryV2;
+    nestedRelations?: FindOptionsRelationsV2;
+  }): Promise<void> {
+    if (!isDefined(joinColumnName)) {
+      throw new TwentyOrmV2Exception(
+        `Relation "${fieldName}" has no join column to resolve`,
+        TwentyOrmV2ExceptionCode.UNKNOWN_RELATION,
+      );
+    }
+
+    const foreignKeys = collectForeignKeys(records, joinColumnName);
+
+    const targets =
+      foreignKeys.length > 0
+        ? await targetRepository.find({
+            where: { id: In(foreignKeys) },
+            withDeleted: true,
+            relations: nestedRelations,
+          })
+        : [];
+
+    attachToOneRelationToRecords({
+      records,
+      fieldName,
+      joinColumnName,
+      targets,
+    });
+  }
+
+  private async attachToManyRelation({
+    records,
+    fieldName,
+    relationShape,
+    targetRepository,
+    nestedRelations,
+  }: {
+    records: ObjectRecord[];
+    fieldName: string;
+    relationShape: WorkspaceRelationShape;
+    targetRepository: WorkspaceRepositoryV2;
+    nestedRelations?: FindOptionsRelationsV2;
+  }): Promise<void> {
+    const inverseForeignKeyColumnName =
+      this.resolveInverseForeignKeyColumnName(relationShape);
+
+    const parentIds = collectRecordIds(records);
+
+    const children =
+      parentIds.length > 0
+        ? await targetRepository.find({
+            where: { [inverseForeignKeyColumnName]: In(parentIds) },
+            relations: nestedRelations,
+          })
+        : [];
+
+    attachToManyRelationToRecords({
+      records,
+      fieldName,
+      inverseForeignKeyColumnName,
+      children,
+    });
+  }
+
+  private resolveInverseForeignKeyColumnName(
+    relationShape: WorkspaceRelationShape,
+  ): string {
+    const targetTableShape = this.options.tableShapeByObjectMetadataId(
+      relationShape.targetObjectMetadataId,
+    );
+
+    const inverseRelationShape = Object.values(
+      targetTableShape.relationShapeByFieldName,
+    ).find(
+      (candidate) =>
+        candidate.fieldMetadataId === relationShape.targetFieldMetadataId,
+    );
+
+    if (!isDefined(inverseRelationShape?.joinColumnName)) {
+      throw new TwentyOrmV2Exception(
+        `Could not resolve the inverse foreign key for a to-many relation on "${this.options.tableShape.nameSingular}"`,
+        TwentyOrmV2ExceptionCode.UNKNOWN_RELATION,
+      );
+    }
+
+    return inverseRelationShape.joinColumnName;
   }
 
   async insert(

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -6,7 +6,7 @@ import {
   type ObjectsPermissions,
 } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { In } from 'typeorm';
+import { DeleteResult, In, InsertResult, UpdateResult } from 'typeorm';
 
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
@@ -34,6 +34,10 @@ import {
   applyFindOptionsToQueryBuilder,
   type FindOptionsV2,
 } from 'src/engine/twenty-orm-v2/query-builder/utils/apply-find-options.util';
+import {
+  applyMutationCriteriaToQueryBuilder,
+  type MutationCriteria,
+} from 'src/engine/twenty-orm-v2/query-builder/utils/apply-mutation-criteria.util';
 import { type ObjectWhereLike } from 'src/engine/twenty-orm-v2/query-builder/types/query-builder-v2.type';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { compileNamedParameters } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
@@ -188,6 +192,122 @@ export class WorkspaceRepositoryV2 {
 
   async existsBy(where: ObjectWhereLike | ObjectWhereLike[]): Promise<boolean> {
     return this.exists({ where });
+  }
+
+  async insert(
+    entityOrEntities: Partial<ObjectRecord> | Partial<ObjectRecord>[],
+  ): Promise<InsertResult> {
+    const records = Array.isArray(entityOrEntities)
+      ? entityOrEntities
+      : [entityOrEntities];
+
+    const { identifiers, generatedMaps, raw } = await this.runInsert({
+      records,
+      columnsToReturn: ['id'],
+    });
+
+    const insertResult = new InsertResult();
+
+    insertResult.identifiers = identifiers;
+    insertResult.generatedMaps = generatedMaps;
+    insertResult.raw = raw;
+
+    return insertResult;
+  }
+
+  async update(
+    criteria: MutationCriteria,
+    partialEntity: Partial<ObjectRecord>,
+  ): Promise<UpdateResult> {
+    const records = await this.runMutation({
+      selectQueryBuilder: applyMutationCriteriaToQueryBuilder(
+        this.createQueryBuilder(),
+        criteria,
+      ),
+      rowLevelPermissionsApplied: false,
+      kind: 'update',
+      columnsToReturn: ['id'],
+      data: partialEntity,
+    });
+
+    return this.buildUpdateResult(records);
+  }
+
+  async updateMany(
+    inputs: { criteria: string; partialEntity: Partial<ObjectRecord> }[],
+  ): Promise<UpdateResult> {
+    const { generatedMaps, raw } = await this.runBatchUpdate({
+      inputs: inputs.map((input) => ({
+        id: input.criteria,
+        data: input.partialEntity,
+      })),
+      columnsToReturn: ['id'],
+    });
+
+    const updateResult = new UpdateResult();
+
+    updateResult.raw = raw;
+    updateResult.affected = raw.length;
+    updateResult.generatedMaps = generatedMaps;
+
+    return updateResult;
+  }
+
+  async delete(criteria: MutationCriteria): Promise<DeleteResult> {
+    const records = await this.runMutation({
+      selectQueryBuilder: applyMutationCriteriaToQueryBuilder(
+        this.createQueryBuilder(),
+        criteria,
+      ),
+      rowLevelPermissionsApplied: false,
+      kind: 'delete',
+      columnsToReturn: ['id'],
+    });
+
+    const deleteResult = new DeleteResult();
+
+    deleteResult.raw = records;
+    deleteResult.affected = records.length;
+
+    return deleteResult;
+  }
+
+  async softDelete(criteria: MutationCriteria): Promise<UpdateResult> {
+    const records = await this.runMutation({
+      selectQueryBuilder: applyMutationCriteriaToQueryBuilder(
+        this.createQueryBuilder(),
+        criteria,
+      ),
+      rowLevelPermissionsApplied: false,
+      kind: 'soft-delete',
+      columnsToReturn: ['id'],
+    });
+
+    return this.buildUpdateResult(records);
+  }
+
+  async restore(criteria: MutationCriteria): Promise<UpdateResult> {
+    const records = await this.runMutation({
+      selectQueryBuilder: applyMutationCriteriaToQueryBuilder(
+        this.createQueryBuilder(),
+        criteria,
+      ),
+      rowLevelPermissionsApplied: false,
+      kind: 'restore',
+      columnsToReturn: ['id'],
+    });
+
+    return this.buildUpdateResult(records);
+  }
+
+  private buildUpdateResult(records: ObjectRecord[]): UpdateResult {
+    const updateResult = new UpdateResult();
+
+    updateResult.raw = records;
+    updateResult.affected = records.length;
+    updateResult.generatedMaps = records;
+
+    return updateResult;
   }
 
   async runInsert({

--- a/packages/twenty-server/src/engine/twenty-orm-v2/utils/twenty-orm-v2-to-user-input-error.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/utils/twenty-orm-v2-to-user-input-error.util.ts
@@ -13,6 +13,7 @@ export const isTwentyOrmV2UserInputError = (
     case TwentyOrmV2ExceptionCode.UNKNOWN_RELATION:
     case TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION:
     case TwentyOrmV2ExceptionCode.TOO_MANY_RECORDS_TO_UPDATE:
+    case TwentyOrmV2ExceptionCode.ENTITY_NOT_FOUND:
       return true;
     default:
       return false;

--- a/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
@@ -201,8 +201,9 @@ export class RelationNestedQueries {
           )
           .getRawMany();
       } else {
-        throw new Error(
+        throw new TwentyORMException(
           'A query builder or a connect query runner is required to resolve connect queries',
+          TwentyORMExceptionCode.INVALID_INPUT,
         );
       }
 

--- a/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
@@ -28,8 +28,6 @@ import { getAssociatedRelationFieldName } from 'src/engine/twenty-orm/utils/get-
 import { getObjectMetadataFromEntityTarget } from 'src/engine/twenty-orm/utils/get-object-metadata-from-entity-target.util';
 import { getRecordToConnectFields } from 'src/engine/twenty-orm/utils/get-record-to-connect-fields.util';
 
-// Resolves the connect lookup off the TypeORM builder so the ORM v2 write path
-// can supply its own query runner while the v1 path keeps using the builder.
 export type ConnectQueryRunner = (args: {
   connectQueryConfig: RelationConnectQueryConfig;
   clause: string;

--- a/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
@@ -28,6 +28,14 @@ import { getAssociatedRelationFieldName } from 'src/engine/twenty-orm/utils/get-
 import { getObjectMetadataFromEntityTarget } from 'src/engine/twenty-orm/utils/get-object-metadata-from-entity-target.util';
 import { getRecordToConnectFields } from 'src/engine/twenty-orm/utils/get-record-to-connect-fields.util';
 
+// Resolves the connect lookup off the TypeORM builder so the ORM v2 write path
+// can supply its own query runner while the v1 path keeps using the builder.
+export type ConnectQueryRunner = (args: {
+  connectQueryConfig: RelationConnectQueryConfig;
+  clause: string;
+  parameters: Record<string, unknown>;
+}) => Promise<Record<string, unknown>[]>;
+
 export class RelationNestedQueries {
   private readonly internalContext: WorkspaceInternalContext;
 
@@ -88,6 +96,7 @@ export class RelationNestedQueries {
     entities,
     relationNestedConfig,
     queryBuilder,
+    connectQueryRunner,
   }: {
     entities:
       | QueryDeepPartialEntityWithNestedRelationFields<Entity>[]
@@ -96,9 +105,10 @@ export class RelationNestedQueries {
       RelationConnectQueryConfig[],
       RelationDisconnectQueryFieldsByEntityIndex,
     ];
-    queryBuilder:
+    queryBuilder?:
       | WorkspaceSelectQueryBuilder<Entity>
       | SelectQueryBuilder<Entity>;
+    connectQueryRunner?: ConnectQueryRunner;
   }): Promise<QueryDeepPartialEntity<Entity>[]> {
     const entitiesArray = Array.isArray(entities) ? entities : [entities];
 
@@ -116,6 +126,7 @@ export class RelationNestedQueries {
       entities: updatedEntitiesWithDisconnect,
       relationConnectQueryConfigs,
       queryBuilder,
+      connectQueryRunner,
     });
 
     return updatedEntitiesWithConnect;
@@ -125,18 +136,21 @@ export class RelationNestedQueries {
     entities,
     relationConnectQueryConfigs,
     queryBuilder,
+    connectQueryRunner,
   }: {
     entities: QueryDeepPartialEntityWithNestedRelationFields<Entity>[];
     relationConnectQueryConfigs: RelationConnectQueryConfig[];
-    queryBuilder:
+    queryBuilder?:
       | WorkspaceSelectQueryBuilder<Entity>
       | SelectQueryBuilder<Entity>;
+    connectQueryRunner?: ConnectQueryRunner;
   }): Promise<QueryDeepPartialEntity<Entity>[]> {
     if (relationConnectQueryConfigs.length === 0) return entities;
 
     const recordsToConnectWithConfig = await this.executeConnectQueries(
       relationConnectQueryConfigs,
       queryBuilder,
+      connectQueryRunner,
     );
 
     const updatedEntities = this.updateEntitiesWithRecordToConnectId<Entity>(
@@ -151,7 +165,9 @@ export class RelationNestedQueries {
     relationConnectQueryConfigs: RelationConnectQueryConfig[],
     queryBuilder:
       | WorkspaceSelectQueryBuilder<Entity>
-      | SelectQueryBuilder<Entity>,
+      | SelectQueryBuilder<Entity>
+      | undefined,
+    connectQueryRunner?: ConnectQueryRunner,
   ): Promise<[RelationConnectQueryConfig, Record<string, unknown>[]][]> {
     const allRecordsToConnectWithConfig: [
       RelationConnectQueryConfig,
@@ -164,17 +180,31 @@ export class RelationNestedQueries {
         connectQueryConfig.targetObjectName,
       );
 
-      queryBuilder.expressionMap.aliases = [];
-      queryBuilder.expressionMap.mainAlias = undefined;
+      let recordsToConnect: Record<string, unknown>[];
 
-      const recordsToConnect = await queryBuilder
-        .select(getRecordToConnectFields(connectQueryConfig))
-        .where(clause, parameters)
-        .from(
-          connectQueryConfig.targetObjectName,
-          connectQueryConfig.targetObjectName,
-        )
-        .getRawMany();
+      if (connectQueryRunner) {
+        recordsToConnect = await connectQueryRunner({
+          connectQueryConfig,
+          clause,
+          parameters,
+        });
+      } else if (queryBuilder) {
+        queryBuilder.expressionMap.aliases = [];
+        queryBuilder.expressionMap.mainAlias = undefined;
+
+        recordsToConnect = await queryBuilder
+          .select(getRecordToConnectFields(connectQueryConfig))
+          .where(clause, parameters)
+          .from(
+            connectQueryConfig.targetObjectName,
+            connectQueryConfig.targetObjectName,
+          )
+          .getRawMany();
+      } else {
+        throw new Error(
+          'A query builder or a connect query runner is required to resolve connect queries',
+        );
+      }
 
       allRecordsToConnectWithConfig.push([
         connectQueryConfig,


### PR DESCRIPTION
## Context

First PR in the workstream to stop computing the TypeORM `EntityMetadata` graph on flag-on (`IS_ORM_V2_READ_PATH_ENABLED`) requests. The API record read/write paths already run on the v2 workspace ORM, but v2's `WorkspaceRepositoryV2` only exposed a low-level surface (`createQueryBuilder` / `runInsert` / `runMutation`). The module/engine repository surface (find/findOne/etc., ~178 call sites) still forces the v1 datasource, which is what pins the `EntityMetadata` build to the request path.

This PR adds the read half of the v1-compatible method surface so later PRs can route a v2-backed repository to those callers.

## What this does

Adds to `WorkspaceRepositoryV2`: `find`, `findBy`, `findOne`, `findOneBy`, `findOneOrFail`, `findOneByOrFail`, `count`, `countBy`, `exists`, `existsBy`.

They delegate to the existing v2 select query builder through a pure `applyFindOptionsToQueryBuilder` translator (`where` incl. `In`/equality/`IS NULL` and OR-arrays, `select`, `order`, `take`/`skip`, `withDeleted`). Row-level permissions and the soft-delete predicate come from the builder, matching the v1 semantics.

**Relation loading is intentionally out of scope** — `find({ relations })` throws `UNSUPPORTED_OPERATION` and is the next increment.

## Safety

Purely additive: nothing calls these methods yet. No behavior change on either flag path.

## Tests

`applyFindOptionsToQueryBuilder` has an exact-SQL unit spec; full v2 unit suite green (111 tests).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

