### PR TITLE
fix(tests): make the gmail mock honour the in:sent search filter

### DIFF
--- a/packages/twenty-server/test/integration/google/mocks/gmail-message-list-handler.util.ts
+++ b/packages/twenty-server/test/integration/google/mocks/gmail-message-list-handler.util.ts
@@ -3,15 +3,32 @@ import { http, HttpResponse } from 'msw';
 
 import { type MswHandler } from 'test/integration/utils/http-mock.util';
 
+// Only the onboarding import sends a positive `in:` term. The full sync's
+// `-label:` / `-category:` exclusions and `label:` inclusions stay unapplied.
+const INCLUDED_LABEL_REGEX = /(?:^|\s)in:(\w+)/g;
+
+const matchesSearchFilter = (
+  message: gmail_v1.Schema$Message,
+  searchFilter: string,
+): boolean =>
+  [...searchFilter.matchAll(INCLUDED_LABEL_REGEX)].every(([, labelName]) =>
+    message.labelIds?.includes(labelName.toUpperCase()),
+  );
+
 export const gmailMessageListHandler = (
   messages: gmail_v1.Schema$Message[],
 ): MswHandler =>
-  http.get('*/gmail/v1/users/me/messages', () =>
-    HttpResponse.json<gmail_v1.Schema$ListMessagesResponse>({
-      messages: messages.map((message) => ({
+  http.get('*/gmail/v1/users/me/messages', ({ request }) => {
+    const searchFilter = new URL(request.url).searchParams.get('q') ?? '';
+    const matchingMessages = messages.filter((message) =>
+      matchesSearchFilter(message, searchFilter),
+    );
+
+    return HttpResponse.json<gmail_v1.Schema$ListMessagesResponse>({
+      messages: matchingMessages.map((message) => ({
         id: message.id,
         threadId: message.threadId,
       })),
-      resultSizeEstimate: messages.length,
-    }),
-  );
+      resultSizeEstimate: matchingMessages.length,
+    });
+  });


### PR DESCRIPTION
`test/integration/google/messaging/token-refresh.integration-spec.ts` is flaky in CI ([example run](https://github.com/twentyhq/twenty/actions/runs/31817919179/job/94824655416)). No production code is involved: the Gmail mock is what's wrong.

`gmailMessageListHandler` ignores the `q` search filter and returns the whole fixture inbox to every caller. The onboarding recent messages import queries `users.messages.list` with `q=in:sent`, so in every suite it gets back that suite's INBOX fixtures and starts importing them, even though only `onboarding-recent-messages-import.integration-spec.ts` sets up sent messages. Real Gmail returns nothing there.

That import isn't a queued job, so `waitForAllJobsToFinish()` can't see it and `connectMessagingAccount` returns while it is still writing `syncStage`. In token-refresh, its `markAsMessagesImportScheduled` write lands after the test has set `MESSAGE_LIST_FETCH_SCHEDULED`, the fetch job's stage guard no longer matches, nothing refreshes the token, and the assertion fails with `Received === Expected`.

The handler now applies positive `in:<label>` terms from `q`. With `in:sent` and INBOX-only fixtures it returns an empty list, so the import returns at its `messageExternalIds.length === 0` check before writing any stage, and the suites stop interfering with themselves.

Only positive `in:` terms are applied, and only the onboarding import sends one. The full sync sends `-label:trash` / `-category:promotions` style exclusions through `computeGmailExcludeSearchFilter`, and under a selected-folders policy `label:` inclusions. Neither is applied here: no suite asserts on which messages a folder-scoped list returns today, and `(label:a OR label:b)` groups would need a real query parser.

## Known gap

`onboarding-recent-messages-import.integration-spec.ts` does have SENT fixtures, so the import still runs for real there and still writes `syncStage` outside the drain. Its `runMessageChannelSync` call can therefore land while the import is mid-write, in which case the fetch job no-ops. That does not fail the suite, since the assertion is that the messages aren't duplicated and they're already imported by then, but the third test can silently exercise nothing. Fixing that properly needs the import to be observable to `waitForAllJobsToFinish`, which is a production change and out of scope here.

Ran locally against a reset db and an isolated redis: `google` and `microsoft` integration suites, 34 suites / 129 tests, all passing.