### PR TITLE
Surface the real ClickHouse error when an insert fails

### DIFF
--- a/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
+++ b/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
@@ -167,7 +167,10 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
 
       return {
         success: false,
-        error: err instanceof Error ? err : new Error(String(err)),
+        error:
+          err instanceof Error
+            ? err
+            : Object.assign(new Error(String(err)), { cause: err }),
       };
     }
   }

--- a/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
+++ b/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
@@ -18,6 +18,10 @@ export type ClickHouseInsertOptions = {
   asyncInsertBusyTimeoutMaxMs?: number;
 };
 
+export type ClickHouseInsertResult =
+  | { success: true }
+  | { success: false; error: Error };
+
 @Injectable()
 export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
   private mainClient: ClickHouseClient | undefined;
@@ -136,14 +140,19 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
     table: string,
     values: T[],
     options: ClickHouseInsertOptions = {},
-  ): Promise<{ success: boolean }> {
+  ): Promise<ClickHouseInsertResult> {
     try {
       const client = options.clientId
         ? await this.connectToClient(options.clientId)
         : this.mainClient;
 
       if (!client) {
-        return { success: false };
+        return {
+          success: false,
+          error: new Error(
+            `No ClickHouse client available${options.clientId ? ` for client ${options.clientId}` : ''}`,
+          ),
+        };
       }
 
       await this.insertInChunks(client, table, values, {
@@ -156,7 +165,10 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
     } catch (err) {
       this.logger.error('Error inserting data into ClickHouse', err);
 
-      return { success: false };
+      return {
+        success: false,
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
     }
   }
 

--- a/packages/twenty-server/src/engine/core-modules/event-logs/ingest/clickhouse-event.sink.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/ingest/clickhouse-event.sink.spec.ts
@@ -68,8 +68,20 @@ describe('ClickHouseEventSink', () => {
   });
 
   it('throws when a ClickHouse insert fails so the consumer retries', async () => {
-    insert.mockResolvedValue({ success: false });
+    insert.mockResolvedValue({ success: false, error: new Error('boom') });
 
     await expect(sink.write([makePageview('a')])).rejects.toThrow();
+  });
+
+  it('surfaces the underlying ClickHouse error in the message and cause', async () => {
+    const error = new Error('socket hang up');
+
+    insert.mockResolvedValue({ success: false, error });
+
+    await expect(sink.write([makePageview('a')])).rejects.toMatchObject({
+      message:
+        'Failed to insert 1 pageview row(s) into ClickHouse: socket hang up',
+      cause: error,
+    });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/event-logs/ingest/clickhouse-event.sink.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/ingest/clickhouse-event.sink.ts
@@ -48,8 +48,11 @@ export class ClickHouseEventSink implements EventSink {
         );
 
         if (!result.success) {
-          throw new Error(
-            `Failed to insert ${rows.length} ${table} row(s) into ClickHouse`,
+          throw Object.assign(
+            new Error(
+              `Failed to insert ${rows.length} ${table} row(s) into ClickHouse: ${result.error.message}`,
+            ),
+            { cause: result.error },
           );
         }
       }),


### PR DESCRIPTION
[TWENTY-SERVER-H9B](https://twenty-v7.sentry.io/issues/7538871080?project=4507072499810304) has fired 2901 times for 611 workspaces, and the event tells us nothing beyond `Failed to insert 1 objectEvent row(s) into ClickHouse`.

The reason is that the real error never leaves `ClickHouseService.insert`: it is caught, logged through the console logger driver (the only driver we support), and collapsed into `{ success: false }`. The sink then throws a brand new `Error` with no `cause`, so Sentry sees a generic message and a stack pointing at the throw site. The actual failure only exists in pod stdout.

This PR just propagates it:

- `insert()` returns a discriminated `ClickHouseInsertResult` carrying the driver error instead of a bare boolean. The no-client branch gets its own explicit error too.
- The sink appends the underlying message and attaches it as `cause`, so the issue splits per distinct cause and the exception chain shows up in Sentry.

`Object.assign` rather than `new Error(msg, { cause })` because the server's `lib` is `es2020`, where the second argument isn't typed.

No behaviour change: the sink still throws on failure, and the job still runs with `attempts: 1`.

## Why nothing else here

The failures are a steady ~40-60/day, spread evenly across all worker pods and 100+ workspaces, almost always single-row inserts. That profile looks transient rather than payload-related, so retries on the enqueue side are the obvious next step, and they would also stop each failure permanently dropping an audit-log row.

Deliberately left out. If these turn out not to be transient, retries would just triple the load on an already unhappy ClickHouse for nothing. Better to read a few days of real error messages first, then decide.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

