### PR TITLE
Make deactivated objects editable from settings

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/objects/components/SettingsObjectInactiveMenuDropDown.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/objects/components/SettingsObjectInactiveMenuDropDown.tsx
@@ -4,7 +4,13 @@ import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/Drop
 import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { t } from '@lingui/core/macro';
-import { IconArchiveOff, IconDotsVertical, IconTrash } from 'twenty-ui/icon';
+import {
+  IconArchiveOff,
+  IconDotsVertical,
+  IconEye,
+  IconPencil,
+  IconTrash,
+} from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
 import { MenuItem } from 'twenty-ui/navigation';
 
@@ -12,14 +18,18 @@ type SettingsObjectInactiveMenuDropDownProps = {
   isCustomObject: boolean;
   onActivate: () => void;
   onDelete: () => void;
+  onEdit: () => void;
   objectMetadataItemNamePlural: string;
+  readonly?: boolean;
 };
 
 export const SettingsObjectInactiveMenuDropDown = ({
   onActivate,
   objectMetadataItemNamePlural,
   onDelete,
+  onEdit,
   isCustomObject,
+  readonly = false,
 }: SettingsObjectInactiveMenuDropDownProps) => {
   const dropdownId = `${objectMetadataItemNamePlural}-settings-object-inactive-menu-dropdown`;
 
@@ -35,6 +45,13 @@ export const SettingsObjectInactiveMenuDropDown = ({
     closeDropdown(dropdownId);
   };
 
+  const handleEdit = () => {
+    onEdit();
+    closeDropdown(dropdownId);
+  };
+
+  const isEditable = isCustomObject && !readonly;
+
   return (
     <Dropdown
       dropdownId={dropdownId}
@@ -49,11 +66,18 @@ export const SettingsObjectInactiveMenuDropDown = ({
         <DropdownContent widthInPixels={GenericDropdownContentWidth.Narrow}>
           <DropdownMenuItemsContainer>
             <MenuItem
-              text={t`Activate`}
-              LeftIcon={IconArchiveOff}
-              onClick={handleActivate}
+              text={isEditable ? t`Edit` : t`View`}
+              LeftIcon={isEditable ? IconPencil : IconEye}
+              onClick={handleEdit}
             />
-            {isCustomObject && (
+            {!readonly && (
+              <MenuItem
+                text={t`Activate`}
+                LeftIcon={IconArchiveOff}
+                onClick={handleActivate}
+              />
+            )}
+            {isCustomObject && !readonly && (
               <MenuItem
                 text={t`Delete`}
                 LeftIcon={IconTrash}

--- a/packages/twenty-front/src/modules/settings/data-model/objects/components/SettingsObjectInactiveMenuDropDown.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/objects/components/SettingsObjectInactiveMenuDropDown.tsx
@@ -20,7 +20,7 @@ type SettingsObjectInactiveMenuDropDownProps = {
   onDelete: () => void;
   onEdit: () => void;
   objectMetadataItemNamePlural: string;
-  readonly?: boolean;
+  isReadOnly?: boolean;
 };
 
 export const SettingsObjectInactiveMenuDropDown = ({
@@ -29,7 +29,7 @@ export const SettingsObjectInactiveMenuDropDown = ({
   onDelete,
   onEdit,
   isCustomObject,
-  readonly = false,
+  isReadOnly = false,
 }: SettingsObjectInactiveMenuDropDownProps) => {
   const dropdownId = `${objectMetadataItemNamePlural}-settings-object-inactive-menu-dropdown`;
 
@@ -50,7 +50,7 @@ export const SettingsObjectInactiveMenuDropDown = ({
     closeDropdown(dropdownId);
   };
 
-  const isEditable = isCustomObject && !readonly;
+  const isEditable = isCustomObject && !isReadOnly;
 
   return (
     <Dropdown
@@ -70,14 +70,14 @@ export const SettingsObjectInactiveMenuDropDown = ({
               LeftIcon={isEditable ? IconPencil : IconEye}
               onClick={handleEdit}
             />
-            {!readonly && (
+            {!isReadOnly && (
               <MenuItem
                 text={t`Activate`}
                 LeftIcon={IconArchiveOff}
                 onClick={handleActivate}
               />
             )}
-            {isCustomObject && !readonly && (
+            {isCustomObject && !isReadOnly && (
               <MenuItem
                 text={t`Delete`}
                 LeftIcon={IconTrash}

--- a/packages/twenty-front/src/modules/settings/data-model/objects/components/__stories__/SettingsObjectInactiveMenuDropDown.stories.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/objects/components/__stories__/SettingsObjectInactiveMenuDropDown.stories.tsx
@@ -10,11 +10,13 @@ import { ComponentDecorator } from 'twenty-ui/testing';
 
 const handleActivateMockFunction = fn();
 const handleDeleteMockFunction = fn();
+const handleEditMockFunction = fn();
 
 const ClearMocksDecorator: Decorator = (Story, context) => {
   if (context.parameters.clearMocks === true) {
     handleActivateMockFunction.mockClear();
     handleDeleteMockFunction.mockClear();
+    handleEditMockFunction.mockClear();
   }
   return <Story />;
 };
@@ -26,6 +28,7 @@ const meta: Meta<typeof SettingsObjectInactiveMenuDropDown> = {
     objectMetadataItemNamePlural: 'settings-object-inactive-menu-dropdown',
     onActivate: handleActivateMockFunction,
     onDelete: handleDeleteMockFunction,
+    onEdit: handleEditMockFunction,
   },
   decorators: [ComponentDecorator, ClearMocksDecorator],
   parameters: {
@@ -67,6 +70,50 @@ export const WithActivate: Story = {
     await userEvent.click(activateMenuItem);
 
     await expect(handleActivateMockFunction).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(dropdownButton);
+  },
+};
+
+export const WithEdit: Story = {
+  args: { isCustomObject: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.ownerDocument.body);
+
+    const dropdownButton = await canvas.findByRole('button', {
+      name: 'Inactive Object Options',
+    });
+
+    await userEvent.click(dropdownButton);
+
+    await expect(handleEditMockFunction).toHaveBeenCalledTimes(0);
+
+    const editMenuItem = await canvas.findByText('Edit');
+
+    await userEvent.click(editMenuItem);
+
+    await expect(handleEditMockFunction).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(dropdownButton);
+  },
+};
+
+export const WithView: Story = {
+  args: { isCustomObject: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.ownerDocument.body);
+
+    const dropdownButton = await canvas.findByRole('button', {
+      name: 'Inactive Object Options',
+    });
+
+    await userEvent.click(dropdownButton);
+
+    const viewMenuItem = await canvas.findByText('View');
+
+    await userEvent.click(viewMenuItem);
+
+    await expect(handleEditMockFunction).toHaveBeenCalledTimes(1);
 
     await userEvent.click(dropdownButton);
   },

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx
@@ -38,6 +38,7 @@ import {
   ThemeContext,
   themeCssVariables,
 } from 'twenty-ui/theme-constants';
+import { useNavigateSettings } from '~/hooks/useNavigateSettings';
 import { GET_SETTINGS_OBJECT_TABLE_METADATA } from '~/pages/settings/data-model/constants/SettingsObjectTableMetadata';
 import type { SettingsObjectTableItem } from '~/pages/settings/data-model/types/SettingsObjectTableItem';
 import { normalizeSearchText } from '~/utils/normalizeSearchText';
@@ -73,6 +74,7 @@ export const SettingsObjectTable = ({
   const { theme } = useContext(ThemeContext);
   const { t } = useLingui();
   const getIsMetadataItemCustom = useGetIsMetadataItemCustom();
+  const navigate = useNavigateSettings();
 
   const isAdvancedModeEnabled = useAtomStateValue(isAdvancedModeEnabledState);
   const isDDLLocked = useAtomStateValue(isDDLLockedState);
@@ -261,13 +263,21 @@ export const SettingsObjectTable = ({
                               stroke={theme.icon.stroke.sm}
                             />
                           </StyledIconChevronRightContainer>
-                        ) : isDDLLocked ? null : (
+                        ) : (
                           <SettingsObjectInactiveMenuDropDown
                             isCustomObject={getIsMetadataItemCustom(
                               objectSettingsItem.objectMetadataItem,
                             )}
+                            readonly={isDDLLocked}
                             objectMetadataItemNamePlural={
                               objectSettingsItem.objectMetadataItem.namePlural
+                            }
+                            onEdit={() =>
+                              navigate(SettingsPath.ObjectDetail, {
+                                objectNamePlural:
+                                  objectSettingsItem.objectMetadataItem
+                                    .namePlural,
+                              })
                             }
                             onActivate={() =>
                               updateOneObjectMetadataItem({

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx
@@ -268,7 +268,7 @@ export const SettingsObjectTable = ({
                             isCustomObject={getIsMetadataItemCustom(
                               objectSettingsItem.objectMetadataItem,
                             )}
-                            readonly={isDDLLocked}
+                            isReadOnly={isDDLLocked}
                             objectMetadataItemNamePlural={
                               objectSettingsItem.objectMetadataItem.namePlural
                             }


### PR DESCRIPTION
Fixes #24093

Once a custom object was deactivated it became unreachable in Settings > Data model: the row stayed visible but had no detail link, and the inactive menu only offered Activate and Delete. The only way to change anything on it was to delete and recreate it.

The detail page itself was always fine (`findObjectMetadataItemByNamePlural` resolves inactive items, and the form's read-only check looks at `isUIReadOnly` / `isRemote` / the DDL lock, not `isActive`), so this was purely a reachability gap in the table.

### What changed

- `SettingsObjectInactiveMenuDropDown` gets an `Edit` / `View` item at the top, navigating to `SettingsPath.ObjectDetail`. Pencil + "Edit" for editable custom objects, eye + "View" otherwise.
- New optional `readonly` prop hides Activate and Delete, mirroring `SettingsObjectFieldDisabledActionDropdown`.
- `SettingsObjectTable` now renders the dropdown for inactive rows even when DDL is locked, passing `readonly={isDDLLocked}` instead of rendering no action at all. Previously a DDL-locked instance showed inactive rows with no affordance whatsoever.
- Active rows are untouched: same chevron, same row link.

This makes the objects table behave like the fields table, which already had this Edit/View entry for deactivated fields.

### Test

Storybook stories added for the Edit and View cases alongside the existing Activate/Delete ones.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

