### PR TITLE
fix(server): add findAndCount to the ORM v2 workspace repository

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -193,6 +193,21 @@ export class WorkspaceRepositoryV2 {
     return this.find({ where });
   }
 
+  async findAndCount(
+    options?: FindOptionsV2,
+  ): Promise<[ObjectRecord[], number]> {
+    const records = await this.find(options);
+    const totalCount = await this.count(options);
+
+    return [records, totalCount];
+  }
+
+  async findAndCountBy(
+    where: ObjectWhereLike | ObjectWhereLike[],
+  ): Promise<[ObjectRecord[], number]> {
+    return this.findAndCount({ where });
+  }
+
   async findOne(options?: FindOptionsV2): Promise<ObjectRecord | null> {
     if (!isDefined(options?.where)) {
       throw new TwentyOrmV2Exception(


### PR DESCRIPTION
## What

Adds `findAndCount` (and its `findAndCountBy` sibling) to `WorkspaceRepositoryV2`.

The ORM v2 repository implements `find`, `findBy`, `findOne`, `findOneBy`, `findOneOrFail`, `findOneByOrFail`, `count`, `countBy`, `exists` and `existsBy`, but not `findAndCount`. The record Calendar panel calls it (`timeline-calendar-event.service.ts:100`), so with `IS_ORM_V2_READ_PATH_ENABLED` on, `GetTimelineCalendarEventsFromObjectRecord` fails with `calendarEventRepository.findAndCount is not a function` and the panel renders its "No Events" empty state.

This is the second v2 gap stacked in that one function: #24230 fixed the relation-keyed `where` that threw first, which uncovered this one.

## Semantics

`findAndCount` returns `[records, totalCount]`, where the count is the total matching the criteria and deliberately ignores `skip`/`take`, matching TypeORM. That falls out of `buildCountStatement`, which emits no `LIMIT`/`OFFSET` — already covered by "should build a COUNT statement that ignores projection, order and pagination".

The two queries run sequentially rather than concurrently, since under `runInWorkspaceTransaction` the executor is bound to a single client.

## Surface audit

Rather than fix this one blind, I diffed the method surface against consumers to see whether other v2 gaps were waiting. Sites calling methods v2 lacks:

| Method | Sites | Verdict |
|---|---|---|
| `findAndCount` | 3 | Only the calendar one is an ORM v2 repository. `applicationRepository` is core; `suppressionRepository` is a `WorkspaceScopedRepository` |
| `increment` | 2 | Both core (`CalendarChannel`, `MessageChannel`) |
| `softRemove` | 1 | Core (`roleTarget`) |
| `findAndCountBy`, `remove`, `recover`, `preload` | 0 | — |

So this should be the last repository-level gap on this panel.

## Testing

`npx jest twenty-orm-v2`: 180 tests green across 17 suites. Typecheck and `lint:diff-with-main` clean.

No new unit test: the method is a composition of `find` and `count`, both already covered, and the pagination semantic it relies on is guarded by the existing count test. A repository-level spec here would be mock-only. The gap that would actually have caught this is an integration test for the timeline calendar resolver running flag-on, which does not exist today and is worth adding separately.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

