### PR TITLE
Point CI dispatches at twentyhq/twenty-factory

### DIFF
--- a/.github/workflows/app-prod-parity-e2e-dispatch.yaml
+++ b/.github/workflows/app-prod-parity-e2e-dispatch.yaml
@@ -50,25 +50,25 @@ jobs:
           gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state=pending \
             -f context=app-prod-parity-e2e \
-            -f description="Dispatching prod-parity e2e to ci-privileged"
+            -f description="Dispatching prod-parity e2e to twenty-factory"
 
-      - name: Mint ci-privileged dispatch token
+      - name: Mint twenty-factory dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: twenty-factory
           permission-actions: write
 
-      - name: Dispatch to ci-privileged
+      - name: Dispatch to twenty-factory
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ steps.sha.outputs.head_sha }}
         run: |
           gh workflow run app-prod-parity-e2e.yaml \
-            --repo twentyhq/ci-privileged \
+            --repo twentyhq/twenty-factory \
             --ref main \
             -f head_sha="$HEAD_SHA"
 
@@ -82,4 +82,4 @@ jobs:
           gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state=failure \
             -f context=app-prod-parity-e2e \
-            -f description="Failed to dispatch prod-parity e2e to ci-privileged"
+            -f description="Failed to dispatch prod-parity e2e to twenty-factory"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -183,7 +183,7 @@ jobs:
                 "PG_DATABASE_URL": "postgres://postgres:postgres@localhost:5432/default"
               }
             }
-      - name: Mint ci-privileged dispatch token
+      - name: Mint twenty-factory dispatch token
         id: app-token
         if: always()
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -191,10 +191,10 @@ jobs:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: twenty-factory
           permission-actions: write
 
-      - name: Dispatch response to ci-privileged
+      - name: Dispatch response to twenty-factory
         if: always()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -202,7 +202,7 @@ jobs:
           ISSUE_NUMBER: ${{ steps.prompt.outputs.issue_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh workflow run post-claude-response.yaml --repo twentyhq/ci-privileged --ref main \
+          gh workflow run post-claude-response.yaml --repo twentyhq/twenty-factory --ref main \
             -f repo="$REPO" \
             -f issue_number="$ISSUE_NUMBER" \
             -f run_url="$RUN_URL"

--- a/.github/workflows/external-contributor-pr-auto-draft.yaml
+++ b/.github/workflows/external-contributor-pr-auto-draft.yaml
@@ -16,20 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Mint ci-privileged dispatch token
+      - name: Mint twenty-factory dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: twenty-factory
           permission-actions: write
 
-      - name: Dispatch to ci-privileged
+      - name: Dispatch to twenty-factory
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh workflow run convert-pr-to-draft.yaml --repo twentyhq/ci-privileged --ref main \
+          gh workflow run convert-pr-to-draft.yaml --repo twentyhq/twenty-factory --ref main \
             -f pr_number="$PR_NUMBER"

--- a/.github/workflows/post-ci-comments.yaml
+++ b/.github/workflows/post-ci-comments.yaml
@@ -61,7 +61,7 @@ jobs:
             core.setOutput('has_pr', 'true');
             core.info(`PR #${prNumber}, Run ID: ${runId}`);
 
-      - name: Mint ci-privileged dispatch token
+      - name: Mint twenty-factory dispatch token
         id: app-token
         if: steps.pr-info.outputs.has_pr == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -69,10 +69,10 @@ jobs:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: twenty-factory
           permission-actions: write
 
-      - name: Dispatch to ci-privileged
+      - name: Dispatch to twenty-factory
         if: steps.pr-info.outputs.has_pr == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -81,7 +81,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           BRANCH_STATE: ${{ github.event.workflow_run.head_branch }}
         run: |
-          gh workflow run post-breaking-changes-comment.yaml --repo twentyhq/ci-privileged --ref main \
+          gh workflow run post-breaking-changes-comment.yaml --repo twentyhq/twenty-factory --ref main \
             -f pr_number="$PR_NUMBER" \
             -f run_id="$RUN_ID" \
             -f repo="$REPOSITORY" \

--- a/.github/workflows/pr-review-dispatch.yaml
+++ b/.github/workflows/pr-review-dispatch.yaml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Mint ci-privileged dispatch token
+      - name: Mint twenty-factory dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: twenty-factory
           permission-actions: write
 
       - name: Forward to PR review
@@ -35,6 +35,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT: ${{ github.event.action }}
         run: |
-          gh workflow run pr-review.yaml --repo twentyhq/ci-privileged --ref main \
+          gh workflow run pr-review.yaml --repo twentyhq/twenty-factory --ref main \
             -f pr_number="$PR_NUMBER" \
             -f event="$EVENT"

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -65,7 +65,7 @@ jobs:
       # Preview envs run on the PUBLIC ci-public repo so the 5h keepalive job
       # consumes free Actions minutes (private repos bill them). ci-public holds
       # no privileged secret: it starts the tunnel and dispatches the URL back to
-      # ci-privileged for the PR comment *before* running any PR-controlled code.
+      # twenty-factory for the PR comment *before* running any PR-controlled code.
       - name: Mint ci-public dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -1,11 +1,11 @@
 name: Visual Regression Dispatch
 
-# Dispatches visual regression processing to ci-privileged after CI completes.
+# Dispatches visual regression processing to twenty-factory after CI completes.
 # Runs in the context of the base repo (not the fork) so it has access to secrets,
 # making it work for external contributor PRs.
 #
-# All paths trigger the same ci-privileged workflow (post-visual-regression-comment.yaml)
-# via workflow_dispatch, passing the project as an input. ci-privileged routes to the
+# All paths trigger the same twenty-factory workflow (post-visual-regression-comment.yaml)
+# via workflow_dispatch, passing the project as an input. twenty-factory routes to the
 # correct Argos project based on it.
 
 on:
@@ -162,17 +162,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Mint ci-privileged dispatch token
+      - name: Mint twenty-factory dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: twenty-factory
           permission-actions: write
 
-      - name: Dispatch to ci-privileged
+      - name: Dispatch to twenty-factory
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT: ${{ needs.resolve-context.outputs.project }}
@@ -204,4 +204,4 @@ jobs:
             ARGS+=(-f parent_commits="$PARENT_COMMITS")
           fi
 
-          gh workflow run post-visual-regression-comment.yaml --repo twentyhq/ci-privileged --ref main "${ARGS[@]}"
+          gh workflow run post-visual-regression-comment.yaml --repo twentyhq/twenty-factory --ref main "${ARGS[@]}"

--- a/.github/workflows/website-preview-dispatch.yaml
+++ b/.github/workflows/website-preview-dispatch.yaml
@@ -35,24 +35,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Mint ci-privileged dispatch token
+      - name: Mint twenty-factory dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: twenty-factory
           permission-actions: write
 
-      - name: Dispatch website-preview-build to ci-privileged
+      - name: Dispatch website-preview-build to twenty-factory
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          gh workflow run website-preview.yaml --repo twentyhq/ci-privileged --ref main \
+          gh workflow run website-preview.yaml --repo twentyhq/twenty-factory --ref main \
             -f action=build \
             -f pr_number="$PR_NUMBER" \
             -f pr_head_sha="$PR_HEAD_SHA" \
@@ -69,21 +69,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Mint ci-privileged dispatch token
+      - name: Mint twenty-factory dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: twenty-factory
           permission-actions: write
 
-      - name: Dispatch website-preview-cleanup to ci-privileged
+      - name: Dispatch website-preview-cleanup to twenty-factory
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh workflow run website-preview.yaml --repo twentyhq/ci-privileged --ref main \
+          gh workflow run website-preview.yaml --repo twentyhq/twenty-factory --ref main \
             -f action=cleanup \
             -f pr_number="$PR_NUMBER"


### PR DESCRIPTION
`twentyhq/ci-privileged` is being renamed to `twentyhq/twenty-factory`. Two things here resolve the repo by name and do not follow GitHub's rename redirect:

- `actions/create-github-app-token` validates the `repositories:` input against the App installation, so the token mint returns 422 under the stale name
- `gh workflow run --repo` POSTs to the repo API, where relying on a 301 redirect is not safe

8 mint steps and 8 dispatch targets across 7 workflows, plus comments in an 8th.

**Merge after the rename, not before.** Until `twentyhq/twenty-factory` exists this branch mints against a repo that is not there. In the window between the rename and this merge, PR comments, AI review, preview envs, website previews, prod-parity e2e and visual regression dispatches all fail at the mint step, so this wants to go in immediately after the rename.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

