### PR TITLE
Fix MCP tool calls reporting structured failures as success

### DIFF
--- a/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-tool-executor.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-tool-executor.service.spec.ts
@@ -1,0 +1,123 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { type ToolSet } from 'ai';
+
+import { McpToolExecutorService } from 'src/engine/api/mcp/services/mcp-tool-executor.service';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
+
+describe('McpToolExecutorService', () => {
+  let service: McpToolExecutorService;
+  let metricsService: jest.Mocked<MetricsService>;
+
+  const buildToolSet = (execute: jest.Mock): ToolSet =>
+    ({
+      create_person: {
+        description: 'Create a person',
+        inputSchema: {},
+        execute,
+      },
+    }) as unknown as ToolSet;
+
+  beforeEach(async () => {
+    metricsService = {
+      incrementCounterBy: jest.fn(),
+      recordHistogram: jest.fn(),
+    } as unknown as jest.Mocked<MetricsService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        McpToolExecutorService,
+        {
+          provide: MetricsService,
+          useValue: metricsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(McpToolExecutorService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handleToolCall', () => {
+    it('should return isError false and count a success when the tool output succeeds', async () => {
+      const toolOutput = { success: true, message: 'Created' };
+      const toolSet = buildToolSet(jest.fn().mockResolvedValue(toolOutput));
+
+      const response = await service.handleToolCall(1, toolSet, {
+        name: 'create_person',
+        arguments: {},
+      });
+
+      expect(response).toEqual({
+        id: 1,
+        jsonrpc: '2.0',
+        result: {
+          content: [{ type: 'text', text: JSON.stringify(toolOutput) }],
+          isError: false,
+        },
+      });
+      expect(metricsService.incrementCounterBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: MetricsKeys.McpToolExecutionSucceeded,
+        }),
+      );
+    });
+
+    it('should return isError true and count a failure when the tool output resolves with success false', async () => {
+      const toolOutput = {
+        success: false,
+        message: 'Validation failed',
+        error: 'Missing required field',
+      };
+      const toolSet = buildToolSet(jest.fn().mockResolvedValue(toolOutput));
+
+      const response = await service.handleToolCall(1, toolSet, {
+        name: 'create_person',
+        arguments: {},
+      });
+
+      expect(response).toEqual({
+        id: 1,
+        jsonrpc: '2.0',
+        result: {
+          content: [{ type: 'text', text: JSON.stringify(toolOutput) }],
+          isError: true,
+        },
+      });
+      expect(metricsService.incrementCounterBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: MetricsKeys.McpToolExecutionFailed,
+        }),
+      );
+    });
+
+    it('should return isError true and count a failure when the tool throws', async () => {
+      const toolSet = buildToolSet(
+        jest.fn().mockRejectedValue(new Error('Database unavailable')),
+      );
+
+      const response = await service.handleToolCall(1, toolSet, {
+        name: 'create_person',
+        arguments: {},
+      });
+
+      expect(response).toEqual({
+        id: 1,
+        jsonrpc: '2.0',
+        result: {
+          content: [{ type: 'text', text: 'Database unavailable' }],
+          isError: true,
+        },
+      });
+      expect(metricsService.incrementCounterBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: MetricsKeys.McpToolExecutionFailed,
+        }),
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/mcp/services/mcp-tool-executor.service.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/mcp-tool-executor.service.ts
@@ -117,7 +117,7 @@ export class McpToolExecutorService {
       return wrapJsonRpcResponse(id, {
         result: {
           content: [{ type: 'text', text: JSON.stringify(result) }],
-          isError: false,
+          isError: !succeeded,
         },
       });
     } catch (executionError) {

--- a/packages/twenty-server/test/integration/ai/suites/mcp-tool-catalog.integration-spec.ts
+++ b/packages/twenty-server/test/integration/ai/suites/mcp-tool-catalog.integration-spec.ts
@@ -11,8 +11,11 @@ import { ToolCategory } from 'twenty-shared/ai';
  * Contract tests for the MCP tool catalog.
  *
  * 1. Catalog contract: every category advertised by get_tool_catalog must be
- *    dispatchable end to end through execute_tool. Scales automatically: a
- *    newly registered provider is covered the moment it appears in the
+ *    dispatchable end to end through execute_tool. Dispatchable means the
+ *    registry resolves and executes the tool: a structured business failure
+ *    (e.g. a search tool rejecting empty arguments) still proves dispatch,
+ *    only "not found" / "not available" outputs do not. Scales automatically:
+ *    a newly registered provider is covered the moment it appears in the
  *    catalog, with no new test code.
  * 2. Permission gating: the catalog is role-dependent. An API key bound to a
  *    role without settings permissions must not see settings-gated tools
@@ -61,6 +64,31 @@ const getToolCatalog = async (
 };
 
 const READ_ONLY_TOOL_NAME_PATTERN = /^(find_|list_|get_|search_)/;
+
+// Dispatch-layer failures come from execute_tool gating or the registry
+// (unknown or unavailable tool), not from the executed tool itself. Their
+// exact wording is pinned by the "should report unknown tools as dispatch
+// failures" control test below, so drift fails loudly instead of silently
+// weakening the catalog contract.
+const DISPATCH_FAILURE_MESSAGE_PATTERN =
+  /^Tool ".+" (not found|is not available)$/;
+
+const isDispatchFailure = (result: {
+  content: { type: string; text: string }[];
+}): boolean => {
+  let output: { success?: boolean; message?: string };
+
+  try {
+    output = JSON.parse(result.content[0].text);
+  } catch {
+    return false;
+  }
+
+  return (
+    output.success === false &&
+    DISPATCH_FAILURE_MESSAGE_PATTERN.test(output.message ?? '')
+  );
+};
 
 // Deliberate exceptions to the "every advertised category is dispatchable
 // through a read-only tool" contract. Currently none: every category the MCP
@@ -197,7 +225,11 @@ describe('MCP tool catalog (integration)', () => {
             arguments: {},
           });
 
-          if (!result.isError) {
+          // Called with empty arguments, a resolved tool may legitimately
+          // return a structured failure (isError true since the MCP layer
+          // surfaces success: false); only a dispatch-layer failure means the
+          // category is advertised but not actually wired up.
+          if (!isDispatchFailure(result)) {
             dispatched = true;
             break;
           }
@@ -214,6 +246,16 @@ describe('MCP tool catalog (integration)', () => {
       expect([...categoriesWithoutReadOnlyTool].sort()).toEqual(
         EXPECTED_CATEGORIES_WITHOUT_READ_ONLY_TOOLS,
       );
+    });
+
+    it('should report unknown tools as dispatch failures', async () => {
+      const result = await callMcpTool(adminApiKeyToken, 'execute_tool', {
+        toolName: 'definitely_not_a_registered_tool',
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      expect(isDispatchFailure(result)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Context

Record CRUD tools catch validation and database errors and resolve with a structured `ToolOutput` of `success: false` instead of throwing. The MCP tool executor only treated thrown exceptions as failures: any resolved result was returned with `isError: false`, so MCP clients (e.g. Codex issuing batch record writes) saw failed mutations as successful, with no actionable error signal.

Metrics were already fixed to use `isToolOutputSuccessful()` for the succeeded/failed counters, but the MCP response itself still hardcoded `isError: false`.

Surfaced by Sentry: https://sentry.io/issues/7652655334/

## What this does

- Reuses the existing `isToolOutputSuccessful()` check to set `isError: true` on the MCP response when a tool resolves with `success: false`, keeping the full serialized payload in `content` so clients can see the error details
- Adds unit tests for the executor covering structured success, structured failure, and thrown errors (including the metric counters)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

