### PR TITLE
fix(tests): correct 'overriden' typo to 'overridden'

### DIFF
--- a/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/granular-object-records-permissions.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/granular-object-records-permissions.integration-spec.ts
@@ -62,7 +62,7 @@ describe('granularObjectRecordsPermissions', () => {
       await deleteRole(client, customRoleId);
     });
 
-    it('should throw permission error when querying person while person reading rights are overriden to false', async () => {
+    it('should throw permission error when querying person while person reading rights are overridden to false', async () => {
       const { roleId } = await createCustomRoleWithObjectPermissions({
         label: 'PersonReadRightsExcludedRole',
         canReadPerson: false,
@@ -112,7 +112,7 @@ describe('granularObjectRecordsPermissions', () => {
       expect(companyResponse.body.data.company).toBeDefined();
     });
 
-    it('should successfully query person when person reading rights are overriden to true', async () => {
+    it('should successfully query person when person reading rights are overridden to true', async () => {
       const { roleId } = await createCustomRoleWithObjectPermissions({
         label: 'PersonRole',
         canReadPerson: true,


### PR DESCRIPTION
Two test descriptions in the granular object-records-permissions integration suite misspelled 'overridden' as 'overriden'.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

