### PR TITLE
Keep the object name and icon in mobile view headers

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -63,14 +63,9 @@ export const PinnedCommandMenuItemButtons = ({
   const isSidePanelFooter =
     containerType === CommandMenuItemContainerType.SidePanelFooter;
 
-  // A record header keeps its breadcrumb on mobile, so its actions stay icons
-  // and leave the record name room. Index and standalone headers drop their
-  // title there, which frees the width for one label.
-  const isRecordPageHeader =
-    containerType === CommandMenuItemContainerType.ShowPageHeader;
-
-  const shouldLabelSingleCommandMenuItem =
-    isSidePanelFooter || (isMobile && !isRecordPageHeader);
+  // Every header keeps its title on mobile, so its actions stay icon-only and
+  // leave the title room. The side panel footer has a full row to itself.
+  const shouldLabelSingleCommandMenuItem = isSidePanelFooter;
 
   const pinnedCommandMenuItems = useMemo(
     () => commandMenuItems.filter((item) => item.isPinned === true),
@@ -82,7 +77,7 @@ export const PinnedCommandMenuItemButtons = ({
     : null;
 
   const shouldHideCommandMenuItemLabel = (commandMenuItemId: string) =>
-    (isMobile && isRecordPageHeader) ||
+    (isMobile && !isSidePanelFooter) ||
     (shouldLabelSingleCommandMenuItem &&
       commandMenuItemId !== labelledCommandMenuItemId);
 

--- a/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
@@ -92,10 +92,7 @@ export const PageCardHeader = ({
   const isMobile = useIsMobile();
   const isNavigationDrawerExpanded = useNavigationDrawerExpanded();
 
-  // Uncentered headers drop the title on mobile to fit a labelled action.
-  const hasTitleContent =
-    (!isMobile || centerTitle) &&
-    (isDefined(icon) || isDefined(title) || isDefined(tag));
+  const hasTitleContent = isDefined(icon) || isDefined(title) || isDefined(tag);
   const shouldCenterTitle = centerTitle && hasTitleContent;
 
   const titleContent = (


### PR DESCRIPTION
Stacked on #24251.

Index and standalone page headers hid their title on mobile. `PageCardHeader` gated `hasTitleContent` behind `!isMobile`, and `PinnedCommandMenuItemButtons` spent the width it freed on labelling one pinned action. The result was a view you could not identify from its header, with one action ("New task") looking primary next to the icon-only ones.

Two changes:

- `PageCardHeader` keeps the icon and title on every viewport. Views now show the object name and icon on mobile, the same as desktop.
- `PinnedCommandMenuItemButtons` drops the label on mobile headers, so pinned actions are icon-only there and the title gets the room back.

The side panel footer is untouched and still labels its primary action; it has a full row to itself rather than sharing one with a title. Desktop headers are unchanged.

Overflow already worked before this change: `usePinnedCommandMenuItemsInlineLayout` measures the row and moves whatever does not fit into the command menu, and icon-only buttons are narrower than the labelled ones they replace.


---
_Generated by [Claude Code](https://claude.ai/code/session_012nQxaGuBEbWDLunLtofzKu)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

