### PR TITLE
fix(front): hide record table header when empty on mobile

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmpty.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmpty.tsx
@@ -23,12 +23,17 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import { styled } from '@linaria/react';
 import { useMemo } from 'react';
 import { isDefined } from 'twenty-shared/utils';
+import { MOBILE_VIEWPORT } from 'twenty-ui/theme-constants';
 import { useIsMobile } from 'twenty-ui/utilities';
 
-const StyledEmptyStateContainer = styled.div<{ width: string }>`
+const StyledEmptyStateContainer = styled.div<{ width: number }>`
   height: 100%;
   overflow: hidden;
-  width: ${({ width }) => width};
+  width: ${({ width }) => width}px;
+
+  @media (max-width: ${MOBILE_VIEWPORT}px) {
+    width: 100%;
+  }
 `;
 
 export interface RecordTableEmptyProps {
@@ -95,11 +100,10 @@ export const RecordTableEmpty = ({ tableBodyRef }: RecordTableEmptyProps) => {
     totalColumnsBorderWidth +
     resizeOffsetToAddOnlyIfItMakesTableContainerGrow;
 
-  // An empty table has no cells to reveal, so on mobile the header would only
-  // add a horizontal scroll to a screen that has nothing to scroll to.
-  const tableContainerWidth = isMobile
-    ? '100%'
-    : `${Math.max(recordTableWidth, emptyTableContainerComputedWidth)}px`;
+  const tableContainerWidth = Math.max(
+    recordTableWidth,
+    emptyTableContainerComputedWidth,
+  );
 
   const columnWidthStyles = useMemo(
     () =>
@@ -122,6 +126,8 @@ export const RecordTableEmpty = ({ tableBodyRef }: RecordTableEmptyProps) => {
         style={columnWidthStyles}
         id={getRecordTableHtmlId(recordTableId)}
       >
+        {/* An empty table has no cells to reveal, so the header would only add
+            a horizontal scroll to a screen with nothing to scroll to. */}
         {!isMobile && <RecordTableHeader />}
       </RecordTableStyleWrapper>
       <RecordTableEmptyState />

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmpty.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmpty.tsx
@@ -23,11 +23,12 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import { styled } from '@linaria/react';
 import { useMemo } from 'react';
 import { isDefined } from 'twenty-shared/utils';
+import { useIsMobile } from 'twenty-ui/utilities';
 
-const StyledEmptyStateContainer = styled.div<{ width: number }>`
+const StyledEmptyStateContainer = styled.div<{ width: string }>`
   height: 100%;
   overflow: hidden;
-  width: ${({ width }) => width}px;
+  width: ${({ width }) => width};
 `;
 
 export interface RecordTableEmptyProps {
@@ -36,6 +37,8 @@ export interface RecordTableEmptyProps {
 
 export const RecordTableEmpty = ({ tableBodyRef }: RecordTableEmptyProps) => {
   const { visibleRecordFields, recordTableId } = useRecordTableContextOrThrow();
+
+  const isMobile = useIsMobile();
 
   const isRecordTableDragColumnHidden = useAtomComponentStateValue(
     isRecordTableDragColumnHiddenComponentState,
@@ -92,14 +95,24 @@ export const RecordTableEmpty = ({ tableBodyRef }: RecordTableEmptyProps) => {
     totalColumnsBorderWidth +
     resizeOffsetToAddOnlyIfItMakesTableContainerGrow;
 
-  const tableContainerWidth = Math.max(
-    recordTableWidth,
-    emptyTableContainerComputedWidth,
-  );
+  // An empty table has no cells to reveal, so on mobile the header would only
+  // add a horizontal scroll to a screen that has nothing to scroll to.
+  const tableContainerWidth = isMobile
+    ? '100%'
+    : `${Math.max(recordTableWidth, emptyTableContainerComputedWidth)}px`;
 
   const columnWidthStyles = useMemo(
-    () => getRecordTableColumnWidthInlineStyles({ visibleRecordFields }),
-    [visibleRecordFields],
+    () =>
+      getRecordTableColumnWidthInlineStyles({
+        visibleRecordFields,
+        isDragColumnHidden: isRecordTableDragColumnHidden,
+        isCheckboxColumnHidden: isRecordTableCheckboxColumnHidden,
+      }),
+    [
+      visibleRecordFields,
+      isRecordTableDragColumnHidden,
+      isRecordTableCheckboxColumnHidden,
+    ],
   );
 
   return (
@@ -109,7 +122,7 @@ export const RecordTableEmpty = ({ tableBodyRef }: RecordTableEmptyProps) => {
         style={columnWidthStyles}
         id={getRecordTableHtmlId(recordTableId)}
       >
-        <RecordTableHeader />
+        {!isMobile && <RecordTableHeader />}
       </RecordTableStyleWrapper>
       <RecordTableEmptyState />
       <RecordTableColumnWidthEffect />


### PR DESCRIPTION
An empty list view on mobile scrolls sideways into nothing: the header row is wider than the screen, the last column is cut off, and there are no cells behind it to reveal.

`RecordTableEmpty` sizes its container to `max(recordTableWidth, sum of all column widths)`, so hiding the header alone would not have removed the scroll. Both are handled:

- the header is not rendered when the table is empty on mobile
- the container width drops to `100%` below the mobile breakpoint instead of following the summed column widths

Desktop keeps the header, where it is still useful for adding columns before the first record exists.

The container width stays a `number` in px, which is the convention the other 14 styled width props in `twenty-front` use, and the mobile case is a media query rather than a widened prop type:

```ts
const StyledEmptyStateContainer = styled.div<{ width: number }>`
  width: ${({ width }) => width}px;

  @media (max-width: ${MOBILE_VIEWPORT}px) {
    width: 100%;
  }
`;
```

Also passes `isDragColumnHidden` / `isCheckboxColumnHidden` to `getRecordTableColumnWidthInlineStyles`. The empty path was the only caller skipping them, which left the sticky offsets on the empty header computed from columns that were not rendered.

### Measured at 390px, empty views

| view | container | horizontal overflow | header cells |
|---|---|---|---|
| Blocklists before | 497px | 107px | 6 |
| Blocklists after | 390px | 0px | 0 |
| Call Recordings before | 698px | 308px | 7 |
| Call Recordings after | 390px | 0px | 0 |

Desktop at 1440px is unchanged before and after: container 1219px, 0px overflow, header cells unchanged. Re-measured after moving the width into CSS — identical numbers to the prop-based version.
