### PR TITLE
fix(front): stop sending the dormant token pair on the SSE stream under cookie auth

### DIFF
--- a/packages/twenty-front/src/modules/sse-db-event/components/SSEClientEffect.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/components/SSEClientEffect.tsx
@@ -1,4 +1,5 @@
 import { useIsLogged } from '@/auth/hooks/useIsLogged';
+import { isCookieAuthActiveState } from '@/auth/states/isCookieAuthActiveState';
 import { tokenPairState } from '@/auth/states/tokenPairState';
 import { useListenToBrowserEvent } from '@/browser-event/hooks/useListenToBrowserEvent';
 import { dispatchBrowserEvent } from '@/browser-event/utils/dispatchBrowserEvent';
@@ -61,7 +62,16 @@ export const SSEClientEffect = () => {
       const newSseClient = createClient({
         url: `${REACT_APP_SERVER_BASE_URL}/metadata`,
         credentials: 'include',
-        headers: () => {
+        headers: (): Record<string, string> => {
+          // Same rule as the Apollo auth link: the retained token pair is a
+          // dormant fallback once cookie auth is active and must not be sent.
+          // The server prefers Bearer over the session cookie, so attaching a
+          // token nothing refreshes any more authenticates the stream with a
+          // credential that expires and never recovers.
+          if (store.get(isCookieAuthActiveState.atom)) {
+            return {};
+          }
+
           const currentTokenPair = store.get(tokenPairState.atom);
           const token = currentTokenPair?.accessOrWorkspaceAgnosticToken?.token;
 

--- a/packages/twenty-front/src/modules/sse-db-event/components/__tests__/SSEClientEffect.test.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/components/__tests__/SSEClientEffect.test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import { type ClientOptions } from 'graphql-sse';
+import { createStore, Provider } from 'jotai';
+import { createElement } from 'react';
+
+import { isCookieAuthActiveState } from '@/auth/states/isCookieAuthActiveState';
+import { tokenPairState } from '@/auth/states/tokenPairState';
+import { SSEClientEffect } from '@/sse-db-event/components/SSEClientEffect';
+import { type AuthTokenPair } from '~/generated-metadata/graphql';
+
+const createClientMock = jest.fn();
+
+jest.mock('graphql-sse', () => ({
+  createClient: (options: ClientOptions) => {
+    createClientMock(options);
+
+    return {
+      subscribe: () => () => {},
+      iterate: async function* () {},
+      dispose: () => {},
+    };
+  },
+}));
+
+jest.mock('@/metadata-store/hooks/useResyncMetadataStore', () => ({
+  useResyncMetadataStore: () => ({ resyncMetadataStore: jest.fn() }),
+}));
+
+const TOKEN_PAIR: AuthTokenPair = {
+  accessOrWorkspaceAgnosticToken: {
+    token: 'access-token',
+    expiresAt: new Date().toISOString(),
+  },
+  refreshToken: {
+    token: 'refresh-token',
+    expiresAt: new Date().toISOString(),
+  },
+};
+
+const renderWithAuthMode = (isCookieAuthActive: boolean) => {
+  const store = createStore();
+
+  store.set(tokenPairState.atom, TOKEN_PAIR);
+  store.set(isCookieAuthActiveState.atom, isCookieAuthActive);
+
+  render(
+    createElement(Provider, { store }, createElement(SSEClientEffect, null)),
+  );
+
+  const options = createClientMock.mock.calls[0]?.[0] as ClientOptions;
+
+  return options.headers as () => Record<string, string>;
+};
+
+describe('SSEClientEffect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should attach the Bearer header when the client authenticates by token', () => {
+    const headers = renderWithAuthMode(false);
+
+    expect(headers()).toEqual({ Authorization: 'Bearer access-token' });
+  });
+
+  // The server prefers Bearer over the session cookie, so a dormant token here
+  // would authenticate the stream with a credential nothing refreshes.
+  it('should not attach the Bearer header while cookie auth is active', () => {
+    const headers = renderWithAuthMode(true);
+
+    expect(headers()).toEqual({});
+  });
+});

--- a/packages/twenty-front/src/modules/sse-db-event/components/__tests__/SSEClientEffect.test.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/components/__tests__/SSEClientEffect.test.tsx
@@ -6,6 +6,7 @@ import { createElement } from 'react';
 import { isCookieAuthActiveState } from '@/auth/states/isCookieAuthActiveState';
 import { tokenPairState } from '@/auth/states/tokenPairState';
 import { SSEClientEffect } from '@/sse-db-event/components/SSEClientEffect';
+import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import { type AuthTokenPair } from '~/generated-metadata/graphql';
 
 const createClientMock = jest.fn();
@@ -47,7 +48,18 @@ const renderWithAuthMode = (isCookieAuthActive: boolean) => {
     createElement(Provider, { store }, createElement(SSEClientEffect, null)),
   );
 
+  // Asserted here rather than per-case: a second client would mean the effect
+  // reconnected, and the stream's credential handling only makes sense against
+  // the rest of the options it was created with.
+  expect(createClientMock).toHaveBeenCalledTimes(1);
+
   const options = createClientMock.mock.calls[0]?.[0] as ClientOptions;
+
+  expect(options).toMatchObject({
+    url: `${REACT_APP_SERVER_BASE_URL}/metadata`,
+    credentials: 'include',
+    retryAttempts: Infinity,
+  });
 
   return options.headers as () => Record<string, string>;
 };


### PR DESCRIPTION
## Problem

`SSEClientEffect` attaches `Authorization: Bearer <tokenPair>` unconditionally, unlike the Apollo `authLink`, which suppresses it once cookie auth is active.

Two things then combine:

- `AccessTokenService.validateTokenByRequest` reads the Bearer header first and only falls through to the session cookie when there is none, so the stream authenticates with the token rather than the cookie.
- Under cookie auth nothing refreshes that token pair any more (`handleSseClientConnectionRetry` skips the renewal branch when `isCookieAuthActive`), so it lapses and stays lapsed.

The result, observed in prod:

```
subscription OnEventSubscription(...)
errors: [{ message: "Token has expired.", extensions: { code: "UNAUTHENTICATED" } }]
```

and then a reconnect loop that re-presents the same expired token forever. Real-time updates are dead for every cookie-auth client that still holds a token pair in localStorage, which is every client that signed in before the migration.

## Change

Gate the header on the same condition as `authLink`: while cookie auth is active, send no `Authorization` header and let `credentials: 'include'` carry the session cookie.

## Notes

- The SSE requests become cookie-authenticated, so they now go through `CookieSessionCsrfMiddleware`. Browsers send `Origin` on fetch POST/PUT and it is same-origin in our deployments, so the check passes. Any deployment where this would fail is already failing on every GraphQL mutation, since those are cookie-authenticated POSTs too.
- Not changed here: the `!isCookieAuthActive` condition around renewal in `useHandleSseClientConnectionRetry`. With this fix there is no token to renew in cookie mode, so it is correct as written.

## Tests

`SSEClientEffect.test.tsx` asserts the header in both auth modes.
