### PR TITLE
fix(messaging): Gmail full-sync fails and stalls on large mailboxes

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/constants/messaging-pending-stale-sync-stages.constant.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/constants/messaging-pending-stale-sync-stages.constant.ts
@@ -1,0 +1,9 @@
+import { MessageChannelSyncStage } from 'twenty-shared/types';
+
+// Unlike MESSAGING_ONGOING_STALE_SYNC_STAGES, a channel in one of these
+// stages is only considered stale when it carries a real (non-null)
+// syncStageStartedAt older than the timeout — see isPendingSyncStale.
+export const MESSAGING_PENDING_STALE_SYNC_STAGES: MessageChannelSyncStage[] = [
+  MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+  MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+];

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/__tests__/messaging-ongoing-stale.cron.job.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/__tests__/messaging-ongoing-stale.cron.job.spec.ts
@@ -6,21 +6,35 @@ import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channe
 import { MessagingOngoingStaleCronJob } from 'src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job';
 import { MessagingOngoingStaleJob } from 'src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job';
 
+const createQueryBuilderMock = (rawResult: Array<{ workspaceId: string }>) => ({
+  select: jest.fn().mockReturnThis(),
+  innerJoin: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  orWhere: jest.fn().mockReturnThis(),
+  getRawMany: jest.fn().mockResolvedValue(rawResult),
+});
+
 describe('MessagingOngoingStaleCronJob', () => {
-  let messageChannelRepository: { find: jest.Mock };
+  let messageChannelRepository: { createQueryBuilder: jest.Mock };
   let messageQueueService: { add: jest.Mock };
   let job: MessagingOngoingStaleCronJob;
 
+  const mockQueryResult = (rawResult: Array<{ workspaceId: string }>) => {
+    const queryBuilder = createQueryBuilderMock(rawResult);
+
+    messageChannelRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+    return queryBuilder;
+  };
+
   beforeEach(() => {
-    messageChannelRepository = {
-      find: jest
-        .fn()
-        .mockResolvedValue([
-          { workspaceId: 'workspace-1' },
-          { workspaceId: 'workspace-1' },
-          { workspaceId: 'workspace-2' },
-        ]),
-    };
+    messageChannelRepository = { createQueryBuilder: jest.fn() };
+    mockQueryResult([
+      { workspaceId: 'workspace-1' },
+      { workspaceId: 'workspace-1' },
+      { workspaceId: 'workspace-2' },
+    ]);
     messageQueueService = { add: jest.fn() };
     job = new MessagingOngoingStaleCronJob(
       messageChannelRepository as unknown as Repository<MessageChannelEntity>,
@@ -52,10 +66,24 @@ describe('MessagingOngoingStaleCronJob', () => {
   });
 
   it('does not enqueue recovery when no workspace has a stale channel', async () => {
-    messageChannelRepository.find.mockResolvedValue([]);
+    mockQueryResult([]);
 
     await job.handle();
 
     expect(messageQueueService.add).not.toHaveBeenCalled();
+  });
+
+  it('builds the query against the messageChannel/workspace join', async () => {
+    const queryBuilder = mockQueryResult([]);
+
+    await job.handle();
+
+    expect(messageChannelRepository.createQueryBuilder).toHaveBeenCalledWith(
+      'messageChannel',
+    );
+    expect(queryBuilder.innerJoin).toHaveBeenCalledWith(
+      'messageChannel.workspace',
+      'workspace',
+    );
   });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job.ts
@@ -1,7 +1,7 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
-import { In, IsNull, LessThan, Or, Repository } from 'typeorm';
+import { Brackets, Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
@@ -13,6 +13,7 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT } from 'src/modules/messaging/message-import-manager/constants/messaging-import-ongoing-sync-timeout.constant';
 import { MESSAGING_ONGOING_STALE_SYNC_STAGES } from 'src/modules/messaging/message-import-manager/constants/messaging-ongoing-stale-sync-stages.constant';
+import { MESSAGING_PENDING_STALE_SYNC_STAGES } from 'src/modules/messaging/message-import-manager/constants/messaging-pending-stale-sync-stages.constant';
 import {
   MessagingOngoingStaleJob,
   type MessagingOngoingStaleJobData,
@@ -60,19 +61,43 @@ export class MessagingOngoingStaleCronJob {
     const staleBefore = new Date(
       Date.now() - MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT,
     );
-    const staleChannels = await this.messageChannelRepository.find({
-      select: {
-        workspaceId: true,
-      },
-      where: {
-        syncStage: In(MESSAGING_ONGOING_STALE_SYNC_STAGES),
-        syncStageStartedAt: Or(IsNull(), LessThan(staleBefore)),
-        workspace: {
-          deletedAt: IsNull(),
-          activationStatus: WorkspaceActivationStatus.ACTIVE,
-        },
-      },
-    });
+
+    // Ongoing/scheduled stages are stale if they've run past the timeout, or
+    // if syncStageStartedAt was never set (shouldn't normally happen for
+    // these stages, but treat it as stale rather than silently skip it).
+    // Pending stages are different: syncStageStartedAt is null while a
+    // channel is healthily waiting for the next fast cron tick, so a
+    // pending channel is only stale once it carries a real, old timestamp
+    // (which only happens via the throttle-recovery path) — see
+    // isPendingSyncStale for the matching per-channel check.
+    const staleChannels = await this.messageChannelRepository
+      .createQueryBuilder('messageChannel')
+      .select('messageChannel.workspaceId', 'workspaceId')
+      .innerJoin('messageChannel.workspace', 'workspace')
+      .where('workspace.deletedAt IS NULL')
+      .andWhere('workspace.activationStatus = :activationStatus', {
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
+      })
+      .andWhere(
+        new Brackets((queryBuilder) => {
+          queryBuilder
+            .where(
+              'messageChannel.syncStage IN (:...ongoingStages) AND (messageChannel.syncStageStartedAt IS NULL OR messageChannel.syncStageStartedAt < :staleBefore)',
+              {
+                ongoingStages: MESSAGING_ONGOING_STALE_SYNC_STAGES,
+                staleBefore,
+              },
+            )
+            .orWhere(
+              'messageChannel.syncStage IN (:...pendingStages) AND messageChannel.syncStageStartedAt < :staleBefore',
+              {
+                pendingStages: MESSAGING_PENDING_STALE_SYNC_STAGES,
+                staleBefore,
+              },
+            );
+        }),
+      )
+      .getRawMany<{ workspaceId: string }>();
 
     return [...new Set(staleChannels.map(({ workspaceId }) => workspaceId))];
   }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-messages.service.ts
@@ -13,9 +13,16 @@ import { MESSAGING_GMAIL_EXCLUDED_SYSTEM_LABELS } from 'src/modules/messaging/me
 import { GmailMessagesImportErrorHandler } from 'src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-messages-import-error-handler.service';
 import { filterGmailMessagesByFolderPolicy } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/filter-gmail-messages-by-folder-policy.util';
 import { parseAndFormatGmailMessage } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-and-format-gmail-message.util';
+import { createConcurrencyLimiter } from 'src/modules/messaging/message-import-manager/drivers/utils/create-concurrency-limiter.util';
 import { type MessageWithParticipants } from 'src/modules/messaging/message-import-manager/types/message';
 
 const GMAIL_BATCH_REQUEST_MAX_SIZE = 50;
+// Gmail enforces a per-user concurrent-request limit ("Too many concurrent
+// requests for user"). Each batch request below already groups up to
+// GMAIL_BATCH_REQUEST_MAX_SIZE messages into one HTTP call, but a large
+// full-sync (thousands of messages) still fires hundreds of those batch
+// calls at once via Promise.all with no cap, which is what trips the limit.
+const GMAIL_FETCH_MAX_CONCURRENT_BATCH_REQUESTS = 4;
 
 @Injectable()
 export class GmailGetMessagesService {
@@ -164,12 +171,22 @@ export class GmailGetMessagesService {
     messageIds: string[],
     connectedAccount: Pick<ConnectedAccountEntity, 'handle' | 'handleAliases'>,
   ): Promise<MessageWithParticipants[]> {
+    const limitConcurrentBatchRequests = createConcurrencyLimiter(
+      GMAIL_FETCH_MAX_CONCURRENT_BATCH_REQUESTS,
+    );
+
     const results = await Promise.all(
       messageIds.map((messageId) =>
-        gmailClient.users.messages
-          .get({ userId: 'me', id: messageId })
-          .then((response) => ({ messageId, data: response.data, error: null }))
-          .catch((error) => ({ messageId, data: null, error })),
+        limitConcurrentBatchRequests(() =>
+          gmailClient.users.messages
+            .get({ userId: 'me', id: messageId })
+            .then((response) => ({
+              messageId,
+              data: response.data,
+              error: null,
+            }))
+            .catch((error) => ({ messageId, data: null, error })),
+        ),
       ),
     );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/utils/__tests__/create-concurrency-limiter.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/utils/__tests__/create-concurrency-limiter.util.spec.ts
@@ -1,0 +1,81 @@
+import { createConcurrencyLimiter } from 'src/modules/messaging/message-import-manager/drivers/utils/create-concurrency-limiter.util';
+
+const createDeferred = <T>() => {
+  let resolve: (value: T | PromiseLike<T>) => void;
+  let reject: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve: resolve!, reject: reject! };
+};
+
+describe('createConcurrencyLimiter', () => {
+  it('should cap concurrent tasks at the configured maximum', async () => {
+    const limitConcurrency = createConcurrencyLimiter(4);
+    const taskStartedDeferreds = Array.from({ length: 12 }, () =>
+      createDeferred<void>(),
+    );
+    const taskFinishedDeferreds = Array.from({ length: 12 }, () =>
+      createDeferred<void>(),
+    );
+    let activeTaskCount = 0;
+    let maximumActiveTaskCount = 0;
+
+    const tasks = Array.from({ length: 12 }, (_, taskIndex) =>
+      limitConcurrency(async () => {
+        activeTaskCount++;
+        maximumActiveTaskCount = Math.max(
+          maximumActiveTaskCount,
+          activeTaskCount,
+        );
+        taskStartedDeferreds[taskIndex].resolve();
+
+        await taskFinishedDeferreds[taskIndex].promise;
+
+        activeTaskCount--;
+
+        return taskIndex;
+      }),
+    );
+
+    await Promise.all(
+      taskStartedDeferreds.slice(0, 4).map(({ promise }) => promise),
+    );
+    expect(activeTaskCount).toBe(4);
+
+    for (let taskIndex = 0; taskIndex < 12; taskIndex++) {
+      await taskStartedDeferreds[taskIndex].promise;
+      taskFinishedDeferreds[taskIndex].resolve();
+    }
+
+    await expect(Promise.all(tasks)).resolves.toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+    ]);
+    expect(maximumActiveTaskCount).toBe(4);
+  });
+
+  it('should release capacity after a task rejects, so later tasks still run', async () => {
+    const limitConcurrency = createConcurrencyLimiter(1);
+    const rejectedTask = limitConcurrency(async () => {
+      throw new Error('Gmail batch request failed');
+    });
+    const nextTask = limitConcurrency(async () => 'completed');
+
+    await expect(rejectedTask).rejects.toThrow('Gmail batch request failed');
+    await expect(nextTask).resolves.toBe('completed');
+  });
+
+  it('should reject invalid concurrency values', () => {
+    expect(() => createConcurrencyLimiter(0)).toThrow(
+      'Maximum concurrency must be a positive integer',
+    );
+    expect(() => createConcurrencyLimiter(-1)).toThrow(
+      'Maximum concurrency must be a positive integer',
+    );
+    expect(() => createConcurrencyLimiter(1.5)).toThrow(
+      'Maximum concurrency must be a positive integer',
+    );
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/utils/create-concurrency-limiter.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/utils/create-concurrency-limiter.util.ts
@@ -1,0 +1,49 @@
+export type ConcurrencyLimiter = <T>(task: () => Promise<T>) => Promise<T>;
+
+// Caps how many async tasks run at once instead of firing every task with
+// Promise.all(), which lets a large batch (e.g. a Gmail full-sync with
+// thousands of messages) trip the provider's per-user rate limit.
+export const createConcurrencyLimiter = (
+  maxConcurrency: number,
+): ConcurrencyLimiter => {
+  if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+    throw new Error('Maximum concurrency must be a positive integer');
+  }
+
+  let activeTaskCount = 0;
+  const waitingTaskResolvers: Array<() => void> = [];
+
+  const acquire = (): Promise<void> => {
+    if (activeTaskCount < maxConcurrency) {
+      activeTaskCount++;
+
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      waitingTaskResolvers.push(resolve);
+    });
+  };
+
+  const release = () => {
+    const nextTaskResolver = waitingTaskResolvers.shift();
+
+    if (nextTaskResolver) {
+      nextTaskResolver();
+
+      return;
+    }
+
+    activeTaskCount--;
+  };
+
+  return async <T>(task: () => Promise<T>): Promise<T> => {
+    await acquire();
+
+    try {
+      return await task();
+    } finally {
+      release();
+    }
+  };
+};

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/__tests__/messaging-ongoing-stale.job.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/__tests__/messaging-ongoing-stale.job.spec.ts
@@ -1,0 +1,142 @@
+import { type Repository } from 'typeorm';
+
+import { MessageChannelSyncStage } from 'twenty-shared/types';
+import { type MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { type GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { type MessageChannelSyncStatusService } from 'src/modules/messaging/common/services/message-channel-sync-status.service';
+import { MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT } from 'src/modules/messaging/message-import-manager/constants/messaging-import-ongoing-sync-timeout.constant';
+import { MessagingOngoingStaleJob } from 'src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job';
+
+jest.useFakeTimers().setSystemTime(new Date('2024-01-01T01:00:00.000Z'));
+
+const STALE_TIMESTAMP = new Date(
+  Date.now() - MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT - 1,
+).toISOString();
+const FRESH_TIMESTAMP = new Date(
+  Date.now() - MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT + 1,
+).toISOString();
+
+describe('MessagingOngoingStaleJob', () => {
+  let messageChannelRepository: { find: jest.Mock };
+  let messageChannelSyncStatusService: {
+    resetSyncStageStartedAt: jest.Mock;
+    markAsMessagesListFetchPending: jest.Mock;
+    markAsMessagesImportPending: jest.Mock;
+  };
+  let job: MessagingOngoingStaleJob;
+
+  const runWithChannels = async (
+    channels: Array<{
+      id: string;
+      syncStage: MessageChannelSyncStage;
+      syncStageStartedAt: string | null;
+    }>,
+  ) => {
+    messageChannelRepository.find.mockResolvedValue(channels);
+
+    await job.handle({ workspaceId: 'workspace-1' });
+  };
+
+  beforeEach(() => {
+    messageChannelRepository = { find: jest.fn().mockResolvedValue([]) };
+    messageChannelSyncStatusService = {
+      resetSyncStageStartedAt: jest.fn(),
+      markAsMessagesListFetchPending: jest.fn(),
+      markAsMessagesImportPending: jest.fn(),
+    };
+
+    const globalWorkspaceOrmManager = {
+      executeInWorkspaceContext: jest
+        .fn()
+        .mockImplementation((fn: () => unknown) => fn()),
+    };
+
+    job = new MessagingOngoingStaleJob(
+      globalWorkspaceOrmManager as unknown as GlobalWorkspaceOrmManager,
+      messageChannelRepository as unknown as Repository<MessageChannelEntity>,
+      messageChannelSyncStatusService as unknown as MessageChannelSyncStatusService,
+    );
+  });
+
+  it('demotes a stale ongoing channel back to pending (existing behavior)', async () => {
+    await runWithChannels([
+      {
+        id: 'channel-ongoing',
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING,
+        syncStageStartedAt: STALE_TIMESTAMP,
+      },
+    ]);
+
+    expect(
+      messageChannelSyncStatusService.resetSyncStageStartedAt,
+    ).toHaveBeenCalledWith(['channel-ongoing'], 'workspace-1');
+    expect(
+      messageChannelSyncStatusService.markAsMessagesImportPending,
+    ).toHaveBeenCalledWith(['channel-ongoing'], 'workspace-1');
+  });
+
+  it('leaves a freshly pending channel alone (null syncStageStartedAt is healthy)', async () => {
+    await runWithChannels([
+      {
+        id: 'channel-pending-fresh',
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+        syncStageStartedAt: null,
+      },
+    ]);
+
+    expect(
+      messageChannelSyncStatusService.resetSyncStageStartedAt,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('leaves a recently-throttled pending channel alone (within timeout)', async () => {
+    await runWithChannels([
+      {
+        id: 'channel-pending-recent',
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+        syncStageStartedAt: FRESH_TIMESTAMP,
+      },
+    ]);
+
+    expect(
+      messageChannelSyncStatusService.resetSyncStageStartedAt,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('recovers a pending channel stuck past the timeout with a preserved timestamp', async () => {
+    await runWithChannels([
+      {
+        id: 'channel-pending-stuck',
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+        syncStageStartedAt: STALE_TIMESTAMP,
+      },
+    ]);
+
+    expect(
+      messageChannelSyncStatusService.resetSyncStageStartedAt,
+    ).toHaveBeenCalledWith(['channel-pending-stuck'], 'workspace-1');
+    expect(
+      messageChannelSyncStatusService.markAsMessagesImportPending,
+    ).not.toHaveBeenCalled();
+    expect(
+      messageChannelSyncStatusService.markAsMessagesListFetchPending,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('recovers a stuck list-fetch-pending channel the same way', async () => {
+    await runWithChannels([
+      {
+        id: 'channel-list-fetch-pending-stuck',
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+        syncStageStartedAt: STALE_TIMESTAMP,
+      },
+    ]);
+
+    expect(
+      messageChannelSyncStatusService.resetSyncStageStartedAt,
+    ).toHaveBeenCalledWith(['channel-list-fetch-pending-stuck'], 'workspace-1');
+    expect(
+      messageChannelSyncStatusService.markAsMessagesListFetchPending,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job.ts
@@ -12,6 +12,8 @@ import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspac
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageChannelSyncStatusService } from 'src/modules/messaging/common/services/message-channel-sync-status.service';
 import { MESSAGING_ONGOING_STALE_SYNC_STAGES } from 'src/modules/messaging/message-import-manager/constants/messaging-ongoing-stale-sync-stages.constant';
+import { MESSAGING_PENDING_STALE_SYNC_STAGES } from 'src/modules/messaging/message-import-manager/constants/messaging-pending-stale-sync-stages.constant';
+import { isPendingSyncStale } from 'src/modules/messaging/message-import-manager/utils/is-pending-sync-stale.util';
 import { isSyncStale } from 'src/modules/messaging/message-import-manager/utils/is-sync-stale.util';
 import { toIsoStringOrNull } from 'src/utils/date/toIsoStringOrNull';
 
@@ -42,44 +44,68 @@ export class MessagingOngoingStaleJob {
       async () => {
         const messageChannels = await this.messageChannelRepository.find({
           where: {
-            syncStage: In(MESSAGING_ONGOING_STALE_SYNC_STAGES),
+            syncStage: In([
+              ...MESSAGING_ONGOING_STALE_SYNC_STAGES,
+              ...MESSAGING_PENDING_STALE_SYNC_STAGES,
+            ]),
             workspaceId,
           },
         });
 
         for (const messageChannel of messageChannels) {
-          if (
-            isSyncStale(toIsoStringOrNull(messageChannel.syncStageStartedAt))
-          ) {
-            await this.messageChannelSyncStatusService.resetSyncStageStartedAt(
-              [messageChannel.id],
-              workspaceId,
-            );
+          const syncStageStartedAt = toIsoStringOrNull(
+            messageChannel.syncStageStartedAt,
+          );
+          const isPendingStage = MESSAGING_PENDING_STALE_SYNC_STAGES.includes(
+            messageChannel.syncStage,
+          );
+          const isStale = isPendingStage
+            ? isPendingSyncStale(syncStageStartedAt)
+            : isSyncStale(syncStageStartedAt);
 
-            switch (messageChannel.syncStage) {
-              case MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING:
-              case MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED:
-                this.logger.log(
-                  `Sync for message channel ${messageChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to MESSAGE_LIST_FETCH_PENDING`,
-                );
-                await this.messageChannelSyncStatusService.markAsMessagesListFetchPending(
-                  [messageChannel.id],
-                  workspaceId,
-                );
-                break;
-              case MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING:
-              case MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED:
-                this.logger.log(
-                  `Sync for message channel ${messageChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to MESSAGES_IMPORT_PENDING`,
-                );
-                await this.messageChannelSyncStatusService.markAsMessagesImportPending(
-                  [messageChannel.id],
-                  workspaceId,
-                );
-                break;
-              default:
-                break;
-            }
+          if (!isStale) {
+            continue;
+          }
+
+          await this.messageChannelSyncStatusService.resetSyncStageStartedAt(
+            [messageChannel.id],
+            workspaceId,
+          );
+
+          switch (messageChannel.syncStage) {
+            case MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING:
+            case MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED:
+              this.logger.log(
+                `Sync for message channel ${messageChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to MESSAGE_LIST_FETCH_PENDING`,
+              );
+              await this.messageChannelSyncStatusService.markAsMessagesListFetchPending(
+                [messageChannel.id],
+                workspaceId,
+              );
+              break;
+            case MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING:
+            case MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED:
+              this.logger.log(
+                `Sync for message channel ${messageChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to MESSAGES_IMPORT_PENDING`,
+              );
+              await this.messageChannelSyncStatusService.markAsMessagesImportPending(
+                [messageChannel.id],
+                workspaceId,
+              );
+              break;
+            case MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING:
+            case MessageChannelSyncStage.MESSAGES_IMPORT_PENDING:
+              // Already in the right stage to be picked up by the fast
+              // cron — it was stuck here despite that, most likely because
+              // a prior cron/queue cycle never ran or never enqueued it.
+              // Clearing syncStageStartedAt above (and any stale throttle
+              // backoff that depended on it) is the actual recovery step.
+              this.logger.log(
+                `Message channel ${messageChannel.id} and workspace ${workspaceId} was stuck in ${messageChannel.syncStage} past the sync timeout with no further activity. Clearing it for retry.`,
+              );
+              break;
+            default:
+              break;
           }
         }
       },

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/is-pending-sync-stale.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/is-pending-sync-stale.util.spec.ts
@@ -1,0 +1,36 @@
+import { MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT } from 'src/modules/messaging/message-import-manager/constants/messaging-import-ongoing-sync-timeout.constant';
+import { isPendingSyncStale } from 'src/modules/messaging/message-import-manager/utils/is-pending-sync-stale.util';
+
+jest.useFakeTimers().setSystemTime(new Date('2024-01-01'));
+
+describe('isPendingSyncStale', () => {
+  it('should return false when syncStageStartedAt is null (freshly pending, healthy)', () => {
+    expect(isPendingSyncStale(null)).toBe(false);
+  });
+
+  it('should return false when syncStageStartedAt is undefined (freshly pending, healthy)', () => {
+    expect(isPendingSyncStale(undefined)).toBe(false);
+  });
+
+  it('should return true when a preserved timestamp is older than the sync timeout', () => {
+    const syncStageStartedAt = new Date(
+      Date.now() - MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT - 1,
+    ).toISOString();
+
+    expect(isPendingSyncStale(syncStageStartedAt)).toBe(true);
+  });
+
+  it('should return false when a preserved timestamp is within the sync timeout', () => {
+    const syncStageStartedAt = new Date(
+      Date.now() - MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT + 1,
+    ).toISOString();
+
+    expect(isPendingSyncStale(syncStageStartedAt)).toBe(false);
+  });
+
+  it('should throw an error if syncStageStartedAt is invalid', () => {
+    expect(() => {
+      isPendingSyncStale('invalid-date');
+    }).toThrow('Invalid date format');
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/is-pending-sync-stale.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/is-pending-sync-stale.util.ts
@@ -1,0 +1,28 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT } from 'src/modules/messaging/message-import-manager/constants/messaging-import-ongoing-sync-timeout.constant';
+
+// A channel normally sits in a *_PENDING stage with syncStageStartedAt set to
+// null while it waits for the next fast cron tick (at most a few minutes) —
+// that's healthy, not stale. syncStageStartedAt is only kept non-null for a
+// pending channel on the throttle-recovery path (see
+// MessageChannelSyncStatusService.markAsMessagesImportPending's
+// preserveSyncStageStartedAt flag), so a real, old timestamp here means the
+// channel fell through the fast cron/queue and never got picked back up.
+export const isPendingSyncStale = (
+  syncStageStartedAt?: string | null,
+): boolean => {
+  if (!isDefined(syncStageStartedAt)) {
+    return false;
+  }
+
+  const syncStageStartedTime = new Date(syncStageStartedAt).getTime();
+
+  if (isNaN(syncStageStartedTime)) {
+    throw new Error('Invalid date format');
+  }
+
+  return (
+    Date.now() - syncStageStartedTime > MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT
+  );
+};


### PR DESCRIPTION
## Summary

Fixes #24034 — a Gmail full-sync on a large mailbox fails immediately and, even after working around that, can stall partway through with no error and no recovery. The issue lists three root causes; this PR addresses all three across two commits.

### 1. Unbounded concurrency in `GmailGetMessagesService.fetchMessages`

`fetchMessages` fired a `.get()` call for every message ID in a batch simultaneously via `Promise.all`, with no concurrency ceiling. `batchFetchImplementation`'s `maxBatchSize` only bounds how many *operations* go in one HTTP batch request — it does not bound how many batch requests are in flight at once. Against a mailbox of several thousand messages this trips Gmail's per-user concurrent-request rate limit almost immediately.

**Fix:** added a small `createConcurrencyLimiter` utility (same pattern already used in `process-nested-relations-v2.helper.ts`, kept local to the messaging driver rather than cross-imported) and capped `fetchMessages` at 4 concurrent batch requests.

### 2 & 3. Channel gets stuck in a `*_PENDING` stage and never resumes

These are reported as two separate symptoms (stuck after a throttle vs. stalling silently partway through a large import), but they trace back to the same gap: `MessagingOngoingStaleJob` — the hourly self-healing job that rescues channels stuck in `*_ONGOING`/`*_SCHEDULED` stages — has no coverage at all for `MESSAGES_IMPORT_PENDING` or `MESSAGE_LIST_FETCH_PENDING`. If a channel ever enters one of those stages and the fast (1-minute/5-minute) cron misses it for any reason, there's no safety net; it stays stuck until someone manually reconnects the account. This also explains the reported lack of any error log — nothing was ever watching that state.

**Fix:** extended stale-recovery coverage to the two `*_PENDING` stages, with different staleness semantics than the existing ongoing/scheduled check: `syncStageStartedAt` is `null` while a channel is healthily waiting for its next fast-cron tick, so `null` must *not* count as stale here (unlike the ongoing/scheduled case). It's only kept non-null for a pending channel via the throttle-recovery path (`preserveSyncStageStartedAt`), so a real, old timestamp is the actual signal that something got stuck. Added `isPendingSyncStale` to encode that, plus matching coverage in both the per-workspace job and the outer hourly cron's workspace-selection query.

**Caveat:** I can't reproduce from static code alone *why* the fast cron missed the channel in the original report (that would need production cron/queue logs I don't have) — but this closes the actual structural gap that leaves a stuck channel with zero recovery path, which matches both reported symptoms.

## Testing

- `npx jest` — all new/modified specs pass (16 tests across `create-concurrency-limiter.util.spec.ts`, `is-pending-sync-stale.util.spec.ts`, `messaging-ongoing-stale.job.spec.ts`, `messaging-ongoing-stale.cron.job.spec.ts`)
- `npx oxfmt --check` — clean on all changed files
- Full `oxlint --type-aware` couldn't complete on my local machine (Windows virtual-memory allocator limit unrelated to this diff) — deferring to CI for that pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

