### PR TITLE
Fix orphaned mirrored field permission blocking relation field updates

### DIFF
--- a/packages/twenty-front/src/modules/object-record/read-only/utils/__tests__/isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.test.ts
+++ b/packages/twenty-front/src/modules/object-record/read-only/utils/__tests__/isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.test.ts
@@ -7,6 +7,10 @@ const buildObjectPermissionsMap = (opts: {
   sourceId: string;
   targetId: string;
   targetCanUpdate: boolean;
+  targetRestrictedFields?: Record<
+    string,
+    { canRead: boolean | null; canUpdate: boolean | null }
+  >;
 }) => ({
   [opts.sourceId]: {
     objectMetadataId: opts.sourceId,
@@ -24,7 +28,7 @@ const buildObjectPermissionsMap = (opts: {
     canUpdateObjectRecords: opts.targetCanUpdate,
     canSoftDeleteObjectRecords: true,
     canDestroyObjectRecords: true,
-    restrictedFields: {},
+    restrictedFields: opts.targetRestrictedFields ?? {},
     rowLevelPermissionPredicates: [],
     rowLevelPermissionPredicateGroups: [],
   },
@@ -75,6 +79,38 @@ describe('isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission', () => {
           sourceId: sourceObjectMetadataId,
           targetId: targetObjectMetadataId,
           targetCanUpdate: true,
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('should return true when the inverse relation field on the related object is update-restricted', () => {
+    expect(
+      isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission({
+        fieldDefinition: oneToManyFieldDefinition,
+        objectPermissionsByObjectMetadataId: buildObjectPermissionsMap({
+          sourceId: sourceObjectMetadataId,
+          targetId: targetObjectMetadataId,
+          targetCanUpdate: true,
+          targetRestrictedFields: {
+            'target-field': { canRead: null, canUpdate: false },
+          },
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false when only unrelated fields on the related object are update-restricted', () => {
+    expect(
+      isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission({
+        fieldDefinition: oneToManyFieldDefinition,
+        objectPermissionsByObjectMetadataId: buildObjectPermissionsMap({
+          sourceId: sourceObjectMetadataId,
+          targetId: targetObjectMetadataId,
+          targetCanUpdate: true,
+          targetRestrictedFields: {
+            'some-other-field': { canRead: null, canUpdate: false },
+          },
         }),
       }),
     ).toBe(false);

--- a/packages/twenty-front/src/modules/object-record/read-only/utils/__tests__/isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.test.ts
+++ b/packages/twenty-front/src/modules/object-record/read-only/utils/__tests__/isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.test.ts
@@ -3,35 +3,40 @@ import { type FieldDefinition } from '@/object-record/record-field/ui/types/Fiel
 import { type FieldMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { FieldMetadataType, RelationType } from '~/generated-metadata/graphql';
 
+type RestrictedFields = Record<
+  string,
+  { canRead: boolean | null; canUpdate: boolean | null }
+>;
+
+const buildObjectPermissions = (opts: {
+  objectMetadataId: string;
+  canUpdate?: boolean;
+  restrictedFields?: RestrictedFields;
+}) => ({
+  objectMetadataId: opts.objectMetadataId,
+  canReadObjectRecords: true,
+  canUpdateObjectRecords: opts.canUpdate ?? true,
+  canSoftDeleteObjectRecords: true,
+  canDestroyObjectRecords: true,
+  restrictedFields: opts.restrictedFields ?? {},
+  rowLevelPermissionPredicates: [],
+  rowLevelPermissionPredicateGroups: [],
+});
+
 const buildObjectPermissionsMap = (opts: {
   sourceId: string;
   targetId: string;
   targetCanUpdate: boolean;
-  targetRestrictedFields?: Record<
-    string,
-    { canRead: boolean | null; canUpdate: boolean | null }
-  >;
+  targetRestrictedFields?: RestrictedFields;
 }) => ({
-  [opts.sourceId]: {
+  [opts.sourceId]: buildObjectPermissions({
     objectMetadataId: opts.sourceId,
-    canReadObjectRecords: true,
-    canUpdateObjectRecords: true,
-    canSoftDeleteObjectRecords: true,
-    canDestroyObjectRecords: true,
-    restrictedFields: {},
-    rowLevelPermissionPredicates: [],
-    rowLevelPermissionPredicateGroups: [],
-  },
-  [opts.targetId]: {
+  }),
+  [opts.targetId]: buildObjectPermissions({
     objectMetadataId: opts.targetId,
-    canReadObjectRecords: true,
-    canUpdateObjectRecords: opts.targetCanUpdate,
-    canSoftDeleteObjectRecords: true,
-    canDestroyObjectRecords: true,
-    restrictedFields: opts.targetRestrictedFields ?? {},
-    rowLevelPermissionPredicates: [],
-    rowLevelPermissionPredicateGroups: [],
-  },
+    canUpdate: opts.targetCanUpdate,
+    restrictedFields: opts.targetRestrictedFields,
+  }),
 });
 
 describe('isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission', () => {
@@ -114,5 +119,136 @@ describe('isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission', () => {
         }),
       }),
     ).toBe(false);
+  });
+
+  it('should return false when the inverse relation field is read-restricted but not update-restricted', () => {
+    expect(
+      isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission({
+        fieldDefinition: oneToManyFieldDefinition,
+        objectPermissionsByObjectMetadataId: buildObjectPermissionsMap({
+          sourceId: sourceObjectMetadataId,
+          targetId: targetObjectMetadataId,
+          targetCanUpdate: true,
+          targetRestrictedFields: {
+            'target-field': { canRead: false, canUpdate: null },
+          },
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  describe('morph relations', () => {
+    const firstMorphTargetObjectMetadataId = 'first-morph-target-object-id';
+    const secondMorphTargetObjectMetadataId = 'second-morph-target-object-id';
+
+    const buildMorphRelation = (targetObjectMetadataId: string) => ({
+      type: RelationType.ONE_TO_MANY,
+      sourceFieldMetadata: { id: 'morph-field-on-person', name: 'targets' },
+      targetFieldMetadata: {
+        id: `inverse-field-on-${targetObjectMetadataId}`,
+        name: 'person',
+      },
+      sourceObjectMetadata: {
+        id: sourceObjectMetadataId,
+        nameSingular: 'person',
+        namePlural: 'people',
+      },
+      targetObjectMetadata: {
+        id: targetObjectMetadataId,
+        nameSingular: 'target',
+        namePlural: 'targets',
+      },
+    });
+
+    const morphOneToManyFieldDefinition = {
+      type: FieldMetadataType.MORPH_RELATION,
+      fieldMetadataId: 'morph-field-on-person',
+      label: 'Targets',
+      iconName: 'IconRelation',
+      metadata: {
+        fieldName: 'targets',
+        relationType: RelationType.ONE_TO_MANY,
+        objectMetadataNameSingular: 'person',
+        morphRelations: [
+          buildMorphRelation(firstMorphTargetObjectMetadataId),
+          buildMorphRelation(secondMorphTargetObjectMetadataId),
+        ],
+        settings: null,
+        isCustom: true,
+        isUIEditable: true,
+      },
+    } as FieldDefinition<FieldMetadata>;
+
+    const buildMorphObjectPermissionsMap = (
+      restrictedFieldsByObjectMetadataId: Record<string, RestrictedFields>,
+    ) =>
+      Object.fromEntries(
+        [
+          firstMorphTargetObjectMetadataId,
+          secondMorphTargetObjectMetadataId,
+        ].map((objectMetadataId) => [
+          objectMetadataId,
+          buildObjectPermissions({
+            objectMetadataId,
+            restrictedFields:
+              restrictedFieldsByObjectMetadataId[objectMetadataId],
+          }),
+        ]),
+      );
+
+    it('should return true when every morph target has its inverse relation field update-restricted', () => {
+      expect(
+        isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission({
+          fieldDefinition: morphOneToManyFieldDefinition,
+          objectPermissionsByObjectMetadataId: buildMorphObjectPermissionsMap({
+            [firstMorphTargetObjectMetadataId]: {
+              [`inverse-field-on-${firstMorphTargetObjectMetadataId}`]: {
+                canRead: null,
+                canUpdate: false,
+              },
+            },
+            [secondMorphTargetObjectMetadataId]: {
+              [`inverse-field-on-${secondMorphTargetObjectMetadataId}`]: {
+                canRead: null,
+                canUpdate: false,
+              },
+            },
+          }),
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false when only one morph target has its inverse relation field update-restricted', () => {
+      expect(
+        isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission({
+          fieldDefinition: morphOneToManyFieldDefinition,
+          objectPermissionsByObjectMetadataId: buildMorphObjectPermissionsMap({
+            [firstMorphTargetObjectMetadataId]: {
+              [`inverse-field-on-${firstMorphTargetObjectMetadataId}`]: {
+                canRead: null,
+                canUpdate: false,
+              },
+            },
+          }),
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false when the morph field has no relations', () => {
+      expect(
+        isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission({
+          fieldDefinition: {
+            ...morphOneToManyFieldDefinition,
+            metadata: {
+              ...morphOneToManyFieldDefinition.metadata,
+              morphRelations: [],
+            },
+          } as FieldDefinition<FieldMetadata>,
+          objectPermissionsByObjectMetadataId: buildMorphObjectPermissionsMap(
+            {},
+          ),
+        }),
+      ).toBe(false);
+    });
   });
 });

--- a/packages/twenty-front/src/modules/object-record/read-only/utils/isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.ts
+++ b/packages/twenty-front/src/modules/object-record/read-only/utils/isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.ts
@@ -37,7 +37,20 @@ export const isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission = ({
       relationObjectMetadataId,
     );
 
-    return relationObjectPermissions.canUpdateObjectRecords === false;
+    if (relationObjectPermissions.canUpdateObjectRecords === false) {
+      return true;
+    }
+
+    // Attaching or detaching writes the join column owned by the inverse
+    // many-to-one field, so a field-level restriction there blocks the edit
+    const inverseRelationFieldMetadataId =
+      fieldDefinition.metadata.relationFieldMetadataId;
+
+    return (
+      isNonEmptyString(inverseRelationFieldMetadataId) &&
+      relationObjectPermissions.restrictedFields[inverseRelationFieldMetadataId]
+        ?.canUpdate === false
+    );
   }
 
   if (isFieldMorphRelationOneToMany(fieldDefinition)) {

--- a/packages/twenty-front/src/modules/object-record/read-only/utils/isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.ts
+++ b/packages/twenty-front/src/modules/object-record/read-only/utils/isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.ts
@@ -6,7 +6,7 @@ import { type FieldMetadata } from '@/object-record/record-field/ui/types/FieldM
 import { isFieldMorphRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldMorphRelationOneToMany';
 import { isFieldRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldRelationOneToMany';
 import { type ObjectPermissions } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
+import { isNonEmptyArray } from 'twenty-shared/utils';
 
 type ObjectPermissionsByObjectMetadataId = Record<
   string,
@@ -16,6 +16,33 @@ type ObjectPermissionsByObjectMetadataId = Record<
 type IsOneToManyRelationFieldReadOnlyDueToTargetUpdatePermissionParams = {
   fieldDefinition: FieldDefinition<FieldMetadata>;
   objectPermissionsByObjectMetadataId: ObjectPermissionsByObjectMetadataId;
+};
+
+// Attaching or detaching writes the join column owned by the inverse many-to-one
+// field, so a field-level restriction there blocks the edit too.
+const isTargetRecordUpdateBlocked = ({
+  objectPermissionsByObjectMetadataId,
+  targetObjectMetadataId,
+  inverseFieldMetadataId,
+}: {
+  objectPermissionsByObjectMetadataId: ObjectPermissionsByObjectMetadataId;
+  targetObjectMetadataId: string;
+  inverseFieldMetadataId: string | undefined;
+}): boolean => {
+  const targetObjectPermissions = getObjectPermissionsForObject(
+    objectPermissionsByObjectMetadataId,
+    targetObjectMetadataId,
+  );
+
+  if (targetObjectPermissions.canUpdateObjectRecords === false) {
+    return true;
+  }
+
+  return (
+    isNonEmptyString(inverseFieldMetadataId) &&
+    targetObjectPermissions.restrictedFields[inverseFieldMetadataId]
+      ?.canUpdate === false
+  );
 };
 
 // One-to-many edits persist by updating the related (or junction) record, not the
@@ -32,48 +59,27 @@ export const isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission = ({
       return false;
     }
 
-    const relationObjectPermissions = getObjectPermissionsForObject(
+    return isTargetRecordUpdateBlocked({
       objectPermissionsByObjectMetadataId,
-      relationObjectMetadataId,
-    );
-
-    if (relationObjectPermissions.canUpdateObjectRecords === false) {
-      return true;
-    }
-
-    // Attaching or detaching writes the join column owned by the inverse
-    // many-to-one field, so a field-level restriction there blocks the edit
-    const inverseRelationFieldMetadataId =
-      fieldDefinition.metadata.relationFieldMetadataId;
-
-    return (
-      isNonEmptyString(inverseRelationFieldMetadataId) &&
-      relationObjectPermissions.restrictedFields[inverseRelationFieldMetadataId]
-        ?.canUpdate === false
-    );
+      targetObjectMetadataId: relationObjectMetadataId,
+      inverseFieldMetadataId: fieldDefinition.metadata.relationFieldMetadataId,
+    });
   }
 
   if (isFieldMorphRelationOneToMany(fieldDefinition)) {
-    const morphTargetIds = [
-      ...new Set(
-        fieldDefinition.metadata.morphRelations.map(
-          (relation) => relation.targetObjectMetadata.id,
-        ),
-      ),
-    ];
+    const morphRelations = fieldDefinition.metadata.morphRelations;
 
-    if (!isDefined(morphTargetIds[0])) {
+    if (!isNonEmptyArray(morphRelations)) {
       return false;
     }
 
-    return morphTargetIds.every((targetObjectMetadataId) => {
-      const targetPermissions = getObjectPermissionsForObject(
+    return morphRelations.every((morphRelation) =>
+      isTargetRecordUpdateBlocked({
         objectPermissionsByObjectMetadataId,
-        targetObjectMetadataId,
-      );
-
-      return targetPermissions.canUpdateObjectRecords === false;
-    });
+        targetObjectMetadataId: morphRelation.targetObjectMetadata.id,
+        inverseFieldMetadataId: morphRelation.targetFieldMetadata.id,
+      }),
+    );
   }
 
   return false;

--- a/packages/twenty-server/src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
@@ -166,13 +166,21 @@ export class FieldPermissionService {
       );
 
       if (!isDefined(current)) {
+        const canReadFieldValue = desired.canReadFieldValue ?? null;
+        const canUpdateFieldValue = desired.canUpdateFieldValue ?? null;
+
+        // A row with no restriction left grants nothing: creating it would only add noise
+        if (!isDefined(canReadFieldValue) && !isDefined(canUpdateFieldValue)) {
+          continue;
+        }
+
         flatEntityToCreate.push(
           fromCreateFieldPermissionInputToUniversalFlatFieldPermission({
             fieldPermissionInput: {
               objectMetadataId: desired.objectMetadataId,
               fieldMetadataId: desired.fieldMetadataId,
-              canReadFieldValue: desired.canReadFieldValue ?? null,
-              canUpdateFieldValue: desired.canUpdateFieldValue ?? null,
+              canReadFieldValue,
+              canUpdateFieldValue,
             },
             roleId: input.roleId,
             flatApplication: workspaceCustomFlatApplication,
@@ -190,6 +198,27 @@ export class FieldPermissionService {
           desired.canUpdateFieldValue !== undefined
             ? desired.canUpdateFieldValue
             : current.canUpdateFieldValue;
+
+        // Once both flags are cleared the row no longer restricts anything: delete it
+        // instead of keeping an empty row (mirrored relation permissions land here on grant-back)
+        if (!isDefined(effectiveCanRead) && !isDefined(effectiveCanUpdate)) {
+          flatEntityToDelete.push({
+            universalIdentifier: current.universalIdentifier,
+            applicationUniversalIdentifier:
+              current.applicationUniversalIdentifier,
+            roleUniversalIdentifier: current.roleUniversalIdentifier,
+            objectMetadataUniversalIdentifier:
+              current.objectMetadataUniversalIdentifier,
+            fieldMetadataUniversalIdentifier:
+              current.fieldMetadataUniversalIdentifier,
+            canReadFieldValue: current.canReadFieldValue ?? undefined,
+            canUpdateFieldValue: current.canUpdateFieldValue ?? undefined,
+            createdAt: current.createdAt,
+            updatedAt: current.updatedAt,
+          });
+          continue;
+        }
+
         const changed =
           effectiveCanRead !== current.canReadFieldValue ||
           effectiveCanUpdate !== current.canUpdateFieldValue;
@@ -476,11 +505,24 @@ export class FieldPermissionService {
         continue;
       }
 
+      // Restricting a relation field mirrors the restriction onto the inverse
+      // field, so clearing it must mirror the clear as well: null propagates
+      // (clears the flag on the inverse side) while undefined leaves it as is.
+      // Otherwise the mirrored row survives as an orphan that keeps blocking
+      // updates on the relation's join column after the admin granted the field back.
+      const sourceIsCleared =
+        !isDefined(fieldPermission.canReadFieldValue) &&
+        !isDefined(fieldPermission.canUpdateFieldValue);
+
       desiredMap.set(targetKey, {
         objectMetadataId: targetObjectId,
         fieldMetadataId: targetFieldId,
-        canReadFieldValue: fieldPermission.canReadFieldValue ?? undefined,
-        canUpdateFieldValue: fieldPermission.canUpdateFieldValue ?? undefined,
+        canReadFieldValue: sourceIsCleared
+          ? null
+          : fieldPermission.canReadFieldValue,
+        canUpdateFieldValue: sourceIsCleared
+          ? null
+          : fieldPermission.canUpdateFieldValue,
       });
     }
   }

--- a/packages/twenty-server/src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
@@ -37,6 +37,23 @@ type DesiredFieldPermission = {
 const keyFrom = (objectMetadataId: string, fieldMetadataId: string) =>
   `${objectMetadataId}:${fieldMetadataId}`;
 
+const toUniversalFlatFieldPermissionToDelete = (
+  fieldPermission: FlatFieldPermission,
+): UniversalFlatFieldPermission => ({
+  universalIdentifier: fieldPermission.universalIdentifier,
+  applicationUniversalIdentifier:
+    fieldPermission.applicationUniversalIdentifier,
+  roleUniversalIdentifier: fieldPermission.roleUniversalIdentifier,
+  objectMetadataUniversalIdentifier:
+    fieldPermission.objectMetadataUniversalIdentifier,
+  fieldMetadataUniversalIdentifier:
+    fieldPermission.fieldMetadataUniversalIdentifier,
+  canReadFieldValue: fieldPermission.canReadFieldValue ?? undefined,
+  canUpdateFieldValue: fieldPermission.canUpdateFieldValue ?? undefined,
+  createdAt: fieldPermission.createdAt,
+  updatedAt: fieldPermission.updatedAt,
+});
+
 @Injectable()
 export class FieldPermissionService {
   constructor(
@@ -202,20 +219,9 @@ export class FieldPermissionService {
         // Once both flags are cleared the row no longer restricts anything: delete it
         // instead of keeping an empty row (mirrored relation permissions land here on grant-back)
         if (!isDefined(effectiveCanRead) && !isDefined(effectiveCanUpdate)) {
-          flatEntityToDelete.push({
-            universalIdentifier: current.universalIdentifier,
-            applicationUniversalIdentifier:
-              current.applicationUniversalIdentifier,
-            roleUniversalIdentifier: current.roleUniversalIdentifier,
-            objectMetadataUniversalIdentifier:
-              current.objectMetadataUniversalIdentifier,
-            fieldMetadataUniversalIdentifier:
-              current.fieldMetadataUniversalIdentifier,
-            canReadFieldValue: current.canReadFieldValue ?? undefined,
-            canUpdateFieldValue: current.canUpdateFieldValue ?? undefined,
-            createdAt: current.createdAt,
-            updatedAt: current.updatedAt,
-          });
+          flatEntityToDelete.push(
+            toUniversalFlatFieldPermissionToDelete(current),
+          );
           continue;
         }
 
@@ -253,20 +259,9 @@ export class FieldPermissionService {
       const key = keyFrom(current.objectMetadataId, current.fieldMetadataId);
 
       if (inputFieldKeys.has(key) && !desiredMap.has(key)) {
-        flatEntityToDelete.push({
-          universalIdentifier: current.universalIdentifier,
-          applicationUniversalIdentifier:
-            current.applicationUniversalIdentifier,
-          roleUniversalIdentifier: current.roleUniversalIdentifier,
-          objectMetadataUniversalIdentifier:
-            current.objectMetadataUniversalIdentifier,
-          fieldMetadataUniversalIdentifier:
-            current.fieldMetadataUniversalIdentifier,
-          canReadFieldValue: current.canReadFieldValue ?? undefined,
-          canUpdateFieldValue: current.canUpdateFieldValue ?? undefined,
-          createdAt: current.createdAt,
-          updatedAt: current.updatedAt,
-        });
+        flatEntityToDelete.push(
+          toUniversalFlatFieldPermissionToDelete(current),
+        );
       }
     }
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
@@ -153,11 +153,17 @@ export class FieldPermissionService {
       );
     }
 
-    this.addRelatedFieldPermissionsToDesired({
+    const mirroredFieldKeys = this.addRelatedFieldPermissionsToDesired({
       desiredMap,
       inputFieldPermissions: input.fieldPermissions,
       flatFieldMetadataMaps,
     });
+
+    const inputFieldKeys = new Set(
+      input.fieldPermissions.map((fp) =>
+        keyFrom(fp.objectMetadataId, fp.fieldMetadataId),
+      ),
+    );
 
     const { workspaceCustomFlatApplication } =
       await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
@@ -177,7 +183,7 @@ export class FieldPermissionService {
       ]),
     );
 
-    for (const [, desired] of desiredMap) {
+    for (const [key, desired] of desiredMap) {
       const current = currentByKey.get(
         keyFrom(desired.objectMetadataId, desired.fieldMetadataId),
       );
@@ -186,7 +192,6 @@ export class FieldPermissionService {
         const canReadFieldValue = desired.canReadFieldValue ?? null;
         const canUpdateFieldValue = desired.canUpdateFieldValue ?? null;
 
-        // A row with no restriction left grants nothing: creating it would only add noise
         if (!isDefined(canReadFieldValue) && !isDefined(canUpdateFieldValue)) {
           continue;
         }
@@ -216,12 +221,21 @@ export class FieldPermissionService {
             ? desired.canUpdateFieldValue
             : current.canUpdateFieldValue;
 
-        // Once both flags are cleared the row no longer restricts anything: delete it
-        // instead of keeping an empty row (mirrored relation permissions land here on grant-back)
         if (!isDefined(effectiveCanRead) && !isDefined(effectiveCanUpdate)) {
-          flatEntityToDelete.push(
-            toUniversalFlatFieldPermissionToDelete(current),
-          );
+          // The mirror pass only owns rows it could have written itself, so a row
+          // another application declared is left alone rather than silently dropped
+          const isForeignMirroredRow =
+            mirroredFieldKeys.has(key) &&
+            !inputFieldKeys.has(key) &&
+            current.applicationUniversalIdentifier !==
+              workspaceCustomFlatApplication.universalIdentifier;
+
+          if (!isForeignMirroredRow) {
+            flatEntityToDelete.push(
+              toUniversalFlatFieldPermissionToDelete(current),
+            );
+          }
+
           continue;
         }
 
@@ -248,12 +262,6 @@ export class FieldPermissionService {
         }
       }
     }
-
-    const inputFieldKeys = new Set(
-      input.fieldPermissions.map((fp) =>
-        keyFrom(fp.objectMetadataId, fp.fieldMetadataId),
-      ),
-    );
 
     for (const current of currentFieldPermissionsForRole) {
       const key = keyFrom(current.objectMetadataId, current.fieldMetadataId);
@@ -436,12 +444,13 @@ export class FieldPermissionService {
     desiredMap: Map<string, DesiredFieldPermission>;
     inputFieldPermissions: UpsertFieldPermissionsInput['fieldPermissions'];
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
-  }) {
+  }): Set<string> {
     const inputKeys = new Set(
       inputFieldPermissions.map((fp) =>
         keyFrom(fp.objectMetadataId, fp.fieldMetadataId),
       ),
     );
+    const mirroredKeys = new Set<string>();
 
     for (const fieldPermission of inputFieldPermissions) {
       const flatFieldMetadata = findFlatEntityByIdInFlatEntityMaps({
@@ -500,11 +509,8 @@ export class FieldPermissionService {
         continue;
       }
 
-      // Restricting a relation field mirrors the restriction onto the inverse
-      // field, so clearing it must mirror the clear as well: null propagates
-      // (clears the flag on the inverse side) while undefined leaves it as is.
-      // Otherwise the mirrored row survives as an orphan that keeps blocking
-      // updates on the relation's join column after the admin granted the field back.
+      // A cleared source row is dropped from desiredMap by the bothNull gate above,
+      // so the mirror has to be told to clear explicitly or it survives as an orphan
       const sourceIsCleared =
         !isDefined(fieldPermission.canReadFieldValue) &&
         !isDefined(fieldPermission.canUpdateFieldValue);
@@ -519,6 +525,9 @@ export class FieldPermissionService {
           ? null
           : fieldPermission.canUpdateFieldValue,
       });
+      mirroredKeys.add(targetKey);
     }
+
+    return mirroredKeys;
   }
 }

--- a/packages/twenty-server/test/integration/metadata/suites/field-permission/relation-field-permission-grant-back.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-permission/relation-field-permission-grant-back.integration-spec.ts
@@ -43,6 +43,32 @@ describe('Relation field permission grant-back', () => {
     return role.fieldPermissions ?? [];
   };
 
+  const restrictFieldUpdate = (field: {
+    objectMetadataId: string;
+    fieldMetadataId: string;
+  }) =>
+    upsertFieldPermissions({
+      expectToFail: false,
+      input: {
+        roleId: createdRoleId,
+        fieldPermissions: [{ ...field, canUpdateFieldValue: false }],
+      },
+    });
+
+  const grantBackField = (field: {
+    objectMetadataId: string;
+    fieldMetadataId: string;
+  }) =>
+    upsertFieldPermissions({
+      expectToFail: false,
+      input: {
+        roleId: createdRoleId,
+        fieldPermissions: [
+          { ...field, canReadFieldValue: null, canUpdateFieldValue: null },
+        ],
+      },
+    });
+
   beforeAll(async () => {
     const { data: roleData } = await createOneRole({
       expectToFail: false,
@@ -144,64 +170,72 @@ describe('Relation field permission grant-back', () => {
     }
   });
 
-  it('should mirror an edit restriction on a relation field onto the inverse relation field', async () => {
-    await upsertFieldPermissions({
-      expectToFail: false,
-      input: {
-        roleId: createdRoleId,
-        fieldPermissions: [
-          {
-            objectMetadataId: sourceObjectMetadataId,
-            fieldMetadataId: relationFieldMetadataId,
-            canUpdateFieldValue: false,
-          },
-        ],
-      },
+  describe.each([
+    {
+      side: 'many-to-one',
+      restricted: () => ({
+        objectMetadataId: sourceObjectMetadataId,
+        fieldMetadataId: relationFieldMetadataId,
+      }),
+      mirrored: () => ({
+        objectMetadataId: targetObjectMetadataId,
+        fieldMetadataId: inverseRelationFieldMetadataId,
+      }),
+    },
+    {
+      side: 'one-to-many',
+      restricted: () => ({
+        objectMetadataId: targetObjectMetadataId,
+        fieldMetadataId: inverseRelationFieldMetadataId,
+      }),
+      mirrored: () => ({
+        objectMetadataId: sourceObjectMetadataId,
+        fieldMetadataId: relationFieldMetadataId,
+      }),
+    },
+  ])('restricting the $side side', ({ restricted, mirrored }) => {
+    afterEach(async () => {
+      await grantBackField(restricted());
     });
 
-    const fieldPermissions = await findFieldPermissionsForRole();
+    it('should mirror the edit restriction onto the inverse relation field', async () => {
+      await restrictFieldUpdate(restricted());
 
-    expect(fieldPermissions).toHaveLength(2);
-    expect(fieldPermissions).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          objectMetadataId: sourceObjectMetadataId,
-          fieldMetadataId: relationFieldMetadataId,
-          canUpdateFieldValue: false,
-        }),
-        expect.objectContaining({
-          objectMetadataId: targetObjectMetadataId,
-          fieldMetadataId: inverseRelationFieldMetadataId,
-          canUpdateFieldValue: false,
-        }),
-      ]),
-    );
-  });
+      const fieldPermissions = await findFieldPermissionsForRole();
 
-  it('should delete the mirrored inverse field permission when the relation field is granted back', async () => {
-    const grantBackRelationField = () =>
-      upsertFieldPermissions({
-        expectToFail: false,
-        input: {
-          roleId: createdRoleId,
-          fieldPermissions: [
-            {
-              objectMetadataId: sourceObjectMetadataId,
-              fieldMetadataId: relationFieldMetadataId,
-              canReadFieldValue: null,
-              canUpdateFieldValue: null,
-            },
-          ],
-        },
-      });
+      expect(fieldPermissions).toHaveLength(2);
+      expect(fieldPermissions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            ...restricted(),
+            canReadFieldValue: null,
+            canUpdateFieldValue: false,
+          }),
+          expect.objectContaining({
+            ...mirrored(),
+            canReadFieldValue: null,
+            canUpdateFieldValue: false,
+          }),
+        ]),
+      );
+    });
 
-    await grantBackRelationField();
+    it('should delete both rows when the restricted field is granted back', async () => {
+      await restrictFieldUpdate(restricted());
 
-    expect(await findFieldPermissionsForRole()).toHaveLength(0);
+      expect(await findFieldPermissionsForRole()).toHaveLength(2);
 
-    // Granting back a field that has no rows left must not create empty ones
-    await grantBackRelationField();
+      await grantBackField(restricted());
 
-    expect(await findFieldPermissionsForRole()).toHaveLength(0);
+      expect(await findFieldPermissionsForRole()).toHaveLength(0);
+    });
+
+    it('should not create empty rows when granting back a field that has no permissions', async () => {
+      expect(await findFieldPermissionsForRole()).toHaveLength(0);
+
+      await grantBackField(restricted());
+
+      expect(await findFieldPermissionsForRole()).toHaveLength(0);
+    });
   });
 });

--- a/packages/twenty-server/test/integration/metadata/suites/field-permission/relation-field-permission-grant-back.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-permission/relation-field-permission-grant-back.integration-spec.ts
@@ -179,44 +179,29 @@ describe('Relation field permission grant-back', () => {
   });
 
   it('should delete the mirrored inverse field permission when the relation field is granted back', async () => {
-    await upsertFieldPermissions({
-      expectToFail: false,
-      input: {
-        roleId: createdRoleId,
-        fieldPermissions: [
-          {
-            objectMetadataId: sourceObjectMetadataId,
-            fieldMetadataId: relationFieldMetadataId,
-            canReadFieldValue: null,
-            canUpdateFieldValue: null,
-          },
-        ],
-      },
-    });
+    const grantBackRelationField = () =>
+      upsertFieldPermissions({
+        expectToFail: false,
+        input: {
+          roleId: createdRoleId,
+          fieldPermissions: [
+            {
+              objectMetadataId: sourceObjectMetadataId,
+              fieldMetadataId: relationFieldMetadataId,
+              canReadFieldValue: null,
+              canUpdateFieldValue: null,
+            },
+          ],
+        },
+      });
 
-    const fieldPermissions = await findFieldPermissionsForRole();
+    await grantBackRelationField();
 
-    expect(fieldPermissions).toHaveLength(0);
-  });
+    expect(await findFieldPermissionsForRole()).toHaveLength(0);
 
-  it('should not create empty rows when granting back a relation field that has no permissions', async () => {
-    await upsertFieldPermissions({
-      expectToFail: false,
-      input: {
-        roleId: createdRoleId,
-        fieldPermissions: [
-          {
-            objectMetadataId: sourceObjectMetadataId,
-            fieldMetadataId: relationFieldMetadataId,
-            canReadFieldValue: null,
-            canUpdateFieldValue: null,
-          },
-        ],
-      },
-    });
+    // Granting back a field that has no rows left must not create empty ones
+    await grantBackRelationField();
 
-    const fieldPermissions = await findFieldPermissionsForRole();
-
-    expect(fieldPermissions).toHaveLength(0);
+    expect(await findFieldPermissionsForRole()).toHaveLength(0);
   });
 });

--- a/packages/twenty-server/test/integration/metadata/suites/field-permission/relation-field-permission-grant-back.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-permission/relation-field-permission-grant-back.integration-spec.ts
@@ -1,0 +1,222 @@
+import { upsertFieldPermissions } from 'test/integration/metadata/suites/field-permission/utils/upsert-field-permissions.util';
+import { createOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/create-one-object-metadata.util';
+import { createRelationBetweenObjects } from 'test/integration/metadata/suites/object-metadata/utils/create-relation-between-objects.util';
+import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { createOneRole } from 'test/integration/metadata/suites/role/utils/create-one-role.util';
+import { deleteOneRole } from 'test/integration/metadata/suites/role/utils/delete-one-role.util';
+import { findRoles } from 'test/integration/metadata/suites/role/utils/find-roles.util';
+import { jestExpectToBeDefined } from 'test/utils/jest-expect-to-be-defined.util.test';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+
+const ROLE_GQL_FIELDS_WITH_FIELD_PERMISSIONS = `
+  id
+  label
+  fieldPermissions {
+    objectMetadataId
+    fieldMetadataId
+    canReadFieldValue
+    canUpdateFieldValue
+  }
+`;
+
+describe('Relation field permission grant-back', () => {
+  let createdRoleId: string;
+  let sourceObjectMetadataId: string;
+  let targetObjectMetadataId: string;
+  let relationFieldMetadataId: string;
+  let inverseRelationFieldMetadataId: string;
+
+  const findFieldPermissionsForRole = async () => {
+    const { data } = await findRoles({
+      expectToFail: false,
+      gqlFields: ROLE_GQL_FIELDS_WITH_FIELD_PERMISSIONS,
+    });
+
+    const role = data?.getRoles?.find((r) => r.id === createdRoleId);
+
+    jestExpectToBeDefined(role);
+
+    return role.fieldPermissions ?? [];
+  };
+
+  beforeAll(async () => {
+    const { data: roleData } = await createOneRole({
+      expectToFail: false,
+      input: {
+        label: 'Test Role For Relation Field Permission Grant Back',
+        description: 'Role for relation field permission mirror tests',
+        icon: 'IconSettings',
+        canUpdateAllSettings: false,
+        canAccessAllTools: true,
+        canReadAllObjectRecords: true,
+        canUpdateAllObjectRecords: true,
+        canSoftDeleteAllObjectRecords: false,
+        canDestroyAllObjectRecords: false,
+        canBeAssignedToUsers: true,
+        canBeAssignedToAgents: false,
+        canBeAssignedToApiKeys: false,
+      },
+    });
+
+    createdRoleId = roleData?.createOneRole?.id;
+    jestExpectToBeDefined(createdRoleId);
+
+    const {
+      data: { createOneObject: sourceObject },
+    } = await createOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        nameSingular: 'fpGrantBackSource',
+        namePlural: 'fpGrantBackSources',
+        labelSingular: 'Fp Grant Back Source',
+        labelPlural: 'Fp Grant Back Sources',
+        icon: 'IconSettings',
+      },
+    });
+
+    sourceObjectMetadataId = sourceObject.id;
+    jestExpectToBeDefined(sourceObjectMetadataId);
+
+    const {
+      data: { createOneObject: targetObject },
+    } = await createOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        nameSingular: 'fpGrantBackTarget',
+        namePlural: 'fpGrantBackTargets',
+        labelSingular: 'Fp Grant Back Target',
+        labelPlural: 'Fp Grant Back Targets',
+        icon: 'IconSettings',
+      },
+    });
+
+    targetObjectMetadataId = targetObject.id;
+    jestExpectToBeDefined(targetObjectMetadataId);
+
+    const relationField = await createRelationBetweenObjects({
+      objectMetadataId: sourceObjectMetadataId,
+      targetObjectMetadataId,
+      type: FieldMetadataType.RELATION,
+      relationType: RelationType.MANY_TO_ONE,
+      name: 'grantBackTarget',
+      label: 'Grant Back Target',
+      targetFieldLabel: 'Grant Back Sources',
+    });
+
+    relationFieldMetadataId = relationField.id;
+    inverseRelationFieldMetadataId =
+      relationField.relation.targetFieldMetadata.id;
+    jestExpectToBeDefined(relationFieldMetadataId);
+    jestExpectToBeDefined(inverseRelationFieldMetadataId);
+  });
+
+  afterAll(async () => {
+    if (isDefined(createdRoleId)) {
+      await deleteOneRole({
+        expectToFail: false,
+        input: { idToDelete: createdRoleId },
+      });
+    }
+
+    for (const objectMetadataId of [
+      sourceObjectMetadataId,
+      targetObjectMetadataId,
+    ]) {
+      if (!isDefined(objectMetadataId)) {
+        continue;
+      }
+
+      await updateOneObjectMetadata({
+        expectToFail: false,
+        input: {
+          idToUpdate: objectMetadataId,
+          updatePayload: { isActive: false },
+        },
+      });
+      await deleteOneObjectMetadata({
+        expectToFail: false,
+        input: { idToDelete: objectMetadataId },
+      });
+    }
+  });
+
+  it('should mirror an edit restriction on a relation field onto the inverse relation field', async () => {
+    await upsertFieldPermissions({
+      expectToFail: false,
+      input: {
+        roleId: createdRoleId,
+        fieldPermissions: [
+          {
+            objectMetadataId: sourceObjectMetadataId,
+            fieldMetadataId: relationFieldMetadataId,
+            canUpdateFieldValue: false,
+          },
+        ],
+      },
+    });
+
+    const fieldPermissions = await findFieldPermissionsForRole();
+
+    expect(fieldPermissions).toHaveLength(2);
+    expect(fieldPermissions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          objectMetadataId: sourceObjectMetadataId,
+          fieldMetadataId: relationFieldMetadataId,
+          canUpdateFieldValue: false,
+        }),
+        expect.objectContaining({
+          objectMetadataId: targetObjectMetadataId,
+          fieldMetadataId: inverseRelationFieldMetadataId,
+          canUpdateFieldValue: false,
+        }),
+      ]),
+    );
+  });
+
+  it('should delete the mirrored inverse field permission when the relation field is granted back', async () => {
+    await upsertFieldPermissions({
+      expectToFail: false,
+      input: {
+        roleId: createdRoleId,
+        fieldPermissions: [
+          {
+            objectMetadataId: sourceObjectMetadataId,
+            fieldMetadataId: relationFieldMetadataId,
+            canReadFieldValue: null,
+            canUpdateFieldValue: null,
+          },
+        ],
+      },
+    });
+
+    const fieldPermissions = await findFieldPermissionsForRole();
+
+    expect(fieldPermissions).toHaveLength(0);
+  });
+
+  it('should not create empty rows when granting back a relation field that has no permissions', async () => {
+    await upsertFieldPermissions({
+      expectToFail: false,
+      input: {
+        roleId: createdRoleId,
+        fieldPermissions: [
+          {
+            objectMetadataId: sourceObjectMetadataId,
+            fieldMetadataId: relationFieldMetadataId,
+            canReadFieldValue: null,
+            canUpdateFieldValue: null,
+          },
+        ],
+      },
+    });
+
+    const fieldPermissions = await findFieldPermissionsForRole();
+
+    expect(fieldPermissions).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Context

Reported by a user: after enabling Edit on a relation field for a role, updating that field still fails with "User does not have permission", even though every permission visible in the role settings is on.

## Root cause

Restricting a relation field deliberately mirrors the restriction onto the inverse field of the target object, so one toggle writes two `fieldPermission` rows.

Granting it back only deleted the row named in the request. The mirror pass mapped `null` (clear) to `undefined` (keep as is), and the deletion loop only looked at fields present in the input, so the mirrored row survived.

Relation writes always go through the join column, which the enforcement layer resolves back to the many-to-one field. When that is the surviving row, the write is denied — while the object the admin actually toggled shows Edit enabled.

## Changes

**`field-permission.service.ts`**

- Grant-back propagates to the mirror: `null` now clears the inverse row too, `undefined` still means keep.
- A row left with both flags cleared is deleted rather than kept as an empty row, and empty mirror rows are no longer created.
- The mirror pass returns the keys it wrote. The both-cleared delete skips a mirrored row belonging to another application, so an app manifest's own field permission is not dropped by a grant-back on the opposite side. `validateFlatFieldPermissionDeletion` has no cross-application guard of its own.
- The delete-entity mapping moves into `toUniversalFlatFieldPermissionToDelete`, shared by both deletion sites.

**`isOneToManyRelationFieldReadOnlyDueToTargetUpdatePermission.ts`**

- A one-to-many field is now read-only when the inverse many-to-one field is update-restricted, so the UI stops offering an edit the server will reject.
- The same check applies to morph one-to-many, per target, through the shared `isTargetRecordUpdateBlocked` helper.

## Tests

**Integration** — `relation-field-permission-grant-back.integration-spec.ts` runs the real upsert flow in both directions via `describe.each`. The one-to-many direction matters on its own: `process-field-metadata-for-column-name-mapping.util.ts` skips one-to-many fields, so only a leftover row on the join-column-owning side can actually deny a write. Each test restricts, asserts both rows including `canReadFieldValue`, grants back, and asserts none, so no test depends on another having run.

**Frontend unit** — inverse field update-restricted is read-only, read-only restriction on that same field is not, unrelated restricted fields are not, plus the three morph equivalents.

Both suites were checked against a reverted fix and fail as expected.

**Manual** — verified on a dev instance with a member role. A leftover row alone reproduces the reported denial, the affected relation renders read-only instead of failing on save, and re-enabling Edit from role settings clears both rows and unblocks the member.

## Notes

Existing databases keep their leftover rows; this PR does not migrate them. No cleanup command is needed: the row surfaces in role settings on the inverse object as an unchecked Edit box, and re-enabling it there clears both sides in one save.

Mirroring is still gated on `FieldMetadataType.RELATION`, so morph one-to-many gets no mirror row server-side. That predates this PR and is left as is; the frontend change keeps the UI honest for it.
