### PR TITLE
fix(server): fail FIND_RECORDS cleanly on an uncomputable filter

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
+import { type RecordGqlOperationFilter } from 'twenty-shared/types';
 import {
   computeRecordGqlOperationFilter,
   isDefined,
@@ -81,19 +82,28 @@ export class FindRecordsWorkflowAction implements WorkflowAction {
 
     const recordFilters = workflowActionInput.filter?.recordFilters;
 
-    const gqlOperationFilter = isDefined(recordFilters)
-      ? computeRecordGqlOperationFilter({
-          fieldMetadataItems: Object.values(
-            flatFieldMetadataMaps.byUniversalIdentifier,
-          ).filter(isDefined),
-          recordFilters,
-          recordFilterGroups:
-            workflowActionInput.filter?.recordFilterGroups ?? [],
-          filterValueDependencies: {
-            timeZone: 'UTC',
-          },
-        })
-      : {};
+    let gqlOperationFilter: RecordGqlOperationFilter;
+
+    try {
+      gqlOperationFilter = isDefined(recordFilters)
+        ? computeRecordGqlOperationFilter({
+            fieldMetadataItems: Object.values(
+              flatFieldMetadataMaps.byUniversalIdentifier,
+            ).filter(isDefined),
+            recordFilters,
+            recordFilterGroups:
+              workflowActionInput.filter?.recordFilterGroups ?? [],
+            filterValueDependencies: {
+              timeZone: 'UTC',
+            },
+          })
+        : {};
+    } catch (error) {
+      throw new WorkflowStepExecutorException(
+        `Filter could not be computed: ${error.message}`,
+        WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
+      );
+    }
 
     if (isNonEmptyArray(recordFilters) && isEmptyObject(gqlOperationFilter)) {
       throw new WorkflowStepExecutorException(


### PR DESCRIPTION
## Problem

`FIND_RECORDS` lets a raw `Error` escape when the filter cannot be compiled. `computeRecordGqlOperationFilter` throws `Unknown operand <X> for <TYPE> filter` when a filter carries an operand the filtered field type does not support.

Because it is not a `WorkflowStepExecutorException`, `executeStep` classifies it as a system error: the exception is captured by Sentry and counted in `WorkflowRunSystemError`, while the user gets a message that reads like an internal failure. It is a step configuration problem.

Reported in prod as `Unknown operand IS for EMAILS filter` (TWENTY-SERVER-JRA), with the same shape recurring for TEXT, DATE and RELATION fields (TWENTY-SERVER-JGY and others, the oldest going back to v2.24.3).

The step editor only offers the operands in `FILTER_OPERANDS_MAP` for a given field type, so these filters come from step settings written elsewhere, or from a filter that outlived a change of its field's type.

## Fix

Wrap the filter computation and rethrow as `INVALID_STEP_INPUT`, keeping the underlying message. `executeStep` already treats that code as a user error, so the run fails with a readable reason instead of being reported as a crash.
