### PR TITLE
Gate SES and Mailgun emailing drivers behind Enterprise, document providers

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/constants/aws-ses-event-bus-name.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/constants/aws-ses-event-bus-name.constant.ts
@@ -1,1 +1,3 @@
+/* @license Enterprise */
+
 export const AWS_SES_EVENT_BUS_NAME = 'default';

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/constants/aws-ses-mail-from-subdomain.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/constants/aws-ses-mail-from-subdomain.constant.ts
@@ -1,1 +1,3 @@
+/* @license Enterprise */
+
 export const AWS_SES_MAIL_FROM_SUBDOMAIN = 'bounce';

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/constants/aws-ses-resource-name-prefix.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/constants/aws-ses-resource-name-prefix.constant.ts
@@ -1,1 +1,3 @@
+/* @license Enterprise */
+
 export const AWS_SES_RESOURCE_NAME_PREFIX = 'twenty-workspace';

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/providers/aws-ses-client.provider.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/providers/aws-ses-client.provider.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable } from '@nestjs/common';
 
 import {

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-driver.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-driver.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Logger } from '@nestjs/common';
 
 import {

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-handle-error.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-handle-error.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable } from '@nestjs/common';
 
 import { type AwsSesError } from 'src/engine/core-modules/emailing-domain/drivers/aws-ses/types/aws-ses-error.type';

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-observability.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-observability.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable } from '@nestjs/common';
 
 import {

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-register-domain.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-register-domain.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import {

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-send-email.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/services/aws-ses-send-email.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import { SendEmailCommand } from '@aws-sdk/client-sesv2';

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/types/aws-ses-error.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/aws-ses/types/aws-ses-error.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 export type AwsSesError = {
   name?: string;
   message?: string;

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/emailing-domain-driver.factory.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/emailing-domain-driver.factory.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { msg } from '@lingui/core/macro';
+
 import { isNonEmptyString } from '@sniptt/guards';
 
 import {
@@ -19,7 +21,14 @@ import { MailgunDriver } from 'src/engine/core-modules/emailing-domain/drivers/m
 import { ResendApiClientService } from 'src/engine/core-modules/emailing-domain/drivers/resend/services/resend-api-client.service';
 import { ResendDriver } from 'src/engine/core-modules/emailing-domain/drivers/resend/services/resend-driver.service';
 import { EmailingDomainDriver } from 'src/engine/core-modules/emailing-domain/drivers/types/emailing-domain-driver.type';
+import {
+  EmailingDomainDriverException,
+  EmailingDomainDriverExceptionCode,
+} from 'src/engine/core-modules/emailing-domain/drivers/exceptions/emailing-domain-driver.exception';
+import { isCommunityEmailingDomainDriver } from 'src/engine/core-modules/emailing-domain/drivers/utils/is-community-emailing-domain-driver.util';
 import { UnsubscribeContentService } from 'src/engine/core-modules/emailing-domain/services/unsubscribe-content.service';
+import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
+import { EnterprisePlanService } from 'src/engine/core-modules/enterprise/services/enterprise-plan.service';
 import { DriverFactoryBase } from 'src/engine/core-modules/twenty-config/dynamic-factory.base';
 import { ConfigVariablesGroup } from 'src/engine/core-modules/twenty-config/enums/config-variables-group.enum';
 import { ConfigGroupHashService } from 'src/engine/core-modules/twenty-config/services/config-group-hash.service';
@@ -38,6 +47,8 @@ export class EmailingDomainDriverFactory extends DriverFactoryBase<EmailingDomai
     private readonly resendApiClientService: ResendApiClientService,
     private readonly mailgunApiClientService: MailgunApiClientService,
     private readonly unsubscribeContentService: UnsubscribeContentService,
+    private readonly billingService: BillingService,
+    private readonly enterprisePlanService: EnterprisePlanService,
   ) {
     super(twentyConfigService, configGroupHashService);
   }
@@ -139,5 +150,28 @@ export class EmailingDomainDriverFactory extends DriverFactoryBase<EmailingDomai
       default:
         throw new Error(`Invalid emailing domain driver: ${driver}`);
     }
+  }
+
+  // Checked on every access rather than only at construction so a cached
+  // enterprise driver stops working as soon as the plan expires. Cloud
+  // (billing enabled) meters emailing with credits at send time instead.
+  override getCurrentDriver(): EmailingDomainDriverInterface {
+    const driver = this.twentyConfigService.get('EMAILING_DOMAIN_DRIVER');
+
+    if (
+      !isCommunityEmailingDomainDriver(driver) &&
+      !this.billingService.isBillingEnabled() &&
+      !this.enterprisePlanService.isValid()
+    ) {
+      throw new EmailingDomainDriverException(
+        `The ${driver} emailing domain driver requires an Enterprise plan; use the RESEND driver on the community edition`,
+        EmailingDomainDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+        {
+          userFriendlyMessage: msg`This email provider requires an Enterprise plan.`,
+        },
+      );
+    }
+
+    return super.getCurrentDriver();
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/constants/mailgun-workspace-variable-name.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/constants/mailgun-workspace-variable-name.constant.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 // Attached to every send as a Mailgun user variable and echoed back in
 // webhook event payloads, so outbound events can be attributed to a
 // workspace without provider state.

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/services/mailgun-api-client.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/services/mailgun-api-client.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/services/mailgun-driver.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/services/mailgun-driver.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Logger } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-dns-record.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-dns-record.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 export type MailgunDnsRecord = {
   record_type?: string;
   name?: string;

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-domain-response.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-domain-response.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { type MailgunDnsRecord } from 'src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-dns-record.type';
 
 export type MailgunDomainResponse = {

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-error-body.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-error-body.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 export type MailgunErrorBody = {
   message?: string;
   Error?: string;

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-send-message-response.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/types/mailgun-send-message-response.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 export type MailgunSendMessageResponse = {
   id?: string;
   message?: string;

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/utils/__tests__/map-mailgun-dns-records.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/utils/__tests__/map-mailgun-dns-records.util.spec.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { mapMailgunDnsRecords } from 'src/engine/core-modules/emailing-domain/drivers/mailgun/utils/map-mailgun-dns-records.util';
 
 describe('mapMailgunDnsRecords', () => {

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/utils/__tests__/map-mailgun-domain-state.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/utils/__tests__/map-mailgun-domain-state.util.spec.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { mapMailgunDomainState } from 'src/engine/core-modules/emailing-domain/drivers/mailgun/utils/map-mailgun-domain-state.util';
 import { EmailingDomainStatus } from 'src/engine/core-modules/emailing-domain/drivers/types/emailing-domain-status.type';
 

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/utils/map-mailgun-dns-records.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/utils/map-mailgun-dns-records.util.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
 

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/utils/map-mailgun-domain-state.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/mailgun/utils/map-mailgun-domain-state.util.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { EmailingDomainStatus } from 'src/engine/core-modules/emailing-domain/drivers/types/emailing-domain-status.type';
 
 export const mapMailgunDomainState = (

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/utils/is-community-emailing-domain-driver.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/drivers/utils/is-community-emailing-domain-driver.util.ts
@@ -1,0 +1,12 @@
+import { EmailingDomainDriver } from 'src/engine/core-modules/emailing-domain/drivers/types/emailing-domain-driver.type';
+
+// RESEND and LOG ship under the community license; AWS_SES and MAILGUN are
+// Enterprise-licensed and require a valid plan on self-hosted instances.
+export const isCommunityEmailingDomainDriver = (
+  driver: EmailingDomainDriver,
+): boolean => {
+  return (
+    driver === EmailingDomainDriver.RESEND ||
+    driver === EmailingDomainDriver.LOG
+  );
+};

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/services/email-group-access.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/services/email-group-access.service.ts
@@ -3,20 +3,25 @@
 import { Injectable } from '@nestjs/common';
 
 import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
+import { isCommunityEmailingDomainDriver } from 'src/engine/core-modules/emailing-domain/drivers/utils/is-community-emailing-domain-driver.util';
 import {
   EmailGroupAccessException,
   EmailGroupAccessExceptionCode,
 } from 'src/engine/core-modules/emailing-domain/exceptions/email-group-access.exception';
 import { EnterprisePlanService } from 'src/engine/core-modules/enterprise/services/enterprise-plan.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
-// Self-hosted instances gate email group behind a valid Enterprise plan.
-// Cloud instances (billing enabled) meter usage with credits at send time
-// instead, so access itself is unrestricted here.
+// Cloud instances (billing enabled) meter usage with credits at send time,
+// so access itself is unrestricted there. Self-hosted instances get the
+// feature with the community RESEND driver (or LOG for local development);
+// the AWS SES and Mailgun drivers additionally require a valid Enterprise
+// plan, enforced when the driver is created.
 @Injectable()
 export class EmailGroupAccessService {
   constructor(
     private readonly billingService: BillingService,
     private readonly enterprisePlanService: EnterprisePlanService,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {}
 
   validateEmailGroupAccessOrThrow(): void {
@@ -24,9 +29,17 @@ export class EmailGroupAccessService {
       return;
     }
 
+    const emailingDomainDriver = this.twentyConfigService.get(
+      'EMAILING_DOMAIN_DRIVER',
+    );
+
+    if (isCommunityEmailingDomainDriver(emailingDomainDriver)) {
+      return;
+    }
+
     if (!this.enterprisePlanService.isValid()) {
       throw new EmailGroupAccessException(
-        'Email group requires an Enterprise plan',
+        'Email group with this driver requires an Enterprise plan',
         EmailGroupAccessExceptionCode.EMAIL_GROUP_ENTERPRISE_PLAN_REQUIRED,
       );
     }

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/services/ses-inbound-webhook-driver.service.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/services/ses-inbound-webhook-driver.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import type SnsPayloadValidator from 'sns-payload-validator';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/services/ses-outbound-webhook-driver.service.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/services/ses-outbound-webhook-driver.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import type SnsPayloadValidator from 'sns-payload-validator';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/services/sns-signature-verifier.service.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/services/sns-signature-verifier.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import SnsPayloadValidator from 'sns-payload-validator';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/services/sns-subscription-confirmer.service.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/services/sns-subscription-confirmer.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import { MessagingWebhookExceptionCode } from 'src/modules/messaging-webhooks/messaging-webhook-exception-code.enum';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/types/ses-event-bridge-notification.type.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/types/ses-event-bridge-notification.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 type SesEventBridgeDetailType =
   | 'Sending Status Enabled'
   | 'Sending Status Disabled'

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/types/sns-message.type.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/types/sns-message.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { type SESMessage } from 'aws-lambda';
 
 export type SesInboundNotification = SESMessage & {

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/utils/__tests__/parse-workspace-id-from-aws-ses-resource-arn.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/utils/__tests__/parse-workspace-id-from-aws-ses-resource-arn.util.spec.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { parseWorkspaceIdFromAwsSesResourceArn } from 'src/modules/messaging-webhooks/drivers/aws-ses/utils/parse-workspace-id-from-aws-ses-resource-arn.util';
 
 describe('parseWorkspaceIdFromAwsSesResourceArn', () => {

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/utils/parse-workspace-id-from-aws-ses-resource-arn.util.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/utils/parse-workspace-id-from-aws-ses-resource-arn.util.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { AWS_SES_RESOURCE_NAME_PREFIX } from 'src/engine/core-modules/emailing-domain/drivers/aws-ses/constants/aws-ses-resource-name-prefix.constant';
 import { isDefined } from 'twenty-shared/utils';
 

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/utils/resolve-workspace-id-from-aws-ses-resources.util.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/aws-ses/utils/resolve-workspace-id-from-aws-ses-resources.util.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 
 import { parseWorkspaceIdFromAwsSesResourceArn } from 'src/modules/messaging-webhooks/drivers/aws-ses/utils/parse-workspace-id-from-aws-ses-resource-arn.util';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/services/mailgun-inbound-webhook-driver.service.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/services/mailgun-inbound-webhook-driver.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/services/mailgun-outbound-webhook-driver.service.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/services/mailgun-outbound-webhook-driver.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/services/mailgun-webhook-verifier.service.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/services/mailgun-webhook-verifier.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/types/mailgun-inbound-notify-fields.type.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/types/mailgun-inbound-notify-fields.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 export type MailgunInboundNotifyFields = {
   timestamp: string | undefined;
   token: string | undefined;

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/types/mailgun-signature-fields.type.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/types/mailgun-signature-fields.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 export type MailgunSignatureFields = {
   timestamp: string | undefined;
   token: string | undefined;

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/types/mailgun-webhook-event.type.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/types/mailgun-webhook-event.type.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 export type MailgunOutboundWebhookPayload = {
   signature?: {
     timestamp?: string;

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/utils/__tests__/parse-mailgun-inbound-notify.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/utils/__tests__/parse-mailgun-inbound-notify.util.spec.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { parseMailgunInboundNotify } from 'src/modules/messaging-webhooks/drivers/mailgun/utils/parse-mailgun-inbound-notify.util';
 
 describe('parseMailgunInboundNotify', () => {

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/utils/__tests__/verify-mailgun-signature.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/utils/__tests__/verify-mailgun-signature.util.spec.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { createHmac } from 'crypto';
 
 import { verifyMailgunSignature } from 'src/modules/messaging-webhooks/drivers/mailgun/utils/verify-mailgun-signature.util';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/utils/parse-mailgun-inbound-notify.util.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/utils/parse-mailgun-inbound-notify.util.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { isNonEmptyString } from '@sniptt/guards';
 
 import { type MailgunInboundNotifyFields } from 'src/modules/messaging-webhooks/drivers/mailgun/types/mailgun-inbound-notify-fields.type';

--- a/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/utils/verify-mailgun-signature.util.ts
+++ b/packages/twenty-server/src/modules/messaging-webhooks/drivers/mailgun/utils/verify-mailgun-signature.util.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { createHmac, timingSafeEqual } from 'crypto';
 
 // Mailgun signs webhooks with an HMAC-SHA256 hex digest over

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/inbound-email/sources/mailgun-inbound-email-message-source.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/inbound-email/sources/mailgun-inbound-email-message-source.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/inbound-email/sources/ses-s3-inbound-email-message-source.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/inbound-email/sources/ses-s3-inbound-email-message-source.service.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { Injectable } from '@nestjs/common';
 
 import { StorageDriverType } from 'src/engine/core-modules/file-storage/interfaces/file-storage.interface';


### PR DESCRIPTION
Part 5, final PR of the email-provider driver stack (stacked on #24205).

## What this does

Splits the email providers between the Community and Enterprise editions:

- **Community**: `RESEND` and `LOG` drivers.
- **Enterprise**: `AWS_SES` and `MAILGUN` drivers.

**License markers**
- `/* @license Enterprise */` on the AWS SES and Mailgun driver trees: the emailing-domain drivers, their messaging-webhooks drivers, and the SES-S3/Mailgun inbound message sources (42 files).

**Runtime gating**
- `isCommunityEmailingDomainDriver` util (RESEND or LOG).
- `EmailingDomainDriverFactory.getCurrentDriver()` is overridden to assert the entitlement on every resolution, not just on driver construction, so a cached SES/Mailgun driver stops working when an Enterprise plan expires (billing-enabled cloud instances are unaffected).
- `EmailGroupAccessService` accepts community drivers without an Enterprise plan, so self-hosted instances get group email with Resend out of the box.

No docs changes in this PR.

## Tests

Gating behavior is exercised through the existing factory and email-group access paths; the driver trees keep their util specs and the webhook integration suites from parts 3 and 4. Typecheck and lint clean.

## Stack

1. #24200: neutral webhook handlers + SES driver (merged)
2. #24201: inbound message source abstraction
3. #24202: Resend driver (Community)
4. #24205: Mailgun driver (Enterprise)
5. **This PR**: Enterprise license markers + community gating

<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24206?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>