### PR TITLE
fix(twenty-slack): point the README setup link at an absolute url

### DIFF
--- a/packages/twenty-apps/public/slack/README.md
+++ b/packages/twenty-apps/public/slack/README.md
@@ -45,4 +45,4 @@ The assistant still runs on your workspace AI credits, billed on the model's tok
 
 ## 📌 Heads up
 
-You need to create a Slack app and connect it — see [SETUP.md](./SETUP.md). The assistant needs a few extra steps (signing secret and event subscriptions) on top of the base connection.
+You need to create a Slack app and connect it — see [SETUP.md](https://github.com/twentyhq/twenty/blob/main/packages/twenty-apps/public/slack/SETUP.md). The assistant needs a few extra steps (signing secret and event subscriptions) on top of the base connection.


### PR DESCRIPTION
The Slack app README linked its setup guide with a relative path: `see [SETUP.md](./SETUP.md)`. The file exists, so the link works on GitHub, but it breaks everywhere else the README is rendered, for two separate reasons.

**On the npm package page.** npm rewrites relative README links against the `repository` field in `package.json`. This package has no `repository` field, so there is nothing to resolve against. Adding one would not help either: npm does not honor `repository.directory` when rewriting these links ([npm/marky-markdown#449](https://github.com/npm/marky-markdown/issues/449)), so for a package nested at `packages/twenty-apps/public/slack` it would resolve against the repo root and 404 anyway.

**In the product.** The README is baked into the published manifest (`manifest-build.ts` `loadReadme()` sets it as `application.aboutDescription`) and rendered in Settings > Applications > Slack > About by `LazyMarkdownRenderer`. That renderer passes every href through `getSafeUrl`, which prepends a scheme to anything not already absolute or root-relative:

```
"./SETUP.md"  ->  href="https://./SETUP.md"
```

The anchor also carries `target="_blank"`, so the setup link opens a new tab on a bogus host.

An absolute GitHub URL sidesteps both: npm leaves it alone and `getSafeUrl` passes it through untouched. Slack was the only README under `packages/twenty-apps` with a relative markdown link.

Note that the README ships inside the published package, so this reaches the npm page and the marketplace listing with the next release of `@twentyhq/slack`.
