### PR TITLE
feat(server): route module workspace repositories through ORM v2 and drop the EntityMetadata build (Stage B + C)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
@@ -234,7 +234,7 @@ export class WorkflowVersionCoreSyncService {
         );
 
       const dataSource =
-        await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+        await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
       const queryRunner = dataSource.createQueryRunner();
 
       await queryRunner.connect();

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
@@ -227,7 +227,7 @@ export class WorkflowVersionCoreSyncService {
   ): Promise<void> {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
           workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
@@ -301,7 +301,7 @@ export class WorkflowVersionCoreSyncService {
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowVersionRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+            await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
               workspaceId,
               'workflowVersion',
               { shouldBypassPermissionChecks: true },
@@ -328,7 +328,7 @@ export class WorkflowVersionCoreSyncService {
   ): Promise<void> {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
           workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
@@ -360,7 +360,7 @@ export class WorkflowVersionCoreSyncService {
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceWorkflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
           workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
@@ -384,7 +384,7 @@ export class WorkflowVersionCoreSyncService {
     entityManager: WorkspaceEntityManager,
   ): Promise<void> {
     const workspaceWorkflowVersionRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+      await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
         workspaceId,
         'workflowVersion',
         { shouldBypassPermissionChecks: true },

--- a/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
@@ -69,22 +69,28 @@ export class WorkspaceDataSourceV2 {
   async transaction<T>(
     work: (transactionScope: WorkspaceTransactionScopeV2) => Promise<T>,
   ): Promise<T> {
-    const client = await this.pool.connect();
-
-    try {
-      await client.query('BEGIN');
-
-      const executor = new ClientQueryExecutor({ client });
-      const transactionScope: WorkspaceTransactionScopeV2 = {
+    return this.runInClientTransaction((executor) =>
+      work({
         getRepository: (nameSingular, rolePermissionConfig) =>
           this.buildRepository({
             nameSingular,
             rolePermissionConfig,
             executor,
+            isTransactional: true,
           }),
-      };
+      }),
+    );
+  }
 
-      const result = await work(transactionScope);
+  private async runInClientTransaction<T>(
+    work: (executor: QueryExecutorV2) => Promise<T>,
+  ): Promise<T> {
+    const client = await this.pool.connect();
+
+    try {
+      await client.query('BEGIN');
+
+      const result = await work(new ClientQueryExecutor({ client }));
 
       await client.query('COMMIT');
 
@@ -102,10 +108,12 @@ export class WorkspaceDataSourceV2 {
     nameSingular,
     rolePermissionConfig,
     executor,
+    isTransactional = false,
   }: {
     nameSingular: string;
     rolePermissionConfig?: RolePermissionConfig;
     executor: QueryExecutorV2;
+    isTransactional?: boolean;
   }): WorkspaceRepositoryV2 {
     const objectMetadataId =
       this.internalContext.objectIdByNameSingular[nameSingular];
@@ -121,6 +129,7 @@ export class WorkspaceDataSourceV2 {
       objectMetadataId,
       rolePermissionConfig,
       executor,
+      isTransactional,
     });
   }
 
@@ -128,10 +137,12 @@ export class WorkspaceDataSourceV2 {
     objectMetadataId,
     rolePermissionConfig,
     executor,
+    isTransactional = false,
   }: {
     objectMetadataId: string;
     rolePermissionConfig?: RolePermissionConfig;
     executor: QueryExecutorV2;
+    isTransactional?: boolean;
   }): WorkspaceRepositoryV2 {
     const flatObjectMetadata =
       this.getFlatObjectMetadataOrThrow(objectMetadataId);
@@ -159,7 +170,20 @@ export class WorkspaceDataSourceV2 {
           objectMetadataId: targetObjectMetadataId,
           rolePermissionConfig,
           executor,
+          isTransactional,
         }),
+      isTransactional,
+      runInNewTransaction: (work) =>
+        this.runInClientTransaction((transactionExecutor) =>
+          work(
+            this.buildRepositoryForObjectMetadataId({
+              objectMetadataId,
+              rolePermissionConfig,
+              executor: transactionExecutor,
+              isTransactional: true,
+            }),
+          ),
+        ),
     });
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/__tests__/workspace-select-query-builder-v2.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/__tests__/workspace-select-query-builder-v2.spec.ts
@@ -1,5 +1,5 @@
 import { FieldMetadataType } from 'twenty-shared/types';
-import { Equal, In, LessThan, Not } from 'typeorm';
+import { And, Equal, In, LessThan, Not } from 'typeorm';
 
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { type CompiledStatement } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
@@ -650,6 +650,19 @@ describe('WorkspaceSelectQueryBuilderV2', () => {
 
     expect(text).toContain('"person"."nameFirstName" < $1');
     expect(values).toContain('x');
+  });
+
+  it('should combine operators with And', () => {
+    const { queryBuilder } = buildQueryBuilder();
+
+    queryBuilder.setFindOptions({ select: { id: true } });
+    queryBuilder.where({ nameFirstName: And(LessThan('z'), Not(Equal('a'))) });
+
+    const [text] = queryBuilder.getQueryAndParameters();
+
+    expect(text).toContain(
+      '("person"."nameFirstName" < $1 AND NOT ("person"."nameFirstName" = $2))',
+    );
   });
 
   it('should negate a nested operator with Not', () => {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/__tests__/workspace-select-query-builder-v2.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/__tests__/workspace-select-query-builder-v2.spec.ts
@@ -1,5 +1,5 @@
 import { FieldMetadataType } from 'twenty-shared/types';
-import { Equal, In, LessThan } from 'typeorm';
+import { Equal, In, LessThan, Not } from 'typeorm';
 
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { type CompiledStatement } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
@@ -640,12 +640,27 @@ describe('WorkspaceSelectQueryBuilderV2', () => {
     );
   });
 
-  it('should reject a non-in operator in an object-literal where', () => {
+  it('should render comparison operators in an object-literal where', () => {
     const { queryBuilder } = buildQueryBuilder();
 
-    expect(() => queryBuilder.where({ id: LessThan('x') })).toThrow(
-      TwentyOrmV2Exception,
-    );
+    queryBuilder.setFindOptions({ select: { id: true } });
+    queryBuilder.where({ nameFirstName: LessThan('x') });
+
+    const [text, values] = queryBuilder.getQueryAndParameters();
+
+    expect(text).toContain('"person"."nameFirstName" < $1');
+    expect(values).toContain('x');
+  });
+
+  it('should negate a nested operator with Not', () => {
+    const { queryBuilder } = buildQueryBuilder();
+
+    queryBuilder.setFindOptions({ select: { id: true } });
+    queryBuilder.where({ id: Not(In(['a', 'b'])) });
+
+    const [text] = queryBuilder.getQueryAndParameters();
+
+    expect(text).toContain('NOT ("person"."id" IN ($1, $2))');
   });
 
   it('should treat a plain value in an object-literal where as equality', () => {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
@@ -687,6 +687,22 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
             value.child ?? value.value,
             parameters,
           )})`;
+        case 'and':
+        case 'or': {
+          const childOperators = value.value as unknown[];
+          const separator = value.type === 'and' ? ' AND ' : ' OR ';
+
+          return `(${childOperators
+            .map((childOperator) =>
+              this.buildValueCondition(
+                quotedColumn,
+                columnName,
+                childOperator,
+                parameters,
+              ),
+            )
+            .join(separator)})`;
+        }
         case 'raw': {
           const rawValue = value.value as
             | string

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
@@ -618,39 +618,95 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
         );
       }
 
-      const quotedColumn = quoteColumn(this.alias, columnName);
-
-      if (value === null) {
-        conditions.push(`${quotedColumn} IS NULL`);
-        continue;
-      }
-
-      const parameterName = `ormV2ObjectWhere_${objectWhereParameterSequence++}`;
-
-      if (value instanceof FindOperator) {
-        if (value.type === 'in') {
-          conditions.push(`${quotedColumn} IN (:...${parameterName})`);
-          parameters[parameterName] = value.value;
-          continue;
-        }
-
-        if (value.type === 'equal') {
-          conditions.push(`${quotedColumn} = :${parameterName}`);
-          parameters[parameterName] = value.value;
-          continue;
-        }
-
-        throw new TwentyOrmV2Exception(
-          `Object where supports only the "in" and "equal" operators on "${columnName}"`,
-          TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION,
-        );
-      }
-
-      conditions.push(`${quotedColumn} = :${parameterName}`);
-      parameters[parameterName] = value;
+      conditions.push(
+        this.buildValueCondition(
+          quoteColumn(this.alias, columnName),
+          columnName,
+          value,
+          parameters,
+        ),
+      );
     }
 
     return { sql: conditions.join(' AND '), parameters };
+  }
+
+  private buildValueCondition(
+    quotedColumn: string,
+    columnName: string,
+    value: unknown,
+    parameters: Record<string, unknown>,
+  ): string {
+    if (value === null) {
+      return `${quotedColumn} IS NULL`;
+    }
+
+    const nextParameter = (parameterValue: unknown): string => {
+      const parameterName = `ormV2ObjectWhere_${objectWhereParameterSequence++}`;
+
+      parameters[parameterName] = parameterValue;
+
+      return parameterName;
+    };
+
+    if (value instanceof FindOperator) {
+      switch (value.type) {
+        case 'in':
+          return `${quotedColumn} IN (:...${nextParameter(value.value)})`;
+        case 'any':
+          return `${quotedColumn} = ANY(:${nextParameter(value.value)})`;
+        case 'equal':
+          return `${quotedColumn} = :${nextParameter(value.value)}`;
+        case 'lessThan':
+          return `${quotedColumn} < :${nextParameter(value.value)}`;
+        case 'lessThanOrEqual':
+          return `${quotedColumn} <= :${nextParameter(value.value)}`;
+        case 'moreThan':
+          return `${quotedColumn} > :${nextParameter(value.value)}`;
+        case 'moreThanOrEqual':
+          return `${quotedColumn} >= :${nextParameter(value.value)}`;
+        case 'like':
+          return `${quotedColumn} LIKE :${nextParameter(value.value)}`;
+        case 'ilike':
+          return `${quotedColumn} ILIKE :${nextParameter(value.value)}`;
+        case 'arrayContains':
+          return `${quotedColumn} @> :${nextParameter(value.value)}`;
+        case 'isNull':
+          return `${quotedColumn} IS NULL`;
+        case 'between': {
+          const [from, to] = value.value as [unknown, unknown];
+
+          return `${quotedColumn} BETWEEN :${nextParameter(
+            from,
+          )} AND :${nextParameter(to)}`;
+        }
+        case 'not':
+          return `NOT (${this.buildValueCondition(
+            quotedColumn,
+            columnName,
+            value.child ?? value.value,
+            parameters,
+          )})`;
+        case 'raw': {
+          const rawValue = value.value as
+            | string
+            | ((columnAlias: string) => string);
+          const rawSql =
+            typeof rawValue === 'function' ? rawValue(quotedColumn) : rawValue;
+
+          Object.assign(parameters, value.objectLiteralParameters ?? {});
+
+          return rawSql;
+        }
+        default:
+          throw new TwentyOrmV2Exception(
+            `Object where does not support the "${value.type}" operator on "${columnName}"`,
+            TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION,
+          );
+      }
+    }
+
+    return `${quotedColumn} = :${nextParameter(value)}`;
   }
 
   private appendOrderBy(

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -53,6 +53,7 @@ import {
 } from 'src/engine/twenty-orm-v2/repository/utils/resolve-save-and-upsert.util';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { compileNamedParameters } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
+import { escapeIdentifier } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
 import { serializeJsonbWriteValue } from 'src/engine/twenty-orm-v2/sql/utils/serialize-jsonb-write-value.util';
 import {
   type WorkspaceRelationShape,
@@ -86,6 +87,10 @@ type WorkspaceRepositoryV2Options = {
   getRepositoryForObjectMetadataId: (
     objectMetadataId: string,
   ) => WorkspaceRepositoryV2;
+  isTransactional: boolean;
+  runInNewTransaction: <T>(
+    work: (transactionalRepository: WorkspaceRepositoryV2) => Promise<T>,
+  ) => Promise<T>;
 };
 
 export class WorkspaceRepositoryV2 {
@@ -446,6 +451,14 @@ export class WorkspaceRepositoryV2 {
   async updateMany(
     inputs: { criteria: string; partialEntity: Partial<ObjectRecord> }[],
   ): Promise<UpdateResult> {
+    if (inputs.length > QUERY_MAX_RECORDS) {
+      throw new TwentyOrmV2Exception(
+        `Cannot update more than ${QUERY_MAX_RECORDS} records at once`,
+        TwentyOrmV2ExceptionCode.TOO_MANY_RECORDS_TO_UPDATE,
+        msg`You can only update up to ${QUERY_MAX_RECORDS} records at once.`,
+      );
+    }
+
     const { generatedMaps, raw } = await this.runBatchUpdate({
       inputs: inputs.map((input) => ({
         id: input.criteria,
@@ -520,6 +533,33 @@ export class WorkspaceRepositoryV2 {
     return updateResult;
   }
 
+  private runAtomically<T>(
+    work: (repository: WorkspaceRepositoryV2) => Promise<T>,
+  ): Promise<T> {
+    return this.options.isTransactional
+      ? work(this)
+      : this.options.runInNewTransaction(work);
+  }
+
+  // Existence check for save/upsert: bypasses row-level permissions and includes
+  // soft-deleted rows so an existing-but-hidden id is updated rather than
+  // misclassified as an insert (which would raise a duplicate-key error).
+  private async findExistingIds(ids: string[]): Promise<Set<string>> {
+    if (ids.length === 0) {
+      return new Set<string>();
+    }
+
+    const { schemaName, tableName } = this.options.tableShape;
+    const rows = await this.executeRaw<{ id: string }>(
+      `SELECT "id" FROM ${escapeIdentifier(schemaName)}.${escapeIdentifier(
+        tableName,
+      )} WHERE "id" IN (:...ids)`,
+      { ids },
+    );
+
+    return new Set(rows.map((row) => row.id));
+  }
+
   async save(
     entityOrEntities: Partial<ObjectRecord> | Partial<ObjectRecord>[],
   ): Promise<ObjectRecord[]> {
@@ -533,52 +573,66 @@ export class WorkspaceRepositoryV2 {
       return [];
     }
 
-    const idsToCheck = entities
-      .map((entity) => entity.id)
-      .filter(isNonEmptyString);
+    return this.runAtomically(async (repository) => {
+      const existingIds = await repository.findExistingIds(
+        entities.map((entity) => entity.id).filter(isNonEmptyString),
+      );
 
-    const existingIds =
-      idsToCheck.length > 0
-        ? new Set(
-            (await this.findBy({ id: In(idsToCheck) })).map(
-              (record) => record.id,
-            ),
-          )
-        : new Set<string>();
+      const { toUpdate, toInsert } = partitionEntitiesForSave(
+        entities,
+        existingIds,
+      );
 
-    const { toUpdate, toInsert } = partitionEntitiesForSave(
-      entities,
-      existingIds,
-    );
+      if (toUpdate.length > 0) {
+        await repository.runBatchUpdate({
+          inputs: toUpdate.flatMap((entity) =>
+            isNonEmptyString(entity.id)
+              ? [{ id: entity.id, data: entity }]
+              : [],
+          ),
+          columnsToReturn: ['id'],
+        });
+      }
 
-    const updatedIds = toUpdate
-      .map((entity) => entity.id)
-      .filter(isNonEmptyString);
+      // runInsert returns identifiers in the same order as `toInsert`, which
+      // partitionEntitiesForSave builds in input order.
+      const insertedIds =
+        toInsert.length > 0
+          ? (
+              await repository.runInsert({
+                records: toInsert,
+                columnsToReturn: ['id'],
+              })
+            ).identifiers.map((identifier) => identifier.id)
+          : [];
 
-    if (updatedIds.length > 0) {
-      await this.runBatchUpdate({
-        inputs: toUpdate.flatMap((entity) =>
-          isNonEmptyString(entity.id) ? [{ id: entity.id, data: entity }] : [],
-        ),
-        columnsToReturn: ['id'],
+      const savedIds = [
+        ...toUpdate.map((entity) => entity.id).filter(isNonEmptyString),
+        ...insertedIds.filter(isNonEmptyString),
+      ];
+
+      const savedById = new Map(
+        savedIds.length > 0
+          ? (await repository.find({ where: { id: In(savedIds) } })).map(
+              (record) => [record.id, record],
+            )
+          : [],
+      );
+
+      let insertCursor = 0;
+
+      return entities.flatMap((entity) => {
+        const savedId =
+          isNonEmptyString(entity.id) && existingIds.has(entity.id)
+            ? entity.id
+            : insertedIds[insertCursor++];
+        const record = isNonEmptyString(savedId)
+          ? savedById.get(savedId)
+          : undefined;
+
+        return isDefined(record) ? [record] : [];
       });
-    }
-
-    const insertedIds =
-      toInsert.length > 0
-        ? (
-            await this.runInsert({
-              records: toInsert,
-              columnsToReturn: ['id'],
-            })
-          ).identifiers.map((identifier) => identifier.id)
-        : [];
-
-    const savedIds = [...updatedIds, ...insertedIds];
-
-    return savedIds.length > 0
-      ? this.find({ where: { id: In(savedIds) } })
-      : [];
+    });
   }
 
   async upsert(
@@ -602,54 +656,63 @@ export class WorkspaceRepositoryV2 {
       );
     }
 
-    const conflictWhere = entities.map((entity) =>
-      Object.fromEntries(
-        conflictPaths.map((path) => [path, entity[path] ?? null]),
-      ),
-    );
+    if (entities.length === 0) {
+      return new InsertResult();
+    }
 
-    const existingRecords =
-      entities.length > 0
-        ? await this.find({ where: conflictWhere, withDeleted: true })
-        : [];
+    return this.runAtomically(async (repository) => {
+      const conflictWhere = entities.map((entity) =>
+        Object.fromEntries(
+          conflictPaths.map((path) => [path, entity[path] ?? null]),
+        ),
+      );
 
-    const { toUpdate, toInsert } = matchEntitiesForUpsert(
-      entities,
-      existingRecords,
-      conflictPaths,
-    );
+      const existingRecords = await repository.find({
+        where: conflictWhere,
+        withDeleted: true,
+      });
 
-    const emptyOutcome = { identifiers: [], generatedMaps: [], raw: [] };
+      const { toUpdate, toInsert } = matchEntitiesForUpsert(
+        entities,
+        existingRecords,
+        conflictPaths,
+      );
 
-    const updateOutcome =
-      toUpdate.length > 0
-        ? await this.runBatchUpdate({
-            inputs: toUpdate.map((match) => ({
-              id: match.id,
-              data: match.entity,
-            })),
-            columnsToReturn: ['id'],
-          })
-        : emptyOutcome;
+      const emptyOutcome = { identifiers: [], generatedMaps: [], raw: [] };
 
-    const insertOutcome =
-      toInsert.length > 0
-        ? await this.runInsert({ records: toInsert, columnsToReturn: ['id'] })
-        : emptyOutcome;
+      const updateOutcome =
+        toUpdate.length > 0
+          ? await repository.runBatchUpdate({
+              inputs: toUpdate.map((match) => ({
+                id: match.id,
+                data: match.entity,
+              })),
+              columnsToReturn: ['id'],
+            })
+          : emptyOutcome;
 
-    const insertResult = new InsertResult();
+      const insertOutcome =
+        toInsert.length > 0
+          ? await repository.runInsert({
+              records: toInsert,
+              columnsToReturn: ['id'],
+            })
+          : emptyOutcome;
 
-    insertResult.identifiers = [
-      ...updateOutcome.identifiers,
-      ...insertOutcome.identifiers,
-    ];
-    insertResult.generatedMaps = [
-      ...updateOutcome.generatedMaps,
-      ...insertOutcome.generatedMaps,
-    ];
-    insertResult.raw = [...updateOutcome.raw, ...insertOutcome.raw];
+      const insertResult = new InsertResult();
 
-    return insertResult;
+      insertResult.identifiers = [
+        ...updateOutcome.identifiers,
+        ...insertOutcome.identifiers,
+      ];
+      insertResult.generatedMaps = [
+        ...updateOutcome.generatedMaps,
+        ...insertOutcome.generatedMaps,
+      ];
+      insertResult.raw = [...updateOutcome.raw, ...insertOutcome.raw];
+
+      return insertResult;
+    });
   }
 
   private assertNoNestedRelationObjects(

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -135,16 +135,8 @@ export class WorkspaceRepositoryV2 {
   }
 
   private createPermissionBypassingQueryBuilder(): WorkspaceSelectQueryBuilderV2 {
-    return new WorkspaceSelectQueryBuilderV2(
+    return this.buildBypassingEventSelectQueryBuilder(
       this.options.tableShape.nameSingular,
-      {
-        tableShape: this.options.tableShape,
-        executor: this.options.executor,
-        objectRecordsPermissions: this.options.objectRecordsPermissions,
-        tableShapeByObjectMetadataId: this.options.tableShapeByObjectMetadataId,
-        onBeforeExecute: () => undefined,
-        formatResult: (records) => this.formatResult(records),
-      },
     );
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -134,6 +134,20 @@ export class WorkspaceRepositoryV2 {
     );
   }
 
+  private createPermissionBypassingQueryBuilder(): WorkspaceSelectQueryBuilderV2 {
+    return new WorkspaceSelectQueryBuilderV2(
+      this.options.tableShape.nameSingular,
+      {
+        tableShape: this.options.tableShape,
+        executor: this.options.executor,
+        objectRecordsPermissions: this.options.objectRecordsPermissions,
+        tableShapeByObjectMetadataId: this.options.tableShapeByObjectMetadataId,
+        onBeforeExecute: () => undefined,
+        formatResult: (records) => this.formatResult(records),
+      },
+    );
+  }
+
   formatResult<T>(records: unknown): T {
     return formatResult<T>(
       records,
@@ -603,9 +617,6 @@ export class WorkspaceRepositoryV2 {
       : this.options.runInNewTransaction(work);
   }
 
-  // Existence check for save/upsert: bypasses row-level permissions and includes
-  // soft-deleted rows so an existing-but-hidden id is updated rather than
-  // misclassified as an insert (which would raise a duplicate-key error).
   private async findExistingIds(ids: string[]): Promise<Set<string>> {
     if (ids.length === 0) {
       return new Set<string>();
@@ -656,8 +667,6 @@ export class WorkspaceRepositoryV2 {
         });
       }
 
-      // runInsert returns identifiers in the same order as `toInsert`, which
-      // partitionEntitiesForSave builds in input order.
       const insertedIds =
         toInsert.length > 0
           ? (
@@ -675,9 +684,12 @@ export class WorkspaceRepositoryV2 {
 
       const savedById = new Map(
         savedIds.length > 0
-          ? (await repository.find({ where: { id: In(savedIds) } })).map(
-              (record) => [record.id, record],
-            )
+          ? (
+              await repository.find({
+                where: { id: In(savedIds) },
+                withDeleted: true,
+              })
+            ).map((record) => [record.id, record])
           : [],
       );
 
@@ -729,10 +741,10 @@ export class WorkspaceRepositoryV2 {
         ),
       );
 
-      const existingRecords = await repository.find({
-        where: conflictWhere,
-        withDeleted: true,
-      });
+      const existingRecords = await applyFindOptionsToQueryBuilder(
+        repository.createPermissionBypassingQueryBuilder(),
+        { where: conflictWhere, withDeleted: true },
+      ).getMany<ObjectRecord>();
 
       const { toUpdate, toInsert } = matchEntitiesForUpsert(
         entities,

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -254,6 +254,68 @@ export class WorkspaceRepositoryV2 {
     return this.exists({ where });
   }
 
+  async minimum(
+    columnName: string,
+    where?: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<number | null> {
+    return this.aggregate('MIN', columnName, where);
+  }
+
+  async maximum(
+    columnName: string,
+    where?: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<number | null> {
+    return this.aggregate('MAX', columnName, where);
+  }
+
+  async sum(
+    columnName: string,
+    where?: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<number | null> {
+    return this.aggregate('SUM', columnName, where);
+  }
+
+  async average(
+    columnName: string,
+    where?: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<number | null> {
+    return this.aggregate('AVG', columnName, where);
+  }
+
+  private async aggregate(
+    sqlFunction: 'MIN' | 'MAX' | 'SUM' | 'AVG',
+    columnName: string,
+    where?: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<number | null> {
+    if (
+      !isDefined(this.options.tableShape.columnShapeByColumnName[columnName])
+    ) {
+      throw new TwentyOrmV2Exception(
+        `Column "${columnName}" does not exist on "${this.options.tableShape.nameSingular}"`,
+        TwentyOrmV2ExceptionCode.UNKNOWN_COLUMN,
+      );
+    }
+
+    const queryBuilder = applyFindOptionsToQueryBuilder(
+      this.createQueryBuilder(),
+      isDefined(where) ? { where } : undefined,
+    );
+
+    queryBuilder.select([]);
+    queryBuilder.addSelect(
+      `${sqlFunction}(${escapeIdentifier(
+        this.options.tableShape.nameSingular,
+      )}.${escapeIdentifier(columnName)})`,
+      'value',
+    );
+
+    const row = await queryBuilder.getRawOne<{
+      value: string | number | null;
+    }>();
+
+    return isDefined(row?.value) ? Number(row.value) : null;
+  }
+
   private async loadRelations(
     records: ObjectRecord[],
     relations: FindOptionsRelationsV2,

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.module.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.module.ts
@@ -16,6 +16,7 @@ import { GlobalWorkspaceDataSourceService } from 'src/engine/twenty-orm/global-w
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { WorkspaceORMEntityMetadatasCacheService } from 'src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service';
 import { TwentyORMModule } from 'src/engine/twenty-orm/twenty-orm.module';
+import { TwentyORMV2Module } from 'src/engine/twenty-orm-v2/twenty-orm-v2.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/workspace-event-emitter.module';
@@ -37,6 +38,7 @@ import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/
     WorkspaceEventEmitterModule,
     WorkspaceCacheModule,
     TwentyORMModule,
+    TwentyORMV2Module,
   ],
   providers: [
     GlobalWorkspaceDataSourceService,

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
@@ -45,15 +45,9 @@ export class GlobalWorkspaceOrmManager {
     workspaceEntityOrObjectMetadataName: Type<T> | string,
     permissionOptions?: RolePermissionConfig,
   ): Promise<WorkspaceRepository<T>> {
-    let objectMetadataName: string;
-
-    if (typeof workspaceEntityOrObjectMetadataName === 'string') {
-      objectMetadataName = workspaceEntityOrObjectMetadataName;
-    } else {
-      objectMetadataName = convertClassNameToObjectMetadataName(
-        workspaceEntityOrObjectMetadataName.name,
-      );
-    }
+    const objectMetadataName = this.resolveObjectMetadataName(
+      workspaceEntityOrObjectMetadataName,
+    );
 
     if (
       getWorkspaceContext().featureFlagsMap[
@@ -98,6 +92,49 @@ export class GlobalWorkspaceOrmManager {
       );
 
     context.entityMetadatas.push(...ORMEntityMetadatas);
+  }
+
+  private resolveObjectMetadataName<T extends ObjectLiteral>(
+    workspaceEntityOrObjectMetadataName: Type<T> | string,
+  ): string {
+    if (typeof workspaceEntityOrObjectMetadataName === 'string') {
+      return workspaceEntityOrObjectMetadataName;
+    }
+
+    return convertClassNameToObjectMetadataName(
+      workspaceEntityOrObjectMetadataName.name,
+    );
+  }
+
+  async getV1Repository<T extends ObjectLiteral>(
+    workspaceId: string,
+    workspaceEntity: Type<T>,
+    permissionOptions?: RolePermissionConfig,
+  ): Promise<WorkspaceRepository<T>>;
+
+  async getV1Repository<T extends ObjectLiteral>(
+    workspaceId: string,
+    objectMetadataName: string,
+    permissionOptions?: RolePermissionConfig,
+  ): Promise<WorkspaceRepository<T>>;
+
+  async getV1Repository<T extends ObjectLiteral>(
+    _workspaceId: string,
+    workspaceEntityOrObjectMetadataName: Type<T> | string,
+    permissionOptions?: RolePermissionConfig,
+  ): Promise<WorkspaceRepository<T>> {
+    const objectMetadataName = this.resolveObjectMetadataName(
+      workspaceEntityOrObjectMetadataName,
+    );
+
+    await this.ensureEntityMetadatasLoaded();
+
+    const globalDataSource = await this.getGlobalWorkspaceDataSource();
+
+    return globalDataSource.getRepository<T>(
+      objectMetadataName,
+      permissionOptions,
+    );
   }
 
   async getGlobalWorkspaceDataSourceWithEntityMetadatas(): Promise<GlobalWorkspaceDataSource> {

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
@@ -108,7 +108,6 @@ export class GlobalWorkspaceOrmManager {
       flatIndexMaps,
       featureFlagsMap,
       rolesPermissions: permissionsPerRoleId,
-      ORMEntityMetadatas: entityMetadatas,
       userWorkspaceRoleMap,
       apiKeyRoleMap,
       flatRowLevelPermissionPredicateMaps,
@@ -119,12 +118,23 @@ export class GlobalWorkspaceOrmManager {
       'flatIndexMaps',
       'featureFlagsMap',
       'rolesPermissions',
-      'ORMEntityMetadatas',
       'userWorkspaceRoleMap',
       'apiKeyRoleMap',
       'flatRowLevelPermissionPredicateMaps',
       'flatRowLevelPermissionPredicateGroupMaps',
     ]);
+
+    // The TypeORM EntityMetadata graph is only consumed by the v1 repository, so
+    // when the ORM v2 read path is enabled it is neither loaded nor unpacked.
+    const entityMetadatas = featureFlagsMap[
+      FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED
+    ]
+      ? []
+      : (
+          await this.workspaceCacheService.getOrRecompute(workspaceId, [
+            'ORMEntityMetadatas',
+          ])
+        ).ORMEntityMetadatas;
 
     const { idByNameSingular: objectIdByNameSingular } =
       buildObjectIdByNameMaps(flatObjectMetadataMaps);

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
@@ -84,6 +84,34 @@ export class GlobalWorkspaceOrmManager {
     return this.globalWorkspaceDataSourceService.getGlobalWorkspaceDataSourceReplica();
   }
 
+  async ensureEntityMetadatasLoaded(): Promise<void> {
+    const context = getWorkspaceContext();
+
+    if (context.entityMetadatas.length > 0) {
+      return;
+    }
+
+    const { ORMEntityMetadatas } =
+      await this.workspaceCacheService.getOrRecompute(
+        context.authContext.workspace.id,
+        ['ORMEntityMetadatas'],
+      );
+
+    context.entityMetadatas.push(...ORMEntityMetadatas);
+  }
+
+  async getGlobalWorkspaceDataSourceWithEntityMetadatas(): Promise<GlobalWorkspaceDataSource> {
+    await this.ensureEntityMetadatasLoaded();
+
+    return this.getGlobalWorkspaceDataSource();
+  }
+
+  async getGlobalWorkspaceDataSourceReplicaWithEntityMetadatas(): Promise<GlobalWorkspaceDataSource> {
+    await this.ensureEntityMetadatasLoaded();
+
+    return this.getGlobalWorkspaceDataSourceReplica();
+  }
+
   async executeInWorkspaceContext<T>(
     fn: () => T | Promise<T>,
     authContext?: WorkspaceAuthContext,
@@ -124,8 +152,6 @@ export class GlobalWorkspaceOrmManager {
       'flatRowLevelPermissionPredicateGroupMaps',
     ]);
 
-    // The TypeORM EntityMetadata graph is only consumed by the v1 repository, so
-    // when the ORM v2 read path is enabled it is neither loaded nor unpacked.
     const entityMetadatas = featureFlagsMap[
       FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED
     ]

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
@@ -1,5 +1,6 @@
 import { Injectable, type Type } from '@nestjs/common';
 
+import { FeatureFlagKey } from 'twenty-shared/types';
 import { type ObjectLiteral } from 'typeorm';
 
 import { getWorkspaceAuthContext } from 'src/engine/core-modules/auth/storage/workspace-auth-context.storage';
@@ -10,10 +11,12 @@ import { GlobalWorkspaceDataSourceService } from 'src/engine/twenty-orm/global-w
 import { ExecuteInWorkspaceContextOptions } from 'src/engine/twenty-orm/global-workspace-datasource/types/execute-in-workspace-context-options.type';
 import type { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import {
+  getWorkspaceContext,
   type ORMWorkspaceContext,
   withWorkspaceContext,
 } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import type { RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
+import { WorkspaceDataSourceV2Service } from 'src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.service';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { convertClassNameToObjectMetadataName } from 'src/engine/workspace-manager/utils/convert-class-to-object-metadata-name.util';
 
@@ -22,6 +25,7 @@ export class GlobalWorkspaceOrmManager {
   constructor(
     private readonly globalWorkspaceDataSourceService: GlobalWorkspaceDataSourceService,
     private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceDataSourceV2Service: WorkspaceDataSourceV2Service,
   ) {}
 
   async getRepository<T extends ObjectLiteral>(
@@ -49,6 +53,19 @@ export class GlobalWorkspaceOrmManager {
       objectMetadataName = convertClassNameToObjectMetadataName(
         workspaceEntityOrObjectMetadataName.name,
       );
+    }
+
+    if (
+      getWorkspaceContext().featureFlagsMap[
+        FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED
+      ]
+    ) {
+      return this.workspaceDataSourceV2Service
+        .getDataSource({ useReplica: false })
+        .getRepository(
+          objectMetadataName,
+          permissionOptions,
+        ) as unknown as WorkspaceRepository<T>;
     }
 
     const globalDataSource = await this.getGlobalWorkspaceDataSource();

--- a/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
@@ -27,7 +27,7 @@ export class CalendarEventCleanerService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarChannelEventAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
+          await this.globalWorkspaceOrmManager.getV1Repository(
             workspaceId,
             'calendarChannelEventAssociation',
           );
@@ -87,7 +87,7 @@ export class CalendarEventCleanerService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarEventRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
+          await this.globalWorkspaceOrmManager.getV1Repository(
             workspaceId,
             'calendarEvent',
           );

--- a/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
@@ -33,7 +33,7 @@ export class CalendarEventCleanerService {
           );
 
         const workspaceDataSource =
-          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
         await workspaceDataSource.transaction(async (manager) => {
           const transactionManager = manager as WorkspaceEntityManager;

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
@@ -37,13 +37,13 @@ export class CalendarSaveEventsService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarEventRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<CalendarEventWorkspaceEntity>(
             workspaceId,
             'calendarEvent',
           );
 
         const calendarChannelEventAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<CalendarChannelEventAssociationWorkspaceEntity>(
             workspaceId,
             'calendarChannelEventAssociation',
           );

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
@@ -49,7 +49,7 @@ export class CalendarSaveEventsService {
           );
 
         const workspaceDataSource =
-          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
         await workspaceDataSource.transaction(
           async (transactionManager: WorkspaceEntityManager) => {

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
@@ -63,7 +63,7 @@ export class CalendarEventParticipantService {
         const chunkedParticipantsToUpdate = chunk(participantsToUpdate, 200);
 
         const calendarEventParticipantRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<CalendarEventParticipantWorkspaceEntity>(
             workspaceId,
             'calendarEventParticipant',
           );

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
@@ -680,7 +680,7 @@ export class MessageCampaignService {
     );
 
     const workspaceDataSource =
-      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
     if (!workspaceDataSource) {
       throw new Error(

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
@@ -136,7 +136,7 @@ export class MessageCampaignService {
     entity: Type<T>,
     roleId: string,
   ) {
-    return this.globalWorkspaceOrmManager.getRepository(workspaceId, entity, {
+    return this.globalWorkspaceOrmManager.getV1Repository(workspaceId, entity, {
       unionOf: [roleId],
     });
   }
@@ -145,7 +145,7 @@ export class MessageCampaignService {
     workspaceId: string,
     entity: Type<T>,
   ) {
-    return this.globalWorkspaceOrmManager.getRepository(workspaceId, entity, {
+    return this.globalWorkspaceOrmManager.getV1Repository(workspaceId, entity, {
       shouldBypassPermissionChecks: true,
     });
   }

--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -68,13 +68,13 @@ export class MatchParticipantService<
     objectMetadataName: 'messageParticipant' | 'calendarEventParticipant',
   ) {
     if (objectMetadataName === 'messageParticipant') {
-      return await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+      return await this.globalWorkspaceOrmManager.getV1Repository<MessageParticipantWorkspaceEntity>(
         workspaceId,
         objectMetadataName,
       );
     }
 
-    return await this.globalWorkspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
+    return await this.globalWorkspaceOrmManager.getV1Repository<CalendarEventParticipantWorkspaceEntity>(
       workspaceId,
       objectMetadataName,
     );
@@ -92,7 +92,7 @@ export class MatchParticipantService<
     }
 
     const personRepository =
-      await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
+      await this.globalWorkspaceOrmManager.getV1Repository<PersonWorkspaceEntity>(
         workspaceId,
         'person',
         { shouldBypassPermissionChecks: true },
@@ -104,7 +104,7 @@ export class MatchParticipantService<
     );
 
     const workspaceMemberRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+      await this.globalWorkspaceOrmManager.getV1Repository<WorkspaceMemberWorkspaceEntity>(
         workspaceId,
         'workspaceMember',
         { shouldBypassPermissionChecks: true },

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -32,19 +32,19 @@ export class MessagingMessageCleanerService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageWorkspaceEntity>(
             workspaceId,
             'message',
           );
 
         const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageChannelMessageAssociationWorkspaceEntity>(
             workspaceId,
             'messageChannelMessageAssociation',
           );
 
         const messageThreadRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageThreadWorkspaceEntity>(
             workspaceId,
             'messageThread',
           );
@@ -136,7 +136,7 @@ export class MessagingMessageCleanerService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageChannelMessageAssociationWorkspaceEntity>(
             workspaceId,
             'messageChannelMessageAssociation',
           );
@@ -196,13 +196,13 @@ export class MessagingMessageCleanerService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageThreadRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageThreadWorkspaceEntity>(
             workspaceId,
             'messageThread',
           );
 
         const messageRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageWorkspaceEntity>(
             workspaceId,
             'message',
           );

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -142,7 +142,7 @@ export class MessagingMessageCleanerService {
           );
 
         const workspaceDataSource =
-          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
         await workspaceDataSource.transaction(async (manager) => {
           const transactionManager = manager as WorkspaceEntityManager;
@@ -208,7 +208,7 @@ export class MessagingMessageCleanerService {
           );
 
         const workspaceDataSource =
-          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
         await workspaceDataSource.transaction(
           async (transactionManager: WorkspaceEntityManager) => {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-folder-association.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-folder-association.service.ts
@@ -32,7 +32,7 @@ export class MessagingMessageFolderAssociationService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const repository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
             workspaceId,
             'messageChannelMessageAssociationMessageFolder',
           );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
@@ -64,19 +64,19 @@ export class MessagingMessageService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageChannelMessageAssociationWorkspaceEntity>(
             workspaceId,
             'messageChannelMessageAssociation',
           );
 
         const messageRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageWorkspaceEntity>(
             workspaceId,
             'message',
           );
 
         const messageThreadRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageThreadWorkspaceEntity>(
             workspaceId,
             'messageThread',
           );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
@@ -63,7 +63,7 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workspaceDataSource =
-            await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+            await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
           return workspaceDataSource?.transaction(
             async (transactionManager: WorkspaceEntityManager) => {

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
@@ -26,7 +26,7 @@ export class MessagingMessageParticipantService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageParticipantRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<MessageParticipantWorkspaceEntity>(
             workspaceId,
             'messageParticipant',
           );

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -427,7 +427,7 @@ export class WorkflowCommonWorkspaceService {
     });
 
     const workspaceDataSource =
-      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
     const queryRunner = workspaceDataSource.createQueryRunner();
 

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -82,7 +82,7 @@ export class WorkflowCommonWorkspaceService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
             workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
@@ -167,7 +167,7 @@ export class WorkflowCommonWorkspaceService {
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+            await this.globalWorkspaceOrmManager.getV1Repository<WorkflowWorkspaceEntity>(
               workspaceId,
               'workflow',
               { shouldBypassPermissionChecks: true },
@@ -320,21 +320,21 @@ export class WorkflowCommonWorkspaceService {
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
           workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
 
       const workflowRunRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+        await this.globalWorkspaceOrmManager.getV1Repository<WorkflowRunWorkspaceEntity>(
           workspaceId,
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );
 
       const workflowAutomatedTriggerRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        await this.globalWorkspaceOrmManager.getV1Repository<WorkflowAutomatedTriggerWorkspaceEntity>(
           workspaceId,
           'workflowAutomatedTrigger',
           { shouldBypassPermissionChecks: true },
@@ -415,7 +415,7 @@ export class WorkflowCommonWorkspaceService {
     }
 
     const workflowRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+      await this.globalWorkspaceOrmManager.getV1Repository<WorkflowWorkspaceEntity>(
         workspaceId,
         'workflow',
         { shouldBypassPermissionChecks: true },

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -294,7 +294,7 @@ export class WorkflowTriggerWorkspaceService {
     );
 
     const workspaceDataSource =
-      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
     const queryRunner = workspaceDataSource.createQueryRunner();
 
@@ -408,7 +408,7 @@ export class WorkflowTriggerWorkspaceService {
     await this.deleteCommandMenuItem(workflowVersion, workspaceId);
 
     const workspaceDataSource =
-      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSourceWithEntityMetadatas();
 
     const queryRunner = workspaceDataSource.createQueryRunner();
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -103,7 +103,7 @@ export class WorkflowTriggerWorkspaceService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
             workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
@@ -121,7 +121,7 @@ export class WorkflowTriggerWorkspaceService {
           );
 
         const workflowRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<WorkflowWorkspaceEntity>(
             workspaceId,
             'workflow',
             { shouldBypassPermissionChecks: true },
@@ -213,7 +213,7 @@ export class WorkflowTriggerWorkspaceService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          await this.globalWorkspaceOrmManager.getV1Repository<WorkflowVersionWorkspaceEntity>(
             workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },


### PR DESCRIPTION
## Goal

Complete the ORM v2 migration so the TypeORM `EntityMetadata` graph is no longer built on `IS_ORM_V2_READ_PATH_ENABLED` (flag-on) requests. Stage A (#24170) took the API record runners off the v1 repository; this PR takes the rest of the surface and then gates the metadata load out.

## Stages

- **B0 — harden `save`/`upsert`** (prerequisite): atomic update+insert (transaction), permission-bypassing + soft-delete-inclusive existence check, input-order-preserving results, `updateMany` cap.
- **B1 — manager swap**: `GlobalWorkspaceOrmManager.getRepository` returns the v2 repository when the flag is on, so the ~178 module/engine call sites move off v1 transparently.
- **C — the payoff**: gate `'ORMEntityMetadatas'` out of `loadWorkspaceContext`'s `getOrRecompute` when the flag is on, removing the `EntityMetadata` build from the request path.

Everything stays behind the flag; flag-off is byte-for-byte unchanged.

## Status

Building incrementally on this branch. Each capability lands with unit tests where the logic is pure; the flag-on integration suites gate the end-to-end behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

