### PR TITLE
perf(server): skip the ORM EntityMetadata build for ORM v2 workspaces at the cache layer

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
+import { FeatureFlagKey } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { type EntityMetadata, EntitySchema, Repository } from 'typeorm';
 import { EntitySchemaTransformer } from 'typeorm/entity-schema/EntitySchemaTransformer';
@@ -16,6 +17,7 @@ import { EntitySchemaFactory } from 'src/engine/twenty-orm/factories/entity-sche
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildEntitySchemaMetadataMaps } from 'src/engine/twenty-orm/global-workspace-datasource/types/entity-schema-metadata.type';
 import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 @Injectable()
 @WorkspaceCache('ORMEntityMetadatas', {
@@ -34,11 +36,21 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
     private readonly applicationRepository: Repository<ApplicationEntity>,
     private readonly entitySchemaFactory: EntitySchemaFactory,
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceCacheService: WorkspaceCacheService,
   ) {
     super();
   }
 
   async computeForCache(workspaceId: string): Promise<EntityMetadata[]> {
+    const { featureFlagsMap } = await this.workspaceCacheService.getOrRecompute(
+      workspaceId,
+      ['featureFlagsMap'],
+    );
+
+    if (featureFlagsMap[FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED]) {
+      return [];
+    }
+
     const [objectMetadatas, fieldMetadatas, twentyStandardApplication] =
       await Promise.all([
         this.objectMetadataRepository.find({


### PR DESCRIPTION
## What

Gate the expensive TypeORM `EntityMetadata` build at the cache-provider layer so it never runs for a workspace on the ORM v2 read/write path.

- `WorkspaceORMEntityMetadatasCacheService.computeForCache` now returns `[]` when `IS_ORM_V2_READ_PATH_ENABLED` is on for the workspace, before loading object/field metadata and building `EntitySchema` + `EntityMetadata`.
- Feature-flag toggles now invalidate `ORMEntityMetadatas` alongside `featureFlagsMap` (extracted as `getCacheKeysToInvalidateForFlags` with a unit spec).

## Why

Under the flag, the ORM v2 path never touches TypeORM `EntityMetadata`, but until now the *callers* were the only thing keeping the build from running. That guard is incomplete: `runInWorkspaceTransaction` returns on the v2 branch before `ensureEntityMetadatasLoaded`, and `loadWorkspaceContext` / `loadLiteWorkspaceContext` set `entityMetadatas = []` — but `ensureEntityMetadatasLoaded` itself is not gated, so any future caller reaching it would trigger the build for a flag-on workspace.

Gating at the provider makes it structurally impossible: no caller can cause the build once the flag is enabled. The build is a known hot spot on the request path, so this also removes it as a source of work for flag-on workspaces.

## Flip-safety

Because the empty result is cached, toggling the flag back **off** must recompute the real metadata — otherwise a v1 read would get an empty `EntityMetadata` set. `getCacheKeysToInvalidateForFlags` adds `ORMEntityMetadatas` to the invalidation set whenever `IS_ORM_V2_READ_PATH_ENABLED` is among the toggled flags, so flipping either direction refreshes it.

## Tests

- `get-cache-keys-to-invalidate-for-flags.util.spec.ts` covers the flag → cache-key mapping (unrelated flags don't invalidate `ORMEntityMetadatas`; the ORM v2 flag does, alone or among several).
- `nx lint:diff-with-main twenty-server` clean; existing feature-flag / workspace-cache suites pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

