### PR TITLE
feat(front): delete a workflow step from the diagram node

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeEditable.tsx
@@ -10,6 +10,7 @@ import { workflowSelectedNodeComponentState } from '@/workflow/workflow-diagram/
 import { type WorkflowDiagramStepNodeData } from '@/workflow/workflow-diagram/types/WorkflowDiagram';
 import { getWorkflowNodeIconKey } from '@/workflow/workflow-diagram/utils/getWorkflowNodeIconKey';
 import { WorkflowDiagramStepNodeEditableContent } from '@/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeEditableContent';
+import { useDeleteStep } from '@/workflow/workflow-steps/hooks/useDeleteStep';
 import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { useIcons } from 'twenty-ui/icon';
@@ -36,6 +37,8 @@ export const WorkflowDiagramStepNodeEditable = ({
   const { openWorkflowEditStepInSidePanel } = useSidePanelWorkflowNavigation();
 
   const { resetWorkflowInsertStepIds } = useResetWorkflowInsertStepIds();
+
+  const { deleteStep } = useDeleteStep();
 
   const { commandMenuContextApi } = useContext(CommandMenuContext);
   const isInSidePanel = commandMenuContextApi.isInSidePanel;
@@ -65,12 +68,17 @@ export const WorkflowDiagramStepNodeEditable = ({
     }
   };
 
+  const handleDelete = () => {
+    deleteStep(data.stepId);
+  };
+
   return (
     <WorkflowDiagramStepNodeEditableContent
       id={id}
       data={data}
       selected={selected}
       onClick={handleClick}
+      onDelete={handleDelete}
     />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeEditableContent.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeEditableContent.tsx
@@ -10,6 +10,7 @@ import { WorkflowDiagramHandleSource } from '@/workflow/workflow-diagram/workflo
 import { WorkflowDiagramHandleTarget } from '@/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramHandleTarget';
 import { WorkflowDiagramStepNodeIcon } from '@/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeIcon';
 import { WorkflowNodeContainer } from '@/workflow/workflow-diagram/workflow-nodes/components/WorkflowNodeContainer';
+import { WorkflowNodeDeleteButton } from '@/workflow/workflow-diagram/workflow-nodes/components/WorkflowNodeDeleteButton';
 import { WorkflowNodeIconContainer } from '@/workflow/workflow-diagram/workflow-nodes/components/WorkflowNodeIconContainer';
 import { WorkflowNodeLabel } from '@/workflow/workflow-diagram/workflow-nodes/components/WorkflowNodeLabel';
 import { WorkflowNodeLabelWithCounterPart } from '@/workflow/workflow-diagram/workflow-nodes/components/WorkflowNodeLabelWithCounterPart';
@@ -45,11 +46,13 @@ export const WorkflowDiagramStepNodeEditableContent = ({
   data,
   selected,
   onClick,
+  onDelete,
 }: {
   id: string;
   data: WorkflowDiagramStepNodeData;
   selected: boolean;
   onClick?: () => void;
+  onDelete?: () => void;
 }) => {
   const { i18n } = useLingui();
 
@@ -124,6 +127,13 @@ export const WorkflowDiagramStepNodeEditableContent = ({
             {data.name}
           </WorkflowNodeTitle>
         </WorkflowNodeRightPart>
+
+        {id !== EMPTY_NODE_ID && isDefined(onDelete) && (
+          <WorkflowNodeDeleteButton
+            shouldDisplay={isHovered && !isConnectionInProgress}
+            onDelete={onDelete}
+          />
+        )}
       </WorkflowNodeContainer>
 
       {!data.hasNextStepIds &&

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowNodeDeleteButton.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowNodeDeleteButton.tsx
@@ -1,0 +1,49 @@
+import { styled } from '@linaria/react';
+import { useLingui } from '@lingui/react/macro';
+import { type MouseEvent } from 'react';
+import { IconTrash } from 'twenty-ui/icon';
+import { IconButtonGroup } from 'twenty-ui/input';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledDeleteButtonContainer = styled.div<{ shouldDisplay: boolean }>`
+  left: 100%;
+  opacity: ${({ shouldDisplay }) => (shouldDisplay ? 1 : 0)};
+  padding-left: ${themeCssVariables.spacing[2]};
+  pointer-events: ${({ shouldDisplay }) => (shouldDisplay ? 'all' : 'none')};
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
+type WorkflowNodeDeleteButtonProps = {
+  shouldDisplay: boolean;
+  onDelete: () => void;
+};
+
+export const WorkflowNodeDeleteButton = ({
+  shouldDisplay,
+  onDelete,
+}: WorkflowNodeDeleteButtonProps) => {
+  const { t } = useLingui();
+
+  const handleClick = (event: MouseEvent) => {
+    event.stopPropagation();
+
+    onDelete();
+  };
+
+  return (
+    <StyledDeleteButtonContainer shouldDisplay={shouldDisplay}>
+      <IconButtonGroup
+        className="nodrag nopan"
+        iconButtons={[
+          {
+            Icon: IconTrash,
+            ariaLabel: t`Delete node`,
+            onClick: handleClick,
+          },
+        ]}
+      />
+    </StyledDeleteButtonContainer>
+  );
+};


### PR DESCRIPTION

<img width="219" height="79" alt="Capture d’écran 2026-08-18 à 11 27 39" src="https://github.com/user-attachments/assets/d9f6813f-9d06-4675-a05d-4d852dfc161b" />


Deleting a workflow step currently requires opening the node in the side panel and using the footer Delete button (or its options dropdown). This adds the same action directly on the diagram: a trash button fades in at the right edge of a node on hover, and clicking it deletes the step.

### How it works

- `WorkflowNodeDeleteButton` is presentational: an `IconButtonGroup` with `IconTrash`, absolutely positioned at `left: 100%` so it floats just outside the node instead of covering the step name. It carries `nodrag nopan` so react-flow does not start a node drag on mousedown, and stops click propagation so the node's own click handler does not open the side panel.
- `WorkflowDiagramStepNodeEditable` owns the behavior and passes `onDelete` down, reusing the existing `useDeleteStep` hook that the side panel footer already calls. Draft-version creation, output-schema cleanup, AI agent permission reset and cache updates all come from that hook unchanged.
- The button is hidden on the `EMPTY_NODE_ID` placeholder node and while a connection drag is in progress. It is a DOM child of the node container, so moving the pointer onto it does not fire the container's `mouseleave`.

Because the button only renders when `onDelete` is passed, the existing `WorkflowDiagramStepNodeEditableContent` story is unaffected and no data-fetching hook runs in Storybook.

### Verified

Ran locally against a seeded workspace: the button appears on hover, survives the pointer moving onto it, and clicking it removes the step, re-links the edge to the next node and flips the workflow from Active to Draft.

### Note

On iterator nodes the right-side source handle sits at the same edge, so the button lands adjacent to it on hover. They do not overlap, but it is tight.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

