### PR TITLE
Make Other an explicit option in the AI chat question card

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AiChatQuestionCard.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatQuestionCard.tsx
@@ -196,7 +196,7 @@ const areAllQuestionsAnswered = (
   questions.every(
     (_, index) =>
       (selectedByQuestion[index]?.length ?? 0) > 0 ||
-      (otherSelectedByQuestion[index] === true &&
+      (otherSelectedByQuestion[index] &&
         (freeTextByQuestion[index] ?? '').trim().length > 0),
   );
 
@@ -248,7 +248,7 @@ export const AiChatQuestionCard = ({
     questions.map((_, index) => {
       const trimmedFreeText = (freeTextByQuestion[index] ?? '').trim();
       const shouldIncludeFreeText =
-        otherSelected[index] === true && trimmedFreeText.length > 0;
+        (otherSelected[index] ?? false) && trimmedFreeText.length > 0;
 
       return {
         questionIndex: index,
@@ -328,7 +328,7 @@ export const AiChatQuestionCard = ({
   const handleToggleOther = () => {
     if (
       currentQuestion.allowMultiSelect === true &&
-      otherSelectedByQuestion[currentIndex] === true
+      otherSelectedByQuestion[currentIndex]
     ) {
       setOtherSelectedByQuestion((previous) => ({
         ...previous,
@@ -434,7 +434,7 @@ export const AiChatQuestionCard = ({
             ).includes(optionIndex);
             const hasSelection =
               (selectedByQuestion[currentIndex] ?? []).length > 0 ||
-              otherSelectedByQuestion[currentIndex] === true;
+              (otherSelectedByQuestion[currentIndex] ?? false);
             const isHighlighted =
               isSelected || (!hasSelection && option.isRecommended === true);
             const tooltipId = `ask-question-option-${toolCallId}-${currentIndex}-${optionIndex}`;
@@ -497,7 +497,7 @@ export const AiChatQuestionCard = ({
               NUMBER_ICONS[currentQuestion.options.length] ??
               NUMBER_ICONS[NUMBER_ICONS.length - 1]
             }
-            isHighlighted={otherSelectedByQuestion[currentIndex] === true}
+            isHighlighted={otherSelectedByQuestion[currentIndex] ?? false}
             value={freeTextByQuestion[currentIndex] ?? ''}
             onChange={handleOtherTextChange}
             onSelect={handleToggleOther}

--- a/packages/twenty-front/src/modules/ai/components/AiChatQuestionCard.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatQuestionCard.tsx
@@ -29,6 +29,7 @@ import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { AgentChatFileUploadButton } from '@/ai/components/internal/AgentChatFileUploadButton';
 import { AiChatContextUsageButton } from '@/ai/components/internal/AiChatContextUsageButton';
+import { AiChatQuestionOtherOption } from '@/ai/components/internal/AiChatQuestionOtherOption';
 import { TextWithChatReferences } from '@/ai/components/TextWithChatReferences';
 import { useAgentChatModelId } from '@/ai/hooks/useAgentChatModelId';
 import { useAiModelOptions } from '@/ai/hooks/useAiModelOptions';
@@ -164,27 +165,7 @@ const StyledComposerSection = styled.div`
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: ${themeCssVariables.spacing[2]};
-  min-height: 80px;
   padding: ${themeCssVariables.spacing[2]};
-`;
-
-const StyledFreeTextArea = styled.textarea`
-  background: transparent;
-  border: none;
-  color: ${themeCssVariables.font.color.primary};
-  flex: 1 0 0;
-  font-family: inherit;
-  font-size: ${themeCssVariables.font.size.md};
-  line-height: 1.4;
-  min-height: 24px;
-  outline: none;
-  resize: none;
-
-  &::placeholder {
-    color: ${themeCssVariables.font.color.light};
-    font-weight: ${themeCssVariables.font.weight.medium};
-  }
 `;
 
 const StyledActionsRow = styled.div`
@@ -210,11 +191,13 @@ const areAllQuestionsAnswered = (
   questions: AskQuestionItem[],
   selectedByQuestion: Record<number, number[]>,
   freeTextByQuestion: Record<number, string>,
+  otherSelectedByQuestion: Record<number, boolean>,
 ) =>
   questions.every(
     (_, index) =>
       (selectedByQuestion[index]?.length ?? 0) > 0 ||
-      (freeTextByQuestion[index] ?? '').trim().length > 0,
+      (otherSelectedByQuestion[index] === true &&
+        (freeTextByQuestion[index] ?? '').trim().length > 0),
   );
 
 type AiChatQuestionCardProps = {
@@ -234,6 +217,9 @@ export const AiChatQuestionCard = ({
   >({});
   const [freeTextByQuestion, setFreeTextByQuestion] = useState<
     Record<number, string>
+  >({});
+  const [otherSelectedByQuestion, setOtherSelectedByQuestion] = useState<
+    Record<number, boolean>
   >({});
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -257,14 +243,17 @@ export const AiChatQuestionCard = ({
 
   const buildAnswers = (
     selected: Record<number, number[]>,
+    otherSelected: Record<number, boolean>,
   ): AskQuestionAnswer[] =>
     questions.map((_, index) => {
       const trimmedFreeText = (freeTextByQuestion[index] ?? '').trim();
+      const shouldIncludeFreeText =
+        otherSelected[index] === true && trimmedFreeText.length > 0;
 
       return {
         questionIndex: index,
         selectedOptionIndices: selected[index] ?? [],
-        freeText: trimmedFreeText.length > 0 ? trimmedFreeText : undefined,
+        freeText: shouldIncludeFreeText ? trimmedFreeText : undefined,
       };
     });
 
@@ -296,8 +285,13 @@ export const AiChatQuestionCard = ({
       ...selectedByQuestion,
       [currentIndex]: [optionIndex],
     };
+    const nextOtherSelected = {
+      ...otherSelectedByQuestion,
+      [currentIndex]: false,
+    };
 
     setSelectedByQuestion(nextSelected);
+    setOtherSelectedByQuestion(nextOtherSelected);
 
     if (!isLastQuestion) {
       setCurrentIndex(currentIndex + 1);
@@ -305,8 +299,56 @@ export const AiChatQuestionCard = ({
       return;
     }
 
-    if (areAllQuestionsAnswered(questions, nextSelected, freeTextByQuestion)) {
-      void submit(buildAnswers(nextSelected));
+    if (
+      areAllQuestionsAnswered(
+        questions,
+        nextSelected,
+        freeTextByQuestion,
+        nextOtherSelected,
+      )
+    ) {
+      void submit(buildAnswers(nextSelected, nextOtherSelected));
+    }
+  };
+
+  const selectOther = () => {
+    setOtherSelectedByQuestion((previous) => ({
+      ...previous,
+      [currentIndex]: true,
+    }));
+
+    if (currentQuestion.allowMultiSelect !== true) {
+      setSelectedByQuestion((previous) => ({
+        ...previous,
+        [currentIndex]: [],
+      }));
+    }
+  };
+
+  const handleToggleOther = () => {
+    if (
+      currentQuestion.allowMultiSelect === true &&
+      otherSelectedByQuestion[currentIndex] === true
+    ) {
+      setOtherSelectedByQuestion((previous) => ({
+        ...previous,
+        [currentIndex]: false,
+      }));
+
+      return;
+    }
+
+    selectOther();
+  };
+
+  const handleOtherTextChange = (value: string) => {
+    setFreeTextByQuestion((previous) => ({
+      ...previous,
+      [currentIndex]: value,
+    }));
+
+    if (value.trim().length > 0) {
+      selectOther();
     }
   };
 
@@ -316,8 +358,14 @@ export const AiChatQuestionCard = ({
         questions,
         selectedByQuestion,
         freeTextByQuestion,
+        otherSelectedByQuestion,
       ),
-    [questions, selectedByQuestion, freeTextByQuestion],
+    [
+      questions,
+      selectedByQuestion,
+      freeTextByQuestion,
+      otherSelectedByQuestion,
+    ],
   );
 
   const handleSend = () => {
@@ -325,7 +373,7 @@ export const AiChatQuestionCard = ({
       return;
     }
 
-    void submit(buildAnswers(selectedByQuestion));
+    void submit(buildAnswers(selectedByQuestion, otherSelectedByQuestion));
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -385,7 +433,8 @@ export const AiChatQuestionCard = ({
               selectedByQuestion[currentIndex] ?? []
             ).includes(optionIndex);
             const hasSelection =
-              (selectedByQuestion[currentIndex] ?? []).length > 0;
+              (selectedByQuestion[currentIndex] ?? []).length > 0 ||
+              otherSelectedByQuestion[currentIndex] === true;
             const isHighlighted =
               isSelected || (!hasSelection && option.isRecommended === true);
             const tooltipId = `ask-question-option-${toolCallId}-${currentIndex}-${optionIndex}`;
@@ -443,24 +492,23 @@ export const AiChatQuestionCard = ({
               </StyledOptionRow>
             );
           })}
+          <AiChatQuestionOtherOption
+            NumberIcon={
+              NUMBER_ICONS[currentQuestion.options.length] ??
+              NUMBER_ICONS[NUMBER_ICONS.length - 1]
+            }
+            isHighlighted={otherSelectedByQuestion[currentIndex] === true}
+            value={freeTextByQuestion[currentIndex] ?? ''}
+            onChange={handleOtherTextChange}
+            onSelect={handleToggleOther}
+            onTextareaKeyDown={handleKeyDown}
+          />
         </StyledOptionsList>
       </StyledQuestionSection>
 
       <StyledDivider />
 
       <StyledComposerSection>
-        <StyledFreeTextArea
-          value={freeTextByQuestion[currentIndex] ?? ''}
-          placeholder={t`Type anything to do differently.`}
-          onChange={(event) =>
-            setFreeTextByQuestion((previous) => ({
-              ...previous,
-              [currentIndex]: event.target.value,
-            }))
-          }
-          onKeyDown={handleKeyDown}
-          autoFocus
-        />
         <StyledActionsRow>
           <StyledLeftActions>
             <AgentChatFileUploadButton />

--- a/packages/twenty-front/src/modules/ai/components/__stories__/AiChatQuestionCard.stories.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__stories__/AiChatQuestionCard.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useStore } from 'jotai';
 import { type ReactNode, useEffect } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 import { ComponentDecorator } from 'twenty-ui/testing';
 
 import { AiChatQuestionCard } from '@/ai/components/AiChatQuestionCard';
@@ -144,4 +145,24 @@ export const LongQuestion: Story = {
 
 export const MultiSelectQuestion: Story = {
   args: { pendingQuestion: multiSelectQuestion },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const emailOption = await canvas.findByRole('button', { name: /Email/ });
+    await userEvent.click(emailOption);
+
+    const otherOption = await canvas.findByRole('button', { name: 'Other' });
+    await userEvent.click(otherOption);
+    expect(otherOption).toHaveAttribute('aria-pressed', 'true');
+
+    const otherTextArea = canvas.getByPlaceholderText(
+      'Type your own answer here',
+    );
+    await userEvent.type(otherTextArea, 'Carrier pigeon');
+    expect(otherOption).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(otherOption);
+    expect(otherOption).toHaveAttribute('aria-pressed', 'false');
+    expect(otherTextArea).toHaveValue('Carrier pigeon');
+  },
 };

--- a/packages/twenty-front/src/modules/ai/components/__stories__/AiChatQuestionCard.stories.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__stories__/AiChatQuestionCard.stories.tsx
@@ -152,17 +152,20 @@ export const MultiSelectQuestion: Story = {
     await userEvent.click(emailOption);
 
     const otherOption = await canvas.findByRole('button', { name: 'Other' });
-    await userEvent.click(otherOption);
-    expect(otherOption).toHaveAttribute('aria-pressed', 'true');
+    expect(otherOption).toHaveAttribute('aria-pressed', 'false');
 
     const otherTextArea = canvas.getByPlaceholderText(
       'Type your own answer here',
     );
-    await userEvent.type(otherTextArea, 'Carrier pigeon');
+    otherTextArea.focus();
+    await userEvent.type(otherTextArea, 'Carrier pigeon', { skipClick: true });
     expect(otherOption).toHaveAttribute('aria-pressed', 'true');
 
     await userEvent.click(otherOption);
     expect(otherOption).toHaveAttribute('aria-pressed', 'false');
     expect(otherTextArea).toHaveValue('Carrier pigeon');
+
+    await userEvent.click(otherOption);
+    expect(otherOption).toHaveAttribute('aria-pressed', 'true');
   },
 };

--- a/packages/twenty-front/src/modules/ai/components/__stories__/AiChatQuestionCard.stories.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__stories__/AiChatQuestionCard.stories.tsx
@@ -76,6 +76,23 @@ const longQuestion: AgentChatPendingQuestion = {
   ],
 };
 
+const multiSelectQuestion: AgentChatPendingQuestion = {
+  messageId: 'assistant-1',
+  toolCallId: 'call-4',
+  questions: [
+    {
+      header: 'Channels',
+      question: 'Which channels should the outreach campaign use?',
+      allowMultiSelect: true,
+      options: [
+        { label: 'Email', isRecommended: true },
+        { label: 'LinkedIn' },
+        { label: 'Phone' },
+      ],
+    },
+  ],
+};
+
 const StoreSeeder = ({ children }: { children: ReactNode }) => {
   const store = useStore();
 
@@ -123,4 +140,8 @@ export const MultipleQuestions: Story = {
 
 export const LongQuestion: Story = {
   args: { pendingQuestion: longQuestion },
+};
+
+export const MultiSelectQuestion: Story = {
+  args: { pendingQuestion: multiSelectQuestion },
 };

--- a/packages/twenty-front/src/modules/ai/components/internal/AiChatQuestionOtherOption.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AiChatQuestionOtherOption.tsx
@@ -1,0 +1,128 @@
+import { styled } from '@linaria/react';
+import { useLingui } from '@lingui/react/macro';
+import { type KeyboardEvent, useContext, useRef } from 'react';
+import { type IconComponent } from 'twenty-ui/icon';
+import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledContainer = styled.div<{ isHighlighted: boolean }>`
+  background: ${({ isHighlighted }) =>
+    isHighlighted
+      ? themeCssVariables.background.transparent.light
+      : 'transparent'};
+  border-radius: ${themeCssVariables.border.radius.sm};
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  padding: 0 ${themeCssVariables.spacing[1]} ${themeCssVariables.spacing[1]};
+
+  &:hover {
+    background: ${themeCssVariables.background.transparent.light};
+  }
+`;
+
+const StyledLabelRow = styled.div`
+  align-items: center;
+  display: flex;
+  gap: ${themeCssVariables.spacing[2]};
+  height: 32px;
+`;
+
+const StyledLabel = styled.span`
+  color: ${themeCssVariables.font.color.secondary};
+  font-size: ${themeCssVariables.font.size.md};
+  line-height: 1.4;
+`;
+
+const StyledTextArea = styled.textarea`
+  background: ${themeCssVariables.background.primary};
+  border: 1px solid ${themeCssVariables.border.color.medium};
+  border-radius: ${themeCssVariables.border.radius.sm};
+  box-sizing: border-box;
+  color: ${themeCssVariables.font.color.primary};
+  font-family: inherit;
+  font-size: ${themeCssVariables.font.size.md};
+  line-height: 1.4;
+  min-height: 24px;
+  outline: none;
+  padding: ${themeCssVariables.spacing[1]} ${themeCssVariables.spacing[2]};
+  resize: none;
+  width: 100%;
+
+  &:focus {
+    border-color: ${themeCssVariables.border.color.blue};
+  }
+
+  &::placeholder {
+    color: ${themeCssVariables.font.color.light};
+    font-weight: ${themeCssVariables.font.weight.medium};
+  }
+`;
+
+type AiChatQuestionOtherOptionProps = {
+  NumberIcon: IconComponent;
+  isHighlighted: boolean;
+  value: string;
+  onChange: (value: string) => void;
+  onSelect: () => void;
+  onTextareaKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+};
+
+export const AiChatQuestionOtherOption = ({
+  NumberIcon,
+  isHighlighted,
+  value,
+  onChange,
+  onSelect,
+  onTextareaKeyDown,
+}: AiChatQuestionOtherOptionProps) => {
+  const { t } = useLingui();
+  const { theme } = useContext(ThemeContext);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const selectAndFocus = () => {
+    onSelect();
+    textareaRef.current?.focus();
+  };
+
+  return (
+    <StyledContainer
+      isHighlighted={isHighlighted}
+      role="button"
+      tabIndex={0}
+      onClick={selectAndFocus}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) {
+          return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          selectAndFocus();
+        }
+      }}
+    >
+      <StyledLabelRow>
+        <NumberIcon
+          size={theme.icon.size.sm}
+          color={themeCssVariables.font.color.tertiary}
+        />
+        <StyledLabel>{t`Other`}</StyledLabel>
+      </StyledLabelRow>
+      <StyledTextArea
+        ref={textareaRef}
+        value={value}
+        placeholder={t`Type your own answer here`}
+        rows={1}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (!isHighlighted) {
+            onSelect();
+          }
+        }}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={onTextareaKeyDown}
+      />
+    </StyledContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/internal/AiChatQuestionOtherOption.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AiChatQuestionOtherOption.tsx
@@ -86,23 +86,18 @@ export const AiChatQuestionOtherOption = ({
   };
 
   return (
-    <StyledContainer
-      isHighlighted={isHighlighted}
-      role="button"
-      tabIndex={0}
-      onClick={selectAndFocus}
-      onKeyDown={(event) => {
-        if (event.target !== event.currentTarget) {
-          return;
-        }
-
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          selectAndFocus();
-        }
-      }}
-    >
-      <StyledLabelRow>
+    <StyledContainer isHighlighted={isHighlighted} onClick={selectAndFocus}>
+      <StyledLabelRow
+        role="button"
+        tabIndex={0}
+        aria-pressed={isHighlighted}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            selectAndFocus();
+          }
+        }}
+      >
         <NumberIcon
           size={theme.icon.size.sm}
           color={themeCssVariables.font.color.tertiary}


### PR DESCRIPTION
## Before

<img width="776" height="542" alt="CleanShot 2026-08-14 at 16 48 56@2x" src="https://github.com/user-attachments/assets/bf3ddff1-a94d-4dc3-8d2d-ab7d87370ccf" />


## After

<img width="778" height="572" alt="CleanShot 2026-08-14 at 16 46 50@2x" src="https://github.com/user-attachments/assets/82073185-283d-4074-aea8-3975a1bebee7" />

In the AI chat ask-question card, the free-text answer was a borderless textarea below the options, and users didn't realize typing there answers the question.

Free text is now an explicit "Other" option box at the end of the options list, with a bordered input inside it. It selects like any other option: exclusive with options in single-select (deselected Other text is kept in the input but not submitted), toggleable alongside them in multi-select, and typing selects it automatically.

No backend or GraphQL changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

