### PR TITLE
Give the mobile settings header its page title

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
@@ -92,8 +92,12 @@ export const PageCardHeader = ({
   const isMobile = useIsMobile();
   const isNavigationDrawerExpanded = useNavigationDrawerExpanded();
 
+  // Index and standalone headers drop their title on mobile so a pinned action
+  // can keep its label. Centered headers have no such action, and without the
+  // title their mobile bar says nothing at all.
   const hasTitleContent =
-    !isMobile && (isDefined(icon) || isDefined(title) || isDefined(tag));
+    (!isMobile || centerTitle) &&
+    (isDefined(icon) || isDefined(title) || isDefined(tag));
   const shouldCenterTitle = centerTitle && hasTitleContent;
 
   const titleContent = (
@@ -107,7 +111,7 @@ export const PageCardHeader = ({
   return (
     <StyledHeader centerTitle={shouldCenterTitle}>
       <StyledLeft>
-        {!isNavigationDrawerExpanded && (
+        {!isMobile && !isNavigationDrawerExpanded && (
           <NavigationDrawerCollapseButton direction="right" />
         )}
         {isDefined(breadcrumb)

--- a/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
@@ -92,9 +92,7 @@ export const PageCardHeader = ({
   const isMobile = useIsMobile();
   const isNavigationDrawerExpanded = useNavigationDrawerExpanded();
 
-  // Index and standalone headers drop their title on mobile so a pinned action
-  // can keep its label. Centered headers have no such action, and without the
-  // title their mobile bar says nothing at all.
+  // Uncentered headers drop the title on mobile to fit a labelled action.
   const hasTitleContent =
     (!isMobile || centerTitle) &&
     (isDefined(icon) || isDefined(title) || isDefined(tag));


### PR DESCRIPTION
## Problem

On mobile, a settings page header contained nothing but the navigation drawer toggle — no page title, so nothing told you which settings page you were on.

Two rules in `PageCardHeader` combined to produce it:

- `hasTitleContent = !isMobile && (...)` drops the title on mobile. That is deliberate for index and standalone headers: it is what frees the width for a pinned action to keep its label (#24156). Settings pages have no pinned action, so they got the cost without the benefit.
- The drawer toggle renders when the drawer is collapsed. `NavigationDrawerCollapseButton` already returns null on mobile *unless* it is the settings drawer, and `useIsSettingsDrawer()` is true on any settings page — so settings pages were the one place it still appeared.

## Change

`centerTitle` is passed by `SettingsPageLayout` and nothing else, so it already separates the two cases exactly. Centered headers keep their title on mobile; index and standalone headers still drop theirs.

The drawer toggle is gated on `!isMobile` in the page header. It is not removed from the drawer itself — `NavigationDrawer` renders its own collapse button via `NavigationDrawerHeader`, which is how the mobile settings drawer is dismissed.

## Screenshots

`/settings/experience` at 390px: the header now reads **Experience** and the toggle is gone.

## Notes

- Reaching another settings page on mobile is bottom bar → Home → Settings tab, which is the flow introduced in #24168. The workspace dropdown's Settings entry still opens the drawer as before.
- Verified at 390px that the title renders on settings pages and the record index header still shows a labelled **+ New Company**, and at 1280px that desktop settings is unchanged (breadcrumb left, centered title, full drawer).
- Verified with `oxlint --type-aware`, `oxfmt`, `nx typecheck twenty-front`, and the page/settings/command-menu jest suites (469 tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_01H4XJwMCrTgaN6e2NyLFrAK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

