### PR TITLE
Show exact date on hover for timeline activity dates

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/EventRow.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/EventRow.tsx
@@ -15,8 +15,6 @@ import { getObjectRecordIdentifier } from '@/object-metadata/utils/getObjectReco
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { dateLocaleState } from '~/localization/states/dateLocaleState';
-import { beautifyPastDateRelativeToNow } from '~/utils/date-utils';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 import { allowRequestsToTwentyIconsState } from '@/client-config/states/allowRequestsToTwentyIcons';
 
@@ -95,16 +93,10 @@ export const EventRow = ({
     allowRequestsToTwentyIconsState,
   );
 
-  const { localeCatalog } = useAtomStateValue(dateLocaleState);
-
   const { recordId } = useContext(TimelineActivityContext);
 
   const recordStore = useAtomFamilyStateValue(recordStoreFamilyState, recordId);
 
-  const beautifiedCreatedAt = beautifyPastDateRelativeToNow(
-    event.createdAt,
-    localeCatalog,
-  );
   const linkedObjectMetadataItem = useLinkedObjectObjectMetadataItem(
     event.linkedObjectMetadataId,
   );
@@ -159,7 +151,7 @@ export const EventRow = ({
               event={event}
               mainObjectMetadataItem={mainObjectMetadataItem}
               linkedObjectMetadataItem={linkedObjectMetadataItem}
-              createdAt={beautifiedCreatedAt}
+              createdAt={event.createdAt}
             />
           </StyledSummary>
         </StyledItemContainer>

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/activity/components/EventRowActivity.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/activity/components/EventRowActivity.tsx
@@ -1,12 +1,12 @@
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 
+import { EventRowDate } from '@/activities/timeline-activities/rows/components/EventRowDate';
 import { type EventRowDynamicComponentProps } from '@/activities/timeline-activities/rows/components/EventRowDynamicComponent.types';
 import { EventRowItem } from '@/activities/timeline-activities/rows/components/EventRowItem';
 import {
   StyledEventRowContainer,
   StyledEventRowContent,
-  StyledEventRowDate,
   StyledEventRowLinkedRecord,
 } from '@/activities/timeline-activities/rows/components/EventRowStyles';
 import { isTimelineActivityWithLinkedRecord } from '@/activities/timeline-activities/types/TimelineActivity';
@@ -89,7 +89,7 @@ export const EventRowActivity = ({
             <OverflowingTextWithTooltip text={activityTitle} />
           </StyledEventRowLinkedRecord>
         </StyledEventRowContent>
-        <StyledEventRowDate>{createdAt}</StyledEventRowDate>
+        <EventRowDate createdAt={createdAt} />
       </StyledEventRowContainer>
     </StyledEventRow>
   );

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDate.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDate.tsx
@@ -1,14 +1,16 @@
 import { styled } from '@linaria/react';
-import { useId } from 'react';
+import { isNonEmptyString } from '@sniptt/guards';
+import { useEffect, useId, useState } from 'react';
 
 import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { isDefined } from 'twenty-shared/utils';
 import { AppTooltip } from 'twenty-ui/surfaces';
 import { MOBILE_VIEWPORT, themeCssVariables } from 'twenty-ui/theme-constants';
 import { dateLocaleState } from '~/localization/states/dateLocaleState';
 import { beautifyPastDateRelativeToNow } from '~/utils/date-utils';
 import { formatDateTimeString } from '~/utils/string/formatDateTimeString';
+
+const TOOLTIP_SHOW_DELAY_IN_MS = 500;
 
 const StyledEventRowDate = styled.div`
   @media (max-width: ${MOBILE_VIEWPORT}px) {
@@ -27,10 +29,29 @@ export const EventRowDate = ({ createdAt }: EventRowDateProps) => {
   const { dateFormat, timeFormat, timeZone } = useDateTimeFormat();
   const { localeCatalog } = useAtomStateValue(dateLocaleState);
 
+  // the tooltip is mounted only once the date has been hovered or focused for
+  // a while, so a long timeline does not keep one tooltip observer per row
+  const [isDateHighlighted, setIsDateHighlighted] = useState(false);
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
   const instanceId = useId();
   const dateElementId = `event-row-date-${instanceId.replace(/[^a-zA-Z0-9-_]/g, '-')}`;
 
-  if (!isDefined(createdAt) || createdAt === '') {
+  useEffect(() => {
+    if (!isDateHighlighted) {
+      setIsTooltipVisible(false);
+      return;
+    }
+
+    const showTooltipTimer = setTimeout(
+      () => setIsTooltipVisible(true),
+      TOOLTIP_SHOW_DELAY_IN_MS,
+    );
+
+    return () => clearTimeout(showTooltipTimer);
+  }, [isDateHighlighted]);
+
+  if (!isNonEmptyString(createdAt)) {
     return null;
   }
 
@@ -48,15 +69,25 @@ export const EventRowDate = ({ createdAt }: EventRowDateProps) => {
 
   return (
     <>
-      <StyledEventRowDate id={dateElementId}>
+      <StyledEventRowDate
+        id={dateElementId}
+        tabIndex={0}
+        onMouseEnter={() => setIsDateHighlighted(true)}
+        onMouseLeave={() => setIsDateHighlighted(false)}
+        onFocus={() => setIsDateHighlighted(true)}
+        onBlur={() => setIsDateHighlighted(false)}
+      >
         {relativeCreatedAt}
       </StyledEventRowDate>
-      <AppTooltip
-        anchorSelect={`#${dateElementId}`}
-        content={exactCreatedAt}
-        noArrow
-        place="left"
-      />
+      {isTooltipVisible && (
+        <AppTooltip
+          anchorSelect={`#${dateElementId}`}
+          content={exactCreatedAt}
+          isOpen
+          noArrow
+          place="left"
+        />
+      )}
     </>
   );
 };

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDate.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDate.tsx
@@ -1,6 +1,7 @@
 import { styled } from '@linaria/react';
 import { isNonEmptyString } from '@sniptt/guards';
-import { useEffect, useId, useState } from 'react';
+import { useId, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
 
 import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -31,25 +32,20 @@ export const EventRowDate = ({ createdAt }: EventRowDateProps) => {
 
   // the tooltip is mounted only once the date has been hovered or focused for
   // a while, so a long timeline does not keep one tooltip observer per row
-  const [isDateHighlighted, setIsDateHighlighted] = useState(false);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
+  const showTooltipAfterDelay = useDebouncedCallback(
+    () => setIsTooltipVisible(true),
+    TOOLTIP_SHOW_DELAY_IN_MS,
+  );
 
   const instanceId = useId();
   const dateElementId = `event-row-date-${instanceId.replace(/[^a-zA-Z0-9-_]/g, '-')}`;
 
-  useEffect(() => {
-    if (!isDateHighlighted) {
-      setIsTooltipVisible(false);
-      return;
-    }
-
-    const showTooltipTimer = setTimeout(
-      () => setIsTooltipVisible(true),
-      TOOLTIP_SHOW_DELAY_IN_MS,
-    );
-
-    return () => clearTimeout(showTooltipTimer);
-  }, [isDateHighlighted]);
+  const handleHideTooltip = () => {
+    showTooltipAfterDelay.cancel();
+    setIsTooltipVisible(false);
+  };
 
   if (!isNonEmptyString(createdAt)) {
     return null;
@@ -72,10 +68,10 @@ export const EventRowDate = ({ createdAt }: EventRowDateProps) => {
       <StyledEventRowDate
         id={dateElementId}
         tabIndex={0}
-        onMouseEnter={() => setIsDateHighlighted(true)}
-        onMouseLeave={() => setIsDateHighlighted(false)}
-        onFocus={() => setIsDateHighlighted(true)}
-        onBlur={() => setIsDateHighlighted(false)}
+        onMouseEnter={showTooltipAfterDelay}
+        onMouseLeave={handleHideTooltip}
+        onFocus={showTooltipAfterDelay}
+        onBlur={handleHideTooltip}
       >
         {relativeCreatedAt}
       </StyledEventRowDate>

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDate.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDate.tsx
@@ -1,0 +1,62 @@
+import { styled } from '@linaria/react';
+import { useId } from 'react';
+
+import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { isDefined } from 'twenty-shared/utils';
+import { AppTooltip } from 'twenty-ui/surfaces';
+import { MOBILE_VIEWPORT, themeCssVariables } from 'twenty-ui/theme-constants';
+import { dateLocaleState } from '~/localization/states/dateLocaleState';
+import { beautifyPastDateRelativeToNow } from '~/utils/date-utils';
+import { formatDateTimeString } from '~/utils/string/formatDateTimeString';
+
+const StyledEventRowDate = styled.div`
+  @media (max-width: ${MOBILE_VIEWPORT}px) {
+    display: none;
+  }
+  color: ${themeCssVariables.font.color.tertiary};
+  padding: 0 ${themeCssVariables.spacing[1]};
+  white-space: nowrap;
+`;
+
+type EventRowDateProps = {
+  createdAt?: string;
+};
+
+export const EventRowDate = ({ createdAt }: EventRowDateProps) => {
+  const { dateFormat, timeFormat, timeZone } = useDateTimeFormat();
+  const { localeCatalog } = useAtomStateValue(dateLocaleState);
+
+  const instanceId = useId();
+  const dateElementId = `event-row-date-${instanceId.replace(/[^a-zA-Z0-9-_]/g, '-')}`;
+
+  if (!isDefined(createdAt) || createdAt === '') {
+    return null;
+  }
+
+  const relativeCreatedAt = beautifyPastDateRelativeToNow(
+    createdAt,
+    localeCatalog,
+  );
+  const exactCreatedAt = formatDateTimeString({
+    value: createdAt,
+    timeZone,
+    dateFormat,
+    timeFormat,
+    localeCatalog,
+  });
+
+  return (
+    <>
+      <StyledEventRowDate id={dateElementId}>
+        {relativeCreatedAt}
+      </StyledEventRowDate>
+      <AppTooltip
+        anchorSelect={`#${dateElementId}`}
+        content={exactCreatedAt}
+        noArrow
+        place="left"
+      />
+    </>
+  );
+};

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDate.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDate.tsx
@@ -1,17 +1,14 @@
 import { styled } from '@linaria/react';
 import { isNonEmptyString } from '@sniptt/guards';
-import { useId, useState } from 'react';
-import { useDebouncedCallback } from 'use-debounce';
+import { useId } from 'react';
 
 import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { AppTooltip } from 'twenty-ui/surfaces';
+import { AppTooltip, TooltipDelay } from 'twenty-ui/surfaces';
 import { MOBILE_VIEWPORT, themeCssVariables } from 'twenty-ui/theme-constants';
 import { dateLocaleState } from '~/localization/states/dateLocaleState';
 import { beautifyPastDateRelativeToNow } from '~/utils/date-utils';
 import { formatDateTimeString } from '~/utils/string/formatDateTimeString';
-
-const TOOLTIP_SHOW_DELAY_IN_MS = 500;
 
 const StyledEventRowDate = styled.div`
   @media (max-width: ${MOBILE_VIEWPORT}px) {
@@ -30,22 +27,8 @@ export const EventRowDate = ({ createdAt }: EventRowDateProps) => {
   const { dateFormat, timeFormat, timeZone } = useDateTimeFormat();
   const { localeCatalog } = useAtomStateValue(dateLocaleState);
 
-  // the tooltip is mounted only once the date has been hovered or focused for
-  // a while, so a long timeline does not keep one tooltip observer per row
-  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
-
-  const showTooltipAfterDelay = useDebouncedCallback(
-    () => setIsTooltipVisible(true),
-    TOOLTIP_SHOW_DELAY_IN_MS,
-  );
-
   const instanceId = useId();
   const dateElementId = `event-row-date-${instanceId.replace(/[^a-zA-Z0-9-_]/g, '-')}`;
-
-  const handleHideTooltip = () => {
-    showTooltipAfterDelay.cancel();
-    setIsTooltipVisible(false);
-  };
 
   if (!isNonEmptyString(createdAt)) {
     return null;
@@ -65,25 +48,16 @@ export const EventRowDate = ({ createdAt }: EventRowDateProps) => {
 
   return (
     <>
-      <StyledEventRowDate
-        id={dateElementId}
-        tabIndex={0}
-        onMouseEnter={showTooltipAfterDelay}
-        onMouseLeave={handleHideTooltip}
-        onFocus={showTooltipAfterDelay}
-        onBlur={handleHideTooltip}
-      >
+      <StyledEventRowDate id={dateElementId} tabIndex={0}>
         {relativeCreatedAt}
       </StyledEventRowDate>
-      {isTooltipVisible && (
-        <AppTooltip
-          anchorSelect={`#${dateElementId}`}
-          content={exactCreatedAt}
-          isOpen
-          noArrow
-          place="left"
-        />
-      )}
+      <AppTooltip
+        anchorSelect={`#${dateElementId}`}
+        content={exactCreatedAt}
+        delay={TooltipDelay.mediumDelay}
+        noArrow
+        place="left"
+      />
     </>
   );
 };

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowStyles.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowStyles.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@linaria/react';
 
-import { MOBILE_VIEWPORT, themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 export const StyledEventRowContainer = styled.div`
   align-items: center;
@@ -14,14 +14,6 @@ export const StyledEventRowContent = styled.div`
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
   overflow: hidden;
-`;
-
-export const StyledEventRowDate = styled.div`
-  @media (max-width: ${MOBILE_VIEWPORT}px) {
-    display: none;
-  }
-  color: ${themeCssVariables.font.color.tertiary};
-  padding: 0 ${themeCssVariables.spacing[1]};
 `;
 
 export const StyledEventRowLinkedRecord = styled.span`

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/__stories__/EventRowDate.stories.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/__stories__/EventRowDate.stories.tsx
@@ -1,0 +1,26 @@
+import { EventRowDate } from '@/activities/timeline-activities/rows/components/EventRowDate';
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+
+import { ComponentDecorator } from 'twenty-ui/testing';
+
+// stories run with a mocked date of 2024-03-12T09:30:00.000Z
+const meta: Meta<typeof EventRowDate> = {
+  title: 'Modules/TimelineActivities/Rows/EventRowDate',
+  component: EventRowDate,
+  decorators: [ComponentDecorator],
+};
+
+export default meta;
+type Story = StoryObj<typeof EventRowDate>;
+
+export const Default: Story = {
+  args: {
+    createdAt: '2024-03-09T09:30:00.000Z',
+  },
+};
+
+export const WithoutDate: Story = {
+  args: {
+    createdAt: undefined,
+  },
+};

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/generic/components/EventRowGenericLinked.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/generic/components/EventRowGenericLinked.tsx
@@ -1,12 +1,12 @@
 import { t } from '@lingui/core/macro';
 import { type KeyboardEvent } from 'react';
 
+import { EventRowDate } from '@/activities/timeline-activities/rows/components/EventRowDate';
 import { type EventRowDynamicComponentProps } from '@/activities/timeline-activities/rows/components/EventRowDynamicComponent.types';
 import { EventRowItem } from '@/activities/timeline-activities/rows/components/EventRowItem';
 import {
   StyledEventRowContainer,
   StyledEventRowContent,
-  StyledEventRowDate,
   StyledEventRowLinkedRecord,
 } from '@/activities/timeline-activities/rows/components/EventRowStyles';
 import { useOpenRecordInSidePanel } from '@/side-panel/hooks/useOpenRecordInSidePanel';
@@ -69,7 +69,7 @@ export const EventRowGenericLinked = ({
           <OverflowingTextWithTooltip text={linkedRecordName} />
         </StyledEventRowLinkedRecord>
       </StyledEventRowContent>
-      <StyledEventRowDate>{createdAt}</StyledEventRowDate>
+      <EventRowDate createdAt={createdAt} />
     </StyledEventRowContainer>
   );
 };

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
@@ -1,9 +1,10 @@
+import { EventRowDate } from '@/activities/timeline-activities/rows/components/EventRowDate';
 import { type EventRowDynamicComponentProps } from '@/activities/timeline-activities/rows/components/EventRowDynamicComponent.types';
 import { EventRowItem } from '@/activities/timeline-activities/rows/components/EventRowItem';
 import { EventRowMainObjectUpdated } from '@/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
-import { MOBILE_VIEWPORT, themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 type EventRowMainObjectProps = EventRowDynamicComponentProps;
 
@@ -19,14 +20,6 @@ const StyledRowContainer = styled.div`
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
   justify-content: space-between;
-`;
-
-const StyledItemTitleDate = styled.div`
-  @media (max-width: ${MOBILE_VIEWPORT}px) {
-    display: none;
-  }
-  color: ${themeCssVariables.font.color.tertiary};
-  padding: 0 ${themeCssVariables.spacing[1]};
 `;
 
 const StyledRow = styled.div`
@@ -55,7 +48,7 @@ export const EventRowMainObject = ({
               <EventRowItem variant="action">{t`was created by`}</EventRowItem>
               <EventRowItem>{authorFullName}</EventRowItem>
             </StyledRow>
-            <StyledItemTitleDate>{createdAt}</StyledItemTitleDate>
+            <EventRowDate createdAt={createdAt} />
           </StyledRowContainer>
         </StyledMainContainer>
       );
@@ -80,7 +73,7 @@ export const EventRowMainObject = ({
               <EventRowItem variant="action">{t`was deleted by`}</EventRowItem>
               <EventRowItem>{authorFullName}</EventRowItem>
             </StyledRow>
-            <StyledItemTitleDate>{createdAt}</StyledItemTitleDate>
+            <EventRowDate createdAt={createdAt} />
           </StyledRowContainer>
         </StyledMainContainer>
       );
@@ -94,7 +87,7 @@ export const EventRowMainObject = ({
               <EventRowItem variant="action">{t`was restored by`}</EventRowItem>
               <EventRowItem>{authorFullName}</EventRowItem>
             </StyledRow>
-            <StyledItemTitleDate>{createdAt}</StyledItemTitleDate>
+            <EventRowDate createdAt={createdAt} />
           </StyledRowContainer>
         </StyledMainContainer>
       );

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated.tsx
@@ -4,11 +4,12 @@ import { useState } from 'react';
 
 import { EventCard } from '@/activities/timeline-activities/rows/components/EventCard';
 import { EventCardToggleButton } from '@/activities/timeline-activities/rows/components/EventCardToggleButton';
+import { EventRowDate } from '@/activities/timeline-activities/rows/components/EventRowDate';
 import { EventRowItem } from '@/activities/timeline-activities/rows/components/EventRowItem';
 import { EventFieldDiffContainer } from '@/activities/timeline-activities/rows/main-object/components/EventFieldDiffContainer';
 import { type TimelineActivity } from '@/activities/timeline-activities/types/TimelineActivity';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
-import { MOBILE_VIEWPORT, themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 type EventRowMainObjectUpdatedProps = {
   mainObjectMetadataItem: EnrichedObjectMetadataItem;
@@ -23,14 +24,6 @@ const StyledRowContainer = styled.div`
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
   justify-content: space-between;
-`;
-
-const StyledItemTitleDate = styled.div`
-  @media (max-width: ${MOBILE_VIEWPORT}px) {
-    display: none;
-  }
-  color: ${themeCssVariables.font.color.tertiary};
-  padding: 0 ${themeCssVariables.spacing[1]};
 `;
 
 const StyledRow = styled.div`
@@ -89,7 +82,7 @@ export const EventRowMainObjectUpdated = ({
             </>
           )}
         </StyledRow>
-        <StyledItemTitleDate>{createdAt}</StyledItemTitleDate>
+        <EventRowDate createdAt={createdAt} />
       </StyledRowContainer>
       {diffEntries.length > 1 && (
         <EventCard isOpen={isOpen}>


### PR DESCRIPTION
Timeline activity rows only showed a relative date on the right ("3 days ago", "about 2 months ago"), so there was no way to know the actual day of an event.

Hovering a timeline date now shows the exact date and time in a tooltip, after the standard hover delay.

## Changes

- New `EventRowDate` component that renders the relative date and an `AppTooltip` anchored to it. The tooltip content is built with `formatDateTimeString` using the workspace member's date format, time format and timezone, so it always includes the day (e.g. `Aug 17, 2026 5:14 AM`).
- Replaced the duplicated date styled-divs (`StyledEventRowDate` and two copies of `StyledItemTitleDate`) in `EventRowActivity`, `EventRowGenericLinked`, `EventRowMainObject` and `EventRowMainObjectUpdated` with that component.
- `EventRow` passes the raw `event.createdAt` down instead of pre-formatting it, since the formatting now lives in `EventRowDate`.

## Testing

Checked in the app on a company record timeline: all row types that display a date show the tooltip, nothing appears on immediate hover, and it dismisses on mouse out. Typecheck, lint and the timeline-activities unit tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2fXyqWrQLxFePGNp8jmNb)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

