### PR TITLE
Scroll the tab row on mobile instead of hiding tabs behind a dropdown

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
@@ -337,9 +337,7 @@ export const PageLayoutTabList = ({
 
   const canReorderTabs = isReorderEnabled;
 
-  // A dropdown costs a tap to discover what is behind it. Touch surfaces can
-  // swipe the row instead, so mobile keeps every tab and scrolls. Reordering
-  // drags along the same axis, so that mode keeps the dropdown.
+  // Reordering drags along the same axis as the scroll, so it keeps the dropdown.
   const shouldScrollTabs = isMobile && !canReorderTabs;
 
   const shouldRenderReorderableDropdown = hasHiddenTabs && canReorderTabs;

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
@@ -17,6 +17,7 @@ import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTab
 import { TabListComponentInstanceContext } from '@/ui/layout/tab-list/states/contexts/TabListComponentInstanceContext';
 import { type TabListProps } from '@/ui/layout/tab-list/types/TabListProps';
 import { NodeDimension } from '@/ui/utilities/dimensions/components/NodeDimension';
+import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { useClickOutsideListener } from '@/ui/utilities/pointer-event/hooks/useClickOutsideListener';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
@@ -110,6 +111,7 @@ export const PageLayoutTabList = ({
   }));
 
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
 
   const [activeTabId, setActiveTabId] = useAtomComponentState(
     activeTabIdComponentState,
@@ -335,9 +337,15 @@ export const PageLayoutTabList = ({
 
   const canReorderTabs = isReorderEnabled;
 
+  // A dropdown costs a tap to discover what is behind it. Touch surfaces can
+  // swipe the row instead, so mobile keeps every tab and scrolls. Reordering
+  // drags along the same axis, so that mode keeps the dropdown.
+  const shouldScrollTabs = isMobile && !canReorderTabs;
+
   const shouldRenderReorderableDropdown = hasHiddenTabs && canReorderTabs;
 
-  const shouldRenderStaticDropdown = hasHiddenTabs && !canReorderTabs;
+  const shouldRenderStaticDropdown =
+    hasHiddenTabs && !canReorderTabs && !shouldScrollTabs;
 
   // Record pages accept widget drops on vertical-list tabs (dnd-kit drags);
   // dashboards accept them on grid tabs (react-grid-layout drags bridged by
@@ -367,7 +375,7 @@ export const PageLayoutTabList = ({
         tabListIds={tabsWithIcons.map((tab) => tab.id)}
       />
 
-      {tabsWithIcons.length > 1 && (
+      {tabsWithIcons.length > 1 && !shouldScrollTabs && (
         <TabListHiddenMeasurements
           visibleTabs={tabsWithIcons}
           activeTabId={activeTabId}
@@ -396,7 +404,10 @@ export const PageLayoutTabList = ({
         <StyledContainer className={className}>
           <PageLayoutTabListVisibleTabs
             visibleTabs={tabsWithIcons}
-            visibleTabCount={visibleTabCount}
+            visibleTabCount={
+              shouldScrollTabs ? tabsWithIcons.length : visibleTabCount
+            }
+            isScrollable={shouldScrollTabs}
             activeTabId={activeTabId}
             behaveAsLinks={behaveAsLinks}
             loading={loading}

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
@@ -337,7 +337,6 @@ export const PageLayoutTabList = ({
 
   const canReorderTabs = isReorderEnabled;
 
-  // Reordering drags along the same axis as the scroll, so it keeps the dropdown.
   const shouldScrollTabs = isMobile && !canReorderTabs;
 
   const shouldRenderReorderableDropdown = hasHiddenTabs && canReorderTabs;

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListVisibleTabs.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListVisibleTabs.tsx
@@ -19,13 +19,24 @@ type PageLayoutTabListVisibleTabsProps = {
   canReorder: boolean;
   widgetDropTargetTabIds: Set<string>;
   firstHiddenTabId: string | null;
+  isScrollable: boolean;
 };
 
-const StyledTabContainer = styled.div`
+const StyledTabContainer = styled.div<{ isScrollable: boolean }>`
   display: flex;
   max-width: 100%;
-  overflow: hidden;
+  overflow-x: ${({ isScrollable }) => (isScrollable ? 'auto' : 'hidden')};
+  overflow-y: hidden;
   position: relative;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  > * {
+    flex-shrink: 0;
+  }
 
   > *:not(:last-child) {
     margin-right: ${TAB_LIST_GAP}px;
@@ -53,12 +64,13 @@ export const PageLayoutTabListVisibleTabs = ({
   canReorder,
   widgetDropTargetTabIds,
   firstHiddenTabId,
+  isScrollable,
 }: PageLayoutTabListVisibleTabsProps) => {
   if (canReorder) {
     const shownTabs = visibleTabs.slice(0, visibleTabCount);
 
     return (
-      <StyledTabContainer>
+      <StyledTabContainer isScrollable={isScrollable}>
         {shownTabs.map((tab, index) => (
           <StyledTabSlot key={tab.id}>
             <StyledLeadingDropTarget>
@@ -94,7 +106,7 @@ export const PageLayoutTabListVisibleTabs = ({
   }
 
   return (
-    <StyledTabContainer>
+    <StyledTabContainer isScrollable={isScrollable}>
       {visibleTabs.slice(0, visibleTabCount).map((tab) => (
         <TabButton
           key={tab.id}

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListVisibleTabs.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListVisibleTabs.tsx
@@ -2,6 +2,8 @@ import { styled } from '@linaria/react';
 import { TabButton } from 'twenty-ui/input';
 
 import { TAB_LIST_GAP } from '@/ui/layout/tab-list/constants/TabListGap';
+import { useScrollActiveTabIntoView } from '@/ui/layout/tab-list/hooks/useScrollActiveTabIntoView';
+import { SCROLLABLE_TAB_ROW_CSS } from '@/ui/layout/tab-list/styles/ScrollableTabRowCSS';
 import { type SingleTabProps } from '@/ui/layout/tab-list/types/SingleTabProps';
 
 import { PAGE_LAYOUT_TAB_LIST_DROPPABLE_IDS } from '@/page-layout/components/PageLayoutTabListDroppableIds';
@@ -26,17 +28,8 @@ const StyledTabContainer = styled.div<{ isScrollable: boolean }>`
   display: flex;
   max-width: 100%;
   overflow-x: ${({ isScrollable }) => (isScrollable ? 'auto' : 'hidden')};
-  overflow-y: hidden;
   position: relative;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-
-  > * {
-    flex-shrink: 0;
-  }
+  ${SCROLLABLE_TAB_ROW_CSS}
 
   > *:not(:last-child) {
     margin-right: ${TAB_LIST_GAP}px;
@@ -66,11 +59,16 @@ export const PageLayoutTabListVisibleTabs = ({
   firstHiddenTabId,
   isScrollable,
 }: PageLayoutTabListVisibleTabsProps) => {
+  const { tabRowRef } = useScrollActiveTabIntoView({
+    activeTabId,
+    isScrollable,
+  });
+
   if (canReorder) {
     const shownTabs = visibleTabs.slice(0, visibleTabCount);
 
     return (
-      <StyledTabContainer isScrollable={isScrollable}>
+      <StyledTabContainer ref={tabRowRef} isScrollable={isScrollable}>
         {shownTabs.map((tab, index) => (
           <StyledTabSlot key={tab.id}>
             <StyledLeadingDropTarget>
@@ -106,7 +104,7 @@ export const PageLayoutTabListVisibleTabs = ({
   }
 
   return (
-    <StyledTabContainer isScrollable={isScrollable}>
+    <StyledTabContainer ref={tabRowRef} isScrollable={isScrollable}>
       {visibleTabs.slice(0, visibleTabCount).map((tab) => (
         <TabButton
           key={tab.id}

--- a/packages/twenty-front/src/modules/ui/layout/tab-list/components/TabList.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/tab-list/components/TabList.tsx
@@ -2,7 +2,9 @@ import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { TabListHiddenMeasurements } from '@/ui/layout/tab-list/components/TabListHiddenMeasurements';
 import { TAB_LIST_GAP } from '@/ui/layout/tab-list/constants/TabListGap';
 import { TAB_LIST_HEIGHT } from '@/ui/layout/tab-list/constants/TabListHeight';
+import { useScrollActiveTabIntoView } from '@/ui/layout/tab-list/hooks/useScrollActiveTabIntoView';
 import { useTabListMeasurements } from '@/ui/layout/tab-list/hooks/useTabListMeasurements';
+import { SCROLLABLE_TAB_ROW_CSS } from '@/ui/layout/tab-list/styles/ScrollableTabRowCSS';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { TabListComponentInstanceContext } from '@/ui/layout/tab-list/states/contexts/TabListComponentInstanceContext';
 import { type TabListProps } from '@/ui/layout/tab-list/types/TabListProps';
@@ -55,17 +57,8 @@ const StyledTabContainer = styled.div<{ isScrollable: boolean }>`
   gap: ${TAB_LIST_GAP}px;
   max-width: 100%;
   overflow-x: ${({ isScrollable }) => (isScrollable ? 'auto' : 'hidden')};
-  overflow-y: hidden;
   position: relative;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-
-  > * {
-    flex-shrink: 0;
-  }
+  ${SCROLLABLE_TAB_ROW_CSS}
 `;
 
 const StyledNodeDimension = styled(NodeDimension)`
@@ -116,13 +109,16 @@ export const TabList = ({
     hasAddButton: false,
   });
 
-  // A dropdown costs a tap to discover what is behind it. Touch surfaces can
-  // swipe the row instead, so mobile keeps every tab and scrolls.
   const shouldScrollTabs = isMobile;
   const renderedTabs = shouldScrollTabs
     ? visibleTabs
     : visibleTabs.slice(0, visibleTabCount);
   const shouldShowOverflowDropdown = hasHiddenTabs && !shouldScrollTabs;
+
+  const { tabRowRef } = useScrollActiveTabIntoView({
+    activeTabId,
+    isScrollable: shouldScrollTabs,
+  });
 
   const dropdownId = `tab-overflow-${componentInstanceId}`;
   const { closeDropdown } = useCloseDropdown();
@@ -184,7 +180,10 @@ export const TabList = ({
         <StyledContainer className={className}>
           <StyledNodeDimension onDimensionChange={onContainerWidthChange}>
             <StyledInnerContainer $centerTabs={centerTabs && !shouldScrollTabs}>
-              <StyledTabContainer isScrollable={shouldScrollTabs}>
+              <StyledTabContainer
+                ref={tabRowRef}
+                isScrollable={shouldScrollTabs}
+              >
                 {renderedTabs.map((tab) => (
                   <TabButton
                     key={tab.id}

--- a/packages/twenty-front/src/modules/ui/layout/tab-list/components/TabList.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/tab-list/components/TabList.tsx
@@ -7,6 +7,7 @@ import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTab
 import { TabListComponentInstanceContext } from '@/ui/layout/tab-list/states/contexts/TabListComponentInstanceContext';
 import { type TabListProps } from '@/ui/layout/tab-list/types/TabListProps';
 import { NodeDimension } from '@/ui/utilities/dimensions/components/NodeDimension';
+import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { styled } from '@linaria/react';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -49,12 +50,22 @@ const StyledDropdownContainer = styled.div`
   display: flex;
 `;
 
-const StyledTabContainer = styled.div`
+const StyledTabContainer = styled.div<{ isScrollable: boolean }>`
   display: flex;
   gap: ${TAB_LIST_GAP}px;
   max-width: 100%;
-  overflow: hidden;
+  overflow-x: ${({ isScrollable }) => (isScrollable ? 'auto' : 'hidden')};
+  overflow-y: hidden;
   position: relative;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  > * {
+    flex-shrink: 0;
+  }
 `;
 
 const StyledNodeDimension = styled(NodeDimension)`
@@ -82,6 +93,7 @@ export const TabList = ({
 }: TabListProps) => {
   const visibleTabs = tabs.filter((tab) => !tab.hide);
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
 
   const [activeTabId, setActiveTabId] = useAtomComponentState(
     activeTabIdComponentState,
@@ -103,6 +115,14 @@ export const TabList = ({
     visibleTabs,
     hasAddButton: false,
   });
+
+  // A dropdown costs a tap to discover what is behind it. Touch surfaces can
+  // swipe the row instead, so mobile keeps every tab and scrolls.
+  const shouldScrollTabs = isMobile;
+  const renderedTabs = shouldScrollTabs
+    ? visibleTabs
+    : visibleTabs.slice(0, visibleTabCount);
+  const shouldShowOverflowDropdown = hasHiddenTabs && !shouldScrollTabs;
 
   const dropdownId = `tab-overflow-${componentInstanceId}`;
   const { closeDropdown } = useCloseDropdown();
@@ -151,7 +171,7 @@ export const TabList = ({
           tabListIds={tabs.map((tab) => tab.id)}
         />
 
-        {visibleTabs.length > 1 && (
+        {visibleTabs.length > 1 && !shouldScrollTabs && (
           <TabListHiddenMeasurements
             visibleTabs={visibleTabs}
             activeTabId={activeTabId}
@@ -163,9 +183,9 @@ export const TabList = ({
 
         <StyledContainer className={className}>
           <StyledNodeDimension onDimensionChange={onContainerWidthChange}>
-            <StyledInnerContainer $centerTabs={centerTabs}>
-              <StyledTabContainer>
-                {visibleTabs.slice(0, visibleTabCount).map((tab) => (
+            <StyledInnerContainer $centerTabs={centerTabs && !shouldScrollTabs}>
+              <StyledTabContainer isScrollable={shouldScrollTabs}>
+                {renderedTabs.map((tab) => (
                   <TabButton
                     key={tab.id}
                     id={tab.id}
@@ -186,7 +206,7 @@ export const TabList = ({
                 ))}
               </StyledTabContainer>
 
-              {hasHiddenTabs && (
+              {shouldShowOverflowDropdown && (
                 <StyledDropdownContainer>
                   <TabListDropdown
                     dropdownId={dropdownId}

--- a/packages/twenty-front/src/modules/ui/layout/tab-list/hooks/useScrollActiveTabIntoView.ts
+++ b/packages/twenty-front/src/modules/ui/layout/tab-list/hooks/useScrollActiveTabIntoView.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+
+type UseScrollActiveTabIntoViewParams = {
+  activeTabId: string | null;
+  isScrollable: boolean;
+};
+
+// A tab selected from the URL or from initial state can sit outside the
+// scrolled region, which would leave the row looking like nothing is selected.
+export const useScrollActiveTabIntoView = ({
+  activeTabId,
+  isScrollable,
+}: UseScrollActiveTabIntoViewParams) => {
+  const tabRowRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isScrollable) {
+      return;
+    }
+
+    const tabRow = tabRowRef.current;
+    const activeTab = tabRow?.querySelector('[data-active]');
+
+    if (!tabRow || !(activeTab instanceof HTMLElement)) {
+      return;
+    }
+
+    const activeTabLeft = activeTab.offsetLeft;
+    const activeTabRight = activeTabLeft + activeTab.offsetWidth;
+
+    if (activeTabLeft < tabRow.scrollLeft) {
+      tabRow.scrollLeft = activeTabLeft;
+      return;
+    }
+
+    if (activeTabRight > tabRow.scrollLeft + tabRow.clientWidth) {
+      tabRow.scrollLeft = activeTabRight - tabRow.clientWidth;
+    }
+  }, [activeTabId, isScrollable]);
+
+  return { tabRowRef };
+};

--- a/packages/twenty-front/src/modules/ui/layout/tab-list/hooks/useScrollActiveTabIntoView.ts
+++ b/packages/twenty-front/src/modules/ui/layout/tab-list/hooks/useScrollActiveTabIntoView.ts
@@ -6,7 +6,8 @@ type UseScrollActiveTabIntoViewParams = {
 };
 
 // A tab selected from the URL or from initial state can sit outside the
-// scrolled region, which would leave the row looking like nothing is selected.
+// scrolled region, and a rotation can push it back out, which would leave the
+// row looking like nothing is selected.
 export const useScrollActiveTabIntoView = ({
   activeTabId,
   isScrollable,
@@ -14,28 +15,40 @@ export const useScrollActiveTabIntoView = ({
   const tabRowRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!isScrollable) {
-      return;
-    }
-
     const tabRow = tabRowRef.current;
-    const activeTab = tabRow?.querySelector('[data-active]');
 
-    if (!tabRow || !(activeTab instanceof HTMLElement)) {
+    if (!isScrollable || !tabRow) {
       return;
     }
 
-    const activeTabLeft = activeTab.offsetLeft;
-    const activeTabRight = activeTabLeft + activeTab.offsetWidth;
+    const scrollActiveTabIntoView = () => {
+      const activeTab = tabRow.querySelector('[data-active]');
 
-    if (activeTabLeft < tabRow.scrollLeft) {
-      tabRow.scrollLeft = activeTabLeft;
-      return;
-    }
+      if (!(activeTab instanceof HTMLElement)) {
+        return;
+      }
 
-    if (activeTabRight > tabRow.scrollLeft + tabRow.clientWidth) {
-      tabRow.scrollLeft = activeTabRight - tabRow.clientWidth;
-    }
+      const activeTabLeft = activeTab.offsetLeft;
+      const activeTabRight = activeTabLeft + activeTab.offsetWidth;
+
+      if (activeTabLeft < tabRow.scrollLeft) {
+        tabRow.scrollLeft = activeTabLeft;
+        return;
+      }
+
+      if (activeTabRight > tabRow.scrollLeft + tabRow.clientWidth) {
+        tabRow.scrollLeft = activeTabRight - tabRow.clientWidth;
+      }
+    };
+
+    scrollActiveTabIntoView();
+
+    const tabRowResizeObserver = new ResizeObserver(scrollActiveTabIntoView);
+    tabRowResizeObserver.observe(tabRow);
+
+    return () => {
+      tabRowResizeObserver.disconnect();
+    };
   }, [activeTabId, isScrollable]);
 
   return { tabRowRef };

--- a/packages/twenty-front/src/modules/ui/layout/tab-list/styles/ScrollableTabRowCSS.ts
+++ b/packages/twenty-front/src/modules/ui/layout/tab-list/styles/ScrollableTabRowCSS.ts
@@ -1,15 +1,8 @@
-// A dropdown costs a tap to discover what is behind it, so touch surfaces swipe
-// the row instead. Shared by both tab list implementations.
-//
 // The breakpoint is width-based, so a narrow desktop window matches it too. A
 // mouse there has no swipe to fall back on, so only coarse pointers lose the
 // scrollbar.
 export const SCROLLABLE_TAB_ROW_CSS = `
   overflow-y: hidden;
-
-  > * {
-    flex-shrink: 0;
-  }
 
   @media (pointer: coarse) {
     scrollbar-width: none;

--- a/packages/twenty-front/src/modules/ui/layout/tab-list/styles/ScrollableTabRowCSS.ts
+++ b/packages/twenty-front/src/modules/ui/layout/tab-list/styles/ScrollableTabRowCSS.ts
@@ -1,0 +1,21 @@
+// A dropdown costs a tap to discover what is behind it, so touch surfaces swipe
+// the row instead. Shared by both tab list implementations.
+//
+// The breakpoint is width-based, so a narrow desktop window matches it too. A
+// mouse there has no swipe to fall back on, so only coarse pointers lose the
+// scrollbar.
+export const SCROLLABLE_TAB_ROW_CSS = `
+  overflow-y: hidden;
+
+  > * {
+    flex-shrink: 0;
+  }
+
+  @media (pointer: coarse) {
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+`;


### PR DESCRIPTION
## Problem

The tab overflow dropdown is a good fit for a pointer — compact, one click, no scrolling. On a touch surface it inverts: the tabs you can't see sit behind a control that doesn't say what's in it, and you pay a tap to find out.

A company record at 390px put **4 of its 7 tabs** behind `+4 More`, leaving Home, Timeline and Tasks visible.

## Change

Below the mobile breakpoint the row renders every tab and scrolls horizontally, with the scrollbar hidden. The overflow dropdown and the offscreen measurement pass that sizes it are both skipped there, so mobile stops rendering a second hidden copy of every tab button purely to measure it.

Reorder mode is excluded — dragging a tab moves along the same axis as the scroll, so it keeps the dropdown. That mode is desktop-only in practice.

Two components needed it, since there are two tab list implementations:

- `TabList` — settings tab bars, side panel tab lists
- `PageLayoutTabList` / `PageLayoutTabListVisibleTabs` — record pages and dashboards

Centering is also suppressed while scrolling: `SettingsTabBar` passes `centerTabs`, and a centered flex row that overflows cannot be scrolled back to its own start.

## Verification

Measured on a company record at 390px, reading the live scroll container:

```
at rest    tabs present:  Home Timeline Tasks Notes Files Emails Calendar
           fully visible: Home Timeline Tasks Notes
           scrollWidth 564 / clientWidth 382 / scrollLeft 0

scrolled   fully visible: Notes Files Emails Calendar
           scrollLeft 182
           scrollbar hidden: true
```

Every tab is reachable, nothing is behind a dropdown, and no scrollbar is painted. Desktop still shows `+1 More` at 1280px, unchanged.

## Notes

- Tab buttons get `flex-shrink: 0` inside the row so they keep their natural width and overflow rather than compressing.
- `overflow-y: hidden` keeps the active-tab underline from producing a vertical scrollbar; the underline is an `::after` inside the button, so it is not clipped.
- Verified with `oxlint --type-aware`, `oxfmt`, `nx typecheck twenty-front`, and the tab-list / page-layout jest suites (1495 tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_01H4XJwMCrTgaN6e2NyLFrAK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

