### PR TITLE
fix(server): report an unauthenticated GraphQL request as UNAUTHENTICATED, not FORBIDDEN

### DIFF
--- a/packages/twenty-server/src/engine/guards/__tests__/workspace-auth.guard.spec.ts
+++ b/packages/twenty-server/src/engine/guards/__tests__/workspace-auth.guard.spec.ts
@@ -1,0 +1,120 @@
+// oxlint-disable twenty/graphql-resolvers-should-be-guarded
+import {
+  type ExecutionContext,
+  ForbiddenException,
+  Module,
+  UseGuards,
+} from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import {
+  GraphQLModule,
+  GraphQLSchemaHost,
+  type GraphQLSchemaHost as GraphQLSchemaHostType,
+  Query,
+  Resolver,
+} from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+
+import { YogaDriver, type YogaDriverConfig } from '@graphql-yoga/nestjs';
+import { type GraphQLSchema, graphql } from 'graphql';
+
+import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
+import { UnhandledExceptionFilter } from 'src/filters/unhandled-exception.filter';
+
+@Resolver()
+class TestResolver {
+  @Query(() => String)
+  @UseGuards(WorkspaceAuthGuard)
+  guardedQuery(): string {
+    return 'ok';
+  }
+}
+
+@Module({ providers: [TestResolver] })
+class FeatureModule {}
+
+// Mirrors the root module: the catch-all filter is what an exception no typed
+// filter claims ends up in, so the assertions below hold in production too.
+@Module({
+  imports: [
+    GraphQLModule.forRoot<YogaDriverConfig>({
+      driver: YogaDriver,
+      autoSchemaFile: true,
+    }),
+    FeatureModule,
+  ],
+  providers: [{ provide: APP_FILTER, useClass: UnhandledExceptionFilter }],
+})
+class RootModule {}
+
+const runGuardedQuery = async (request: Record<string, unknown>) => {
+  const moduleRef = await Test.createTestingModule({
+    imports: [RootModule],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+
+  await app.init();
+
+  const schema = app.get<GraphQLSchemaHostType>(GraphQLSchemaHost)
+    .schema as GraphQLSchema;
+
+  const result = await graphql({
+    schema,
+    source: '{ guardedQuery }',
+    contextValue: { req: request },
+  });
+
+  await app.close();
+
+  return result;
+};
+
+describe('WorkspaceAuthGuard', () => {
+  it('should let a workspace-scoped request through', async () => {
+    const result = await runGuardedQuery({
+      user: { id: 'user-id' },
+      workspace: { id: 'workspace-id' },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.guardedQuery).toBe('ok');
+  });
+
+  // Otherwise a client whose credential lapsed reads the refusal as a
+  // permission problem and never renews or signs out.
+  it('should report an unauthenticated request as UNAUTHENTICATED', async () => {
+    const result = await runGuardedQuery({});
+
+    expect(result.errors?.[0]?.extensions?.code).toBe(
+      ErrorCode.UNAUTHENTICATED,
+    );
+  });
+
+  // A credential that authenticated but is not scoped to a workspace is a real
+  // refusal: renewing it would return the same token. Asserted on the exception
+  // rather than on the code, which the Yoga error handler derives from its HTTP
+  // status further down the request than this harness reaches.
+  it('should keep refusing an authenticated request with no workspace', async () => {
+    const result = await runGuardedQuery({ user: { id: 'user-id' } });
+
+    expect(result.errors?.[0]?.originalError).toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(result.errors?.[0]?.message).toBe('Forbidden resource');
+  });
+
+  // The catch-all filter turns a GraphQL error thrown on the REST path into a
+  // 500, so those clients keep the refusal they get today.
+  it('should keep refusing an unauthenticated REST request without throwing', () => {
+    const guard = new WorkspaceAuthGuard();
+
+    const httpContext = {
+      getType: () => 'http',
+      switchToHttp: () => ({ getRequest: () => ({}) }),
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(httpContext)).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/guards/__tests__/workspace-auth.guard.spec.ts
+++ b/packages/twenty-server/src/engine/guards/__tests__/workspace-auth.guard.spec.ts
@@ -34,8 +34,8 @@ class TestResolver {
 @Module({ providers: [TestResolver] })
 class FeatureModule {}
 
-// Mirrors the root module: the catch-all filter is what an exception no typed
-// filter claims ends up in, so the assertions below hold in production too.
+// Mirrors the root module so an exception no typed filter claims lands in the
+// catch-all filter, as it does in production.
 @Module({
   imports: [
     GraphQLModule.forRoot<YogaDriverConfig>({
@@ -82,8 +82,6 @@ describe('WorkspaceAuthGuard', () => {
     expect(result.data?.guardedQuery).toBe('ok');
   });
 
-  // Otherwise a client whose credential lapsed reads the refusal as a
-  // permission problem and never renews or signs out.
   it('should report an unauthenticated request as UNAUTHENTICATED', async () => {
     const result = await runGuardedQuery({});
 
@@ -92,10 +90,8 @@ describe('WorkspaceAuthGuard', () => {
     );
   });
 
-  // A credential that authenticated but is not scoped to a workspace is a real
-  // refusal: renewing it would return the same token. Asserted on the exception
-  // rather than on the code, which the Yoga error handler derives from its HTTP
-  // status further down the request than this harness reaches.
+  // Asserted on the exception rather than the code, which the Yoga error handler
+  // derives from the HTTP status further down than this harness reaches.
   it('should keep refusing an authenticated request with no workspace', async () => {
     const result = await runGuardedQuery({ user: { id: 'user-id' } });
 
@@ -105,8 +101,6 @@ describe('WorkspaceAuthGuard', () => {
     expect(result.errors?.[0]?.message).toBe('Forbidden resource');
   });
 
-  // The catch-all filter turns a GraphQL error thrown on the REST path into a
-  // 500, so those clients keep the refusal they get today.
   it('should keep refusing an unauthenticated REST request without throwing', () => {
     const guard = new WorkspaceAuthGuard();
 

--- a/packages/twenty-server/src/engine/guards/workspace-auth.guard.ts
+++ b/packages/twenty-server/src/engine/guards/workspace-auth.guard.ts
@@ -4,9 +4,27 @@ import {
   Injectable,
 } from '@nestjs/common';
 
-import { type Observable } from 'rxjs';
+import { type GqlContextType } from '@nestjs/graphql';
 
+import { msg } from '@lingui/core/macro';
+import { type Observable } from 'rxjs';
+import { isDefined } from 'twenty-shared/utils';
+
+import { AuthExceptionCode } from 'src/engine/core-modules/auth/auth.exception';
+import { AuthenticationError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { getRequest } from 'src/utils/extract-request';
+
+// A request that presented no credential at all is never hydrated: the token
+// middleware returns early so public endpoints keep working, which leaves the
+// guarded ones to reject an unauthenticated request.
+const hasAuthenticatedPrincipal = (request: {
+  user?: unknown;
+  apiKey?: unknown;
+  application?: unknown;
+}): boolean =>
+  isDefined(request.user) ||
+  isDefined(request.apiKey) ||
+  isDefined(request.application);
 
 @Injectable()
 export class WorkspaceAuthGuard implements CanActivate {
@@ -19,6 +37,24 @@ export class WorkspaceAuthGuard implements CanActivate {
       return false;
     }
 
+    // Rejecting by returning false reports Nest's default FORBIDDEN, which
+    // clients read as a permission problem: nothing renews the credential and
+    // nothing signs the user out, so a client whose credential silently lapsed
+    // keeps every query failing while believing itself signed in. Restricted to
+    // GraphQL because the catch-all filter turns a GraphQL error thrown on the
+    // REST path into a 500; those clients keep the 403 they get today.
+    if (
+      !hasAuthenticatedPrincipal(request) &&
+      context.getType<GqlContextType>() === 'graphql'
+    ) {
+      throw new AuthenticationError('Missing authentication token', {
+        subCode: AuthExceptionCode.UNAUTHENTICATED,
+        userFriendlyMessage: msg`You must be authenticated to perform this action.`,
+      });
+    }
+
+    // Authenticated but carrying no workspace -- a workspace-agnostic token --
+    // is a genuine refusal: renewing it would return the same token.
     if (!request.workspace) {
       return false;
     }

--- a/packages/twenty-server/src/engine/guards/workspace-auth.guard.ts
+++ b/packages/twenty-server/src/engine/guards/workspace-auth.guard.ts
@@ -14,9 +14,6 @@ import { AuthExceptionCode } from 'src/engine/core-modules/auth/auth.exception';
 import { AuthenticationError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { getRequest } from 'src/utils/extract-request';
 
-// A request that presented no credential at all is never hydrated: the token
-// middleware returns early so public endpoints keep working, which leaves the
-// guarded ones to reject an unauthenticated request.
 const hasAuthenticatedPrincipal = (request: {
   user?: unknown;
   apiKey?: unknown;
@@ -37,12 +34,9 @@ export class WorkspaceAuthGuard implements CanActivate {
       return false;
     }
 
-    // Rejecting by returning false reports Nest's default FORBIDDEN, which
-    // clients read as a permission problem: nothing renews the credential and
-    // nothing signs the user out, so a client whose credential silently lapsed
-    // keeps every query failing while believing itself signed in. Restricted to
-    // GraphQL because the catch-all filter turns a GraphQL error thrown on the
-    // REST path into a 500; those clients keep the 403 they get today.
+    // Returning false here would report FORBIDDEN, which clients read as a
+    // permission problem and never recover from. GraphQL only: the catch-all
+    // filter turns a GraphQL error thrown on the REST path into a 500.
     if (
       !hasAuthenticatedPrincipal(request) &&
       context.getType<GqlContextType>() === 'graphql'
@@ -53,8 +47,7 @@ export class WorkspaceAuthGuard implements CanActivate {
       });
     }
 
-    // Authenticated but carrying no workspace -- a workspace-agnostic token --
-    // is a genuine refusal: renewing it would return the same token.
+    // Workspace-agnostic token: a genuine refusal, renewing returns the same one.
     if (!request.workspace) {
       return false;
     }

--- a/packages/twenty-server/test/integration/graphql/suites/impersonation/__snapshots__/failing-unauthenticated-impersonation.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/graphql/suites/impersonation/__snapshots__/failing-unauthenticated-impersonation.integration-spec.ts.snap
@@ -3,9 +3,11 @@
 exports[`Impersonation - unauthenticated request denial (integration) rejects an impersonation request with no authentication 1`] = `
 {
   "extensions": {
-    "code": "FORBIDDEN",
-    "userFriendlyMessage": "An error occurred.",
+    "code": "UNAUTHENTICATED",
+    "subCode": "UNAUTHENTICATED",
+    "userFriendlyMessage": "You must be authenticated to perform this action.",
   },
-  "message": "Forbidden resource",
+  "message": "Missing authentication token",
+  "name": "AuthenticationError",
 }
 `;


### PR DESCRIPTION
## Problem

A GraphQL request that presents no credential is never hydrated. `MiddlewareService.hydrateGraphqlRequest` returns early when `isTokenPresent` is false, which is load-bearing since sign-in and client config go through the same middleware. That leaves `WorkspaceAuthGuard` to reject an unhydrated request by returning `false`, and Nest turns that into its default `ForbiddenException`: `"Forbidden resource"`, code `FORBIDDEN`.

Clients read `FORBIDDEN` as a permission problem. Nothing renews the credential, nothing signs the user out. A web client whose session cookie stops being accepted therefore stays "logged in" with every query returning null, and the record/page-layout routes land on `/not-found`.

That state needs no deploy to reach. `AUTH_COOKIE_SESSIONS_ENABLED` is runtime config: it defaults to `false`, it is not env-only, so it can live in `core."keyValuePair"`, and `DatabaseConfigDriver` re-reads it on a 15-second cron. If it goes false — flipped, deleted, or a pod whose `onModuleInit` config load failed and fell back to the default — the server stops reading session cookies while cookie-mode clients have already stopped sending the Bearer. A cookie the browser no longer holds, or one the server cleared via `clearDeadSessionCookie`, lands in the same place.

The distinguishing detail is that the user is not signed out. A session that merely died throws `UNAUTHENTICATED`, which the client acts on: it falls back to the token pair, renews, and signs out if the refresh token is dead. Silent nulls with an intact session mean the client never saw an auth code at all.

This is the root cause of the two front-end symptoms, and it is the only one of the three fixes that also unbreaks clients running an already-shipped bundle, since they do handle `UNAUTHENTICATED`.

Worth noting alongside #24257: the boot effect on `main` today still has a recovery path for this, turning cookie auth back off when the server advertises `isCookieSessionEnabled: false`. #24257 removes it. Once that ships, this PR is the only thing that makes the state recoverable.

## Change

`WorkspaceAuthGuard` throws `AuthenticationError` (code `UNAUTHENTICATED`) when nothing authenticated the request: no `user`, no `apiKey`, no `application` on the request.

Two deliberate boundaries:

- **A request that did authenticate but carries no workspace stays `FORBIDDEN`.** That is a workspace-agnostic token, which is a genuine refusal: renewing it returns the same token, and reporting it as `UNAUTHENTICATED` would push clients sitting on the workspace chooser into a renewal loop or a sign-out.
- **GraphQL only.** `WorkspaceAuthGuard` also guards REST and MCP controllers, where the catch-all `UnhandledExceptionFilter` would turn a thrown `GraphQLError` into a 500. Those clients keep the 403 they get today. Widening this to a 401 on the REST path is defensible but is a separate change.

## Risk

This changes the error code every `WorkspaceAuthGuard`-protected GraphQL resolver returns to an anonymous caller (119 files reference the guard). Anything branching on `FORBIDDEN` for that case sees `UNAUTHENTICATED` instead. The intended consequence is that the front end's existing renewal path fires, and, when renewal fails, signs the user out rather than leaving them in the current silent-null state. Worth confirming that is the behaviour we want before merging.

The `userFriendlyMessage` matches the one the auth stack already produces for `UNAUTHENTICATED`, so the shape is identical to the auth exceptions clients already see.

## Blast radius, measured

The integration suite has exactly one assertion of the old shape, which is the clearest evidence of how wide this is: `failing-unauthenticated-impersonation` posts to `/metadata` with no authentication and snapshotted `FORBIDDEN` / `"Forbidden resource"`. Its snapshot moves to `UNAUTHENTICATED` / `"Missing authentication token"` in this PR.

Nothing else in the suite asserts the old shape. The `failing-file-by-id-download` snapshots keep their HTTP 403, since they come from a REST controller and the guard only throws on the GraphQL path, which is the boundary above holding in practice.

## Tests

`workspace-auth.guard.spec.ts` builds a real Nest + Yoga schema (same harness as `unhandled-exception.filter.spec.ts`) and asserts all four paths: authorised, unauthenticated to `UNAUTHENTICATED`, authenticated-without-workspace to still `ForbiddenException`, and REST to still `false` without throwing.

The workspace-agnostic case is asserted on the exception rather than the code, because the code is derived from the HTTP status by `useGraphQLErrorHandler` further down the request than this harness reaches.
