### PR TITLE
Add a video player with synced transcript to the native call recording transcript tab

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/hooks/__tests__/useCalendarEventCallRecording.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/hooks/__tests__/useCalendarEventCallRecording.test.tsx
@@ -38,6 +38,7 @@ jest.mock('@/object-metadata/hooks/useObjectMetadataItem', () => ({
         { id: 'status-field-id', name: 'status', label: 'Status' },
         { id: 'transcript-field-id', name: 'transcript', label: 'Transcript' },
         { id: 'summary-field-id', name: 'summary', label: 'Summary' },
+        { id: 'video-field-id', name: 'video', label: 'Video' },
         {
           id: 'created-at-field-id',
           name: 'createdAt',
@@ -128,6 +129,7 @@ describe('useCalendarEventCallRecording', () => {
           status: true,
           transcript: true,
           summary: true,
+          video: true,
           createdAt: true,
         },
         skip: false,
@@ -254,6 +256,30 @@ describe('useCalendarEventCallRecording', () => {
     );
 
     expect(transcriptResult.current.restriction).toBeUndefined();
+  });
+
+  it('reports a video field restriction for the transcript scope only', () => {
+    objectPermissionsResult = {
+      canReadObjectRecords: true,
+      restrictedFields: { 'video-field-id': { canRead: false } },
+    };
+
+    const { result: transcriptResult } = renderHook(() =>
+      useCalendarEventCallRecording({
+        queryScope: 'call-recording-transcript',
+      }),
+    );
+
+    expect(transcriptResult.current.restriction).toEqual({
+      type: 'field',
+      fieldNames: ['Video'],
+    });
+
+    const { result: summaryResult } = renderHook(() =>
+      useCalendarEventCallRecording({ queryScope: 'call-recording-summary' }),
+    );
+
+    expect(summaryResult.current.restriction).toBeUndefined();
   });
 
   it('passes loading through and resolves to no recording without records', () => {

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/hooks/useCalendarEventCallRecording.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/hooks/useCalendarEventCallRecording.ts
@@ -23,6 +23,7 @@ const CALL_RECORDING_RECORD_FIELDS = {
   status: true,
   transcript: true,
   summary: true,
+  video: true,
   createdAt: true,
 } as const satisfies RecordGqlOperationGqlRecordFields;
 
@@ -40,7 +41,7 @@ const REQUIRED_FIELD_NAMES_BY_QUERY_SCOPE: Record<
   string[]
 > = {
   'call-recording-summary': ['status', 'summary', 'createdAt'],
-  'call-recording-transcript': ['status', 'transcript', 'createdAt'],
+  'call-recording-transcript': ['status', 'transcript', 'video', 'createdAt'],
 };
 
 export const useCalendarEventCallRecording = ({
@@ -49,9 +50,11 @@ export const useCalendarEventCallRecording = ({
   queryScope: CalendarEventCallRecordingQueryScope;
 }): {
   callRecording: CalendarEventCallRecordingCandidate | undefined;
+  callRecordingsCount: number;
   loading: boolean;
   error: Error | undefined;
   restriction: WidgetAccessDenialInfo | undefined;
+  refetch: () => Promise<unknown>;
 } => {
   const { targetRecordIdentifier } = useLayoutRenderingContext();
 
@@ -167,5 +170,12 @@ export const useCalendarEventCallRecording = ({
 
   const callRecording = selectCalendarEventCallRecording(callRecordings);
 
-  return { callRecording, loading, error, restriction };
+  return {
+    callRecording,
+    callRecordingsCount: callRecordings.length,
+    loading,
+    error,
+    restriction,
+    refetch,
+  };
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/hooks/useCallRecordingsSeeAllHref.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/hooks/useCallRecordingsSeeAllHref.ts
@@ -1,0 +1,51 @@
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
+import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
+import { indexViewIdFromObjectMetadataItemFamilySelector } from '@/views/states/selectors/indexViewIdFromObjectMetadataItemFamilySelector';
+import {
+  AppPath,
+  CoreObjectNameSingular,
+  ViewFilterOperand,
+} from 'twenty-shared/types';
+import { getAppPath, isDefined } from 'twenty-shared/utils';
+
+export const useCallRecordingsSeeAllHref = (): string | undefined => {
+  const { targetRecordIdentifier } = useLayoutRenderingContext();
+
+  const calendarEventId =
+    targetRecordIdentifier?.targetObjectNameSingular ===
+    CoreObjectNameSingular.CalendarEvent
+      ? targetRecordIdentifier.id
+      : undefined;
+
+  const { objectMetadataItem: callRecordingObjectMetadataItem } =
+    useObjectMetadataItem({
+      objectNameSingular: CoreObjectNameSingular.CallRecording,
+    });
+
+  const indexViewId = useAtomFamilySelectorValue(
+    indexViewIdFromObjectMetadataItemFamilySelector,
+    { objectMetadataItemId: callRecordingObjectMetadataItem.id },
+  );
+
+  if (!isDefined(calendarEventId)) {
+    return undefined;
+  }
+
+  return getAppPath(
+    AppPath.RecordIndexPage,
+    {
+      objectNamePlural: callRecordingObjectMetadataItem.namePlural,
+    },
+    {
+      filter: {
+        calendarEvent: {
+          [ViewFilterOperand.IS]: {
+            selectedRecordIds: [calendarEventId],
+          },
+        },
+      },
+      viewId: indexViewId,
+    },
+  );
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/types/CalendarEventCallRecordingCandidate.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/types/CalendarEventCallRecordingCandidate.ts
@@ -1,3 +1,4 @@
+import { type FieldFilesValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { type CallRecordingStatus } from '~/generated/graphql';
 
 export type CalendarEventCallRecordingCandidate = {
@@ -6,5 +7,6 @@ export type CalendarEventCallRecordingCandidate = {
   status: CallRecordingStatus;
   transcript: unknown;
   summary: { markdown: string | null } | null | undefined;
+  video: FieldFilesValue[] | null | undefined;
   createdAt: string | null | undefined;
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/getCallRecordingVideoFileUrl.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/getCallRecordingVideoFileUrl.test.ts
@@ -1,0 +1,44 @@
+import { type CalendarEventCallRecordingCandidate } from '@/page-layout/widgets/calendar-event-call-recording/types/CalendarEventCallRecordingCandidate';
+import { getCallRecordingVideoFileUrl } from '@/page-layout/widgets/calendar-event-call-recording/utils/getCallRecordingVideoFileUrl';
+import { CallRecordingStatus } from '~/generated/graphql';
+
+const makeCallRecording = (
+  video: CalendarEventCallRecordingCandidate['video'],
+): CalendarEventCallRecordingCandidate => ({
+  __typename: 'CallRecording',
+  id: 'call-recording-id',
+  status: CallRecordingStatus.COMPLETED,
+  transcript: null,
+  summary: null,
+  video,
+  createdAt: '2026-01-01T00:00:00Z',
+});
+
+describe('getCallRecordingVideoFileUrl', () => {
+  it('returns the first video file url with a non-empty url', () => {
+    expect(
+      getCallRecordingVideoFileUrl(
+        makeCallRecording([
+          {
+            fileId: 'file-without-url',
+            label: 'broken.mp4',
+            extension: 'mp4',
+          },
+          {
+            fileId: 'file-with-url',
+            label: 'recording.mp4',
+            extension: 'mp4',
+            url: 'https://files.example.com/recording.mp4',
+          },
+        ]),
+      ),
+    ).toBe('https://files.example.com/recording.mp4');
+  });
+
+  it('returns undefined without a playable video file', () => {
+    expect(getCallRecordingVideoFileUrl(makeCallRecording(null))).toBe(
+      undefined,
+    );
+    expect(getCallRecordingVideoFileUrl(makeCallRecording([]))).toBe(undefined);
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/isCallRecordingInProgress.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/isCallRecordingInProgress.test.ts
@@ -7,6 +7,7 @@ const createCallRecording = (status: CallRecordingStatus) => ({
   status,
   transcript: null,
   summary: null,
+  video: null,
   createdAt: '2026-08-01T00:00:00.000Z',
 });
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/isCallRecordingTranscriptFailed.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/isCallRecordingTranscriptFailed.test.ts
@@ -13,6 +13,7 @@ const createCallRecording = ({
   status,
   transcript,
   summary: null,
+  video: null,
   createdAt: '2026-08-01T00:00:00.000Z',
 });
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/isCallRecordingTranscriptPending.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/isCallRecordingTranscriptPending.test.ts
@@ -13,6 +13,7 @@ const createCallRecording = ({
   status,
   transcript,
   summary: null,
+  video: null,
   createdAt: '2026-08-01T00:00:00.000Z',
 });
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/selectCalendarEventCallRecording.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/__tests__/selectCalendarEventCallRecording.test.ts
@@ -13,6 +13,7 @@ const createCallRecording = ({
   status,
   transcript: null,
   summary: null,
+  video: null,
   createdAt: '2026-08-01T00:00:00.000Z',
 });
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/getCallRecordingVideoFileUrl.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/calendar-event-call-recording/utils/getCallRecordingVideoFileUrl.ts
@@ -1,0 +1,8 @@
+import { type CalendarEventCallRecordingCandidate } from '@/page-layout/widgets/calendar-event-call-recording/types/CalendarEventCallRecordingCandidate';
+import { isNonEmptyString } from '@sniptt/guards';
+
+export const getCallRecordingVideoFileUrl = (
+  callRecording: CalendarEventCallRecordingCandidate,
+): string | undefined =>
+  callRecording.video?.find((videoFile) => isNonEmptyString(videoFile.url))
+    ?.url;

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/__stories__/CallRecordingSummaryBody.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/__stories__/CallRecordingSummaryBody.stories.tsx
@@ -94,6 +94,7 @@ const summarizedCallRecording: CalendarEventCallRecordingCandidate = {
   status: CallRecordingStatus.COMPLETED,
   transcript: [],
   summary: { markdown: summaryMarkdown },
+  video: null,
   createdAt: '2026-01-01T00:00:00Z',
 };
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptBody.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptBody.tsx
@@ -4,31 +4,75 @@ import { type CalendarEventCallRecordingCandidate } from '@/page-layout/widgets/
 import { isCallRecordingTranscriptFailed } from '@/page-layout/widgets/calendar-event-call-recording/utils/isCallRecordingTranscriptFailed';
 import { isCallRecordingTranscriptPending } from '@/page-layout/widgets/calendar-event-call-recording/utils/isCallRecordingTranscriptPending';
 import { CallRecordingTranscriptEntryList } from '@/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptEntryList';
+import { CallRecordingVideoPlayer } from '@/page-layout/widgets/call-recording-transcript/components/CallRecordingVideoPlayer';
 import { PageLayoutWidgetErrorDisplay } from '@/page-layout/widgets/components/PageLayoutWidgetErrorDisplay';
 import { WidgetSkeletonLoader } from '@/page-layout/widgets/components/WidgetSkeletonLoader';
 import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
 import { type WidgetAccessDenialInfo } from '@/page-layout/widgets/types/WidgetAccessDenialInfo';
+import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
-import {
-  isDefined,
-  isNonEmptyArray,
-  parseCallRecordingTranscriptEntries,
-} from 'twenty-shared/utils';
+import { useState, type ReactNode } from 'react';
+import { type CallRecordingParsedTranscriptEntry } from 'twenty-shared/types';
+import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const VIDEO_TIME_QUANTIZATION_STEP_SECONDS = 0.25;
+
+const StyledRecordingLayout = styled.div`
+  display: grid;
+  flex: 1;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+`;
+
+const StyledPlayerSection = styled.div`
+  padding: ${themeCssVariables.spacing[2]} ${themeCssVariables.spacing[6]} 0;
+`;
+
+const StyledTranscriptScrollContainer = styled.div`
+  min-height: 0;
+  overflow-y: auto;
+`;
 
 type CallRecordingTranscriptBodyProps = {
   callRecording: CalendarEventCallRecordingCandidate | undefined;
+  transcriptEntries: CallRecordingParsedTranscriptEntry[] | undefined;
+  videoFileUrl: string | undefined;
   loading: boolean;
   error: Error | undefined;
   restriction: WidgetAccessDenialInfo | undefined;
+  refetchCallRecording: () => void;
 };
 
 export const CallRecordingTranscriptBody = ({
   callRecording,
+  transcriptEntries,
+  videoFileUrl,
   loading,
   error,
   restriction,
+  refetchCallRecording,
 }: CallRecordingTranscriptBodyProps) => {
   const widget = useCurrentWidget();
+  const [currentTimeSeconds, setCurrentTimeSeconds] = useState(0);
+
+  const updateCurrentTimeSeconds = (videoCurrentTimeSeconds: number) => {
+    const nextCurrentTimeSeconds =
+      Math.floor(
+        videoCurrentTimeSeconds / VIDEO_TIME_QUANTIZATION_STEP_SECONDS,
+      ) * VIDEO_TIME_QUANTIZATION_STEP_SECONDS;
+
+    setCurrentTimeSeconds((previousCurrentTimeSeconds) =>
+      previousCurrentTimeSeconds === nextCurrentTimeSeconds
+        ? previousCurrentTimeSeconds
+        : nextCurrentTimeSeconds,
+    );
+  };
+
+  const handleVideoRetry = () => {
+    setCurrentTimeSeconds(0);
+    refetchCallRecording();
+  };
 
   if (isDefined(restriction)) {
     return <CallRecordingWidgetForbiddenDisplay restriction={restriction} />;
@@ -52,39 +96,59 @@ export const CallRecordingTranscriptBody = ({
     );
   }
 
-  const transcriptEntries = parseCallRecordingTranscriptEntries(
-    callRecording.transcript,
-  );
+  let transcriptContent: ReactNode;
 
-  if (isNonEmptyArray(transcriptEntries)) {
-    return <CallRecordingTranscriptEntryList entries={transcriptEntries} />;
-  }
-
-  if (isCallRecordingTranscriptPending(callRecording)) {
-    return (
+  if (isDefined(transcriptEntries) && isNonEmptyArray(transcriptEntries)) {
+    transcriptContent = (
+      <CallRecordingTranscriptEntryList
+        entries={transcriptEntries}
+        currentTimeSeconds={
+          isDefined(videoFileUrl) ? currentTimeSeconds : undefined
+        }
+      />
+    );
+  } else if (isCallRecordingTranscriptPending(callRecording)) {
+    transcriptContent = (
       <CallRecordingWidgetEmptyStateDisplay
         animatedPlaceholderType="loadingMessages"
         title={t`Preparing Transcript`}
         subTitle={t`Transcript is being prepared…`}
       />
     );
-  }
-
-  if (isCallRecordingTranscriptFailed(callRecording)) {
-    return (
+  } else if (isCallRecordingTranscriptFailed(callRecording)) {
+    transcriptContent = (
       <CallRecordingWidgetEmptyStateDisplay
         animatedPlaceholderType="errorIndex"
         title={t`Transcript Failed`}
         subTitle={t`The transcript could not be generated.`}
       />
     );
+  } else {
+    transcriptContent = (
+      <CallRecordingWidgetEmptyStateDisplay
+        animatedPlaceholderType="noMatchRecord"
+        title={t`No Transcript`}
+        subTitle={t`No transcript is available for this recording.`}
+      />
+    );
+  }
+
+  if (!isDefined(videoFileUrl)) {
+    return transcriptContent;
   }
 
   return (
-    <CallRecordingWidgetEmptyStateDisplay
-      animatedPlaceholderType="noMatchRecord"
-      title={t`No Transcript`}
-      subTitle={t`No transcript is available for this recording.`}
-    />
+    <StyledRecordingLayout>
+      <StyledPlayerSection>
+        <CallRecordingVideoPlayer
+          src={videoFileUrl}
+          onTimeUpdate={updateCurrentTimeSeconds}
+          onRetry={handleVideoRetry}
+        />
+      </StyledPlayerSection>
+      <StyledTranscriptScrollContainer>
+        {transcriptContent}
+      </StyledTranscriptScrollContainer>
+    </StyledRecordingLayout>
   );
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptEntryList.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptEntryList.tsx
@@ -1,7 +1,9 @@
 import { CallRecordingTranscriptEntryListItem } from '@/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptEntryListItem';
+import { findActiveCallRecordingTranscriptEntryIndex } from '@/page-layout/widgets/call-recording-transcript/utils/findActiveCallRecordingTranscriptEntryIndex';
 import { styled } from '@linaria/react';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { type CallRecordingParsedTranscriptEntry } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledEntryList = styled.ul`
   display: flex;
@@ -9,19 +11,35 @@ const StyledEntryList = styled.ul`
   gap: ${themeCssVariables.spacing[6]};
   list-style: none;
   margin: 0;
-  padding: ${themeCssVariables.spacing[6]};
+  padding: ${themeCssVariables.spacing[4]} ${themeCssVariables.spacing[6]} 0;
 `;
 
 type CallRecordingTranscriptEntryListProps = {
   entries: CallRecordingParsedTranscriptEntry[];
+  currentTimeSeconds?: number;
 };
 
 export const CallRecordingTranscriptEntryList = ({
   entries,
-}: CallRecordingTranscriptEntryListProps) => (
-  <StyledEntryList>
-    {entries.map((entry, entryIndex) => (
-      <CallRecordingTranscriptEntryListItem key={entryIndex} entry={entry} />
-    ))}
-  </StyledEntryList>
-);
+  currentTimeSeconds,
+}: CallRecordingTranscriptEntryListProps) => {
+  const activeEntryIndex = isDefined(currentTimeSeconds)
+    ? findActiveCallRecordingTranscriptEntryIndex({
+        entries,
+        currentTimeSeconds,
+      })
+    : -1;
+
+  return (
+    <StyledEntryList>
+      {entries.map((entry, entryIndex) => (
+        <CallRecordingTranscriptEntryListItem
+          key={entryIndex}
+          entry={entry}
+          isActive={entryIndex === activeEntryIndex}
+          currentTimeSeconds={currentTimeSeconds}
+        />
+      ))}
+    </StyledEntryList>
+  );
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptEntryListItem.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptEntryListItem.tsx
@@ -1,15 +1,22 @@
 import { formatCallRecordingTranscriptTimestamp } from '@/page-layout/widgets/call-recording-transcript/utils/formatCallRecordingTranscriptTimestamp';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
+import {
+  type CallRecordingParsedTranscriptEntry,
+  type CallRecordingParsedTranscriptWord,
+} from 'twenty-shared/types';
+import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 import { Avatar, Chip, ChipVariant } from 'twenty-ui/data-display';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { type CallRecordingParsedTranscriptEntry } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
 
-const StyledEntry = styled.li`
+const StyledEntry = styled.li<{ isActive: boolean }>`
+  background: ${({ isActive }) =>
+    isActive ? themeCssVariables.background.transparent.blue : 'transparent'};
+  border-radius: ${themeCssVariables.border.radius.sm};
   display: flex;
   flex-direction: column;
   gap: ${themeCssVariables.spacing[2]};
+  padding: ${themeCssVariables.spacing[2]};
 `;
 
 const StyledEntryHeader = styled.div`
@@ -34,17 +41,29 @@ const StyledText = styled.p`
   white-space: pre-wrap;
 `;
 
+const StyledWord = styled.span<{ isHighlighted: boolean }>`
+  color: ${({ isHighlighted }) =>
+    isHighlighted
+      ? themeCssVariables.font.color.primary
+      : themeCssVariables.font.color.secondary};
+  transition: color calc(${themeCssVariables.animation.duration.fast} * 1s) ease;
+`;
+
 type CallRecordingTranscriptEntryListItemProps = {
   entry: CallRecordingParsedTranscriptEntry;
+  isActive?: boolean;
+  currentTimeSeconds?: number;
 };
 
 export const CallRecordingTranscriptEntryListItem = ({
   entry,
+  isActive = false,
+  currentTimeSeconds,
 }: CallRecordingTranscriptEntryListItemProps) => {
   const speakerName = entry.speakerName ?? t`Unknown speaker`;
 
   return (
-    <StyledEntry>
+    <StyledEntry isActive={isActive}>
       <StyledEntryHeader>
         <Chip
           clickable={false}
@@ -65,7 +84,29 @@ export const CallRecordingTranscriptEntryListItem = ({
           </StyledTimestamp>
         )}
       </StyledEntryHeader>
-      <StyledText>{entry.text}</StyledText>
+      <StyledText>
+        {isNonEmptyArray(entry.words)
+          ? entry.words.map((word, wordIndex) => (
+              <StyledWord
+                key={wordIndex}
+                isHighlighted={isWordHighlighted({ word, currentTimeSeconds })}
+              >
+                {wordIndex > 0 ? ' ' : ''}
+                {word.text}
+              </StyledWord>
+            ))
+          : entry.text}
+      </StyledText>
     </StyledEntry>
   );
 };
+
+const isWordHighlighted = ({
+  word,
+  currentTimeSeconds,
+}: {
+  word: CallRecordingParsedTranscriptWord;
+  currentTimeSeconds: number | undefined;
+}): boolean =>
+  !isDefined(currentTimeSeconds) ||
+  (isDefined(word.startSeconds) && currentTimeSeconds >= word.startSeconds);

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptWidgetContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptWidgetContent.tsx
@@ -1,16 +1,114 @@
 import { useCalendarEventCallRecording } from '@/page-layout/widgets/calendar-event-call-recording/hooks/useCalendarEventCallRecording';
+import { useCallRecordingsSeeAllHref } from '@/page-layout/widgets/calendar-event-call-recording/hooks/useCallRecordingsSeeAllHref';
+import { getCallRecordingVideoFileUrl } from '@/page-layout/widgets/calendar-event-call-recording/utils/getCallRecordingVideoFileUrl';
 import { CallRecordingTranscriptBody } from '@/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptBody';
+import { buildCallRecordingTranscriptPlainText } from '@/page-layout/widgets/call-recording-transcript/utils/buildCallRecordingTranscriptPlainText';
+import { WidgetHeaderInfoEffect } from '@/page-layout/widgets/components/WidgetHeaderInfoEffect';
+import { type WidgetHeaderAction } from '@/page-layout/widgets/types/WidgetHeaderInfo';
+import { t } from '@lingui/core/macro';
+import { useMemo } from 'react';
+import {
+  isDefined,
+  isNonEmptyArray,
+  parseCallRecordingTranscriptEntries,
+} from 'twenty-shared/utils';
+import { IconArrowUpRight, IconCopy, IconLink } from 'twenty-ui/icon';
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 export const CallRecordingTranscriptWidgetContent = () => {
-  const { callRecording, loading, error, restriction } =
-    useCalendarEventCallRecording({ queryScope: 'call-recording-transcript' });
+  const {
+    callRecording,
+    callRecordingsCount,
+    loading,
+    error,
+    restriction,
+    refetch,
+  } = useCalendarEventCallRecording({
+    queryScope: 'call-recording-transcript',
+  });
+
+  const { copyToClipboard } = useCopyToClipboard();
+  const callRecordingsSeeAllHref = useCallRecordingsSeeAllHref();
+
+  const transcriptEntries = useMemo(
+    () =>
+      isDefined(callRecording)
+        ? parseCallRecordingTranscriptEntries(callRecording.transcript)
+        : undefined,
+    [callRecording],
+  );
+
+  const transcriptPlainText = useMemo(
+    () =>
+      isDefined(transcriptEntries) && isNonEmptyArray(transcriptEntries)
+        ? buildCallRecordingTranscriptPlainText(transcriptEntries)
+        : undefined,
+    [transcriptEntries],
+  );
+
+  const videoFileUrl = isDefined(callRecording)
+    ? getCallRecordingVideoFileUrl(callRecording)
+    : undefined;
+
+  const headerActions = useMemo(() => {
+    const actions: WidgetHeaderAction[] = [];
+
+    if (isDefined(transcriptPlainText)) {
+      actions.push({
+        id: 'copy-transcript',
+        Icon: IconCopy,
+        label: t`Copy transcript`,
+        onClick: () =>
+          copyToClipboard(
+            transcriptPlainText,
+            t`Transcript copied to clipboard`,
+          ),
+      });
+    }
+
+    if (isDefined(videoFileUrl)) {
+      actions.push({
+        id: 'copy-video-download-link',
+        Icon: IconLink,
+        label: t`Copy video download link`,
+        onClick: () =>
+          copyToClipboard(videoFileUrl, t`Link copied to clipboard`),
+      });
+    }
+
+    if (isDefined(callRecordingsSeeAllHref) && callRecordingsCount > 0) {
+      actions.push({
+        id: 'see-all-call-recordings',
+        Icon: IconArrowUpRight,
+        label: t`See all call recordings linked to this calendar event`,
+        to: callRecordingsSeeAllHref,
+      });
+    }
+
+    return isNonEmptyArray(actions) ? actions : undefined;
+  }, [
+    transcriptPlainText,
+    videoFileUrl,
+    callRecordingsSeeAllHref,
+    callRecordingsCount,
+    copyToClipboard,
+  ]);
 
   return (
-    <CallRecordingTranscriptBody
-      callRecording={callRecording}
-      loading={loading}
-      error={error}
-      restriction={restriction}
-    />
+    <>
+      <WidgetHeaderInfoEffect
+        count={callRecordingsCount > 0 ? callRecordingsCount : undefined}
+        actions={headerActions}
+      />
+      <CallRecordingTranscriptBody
+        callRecording={callRecording}
+        transcriptEntries={transcriptEntries}
+        videoFileUrl={videoFileUrl}
+        loading={loading}
+        error={error}
+        restriction={restriction}
+        refetchCallRecording={refetch}
+      />
+    </>
   );
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingVideoPlayer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingVideoPlayer.tsx
@@ -1,0 +1,163 @@
+import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
+import { useState, type SyntheticEvent } from 'react';
+import { CircularProgressBar } from 'twenty-ui/feedback';
+import { Button } from 'twenty-ui/input';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const DEFAULT_VIDEO_ASPECT_RATIO = '16 / 9';
+
+// Forces Safari to decode the first frame under preload="metadata".
+const FIRST_FRAME_SEEK_FRAGMENT = '#t=0.001';
+
+type CallRecordingVideoLoadState = 'awaiting-first-frame' | 'ready' | 'errored';
+
+const StyledVideoViewport = styled.div`
+  aspect-ratio: ${DEFAULT_VIDEO_ASPECT_RATIO};
+  background: ${themeCssVariables.background.primary};
+  border-radius: ${themeCssVariables.border.radius.sm};
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+`;
+
+const StyledVideo = styled.video<{ isFirstFrameReady: boolean }>`
+  accent-color: ${themeCssVariables.accent.accent9};
+  background: ${themeCssVariables.background.primary};
+  color-scheme: light dark;
+  display: block;
+  height: 100%;
+  object-fit: contain;
+  opacity: ${({ isFirstFrameReady }) => (isFirstFrameReady ? 1 : 0)};
+  transition: opacity calc(${themeCssVariables.animation.duration.fast} * 1s)
+    ease;
+  width: 100%;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;
+
+const StyledBufferingOverlay = styled.div<{ isVisible: boolean }>`
+  align-items: center;
+  color: ${themeCssVariables.font.color.tertiary};
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+  pointer-events: none;
+  position: absolute;
+  transition: opacity calc(${themeCssVariables.animation.duration.fast} * 1s)
+    ease
+    ${({ isVisible }) =>
+      isVisible
+        ? `calc(${themeCssVariables.animation.duration.normal} * 1s)`
+        : '0s'};
+
+  @media (prefers-reduced-motion: reduce) {
+    transition-duration: 0ms;
+  }
+`;
+
+const StyledPlaybackErrorState = styled.div`
+  align-items: center;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[2]};
+  height: 100%;
+  justify-content: center;
+  padding: ${themeCssVariables.spacing[4]};
+`;
+
+const StyledPlaybackErrorTitle = styled.span`
+  color: ${themeCssVariables.font.color.primary};
+  font-size: ${themeCssVariables.font.size.sm};
+  font-weight: ${themeCssVariables.font.weight.medium};
+`;
+
+const StyledPlaybackErrorDescription = styled.span`
+  color: ${themeCssVariables.font.color.secondary};
+  font-size: ${themeCssVariables.font.size.xs};
+`;
+
+type CallRecordingVideoPlayerProps = {
+  src: string;
+  onTimeUpdate: (currentTimeSeconds: number) => void;
+  onRetry: () => void;
+};
+
+export const CallRecordingVideoPlayer = ({
+  src,
+  onTimeUpdate,
+  onRetry,
+}: CallRecordingVideoPlayerProps) => {
+  const [loadState, setLoadState] = useState<CallRecordingVideoLoadState>(
+    'awaiting-first-frame',
+  );
+  const [isPlaybackStalled, setIsPlaybackStalled] = useState(false);
+
+  const markFirstFrameReady = () => {
+    setLoadState((previousLoadState) =>
+      previousLoadState === 'awaiting-first-frame'
+        ? 'ready'
+        : previousLoadState,
+    );
+    setIsPlaybackStalled(false);
+  };
+
+  const handleTimeUpdate = (event: SyntheticEvent<HTMLVideoElement>) => {
+    markFirstFrameReady();
+    onTimeUpdate(event.currentTarget.currentTime);
+  };
+
+  const handleWaiting = () => setIsPlaybackStalled(true);
+
+  const handlePause = () => setIsPlaybackStalled(false);
+
+  const handleError = () => setLoadState('errored');
+
+  const handleRetry = () => {
+    setLoadState('awaiting-first-frame');
+    setIsPlaybackStalled(false);
+    onRetry();
+  };
+
+  if (loadState === 'errored') {
+    return (
+      <StyledVideoViewport>
+        <StyledPlaybackErrorState>
+          <StyledPlaybackErrorTitle>{t`Playback failed`}</StyledPlaybackErrorTitle>
+          <StyledPlaybackErrorDescription>
+            {t`The recording could not be loaded.`}
+          </StyledPlaybackErrorDescription>
+          <Button title={t`Retry`} variant="secondary" onClick={handleRetry} />
+        </StyledPlaybackErrorState>
+      </StyledVideoViewport>
+    );
+  }
+
+  return (
+    <StyledVideoViewport>
+      <StyledVideo
+        isFirstFrameReady={loadState === 'ready'}
+        controls
+        playsInline
+        preload="metadata"
+        src={`${src}${FIRST_FRAME_SEEK_FRAGMENT}`}
+        onCanPlay={markFirstFrameReady}
+        onError={handleError}
+        onLoadedData={markFirstFrameReady}
+        onPause={handlePause}
+        onSeeked={markFirstFrameReady}
+        onTimeUpdate={handleTimeUpdate}
+        onWaiting={handleWaiting}
+      />
+      <StyledBufferingOverlay
+        isVisible={loadState === 'awaiting-first-frame' || isPlaybackStalled}
+      >
+        <CircularProgressBar barWidth={3} size={24} />
+      </StyledBufferingOverlay>
+    </StyledVideoViewport>
+  );
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/__stories__/CallRecordingTranscriptBody.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/__stories__/CallRecordingTranscriptBody.stories.tsx
@@ -6,6 +6,7 @@ import { type CalendarEventCallRecordingCandidate } from '@/page-layout/widgets/
 import { CallRecordingTranscriptBody } from '@/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptBody';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { expect, waitFor, within } from 'storybook/test';
+import { parseCallRecordingTranscriptEntries } from 'twenty-shared/utils';
 import { ComponentDecorator } from 'twenty-ui/testing';
 import {
   PageLayoutType,
@@ -80,6 +81,7 @@ const completedCallRecording: CalendarEventCallRecordingCandidate = {
   status: CallRecordingStatus.COMPLETED,
   transcript: [],
   summary: null,
+  video: null,
   createdAt: '2026-01-01T00:00:00Z',
 };
 
@@ -127,6 +129,21 @@ const readableCallRecording: CalendarEventCallRecordingCandidate = {
   transcript: rawTranscript,
 };
 
+const recordedCallRecording: CalendarEventCallRecordingCandidate = {
+  ...readableCallRecording,
+  video: [
+    {
+      fileId: 'video-file-id',
+      label: 'recording.mp4',
+      extension: 'mp4',
+      url: 'https://files.example.com/recording.mp4',
+    },
+  ],
+};
+
+const parsedTranscriptEntries =
+  parseCallRecordingTranscriptEntries(rawTranscript);
+
 const meta: Meta<typeof CallRecordingTranscriptBody> = {
   title: 'Modules/PageLayout/Widgets/CallRecordingTranscriptBody',
   component: CallRecordingTranscriptBody,
@@ -141,6 +158,11 @@ const meta: Meta<typeof CallRecordingTranscriptBody> = {
   parameters: {
     layout: 'centered',
   },
+  args: {
+    transcriptEntries: undefined,
+    videoFileUrl: undefined,
+    refetchCallRecording: () => {},
+  },
 };
 
 export default meta;
@@ -149,6 +171,7 @@ type Story = StoryObj<typeof CallRecordingTranscriptBody>;
 export const Ready: Story = {
   args: {
     callRecording: readableCallRecording,
+    transcriptEntries: parsedTranscriptEntries,
     loading: false,
     error: undefined,
     restriction: undefined,
@@ -161,6 +184,25 @@ export const Ready: Story = {
       'Happy to. Pipeline grew twenty percent since the last call.',
     );
     await canvas.findByText('Inaudible segment.');
+  },
+};
+
+export const WithVideo: Story = {
+  args: {
+    callRecording: recordedCallRecording,
+    transcriptEntries: parsedTranscriptEntries,
+    videoFileUrl: 'https://files.example.com/recording.mp4',
+    loading: false,
+    error: undefined,
+    restriction: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText('Ada Lovelace');
+    await canvas.findByText(
+      'Happy to. Pipeline grew twenty percent since the last call.',
+    );
   },
 };
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/__stories__/CallRecordingTranscriptEntryListItem.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/__stories__/CallRecordingTranscriptEntryListItem.stories.tsx
@@ -54,6 +54,31 @@ export const WithHourLongTimestamp: Story = {
   },
 };
 
+export const ActiveDuringPlayback: Story = {
+  args: {
+    entry: {
+      speakerName: 'Ada Lovelace',
+      startSeconds: 10,
+      endSeconds: 14,
+      text: 'Thanks for joining everyone',
+      words: [
+        { text: 'Thanks', startSeconds: 10, endSeconds: 11 },
+        { text: 'for', startSeconds: 11, endSeconds: 12 },
+        { text: 'joining', startSeconds: 12, endSeconds: 13 },
+        { text: 'everyone', startSeconds: 13, endSeconds: 14 },
+      ],
+    },
+    isActive: true,
+    currentTimeSeconds: 12,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText('Thanks');
+    await canvas.findByText('everyone');
+  },
+};
+
 export const WithoutSpeaker: Story = {
   args: {
     entry: {

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/__stories__/CallRecordingVideoPlayer.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/__stories__/CallRecordingVideoPlayer.stories.tsx
@@ -1,0 +1,39 @@
+import { CallRecordingVideoPlayer } from '@/page-layout/widgets/call-recording-transcript/components/CallRecordingVideoPlayer';
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { within } from 'storybook/test';
+import { ComponentDecorator } from 'twenty-ui/testing';
+
+const meta: Meta<typeof CallRecordingVideoPlayer> = {
+  title: 'Modules/PageLayout/Widgets/CallRecordingVideoPlayer',
+  component: CallRecordingVideoPlayer,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 480 }}>
+        <Story />
+      </div>
+    ),
+    ComponentDecorator,
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    onTimeUpdate: () => {},
+    onRetry: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CallRecordingVideoPlayer>;
+
+export const PlaybackError: Story = {
+  args: {
+    src: 'data:video/mp4,not-a-video',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText('Playback failed');
+    await canvas.findByText('Retry');
+  },
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/utils/__tests__/buildCallRecordingTranscriptPlainText.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/utils/__tests__/buildCallRecordingTranscriptPlainText.test.ts
@@ -1,0 +1,42 @@
+import { buildCallRecordingTranscriptPlainText } from '@/page-layout/widgets/call-recording-transcript/utils/buildCallRecordingTranscriptPlainText';
+import { type CallRecordingParsedTranscriptEntry } from 'twenty-shared/types';
+
+const makeTranscriptEntry = (
+  overrides: Partial<CallRecordingParsedTranscriptEntry>,
+): CallRecordingParsedTranscriptEntry => ({
+  speakerName: 'Ada Lovelace',
+  startSeconds: 12,
+  endSeconds: 21,
+  text: 'Hello there.',
+  words: [],
+  ...overrides,
+});
+
+describe('buildCallRecordingTranscriptPlainText', () => {
+  it('renders speaker, timestamp and text per entry separated by blank lines', () => {
+    expect(
+      buildCallRecordingTranscriptPlainText([
+        makeTranscriptEntry({}),
+        makeTranscriptEntry({
+          speakerName: 'Grace Hopper',
+          startSeconds: 3675,
+          text: 'Pipeline grew.',
+        }),
+      ]),
+    ).toBe(
+      'Ada Lovelace (0:12)\nHello there.\n\nGrace Hopper (1:01:15)\nPipeline grew.',
+    );
+  });
+
+  it('falls back to an unknown speaker and omits missing timestamps', () => {
+    expect(
+      buildCallRecordingTranscriptPlainText([
+        makeTranscriptEntry({
+          speakerName: undefined,
+          startSeconds: undefined,
+          text: 'Inaudible segment.',
+        }),
+      ]),
+    ).toBe('Unknown speaker\nInaudible segment.');
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/utils/__tests__/findActiveCallRecordingTranscriptEntryIndex.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/utils/__tests__/findActiveCallRecordingTranscriptEntryIndex.test.ts
@@ -1,0 +1,64 @@
+import { findActiveCallRecordingTranscriptEntryIndex } from '@/page-layout/widgets/call-recording-transcript/utils/findActiveCallRecordingTranscriptEntryIndex';
+import { type CallRecordingParsedTranscriptEntry } from 'twenty-shared/types';
+
+const makeTranscriptEntry = ({
+  startSeconds,
+  endSeconds,
+}: {
+  startSeconds: number | undefined;
+  endSeconds: number | undefined;
+}): CallRecordingParsedTranscriptEntry => ({
+  speakerName: 'Ada Lovelace',
+  startSeconds,
+  endSeconds,
+  text: 'Hello',
+  words: [{ text: 'Hello', startSeconds, endSeconds }],
+});
+
+describe('findActiveCallRecordingTranscriptEntryIndex', () => {
+  it('does not keep an open-ended entry active after the next entry starts', () => {
+    expect(
+      findActiveCallRecordingTranscriptEntryIndex({
+        entries: [
+          makeTranscriptEntry({ startSeconds: 1, endSeconds: undefined }),
+          makeTranscriptEntry({ startSeconds: 10, endSeconds: 20 }),
+        ],
+        currentTimeSeconds: 25,
+      }),
+    ).toBe(-1);
+  });
+
+  it('uses the next known start as the boundary for entries without an end time', () => {
+    expect(
+      findActiveCallRecordingTranscriptEntryIndex({
+        entries: [
+          makeTranscriptEntry({ startSeconds: 1, endSeconds: undefined }),
+          makeTranscriptEntry({ startSeconds: 10, endSeconds: 20 }),
+        ],
+        currentTimeSeconds: 9,
+      }),
+    ).toBe(0);
+
+    expect(
+      findActiveCallRecordingTranscriptEntryIndex({
+        entries: [
+          makeTranscriptEntry({ startSeconds: 1, endSeconds: undefined }),
+          makeTranscriptEntry({ startSeconds: 10, endSeconds: 20 }),
+        ],
+        currentTimeSeconds: 10,
+      }),
+    ).toBe(1);
+  });
+
+  it('keeps the final open-ended entry active after it starts', () => {
+    expect(
+      findActiveCallRecordingTranscriptEntryIndex({
+        entries: [
+          makeTranscriptEntry({ startSeconds: 1, endSeconds: 2 }),
+          makeTranscriptEntry({ startSeconds: 10, endSeconds: undefined }),
+        ],
+        currentTimeSeconds: 25,
+      }),
+    ).toBe(1);
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/utils/buildCallRecordingTranscriptPlainText.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/utils/buildCallRecordingTranscriptPlainText.ts
@@ -1,0 +1,18 @@
+import { formatCallRecordingTranscriptTimestamp } from '@/page-layout/widgets/call-recording-transcript/utils/formatCallRecordingTranscriptTimestamp';
+import { t } from '@lingui/core/macro';
+import { isUndefined } from '@sniptt/guards';
+import { type CallRecordingParsedTranscriptEntry } from 'twenty-shared/types';
+
+export const buildCallRecordingTranscriptPlainText = (
+  entries: CallRecordingParsedTranscriptEntry[],
+): string =>
+  entries
+    .map((entry) => {
+      const speakerName = entry.speakerName ?? t`Unknown speaker`;
+      const timestamp = isUndefined(entry.startSeconds)
+        ? ''
+        : ` (${formatCallRecordingTranscriptTimestamp(entry.startSeconds)})`;
+
+      return `${speakerName}${timestamp}\n${entry.text}`;
+    })
+    .join('\n\n');

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/utils/findActiveCallRecordingTranscriptEntryIndex.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/utils/findActiveCallRecordingTranscriptEntryIndex.ts
@@ -1,0 +1,49 @@
+import { isUndefined } from '@sniptt/guards';
+import { type CallRecordingParsedTranscriptEntry } from 'twenty-shared/types';
+
+export const findActiveCallRecordingTranscriptEntryIndex = ({
+  entries,
+  currentTimeSeconds,
+}: {
+  entries: CallRecordingParsedTranscriptEntry[];
+  currentTimeSeconds: number;
+}): number =>
+  entries.findLastIndex((entry, entryIndex) =>
+    isTranscriptEntryActive({
+      entries,
+      entry,
+      entryIndex,
+      currentTimeSeconds,
+    }),
+  );
+
+const isTranscriptEntryActive = ({
+  entries,
+  entry,
+  entryIndex,
+  currentTimeSeconds,
+}: {
+  entries: CallRecordingParsedTranscriptEntry[];
+  entry: CallRecordingParsedTranscriptEntry;
+  entryIndex: number;
+  currentTimeSeconds: number;
+}): boolean => {
+  if (
+    isUndefined(entry.startSeconds) ||
+    currentTimeSeconds < entry.startSeconds
+  ) {
+    return false;
+  }
+
+  if (!isUndefined(entry.endSeconds)) {
+    return currentTimeSeconds <= entry.endSeconds;
+  }
+
+  const nextTranscriptEntryStartSeconds = entries
+    .slice(entryIndex + 1)
+    .find((nextEntry) => !isUndefined(nextEntry.startSeconds))?.startSeconds;
+
+  return isUndefined(nextTranscriptEntryStartSeconds)
+    ? true
+    : currentTimeSeconds < nextTranscriptEntryStartSeconds;
+};


### PR DESCRIPTION
Stacked on #24204.

- Video player above the transcript; entries and words highlight in sync with playback
- Widget header publishes the recordings count and actions: copy transcript, copy video download link, see all call recordings
- Video load errors show a retry that refetches the recording

Transcript-only recordings (no video file) render unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

