### PR TITLE
fix(server): quote the alias in ORM v2 record-identifier where clauses

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-record-identifier.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-record-identifier.service.ts
@@ -96,7 +96,7 @@ export class NavigationMenuItemRecordIdentifierService {
           }
 
           const rawResult = await queryBuilder
-            .where(`${alias}.id = :id`, { id: targetRecordId })
+            .where(`"${alias}".id = :id`, { id: targetRecordId })
             .getRawOne();
 
           if (!isDefined(rawResult)) {

--- a/packages/twenty-server/src/modules/dashboard/chart-data/services/chart-relation-label.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/services/chart-relation-label.service.ts
@@ -236,7 +236,7 @@ export class ChartRelationLabelService {
                 }
 
                 return queryBuilder
-                  .where(`${alias}.id IN (:...recordIdChunk)`, {
+                  .where(`"${alias}".id IN (:...recordIdChunk)`, {
                     recordIdChunk,
                   })
                   .getRawMany();


### PR DESCRIPTION
## Problem

Under the ORM v2 read path, `FindManyNavigationMenuItems` fails in prod with:

```
error: missing FROM-clause entry for table "salesactionitem"
```

Stack: `NavigationMenuItemResolver.targetRecordIdentifier` → `NavigationMenuItemService.findTargetRecord` → `NavigationMenuItemRecordIdentifierService.resolveRecordIdentifier` → v2 `WorkspaceSelectQueryBuilderV2.getRawOne` → `PoolQueryExecutor`.

## Root cause

The record-identifier read builds the query with a **quoted, case-preserved alias in the SELECT** but an **unquoted alias in the WHERE**:

```ts
const alias = objectMetadata.nameSingular;            // e.g. "salesActionItem"
queryBuilder.addSelect(`"${alias}"."${column}"`, column);   // "salesActionItem"."..."  (case preserved)
queryBuilder.where(`${alias}.id = :id`, { id });            // salesActionItem.id       (unquoted)
```

Postgres folds the unquoted identifier to lower case, so the WHERE references `salesactionitem` while the FROM/SELECT alias is `"salesActionItem"`. The table isn't in the FROM under that name → the query fails.

Objects whose `nameSingular` is all lower-case (`company`, `person`, …) are unaffected — folding is a no-op — which is why this only surfaced for **camelCase custom objects** (`salesActionItem`) under v2.

The same antipattern exists in `chart-relation-label.service.ts` (dashboard chart relation labels), which would hit the same error for camelCase custom objects.

## Fix

Quote the alias in the WHERE so it matches the FROM/SELECT aliasing. Two call sites, one line each.

## Notes

- Discovered while triaging the ORM-v2-flag prod test (release v2.31.2). Unrelated to and not covered by #24182.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

