### PR TITLE
Read property-mapped attributes back from getAttribute on remote elements

### DIFF
--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
@@ -113,6 +113,47 @@ describe('patchRemoteElementAttributes', () => {
     });
   });
 
+  describe('getAttributeNames on property-mapped attributes', () => {
+    it('should not list a mapped attribute whose property was never set', () => {
+      expect(createHtmlDivElement().getAttributeNames()).not.toContain('class');
+    });
+
+    it('should list the canonical name, not the property alias', () => {
+      const element = createHtmlDivElement();
+
+      element.className = 'from-react';
+
+      expect(element.getAttributeNames()).toEqual(['class']);
+    });
+
+    it('should list a mapped attribute holding a falsy value', () => {
+      const element = createHtmlDivElement();
+
+      element.tabIndex = 0;
+
+      expect(element.getAttributeNames()).toEqual(['tabindex']);
+    });
+
+    it('should list mapped attributes alongside real ones', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('id', 'anchor');
+      element.setAttribute('class', 'present');
+
+      expect(element.getAttributeNames()).toEqual(['id', 'class']);
+    });
+
+    it('should stop listing a mapped attribute after removeAttribute', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('id', 'anchor');
+      element.setAttribute('class', 'present');
+      element.removeAttribute('class');
+
+      expect(element.getAttributeNames()).toEqual(['id']);
+    });
+  });
+
   describe('attribute names colliding with Object prototype keys', () => {
     it('should store them as real attributes instead of mapping them to a property', () => {
       const element = createHtmlDivElement();

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
@@ -1,0 +1,65 @@
+import '@/remote/generated/remote-elements';
+
+import { patchRemoteElementAttributes } from '../patchRemoteElementAttributes';
+
+patchRemoteElementAttributes();
+
+type PatchedRemoteElement = {
+  className?: string;
+  tabIndex?: number;
+  getAttribute: (attributeName: string) => string | null;
+  setAttribute: (attributeName: string, attributeValue: string) => void;
+  removeAttribute: (attributeName: string) => void;
+};
+
+const createHtmlDivElement = (): PatchedRemoteElement =>
+  document.createElement('html-div');
+
+describe('patchRemoteElementAttributes', () => {
+  describe('getAttribute on property-mapped attributes', () => {
+    it('should return null when the mapped property was never set', () => {
+      expect(createHtmlDivElement().getAttribute('class')).toBeNull();
+    });
+
+    it('should read the value written through the redirected setAttribute', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('class', 'first second');
+
+      expect(element.getAttribute('class')).toBe('first second');
+    });
+
+    it('should read a value assigned directly to the mapped property', () => {
+      const element = createHtmlDivElement();
+
+      element.className = 'from-react';
+
+      expect(element.getAttribute('class')).toBe('from-react');
+    });
+
+    it('should stringify a non-string mapped property value', () => {
+      const element = createHtmlDivElement();
+
+      element.tabIndex = 3;
+
+      expect(element.getAttribute('tabindex')).toBe('3');
+    });
+
+    it('should return null again after removeAttribute', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('class', 'present');
+      element.removeAttribute('class');
+
+      expect(element.getAttribute('class')).toBeNull();
+    });
+
+    it('should keep the original getAttribute for unmapped attributes', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('id', 'anchor');
+
+      expect(element.getAttribute('id')).toBe('anchor');
+    });
+  });
+});

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
@@ -2,20 +2,14 @@ import '@/remote/generated/remote-elements';
 
 import { patchRemoteElementAttributes } from '../patchRemoteElementAttributes';
 
-patchRemoteElementAttributes();
-
-type PatchedRemoteElement = {
-  className?: string;
-  tabIndex?: number;
-  getAttribute: (attributeName: string) => string | null;
-  setAttribute: (attributeName: string, attributeValue: string) => void;
-  removeAttribute: (attributeName: string) => void;
-};
-
-const createHtmlDivElement = (): PatchedRemoteElement =>
+const createHtmlDivElement = (): HTMLElement =>
   document.createElement('html-div');
 
 describe('patchRemoteElementAttributes', () => {
+  beforeAll(() => {
+    patchRemoteElementAttributes();
+  });
+
   describe('getAttribute on property-mapped attributes', () => {
     it('should return null when the mapped property was never set', () => {
       expect(createHtmlDivElement().getAttribute('class')).toBeNull();
@@ -60,6 +54,53 @@ describe('patchRemoteElementAttributes', () => {
       element.setAttribute('id', 'anchor');
 
       expect(element.getAttribute('id')).toBe('anchor');
+    });
+  });
+
+  describe('hasAttribute on property-mapped attributes', () => {
+    it('should return false when the mapped property was never set', () => {
+      expect(createHtmlDivElement().hasAttribute('class')).toBe(false);
+    });
+
+    it('should return true once the mapped property holds a value', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('class', 'present');
+
+      expect(element.hasAttribute('class')).toBe(true);
+    });
+
+    it('should return false again after removeAttribute', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('class', 'present');
+      element.removeAttribute('class');
+
+      expect(element.hasAttribute('class')).toBe(false);
+    });
+
+    it('should keep the original hasAttribute for unmapped attributes', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('id', 'anchor');
+
+      expect(element.hasAttribute('id')).toBe(true);
+      expect(element.hasAttribute('title')).toBe(false);
+    });
+  });
+
+  describe('attribute names colliding with Object prototype keys', () => {
+    it('should store them as real attributes instead of mapping them to a property', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('constructor', 'plain-attribute-value');
+
+      expect(element.getAttribute('constructor')).toBe('plain-attribute-value');
+      expect(element.hasAttribute('constructor')).toBe(true);
+    });
+
+    it('should return null for an unset attribute named after an Object prototype key', () => {
+      expect(createHtmlDivElement().getAttribute('toString')).toBeNull();
     });
   });
 });

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
@@ -121,6 +121,7 @@ describe('patchRemoteElementAttributes', () => {
 
       expect(element.getAttribute('constructor')).toBe('plain-attribute-value');
       expect(element.hasAttribute('constructor')).toBe(true);
+      expect(element.getAttributeNames()).toContain('constructor');
     });
 
     it('should return null for an unset attribute named after an Object prototype key', () => {

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/__tests__/patchRemoteElementAttributes.test.ts
@@ -39,6 +39,22 @@ describe('patchRemoteElementAttributes', () => {
       expect(element.getAttribute('tabindex')).toBe('3');
     });
 
+    it('should read a falsy mapped property value', () => {
+      const element = createHtmlDivElement();
+
+      element.tabIndex = 0;
+
+      expect(element.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should read an explicitly emptied mapped property as an empty value', () => {
+      const element = createHtmlDivElement();
+
+      element.setAttribute('class', '');
+
+      expect(element.getAttribute('class')).toBe('');
+    });
+
     it('should return null again after removeAttribute', () => {
       const element = createHtmlDivElement();
 
@@ -68,6 +84,14 @@ describe('patchRemoteElementAttributes', () => {
       element.setAttribute('class', 'present');
 
       expect(element.hasAttribute('class')).toBe(true);
+    });
+
+    it('should return true for a falsy mapped property value', () => {
+      const element = createHtmlDivElement();
+
+      element.tabIndex = 0;
+
+      expect(element.hasAttribute('tabindex')).toBe(true);
     });
 
     it('should return false again after removeAttribute', () => {

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
@@ -55,7 +55,7 @@ export const patchRemoteElementAttributes = (): void => {
       const mappedElementPropertyName =
         ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME[attributeName];
 
-      if (mappedElementPropertyName) {
+      if (isDefined(mappedElementPropertyName)) {
         const elementPropertyValue = this[mappedElementPropertyName];
 
         return isDefined(elementPropertyValue)

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { ALLOWED_HTML_ELEMENTS } from '@/constants/AllowedHtmlElements';
 import { isAriaOrDataAttribute } from '@/remote/elements/utils/isAriaOrDataAttribute';
 
@@ -41,6 +43,28 @@ export const patchRemoteElementAttributes = (): void => {
     ): boolean =>
       isAriaOrDataAttribute(attributeName) &&
       !attributeNamesAlreadySyncedByRemoteDom.has(attributeName);
+
+    const originalGetAttribute = elementConstructor.prototype.getAttribute as (
+      attributeName: string,
+    ) => string | null;
+
+    elementConstructor.prototype.getAttribute = function (
+      this: RemoteElementWithAttributeUpdater,
+      attributeName: string,
+    ) {
+      const mappedElementPropertyName =
+        ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME[attributeName];
+
+      if (mappedElementPropertyName) {
+        const elementPropertyValue = this[mappedElementPropertyName];
+
+        return isDefined(elementPropertyValue)
+          ? String(elementPropertyValue)
+          : null;
+      }
+
+      return originalGetAttribute.call(this, attributeName);
+    };
 
     const originalSetAttribute = elementConstructor.prototype.setAttribute as (
       attributeName: string,

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
@@ -3,19 +3,21 @@ import { isDefined } from 'twenty-shared/utils';
 import { ALLOWED_HTML_ELEMENTS } from '@/constants/AllowedHtmlElements';
 import { isAriaOrDataAttribute } from '@/remote/elements/utils/isAriaOrDataAttribute';
 
-const ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME = new Map<string, string>([
-  ['className', 'className'],
-  ['class', 'className'],
+const PROPERTY_MAPPED_ATTRIBUTES = [
+  { attributeName: 'class', elementPropertyName: 'className' },
+  { attributeName: 'for', elementPropertyName: 'htmlFor' },
+  { attributeName: 'tabindex', elementPropertyName: 'tabIndex' },
+  { attributeName: 'srcdoc', elementPropertyName: 'srcDoc' },
+];
 
-  ['htmlFor', 'htmlFor'],
-  ['for', 'htmlFor'],
-
-  ['tabIndex', 'tabIndex'],
-  ['tabindex', 'tabIndex'],
-
-  ['srcDoc', 'srcDoc'],
-  ['srcdoc', 'srcDoc'],
-]);
+const ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME = new Map<string, string>(
+  PROPERTY_MAPPED_ATTRIBUTES.flatMap(
+    ({ attributeName, elementPropertyName }): [string, string][] => [
+      [attributeName, elementPropertyName],
+      [elementPropertyName, elementPropertyName],
+    ],
+  ),
+);
 
 type RemoteElementWithAttributeUpdater = Element &
   Record<string, unknown> & {
@@ -81,6 +83,19 @@ export const patchRemoteElementAttributes = (): void => {
       }
 
       return originalHasAttribute.call(this, attributeName);
+    };
+
+    const originalGetAttributeNames =
+      elementConstructor.prototype.getAttributeNames;
+
+    elementConstructor.prototype.getAttributeNames = function (
+      this: RemoteElementWithAttributeUpdater,
+    ) {
+      const mappedAttributeNames = PROPERTY_MAPPED_ATTRIBUTES.filter(
+        ({ elementPropertyName }) => isDefined(this[elementPropertyName]),
+      ).map(({ attributeName }) => attributeName);
+
+      return [...originalGetAttributeNames.call(this), ...mappedAttributeNames];
     };
 
     const originalSetAttribute = elementConstructor.prototype.setAttribute;

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
@@ -3,19 +3,19 @@ import { isDefined } from 'twenty-shared/utils';
 import { ALLOWED_HTML_ELEMENTS } from '@/constants/AllowedHtmlElements';
 import { isAriaOrDataAttribute } from '@/remote/elements/utils/isAriaOrDataAttribute';
 
-const ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME: Record<string, string> = {
-  className: 'className',
-  class: 'className',
+const ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME = new Map<string, string>([
+  ['className', 'className'],
+  ['class', 'className'],
 
-  htmlFor: 'htmlFor',
-  for: 'htmlFor',
+  ['htmlFor', 'htmlFor'],
+  ['for', 'htmlFor'],
 
-  tabIndex: 'tabIndex',
-  tabindex: 'tabIndex',
+  ['tabIndex', 'tabIndex'],
+  ['tabindex', 'tabIndex'],
 
-  srcDoc: 'srcDoc',
-  srcdoc: 'srcDoc',
-};
+  ['srcDoc', 'srcDoc'],
+  ['srcdoc', 'srcDoc'],
+]);
 
 type RemoteElementWithAttributeUpdater = Element &
   Record<string, unknown> & {
@@ -53,7 +53,7 @@ export const patchRemoteElementAttributes = (): void => {
       attributeName: string,
     ) {
       const mappedElementPropertyName =
-        ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME[attributeName];
+        ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME.get(attributeName);
 
       if (isDefined(mappedElementPropertyName)) {
         const elementPropertyValue = this[mappedElementPropertyName];
@@ -64,6 +64,24 @@ export const patchRemoteElementAttributes = (): void => {
       }
 
       return originalGetAttribute.call(this, attributeName);
+    };
+
+    const originalHasAttribute = elementConstructor.prototype.hasAttribute as (
+      attributeName: string,
+    ) => boolean;
+
+    elementConstructor.prototype.hasAttribute = function (
+      this: RemoteElementWithAttributeUpdater,
+      attributeName: string,
+    ) {
+      const mappedElementPropertyName =
+        ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME.get(attributeName);
+
+      if (isDefined(mappedElementPropertyName)) {
+        return isDefined(this[mappedElementPropertyName]);
+      }
+
+      return originalHasAttribute.call(this, attributeName);
     };
 
     const originalSetAttribute = elementConstructor.prototype.setAttribute as (
@@ -77,9 +95,9 @@ export const patchRemoteElementAttributes = (): void => {
       attributeValue: string,
     ) {
       const mappedElementPropertyName =
-        ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME[attributeName];
+        ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME.get(attributeName);
 
-      if (mappedElementPropertyName) {
+      if (isDefined(mappedElementPropertyName)) {
         this[mappedElementPropertyName] = attributeValue;
 
         return;
@@ -100,9 +118,9 @@ export const patchRemoteElementAttributes = (): void => {
       attributeName: string,
     ) {
       const mappedElementPropertyName =
-        ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME[attributeName];
+        ATTRIBUTE_NAME_TO_ELEMENT_PROPERTY_NAME.get(attributeName);
 
-      if (mappedElementPropertyName) {
+      if (isDefined(mappedElementPropertyName)) {
         this[mappedElementPropertyName] = undefined;
 
         return;

--- a/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
+++ b/packages/twenty-front-component-renderer/src/remote/elements/utils/patchRemoteElementAttributes.ts
@@ -22,20 +22,23 @@ type RemoteElementWithAttributeUpdater = Element &
     updateRemoteAttribute: (attributeName: string, value?: string) => void;
   };
 
+type RemoteElementConstructor = CustomElementConstructor & {
+  observedAttributes?: string[];
+  prototype: RemoteElementWithAttributeUpdater;
+};
+
 export const patchRemoteElementAttributes = (): void => {
   for (const allowedHtmlElement of ALLOWED_HTML_ELEMENTS) {
-    const elementConstructor = customElements.get(allowedHtmlElement.tag);
+    const elementConstructor = customElements.get(allowedHtmlElement.tag) as
+      | RemoteElementConstructor
+      | undefined;
 
-    if (!elementConstructor) {
+    if (!isDefined(elementConstructor)) {
       continue;
     }
 
     const attributeNamesAlreadySyncedByRemoteDom = new Set<string>(
-      (
-        elementConstructor as CustomElementConstructor & {
-          observedAttributes?: string[];
-        }
-      ).observedAttributes ?? [],
+      elementConstructor.observedAttributes ?? [],
     );
 
     const shouldForwardAttributeAcrossBoundary = (
@@ -44,9 +47,7 @@ export const patchRemoteElementAttributes = (): void => {
       isAriaOrDataAttribute(attributeName) &&
       !attributeNamesAlreadySyncedByRemoteDom.has(attributeName);
 
-    const originalGetAttribute = elementConstructor.prototype.getAttribute as (
-      attributeName: string,
-    ) => string | null;
+    const originalGetAttribute = elementConstructor.prototype.getAttribute;
 
     elementConstructor.prototype.getAttribute = function (
       this: RemoteElementWithAttributeUpdater,
@@ -66,9 +67,7 @@ export const patchRemoteElementAttributes = (): void => {
       return originalGetAttribute.call(this, attributeName);
     };
 
-    const originalHasAttribute = elementConstructor.prototype.hasAttribute as (
-      attributeName: string,
-    ) => boolean;
+    const originalHasAttribute = elementConstructor.prototype.hasAttribute;
 
     elementConstructor.prototype.hasAttribute = function (
       this: RemoteElementWithAttributeUpdater,
@@ -84,10 +83,7 @@ export const patchRemoteElementAttributes = (): void => {
       return originalHasAttribute.call(this, attributeName);
     };
 
-    const originalSetAttribute = elementConstructor.prototype.setAttribute as (
-      attributeName: string,
-      attributeValue: string,
-    ) => void;
+    const originalSetAttribute = elementConstructor.prototype.setAttribute;
 
     elementConstructor.prototype.setAttribute = function (
       this: RemoteElementWithAttributeUpdater,
@@ -110,8 +106,8 @@ export const patchRemoteElementAttributes = (): void => {
       }
     };
 
-    const originalRemoveAttribute = elementConstructor.prototype
-      .removeAttribute as (attributeName: string) => void;
+    const originalRemoveAttribute =
+      elementConstructor.prototype.removeAttribute;
 
     elementConstructor.prototype.removeAttribute = function (
       this: RemoteElementWithAttributeUpdater,


### PR DESCRIPTION
Remote elements redirect `setAttribute` for `class`, `for`, `tabindex`, and `srcdoc` into property assignments, so the attribute is never set and `getAttribute('class')` returns `null`. Consumers work around it with `className` fallbacks.

This patches `getAttribute`, `hasAttribute`, and `getAttributeNames` with the same attribute-to-property map, so all three read the mapped value. Serialization still ignores them. #24191 is stacked on this and drops its fallback.
