### PR TITLE
fix(billing) - void unpaid upgrade invoices so a failed charge cannot be collected later

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/billing.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.exception.ts
@@ -40,6 +40,8 @@ export enum BillingExceptionCode {
   BILLING_CREDIT_GRANT_VALIDITY_INVALID = 'BILLING_CREDIT_GRANT_VALIDITY_INVALID',
   BILLING_USAGE_UNAVAILABLE = 'BILLING_USAGE_UNAVAILABLE',
   BILLING_CREDIT_GRANT_TYPE_NOT_GRANTABLE = 'BILLING_CREDIT_GRANT_TYPE_NOT_GRANTABLE',
+  BILLING_UPGRADE_INVOICE_PAYMENT_FAILED = 'BILLING_UPGRADE_INVOICE_PAYMENT_FAILED',
+  BILLING_UPGRADE_INVOICE_VOID_FAILED = 'BILLING_UPGRADE_INVOICE_VOID_FAILED',
 }
 
 const getBillingExceptionUserFriendlyMessage = (code: BillingExceptionCode) => {
@@ -108,6 +110,10 @@ const getBillingExceptionUserFriendlyMessage = (code: BillingExceptionCode) => {
       return msg`Usage could not be read. Please try again later.`;
     case BillingExceptionCode.BILLING_CREDIT_GRANT_TYPE_NOT_GRANTABLE:
       return msg`This kind of credit grant cannot be created by hand.`;
+    case BillingExceptionCode.BILLING_UPGRADE_INVOICE_PAYMENT_FAILED:
+      return msg`Your payment method was declined. Please update it and try again.`;
+    case BillingExceptionCode.BILLING_UPGRADE_INVOICE_VOID_FAILED:
+      return msg`An unexpected billing error occurred. Please contact support.`;
     default:
       assertUnreachable(code);
   }

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
@@ -4,6 +4,10 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import type Stripe from 'stripe';
 
+import {
+  BillingException,
+  BillingExceptionCode,
+} from 'src/engine/core-modules/billing/billing.exception';
 import { StripeSDKService } from 'src/engine/core-modules/billing/stripe/stripe-sdk/services/stripe-sdk.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
@@ -54,17 +58,19 @@ export class StripeInvoiceService {
     currency: string;
     description: string;
   }): Promise<void> {
-    await this.stripe.invoiceItems.create({
-      customer: stripeCustomerId,
-      subscription: stripeSubscriptionId,
-      amount: diffAmountInCents,
-      currency,
-      description,
-    });
-
     const invoice = await this.stripe.invoices.create({
       customer: stripeCustomerId,
       subscription: stripeSubscriptionId,
+      pending_invoice_items_behavior: 'exclude',
+    });
+
+    await this.stripe.invoiceItems.create({
+      customer: stripeCustomerId,
+      subscription: stripeSubscriptionId,
+      invoice: invoice.id,
+      amount: diffAmountInCents,
+      currency,
+      description,
     });
 
     const finalizedInvoice = await this.stripe.invoices.finalizeInvoice(
@@ -81,11 +87,43 @@ export class StripeInvoiceService {
     try {
       await this.stripe.invoices.pay(invoice.id);
     } catch (error) {
-      const refreshedInvoice = await this.stripe.invoices.retrieve(invoice.id);
+      await this.settleFailedUpgradeInvoiceOrThrow(invoice.id, error);
+    }
+  }
 
-      if (refreshedInvoice.status !== 'paid') {
-        throw error;
+  private async settleFailedUpgradeInvoiceOrThrow(
+    invoiceId: string,
+    payError: unknown,
+  ): Promise<void> {
+    const invoice = await this.stripe.invoices.retrieve(invoiceId);
+
+    if (invoice.status === 'paid') {
+      return;
+    }
+
+    const payErrorMessage =
+      payError instanceof Error ? payError.message : 'unknown error';
+
+    try {
+      await this.stripe.invoices.voidInvoice(invoiceId);
+    } catch (voidError) {
+      const refreshedInvoice = await this.stripe.invoices.retrieve(invoiceId);
+
+      if (refreshedInvoice.status === 'paid') {
+        return;
+      }
+
+      if (refreshedInvoice.status !== 'void') {
+        throw new BillingException(
+          `Failed to void upgrade invoice ${invoiceId} after payment failure: ${payErrorMessage}`,
+          BillingExceptionCode.BILLING_UPGRADE_INVOICE_VOID_FAILED,
+        );
       }
     }
+
+    throw new BillingException(
+      `Failed to pay upgrade invoice ${invoiceId}: ${payErrorMessage}`,
+      BillingExceptionCode.BILLING_UPGRADE_INVOICE_PAYMENT_FAILED,
+    );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
@@ -64,21 +64,29 @@ export class StripeInvoiceService {
       pending_invoice_items_behavior: 'exclude',
     });
 
-    await this.stripe.invoiceItems.create({
-      customer: stripeCustomerId,
-      subscription: stripeSubscriptionId,
-      invoice: invoice.id,
-      amount: diffAmountInCents,
-      currency,
-      description,
-    });
+    let finalizedInvoice: Stripe.Invoice;
 
-    const finalizedInvoice = await this.stripe.invoices.finalizeInvoice(
-      invoice.id,
-      {
-        auto_advance: true,
-      },
-    );
+    try {
+      await this.stripe.invoiceItems.create({
+        customer: stripeCustomerId,
+        subscription: stripeSubscriptionId,
+        invoice: invoice.id,
+        amount: diffAmountInCents,
+        currency,
+        description,
+      });
+
+      finalizedInvoice = await this.stripe.invoices.finalizeInvoice(
+        invoice.id,
+        {
+          auto_advance: true,
+        },
+      );
+    } catch (error) {
+      await this.deleteDraftUpgradeInvoice(invoice.id);
+
+      throw error;
+    }
 
     if (finalizedInvoice.status === 'paid') {
       return;
@@ -86,23 +94,28 @@ export class StripeInvoiceService {
 
     try {
       await this.stripe.invoices.pay(invoice.id);
-    } catch (error) {
-      await this.settleFailedUpgradeInvoiceOrThrow(invoice.id, error);
+    } catch (payError) {
+      await this.settleFailedUpgradeInvoiceOrThrow({
+        invoiceId: invoice.id,
+        payError,
+      });
     }
   }
 
-  private async settleFailedUpgradeInvoiceOrThrow(
-    invoiceId: string,
-    payError: unknown,
-  ): Promise<void> {
+  private async settleFailedUpgradeInvoiceOrThrow({
+    invoiceId,
+    payError,
+  }: {
+    invoiceId: string;
+    payError: unknown;
+  }): Promise<void> {
     const invoice = await this.stripe.invoices.retrieve(invoiceId);
 
     if (invoice.status === 'paid') {
       return;
     }
 
-    const payErrorMessage =
-      payError instanceof Error ? payError.message : 'unknown error';
+    const payErrorMessage = this.getErrorMessage(payError);
 
     try {
       await this.stripe.invoices.voidInvoice(invoiceId);
@@ -115,15 +128,34 @@ export class StripeInvoiceService {
 
       if (refreshedInvoice.status !== 'void') {
         throw new BillingException(
-          `Failed to void upgrade invoice ${invoiceId} after payment failure: ${payErrorMessage}`,
+          `Failed to void upgrade invoice ${invoiceId} after payment failure (${payErrorMessage}): ${this.getErrorMessage(voidError)}`,
           BillingExceptionCode.BILLING_UPGRADE_INVOICE_VOID_FAILED,
         );
       }
     }
 
+    const isCardDecline =
+      payError instanceof this.stripe.errors.StripeCardError;
+
     throw new BillingException(
       `Failed to pay upgrade invoice ${invoiceId}: ${payErrorMessage}`,
-      BillingExceptionCode.BILLING_UPGRADE_INVOICE_PAYMENT_FAILED,
+      isCardDecline
+        ? BillingExceptionCode.BILLING_UPGRADE_INVOICE_PAYMENT_FAILED
+        : BillingExceptionCode.BILLING_STRIPE_ERROR,
     );
+  }
+
+  private async deleteDraftUpgradeInvoice(invoiceId: string): Promise<void> {
+    try {
+      await this.stripe.invoices.del(invoiceId);
+    } catch (deleteError) {
+      this.logger.error(
+        `Failed to delete draft upgrade invoice ${invoiceId}: ${this.getErrorMessage(deleteError)}`,
+      );
+    }
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'unknown error';
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
@@ -79,7 +79,7 @@ export class StripeInvoiceService {
       finalizedInvoice = await this.stripe.invoices.finalizeInvoice(
         invoice.id,
         {
-          auto_advance: true,
+          auto_advance: false,
         },
       );
     } catch (error) {

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/get-billing-exception-status-code.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/get-billing-exception-status-code.util.ts
@@ -31,6 +31,7 @@ export const getBillingExceptionStatusCode = (
     case BillingExceptionCode.BILLING_SUBSCRIPTION_ALREADY_EXISTS:
       return 400;
     case BillingExceptionCode.BILLING_CREDITS_EXHAUSTED:
+    case BillingExceptionCode.BILLING_UPGRADE_INVOICE_PAYMENT_FAILED:
       return 402;
     case BillingExceptionCode.BILLING_CUSTOMER_EVENT_WORKSPACE_NOT_FOUND:
     case BillingExceptionCode.BILLING_PRICE_NOT_FOUND:
@@ -46,6 +47,7 @@ export const getBillingExceptionStatusCode = (
     case BillingExceptionCode.BILLING_TOO_MUCH_SUBSCRIPTIONS_FOUND:
     case BillingExceptionCode.BILLING_SUBSCRIPTION_NOT_CANCELED:
     case BillingExceptionCode.BILLING_USAGE_UNAVAILABLE:
+    case BillingExceptionCode.BILLING_UPGRADE_INVOICE_VOID_FAILED:
       return 500;
     default: {
       return assertUnreachable(exception.code);


### PR DESCRIPTION
fixes https://discord.com/channels/1130383047699738754/1536254772326432779

## Problem

A failed `invoices.pay` on an immediate upgrade invoice does not mean no money moved, but `createImmediateUpgradeInvoice` treats it that way.

The invoice is finalized with `auto_advance: true`, so Stripe keeps working it after we stop. When `pay` returns a 402, we re-read the invoice once, see it still `open`, and rethrow. The caller aborts before `runSubscriptionUpdate`, so the subscription is never upgraded, but the invoice is left open and Stripe collects it minutes later on its own.

Observed in production on a resource credit upgrade:

```
00:14:43  payment created
00:14:52  POST /v1/invoices/in_.../pay -> 402 (insufficient funds, first attempt on Link)
          our retrieve sees status=open -> rethrow -> upgrade aborted
00:17:56  Stripe retries the card on its own and succeeds, $30 collected
```

From there it compounds. The customer sees no upgrade and tries again, and since nothing looks for an existing open upgrade invoice, each attempt mints a fresh invoice item and invoice. One workspace produced six invoices over two days for the same upgrade. Four were voided by Stripe's own failed-payment settings, two were collected. The customer was charged twice for an upgrade that was never applied, and the subscription stayed on the old price the whole time.

Nothing in the codebase voids these invoices today, and `processInvoicePaid` does not apply a pending upgrade, so once we have rethrown there is no path that reconciles a late collection.

## Fix

Make a rethrow actually mean the customer was not charged.

- Finalize with `auto_advance: false`. We collect explicitly on the next line, so Stripe advancing the invoice in parallel only adds a second collector that keeps working it after we have given up.
- On a `pay` failure, re-read the invoice. If it is paid, return and let the upgrade proceed. If it is still open, void it before rethrowing.
- Voiding races too, so a failed void re-reads once more and treats a meanwhile-paid invoice as collected rather than losing the upgrade.
- Create the invoice first and attach the item to it explicitly, with `pending_invoice_items_behavior: 'exclude'`. Previously the item was created loose and `invoices.create` swept in every pending invoice item on the customer, so a stray item from an earlier attempt could ride along on the next invoice.
- Delete the draft if item creation or finalization fails. A draft left behind is matched later by `finalizePastDueDraftInvoicesAfterPaidInvoice`, which finalizes it with `auto_advance` and collects it.
- Report only `StripeCardError` as a declined payment. Network, rate limit and Stripe service errors were telling customers to update a payment method that is fine.

## On auto_advance

This flag has been flipped twice before and it is worth saying why `false` holds this time. #21097 set it to `false` on the same reasoning used here and was reverted, because that version went straight from `finalizeInvoice` to `invoices.pay`: a zero-due invoice, where credits or a coupon cover the diff, is settled by Stripe at finalization regardless of the flag, so `pay` threw "Invoice is already paid" and the upgrade aborted. #21450 restored `true` and swallowed that error by error code, which #22705 then showed Stripe never sends, replacing it with the `finalizedInvoice.status === 'paid'` check that returns before `pay` is called. That check is what actually protects the zero-due path, and it does not depend on `auto_advance`, so the failure that reverted `false` cannot recur. Whichever mechanism the #21450 incident hit is covered: a zero-due settlement by the paid check, a collection landing between finalize and `pay` by there no longer being a background collector to race.

## Out of scope

Reconciling a deferred collection after the fact, by applying the pending upgrade from the `invoice.paid` webhook, would make this robust even if a void fails. Worth doing separately. It is a behaviour change on the webhook path rather than a containment fix here.

## Tests

No unit spec. `stripe-invoice.service.spec.ts` was removed in #24094 along with every other `*.service.spec.ts`, and this logic is Stripe I/O orchestration with no pure part to extract to a util, which is exactly the shape that PR argued against mock-testing. Verified with `nx typecheck twenty-server` and oxlint/oxfmt on the changed file.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

