### PR TITLE
fix(front): wrap relation card rows in RecordDetailRecordsListContainer

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationCard.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationCard.tsx
@@ -5,6 +5,7 @@ import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadata
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { useIsRecordFieldReadOnly } from '@/object-record/read-only/hooks/useIsRecordFieldReadOnly';
 import { RecordFieldsScopeContextProvider } from '@/object-record/record-field-list/contexts/RecordFieldsScopeContext';
+import { RecordDetailRecordsListContainer } from '@/object-record/record-field-list/record-detail-section/components/RecordDetailRecordsListContainer';
 import { RecordDetailRelationRecordsListItem } from '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsListItem';
 import { RecordDetailRelationRecordsListItemEffect } from '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsListItemEffect';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
@@ -141,33 +142,35 @@ export const FieldWidgetRelationCard = ({
           }}
         >
           <FieldInputEventContext.Provider value={{ onSubmit: handleSubmit }}>
-            {visibleRecords.map((record) => (
-              <Fragment key={record.id}>
-                <RecordDetailRelationRecordsListItemEffect
-                  relationRecordId={record.id}
-                  relationObjectMetadataNameSingular={
-                    relationObjectNameSingular
-                  }
-                />
-                <RecordDetailRelationRecordsListItem
-                  isExpanded={expandedItem === record.id}
-                  onClick={handleItemClick}
-                  relationRecord={record}
-                  relationObjectMetadataNameSingular={
-                    relationObjectNameSingular
-                  }
-                  relationFieldMetadataId={relationFieldMetadataId}
-                />
-              </Fragment>
-            ))}
-            {hasMoreRecords && (
-              <StyledShowMoreButtonContainer>
-                <FieldWidgetShowMoreButton
-                  remainingCount={remainingCount}
-                  onClick={handleShowMore}
-                />
-              </StyledShowMoreButtonContainer>
-            )}
+            <RecordDetailRecordsListContainer>
+              {visibleRecords.map((record) => (
+                <Fragment key={record.id}>
+                  <RecordDetailRelationRecordsListItemEffect
+                    relationRecordId={record.id}
+                    relationObjectMetadataNameSingular={
+                      relationObjectNameSingular
+                    }
+                  />
+                  <RecordDetailRelationRecordsListItem
+                    isExpanded={expandedItem === record.id}
+                    onClick={handleItemClick}
+                    relationRecord={record}
+                    relationObjectMetadataNameSingular={
+                      relationObjectNameSingular
+                    }
+                    relationFieldMetadataId={relationFieldMetadataId}
+                  />
+                </Fragment>
+              ))}
+              {hasMoreRecords && (
+                <StyledShowMoreButtonContainer>
+                  <FieldWidgetShowMoreButton
+                    remainingCount={remainingCount}
+                    onClick={handleShowMore}
+                  />
+                </StyledShowMoreButtonContainer>
+              )}
+            </RecordDetailRecordsListContainer>
           </FieldInputEventContext.Provider>
         </FieldContext.Provider>
       </RecordFieldsScopeContextProvider>


### PR DESCRIPTION
Fixes #24231

## Problem

On a record page, a one-to-many relation FIELD widget in CARD mode renders its rows stretched across the whole card with huge gaps, and the expand/open interactions become hard to hit.

`FieldWidgetRelationCard` mapped `visibleRecords` into Fragments directly inside `FieldInputEventContext.Provider`, with no list wrapper. The parent `WidgetCardContent` is `display: grid` with `height: 100%` (whenever `hasBoundedHeight` is false, i.e. every variant except a record-page widget inside a vertical-list tab), so each row became a top-level grid item and the implicit auto rows stretched to fill the card height.

The sibling cards already do this correctly: `FieldWidgetMorphRelationCard` and `FieldWidgetJunctionRelationCard` both wrap their items in `RecordDetailRecordsListContainer`.

## Fix

Wrap the `visibleRecords` map in `RecordDetailRecordsListContainer`, matching the morph and junction cards exactly. The show-more button stays inside the container, as it is in both siblings.

Before
<img width="342" height="479" alt="Capture d’écran 2026-08-17 à 13 48 55" src="https://github.com/user-attachments/assets/595369f3-0db7-485c-b88d-b68c7c15e520" />

After
<img width="342" height="479" alt="Capture d’écran 2026-08-17 à 13 49 03" src="https://github.com/user-attachments/assets/c68693d9-6ac9-42c0-a13e-1173e21f504c" />

## Verification

Reproduced on a local instance with a People (one-to-many) field widget in CARD mode on a company record page, in a tab where the card is unbounded:

- With the fix, `WidgetCardContent` has a single child (the list container). Forcing the card to 420px tall keeps the rows compact at the top.
- Unwrapping that container in the DOM (the pre-fix structure) gives 4 direct grid children at heights `[40, 81, 40, 81]` and reproduces the reported gaps.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

