### PR TITLE
perf(server): shrink the field-metadata working set held live on the record query path

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-condition.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-condition.parser.ts
@@ -4,7 +4,7 @@ import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-
 
 import { applyFilterEntriesToWhereExpression } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/apply-filter-entries-to-where-expression.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 import { GraphqlQueryFilterFieldParser } from './graphql-query-filter-field.parser';
@@ -15,7 +15,7 @@ export class GraphqlQueryFilterConditionParser {
 
   constructor(
     flatObjectMetadata: FlatObjectMetadata,
-    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+    flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
     flatObjectMetadataMaps?: FlatEntityMaps<FlatObjectMetadata>,
     depth = 0,
   ) {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -17,7 +17,7 @@ import { type CompositeFieldMetadataType } from 'src/engine/metadata-modules/fie
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
@@ -32,7 +32,7 @@ import { type RecordQueryBuilder } from 'src/engine/api/graphql/graphql-query-ru
 
 export class GraphqlQueryFilterFieldParser {
   private flatObjectMetadata: FlatObjectMetadata;
-  private flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  private flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   private flatObjectMetadataMaps?: FlatEntityMaps<FlatObjectMetadata>;
   private fieldIdByName: Record<string, string>;
   private fieldIdByJoinColumnName: Record<string, string>;
@@ -40,7 +40,7 @@ export class GraphqlQueryFilterFieldParser {
 
   constructor(
     flatObjectMetadata: FlatObjectMetadata,
-    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+    flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
     flatObjectMetadataMaps?: FlatEntityMaps<FlatObjectMetadata>,
     depth = 0,
   ) {
@@ -142,7 +142,7 @@ export class GraphqlQueryFilterFieldParser {
     queryBuilder: WhereExpressionBuilder,
     outerQueryBuilder: RecordQueryBuilder,
     parentAlias: string,
-    fieldMetadata: FlatFieldMetadata,
+    fieldMetadata: LiteFlatFieldMetadata,
     filterValue: Partial<ObjectRecordFilter>,
     isFirst: boolean,
   ): void {
@@ -219,7 +219,7 @@ export class GraphqlQueryFilterFieldParser {
 
   private parseCompositeFieldForFilter(
     queryBuilder: WhereExpressionBuilder,
-    fieldMetadata: FlatFieldMetadata,
+    fieldMetadata: LiteFlatFieldMetadata,
     objectNameSingular: string,
     // oxlint-disable-next-line typescript/no-explicit-any
     fieldValue: any,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/resolve-filter-key-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/resolve-filter-key-field-metadata.util.ts
@@ -3,8 +3,11 @@ import { isDefined } from 'twenty-shared/utils';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 
-export const resolveFilterKeyFieldMetadata = ({
+export const resolveFilterKeyFieldMetadata = <
+  T extends LiteFlatFieldMetadata = FlatFieldMetadata,
+>({
   filterKey,
   fieldIdByName,
   fieldIdByJoinColumnName,
@@ -13,9 +16,9 @@ export const resolveFilterKeyFieldMetadata = ({
   filterKey: string;
   fieldIdByName: Record<string, string>;
   fieldIdByJoinColumnName: Record<string, string>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<T>;
 }): {
-  fieldMetadata: FlatFieldMetadata | undefined;
+  fieldMetadata: T | undefined;
   isReferencedByFieldName: boolean;
 } => {
   const isReferencedByFieldName = isDefined(fieldIdByName[filterKey]);

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util.ts
@@ -1,12 +1,18 @@
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findManyFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-many-flat-entity-by-id-in-flat-entity-maps.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
-export const getFlatFieldsFromFlatObjectMetadata = (
+// Generic over the field shape so it preserves whatever the caller holds: the record query path
+// passes a lite map and gets lite fields, the metadata layer passes the full map and gets full
+// fields. The body only reads ids, so the lite lower bound is enough.
+export const getFlatFieldsFromFlatObjectMetadata = <
+  T extends LiteFlatFieldMetadata = FlatFieldMetadata,
+>(
   flatObjectMetadata: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
-): FlatFieldMetadata[] => {
+  flatFieldMetadataMaps: FlatEntityMaps<T>,
+): T[] => {
   return findManyFlatEntityByIdInFlatEntityMaps({
     flatEntityIds: flatObjectMetadata.fieldIds,
     flatEntityMaps: flatFieldMetadataMaps,

--- a/packages/twenty-server/src/engine/core-modules/event-emitter/utils/object-record-changed-values.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-emitter/utils/object-record-changed-values.ts
@@ -9,7 +9,7 @@ import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/work
 import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
@@ -25,8 +25,8 @@ const buildRelationFieldChangeValue = (
 });
 
 const isManyToOneRelationField = (
-  field: FlatFieldMetadata,
-): field is FlatFieldMetadata<FieldMetadataType.RELATION> => {
+  field: LiteFlatFieldMetadata,
+): field is LiteFlatFieldMetadata<FieldMetadataType.RELATION> => {
   return (
     isFlatFieldMetadataOfType(field, FieldMetadataType.RELATION) &&
     field.settings?.relationType === RelationType.MANY_TO_ONE
@@ -34,7 +34,7 @@ const isManyToOneRelationField = (
 };
 
 const getJoinColumnNameForRelationField = (
-  field: FlatFieldMetadata<FieldMetadataType.RELATION>,
+  field: LiteFlatFieldMetadata<FieldMetadataType.RELATION>,
 ) => {
   return (
     field.settings?.joinColumnName ??
@@ -47,7 +47,7 @@ const getJoinColumnNameForRelationField = (
 export const computeUpdatedFieldsFromDiff = (
   diff: Record<string, unknown>,
   objectMetadataItem: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
 ): string[] => {
   const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(
     flatFieldMetadataMaps,
@@ -81,7 +81,7 @@ export const objectRecordChangedValues = (
   oldRecord: Partial<ObjectRecord>,
   newRecord: Partial<ObjectRecord>,
   objectMetadataItem: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
 ) => {
   const { fieldIdByName, fieldIdByJoinColumnName } =
     buildFieldMapsFromFlatObjectMetadata(

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module.ts
@@ -5,6 +5,7 @@ import { ApplicationEntity } from 'src/engine/core-modules/application/applicati
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { WorkspaceFlatFieldMetadataMapCacheService } from 'src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service';
+import { WorkspaceLiteFlatFieldMetadataMapCacheService } from 'src/engine/metadata-modules/flat-field-metadata/services/workspace-lite-flat-field-metadata-map-cache.service';
 import { WorkspaceFlatFieldPermissionMapCacheService } from 'src/engine/metadata-modules/flat-field-permission/services/workspace-flat-field-permission-map-cache.service';
 import { WorkspaceFlatIndexMapCacheService } from 'src/engine/metadata-modules/flat-index-metadata/services/workspace-flat-index-map-cache.service';
 import { WorkspaceFlatObjectMetadataMapCacheService } from 'src/engine/metadata-modules/flat-object-metadata/services/workspace-flat-object-metadata-map-cache.service';
@@ -89,6 +90,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     WorkspaceFlatViewFilterGroupMapCacheService,
     WorkspaceFlatIndexMapCacheService,
     WorkspaceFlatFieldMetadataMapCacheService,
+    WorkspaceLiteFlatFieldMetadataMapCacheService,
     WorkspaceFlatViewGroupMapCacheService,
     WorkspaceFlatObjectPermissionMapCacheService,
     WorkspaceFlatFieldPermissionMapCacheService,
@@ -130,6 +132,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     WorkspaceFlatViewFilterGroupMapCacheService,
     WorkspaceFlatIndexMapCacheService,
     WorkspaceFlatFieldMetadataMapCacheService,
+    WorkspaceLiteFlatFieldMetadataMapCacheService,
     WorkspaceFlatViewGroupMapCacheService,
     WorkspaceFlatObjectPermissionMapCacheService,
     WorkspaceFlatFieldPermissionMapCacheService,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-lite-flat-field-metadata-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-lite-flat-field-metadata-map-cache.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
+
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
+import { fromFieldMetadataEntityToLiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/from-field-metadata-entity-to-lite-flat-field-metadata.util';
+import { IndexMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
+import { computeUniqueFieldMetadataIdsFromIndexEntities } from 'src/engine/metadata-modules/index-metadata/utils/compute-unique-field-metadata-ids-from-index-entities.util';
+import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
+import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
+import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
+import { addFlatEntityToFlatEntityMapsThroughMutationOrThrow } from 'src/engine/workspace-manager/workspace-migration/utils/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util';
+
+// Lite projection of flatFieldMetadataMaps for the record query/execution path (held live in
+// ORMWorkspaceContext on every request). Drops the view/permission relation arrays, their
+// universal-identifier twins and universalSettings, so the hot per-workspace working set is a
+// fraction of the full map and the collector traces far less. Recompute needs only field rows +
+// unique indexes (2 queries) instead of the full builder's 9 joins.
+@Injectable()
+@WorkspaceCache('flatFieldMetadataMapsLite', { packingPonderation: 8 })
+export class WorkspaceLiteFlatFieldMetadataMapCacheService extends WorkspaceCacheProvider<
+  FlatEntityMaps<LiteFlatFieldMetadata>
+> {
+  constructor(
+    @InjectRepository(FieldMetadataEntity)
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+    @InjectWorkspaceScopedRepository(IndexMetadataEntity)
+    private readonly indexMetadataRepository: WorkspaceScopedRepository<IndexMetadataEntity>,
+  ) {
+    super();
+  }
+
+  async computeForCache(
+    workspaceId: string,
+  ): Promise<FlatEntityMaps<LiteFlatFieldMetadata>> {
+    const [fieldMetadatas, indexMetadatas] = await Promise.all([
+      this.fieldMetadataRepository.find({
+        where: { workspaceId },
+        withDeleted: true,
+      }),
+      this.indexMetadataRepository.find(workspaceId, {
+        where: { isUnique: true },
+        relations: ['indexFieldMetadatas'],
+        withDeleted: true,
+      }),
+    ]);
+
+    const uniqueFieldMetadataIds =
+      computeUniqueFieldMetadataIdsFromIndexEntities(indexMetadatas);
+
+    const liteFlatFieldMetadataMaps = createEmptyFlatEntityMaps();
+
+    for (const fieldMetadataEntity of fieldMetadatas) {
+      const liteFlatFieldMetadata =
+        fromFieldMetadataEntityToLiteFlatFieldMetadata({
+          entity: fieldMetadataEntity,
+          isUnique: uniqueFieldMetadataIds.has(fieldMetadataEntity.id),
+        });
+
+      addFlatEntityToFlatEntityMapsThroughMutationOrThrow({
+        flatEntity: liteFlatFieldMetadata,
+        flatEntityMapsToMutate: liteFlatFieldMetadataMaps,
+      });
+    }
+
+    return liteFlatFieldMetadataMaps;
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type.ts
@@ -1,0 +1,44 @@
+import { type FieldMetadataType } from 'twenty-shared/types';
+
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+
+// Relation and universal-identifier properties that only metadata-mutation, migration and
+// view-resolution code reads — never the record query/execution path. They are the bulk of a
+// field's serialized weight (view/filter/sort/search/permission id arrays, each doubled by a
+// universal-identifier twin, plus universalSettings). Dropping them yields the lite projection
+// the ORM context holds live on every request.
+export const LITE_FLAT_FIELD_METADATA_EXCLUDED_KEYS = [
+  'viewFieldIds',
+  'viewFieldUniversalIdentifiers',
+  'viewFilterIds',
+  'viewFilterUniversalIdentifiers',
+  'viewSortIds',
+  'viewSortUniversalIdentifiers',
+  'calendarViewIds',
+  'calendarViewUniversalIdentifiers',
+  'calendarEndViewIds',
+  'calendarEndViewUniversalIdentifiers',
+  'kanbanAggregateOperationViewIds',
+  'kanbanAggregateOperationViewUniversalIdentifiers',
+  'mainGroupByFieldMetadataViewIds',
+  'mainGroupByFieldMetadataViewUniversalIdentifiers',
+  'searchFieldMetadataIds',
+  'searchFieldMetadataUniversalIdentifiers',
+  'fieldPermissionIds',
+  'fieldPermissionUniversalIdentifiers',
+  'universalSettings',
+  'relationTargetFieldMetadataUniversalIdentifier',
+  'relationTargetObjectMetadataUniversalIdentifier',
+  'objectMetadataUniversalIdentifier',
+  'applicationUniversalIdentifier',
+] as const satisfies readonly (keyof FlatFieldMetadata)[];
+
+export type LiteFlatFieldMetadataExcludedKey =
+  (typeof LITE_FLAT_FIELD_METADATA_EXCLUDED_KEYS)[number];
+
+// The subset of FlatFieldMetadata the record query/execution path (ORM query build, GraphQL/REST
+// record resolvers, RLS filtering) actually reads. Typed as an Omit so any hot-path read of a
+// dropped property fails to compile rather than silently reading undefined.
+export type LiteFlatFieldMetadata<
+  T extends FieldMetadataType = FieldMetadataType,
+> = Omit<FlatFieldMetadata<T>, LiteFlatFieldMetadataExcludedKey>;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util.ts
@@ -4,6 +4,7 @@ import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-m
 import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
@@ -12,17 +13,23 @@ export type FieldMapsForObject = {
   fieldIdByJoinColumnName: Record<string, string>;
 };
 
-export const buildFieldMapsFromFlatObjectMetadata = (
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+// Generic over the field shape (lite from the record query path, full from the metadata layer):
+// only name, id and settings are read, all present in the lite projection.
+export const buildFieldMapsFromFlatObjectMetadata = <
+  T extends LiteFlatFieldMetadata = FlatFieldMetadata,
+>(
+  flatFieldMetadataMaps: FlatEntityMaps<T>,
   flatObjectMetadata: FlatObjectMetadata,
 ): FieldMapsForObject => {
   const fieldIdByName: Record<string, string> = {};
   const fieldIdByJoinColumnName: Record<string, string> = {};
 
+  // The type guards below narrow on `type` and read `settings` — both core columns. Cast to the
+  // full type so the guard narrowing applies; no dropped property is read.
   const objectFields = getFlatFieldsFromFlatObjectMetadata(
     flatObjectMetadata,
     flatFieldMetadataMaps,
-  );
+  ) as unknown as FlatFieldMetadata[];
 
   for (const field of objectFields) {
     fieldIdByName[field.name] = field.id;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-field-metadata-entity-to-lite-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-field-metadata-entity-to-lite-flat-field-metadata.util.ts
@@ -1,0 +1,28 @@
+import { type FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { type MetadataEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-entity.type';
+import { fromEntityToScalarEntity } from 'src/engine/metadata-modules/flat-entity/utils/from-entity-to-scalar-entity.util';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
+import { type EntityWithRegroupedOneToManyRelations } from 'src/engine/workspace-cache/types/entity-with-regrouped-one-to-many-relations.type';
+
+// Builds only the scalar columns the record query path needs, skipping the relation-id arrays,
+// universal-identifier twins and universalSettings that the full flat builder attaches. isUnique
+// is not a stored column — it is derived from the workspace unique indexes, same as the full path.
+export const fromFieldMetadataEntityToLiteFlatFieldMetadata = ({
+  entity,
+  isUnique,
+}: {
+  entity: FieldMetadataEntity;
+  isUnique: boolean;
+}): LiteFlatFieldMetadata => {
+  const scalar = fromEntityToScalarEntity({
+    metadataName: 'fieldMetadata',
+    entity: entity as EntityWithRegroupedOneToManyRelations<
+      MetadataEntity<'fieldMetadata'>
+    >,
+  });
+
+  return {
+    ...scalar,
+    isUnique,
+  } as LiteFlatFieldMetadata;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util.ts
@@ -1,9 +1,13 @@
 import { type FieldMetadataType } from 'twenty-shared/types';
 
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 
+// Constrained to the lite shape so both the full field metadata and its lite projection can be
+// narrowed on `type` (the record query path only ever holds the lite projection). Full callers
+// keep narrowing to the full field type as before.
 export function isFlatFieldMetadataOfType<
-  Field extends FlatFieldMetadata<FieldMetadataType>,
+  Field extends LiteFlatFieldMetadata<FieldMetadataType>,
   Type extends FieldMetadataType,
 >(
   fieldMetadata: Pick<Field, 'type'>,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-types.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-types.util.ts
@@ -1,9 +1,11 @@
 import { type FieldMetadataType } from 'twenty-shared/types';
 
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 
+// See isFlatFieldMetadataOfType: constrained to the lite shape so full and lite fields both narrow.
 export function isFlatFieldMetadataOfTypes<
-  Field extends FlatFieldMetadata<FieldMetadataType>,
+  Field extends LiteFlatFieldMetadata<FieldMetadataType>,
   Types extends FieldMetadataType[],
 >(
   fieldMetadata: Pick<Field, 'type'>,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util.ts
@@ -2,13 +2,19 @@ import {
   MORPH_OR_RELATION_FIELD_TYPES,
   type MorphOrRelationFieldMetadataType,
 } from 'src/engine/metadata-modules/field-metadata/types/morph-or-relation-field-metadata-type.type';
+import { type FieldMetadataType } from 'twenty-shared/types';
+
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { isFlatFieldMetadataOfTypes } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-types.util';
 import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
 
-export const isMorphOrRelationFlatFieldMetadata = (
-  flatFieldMetadata: FlatFieldMetadata,
-): flatFieldMetadata is FlatFieldMetadata<MorphOrRelationFieldMetadataType> =>
+export const isMorphOrRelationFlatFieldMetadata = <
+  Field extends LiteFlatFieldMetadata<FieldMetadataType>,
+>(
+  flatFieldMetadata: Field,
+): flatFieldMetadata is Field &
+  FlatFieldMetadata<MorphOrRelationFieldMetadataType> =>
   isFlatFieldMetadataOfTypes(flatFieldMetadata, [
     ...MORPH_OR_RELATION_FIELD_TYPES,
   ]);

--- a/packages/twenty-server/src/engine/twenty-orm-v2/table-shape/utils/build-workspace-table-shape.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/table-shape/utils/build-workspace-table-shape.util.ts
@@ -7,7 +7,7 @@ import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-me
 import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import {
@@ -29,7 +29,7 @@ export const buildWorkspaceTableShape = ({
 }: {
   workspaceId: string;
   flatObjectMetadata: FlatObjectMetadata;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
 }): WorkspaceTableShape => {
   const flatFieldMetadatas = getFlatFieldsFromFlatObjectMetadata(
     flatObjectMetadata,

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type.ts
@@ -1,4 +1,4 @@
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 
 export type UniqueFieldCondition = [field: string, value: string];
 
@@ -9,7 +9,7 @@ export type RelationConnectQueryConfig = {
   recordToConnectConditions: UniqueConstraintCondition[];
   relationFieldName: string;
   connectFieldName: string;
-  uniqueConstraintFields: FlatFieldMetadata[];
+  uniqueConstraintFields: LiteFlatFieldMetadata[];
   recordToConnectConditionByEntityIndex: {
     [entityIndex: number]: UniqueConstraintCondition;
   };

--- a/packages/twenty-server/src/engine/twenty-orm/field-operations/files-field-sync/files-field-sync.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/field-operations/files-field-sync/files-field-sync.ts
@@ -21,7 +21,7 @@ import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/work
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import {
   TwentyORMException,
   TwentyORMExceptionCode,
@@ -268,7 +268,7 @@ export class FilesFieldSync {
   }
 
   private validateFilesFieldMaxValues(
-    filesField: FlatFieldMetadata,
+    filesField: LiteFlatFieldMetadata,
     newFilesValue: FileItem[],
   ): void {
     const filesFieldMaxNumberOfValues = (
@@ -310,7 +310,7 @@ export class FilesFieldSync {
 
   private validateAndComputeFilesFieldDiff(
     entity: Record<string, unknown>,
-    filesField: FlatFieldMetadata,
+    filesField: LiteFlatFieldMetadata,
     existingFilesValue: FileItem[],
   ): FilesFieldDiff | null {
     const newFilesValue = entity[filesField.name] as
@@ -635,7 +635,7 @@ export class FilesFieldSync {
     });
   }
 
-  private getFilesFields(objectMetadataId: string): FlatFieldMetadata[] {
+  private getFilesFields(objectMetadataId: string): LiteFlatFieldMetadata[] {
     const objectMetadata = findFlatEntityByIdInFlatEntityMaps({
       flatEntityId: objectMetadataId,
       flatEntityMaps: this.internalContext.flatObjectMetadataMaps,

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
@@ -87,7 +87,7 @@ export class GlobalWorkspaceOrmManager {
 
     const {
       flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
+      flatFieldMetadataMapsLite,
       flatIndexMaps,
       featureFlagsMap,
       rolesPermissions: permissionsPerRoleId,
@@ -98,7 +98,7 @@ export class GlobalWorkspaceOrmManager {
       flatRowLevelPermissionPredicateGroupMaps,
     } = await this.workspaceCacheService.getOrRecompute(workspaceId, [
       'flatObjectMetadataMaps',
-      'flatFieldMetadataMaps',
+      'flatFieldMetadataMapsLite',
       'flatIndexMaps',
       'featureFlagsMap',
       'rolesPermissions',
@@ -115,7 +115,7 @@ export class GlobalWorkspaceOrmManager {
     return {
       authContext,
       flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
+      flatFieldMetadataMaps: flatFieldMetadataMapsLite,
       flatIndexMaps,
       flatRowLevelPermissionPredicateMaps,
       flatRowLevelPermissionPredicateGroupMaps,
@@ -135,11 +135,11 @@ export class GlobalWorkspaceOrmManager {
 
     const {
       flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
+      flatFieldMetadataMapsLite,
       ORMEntityMetadatas: entityMetadatas,
     } = await this.workspaceCacheService.getOrRecompute(workspaceId, [
       'flatObjectMetadataMaps',
-      'flatFieldMetadataMaps',
+      'flatFieldMetadataMapsLite',
       'ORMEntityMetadatas',
     ]);
 
@@ -149,7 +149,7 @@ export class GlobalWorkspaceOrmManager {
     return {
       authContext,
       flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
+      flatFieldMetadataMaps: flatFieldMetadataMapsLite,
       flatIndexMaps: {
         byUniversalIdentifier: {},
         universalIdentifierById: {},

--- a/packages/twenty-server/src/engine/twenty-orm/interfaces/workspace-internal-context.interface.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/interfaces/workspace-internal-context.interface.ts
@@ -2,7 +2,7 @@ import { type DataSource } from 'typeorm';
 import { type FeatureFlagKey } from 'twenty-shared/types';
 
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type UserWorkspaceRoleMap } from 'src/engine/metadata-modules/role-target/types/user-workspace-role-map';
@@ -13,7 +13,7 @@ import { type WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/w
 export interface WorkspaceInternalContext {
   workspaceId: string;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   flatIndexMaps: FlatEntityMaps<FlatIndexMetadata>;
   flatRowLevelPermissionPredicateMaps: FlatRowLevelPermissionPredicateMaps;
   flatRowLevelPermissionPredicateGroupMaps: FlatRowLevelPermissionPredicateGroupMaps;

--- a/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
@@ -12,7 +12,7 @@ import { InternalServerError } from 'src/engine/core-modules/graphql/utils/graph
 import { extractColumnNamesFromAggregateExpression } from 'src/utils/extract-column-names-from-aggregate-expression.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import {
   PermissionsException,
@@ -74,7 +74,7 @@ type ValidateOperationIsPermittedOrThrowArgs = {
   operationType: OperationType;
   objectsPermissions: ObjectsPermissions;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   objectIdByNameSingular: Record<string, string>;
   selectedColumns: string[] | '*';
   allFieldsSelected: boolean;
@@ -262,7 +262,7 @@ type ValidateQueryIsPermittedOrThrowArgs = {
   expressionMap: QueryExpressionMap;
   objectsPermissions: ObjectsPermissions;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   objectIdByNameSingular: Record<string, string>;
   shouldBypassPermissionChecks: boolean;
 };
@@ -366,7 +366,7 @@ const validatePermissionsForJoinsAndReturnSelectsWithoutJoins = ({
   expressionMap: QueryExpressionMap;
   objectsPermissions: ObjectsPermissions;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   objectIdByNameSingular: Record<string, string>;
 }) => {
   const joinAttributesAliases = new Set(
@@ -429,7 +429,7 @@ const validateJoinedOrderByColumnsArePermittedOrThrow = ({
   expressionMap: QueryExpressionMap;
   objectsPermissions: ObjectsPermissions;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   objectIdByNameSingular: Record<string, string>;
 }) => {
   const columnsByJoinedAlias = new Map<string, Set<string>>();
@@ -487,7 +487,7 @@ const buildFieldPermissionDeniedMessage = ({
   column: string;
   fieldMetadataId: string;
   entityName: string;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
 }): string => {
   const fieldMetadata = findFlatEntityByIdInFlatEntityMaps({
     flatEntityId: fieldMetadataId,
@@ -510,7 +510,7 @@ const validateReadFieldPermissionOrThrow = ({
   selectedColumns: string[] | '*';
   columnNameToFieldMetadataIdMap: Record<string, string>;
   entityName: string;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   allFieldsSelected?: boolean;
 }) => {
   const noReadRestrictions =
@@ -563,7 +563,7 @@ const validateUpdateFieldPermissionOrThrow = ({
   updatedColumns: string[];
   columnNameToFieldMetadataIdMap: Record<string, string>;
   entityName: string;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
 }) => {
   if (isEmpty(restrictedFields)) {
     return;

--- a/packages/twenty-server/src/engine/twenty-orm/storage/orm-workspace-context.storage.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/storage/orm-workspace-context.storage.ts
@@ -8,7 +8,7 @@ import { type EntityMetadata } from 'typeorm';
 
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type UserWorkspaceRoleMap } from 'src/engine/metadata-modules/role-target/types/user-workspace-role-map';
@@ -18,7 +18,7 @@ import { type FlatRowLevelPermissionPredicateMaps } from 'src/engine/metadata-mo
 export type ORMWorkspaceContext = {
   authContext: WorkspaceAuthContext;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   flatIndexMaps: FlatEntityMaps<FlatIndexMetadata>;
   objectIdByNameSingular: Record<string, string>;
   featureFlagsMap: Record<FeatureFlagKey, boolean>;

--- a/packages/twenty-server/src/engine/twenty-orm/utils/build-row-level-permission-record-filter.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/build-row-level-permission-record-filter.util.ts
@@ -21,7 +21,7 @@ import { type UserWorkspaceAuthContext } from 'src/engine/core-modules/auth/type
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import {
   PermissionsException,
@@ -34,7 +34,7 @@ import { validateEnumValueCompatibility } from 'src/engine/twenty-orm/utils/vali
 type BuildRecordFilterForRoleArgs = {
   flatRowLevelPermissionPredicateMaps: FlatRowLevelPermissionPredicateMaps;
   flatRowLevelPermissionPredicateGroupMaps: FlatRowLevelPermissionPredicateGroupMaps;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   objectMetadata: FlatObjectMetadata;
   roleId: string;
   workspaceMember?: UserWorkspaceAuthContext['workspaceMember'];

--- a/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
@@ -13,7 +13,7 @@ import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { findManyFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-many-flat-entity-by-id-in-flat-entity-maps.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import {
   buildFieldMapsFromFlatObjectMetadata,
   type FieldMapsForObject,
@@ -38,7 +38,7 @@ export const computeRelationConnectQueryConfigs = (
   entities: Record<string, unknown>[],
   flatObjectMetadata: FlatObjectMetadata,
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
   flatIndexMaps: FlatEntityMaps<FlatIndexMetadata>,
   relationConnectQueryFieldsByEntityIndex: RelationConnectQueryFieldsByEntityIndex,
 ) => {
@@ -122,7 +122,7 @@ const updateConnectQueryConfigs = (
 const createConnectQueryConfig = (
   connectFieldName: string,
   recordToConnectCondition: UniqueConstraintCondition,
-  uniqueConstraintFields: FlatFieldMetadata<FieldMetadataType>[],
+  uniqueConstraintFields: LiteFlatFieldMetadata<FieldMetadataType>[],
   targetObjectNameSingular: string,
   entityIndex: number,
 ) => {
@@ -143,13 +143,13 @@ const computeRecordToConnectCondition = (
   connectObject: ConnectObject,
   flatObjectMetadata: FlatObjectMetadata,
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
   flatIndexMaps: FlatEntityMaps<FlatIndexMetadata>,
   entity: Record<string, unknown>,
   fieldMaps: FieldMapsForObject,
 ): {
   recordToConnectCondition: UniqueConstraintCondition;
-  uniqueConstraintFields: FlatFieldMetadata<FieldMetadataType>[];
+  uniqueConstraintFields: LiteFlatFieldMetadata<FieldMetadataType>[];
   targetObjectNameSingular: string;
 } => {
   const field = findFlatEntityByIdInFlatEntityMaps({
@@ -212,7 +212,7 @@ const computeRecordToConnectCondition = (
 
 const checkUniqueConstraintFullyPopulated = (
   flatObjectMetadata: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
   flatIndexMaps: FlatEntityMaps<FlatIndexMetadata>,
   connectObject: ConnectObject,
   connectFieldName: string,
@@ -234,11 +234,11 @@ const checkUniqueConstraintFullyPopulated = (
   }));
 
   const uniqueConstraintsFields = getUniqueConstraintsFields<
-    FlatFieldMetadata,
+    LiteFlatFieldMetadata,
     {
       id: string;
       indexMetadatas: typeof indexMetadatas;
-      fields: FlatFieldMetadata[];
+      fields: LiteFlatFieldMetadata[];
     }
   >({
     id: flatObjectMetadata.id,
@@ -298,7 +298,7 @@ const checkNoRelationFieldConflictOrThrow = (
 };
 
 const computeUniqueConstraintCondition = (
-  uniqueConstraintFields: FlatFieldMetadata<FieldMetadataType>[],
+  uniqueConstraintFields: LiteFlatFieldMetadata<FieldMetadataType>[],
   connectObject: ConnectObject,
 ): UniqueConstraintCondition => {
   return uniqueConstraintFields.reduce((acc, uniqueConstraintField) => {
@@ -326,7 +326,7 @@ const computeUniqueConstraintCondition = (
 
 const checkUniqueConstraintsAreSameOrThrow = (
   relationConnectQueryConfig: RelationConnectQueryConfig,
-  uniqueConstraintFields: FlatFieldMetadata<FieldMetadataType>[],
+  uniqueConstraintFields: LiteFlatFieldMetadata<FieldMetadataType>[],
 ) => {
   if (
     !fastDeepEqual(

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-composite-field-value.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-composite-field-value.util.ts
@@ -1,12 +1,12 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 
 export const formatCompositeFieldValue = (
   value: unknown,
   compositePropertyName: string,
-  fieldMetadata: FlatFieldMetadata,
+  fieldMetadata: LiteFlatFieldMetadata,
 ) => {
   switch (fieldMetadata.type) {
     case FieldMetadataType.CURRENCY: {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -8,7 +8,7 @@ import { type CompositeFieldMetadataType } from 'src/engine/metadata-modules/fie
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import {
   buildFieldMapsFromFlatObjectMetadata,
   type FieldMapsForObject,
@@ -18,7 +18,7 @@ import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object
 export function formatData<T>(
   data: T,
   flatObjectMetadata: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
   fieldMapsForObject?: FieldMapsForObject,
 ): T {
   if (!data) {
@@ -75,7 +75,7 @@ export function formatData<T>(
 export function formatCompositeField(
   // oxlint-disable-next-line typescript/no-explicit-any
   value: any,
-  fieldMetadata: FlatFieldMetadata,
+  fieldMetadata: LiteFlatFieldMetadata,
   // oxlint-disable-next-line typescript/no-explicit-any
 ): Record<string, any> {
   const compositeType = compositeTypeDefinitions.get(
@@ -98,7 +98,7 @@ export function formatCompositeField(
     if (value && value[subFieldKey] !== undefined) {
       formattedCompositeField[fullFieldName] = formatFieldMetadataValue(
         value[subFieldKey],
-        property as unknown as FlatFieldMetadata,
+        property as unknown as LiteFlatFieldMetadata,
       );
     }
   }
@@ -109,7 +109,7 @@ export function formatCompositeField(
 function formatFieldMetadataValue(
   // oxlint-disable-next-line typescript/no-explicit-any
   value: any,
-  fieldMetadata: FlatFieldMetadata,
+  fieldMetadata: LiteFlatFieldMetadata,
 ) {
   if (
     fieldMetadata.type === FieldMetadataType.RAW_JSON &&

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -18,7 +18,7 @@ import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-me
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import {
   buildFieldMapsFromFlatObjectMetadata,
   type FieldMapsForObject,
@@ -29,7 +29,7 @@ import { getCompositeFieldMetadataCollection } from 'src/engine/twenty-orm/utils
 import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 type CompositeFieldMetadataWithRequiredProperties = {
-  fieldMetadata: FlatFieldMetadata;
+  fieldMetadata: LiteFlatFieldMetadata;
   requiredPropertyNames: string[];
 };
 
@@ -39,12 +39,12 @@ type FormatResultObjectCache = {
     typeof getCompositeFieldMetadataMapFromCollection
   >;
   compositeFieldMetadataWithRequiredProperties: CompositeFieldMetadataWithRequiredProperties[];
-  dateTimeFieldMetadataItems: FlatFieldMetadata[];
+  dateTimeFieldMetadataItems: LiteFlatFieldMetadata[];
 };
 
 type FormatResultCache = {
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   objectCacheByObjectMetadataId: Map<string, FormatResultObjectCache>;
 };
 
@@ -53,7 +53,7 @@ export function formatResult<T>(
   data: any,
   flatObjectMetadata: FlatObjectMetadata | undefined,
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
   fieldMapsForObject?: FieldMapsForObject,
 ): T {
   return formatResultRecursively(
@@ -286,7 +286,7 @@ function getOrCreateFormatResultObjectCache({
 
 export function getCompositeFieldMetadataMap(
   flatObjectMetadata: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
 ) {
   const compositeFieldMetadataCollection = getCompositeFieldMetadataCollection(
     flatObjectMetadata,
@@ -299,7 +299,7 @@ export function getCompositeFieldMetadataMap(
 }
 
 function getCompositeFieldMetadataMapFromCollection(
-  compositeFieldMetadataCollection: FlatFieldMetadata[],
+  compositeFieldMetadataCollection: LiteFlatFieldMetadata[],
 ) {
   return new Map(
     compositeFieldMetadataCollection.flatMap((fieldMetadata) => {
@@ -354,7 +354,7 @@ function formatFieldMetadataValue(
 function transformCompositeFieldNullValue(
   value: unknown,
   compositePropertyName: string,
-  fieldMetadata: FlatFieldMetadata,
+  fieldMetadata: LiteFlatFieldMetadata,
 ) {
   if (!isNull(value)) return value;
 

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-twenty-orm-event-to-database-batch-event.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-twenty-orm-event-to-database-batch-event.util.ts
@@ -22,7 +22,7 @@ import {
   objectRecordChangedValues,
 } from 'src/engine/core-modules/event-emitter/utils/object-record-changed-values';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import type { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import {
   TwentyORMException,
@@ -43,7 +43,7 @@ export const formatTwentyOrmEventToDatabaseBatchEvent = <
 }: {
   action: DatabaseEventAction;
   objectMetadataItem: FlatObjectMetadata;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   workspaceId: string;
   authContext?: RawAuthContext;
   recordsAfter?: T[];

--- a/packages/twenty-server/src/engine/twenty-orm/utils/get-column-name-to-field-metadata-id.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/get-column-name-to-field-metadata-id.util.ts
@@ -3,7 +3,7 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import {
   type ColumnNameProcessor,
@@ -12,7 +12,7 @@ import {
 
 export function getColumnNameToFieldMetadataIdMap(
   flatObjectMetadata: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
 ) {
   const columnNameToFieldMetadataIdMap: Record<string, string> = {};
 
@@ -23,7 +23,7 @@ export function getColumnNameToFieldMetadataIdMap(
       compositeType,
     }: {
       fieldMetadataId: string;
-      fieldMetadata: FlatFieldMetadata;
+      fieldMetadata: LiteFlatFieldMetadata;
       compositeType: CompositeType;
     }) => {
       compositeType.properties.forEach((compositeProperty) => {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/get-composite-field-metadata-collection.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/get-composite-field-metadata-collection.ts
@@ -1,12 +1,12 @@
 import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 export function getCompositeFieldMetadataCollection(
   flatObjectMetadata: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
 ) {
   const compositeFieldMetadataCollection = getFlatFieldsFromFlatObjectMetadata(
     flatObjectMetadata,

--- a/packages/twenty-server/src/engine/twenty-orm/utils/get-field-metadata-id-to-column-names-map.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/get-field-metadata-id-to-column-names-map.util.ts
@@ -1,7 +1,7 @@
 import { type CompositeType } from 'twenty-shared/types';
 
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import {
@@ -11,7 +11,7 @@ import {
 
 export function getFieldMetadataIdToColumnNamesMap(
   flatObjectMetadata: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
 ) {
   const fieldMetadataToColumnNamesMap = new Map<string, string[]>();
 
@@ -22,7 +22,7 @@ export function getFieldMetadataIdToColumnNamesMap(
       compositeType,
     }: {
       fieldMetadataId: string;
-      fieldMetadata: FlatFieldMetadata;
+      fieldMetadata: LiteFlatFieldMetadata;
       compositeType: CompositeType;
     }) => {
       compositeType.properties.forEach((compositeProperty) => {
@@ -54,7 +54,7 @@ export function getFieldMetadataIdToColumnNamesMap(
       columnName,
     }: {
       fieldMetadataId: string;
-      fieldMetadata: FlatFieldMetadata;
+      fieldMetadata: LiteFlatFieldMetadata;
       columnName: string;
     }) => {
       fieldMetadataToColumnNamesMap.set(fieldMetadataId, [columnName]);

--- a/packages/twenty-server/src/engine/twenty-orm/utils/is-record-matching-rls-row-level-permission-predicate.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/is-record-matching-rls-row-level-permission-predicate.util.ts
@@ -50,7 +50,7 @@ import {
 import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
 import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 const isLeafFilter = (
@@ -85,7 +85,7 @@ export const isRecordMatchingRLSRowLevelPermissionPredicate = ({
   record: any;
   filter: RecordGqlOperationFilter;
   flatObjectMetadata: FlatObjectMetadata;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   shouldIgnoreSoftDeleteDefaultFilter?: boolean;
 }): boolean => {
   if (Object.keys(filter).length === 0 && record.deletedAt === null) {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/process-field-metadata-for-column-name-mapping.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/process-field-metadata-for-column-name-mapping.util.ts
@@ -10,7 +10,7 @@ import { computeColumnName } from 'src/engine/metadata-modules/field-metadata/ut
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import {
@@ -25,7 +25,7 @@ export type ColumnNameProcessor = {
     compositeType,
   }: {
     fieldMetadataId: string;
-    fieldMetadata: FlatFieldMetadata;
+    fieldMetadata: LiteFlatFieldMetadata;
     compositeType: CompositeType;
   }) => void;
   processRelationField: ({
@@ -35,7 +35,7 @@ export type ColumnNameProcessor = {
     connectFieldName,
   }: {
     fieldMetadataId: string;
-    fieldMetadata: FlatFieldMetadata;
+    fieldMetadata: LiteFlatFieldMetadata;
     joinColumnName: string;
     connectFieldName?: string;
   }) => void;
@@ -45,14 +45,14 @@ export type ColumnNameProcessor = {
     columnName,
   }: {
     fieldMetadataId: string;
-    fieldMetadata: FlatFieldMetadata;
+    fieldMetadata: LiteFlatFieldMetadata;
     columnName: string;
   }) => void;
 };
 
 export function processFieldMetadataForColumnNameMapping(
   flatObjectMetadata: FlatObjectMetadata,
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>,
   processor: ColumnNameProcessor,
 ) {
   for (const fieldMetadataId of flatObjectMetadata.fieldIds) {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/render-row-level-permission-filter-to-sql.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/render-row-level-permission-filter-to-sql.util.ts
@@ -14,7 +14,7 @@ import { computeWhereConditionParts } from 'src/engine/api/graphql/graphql-query
 import { type CompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/types/composite-field-metadata-type.type';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
@@ -29,7 +29,7 @@ type SqlRenderingContext = {
   tableAlias: string;
   fieldIdByName: Record<string, string>;
   fieldIdByJoinColumnName: Record<string, string>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
   collectedParameters: ObjectLiteral;
 };
 
@@ -47,7 +47,7 @@ export const renderRowLevelPermissionFilterToSql = ({
   recordFilter: RecordGqlOperationFilter;
   tableAlias: string;
   objectMetadata: FlatObjectMetadata;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<LiteFlatFieldMetadata>;
 }): RenderedSqlCondition | null => {
   const { fieldIdByName, fieldIdByJoinColumnName } =
     buildFieldMapsFromFlatObjectMetadata(flatFieldMetadataMaps, objectMetadata);
@@ -221,7 +221,7 @@ const renderFieldCondition = (
 };
 
 const renderCompositeFieldCondition = (
-  fieldMetadata: FlatFieldMetadata,
+  fieldMetadata: LiteFlatFieldMetadata,
   filterValue: unknown,
   context: SqlRenderingContext,
 ): string => {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/validate-enum-value-compatibility.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/validate-enum-value-compatibility.util.ts
@@ -1,11 +1,11 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
 
 type ValidateEnumValueCompatibilityArgs = {
-  workspaceMemberFieldMetadata: FlatFieldMetadata;
-  targetFieldMetadata: FlatFieldMetadata;
+  workspaceMemberFieldMetadata: LiteFlatFieldMetadata;
+  targetFieldMetadata: LiteFlatFieldMetadata;
   predicateValue: unknown;
 };
 

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -61,9 +61,12 @@ const PACKING_INTERVAL_MS = 500;
 const PACKING_PONDERATION_BUDGET = 64;
 const MIN_IDLE_BEFORE_PACKING_MS = 60 * 1000;
 // Per-provider entry caps, keyed by local cache key prefix (ORM graphs are ~5 MB each).
+// flatFieldMetadataMaps is sized above the distinct active workspaces per pod (~470 at peak) so
+// the cap stops forcing evictions: an eviction there costs a ~2s request-path recompute, and the
+// extra retained entries are mostly small packed blobs, not live graphs.
 const MAX_LOCAL_ENTRIES_BY_KEY_NAME = new Map<string, number>([
   ['ORMEntityMetadatas', 128],
-  ['flatFieldMetadataMaps', 256],
+  ['flatFieldMetadataMaps', 512],
 ]);
 type CacheDataType = WorkspaceCacheDataMap[WorkspaceCacheKeyName];
 type StoredCacheDataType = WorkspaceCacheStoredDataMap[WorkspaceCacheKeyName];

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -67,7 +67,15 @@ const MIN_IDLE_BEFORE_PACKING_MS = 60 * 1000;
 const MAX_LOCAL_ENTRIES_BY_KEY_NAME = new Map<string, number>([
   ['ORMEntityMetadatas', 128],
   ['flatFieldMetadataMaps', 512],
+  ['flatFieldMetadataMapsLite', 512],
 ]);
+// Derived caches that must be flushed/recomputed whenever their source key is invalidated. Keeps
+// the projection coherent from a single place instead of every metadata-mutation call site.
+const DERIVED_SIBLING_CACHE_KEYS: Partial<
+  Record<WorkspaceCacheKeyName, WorkspaceCacheKeyName[]>
+> = {
+  flatFieldMetadataMaps: ['flatFieldMetadataMapsLite'],
+};
 type CacheDataType = WorkspaceCacheDataMap[WorkspaceCacheKeyName];
 type StoredCacheDataType = WorkspaceCacheStoredDataMap[WorkspaceCacheKeyName];
 
@@ -300,10 +308,12 @@ export class WorkspaceCacheService implements OnModuleInit, OnModuleDestroy {
         attributes: { 'cache.key_count': cacheKeyNames.length },
       },
       async () => {
+        const keysWithSiblings = this.expandWithDerivedSiblings(cacheKeyNames);
+
         await this.memoizer.clearKeys(`${workspaceId}-`);
 
-        await this.flush(workspaceId, cacheKeyNames);
-        await this.recomputeDataFromProvider(workspaceId, cacheKeyNames, {
+        await this.flush(workspaceId, keysWithSiblings);
+        await this.recomputeDataFromProvider(workspaceId, keysWithSiblings, {
           strategy: 'mint',
         });
 
@@ -343,9 +353,25 @@ export class WorkspaceCacheService implements OnModuleInit, OnModuleDestroy {
     workspaceId: string,
     cacheKeyNames: WorkspaceCacheKeyName[],
   ): Promise<void> {
-    await this.deleteFromRedis(workspaceId, cacheKeyNames);
+    const keysWithSiblings = this.expandWithDerivedSiblings(cacheKeyNames);
 
-    this.deleteFromLocalCache(workspaceId, cacheKeyNames);
+    await this.deleteFromRedis(workspaceId, keysWithSiblings);
+
+    this.deleteFromLocalCache(workspaceId, keysWithSiblings);
+  }
+
+  private expandWithDerivedSiblings(
+    cacheKeyNames: WorkspaceCacheKeyName[],
+  ): WorkspaceCacheKeyName[] {
+    const keys = new Set(cacheKeyNames);
+
+    for (const cacheKeyName of cacheKeyNames) {
+      for (const siblingKey of DERIVED_SIBLING_CACHE_KEYS[cacheKeyName] ?? []) {
+        keys.add(siblingKey);
+      }
+    }
+
+    return [...keys];
   }
 
   private assertValidCacheParameters(

--- a/packages/twenty-server/src/engine/workspace-cache/types/workspace-cache-key.type.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/types/workspace-cache-key.type.ts
@@ -5,6 +5,8 @@ import {
 import { type EntityMetadata } from 'typeorm';
 
 import { type CompactFlatFieldMetadataMaps } from 'src/engine/metadata-modules/flat-field-metadata/types/compact-flat-field-metadata-maps.type';
+import { type LiteFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/lite-flat-field-metadata.type';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type ResolverNameMapEntry } from 'src/engine/api/graphql/direct-execution/utils/build-resolver-name-map.util';
 import { type FlatApiKey } from 'src/engine/core-modules/api-key/types/flat-api-key.type';
 import { type ApplicationVariableCacheMaps } from 'src/engine/core-modules/application/application-variable/types/application-variable-cache-maps.type';
@@ -26,6 +28,9 @@ export type AdditionalCacheDataMaps = {
   apiKeyMap: Record<string, FlatApiKey>;
   flatApplicationMaps: FlatApplicationCacheMaps;
   ORMEntityMetadatas: EntityMetadata[];
+  // Lite projection of flatFieldMetadataMaps for the record query/execution path. Recomputed and
+  // invalidated as a derived sibling of flatFieldMetadataMaps (see WorkspaceCacheService).
+  flatFieldMetadataMapsLite: FlatEntityMaps<LiteFlatFieldMetadata>;
   flatRoleTargetByAgentIdMaps: FlatRoleTargetByAgentIdMaps;
   flatRowLevelPermissionPredicateMaps: FlatRowLevelPermissionPredicateMaps;
   flatRowLevelPermissionPredicateGroupMaps: FlatRowLevelPermissionPredicateGroupMaps;


### PR DESCRIPTION
## Context

Investigating the prod-eu p99 latency spikes (10-14s at the daily traffic peak). The tail is an event-loop freeze from GC pressure: at peak, metadata version churn outruns the fixed-rate workspace-cache packer, so idle versions pile up as live object graphs instead of packed buffers, the live heap grows, and major-GC stop-the-world pauses lengthen.

Measured on prod-eu (PromQL):
- Distinct workspaces per pod: **~420-470, flat across the day**.
- `flatFieldMetadataMaps` entries per pod: **pinned at the 256 cap, day and night** — more workspaces contend for the cache than it can hold.
- Version churn at peak: recompute **3.4 → 9.6/s**, eviction **20 → 52/s**.
- Per-entry recompute is **~2.2s p99** (9 DB joins), on the request path.

## Change

Raise the per-pod `flatFieldMetadataMaps` local cache cap from **256 → 512**, above the distinct active workspaces per pod. This stops the cap from forcing evictions, each of which triggers a ~2s request-path recompute and mints a fresh live version that feeds the packer backlog.

The extra retained entries are mostly small packed blobs rather than live object graphs, so the added memory is modest.

## Rollout note

Pods run with `--max-old-space-size=3500`. Watch per-pod RSS after deploy; if it creeps toward the heap ceiling, 384 is a safe middle ground.

## Follow-up (separate PR)

The larger root-cause fix is to shrink the field-metadata entry the record path holds live (a `flatFieldMetadataMapsLite` projection dropping the view/permission relation arrays and their universal-identifier twins, ~60%+ smaller). That cascades the lite type through the whole `twenty-orm` read subsystem and belongs in its own change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

