### PR TITLE
fix(server): resolve morph join column when walking relations to person

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/__tests__/find-relation-paths-to-person.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/__tests__/find-relation-paths-to-person.util.spec.ts
@@ -1,30 +1,62 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { resolveRelationFromFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/resolve-relation-from-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { findRelationPathsToPerson } from 'src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util';
-
-jest.mock(
-  'src/engine/metadata-modules/flat-field-metadata/utils/resolve-relation-from-flat-field-metadata.util',
-);
-
-const resolveRelationMock = jest.mocked(resolveRelationFromFlatFieldMetadata);
 
 type RelationSpec = {
   fieldName: string;
   relationType: RelationType;
   targetObjectNameSingular: string;
   inverseFieldName: string;
+  morphId?: string;
 };
+
+const fieldId = (objectNameSingular: string, fieldName: string) =>
+  `${objectNameSingular}.${fieldName}`;
+
+const invertRelationType = (relationType: RelationType) =>
+  relationType === RelationType.MANY_TO_ONE
+    ? RelationType.ONE_TO_MANY
+    : RelationType.MANY_TO_ONE;
 
 const buildGraphFixtures = (
   graph: Record<string, RelationSpec[]>,
   options: { systemObjectNames?: string[] } = {},
 ) => {
   const systemObjectNames = options.systemObjectNames ?? [];
-  const fieldId = (objectNameSingular: string, fieldName: string) =>
-    `${objectNameSingular}.${fieldName}`;
+  const specsByObjectNameSingular = Object.fromEntries(
+    Object.entries(graph).map(([objectNameSingular, relationSpecs]) => [
+      objectNameSingular,
+      [...relationSpecs],
+    ]),
+  );
+
+  for (const [objectNameSingular, relationSpecs] of Object.entries(graph)) {
+    for (const spec of relationSpecs) {
+      const inverseSpecs =
+        specsByObjectNameSingular[spec.targetObjectNameSingular];
+
+      if (
+        !isDefined(inverseSpecs) ||
+        inverseSpecs.some(
+          (inverseSpec) => inverseSpec.fieldName === spec.inverseFieldName,
+        )
+      ) {
+        continue;
+      }
+
+      inverseSpecs.push({
+        fieldName: spec.inverseFieldName,
+        relationType: invertRelationType(spec.relationType),
+        targetObjectNameSingular: objectNameSingular,
+        inverseFieldName: spec.fieldName,
+      });
+    }
+  }
 
   const flatObjectMetadataMaps = {
     byUniversalIdentifier: {},
@@ -36,15 +68,15 @@ const buildGraphFixtures = (
     universalIdentifierById: {},
   } as unknown as FlatEntityMaps<FlatFieldMetadata>;
 
-  const relationSpecByFieldId = new Map<
-    string,
-    { sourceObjectNameSingular: string; spec: RelationSpec }
-  >();
-
-  for (const [objectNameSingular, relationSpecs] of Object.entries(graph)) {
+  for (const [objectNameSingular, relationSpecs] of Object.entries(
+    specsByObjectNameSingular,
+  )) {
     flatObjectMetadataMaps.byUniversalIdentifier[objectNameSingular] = {
       id: objectNameSingular,
+      universalIdentifier: objectNameSingular,
       nameSingular: objectNameSingular,
+      namePlural: `${objectNameSingular}s`,
+      isSystem: systemObjectNames.includes(objectNameSingular),
       fieldIds: relationSpecs.map((spec) =>
         fieldId(objectNameSingular, spec.fieldName),
       ),
@@ -57,48 +89,28 @@ const buildGraphFixtures = (
 
       flatFieldMetadataMaps.byUniversalIdentifier[id] = {
         id,
-        type: 'RELATION',
+        universalIdentifier: id,
+        name: spec.fieldName,
+        objectMetadataId: objectNameSingular,
+        type: isDefined(spec.morphId)
+          ? FieldMetadataType.MORPH_RELATION
+          : FieldMetadataType.RELATION,
+        morphId: spec.morphId ?? null,
+        isActive: true,
+        isSystem: false,
+        relationTargetFieldMetadataId: fieldId(
+          spec.targetObjectNameSingular,
+          spec.inverseFieldName,
+        ),
+        settings: { relationType: spec.relationType },
+        universalSettings: { relationType: spec.relationType },
       } as unknown as FlatFieldMetadata;
       flatFieldMetadataMaps.universalIdentifierById[id] = id;
-
-      relationSpecByFieldId.set(id, {
-        sourceObjectNameSingular: objectNameSingular,
-        spec,
-      });
     }
   }
 
-  resolveRelationMock.mockImplementation(({ sourceFlatFieldMetadata }) => {
-    const resolved = relationSpecByFieldId.get(sourceFlatFieldMetadata.id);
-
-    if (resolved === undefined) {
-      return null;
-    }
-
-    const { sourceObjectNameSingular, spec } = resolved;
-
-    return {
-      type: spec.relationType,
-      sourceObjectMetadata: {
-        id: sourceObjectNameSingular,
-        nameSingular: sourceObjectNameSingular,
-      },
-      targetObjectMetadata: {
-        id: spec.targetObjectNameSingular,
-        nameSingular: spec.targetObjectNameSingular,
-        isSystem: systemObjectNames.includes(spec.targetObjectNameSingular),
-      },
-      sourceFieldMetadata: { name: spec.fieldName },
-      targetFieldMetadata: { name: spec.inverseFieldName },
-    } as ReturnType<typeof resolveRelationFromFlatFieldMetadata>;
-  });
-
   return { flatObjectMetadataMaps, flatFieldMetadataMaps };
 };
-
-afterEach(() => {
-  resolveRelationMock.mockReset();
-});
 
 describe('findRelationPathsToPerson', () => {
   it('returns the empty path for the person object itself', () => {
@@ -261,6 +273,76 @@ describe('findRelationPathsToPerson', () => {
           direction: RelationType.ONE_TO_MANY,
           queryObjectNameSingular: 'person',
           joinColumnName: 'companyId',
+        },
+      ],
+    ]);
+  });
+
+  it('targets the morph field owning the join column rather than the morph group name', () => {
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      buildGraphFixtures({
+        note: [
+          {
+            fieldName: 'peopleWithLastActivityItem',
+            relationType: RelationType.ONE_TO_MANY,
+            targetObjectNameSingular: 'person',
+            inverseFieldName: 'lastActivityItemNote',
+          },
+        ],
+        task: [
+          {
+            fieldName: 'peopleWithLastActivityItem',
+            relationType: RelationType.ONE_TO_MANY,
+            targetObjectNameSingular: 'person',
+            inverseFieldName: 'lastActivityItemTask',
+          },
+        ],
+        person: [
+          {
+            fieldName: 'lastActivityItemNote',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'note',
+            inverseFieldName: 'peopleWithLastActivityItem',
+            morphId: 'lastActivityItem',
+          },
+          {
+            fieldName: 'lastActivityItemTask',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'task',
+            inverseFieldName: 'peopleWithLastActivityItem',
+            morphId: 'lastActivityItem',
+          },
+        ],
+      });
+
+    expect(
+      findRelationPathsToPerson({
+        rootObjectNameSingular: 'note',
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+      }),
+    ).toEqual([
+      [
+        {
+          direction: RelationType.ONE_TO_MANY,
+          queryObjectNameSingular: 'person',
+          joinColumnName: 'lastActivityItemNoteId',
+        },
+      ],
+    ]);
+
+    expect(
+      findRelationPathsToPerson({
+        rootObjectNameSingular: 'task',
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+      }),
+    ).toEqual([
+      [
+        {
+          direction: RelationType.ONE_TO_MANY,
+          queryObjectNameSingular: 'person',
+          joinColumnName: 'lastActivityItemTaskId',
         },
       ],
     ]);

--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/__tests__/find-relation-paths-to-person.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/__tests__/find-relation-paths-to-person.util.spec.ts
@@ -281,22 +281,8 @@ describe('findRelationPathsToPerson', () => {
   it('targets the morph field owning the join column rather than the morph group name', () => {
     const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
       buildGraphFixtures({
-        note: [
-          {
-            fieldName: 'peopleWithLastActivityItem',
-            relationType: RelationType.ONE_TO_MANY,
-            targetObjectNameSingular: 'person',
-            inverseFieldName: 'lastActivityItemNote',
-          },
-        ],
-        task: [
-          {
-            fieldName: 'peopleWithLastActivityItem',
-            relationType: RelationType.ONE_TO_MANY,
-            targetObjectNameSingular: 'person',
-            inverseFieldName: 'lastActivityItemTask',
-          },
-        ],
+        note: [],
+        task: [],
         person: [
           {
             fieldName: 'lastActivityItemNote',

--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util.ts
@@ -5,6 +5,7 @@ import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfa
 import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { resolveRelationFromFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/resolve-relation-from-flat-field-metadata.util';
@@ -87,14 +88,10 @@ export const findRelationPathsToPerson = ({
         const joinColumnOwnerFlatFieldMetadata =
           relation.type === RelationType.MANY_TO_ONE
             ? field
-            : findFlatEntityByIdInFlatEntityMaps({
+            : findFlatEntityByIdInFlatEntityMapsOrThrow({
                 flatEntityId: field.relationTargetFieldMetadataId,
                 flatEntityMaps: flatFieldMetadataMaps,
               });
-
-        if (!isDefined(joinColumnOwnerFlatFieldMetadata)) {
-          continue;
-        }
 
         const joinColumnOwnerObjectMetadata =
           relation.type === RelationType.MANY_TO_ONE

--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util.ts
@@ -84,24 +84,30 @@ export const findRelationPathsToPerson = ({
           continue;
         }
 
-        const joinColumnOwner =
+        const joinColumnOwnerFlatFieldMetadata =
           relation.type === RelationType.MANY_TO_ONE
-            ? {
-                object: relation.sourceObjectMetadata,
-                field: relation.sourceFieldMetadata,
-              }
-            : {
-                object: relation.targetObjectMetadata,
-                field: relation.targetFieldMetadata,
-              };
+            ? field
+            : findFlatEntityByIdInFlatEntityMaps({
+                flatEntityId: field.relationTargetFieldMetadataId,
+                flatEntityMaps: flatFieldMetadataMaps,
+              });
+
+        if (!isDefined(joinColumnOwnerFlatFieldMetadata)) {
+          continue;
+        }
+
+        const joinColumnOwnerObjectMetadata =
+          relation.type === RelationType.MANY_TO_ONE
+            ? relation.sourceObjectMetadata
+            : relation.targetObjectMetadata;
 
         const nextPath: RelationPathToPerson = [
           ...path,
           {
             direction: relation.type,
-            queryObjectNameSingular: joinColumnOwner.object.nameSingular,
+            queryObjectNameSingular: joinColumnOwnerObjectMetadata.nameSingular,
             joinColumnName: computeMorphOrRelationFieldJoinColumnName({
-              name: joinColumnOwner.field.name,
+              name: joinColumnOwnerFlatFieldMetadata.name,
             }),
           },
         ];


### PR DESCRIPTION
### Problem

`GetTimelineThreadsFromObjectRecord` throws for workspaces that have a morph relation to `person`:

```
Error: Field metadata for field "lastActivityItemId" is missing in object metadata person
```

107 occurrences over 11 users in production ([TWENTY-SERVER-HT8](https://twenty-v7.sentry.io/issues/TWENTY-SERVER-HT8)), across four different field/object pairs (`lastActivityItem`/person, `primaryRelation`/meeting, `source`/relationEconomique, `client`/opportunity). All four are morph group names. The whole timeline query fails, so the Emails/Calendar tab is empty for the affected records.

### Root cause

`findRelationPathsToPerson` built the hop's join column from `relation.targetFieldMetadata.name`, taken from the DTO returned by `resolveRelationFromFlatFieldMetadata`. For a morph target that DTO carries a name that no field actually has:

- the name is rewritten to the morph group name (`lastActivityItemNote` becomes `lastActivityItem`), and the join column lives on the per-target field, not on the group;
- the returned field is `pickMorphGroupSurvivorOrThrow(...)`, which can be a sibling of the morph group rather than the field the source relation points to.

So the walk queried `person` with `where: { lastActivityItemId: In(...) }`, no field metadata matched that key, and `formatData` threw.

Only `ONE_TO_MANY` hops were affected: `MANY_TO_ONE` hops take their name from the source field, which the traversal only ever visits when it is a plain `RELATION`.

### Fix

Read the join column owner from `flatFieldMetadataMaps` via `field.relationTargetFieldMetadataId` instead of the DTO, so the column always comes from the field that owns it. `MANY_TO_ONE` hops now use `field` directly rather than round-tripping through the DTO.

### Test

`find-relation-paths-to-person.util.spec.ts` mocked `resolveRelationFromFlatFieldMetadata` wholesale, which is why the morph naming was never exercised. The spec now builds real flat metadata (relation settings, `morphId`, `relationTargetFieldMetadataId`, synthesized inverse fields) and runs the real resolver.

New case covers a `lastActivityItem` morph group on `person` targeting `note` and `task`, asserting `lastActivityItemNoteId` / `lastActivityItemTaskId`. Without the fix it produces exactly the production string `lastActivityItemId`. The six existing cases are unchanged and still pass.

### Verified locally

On a dev instance running this branch: created a `Sentry Check` relation on Person targeting Company from the metadata API (lands as `sentryCheckCompany`, `MORPH_RELATION`), then queried `getTimelineThreadsFromObjectRecord` on a company record.

- pre-fix code: `Field metadata for field "sentryCheckId" is missing in object metadata person`
- with the fix: `totalNumberOfThreads: 1`, two related person ids

### Out of scope

Two related gaps left as is:

- morph fields are skipped on the source side of the traversal, so a direct morph relation to `person` is never followed and those people are missing from the timeline;
- one broken path fails the entire query rather than degrading.
