### PR TITLE
Restore primary pinned actions with footer-owned width measurement

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelCommandMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelCommandMenuDropdown.tsx
@@ -1,3 +1,4 @@
+import { SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH } from '@/command-menu-item/constants/SidePanelFooterOptionsReservedWidth';
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
 import { CommandMenuItemRenderer } from '@/command-menu-item/display/components/CommandMenuItemRenderer';
 import { usePinnedCommandMenuItemsInlineLayout } from '@/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout';
@@ -5,6 +6,7 @@ import { getSidePanelCommandMenuDropdownIdFromCommandMenuId } from '@/command-me
 import { CommandMenuComponentInstanceContext } from '@/command-menu/states/contexts/CommandMenuComponentInstanceContext';
 import { OptionsDropdownMenu } from '@/ui/layout/dropdown/components/OptionsDropdownMenu';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
+import { SidePanelFooterWidthContext } from '@/ui/layout/side-panel/contexts/SidePanelFooterWidthContext';
 import { sidePanelWidgetFooterCommandMenuItemsState } from '@/ui/layout/side-panel/states/sidePanelWidgetFooterCommandMenuItemsState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -49,12 +51,18 @@ export const RecordPageSidePanelCommandMenuDropdown = () => {
     [commandMenuItems],
   );
 
+  const sidePanelFooterWidth = useContext(SidePanelFooterWidthContext);
+
   // Pinned items are buttons in the footer, so the dropdown only repeats the
-  // ones the footer could not fit.
+  // ones the footer could not fit next to this dropdown's own footprint.
   const { pinnedOverflowCommandMenuItems } =
     usePinnedCommandMenuItemsInlineLayout({
       pinnedCommandMenuItems,
       layoutKey: 'side-panel-footer',
+      containerWidth: Math.max(
+        sidePanelFooterWidth - SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH,
+        0,
+      ),
     });
 
   // A widget owning the footer suppresses those buttons entirely, and leaves

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelCommandMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelCommandMenuDropdown.tsx
@@ -1,12 +1,11 @@
-import { SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH } from '@/command-menu-item/constants/SidePanelFooterOptionsReservedWidth';
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
 import { CommandMenuItemRenderer } from '@/command-menu-item/display/components/CommandMenuItemRenderer';
 import { usePinnedCommandMenuItemsInlineLayout } from '@/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout';
+import { useSidePanelFooterPinnedItemsAvailableWidth } from '@/command-menu-item/hooks/useSidePanelFooterPinnedItemsAvailableWidth';
 import { getSidePanelCommandMenuDropdownIdFromCommandMenuId } from '@/command-menu-item/utils/getSidePanelCommandMenuDropdownIdFromCommandMenuId';
 import { CommandMenuComponentInstanceContext } from '@/command-menu/states/contexts/CommandMenuComponentInstanceContext';
 import { OptionsDropdownMenu } from '@/ui/layout/dropdown/components/OptionsDropdownMenu';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { SidePanelFooterWidthContext } from '@/ui/layout/side-panel/contexts/SidePanelFooterWidthContext';
 import { sidePanelWidgetFooterCommandMenuItemsState } from '@/ui/layout/side-panel/states/sidePanelWidgetFooterCommandMenuItemsState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -51,7 +50,7 @@ export const RecordPageSidePanelCommandMenuDropdown = () => {
     [commandMenuItems],
   );
 
-  const sidePanelFooterWidth = useContext(SidePanelFooterWidthContext);
+  const availableWidth = useSidePanelFooterPinnedItemsAvailableWidth();
 
   // Pinned items are buttons in the footer, so the dropdown only repeats the
   // ones the footer could not fit next to this dropdown's own footprint.
@@ -59,10 +58,7 @@ export const RecordPageSidePanelCommandMenuDropdown = () => {
     usePinnedCommandMenuItemsInlineLayout({
       pinnedCommandMenuItems,
       layoutKey: 'side-panel-footer',
-      containerWidth: Math.max(
-        sidePanelFooterWidth - SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH,
-        0,
-      ),
+      containerWidth: availableWidth,
     });
 
   // A widget owning the footer suppresses those buttons entirely, and leaves

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelPinnedCommandMenuItems.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelPinnedCommandMenuItems.tsx
@@ -1,19 +1,31 @@
 import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { isDefined } from 'twenty-shared/utils';
 
+import { SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH } from '@/command-menu-item/constants/SidePanelFooterOptionsReservedWidth';
 import { CommandMenuContextProvider } from '@/command-menu-item/contexts/CommandMenuContextProvider';
 import { PinnedCommandMenuItemButtons } from '@/command-menu-item/display/components/PinnedCommandMenuItemButtons';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
+import { SidePanelFooterWidthContext } from '@/ui/layout/side-panel/contexts/SidePanelFooterWidthContext';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useContext } from 'react';
 
 export const RecordPageSidePanelPinnedCommandMenuItems = () => {
   const contextStoreCurrentObjectMetadataItemId = useAtomComponentStateValue(
     contextStoreCurrentObjectMetadataItemIdComponentState,
   );
 
+  const sidePanelFooterWidth = useContext(SidePanelFooterWidthContext);
+
   if (!isDefined(contextStoreCurrentObjectMetadataItemId)) {
     return null;
   }
+
+  // The options dropdown shares the footer row, so its footprint is reserved
+  // out of the width the pinned buttons may occupy.
+  const availableWidth = Math.max(
+    sidePanelFooterWidth - SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH,
+    0,
+  );
 
   return (
     <CommandMenuContextProvider
@@ -21,7 +33,7 @@ export const RecordPageSidePanelPinnedCommandMenuItems = () => {
       displayType="button"
       containerType={CommandMenuItemContainerType.SidePanelFooter}
     >
-      <PinnedCommandMenuItemButtons />
+      <PinnedCommandMenuItemButtons containerWidth={availableWidth} />
     </CommandMenuContextProvider>
   );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelPinnedCommandMenuItems.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordPageSidePanelPinnedCommandMenuItems.tsx
@@ -1,31 +1,22 @@
 import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
 import { isDefined } from 'twenty-shared/utils';
 
-import { SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH } from '@/command-menu-item/constants/SidePanelFooterOptionsReservedWidth';
 import { CommandMenuContextProvider } from '@/command-menu-item/contexts/CommandMenuContextProvider';
 import { PinnedCommandMenuItemButtons } from '@/command-menu-item/display/components/PinnedCommandMenuItemButtons';
+import { useSidePanelFooterPinnedItemsAvailableWidth } from '@/command-menu-item/hooks/useSidePanelFooterPinnedItemsAvailableWidth';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
-import { SidePanelFooterWidthContext } from '@/ui/layout/side-panel/contexts/SidePanelFooterWidthContext';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { useContext } from 'react';
 
 export const RecordPageSidePanelPinnedCommandMenuItems = () => {
   const contextStoreCurrentObjectMetadataItemId = useAtomComponentStateValue(
     contextStoreCurrentObjectMetadataItemIdComponentState,
   );
 
-  const sidePanelFooterWidth = useContext(SidePanelFooterWidthContext);
+  const availableWidth = useSidePanelFooterPinnedItemsAvailableWidth();
 
   if (!isDefined(contextStoreCurrentObjectMetadataItemId)) {
     return null;
   }
-
-  // The options dropdown shares the footer row, so its footprint is reserved
-  // out of the width the pinned buttons may occupy.
-  const availableWidth = Math.max(
-    sidePanelFooterWidth - SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH,
-    0,
-  );
 
   return (
     <CommandMenuContextProvider

--- a/packages/twenty-front/src/modules/command-menu-item/constants/SidePanelFooterOptionsReservedWidth.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/constants/SidePanelFooterOptionsReservedWidth.ts
@@ -1,0 +1,3 @@
+// Footprint of the options dropdown in the side panel footer: a small icon
+// button (24px) plus the footer gap separating it from the pinned buttons.
+export const SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH = 32;

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -42,10 +42,18 @@ const StyledItemsContainer = styled.div<{ shouldReverse: boolean }>`
     shouldReverse ? 'row-reverse' : 'row'};
   gap: ${PINNED_COMMAND_MENU_ITEMS_GAP}px;
   max-width: 100%;
+  min-width: 0;
   overflow: hidden;
 `;
 
-export const PinnedCommandMenuItemButtons = () => {
+export const PinnedCommandMenuItemButtons = ({
+  containerWidth,
+}: {
+  // Provided when an ancestor already knows the width available to the
+  // buttons; the row then shrinks to fit instead of stretching over the free
+  // space to measure it, so sibling actions stay adjacent to the buttons.
+  containerWidth?: number;
+}) => {
   const { theme } = useContext(ThemeContext);
   const { commandMenuItems, containerType } = useContext(CommandMenuContext);
   const isMobile = useIsMobile();
@@ -86,6 +94,7 @@ export const PinnedCommandMenuItemButtons = () => {
   } = usePinnedCommandMenuItemsInlineLayout({
     pinnedCommandMenuItems,
     layoutKey: isSidePanelFooter ? 'side-panel-footer' : 'page-header',
+    containerWidth,
   });
 
   const isCommandMenuItemLabelled = (
@@ -103,6 +112,35 @@ export const PinnedCommandMenuItemButtons = () => {
     ...pinnedInlineCommandMenuItems.filter(isCommandMenuItemLabelled),
   ];
 
+  const inlineItemsRow = (
+    <StyledItemsContainer shouldReverse={!isSidePanelFooter}>
+      {displayedInlineCommandMenuItems.map((item) => (
+        <StyledCommandMenuItemContainer
+          key={item.id}
+          initial={{ width: 0, opacity: 0 }}
+          animate={{ width: 'unset', opacity: 1 }}
+          exit={{ width: 0, opacity: 0 }}
+          transition={{
+            duration: theme.animation.duration.instant,
+            ease: 'easeInOut',
+          }}
+        >
+          <CommandMenuItemRenderer
+            item={item}
+            shouldHideLabel={shouldHideCommandMenuItemLabel(item.id)}
+            isPrimaryAction={
+              item.engineComponentKey ===
+                EngineComponentKey.CREATE_NEW_RECORD ||
+              item.engineComponentKey === EngineComponentKey.COMPOSE_CAMPAIGN ||
+              item.engineComponentKey ===
+                EngineComponentKey.SEND_MESSAGE_CAMPAIGN
+            }
+          />
+        </StyledCommandMenuItemContainer>
+      ))}
+    </StyledItemsContainer>
+  );
+
   return (
     <>
       <PinnedCommandMenuItemsInlineMeasurements
@@ -115,39 +153,15 @@ export const PinnedCommandMenuItemButtons = () => {
           onCommandMenuItemDimensionChange
         }
       />
-      <StyledWrapper>
-        <NodeDimension onDimensionChange={onContainerDimensionChange}>
-          <StyledContainer>
-            <StyledItemsContainer shouldReverse={!isSidePanelFooter}>
-              {displayedInlineCommandMenuItems.map((item) => (
-                <StyledCommandMenuItemContainer
-                  key={item.id}
-                  initial={{ width: 0, opacity: 0 }}
-                  animate={{ width: 'unset', opacity: 1 }}
-                  exit={{ width: 0, opacity: 0 }}
-                  transition={{
-                    duration: theme.animation.duration.instant,
-                    ease: 'easeInOut',
-                  }}
-                >
-                  <CommandMenuItemRenderer
-                    item={item}
-                    shouldHideLabel={shouldHideCommandMenuItemLabel(item.id)}
-                    isPrimaryAction={
-                      item.engineComponentKey ===
-                        EngineComponentKey.CREATE_NEW_RECORD ||
-                      item.engineComponentKey ===
-                        EngineComponentKey.COMPOSE_CAMPAIGN ||
-                      item.engineComponentKey ===
-                        EngineComponentKey.SEND_MESSAGE_CAMPAIGN
-                    }
-                  />
-                </StyledCommandMenuItemContainer>
-              ))}
-            </StyledItemsContainer>
-          </StyledContainer>
-        </NodeDimension>
-      </StyledWrapper>
+      {isDefined(containerWidth) ? (
+        inlineItemsRow
+      ) : (
+        <StyledWrapper>
+          <NodeDimension onDimensionChange={onContainerDimensionChange}>
+            <StyledContainer>{inlineItemsRow}</StyledContainer>
+          </NodeDimension>
+        </StyledWrapper>
+      )}
     </>
   );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout.ts
@@ -15,14 +15,21 @@ type ElementDimensions = {
 type UsePinnedCommandMenuItemsInlineLayoutParams = {
   pinnedCommandMenuItems: CommandMenuItemFieldsFragment[];
   layoutKey: PinnedCommandMenuItemsLayoutKey;
+  // Overrides the self-measured container width when an ancestor already
+  // knows how much space the inline buttons may occupy.
+  containerWidth?: number;
 };
 
 export const usePinnedCommandMenuItemsInlineLayout = ({
   pinnedCommandMenuItems,
   layoutKey,
+  containerWidth,
 }: UsePinnedCommandMenuItemsInlineLayoutParams) => {
   const [commandMenuPinnedInlineLayout, setCommandMenuPinnedInlineLayout] =
     useAtomFamilyState(commandMenuPinnedInlineLayoutFamilyState, layoutKey);
+
+  const effectiveContainerWidth =
+    containerWidth ?? commandMenuPinnedInlineLayout.containerWidth;
 
   const pinnedCommandMenuItemKeysInDisplayOrder = useMemo(
     () => pinnedCommandMenuItems.map((item) => item.id),
@@ -31,7 +38,7 @@ export const usePinnedCommandMenuItemsInlineLayout = ({
 
   const hasKnownPinnedInlineLayout = useMemo(
     () =>
-      commandMenuPinnedInlineLayout.containerWidth > 0 &&
+      effectiveContainerWidth > 0 &&
       pinnedCommandMenuItemKeysInDisplayOrder.every((commandMenuItemKey) =>
         isNumber(
           commandMenuPinnedInlineLayout.commandMenuItemWidthsByKey[
@@ -39,7 +46,11 @@ export const usePinnedCommandMenuItemsInlineLayout = ({
           ],
         ),
       ),
-    [commandMenuPinnedInlineLayout, pinnedCommandMenuItemKeysInDisplayOrder],
+    [
+      commandMenuPinnedInlineLayout,
+      effectiveContainerWidth,
+      pinnedCommandMenuItemKeysInDisplayOrder,
+    ],
   );
 
   const visiblePinnedCommandMenuItemCount = useMemo(
@@ -50,13 +61,13 @@ export const usePinnedCommandMenuItemsInlineLayout = ({
               pinnedCommandMenuItemKeysInDisplayOrder,
             commandMenuItemWidthsByKey:
               commandMenuPinnedInlineLayout.commandMenuItemWidthsByKey,
-            commandMenuItemsContainerWidth:
-              commandMenuPinnedInlineLayout.containerWidth,
+            commandMenuItemsContainerWidth: effectiveContainerWidth,
             commandMenuItemsGapWidth: PINNED_COMMAND_MENU_ITEMS_GAP,
           })
         : 0,
     [
       commandMenuPinnedInlineLayout,
+      effectiveContainerWidth,
       hasKnownPinnedInlineLayout,
       pinnedCommandMenuItemKeysInDisplayOrder,
     ],

--- a/packages/twenty-front/src/modules/command-menu-item/hooks/useSidePanelFooterPinnedItemsAvailableWidth.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/hooks/useSidePanelFooterPinnedItemsAvailableWidth.ts
@@ -1,0 +1,15 @@
+import { SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH } from '@/command-menu-item/constants/SidePanelFooterOptionsReservedWidth';
+import { SidePanelFooterWidthContext } from '@/ui/layout/side-panel/contexts/SidePanelFooterWidthContext';
+import { useContext } from 'react';
+
+// Width left for the pinned buttons once the options dropdown footprint is
+// reserved out of the measured footer row. The buttons and the overflow
+// dropdown both size against this so they can never disagree on what fits.
+export const useSidePanelFooterPinnedItemsAvailableWidth = () => {
+  const sidePanelFooterWidth = useContext(SidePanelFooterWidthContext);
+
+  return Math.max(
+    sidePanelFooterWidth - SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH,
+    0,
+  );
+};

--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuButton.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuButton.tsx
@@ -65,7 +65,7 @@ export const CommandMenuButton = ({
           <IconButton
             Icon={command.Icon}
             size="small"
-            variant={buttonAccent === 'blue' ? 'primary' : 'tertiary'}
+            variant="primary"
             accent={buttonAccent}
             to={to}
             onClick={onClick}

--- a/packages/twenty-front/src/modules/object-record/record-show/components/PageLayoutRecordPageRenderer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/PageLayoutRecordPageRenderer.tsx
@@ -124,9 +124,7 @@ export const PageLayoutRecordPageRenderer = ({
                     <Button
                       key={commandMenuItem.id}
                       size="small"
-                      variant={
-                        commandMenuItem.isPrimaryCTA ? 'primary' : 'secondary'
-                      }
+                      variant="primary"
                       accent={commandMenuItem.isPrimaryCTA ? 'blue' : 'default'}
                       title={commandMenuItem.label}
                       Icon={commandMenuItem.Icon}

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
@@ -217,7 +217,7 @@ export const SidePanelTopBar = () => {
           <IconButton
             Icon={IconX}
             size="small"
-            variant="tertiary"
+            variant="primary"
             onClick={closeSidePanelMenu}
             ariaLabel={t`Close side panel`}
           />

--- a/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
@@ -96,7 +96,7 @@ export const SidePanelComposeEmailPage = () => {
           <IconButton
             key="discard"
             size="small"
-            variant="secondary"
+            variant="primary"
             Icon={IconTrash}
             ariaLabel={t`Discard`}
             onClick={goBackFromSidePanel}
@@ -104,7 +104,7 @@ export const SidePanelComposeEmailPage = () => {
           <IconButton
             key="attach"
             size="small"
-            variant="secondary"
+            variant="primary"
             Icon={IconPaperclip}
             ariaLabel={t`Attach files`}
             onClick={openAttachmentPicker}

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx
@@ -70,7 +70,7 @@ export const OptionsDropdownMenu = ({
           Icon={IconDotsVertical}
           ariaLabel={t`Options`}
           size="small"
-          variant="tertiary"
+          variant="primary"
         />
       }
       dropdownPlacement="top-end"

--- a/packages/twenty-front/src/modules/ui/layout/side-panel/components/SidePanelFooter.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/side-panel/components/SidePanelFooter.tsx
@@ -1,17 +1,23 @@
+import { SidePanelFooterWidthContext } from '@/ui/layout/side-panel/contexts/SidePanelFooterWidthContext';
+import { NodeDimension } from '@/ui/utilities/dimensions/components/NodeDimension';
 import { styled } from '@linaria/react';
-import { Fragment } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledContainer = styled.div`
-  align-items: center;
   background: ${themeCssVariables.background.secondary};
   border-top: 1px solid ${themeCssVariables.border.color.light};
   bottom: 0;
   box-sizing: border-box;
+  padding: ${themeCssVariables.spacing[2]} ${themeCssVariables.spacing[3]};
+  width: 100%;
+`;
+
+const StyledActionsRow = styled(NodeDimension)`
+  align-items: center;
   display: flex;
   gap: ${themeCssVariables.spacing[2]};
   justify-content: flex-end;
-  padding: ${themeCssVariables.spacing[2]} ${themeCssVariables.spacing[3]};
   width: 100%;
 `;
 
@@ -20,11 +26,24 @@ type SidePanelFooterProps = {
 };
 
 export const SidePanelFooter = ({ actions }: SidePanelFooterProps) => {
+  const [actionsRowWidth, setActionsRowWidth] = useState(0);
+
+  const handleActionsRowDimensionChange = useCallback(
+    (dimensions: { width: number; height: number }) => {
+      setActionsRowWidth(dimensions.width);
+    },
+    [],
+  );
+
   return (
     <StyledContainer>
-      {actions.map((action, index) => (
-        <Fragment key={index}>{action}</Fragment>
-      ))}
+      <SidePanelFooterWidthContext.Provider value={actionsRowWidth}>
+        <StyledActionsRow onDimensionChange={handleActionsRowDimensionChange}>
+          {actions.map((action, index) => (
+            <Fragment key={index}>{action}</Fragment>
+          ))}
+        </StyledActionsRow>
+      </SidePanelFooterWidthContext.Provider>
     </StyledContainer>
   );
 };

--- a/packages/twenty-front/src/modules/ui/layout/side-panel/contexts/SidePanelFooterWidthContext.ts
+++ b/packages/twenty-front/src/modules/ui/layout/side-panel/contexts/SidePanelFooterWidthContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+// Content width of the footer actions row, so an action that adapts to the
+// available space can size itself without stretching over the row to measure.
+export const SidePanelFooterWidthContext = createContext<number>(0);


### PR DESCRIPTION
Alternative to #24221 for comparison, per the discussion about `leadingAction`. Same design fixes (identical button variant changes, identical visual result, verified pixel-identical in the running app), different footer layout mechanism. Merge one or the other, not both.

## The difference

#24221 keeps the pinned buttons component stretching over the footer's free space to measure it, so the options menu has to be injected inside that stretchy cluster through a `leadingAction` slot, and its runtime-measured width is reserved through the shared layout state.

Here the ownership flips:

- `SidePanelFooter` measures its actions row once and provides the width through a small generic context (`SidePanelFooterWidthContext`).
- `PinnedCommandMenuItemButtons` accepts an optional `containerWidth`. When provided it shrinks to fit and renders just the buttons row; no stretching, no self-measurement. Header surfaces pass nothing and keep the existing self-measuring behavior.
- The options menu is a plain first action again, grouped by the footer's existing `justify-content: flex-end`.
- The record page reserves the options menu footprint with a constant (`SIDE_PANEL_FOOTER_OPTIONS_RESERVED_WIDTH = 32`, a 24px small icon button plus the 8px footer gap) when deriving the width it hands to the buttons and to the overflow dropdown.

## Tradeoffs vs #24221

- Removed: the `leadingAction` ReactNode slot, the nested measuring node around it, and the width-reservation plumbing in the shared state and fit util (`leadingActionWidth`, `hasLeadingAction`). The fit util is untouched from main.
- Added: a footer width context (generic, reusable by any adaptive footer action) and one constant.
- The constant is the cost: if the options button ever changes size, it must be updated by hand, while #24221 tracks it automatically by measuring. It degrades gracefully (a few px of early overflow or clipping) rather than breaking.

## Design fixes carried over unchanged from #24221

- Icon-only pinned actions render as bordered primary icon buttons again (`CommandMenuButton`).
- Options trigger and side panel close button are primary; expand stays tertiary.
- Footer actions grouped bottom right with the options menu leftmost of the group, matching [the Figma frame](https://www.figma.com/design/xt8O9mFeLl46C5InWwoMrN/Twenty?node-id=110786-425955).
- Widget footer buttons and compose email discard/attach are primary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4XJwMCrTgaN6e2NyLFrAK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

