### PR TITLE
fix(server): make the ORM v2 timeline messaging panel work (add innerJoin + v2-native rewrite)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
@@ -5,6 +5,7 @@ import {
   MessageChannelVisibility,
   MessageParticipantRole,
 } from 'twenty-shared/types';
+import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 import { In, type Repository } from 'typeorm';
 
 import { FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
@@ -14,8 +15,10 @@ import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-ac
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { type MessageParticipantWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-participant.workspace-entity';
 import { type MessageThreadWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-thread.workspace-entity';
+import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @Injectable()
@@ -56,33 +59,62 @@ export class TimelineMessagingService {
             workspaceId,
             'messageThread',
           );
+        const messageParticipantRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+            workspaceId,
+            'messageParticipant',
+          );
+        const messageRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+            workspaceId,
+            'message',
+          );
 
-        const totalNumberOfThreads = await messageThreadRepository
-          .createQueryBuilder('messageThread')
-          .innerJoin('messageThread.messages', 'messages')
-          .innerJoin('messages.messageParticipants', 'messageParticipants')
-          .where('messageParticipants.personId IN(:...personIds)', {
-            personIds,
-          })
-          .groupBy('messageThread.id')
-          .getCount();
+        // ORM v2 does not join to-many relations, so the thread set is resolved
+        // with flat queries: participants of these people -> their messages ->
+        // threads, tracking the latest message date per thread for ordering.
+        const participants = await messageParticipantRepository.find({
+          where: { personId: In(personIds) },
+          select: { messageId: true },
+        });
 
-        const threadIdsQuery = await messageThreadRepository
-          .createQueryBuilder('messageThread')
-          .select('messageThread.id', 'id')
-          .addSelect('MAX(messages.receivedAt)', 'max_received_at')
-          .innerJoin('messageThread.messages', 'messages')
-          .innerJoin('messages.messageParticipants', 'messageParticipants')
-          .where('messageParticipants.personId IN (:...personIds)', {
-            personIds,
-          })
-          .groupBy('messageThread.id')
-          .orderBy('max_received_at', 'DESC')
-          .offset(offset)
-          .limit(pageSize)
-          .getRawMany();
+        const participantMessageIds = [
+          ...new Set(participants.map((participant) => participant.messageId)),
+        ];
 
-        const messageThreadIds = threadIdsQuery.map((thread) => thread.id);
+        const participantMessages = isNonEmptyArray(participantMessageIds)
+          ? await messageRepository.find({
+              where: { id: In(participantMessageIds) },
+              select: { messageThreadId: true, receivedAt: true },
+            })
+          : [];
+
+        const latestReceivedAtByThreadId = new Map<string, number>();
+
+        for (const message of participantMessages) {
+          if (!isDefined(message.messageThreadId)) {
+            continue;
+          }
+
+          const receivedAtTime = (message.receivedAt ?? new Date(0)).getTime();
+          const currentLatest = latestReceivedAtByThreadId.get(
+            message.messageThreadId,
+          );
+
+          if (!isDefined(currentLatest) || receivedAtTime > currentLatest) {
+            latestReceivedAtByThreadId.set(
+              message.messageThreadId,
+              receivedAtTime,
+            );
+          }
+        }
+
+        const totalNumberOfThreads = latestReceivedAtByThreadId.size;
+
+        const messageThreadIds = [...latestReceivedAtByThreadId.entries()]
+          .sort(([, aReceivedAt], [, bReceivedAt]) => bReceivedAt - aReceivedAt)
+          .slice(offset, offset + pageSize)
+          .map(([threadId]) => threadId);
 
         const messageThreads = await messageThreadRepository.find({
           where: {
@@ -133,27 +165,54 @@ export class TimelineMessagingService {
             workspaceId,
             'messageParticipant',
           );
+        const messageRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+            workspaceId,
+            'message',
+          );
 
-        const threadParticipants = await messageParticipantRepository
-          .createQueryBuilder()
-          .select('messageParticipant')
-          .addSelect('message.messageThreadId')
-          .addSelect('message.receivedAt')
-          .leftJoinAndSelect('messageParticipant.person', 'person')
-          .leftJoinAndSelect(
-            'messageParticipant.workspaceMember',
-            'workspaceMember',
-          )
-          .leftJoin('messageParticipant.message', 'message')
-          .where('message.messageThreadId = ANY(:messageThreadIds)', {
-            messageThreadIds,
-          })
-          .andWhere('messageParticipant.role = :role', {
-            role: MessageParticipantRole.FROM,
-          })
-          .orderBy('message.messageThreadId')
-          .distinctOn(['message.messageThreadId', 'messageParticipant.handle'])
-          .getMany();
+        const threadMessages = await messageRepository.find({
+          where: { messageThreadId: In(messageThreadIds) },
+          select: { id: true, messageThreadId: true, receivedAt: true },
+        });
+
+        const messageById = new Map(
+          threadMessages.map((message) => [message.id, message]),
+        );
+
+        const threadMessageIds = threadMessages.map((message) => message.id);
+
+        const fromParticipants = isNonEmptyArray(threadMessageIds)
+          ? await messageParticipantRepository.find({
+              where: {
+                messageId: In(threadMessageIds),
+                role: MessageParticipantRole.FROM,
+              },
+              relations: ['person', 'workspaceMember'],
+            })
+          : [];
+
+        // ORM v2 has no DISTINCT ON, so keep one FROM participant per
+        // (thread, handle) in memory, attaching its message for downstream use.
+        const seenThreadHandleKeys = new Set<string>();
+        const threadParticipants: MessageParticipantWorkspaceEntity[] = [];
+
+        for (const participant of fromParticipants) {
+          const message = messageById.get(participant.messageId);
+
+          if (!isDefined(message) || !isDefined(message.messageThreadId)) {
+            continue;
+          }
+
+          const threadHandleKey = `${message.messageThreadId}:${participant.handle}`;
+
+          if (seenThreadHandleKeys.has(threadHandleKey)) {
+            continue;
+          }
+
+          seenThreadHandleKeys.add(threadHandleKey);
+          threadParticipants.push({ ...participant, message });
+        }
 
         const orderedThreadParticipants = threadParticipants.sort(
           (a, b) =>
@@ -271,28 +330,46 @@ export class TimelineMessagingService {
 
         const currentUserWorkspaceId = currentUserWorkspace.id;
 
-        const messageThreadRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+        const messageRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
             workspaceId,
-            'messageThread',
+            'message',
+          );
+        const messageChannelMessageAssociationRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+            workspaceId,
+            'messageChannelMessageAssociation',
           );
 
-        const threadChannelRows = await messageThreadRepository
-          .createQueryBuilder()
-          .select('messageThread.id', 'id')
-          .addSelect(
-            'messageChannelMessageAssociation.messageChannelId',
-            'messageChannelId',
-          )
-          .leftJoin('messageThread.messages', 'message')
-          .leftJoin(
-            'message.messageChannelMessageAssociations',
-            'messageChannelMessageAssociation',
-          )
-          .where('messageThread.id = ANY(:messageThreadIds)', {
-            messageThreadIds,
-          })
-          .getRawMany<{ id: string; messageChannelId: string | null }>();
+        // ORM v2 does not join to-many relations: resolve thread -> messages ->
+        // channel associations with flat queries and stitch them in memory.
+        const threadMessages = await messageRepository.find({
+          where: { messageThreadId: In(messageThreadIds) },
+          select: { id: true, messageThreadId: true },
+        });
+
+        const threadIdByMessageId = new Map(
+          threadMessages.map((message) => [message.id, message.messageThreadId]),
+        );
+
+        const threadMessageIds = threadMessages.map((message) => message.id);
+
+        const messageChannelAssociations = isNonEmptyArray(threadMessageIds)
+          ? await messageChannelMessageAssociationRepository.find({
+              where: { messageId: In(threadMessageIds) },
+              select: { messageId: true, messageChannelId: true },
+            })
+          : [];
+
+        const threadChannelRows = messageChannelAssociations
+          .map((association) => ({
+            id: threadIdByMessageId.get(association.messageId) ?? null,
+            messageChannelId: association.messageChannelId,
+          }))
+          .filter(
+            (row): row is { id: string; messageChannelId: string } =>
+              isDefined(row.id),
+          );
 
         const allMessageChannelIds = [
           ...new Set(

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/__tests__/workspace-select-query-builder-v2.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/__tests__/workspace-select-query-builder-v2.spec.ts
@@ -167,6 +167,18 @@ describe('WorkspaceSelectQueryBuilderV2', () => {
     );
   });
 
+  it('should render an inner join for a to-one relation', () => {
+    const { queryBuilder } = buildQueryBuilder();
+
+    queryBuilder.setFindOptions({ select: { id: true } });
+    queryBuilder.innerJoin('person.company', 'company');
+
+    expect(queryBuilder.getQuery()).toContain(
+      `INNER JOIN "${SCHEMA_NAME}"."company" AS "company" ` +
+        'ON ("person"."companyId" = "company"."id")',
+    );
+  });
+
   it('should report a to-many join to the shared guard rather than rendering it', () => {
     const { queryBuilder } = buildQueryBuilder();
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
@@ -256,6 +256,25 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     condition?: string,
     options?: { allowToManyJoin?: boolean },
   ): this {
+    return this.addJoin('LEFT', relationPath, alias, condition, options);
+  }
+
+  innerJoin(
+    relationPath: string,
+    alias: string,
+    condition?: string,
+    options?: { allowToManyJoin?: boolean },
+  ): this {
+    return this.addJoin('INNER', relationPath, alias, condition, options);
+  }
+
+  private addJoin(
+    joinType: 'INNER' | 'LEFT',
+    relationPath: string,
+    alias: string,
+    condition?: string,
+    options?: { allowToManyJoin?: boolean },
+  ): this {
     const [parentAlias, relationFieldName] = relationPath.split('.');
 
     if (!isDefined(relationFieldName)) {
@@ -304,6 +323,7 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
       alias,
       targetTableShape,
       relationType: relationShape.relationType,
+      joinType,
       condition: isDefined(joinColumnName)
         ? (condition ??
           `${this.quoteColumn(parentAlias, joinColumnName)} = ${this.quoteColumn(alias, 'id')}`)

--- a/packages/twenty-server/src/engine/twenty-orm-v2/sql/utils/build-select-statement.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/sql/utils/build-select-statement.util.ts
@@ -20,6 +20,7 @@ export type JoinClause = {
   alias: string;
   targetTableShape: WorkspaceTableShape;
   relationType: RelationType;
+  joinType: 'INNER' | 'LEFT';
   condition?: string;
   toManyForeignKeyColumnName?: string;
   additionalOnConditions: string[];
@@ -215,7 +216,7 @@ export const buildJoinClause = (state: SelectStatementState): string =>
           })
         : tableExpression;
 
-      return `LEFT JOIN ${joinSource} AS ${escapeIdentifier(
+      return `${joinClause.joinType} JOIN ${joinSource} AS ${escapeIdentifier(
         joinClause.alias,
       )} ON ${onConditions.map((condition) => `(${condition})`).join(' AND ')}`;
     })


### PR DESCRIPTION
## Problem

With `IS_ORM_V2_READ_PATH_ENABLED` on, the record **Emails/Timeline panel** (company/person) 500s. `GetTimelineThreadsFromObjectRecord` fails, first with:

```
messageThreadRepository.createQueryBuilder(...).innerJoin is not a function
```

`TimelineMessagingService` builds its queries with query-builder features the ORM v2 read path doesn't support:
- `innerJoin`
- **to-many joins** (`messageThread.messages`, `messages.messageParticipants`, `message.messageChannelMessageAssociations`) — v2 rejects these by design
- `leftJoinAndSelect`, `distinctOn`

Under v1 these worked; under v2 they throw. `getV1Repository` (the old escape hatch) was removed in #24182, so pinning to v1 isn't an option.

## Fix

**1. Add `innerJoin` to `WorkspaceSelectQueryBuilderV2`** (a genuine parity gap). Extract the shared join logic into a private `addJoin(joinType, …)`; expose `leftJoin`/`innerJoin` wrappers; carry `joinType: 'INNER' | 'LEFT'` on `JoinClause` and render it in `buildJoinClause` (was hard-coded `LEFT JOIN`). Unit-tested; `leftJoin` behaviour unchanged.

**2. Rewrite the three `TimelineMessagingService` methods to v2-native `find()` + in-memory joins**, preserving behaviour:
- `getAndCountMessageThreads`: participants → messages → threads, latest message date per thread for count / ordering / pagination.
- `getThreadParticipantsByThreadId`: messages of the threads, then their `FROM` participants with `person`/`workspaceMember` relations, deduped one per `(thread, handle)` in memory (replacing `DISTINCT ON`).
- `getThreadVisibilityByThreadId`: thread messages → channel associations stitched in memory (replacing the to-many joins).

## Testing

- `twenty-orm-v2` query-builder suite green (48 tests, incl. new `innerJoin` case); `lint:diff` and `typecheck` clean.
- The timeline methods are DB-query services with no unit coverage (per repo convention). **Recommend integration verification** on a workspace with the flag on: open a company/person with email history and confirm threads, participants, and visibility render correctly.
