### PR TITLE
fix(front): stop losing the admin session when impersonation cannot be handed back

### DIFF
--- a/packages/twenty-front/src/modules/auth/hooks/__tests__/useImpersonationSession.test.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/__tests__/useImpersonationSession.test.ts
@@ -74,6 +74,8 @@ describe('useImpersonationSession', () => {
         await result.current.stopImpersonating();
       });
 
+      expect(stopImpersonationMock).toHaveBeenCalledTimes(1);
+      expect(stopImpersonationMock).toHaveBeenCalledWith();
       expect(store.get(tokenPairState.atom)).toBeNull();
       expect(store.get(isCookieAuthActiveState.atom)).toBe(true);
       expect(sessionStorage.getItem(IMPERSONATION_SESSION_KEY)).toBeNull();
@@ -98,12 +100,18 @@ describe('useImpersonationSession', () => {
         await result.current.stopImpersonating();
       });
 
+      expect(stopImpersonationMock).toHaveBeenCalledTimes(1);
+      expect(stopImpersonationMock).toHaveBeenCalledWith();
       expect(store.get(tokenPairState.atom)).toEqual(ADMIN_TOKEN_PAIR);
       expect(store.get(isCookieAuthActiveState.atom)).toBe(false);
       expect(signOutMock).not.toHaveBeenCalled();
     });
 
-    it('should restore the parked token pair when the mutation itself fails', async () => {
+    // A rejection cannot tell "the server never ran it" from "the answer was
+    // lost", and in the first case the impersonation cookie is still live: the
+    // boot probe would authenticate on it and switch cookie auth back on,
+    // suppressing the restored Bearer and silently keeping the impersonation.
+    it('should sign out rather than restore when the mutation itself fails', async () => {
       stopImpersonationMock.mockRejectedValue(new Error('network'));
       sessionStorage.setItem(
         IMPERSONATION_SESSION_KEY,
@@ -119,9 +127,29 @@ describe('useImpersonationSession', () => {
         await result.current.stopImpersonating();
       });
 
-      expect(store.get(tokenPairState.atom)).toEqual(ADMIN_TOKEN_PAIR);
-      expect(store.get(isCookieAuthActiveState.atom)).toBe(false);
-      expect(signOutMock).not.toHaveBeenCalled();
+      expect(store.get(tokenPairState.atom)).toBeNull();
+      expect(store.get(isCookieAuthActiveState.atom)).toBe(true);
+      expect(signOutMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should sign out when the server answers without a verdict', async () => {
+      stopImpersonationMock.mockResolvedValue({ data: undefined });
+      sessionStorage.setItem(
+        IMPERSONATION_SESSION_KEY,
+        JSON.stringify({
+          tokenPair: ADMIN_TOKEN_PAIR,
+          returnPath: '/admin-panel',
+        }),
+      );
+
+      const { store, result } = setup();
+
+      await act(async () => {
+        await result.current.stopImpersonating();
+      });
+
+      expect(store.get(tokenPairState.atom)).toBeNull();
+      expect(signOutMock).toHaveBeenCalledTimes(1);
     });
 
     it('should sign out when nothing was parked on this origin', async () => {

--- a/packages/twenty-front/src/modules/auth/hooks/__tests__/useImpersonationSession.test.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/__tests__/useImpersonationSession.test.ts
@@ -1,0 +1,148 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+import { createElement, type ReactNode } from 'react';
+
+import { useImpersonationSession } from '@/auth/hooks/useImpersonationSession';
+import { isCookieAuthActiveState } from '@/auth/states/isCookieAuthActiveState';
+import { tokenPairState } from '@/auth/states/tokenPairState';
+import { type AuthTokenPair } from '~/generated-metadata/graphql';
+
+const stopImpersonationMock = jest.fn();
+const signOutMock = jest.fn();
+const getAuthTokensFromLoginTokenMock = jest.fn();
+
+jest.mock('@apollo/client/react', () => ({
+  useMutation: () => [stopImpersonationMock],
+}));
+
+jest.mock('@/auth/hooks/useAuth', () => ({
+  useAuth: () => ({
+    getAuthTokensFromLoginToken: (...args: unknown[]) =>
+      getAuthTokensFromLoginTokenMock(...args),
+    signOut: () => signOutMock(),
+  }),
+}));
+
+const IMPERSONATION_SESSION_KEY = 'impersonation_original_session';
+
+const ADMIN_TOKEN_PAIR: AuthTokenPair = {
+  accessOrWorkspaceAgnosticToken: { token: 'admin-access', expiresAt: '' },
+  refreshToken: { token: 'admin-refresh', expiresAt: '' },
+};
+
+const closeMock = jest.fn();
+
+const setup = () => {
+  const store = createStore();
+
+  store.set(isCookieAuthActiveState.atom, true);
+  store.set(tokenPairState.atom, null);
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(Provider, { store }, children);
+
+  const { result } = renderHook(() => useImpersonationSession(), { wrapper });
+
+  return { store, result };
+};
+
+describe('useImpersonationSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+
+    window.history.replaceState(null, '', '/impersonated');
+    window.close = closeMock;
+  });
+
+  describe('stopImpersonating under cookie auth', () => {
+    it('should let the server hand the impersonator session back when it can', async () => {
+      stopImpersonationMock.mockResolvedValue({
+        data: { stopImpersonation: { canRestoreImpersonatorSession: true } },
+      });
+      sessionStorage.setItem(
+        IMPERSONATION_SESSION_KEY,
+        JSON.stringify({
+          tokenPair: ADMIN_TOKEN_PAIR,
+          returnPath: '/admin-panel',
+        }),
+      );
+
+      const { store, result } = setup();
+
+      await act(async () => {
+        await result.current.stopImpersonating();
+      });
+
+      expect(store.get(tokenPairState.atom)).toBeNull();
+      expect(store.get(isCookieAuthActiveState.atom)).toBe(true);
+      expect(sessionStorage.getItem(IMPERSONATION_SESSION_KEY)).toBeNull();
+      expect(signOutMock).not.toHaveBeenCalled();
+    });
+
+    // The server cleared the session cookie on its way out, and startImpersonating
+    // had already dropped the token pair. Signing out here would end a session the
+    // admin still holds, and leaving cookie auth on would strand the tab with no
+    // credential at all.
+    it('should restore the parked token pair when the server cannot hand the session back', async () => {
+      stopImpersonationMock.mockResolvedValue({
+        data: { stopImpersonation: { canRestoreImpersonatorSession: false } },
+      });
+      sessionStorage.setItem(
+        IMPERSONATION_SESSION_KEY,
+        JSON.stringify({
+          tokenPair: ADMIN_TOKEN_PAIR,
+          returnPath: '/admin-panel',
+        }),
+      );
+
+      const { store, result } = setup();
+
+      await act(async () => {
+        await result.current.stopImpersonating();
+      });
+
+      expect(store.get(tokenPairState.atom)).toEqual(ADMIN_TOKEN_PAIR);
+      expect(store.get(isCookieAuthActiveState.atom)).toBe(false);
+      expect(signOutMock).not.toHaveBeenCalled();
+    });
+
+    it('should restore the parked token pair when the mutation itself fails', async () => {
+      stopImpersonationMock.mockRejectedValue(new Error('network'));
+      sessionStorage.setItem(
+        IMPERSONATION_SESSION_KEY,
+        JSON.stringify({
+          tokenPair: ADMIN_TOKEN_PAIR,
+          returnPath: '/admin-panel',
+        }),
+      );
+
+      const { store, result } = setup();
+
+      await act(async () => {
+        await result.current.stopImpersonating();
+      });
+
+      expect(store.get(tokenPairState.atom)).toEqual(ADMIN_TOKEN_PAIR);
+      expect(store.get(isCookieAuthActiveState.atom)).toBe(false);
+      expect(signOutMock).not.toHaveBeenCalled();
+    });
+
+    // A tab opened on the impersonated workspace's own origin never parked
+    // anything, so there is nothing to go back to.
+    it('should sign out when nothing was parked on this origin', async () => {
+      stopImpersonationMock.mockResolvedValue({
+        data: { stopImpersonation: { canRestoreImpersonatorSession: false } },
+      });
+
+      const { store, result } = setup();
+
+      await act(async () => {
+        await result.current.stopImpersonating();
+      });
+
+      expect(store.get(tokenPairState.atom)).toBeNull();
+      expect(signOutMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/auth/hooks/__tests__/useImpersonationSession.test.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/__tests__/useImpersonationSession.test.ts
@@ -80,10 +80,6 @@ describe('useImpersonationSession', () => {
       expect(signOutMock).not.toHaveBeenCalled();
     });
 
-    // The server cleared the session cookie on its way out, and startImpersonating
-    // had already dropped the token pair. Signing out here would end a session the
-    // admin still holds, and leaving cookie auth on would strand the tab with no
-    // credential at all.
     it('should restore the parked token pair when the server cannot hand the session back', async () => {
       stopImpersonationMock.mockResolvedValue({
         data: { stopImpersonation: { canRestoreImpersonatorSession: false } },
@@ -128,8 +124,6 @@ describe('useImpersonationSession', () => {
       expect(signOutMock).not.toHaveBeenCalled();
     });
 
-    // A tab opened on the impersonated workspace's own origin never parked
-    // anything, so there is nothing to go back to.
     it('should sign out when nothing was parked on this origin', async () => {
       stopImpersonationMock.mockResolvedValue({
         data: { stopImpersonation: { canRestoreImpersonatorSession: false } },

--- a/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
@@ -98,13 +98,10 @@ export const useImpersonationSession = () => {
         }
       } catch {}
 
-      // The server had no impersonator session to hand back, and it cleared the
-      // session cookie on its way out. startImpersonating parked the token pair
-      // it dropped, so hand that back: it is the same credential the admin held
-      // before impersonating, and signing them out of it instead would end a
-      // session that is still valid. Cookie auth goes off with it, otherwise the
-      // auth link keeps suppressing the Bearer and the tab is left holding no
-      // credential at all.
+      // The server cleared the session cookie, so hand back the pair
+      // startImpersonating parked rather than signing out of a session the admin
+      // still holds. Cookie auth goes off with it, or the auth link keeps
+      // suppressing the Bearer and the tab holds no credential at all.
       if (isDefined(parkedTokenPair)) {
         store.set(isCookieAuthActiveState.atom, false);
         store.set(tokenPairState.atom, parkedTokenPair);

--- a/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
@@ -88,9 +88,31 @@ export const useImpersonationSession = () => {
 
       try {
         const { data } = await stopImpersonationMutation();
+        const canRestoreImpersonatorSession =
+          data?.stopImpersonation.canRestoreImpersonatorSession;
 
-        if (data?.stopImpersonation.canRestoreImpersonatorSession === true) {
+        if (canRestoreImpersonatorSession === true) {
           store.set(tokenPairState.atom, null);
+          clearSessionLocalStorageKeys();
+          reloadWithSession(returnPath);
+
+          return;
+        }
+
+        // An explicit false means the server ran and cleared the session
+        // cookie, so hand back the pair startImpersonating parked rather than
+        // signing out of a session the admin still holds. Cookie auth goes off
+        // with it, or the auth link keeps suppressing the Bearer and the tab
+        // holds no credential at all. Never on a rejection: the impersonation
+        // cookie may still be live, and the boot probe would authenticate on it
+        // and switch cookie auth back on, leaving the admin impersonating
+        // without knowing it.
+        if (
+          canRestoreImpersonatorSession === false &&
+          isDefined(parkedTokenPair)
+        ) {
+          store.set(isCookieAuthActiveState.atom, false);
+          store.set(tokenPairState.atom, parkedTokenPair);
           clearSessionLocalStorageKeys();
           reloadWithSession(returnPath);
 
@@ -98,21 +120,7 @@ export const useImpersonationSession = () => {
         }
       } catch {}
 
-      // The server cleared the session cookie, so hand back the pair
-      // startImpersonating parked rather than signing out of a session the admin
-      // still holds. Cookie auth goes off with it, or the auth link keeps
-      // suppressing the Bearer and the tab holds no credential at all.
-      if (isDefined(parkedTokenPair)) {
-        store.set(isCookieAuthActiveState.atom, false);
-        store.set(tokenPairState.atom, parkedTokenPair);
-        clearSessionLocalStorageKeys();
-        reloadWithSession(returnPath);
-
-        return;
-      }
-
-      // Cross-workspace: the admin session on its own origin was never replaced,
-      // and this origin never held one to park.
+      // Nothing parked to hand back, or the stop never got a confirmed answer.
       window.close();
       await signOut();
 

--- a/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client/react';
 import { useStore } from 'jotai';
 import { useCallback } from 'react';
+import { isDefined } from 'twenty-shared/utils';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { isCookieAuthActiveState } from '@/auth/states/isCookieAuthActiveState';
@@ -73,12 +74,15 @@ export const useImpersonationSession = () => {
 
     if (isCookieAuthActive) {
       let returnPath = window.location.pathname;
+      let parkedTokenPair: AuthTokenPair | undefined;
 
       if (raw !== null) {
         sessionStorage.removeItem(IMPERSONATION_SESSION_KEY);
         try {
-          returnPath = (JSON.parse(raw) as StoredImpersonationSession)
-            .returnPath;
+          const session = JSON.parse(raw) as StoredImpersonationSession;
+
+          returnPath = session.returnPath;
+          parkedTokenPair = session.tokenPair;
         } catch {}
       }
 
@@ -94,7 +98,24 @@ export const useImpersonationSession = () => {
         }
       } catch {}
 
-      // Cross-workspace: the admin session on its own origin was never replaced.
+      // The server had no impersonator session to hand back, and it cleared the
+      // session cookie on its way out. startImpersonating parked the token pair
+      // it dropped, so hand that back: it is the same credential the admin held
+      // before impersonating, and signing them out of it instead would end a
+      // session that is still valid. Cookie auth goes off with it, otherwise the
+      // auth link keeps suppressing the Bearer and the tab is left holding no
+      // credential at all.
+      if (isDefined(parkedTokenPair)) {
+        store.set(isCookieAuthActiveState.atom, false);
+        store.set(tokenPairState.atom, parkedTokenPair);
+        clearSessionLocalStorageKeys();
+        reloadWithSession(returnPath);
+
+        return;
+      }
+
+      // Cross-workspace: the admin session on its own origin was never replaced,
+      // and this origin never held one to park.
       window.close();
       await signOut();
 


### PR DESCRIPTION
## Problem

`startImpersonating` parks the impersonator's token pair in `sessionStorage` and then drops it from the store, so the impersonation cookie is the only credential in play:

```ts
if (isCookieAuthActive) {
  // Drop the token pair the exchange also returned, so the cookie it set stays
  // the only credential.
  store.set(tokenPairState.atom, null);
}
```

`stopImpersonating` never reads that parked pair back. In the cookie-auth branch it pulls `returnPath` out of the stored session and discards everything else:

```ts
returnPath = (JSON.parse(raw) as StoredImpersonationSession).returnPath;
```

So when `stopImpersonation` reports `canRestoreImpersonatorSession: false` — the impersonator's own session lives on another origin, and the server responds by clearing the session cookie (`impersonation.service.ts:161-163`) — the client ends up with no cookie and no token pair, and signs the admin out of a session they still hold. The parked credential that would have restored them was sitting in `sessionStorage` the whole time.

## Change

Read the parked pair back and hand it over, turning cookie auth off with it. The flag matters: the auth link suppresses the Bearer while `isCookieAuthActive` is on, so restoring the pair without clearing the flag would leave the tab holding no credential at all — the same dead end this is meant to avoid.

Signing out stays the behaviour when this origin parked nothing, which is the cross-workspace tab opened by redirect. That path is unchanged.

## Context

This came out of investigating today's incident, where a tab was left with `isCookieAuthActiveState: true`, no `tokenPair` key, and no `__Host-twenty-session` cookie — every request anonymous, refused as `"Forbidden resource"`, swallowed by the error link, so the client stayed "logged in" while every query returned null. `useImpersonationSession` holds the only two writers that null the token pair while leaving `isCookieAuthActive` true; every other writer (`clearSession`, `onUnauthenticatedError`) clears both.

This PR removes one route into that state and stops a valid admin session being thrown away. It does not fix the state itself — a tab whose impersonation cookie dies without a clean stop (the session lifetime is `1d`, against 180d absolute / 30d idle for a normal one) still has no way to detect it, because a *missing* cookie produces `FORBIDDEN` rather than `UNAUTHENTICATED`. That detection is #24276.

## Tests

`useImpersonationSession.test.ts` covers the cookie-auth stop path: server restores the session, server cannot restore it (parked pair handed back, cookie auth off, no sign-out), the mutation itself fails, and nothing parked on this origin (still signs out).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BhKxHLHcBHqJ7q8aTN9vkB)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

