### PR TITLE
Merge language and scale into one Interface settings section

### DIFF
--- a/packages/twenty-front/src/modules/settings/experience/components/UiScalePicker.tsx
+++ b/packages/twenty-front/src/modules/settings/experience/components/UiScalePicker.tsx
@@ -15,6 +15,7 @@ export const UiScalePicker = () => {
   return (
     <Select
       dropdownId="ui-scale-picker"
+      label={t`Scale`}
       dropdownWidth={218}
       dropdownWidthAuto
       fullWidth

--- a/packages/twenty-front/src/pages/settings/profile/appearance/components/LocalePicker.tsx
+++ b/packages/twenty-front/src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -244,6 +244,7 @@ export const LocalePicker = () => {
     <StyledContainer>
       <Select
         dropdownId="preferred-locale"
+        label={t`Language`}
         dropdownWidthAuto
         fullWidth
         withSearchInput

--- a/packages/twenty-front/src/pages/settings/profile/appearance/components/SettingsExperience.tsx
+++ b/packages/twenty-front/src/pages/settings/profile/appearance/components/SettingsExperience.tsx
@@ -1,3 +1,5 @@
+import { styled } from '@linaria/react';
+
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { FormatPreferencesSettings } from '@/settings/experience/components/FormatPreferencesSettings';
 import { UiScalePicker } from '@/settings/experience/components/UiScalePicker';
@@ -10,7 +12,14 @@ import { getSettingsPath } from 'twenty-shared/utils';
 import { H2Title } from 'twenty-ui/typography';
 import { ColorSchemePicker } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { LocalePicker } from '~/pages/settings/profile/appearance/components/LocalePicker';
+
+const StyledInterfaceControls = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[4]};
+`;
 
 export const SettingsExperience = () => {
   const { colorScheme, setColorScheme } = useColorScheme();
@@ -41,10 +50,13 @@ export const SettingsExperience = () => {
 
         <Section>
           <H2Title
-            title={t`Interface scale`}
-            description={t`Adjust the size of text and interface elements`}
+            title={t`Interface`}
+            description={t`Select your language and adjust the size of the interface`}
           />
-          <UiScalePicker />
+          <StyledInterfaceControls>
+            <LocalePicker />
+            <UiScalePicker />
+          </StyledInterfaceControls>
         </Section>
 
         <Section>
@@ -53,14 +65,6 @@ export const SettingsExperience = () => {
             description={t`Choose where records open by default. Some objects may use a workspace setting`}
           />
           <OpenRecordInPreferencePicker />
-        </Section>
-
-        <Section>
-          <H2Title
-            title={t`Language`}
-            description={t`Select your preferred language`}
-          />
-          <LocalePicker />
         </Section>
 
         <Section>


### PR DESCRIPTION
Designer feedback: the Language and Interface scale settings belong in a single section called Interface.

## Changes

- Settings > Experience now has one Interface section containing the language picker and the scale picker, replacing the two separate sections.
- Each select gets its own label (Language, Scale), following the pattern already used by the Formats section with its labeled Time zone select.
- Section order is now Appearance, Interface, Navigation, Formats.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4XJwMCrTgaN6e2NyLFrAK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

