### PR TITLE
Restore primary icon buttons on pinned actions and group the panel footer

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelCommandMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelCommandMenuDropdown.tsx
@@ -50,11 +50,13 @@ export const RecordPageSidePanelCommandMenuDropdown = () => {
   );
 
   // Pinned items are buttons in the footer, so the dropdown only repeats the
-  // ones the footer could not fit.
+  // ones the footer could not fit. This dropdown is itself the footer's
+  // leading action, so the fit keeps its width reserved.
   const { pinnedOverflowCommandMenuItems } =
     usePinnedCommandMenuItemsInlineLayout({
       pinnedCommandMenuItems,
       layoutKey: 'side-panel-footer',
+      hasLeadingAction: true,
     });
 
   // A widget owning the footer suppresses those buttons entirely, and leaves

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelPinnedCommandMenuItems.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelPinnedCommandMenuItems.tsx
@@ -6,7 +6,11 @@ import { PinnedCommandMenuItemButtons } from '@/command-menu-item/display/compon
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 
-export const RecordPageSidePanelPinnedCommandMenuItems = () => {
+export const RecordPageSidePanelPinnedCommandMenuItems = ({
+  leadingAction,
+}: {
+  leadingAction?: React.ReactNode;
+}) => {
   const contextStoreCurrentObjectMetadataItemId = useAtomComponentStateValue(
     contextStoreCurrentObjectMetadataItemIdComponentState,
   );
@@ -21,7 +25,7 @@ export const RecordPageSidePanelPinnedCommandMenuItems = () => {
       displayType="button"
       containerType={CommandMenuItemContainerType.SidePanelFooter}
     >
-      <PinnedCommandMenuItemButtons />
+      <PinnedCommandMenuItemButtons leadingAction={leadingAction} />
     </CommandMenuContextProvider>
   );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -9,7 +9,7 @@ import { NodeDimension } from '@/ui/utilities/dimensions/components/NodeDimensio
 import { styled } from '@linaria/react';
 import { isDefined } from 'twenty-shared/utils';
 import { motion } from 'framer-motion';
-import { useContext, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 import { ThemeContext } from 'twenty-ui/theme-constants';
 import { useIsMobile } from 'twenty-ui/utilities';
 import {
@@ -97,6 +97,14 @@ export const PinnedCommandMenuItemButtons = ({
     pinnedCommandMenuItems,
     layoutKey: isSidePanelFooter ? 'side-panel-footer' : 'page-header',
   });
+
+  // Without a leading action there is no measuring node left to report a zero
+  // width, so the shared reservation is cleared here instead.
+  useEffect(() => {
+    if (!isDefined(leadingAction)) {
+      onLeadingActionDimensionChange({ width: 0, height: 0 });
+    }
+  }, [leadingAction, onLeadingActionDimensionChange]);
 
   const isCommandMenuItemLabelled = (
     commandMenuItem: CommandMenuItemFieldsFragment,

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -30,7 +30,9 @@ const StyledWrapper = styled.div`
 `;
 
 const StyledContainer = styled.div`
+  align-items: center;
   display: flex;
+  gap: ${PINNED_COMMAND_MENU_ITEMS_GAP}px;
   justify-content: flex-end;
   min-width: 0;
   width: 100%;
@@ -45,7 +47,14 @@ const StyledItemsContainer = styled.div<{ shouldReverse: boolean }>`
   overflow: hidden;
 `;
 
-export const PinnedCommandMenuItemButtons = () => {
+export const PinnedCommandMenuItemButtons = ({
+  leadingAction,
+}: {
+  // Rendered inside the right-aligned cluster, before the pinned buttons, so
+  // an options menu can sit leftmost of the group instead of being pushed to
+  // the far side by the measurement wrapper stretching over the free space.
+  leadingAction?: React.ReactNode;
+}) => {
   const { theme } = useContext(ThemeContext);
   const { commandMenuItems, containerType } = useContext(CommandMenuContext);
   const isMobile = useIsMobile();
@@ -118,6 +127,7 @@ export const PinnedCommandMenuItemButtons = () => {
       <StyledWrapper>
         <NodeDimension onDimensionChange={onContainerDimensionChange}>
           <StyledContainer>
+            {leadingAction}
             <StyledItemsContainer shouldReverse={!isSidePanelFooter}>
               {displayedInlineCommandMenuItems.map((item) => (
                 <StyledCommandMenuItemContainer

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -9,7 +9,7 @@ import { NodeDimension } from '@/ui/utilities/dimensions/components/NodeDimensio
 import { styled } from '@linaria/react';
 import { isDefined } from 'twenty-shared/utils';
 import { motion } from 'framer-motion';
-import { useContext, useEffect, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import { ThemeContext } from 'twenty-ui/theme-constants';
 import { useIsMobile } from 'twenty-ui/utilities';
 import {
@@ -96,15 +96,8 @@ export const PinnedCommandMenuItemButtons = ({
   } = usePinnedCommandMenuItemsInlineLayout({
     pinnedCommandMenuItems,
     layoutKey: isSidePanelFooter ? 'side-panel-footer' : 'page-header',
+    hasLeadingAction: isDefined(leadingAction),
   });
-
-  // Without a leading action there is no measuring node left to report a zero
-  // width, so the shared reservation is cleared here instead.
-  useEffect(() => {
-    if (!isDefined(leadingAction)) {
-      onLeadingActionDimensionChange({ width: 0, height: 0 });
-    }
-  }, [leadingAction, onLeadingActionDimensionChange]);
 
   const isCommandMenuItemLabelled = (
     commandMenuItem: CommandMenuItemFieldsFragment,

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -91,6 +91,7 @@ export const PinnedCommandMenuItemButtons = ({
     pinnedInlineCommandMenuItems,
     pinnedOverflowCommandMenuItems,
     onContainerDimensionChange,
+    onLeadingActionDimensionChange,
     onCommandMenuItemDimensionChange,
   } = usePinnedCommandMenuItemsInlineLayout({
     pinnedCommandMenuItems,
@@ -127,7 +128,11 @@ export const PinnedCommandMenuItemButtons = ({
       <StyledWrapper>
         <NodeDimension onDimensionChange={onContainerDimensionChange}>
           <StyledContainer>
-            {leadingAction}
+            {isDefined(leadingAction) && (
+              <NodeDimension onDimensionChange={onLeadingActionDimensionChange}>
+                {leadingAction}
+              </NodeDimension>
+            )}
             <StyledItemsContainer shouldReverse={!isSidePanelFooter}>
               {displayedInlineCommandMenuItems.map((item) => (
                 <StyledCommandMenuItemContainer

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
@@ -68,6 +68,8 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
       commandMenuItemsContainerWidth:
         commandMenuPinnedInlineLayout.containerWidth,
       commandMenuItemsGapWidth: PINNED_COMMAND_MENU_ITEMS_GAP,
+      commandMenuItemsLeadingActionWidth:
+        commandMenuPinnedInlineLayout.leadingActionWidth,
     });
 
   const hasKnownPinnedInlineLayout =

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
@@ -68,8 +68,6 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
       commandMenuItemsContainerWidth:
         commandMenuPinnedInlineLayout.containerWidth,
       commandMenuItemsGapWidth: PINNED_COMMAND_MENU_ITEMS_GAP,
-      commandMenuItemsLeadingActionWidth:
-        commandMenuPinnedInlineLayout.leadingActionWidth,
     });
 
   const hasKnownPinnedInlineLayout =

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -96,6 +96,7 @@ const createDecorator =
       commandMenuPinnedInlineLayoutFamilyState.atomFamily('page-header'),
       {
         containerWidth: pinnedItemsContainerWidth,
+        leadingActionWidth: 0,
         commandMenuItemWidthsByKey: Object.fromEntries(
           PINNED_ITEMS.map((item) => [item.id, PINNED_ITEM_WIDTH]),
         ),

--- a/packages/twenty-front/src/modules/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout.ts
@@ -53,6 +53,8 @@ export const usePinnedCommandMenuItemsInlineLayout = ({
             commandMenuItemsContainerWidth:
               commandMenuPinnedInlineLayout.containerWidth,
             commandMenuItemsGapWidth: PINNED_COMMAND_MENU_ITEMS_GAP,
+            commandMenuItemsLeadingActionWidth:
+              commandMenuPinnedInlineLayout.leadingActionWidth,
           })
         : 0,
     [
@@ -88,6 +90,22 @@ export const usePinnedCommandMenuItemsInlineLayout = ({
     [setCommandMenuPinnedInlineLayout],
   );
 
+  const onLeadingActionDimensionChange = useCallback(
+    (dimensions: ElementDimensions) => {
+      setCommandMenuPinnedInlineLayout(
+        (previousCommandMenuPinnedInlineLayout) =>
+          previousCommandMenuPinnedInlineLayout.leadingActionWidth !==
+          dimensions.width
+            ? {
+                ...previousCommandMenuPinnedInlineLayout,
+                leadingActionWidth: dimensions.width,
+              }
+            : previousCommandMenuPinnedInlineLayout,
+      );
+    },
+    [setCommandMenuPinnedInlineLayout],
+  );
+
   const onCommandMenuItemDimensionChange = useCallback(
     (commandMenuItemKey: string) => (dimensions: ElementDimensions) => {
       setCommandMenuPinnedInlineLayout(
@@ -112,6 +130,7 @@ export const usePinnedCommandMenuItemsInlineLayout = ({
     pinnedInlineCommandMenuItems,
     pinnedOverflowCommandMenuItems,
     onContainerDimensionChange,
+    onLeadingActionDimensionChange,
     onCommandMenuItemDimensionChange,
   };
 };

--- a/packages/twenty-front/src/modules/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout.ts
@@ -15,11 +15,13 @@ type ElementDimensions = {
 type UsePinnedCommandMenuItemsInlineLayoutParams = {
   pinnedCommandMenuItems: CommandMenuItemFieldsFragment[];
   layoutKey: PinnedCommandMenuItemsLayoutKey;
+  hasLeadingAction?: boolean;
 };
 
 export const usePinnedCommandMenuItemsInlineLayout = ({
   pinnedCommandMenuItems,
   layoutKey,
+  hasLeadingAction = false,
 }: UsePinnedCommandMenuItemsInlineLayoutParams) => {
   const [commandMenuPinnedInlineLayout, setCommandMenuPinnedInlineLayout] =
     useAtomFamilyState(commandMenuPinnedInlineLayoutFamilyState, layoutKey);
@@ -53,13 +55,15 @@ export const usePinnedCommandMenuItemsInlineLayout = ({
             commandMenuItemsContainerWidth:
               commandMenuPinnedInlineLayout.containerWidth,
             commandMenuItemsGapWidth: PINNED_COMMAND_MENU_ITEMS_GAP,
-            commandMenuItemsLeadingActionWidth:
-              commandMenuPinnedInlineLayout.leadingActionWidth,
+            commandMenuItemsLeadingActionWidth: hasLeadingAction
+              ? commandMenuPinnedInlineLayout.leadingActionWidth
+              : 0,
           })
         : 0,
     [
       commandMenuPinnedInlineLayout,
       hasKnownPinnedInlineLayout,
+      hasLeadingAction,
       pinnedCommandMenuItemKeysInDisplayOrder,
     ],
   );

--- a/packages/twenty-front/src/modules/command-menu-item/display/states/commandMenuPinnedInlineLayoutFamilyState.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/states/commandMenuPinnedInlineLayoutFamilyState.ts
@@ -12,6 +12,7 @@ export const commandMenuPinnedInlineLayoutFamilyState = createAtomFamilyState<
   key: 'commandMenuPinnedInlineLayoutFamilyState',
   defaultValue: {
     containerWidth: 0,
+    leadingActionWidth: 0,
     commandMenuItemWidthsByKey: {},
   },
 });

--- a/packages/twenty-front/src/modules/command-menu-item/display/types/CommandMenuPinnedInlineLayout.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/types/CommandMenuPinnedInlineLayout.ts
@@ -1,7 +1,5 @@
 export type CommandMenuPinnedInlineLayout = {
   containerWidth: number;
-  // Width of the leading action sharing the measured container with the pinned
-  // items, reserved by the inline-fit calculation so it never over-counts.
   leadingActionWidth: number;
   commandMenuItemWidthsByKey: Record<string, number>;
 };

--- a/packages/twenty-front/src/modules/command-menu-item/display/types/CommandMenuPinnedInlineLayout.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/types/CommandMenuPinnedInlineLayout.ts
@@ -1,4 +1,7 @@
 export type CommandMenuPinnedInlineLayout = {
   containerWidth: number;
+  // Width of the leading action sharing the measured container with the pinned
+  // items, reserved by the inline-fit calculation so it never over-counts.
+  leadingActionWidth: number;
   commandMenuItemWidthsByKey: Record<string, number>;
 };

--- a/packages/twenty-front/src/modules/command-menu-item/display/utils/__tests__/getVisibleCommandMenuItemCountForContainerWidth.test.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/utils/__tests__/getVisibleCommandMenuItemCountForContainerWidth.test.ts
@@ -36,4 +36,30 @@ describe('getVisibleCommandMenuItemCountForContainerWidth', () => {
 
     expect(visibleCommandMenuItemCount).toBe(2);
   });
+
+  it('should reserve the leading action width and its gap', () => {
+    const visibleCommandMenuItemCount =
+      getVisibleCommandMenuItemCountForContainerWidth({
+        commandMenuItemKeysInDisplayOrder: ['a', 'b', 'c'],
+        commandMenuItemWidthsByKey: { a: 40, b: 40, c: 40 },
+        commandMenuItemsContainerWidth: 148,
+        commandMenuItemsGapWidth: 8,
+        commandMenuItemsLeadingActionWidth: 24,
+      });
+
+    expect(visibleCommandMenuItemCount).toBe(2);
+  });
+
+  it('should overflow every item when the leading action fills the container', () => {
+    const visibleCommandMenuItemCount =
+      getVisibleCommandMenuItemCountForContainerWidth({
+        commandMenuItemKeysInDisplayOrder: ['a'],
+        commandMenuItemWidthsByKey: { a: 40 },
+        commandMenuItemsContainerWidth: 30,
+        commandMenuItemsGapWidth: 8,
+        commandMenuItemsLeadingActionWidth: 24,
+      });
+
+    expect(visibleCommandMenuItemCount).toBe(0);
+  });
 });

--- a/packages/twenty-front/src/modules/command-menu-item/display/utils/getVisibleCommandMenuItemCountForContainerWidth.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/utils/getVisibleCommandMenuItemCountForContainerWidth.ts
@@ -3,6 +3,7 @@ type GetVisibleCommandMenuItemCountForContainerWidthParams = {
   commandMenuItemWidthsByKey: Record<string, number>;
   commandMenuItemsContainerWidth: number;
   commandMenuItemsGapWidth: number;
+  commandMenuItemsLeadingActionWidth?: number;
 };
 
 export const getVisibleCommandMenuItemCountForContainerWidth = ({
@@ -10,10 +11,20 @@ export const getVisibleCommandMenuItemCountForContainerWidth = ({
   commandMenuItemWidthsByKey,
   commandMenuItemsContainerWidth,
   commandMenuItemsGapWidth,
+  commandMenuItemsLeadingActionWidth = 0,
 }: GetVisibleCommandMenuItemCountForContainerWidthParams): number => {
   if (commandMenuItemsContainerWidth <= 0) {
     return commandMenuItemKeysInDisplayOrder.length;
   }
+
+  // A leading action shares the container with the items and is separated from
+  // them by one gap, so its footprint is reserved before fitting the items.
+  const availableContainerWidth =
+    commandMenuItemsLeadingActionWidth > 0
+      ? commandMenuItemsContainerWidth -
+        commandMenuItemsLeadingActionWidth -
+        commandMenuItemsGapWidth
+      : commandMenuItemsContainerWidth;
 
   let usedWidth = 0;
   let visibleCommandMenuItemCount = 0;
@@ -30,7 +41,7 @@ export const getVisibleCommandMenuItemCountForContainerWidth = ({
         ? commandMenuItemWidth
         : usedWidth + commandMenuItemsGapWidth + commandMenuItemWidth;
 
-    if (nextWidth > commandMenuItemsContainerWidth) {
+    if (nextWidth > availableContainerWidth) {
       break;
     }
 

--- a/packages/twenty-front/src/modules/command-menu-item/display/utils/getVisibleCommandMenuItemCountForContainerWidth.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/utils/getVisibleCommandMenuItemCountForContainerWidth.ts
@@ -17,8 +17,6 @@ export const getVisibleCommandMenuItemCountForContainerWidth = ({
     return commandMenuItemKeysInDisplayOrder.length;
   }
 
-  // A leading action shares the container with the items and is separated from
-  // them by one gap, so its footprint is reserved before fitting the items.
   const availableContainerWidth =
     commandMenuItemsLeadingActionWidth > 0
       ? commandMenuItemsContainerWidth -

--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuButton.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuButton.tsx
@@ -65,7 +65,7 @@ export const CommandMenuButton = ({
           <IconButton
             Icon={command.Icon}
             size="small"
-            variant={buttonAccent === 'blue' ? 'primary' : 'tertiary'}
+            variant="primary"
             accent={buttonAccent}
             to={to}
             onClick={onClick}

--- a/packages/twenty-front/src/modules/object-record/record-show/components/PageLayoutRecordPageRenderer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/PageLayoutRecordPageRenderer.tsx
@@ -117,26 +117,33 @@ export const PageLayoutRecordPageRenderer = ({
 
         {isInSidePanel && (
           <SidePanelFooter
-            actions={[
-              <RecordPageSidePanelCommandMenu key="options" />,
-              ...(hasPinnedWidgetCommandMenuItems
-                ? pinnedWidgetCommandMenuItems.map((commandMenuItem) => (
-                    <Button
-                      key={commandMenuItem.id}
-                      size="small"
-                      variant={
-                        commandMenuItem.isPrimaryCTA ? 'primary' : 'secondary'
-                      }
-                      accent={commandMenuItem.isPrimaryCTA ? 'blue' : 'default'}
-                      title={commandMenuItem.label}
-                      Icon={commandMenuItem.Icon}
-                      hotkeys={commandMenuItem.hotkeys}
-                      onClick={commandMenuItem.onClick}
-                      disabled={commandMenuItem.disabled}
-                    />
-                  ))
-                : [<RecordPageSidePanelPinnedCommandMenuItems key="pinned" />]),
-            ]}
+            actions={
+              hasPinnedWidgetCommandMenuItems
+                ? [
+                    <RecordPageSidePanelCommandMenu key="options" />,
+                    ...pinnedWidgetCommandMenuItems.map((commandMenuItem) => (
+                      <Button
+                        key={commandMenuItem.id}
+                        size="small"
+                        variant="primary"
+                        accent={
+                          commandMenuItem.isPrimaryCTA ? 'blue' : 'default'
+                        }
+                        title={commandMenuItem.label}
+                        Icon={commandMenuItem.Icon}
+                        hotkeys={commandMenuItem.hotkeys}
+                        onClick={commandMenuItem.onClick}
+                        disabled={commandMenuItem.disabled}
+                      />
+                    )),
+                  ]
+                : [
+                    <RecordPageSidePanelPinnedCommandMenuItems
+                      key="pinned"
+                      leadingAction={<RecordPageSidePanelCommandMenu />}
+                    />,
+                  ]
+            }
           />
         )}
       </StyledShowPageRightContainer>

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
@@ -217,7 +217,7 @@ export const SidePanelTopBar = () => {
           <IconButton
             Icon={IconX}
             size="small"
-            variant="tertiary"
+            variant="primary"
             onClick={closeSidePanelMenu}
             ariaLabel={t`Close side panel`}
           />

--- a/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
@@ -96,7 +96,7 @@ export const SidePanelComposeEmailPage = () => {
           <IconButton
             key="discard"
             size="small"
-            variant="secondary"
+            variant="primary"
             Icon={IconTrash}
             ariaLabel={t`Discard`}
             onClick={goBackFromSidePanel}
@@ -104,7 +104,7 @@ export const SidePanelComposeEmailPage = () => {
           <IconButton
             key="attach"
             size="small"
-            variant="secondary"
+            variant="primary"
             Icon={IconPaperclip}
             ariaLabel={t`Attach files`}
             onClick={openAttachmentPicker}

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx
@@ -70,7 +70,7 @@ export const OptionsDropdownMenu = ({
           Icon={IconDotsVertical}
           ariaLabel={t`Options`}
           size="small"
-          variant="tertiary"
+          variant="primary"
         />
       }
       dropdownPlacement="top-end"


### PR DESCRIPTION
Fixes the design regressions Thomas flagged on record pages and the side panel, matching [this Figma frame](https://www.figma.com/design/xt8O9mFeLl46C5InWwoMrN/Twenty?node-id=110786-425955).

## What was wrong

- Icon-only pinned actions (trash, favorites, previous/next record chevrons) rendered as borderless tertiary icon buttons instead of primary ones with a border.
- The options menu trigger and the side panel close button were tertiary too.
- In the side panel footer, the options menu was stranded at the far left while the pinned actions sat at the right.

## Changes

- `CommandMenuButton`: icon-only pinned actions are back to `IconButton variant="primary"` (blue accent still applies to primary CTAs). This is the root cause fix, it covers the record page header and the side panel footer since every pinned action renders through this component.
- `OptionsDropdownMenu`: the shared options trigger is now primary (record side panel, workflow step footer, widget settings footer).
- `SidePanelTopBar`: the close button is now primary; the expand button stays tertiary so the close action stands out.
- Side panel footer: all actions are grouped to the right, with the options menu leftmost within the group. `PinnedCommandMenuItemButtons` takes a `leadingAction` rendered inside its right-aligned cluster, because its width-measurement wrapper stretches over the free space and pushed any separate sibling to the opposite edge.
- Widget footer buttons (email composer) always use `variant="primary"`, keeping the blue accent for the CTA only, and the compose email discard/attach icon buttons are primary instead of secondary.

## Verified

Checked against the Figma reference in the running app: record header shows all bordered buttons, footer actions are clustered bottom-right with the options menu first, top bar shows lighter expand next to a bordered close.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4XJwMCrTgaN6e2NyLFrAK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

