### PR TITLE
Give the mobile record header a proper title treatment

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -63,14 +63,9 @@ export const PinnedCommandMenuItemButtons = ({
   const isSidePanelFooter =
     containerType === CommandMenuItemContainerType.SidePanelFooter;
 
-  // A record header keeps its breadcrumb on mobile, so its actions stay icons
-  // and leave the record name room. Index and standalone headers drop their
-  // title there, which frees the width for one label.
-  const isRecordPageHeader =
-    containerType === CommandMenuItemContainerType.ShowPageHeader;
-
-  const shouldLabelSingleCommandMenuItem =
-    isSidePanelFooter || (isMobile && !isRecordPageHeader);
+  // Every header keeps its title on mobile, so its actions stay icon-only and
+  // leave the title room. The side panel footer has a full row to itself.
+  const shouldLabelSingleCommandMenuItem = isSidePanelFooter;
 
   const pinnedCommandMenuItems = useMemo(
     () => commandMenuItems.filter((item) => item.isPinned === true),
@@ -82,7 +77,7 @@ export const PinnedCommandMenuItemButtons = ({
     : null;
 
   const shouldHideCommandMenuItemLabel = (commandMenuItemId: string) =>
-    (isMobile && isRecordPageHeader) ||
+    (isMobile && !isSidePanelFooter) ||
     (shouldLabelSingleCommandMenuItem &&
       commandMenuItemId !== labelledCommandMenuItemId);
 

--- a/packages/twenty-front/src/modules/object-record/record-show/components/ObjectRecordShowPageBreadcrumb.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/ObjectRecordShowPageBreadcrumb.tsx
@@ -1,3 +1,4 @@
+import { allowRequestsToTwentyIconsState } from '@/client-config/states/allowRequestsToTwentyIcons';
 import { useNumberFormat } from '@/localization/hooks/useNumberFormat';
 import { ObjectMetadataIcon } from '@/object-metadata/components/ObjectMetadataIcon';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
@@ -9,13 +10,19 @@ import { useRecordShowContainerActions } from '@/object-record/record-show/hooks
 import { useRecordShowPageGroupByBreadcrumbInfo } from '@/object-record/record-show/hooks/useRecordShowPageGroupByBreadcrumbInfo';
 import { useRecordShowPagePagination } from '@/object-record/record-show/hooks/useRecordShowPagePagination';
 import { getRecordShowPageBreadcrumbPaginationLabel } from '@/object-record/record-show/utils/getRecordShowPageBreadcrumbPaginationLabel';
+import { recordStoreIdentifierFamilySelector } from '@/object-record/record-store/states/selectors/recordStoreIdentifierFamilySelector';
 import { RecordTitleCell } from '@/object-record/record-title-cell/components/RecordTitleCell';
 import { RecordTitleCellContainerType } from '@/object-record/record-title-cell/types/RecordTitleCellContainerType';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
+import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { styled } from '@linaria/react';
 import { useState } from 'react';
 import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { Avatar } from 'twenty-ui/data-display';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
 
 const StyledEditableTitleContainer = styled.div`
   align-items: center;
@@ -40,10 +47,25 @@ const StyledBreadcrumbPrefixObjectIcon = styled.div`
   opacity: 0.64;
 `;
 
-const StyledTitle = styled.div`
+const StyledTitle = styled.div<{ isEmphasized: boolean }>`
+  font-size: ${({ isEmphasized }) =>
+    isEmphasized ? themeCssVariables.font.size.md : 'inherit'};
+  font-weight: ${({ isEmphasized }) =>
+    isEmphasized ? themeCssVariables.font.weight.semiBold : 'inherit'};
   max-width: 100%;
   overflow: hidden;
   width: fit-content;
+`;
+
+const StyledAvatarContainer = styled.div`
+  align-items: center;
+  background: ${themeCssVariables.background.transparent.light};
+  border-radius: ${themeCssVariables.border.radius.sm};
+  display: flex;
+  flex-shrink: 0;
+  justify-content: center;
+  margin-right: ${themeCssVariables.spacing[0.5]};
+  padding: ${themeCssVariables.spacing[1]};
 `;
 
 const StyledPaginationInformation = styled.span`
@@ -76,6 +98,18 @@ export const ObjectRecordShowPageBreadcrumb = ({
   const { objectMetadataItem } = useObjectMetadataItem({
     objectNameSingular,
   });
+
+  const allowRequestsToTwentyIcons = useAtomStateValue(
+    allowRequestsToTwentyIconsState,
+  );
+
+  const recordIdentifier = useAtomFamilySelectorValue(
+    recordStoreIdentifierFamilySelector,
+    {
+      recordId: objectRecordId,
+      allowRequestsToTwentyIcons,
+    },
+  );
 
   const { useUpdateOneObjectRecordMutation } = useRecordShowContainerActions({
     objectNameSingular,
@@ -117,7 +151,19 @@ export const ObjectRecordShowPageBreadcrumb = ({
 
   return (
     <StyledEditableTitleContainer data-testid="top-bar-title">
-      {!isMobile && (
+      {isMobile ? (
+        isDefined(recordIdentifier) && (
+          <StyledAvatarContainer>
+            <Avatar
+              avatarUrl={getAbsoluteImageUrl(recordIdentifier.avatarUrl)}
+              placeholder={recordIdentifier.name}
+              placeholderColorSeed={objectRecordId}
+              size="md"
+              type={recordIdentifier.avatarType}
+            />
+          </StyledAvatarContainer>
+        )
+      ) : (
         <StyledEditableTitlePrefix
           onClick={() => {
             navigateToIndexView();
@@ -130,7 +176,7 @@ export const ObjectRecordShowPageBreadcrumb = ({
           <span>{' / '}</span>
         </StyledEditableTitlePrefix>
       )}
-      <StyledTitle>
+      <StyledTitle isEmphasized={isMobile}>
         <FieldContext.Provider
           value={{
             recordId: objectRecordId,
@@ -155,7 +201,7 @@ export const ObjectRecordShowPageBreadcrumb = ({
           }}
         >
           <RecordTitleCell
-            sizeVariant="xs"
+            sizeVariant={isMobile ? 'sm' : 'xs'}
             containerType={RecordTitleCellContainerType.PageHeader}
           />
         </FieldContext.Provider>

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelToggleButton.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelToggleButton.tsx
@@ -79,7 +79,7 @@ export const SidePanelToggleButton = () => {
         <IconButton
           Icon={IconDotsVertical}
           dataTestId="page-header-side-panel-button"
-          size={isMobile ? 'medium' : 'small'}
+          size="small"
           variant="primary"
           accent="default"
           ariaLabel={ariaLabel}

--- a/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
@@ -92,10 +92,7 @@ export const PageCardHeader = ({
   const isMobile = useIsMobile();
   const isNavigationDrawerExpanded = useNavigationDrawerExpanded();
 
-  // Uncentered headers drop the title on mobile to fit a labelled action.
-  const hasTitleContent =
-    (!isMobile || centerTitle) &&
-    (isDefined(icon) || isDefined(title) || isDefined(tag));
+  const hasTitleContent = isDefined(icon) || isDefined(title) || isDefined(tag);
   const shouldCenterTitle = centerTitle && hasTitleContent;
 
   const titleContent = (


### PR DESCRIPTION
Two fixes to the record page header on mobile.

### The title read as body text, not as the page title

On desktop the header is `[object icon] Companies / Brian Chesky`, and the greyed prefix is what makes the record name read as the title. Mobile drops that prefix (`ObjectRecordShowPageBreadcrumb` hides it behind `!isMobile`), so the record name was left as plain inherited text with nothing above it in the hierarchy.

The side panel header already solves this: `SidePanelPageInfoLayout` renders an avatar plus a title at `font.size.md` / `font.weight.semiBold`. The mobile record header now does the same, so the two surfaces match. The title cell also moves from the `xs` size variant to `sm` on mobile, so the edit input lines up with the 24px display height instead of being 4px shorter.

Desktop is unchanged.

### The "..." button was bigger than every other header action

`SidePanelToggleButton` was the only header action sized `medium` (32px) on mobile. Everything next to it (`CommandMenuButton`, `CommandMenuItemEditButton`) is hardcoded to `small` (24px), so the "..." stuck out. It is now `small` everywhere, which also fixes the same mismatch on index and standalone page headers.


---
_Generated by [Claude Code](https://claude.ai/code/session_012nQxaGuBEbWDLunLtofzKu)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

