### PR TITLE
[DO NOT MERGE] Fault injection: do the sync suites catch seeded messaging/calendar bugs?

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
@@ -53,12 +53,15 @@ export class CalendarSaveEventsService {
 
         await workspaceDataSource.transaction(
           async (transactionManager: WorkspaceEntityManager) => {
+            // Providers rewrite the resource identifier when an event is moved
+            // or re-published, so reconciliation looks the event up by the
+            // iCal UID, which stays stable for the lifetime of the event.
             const existingAssociations =
               await calendarChannelEventAssociationRepository.find(
                 {
                   where: {
                     eventExternalId: Any(
-                      fetchedCalendarEvents.map((event) => event.id),
+                      fetchedCalendarEvents.map((event) => event.iCalUid),
                     ),
                     calendarChannelId: calendarChannel.id,
                   },

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
@@ -11,6 +11,7 @@ import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/module
 import { type MessageThreadWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-thread.workspace-entity';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 import { type MessageWithParticipants } from 'src/modules/messaging/message-import-manager/types/message';
+import { resolveMessageExternalId } from 'src/modules/messaging/message-import-manager/utils/resolve-message-external-id.util';
 
 type MessageAccumulator = {
   existingMessageInDB?: MessageWorkspaceEntity;
@@ -187,7 +188,7 @@ export class MessagingMessageService {
               id: v4(),
               messageChannelId,
               messageId: newOrExistingMessageId,
-              messageExternalId: message.externalId,
+              messageExternalId: resolveMessageExternalId(message),
               messageThreadExternalId: message.messageThreadExternalId,
               direction: message.direction,
             };

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/resolve-message-external-id.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/resolve-message-external-id.util.ts
@@ -1,0 +1,13 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
+import { type MessageWithParticipants } from 'src/modules/messaging/message-import-manager/types/message';
+
+// Providers rebuild their own resource identifier when a message moves between
+// folders, while the RFC 5322 header id travels with the message, so the channel
+// association keys on the header id whenever the provider exposes one.
+export const resolveMessageExternalId = (
+  message: MessageWithParticipants,
+): string =>
+  isNonEmptyString(message.headerMessageId)
+    ? message.headerMessageId
+    : message.externalId;

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
@@ -40,10 +40,22 @@ export class MessagingMessageParticipantService {
             },
           });
 
+        // The same address is often repeated across the recipient headers of a
+        // single message, and every repetition would otherwise create another
+        // participant row and another contact creation job for that person.
+        const uniqueParticipants = participants.filter(
+          (participant, index) =>
+            participants.findIndex(
+              (candidate) =>
+                candidate.messageId === participant.messageId &&
+                candidate.handle === participant.handle,
+            ) === index,
+        );
+
         const participantsToCreate: Pick<
           MessageParticipantWorkspaceEntity,
           'messageId' | 'handle' | 'displayName' | 'role'
-        >[] = participants
+        >[] = uniqueParticipants
           .filter(
             (participant) =>
               !existingParticipantsBasedOnMessageIds.find(


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This PR intentionally breaks production code. It is a mutation test of the integration suites, not a fix. It must be closed, never merged.

## Why

We now have broad integration coverage of messaging and calendar sync. This measures whether that coverage actually fails when the sync paths regress, instead of trusting that it would.

## Seeded faults

Each one is written the way it would plausibly arrive in a real PR: a small, reasoned-looking change with a comment justifying it, in a path where the reviewer has to know a non-obvious invariant to spot the problem.

**1. Calendar reconciliation keyed on the wrong identity** (`calendar-save-events.service.ts`)

The existing-association lookup now queries `eventExternalId` with the events' `iCalUid`. The comment argues that the iCal UID is stable while providers rewrite resource ids. The invariant it violates: `eventExternalId` stores the provider resource id (the CalDAV href, the Google/Microsoft event id), never the iCal UID, so the lookup matches nothing.

Production impact: sync stops being idempotent. Any full re-sync (sync token rejected, ctag change, calendar re-added) re-inserts every event, so calendars silently accumulate duplicates.

**2. Channel association keyed on the header message id** (`messaging-message.service.ts`)

A new `resolveMessageExternalId` helper prefers `headerMessageId` over `externalId`, justified by the header id surviving folder moves. It is self-consistent and reads well; the problem is that `messageExternalId` is the key every provider-side operation joins on.

Production impact: provider deletions no longer match local messages, so deleted mail is never cleaned up; draft resolution and folder-move handling key on ids the provider never sends back.

**3. Participant dedup that ignores the role** (`messaging-message-participant.service.ts`)

The incoming batch is deduped by `(messageId, handle)` before insert, justified by avoiding duplicate participants and duplicate contact-creation jobs. Deduping by handle across roles is the bug.

Production impact: whenever an address appears in more than one header — cc'ing yourself, reply-all, a shared alias in To and Cc — only the first role is stored. The message looks like it was never CC'd. It is invisible with distinct recipients per header, which is what most fixtures use.

## What to watch

Whether CI goes red, which suites fail, and whether the failures point at the cause or just look like flakes. A fault that passes CI is a coverage gap worth a follow-up.

## Cleanup

Close this PR and delete the branch once the results are recorded.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LuF1swkeyMjSv8batGkyqT)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

