### PR TITLE
fix(server): ORM v2 rollout safety - rollback-proof transactions and a working flag rollback

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag.service.ts
@@ -10,6 +10,7 @@ import {
   FeatureFlagException,
   FeatureFlagExceptionCode,
 } from 'src/engine/core-modules/feature-flag/feature-flag.exception';
+import { getFeatureFlagCacheKeysToInvalidate } from 'src/engine/core-modules/feature-flag/utils/get-feature-flag-cache-keys-to-invalidate.util';
 import { featureFlagValidator } from 'src/engine/core-modules/feature-flag/validates/feature-flag.validate';
 import { publicFeatureFlagValidator } from 'src/engine/core-modules/feature-flag/validates/is-public-feature-flag.validate';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
@@ -72,9 +73,10 @@ export class FeatureFlagService {
         },
       );
 
-      await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
-        'featureFlagsMap',
-      ]);
+      await this.workspaceCacheService.invalidateAndRecompute(
+        workspaceId,
+        getFeatureFlagCacheKeysToInvalidate(keys),
+      );
     }
   }
 
@@ -113,9 +115,10 @@ export class FeatureFlagService {
       ['workspaceId', 'key'],
     );
 
-    await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
-      'featureFlagsMap',
-    ]);
+    await this.workspaceCacheService.invalidateAndRecompute(
+      workspaceId,
+      getFeatureFlagCacheKeysToInvalidate([featureFlag]),
+    );
 
     return result;
   }

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag.service.ts
@@ -109,6 +109,15 @@ export class FeatureFlagService {
       );
     }
 
+    const existingFeatureFlag = await this.featureFlagRepository.findOne(
+      workspaceId,
+      { where: { key: featureFlag } },
+    );
+
+    if (existingFeatureFlag?.value === value) {
+      return existingFeatureFlag;
+    }
+
     const result = await this.featureFlagRepository.upsertAndReturnOne(
       workspaceId,
       { key: featureFlag, value },

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/utils/__tests__/get-feature-flag-cache-keys-to-invalidate.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/utils/__tests__/get-feature-flag-cache-keys-to-invalidate.util.spec.ts
@@ -1,0 +1,36 @@
+import { FeatureFlagKey } from 'twenty-shared/types';
+
+import { getFeatureFlagCacheKeysToInvalidate } from 'src/engine/core-modules/feature-flag/utils/get-feature-flag-cache-keys-to-invalidate.util';
+
+describe('getFeatureFlagCacheKeysToInvalidate', () => {
+  it('should invalidate ORMEntityMetadatas when the ORM v2 flag changes', () => {
+    expect(
+      getFeatureFlagCacheKeysToInvalidate([
+        FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED,
+      ]),
+    ).toEqual(['featureFlagsMap', 'ORMEntityMetadatas']);
+  });
+
+  it('should invalidate ORMEntityMetadatas when the ORM v2 flag changes among others', () => {
+    expect(
+      getFeatureFlagCacheKeysToInvalidate([
+        FeatureFlagKey.IS_JSON_FILTER_ENABLED,
+        FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED,
+      ]),
+    ).toEqual(['featureFlagsMap', 'ORMEntityMetadatas']);
+  });
+
+  it('should only invalidate featureFlagsMap for unrelated flags', () => {
+    expect(
+      getFeatureFlagCacheKeysToInvalidate([
+        FeatureFlagKey.IS_JSON_FILTER_ENABLED,
+      ]),
+    ).toEqual(['featureFlagsMap']);
+  });
+
+  it('should only invalidate featureFlagsMap for an empty change set', () => {
+    expect(getFeatureFlagCacheKeysToInvalidate([])).toEqual([
+      'featureFlagsMap',
+    ]);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/utils/get-feature-flag-cache-keys-to-invalidate.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/utils/get-feature-flag-cache-keys-to-invalidate.util.ts
@@ -2,9 +2,6 @@ import { FeatureFlagKey } from 'twenty-shared/types';
 
 import { type WorkspaceCacheKeyName } from 'src/engine/workspace-cache/types/workspace-cache-key.type';
 
-// ORMEntityMetadatas computes from IS_ORM_V2_READ_PATH_ENABLED (it caches an
-// empty array for v2 workspaces), so flipping the flag must invalidate it too:
-// a stale empty entry makes every v1 query throw EntityMetadataNotFoundError.
 export const getFeatureFlagCacheKeysToInvalidate = (
   changedFeatureFlagKeys: FeatureFlagKey[],
 ): WorkspaceCacheKeyName[] => {

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/utils/get-feature-flag-cache-keys-to-invalidate.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/utils/get-feature-flag-cache-keys-to-invalidate.util.ts
@@ -1,0 +1,18 @@
+import { FeatureFlagKey } from 'twenty-shared/types';
+
+import { type WorkspaceCacheKeyName } from 'src/engine/workspace-cache/types/workspace-cache-key.type';
+
+// ORMEntityMetadatas computes from IS_ORM_V2_READ_PATH_ENABLED (it caches an
+// empty array for v2 workspaces), so flipping the flag must invalidate it too:
+// a stale empty entry makes every v1 query throw EntityMetadataNotFoundError.
+export const getFeatureFlagCacheKeysToInvalidate = (
+  changedFeatureFlagKeys: FeatureFlagKey[],
+): WorkspaceCacheKeyName[] => {
+  if (
+    changedFeatureFlagKeys.includes(FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED)
+  ) {
+    return ['featureFlagsMap', 'ORMEntityMetadatas'];
+  }
+
+  return ['featureFlagsMap'];
+};

--- a/packages/twenty-server/src/engine/twenty-orm-v2/datasource/__tests__/workspace-data-source-v2-transaction.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/datasource/__tests__/workspace-data-source-v2-transaction.spec.ts
@@ -1,0 +1,127 @@
+import { type Pool, type PoolClient } from 'pg';
+
+import { type ObjectsPermissionsByRoleId } from 'twenty-shared/types';
+
+import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
+import { WorkspaceDataSourceV2 } from 'src/engine/twenty-orm-v2/datasource/workspace-data-source-v2';
+
+const buildDataSource = (client: {
+  query: jest.Mock;
+  release: jest.Mock;
+}): WorkspaceDataSourceV2 =>
+  new WorkspaceDataSourceV2({
+    pool: {
+      connect: jest.fn().mockResolvedValue(client as unknown as PoolClient),
+    } as unknown as Pool,
+    internalContext: {} as WorkspaceInternalContext,
+    authContext: {} as WorkspaceAuthContext,
+    objectPermissionsByRoleId: {} as ObjectsPermissionsByRoleId,
+  });
+
+const buildClient = () => ({
+  query: jest.fn().mockResolvedValue({ rows: [] }),
+  release: jest.fn(),
+});
+
+describe('WorkspaceDataSourceV2.transaction', () => {
+  it('should wrap the work in BEGIN/COMMIT and release the client reusable', async () => {
+    const client = buildClient();
+    const dataSource = buildDataSource(client);
+
+    const result = await dataSource.transaction(async () => 'done');
+
+    expect(result).toBe('done');
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(client.query).toHaveBeenNthCalledWith(2, 'COMMIT');
+    expect(client.release).toHaveBeenCalledWith(false);
+  });
+
+  it('should roll back and rethrow the work error', async () => {
+    const client = buildClient();
+    const dataSource = buildDataSource(client);
+    const workError = new Error('Query read timeout');
+
+    await expect(
+      dataSource.transaction(async () => {
+        throw workError;
+      }),
+    ).rejects.toBe(workError);
+
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
+    expect(client.release).toHaveBeenCalledWith(false);
+  });
+
+  it('should rethrow the original error, not the rollback error, when ROLLBACK also fails', async () => {
+    const client = buildClient();
+    client.query.mockImplementation((statement: string) =>
+      statement === 'ROLLBACK'
+        ? Promise.reject(new Error('Query read timeout'))
+        : Promise.resolve({ rows: [] }),
+    );
+    const dataSource = buildDataSource(client);
+    const workError = new Error('original failure');
+
+    await expect(
+      dataSource.transaction(async () => {
+        throw workError;
+      }),
+    ).rejects.toBe(workError);
+  });
+
+  it('should destroy the connection instead of pooling it when ROLLBACK fails', async () => {
+    const client = buildClient();
+    client.query.mockImplementation((statement: string) =>
+      statement === 'ROLLBACK'
+        ? Promise.reject(new Error('Query read timeout'))
+        : Promise.resolve({ rows: [] }),
+    );
+    const dataSource = buildDataSource(client);
+
+    await expect(
+      dataSource.transaction(async () => {
+        throw new Error('original failure');
+      }),
+    ).rejects.toThrow('original failure');
+
+    expect(client.release).toHaveBeenCalledWith(true);
+  });
+
+  it('should rethrow a BEGIN failure and release the client reusable when ROLLBACK succeeds', async () => {
+    const client = buildClient();
+    const beginError = new Error('BEGIN failed');
+
+    client.query.mockImplementation((statement: string) =>
+      statement === 'BEGIN'
+        ? Promise.reject(beginError)
+        : Promise.resolve({ rows: [] }),
+    );
+    const dataSource = buildDataSource(client);
+    const work = jest.fn();
+
+    await expect(dataSource.transaction(work)).rejects.toBe(beginError);
+
+    expect(work).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
+    expect(client.release).toHaveBeenCalledWith(false);
+  });
+
+  it('should roll back when COMMIT fails and release the client reusable', async () => {
+    const client = buildClient();
+    const commitError = new Error('COMMIT failed');
+
+    client.query.mockImplementation((statement: string) =>
+      statement === 'COMMIT'
+        ? Promise.reject(commitError)
+        : Promise.resolve({ rows: [] }),
+    );
+    const dataSource = buildDataSource(client);
+
+    await expect(dataSource.transaction(async () => 'done')).rejects.toBe(
+      commitError,
+    );
+
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
+    expect(client.release).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm-v2/datasource/utils/__tests__/run-in-rollback-safe-transaction.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/datasource/utils/__tests__/run-in-rollback-safe-transaction.util.spec.ts
@@ -1,35 +1,25 @@
 import { type Pool, type PoolClient } from 'pg';
 
-import { type ObjectsPermissionsByRoleId } from 'twenty-shared/types';
-
-import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
-import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
-import { WorkspaceDataSourceV2 } from 'src/engine/twenty-orm-v2/datasource/workspace-data-source-v2';
-
-const buildDataSource = (client: {
-  query: jest.Mock;
-  release: jest.Mock;
-}): WorkspaceDataSourceV2 =>
-  new WorkspaceDataSourceV2({
-    pool: {
-      connect: jest.fn().mockResolvedValue(client as unknown as PoolClient),
-    } as unknown as Pool,
-    internalContext: {} as WorkspaceInternalContext,
-    authContext: {} as WorkspaceAuthContext,
-    objectPermissionsByRoleId: {} as ObjectsPermissionsByRoleId,
-  });
+import { runInRollbackSafeTransaction } from 'src/engine/twenty-orm-v2/datasource/utils/run-in-rollback-safe-transaction.util';
 
 const buildClient = () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   release: jest.fn(),
 });
 
-describe('WorkspaceDataSourceV2.transaction', () => {
+const buildPool = (client: ReturnType<typeof buildClient>): Pool =>
+  ({
+    connect: jest.fn().mockResolvedValue(client as unknown as PoolClient),
+  }) as unknown as Pool;
+
+describe('runInRollbackSafeTransaction', () => {
   it('should wrap the work in BEGIN/COMMIT and release the client reusable', async () => {
     const client = buildClient();
-    const dataSource = buildDataSource(client);
 
-    const result = await dataSource.transaction(async () => 'done');
+    const result = await runInRollbackSafeTransaction({
+      pool: buildPool(client),
+      work: async () => 'done',
+    });
 
     expect(result).toBe('done');
     expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
@@ -39,12 +29,14 @@ describe('WorkspaceDataSourceV2.transaction', () => {
 
   it('should roll back and rethrow the work error', async () => {
     const client = buildClient();
-    const dataSource = buildDataSource(client);
     const workError = new Error('Query read timeout');
 
     await expect(
-      dataSource.transaction(async () => {
-        throw workError;
+      runInRollbackSafeTransaction({
+        pool: buildPool(client),
+        work: async () => {
+          throw workError;
+        },
       }),
     ).rejects.toBe(workError);
 
@@ -54,33 +46,39 @@ describe('WorkspaceDataSourceV2.transaction', () => {
 
   it('should rethrow the original error, not the rollback error, when ROLLBACK also fails', async () => {
     const client = buildClient();
+
     client.query.mockImplementation((statement: string) =>
       statement === 'ROLLBACK'
         ? Promise.reject(new Error('Query read timeout'))
         : Promise.resolve({ rows: [] }),
     );
-    const dataSource = buildDataSource(client);
     const workError = new Error('original failure');
 
     await expect(
-      dataSource.transaction(async () => {
-        throw workError;
+      runInRollbackSafeTransaction({
+        pool: buildPool(client),
+        work: async () => {
+          throw workError;
+        },
       }),
     ).rejects.toBe(workError);
   });
 
   it('should destroy the connection instead of pooling it when ROLLBACK fails', async () => {
     const client = buildClient();
+
     client.query.mockImplementation((statement: string) =>
       statement === 'ROLLBACK'
         ? Promise.reject(new Error('Query read timeout'))
         : Promise.resolve({ rows: [] }),
     );
-    const dataSource = buildDataSource(client);
 
     await expect(
-      dataSource.transaction(async () => {
-        throw new Error('original failure');
+      runInRollbackSafeTransaction({
+        pool: buildPool(client),
+        work: async () => {
+          throw new Error('original failure');
+        },
       }),
     ).rejects.toThrow('original failure');
 
@@ -96,10 +94,11 @@ describe('WorkspaceDataSourceV2.transaction', () => {
         ? Promise.reject(beginError)
         : Promise.resolve({ rows: [] }),
     );
-    const dataSource = buildDataSource(client);
     const work = jest.fn();
 
-    await expect(dataSource.transaction(work)).rejects.toBe(beginError);
+    await expect(
+      runInRollbackSafeTransaction({ pool: buildPool(client), work }),
+    ).rejects.toBe(beginError);
 
     expect(work).not.toHaveBeenCalled();
     expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
@@ -115,11 +114,13 @@ describe('WorkspaceDataSourceV2.transaction', () => {
         ? Promise.reject(commitError)
         : Promise.resolve({ rows: [] }),
     );
-    const dataSource = buildDataSource(client);
 
-    await expect(dataSource.transaction(async () => 'done')).rejects.toBe(
-      commitError,
-    );
+    await expect(
+      runInRollbackSafeTransaction({
+        pool: buildPool(client),
+        work: async () => 'done',
+      }),
+    ).rejects.toBe(commitError);
 
     expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
     expect(client.release).toHaveBeenCalledWith(false);

--- a/packages/twenty-server/src/engine/twenty-orm-v2/datasource/utils/run-in-rollback-safe-transaction.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/datasource/utils/run-in-rollback-safe-transaction.util.ts
@@ -1,0 +1,44 @@
+import { Logger } from '@nestjs/common';
+
+import { type Pool, type PoolClient } from 'pg';
+
+const logger = new Logger('runInRollbackSafeTransaction');
+
+export const runInRollbackSafeTransaction = async <T>({
+  pool,
+  work,
+}: {
+  pool: Pool;
+  work: (client: PoolClient) => Promise<T>;
+}): Promise<T> => {
+  const client = await pool.connect();
+  let shouldDestroyConnection = false;
+
+  try {
+    await client.query('BEGIN');
+
+    const result = await work(client);
+
+    await client.query('COMMIT');
+
+    return result;
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackError) {
+      shouldDestroyConnection = true;
+
+      logger.warn(
+        `Destroying connection after failed transaction ROLLBACK: ${
+          rollbackError instanceof Error
+            ? rollbackError.message
+            : String(rollbackError)
+        }`,
+      );
+    }
+
+    throw error;
+  } finally {
+    client.release(shouldDestroyConnection);
+  }
+};

--- a/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
@@ -1,5 +1,3 @@
-import { Logger } from '@nestjs/common';
-
 import { type Pool } from 'pg';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -17,6 +15,7 @@ import {
   TwentyOrmV2Exception,
   TwentyOrmV2ExceptionCode,
 } from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
+import { runInRollbackSafeTransaction } from 'src/engine/twenty-orm-v2/datasource/utils/run-in-rollback-safe-transaction.util';
 import { WorkspaceRepositoryV2 } from 'src/engine/twenty-orm-v2/repository/workspace-repository-v2';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
 import { buildWorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/utils/build-workspace-table-shape.util';
@@ -39,7 +38,6 @@ export type WorkspaceTransactionScopeV2 = {
 };
 
 export class WorkspaceDataSourceV2 {
-  private readonly logger = new Logger(WorkspaceDataSourceV2.name);
   private readonly pool: Pool;
   private readonly internalContext: WorkspaceInternalContext;
   private readonly authContext: WorkspaceAuthContext;
@@ -94,39 +92,10 @@ export class WorkspaceDataSourceV2 {
   private async runInClientTransaction<T>(
     work: (executor: QueryExecutorV2) => Promise<T>,
   ): Promise<T> {
-    const client = await this.pool.connect();
-    let shouldDestroyConnection = false;
-
-    try {
-      await client.query('BEGIN');
-
-      const result = await work(new ClientQueryExecutor({ client }));
-
-      await client.query('COMMIT');
-
-      return result;
-    } catch (error) {
-      try {
-        await client.query('ROLLBACK');
-      } catch (rollbackError) {
-        // The transaction may still be open on the server; releasing the client
-        // back to the shared pool would let a later checkout commit the aborted
-        // work. Destroy the connection and surface the original error.
-        shouldDestroyConnection = true;
-
-        this.logger.warn(
-          `Destroying connection after failed transaction ROLLBACK: ${
-            rollbackError instanceof Error
-              ? rollbackError.message
-              : String(rollbackError)
-          }`,
-        );
-      }
-
-      throw error;
-    } finally {
-      client.release(shouldDestroyConnection);
-    }
+    return runInRollbackSafeTransaction({
+      pool: this.pool,
+      work: (client) => work(new ClientQueryExecutor({ client })),
+    });
   }
 
   private buildRepository({

--- a/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@nestjs/common';
+
 import { type Pool } from 'pg';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -37,6 +39,7 @@ export type WorkspaceTransactionScopeV2 = {
 };
 
 export class WorkspaceDataSourceV2 {
+  private readonly logger = new Logger(WorkspaceDataSourceV2.name);
   private readonly pool: Pool;
   private readonly internalContext: WorkspaceInternalContext;
   private readonly authContext: WorkspaceAuthContext;
@@ -92,6 +95,7 @@ export class WorkspaceDataSourceV2 {
     work: (executor: QueryExecutorV2) => Promise<T>,
   ): Promise<T> {
     const client = await this.pool.connect();
+    let shouldDestroyConnection = false;
 
     try {
       await client.query('BEGIN');
@@ -102,11 +106,26 @@ export class WorkspaceDataSourceV2 {
 
       return result;
     } catch (error) {
-      await client.query('ROLLBACK');
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackError) {
+        // The transaction may still be open on the server; releasing the client
+        // back to the shared pool would let a later checkout commit the aborted
+        // work. Destroy the connection and surface the original error.
+        shouldDestroyConnection = true;
+
+        this.logger.warn(
+          `Destroying connection after failed transaction ROLLBACK: ${
+            rollbackError instanceof Error
+              ? rollbackError.message
+              : String(rollbackError)
+          }`,
+        );
+      }
 
       throw error;
     } finally {
-      client.release();
+      client.release(shouldDestroyConnection);
     }
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.module.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { TwentyConfigModule } from 'src/engine/core-modules/twenty-config/twenty-config.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
@@ -16,6 +17,7 @@ import { GlobalWorkspaceDataSourceService } from 'src/engine/twenty-orm/global-w
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { WorkspaceORMEntityMetadatasCacheService } from 'src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service';
 import { TwentyORMModule } from 'src/engine/twenty-orm/twenty-orm.module';
+import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 import { TwentyORMV2Module } from 'src/engine/twenty-orm-v2/twenty-orm-v2.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -30,6 +32,7 @@ import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/
       ObjectMetadataEntity,
       FieldMetadataEntity,
       ApplicationEntity,
+      FeatureFlagEntity,
     ]),
     WorkspaceCacheStorageModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
@@ -47,6 +50,7 @@ import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/
     EntitySchemaColumnFactory,
     EntitySchemaRelationFactory,
     WorkspaceORMEntityMetadatasCacheService,
+    provideWorkspaceScopedRepository(FeatureFlagEntity),
   ],
   exports: [GlobalWorkspaceDataSourceService, GlobalWorkspaceOrmManager],
 })

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
@@ -11,13 +11,15 @@ import { EntityMetadataBuilder } from 'typeorm/metadata-builder/EntityMetadataBu
 import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
 
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { EntitySchemaFactory } from 'src/engine/twenty-orm/factories/entity-schema.factory';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildEntitySchemaMetadataMaps } from 'src/engine/twenty-orm/global-workspace-datasource/types/entity-schema-metadata.type';
+import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
+import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
-import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 @Injectable()
 @WorkspaceCache('ORMEntityMetadatas', {
@@ -34,20 +36,24 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
     private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
     @InjectRepository(ApplicationEntity)
     private readonly applicationRepository: Repository<ApplicationEntity>,
+    @InjectWorkspaceScopedRepository(FeatureFlagEntity)
+    private readonly featureFlagRepository: WorkspaceScopedRepository<FeatureFlagEntity>,
     private readonly entitySchemaFactory: EntitySchemaFactory,
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-    private readonly workspaceCacheService: WorkspaceCacheService,
   ) {
     super();
   }
 
   async computeForCache(workspaceId: string): Promise<EntityMetadata[]> {
-    const { featureFlagsMap } = await this.workspaceCacheService.getOrRecompute(
+    // Read the flag row directly: the cached featureFlagsMap can be stale for
+    // seconds after a flip, and a recompute that reads it would store an empty
+    // entry under a hash that validates as current on a v1 workspace.
+    const ormV2FeatureFlag = await this.featureFlagRepository.findOne(
       workspaceId,
-      ['featureFlagsMap'],
+      { where: { key: FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED } },
     );
 
-    if (featureFlagsMap[FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED]) {
+    if (ormV2FeatureFlag?.value === true) {
       return [];
     }
 

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
@@ -45,15 +45,12 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
   }
 
   async computeForCache(workspaceId: string): Promise<EntityMetadata[]> {
-    // Read the flag row directly: the cached featureFlagsMap can be stale for
-    // seconds after a flip, and a recompute that reads it would store an empty
-    // entry under a hash that validates as current on a v1 workspace.
     const ormV2FeatureFlag = await this.featureFlagRepository.findOne(
       workspaceId,
       { where: { key: FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED } },
     );
 
-    if (ormV2FeatureFlag?.value === true) {
+    if (ormV2FeatureFlag?.value) {
       return [];
     }
 


### PR DESCRIPTION
## Context

A review of the ORM v2 rollout surfaced two failure modes that both undermine the safety rails of the migration itself. Both are fixed here; neither changes any happy-path behavior.

## 1. Transaction rollback could poison the shared pool

`WorkspaceDataSourceV2.runInClientTransaction` did:

```ts
catch (error) {
  await client.query('ROLLBACK');
  throw error;
} finally {
  client.release();
}
```

Verified against the vendored `pg` 8.x / `pg-pool` 3.6 sources:

- If ROLLBACK rejects, its rejection propagates from the `catch` before `throw error` runs, so the rollback failure **masks the original error**. TypeORM's `EntityManager.transaction` (the v1 path) explicitly guards against this.
- `client.release()` with no argument returns the client to the pool unless the connection is dead. But `pg`'s client-side `query_timeout` (the only timeout the v2 pool sets) neither cancels the server-side statement nor closes the connection, and a ROLLBACK that times out is spliced from the query queue **unsent**. Sequence: a slow mutation (a `mergeMany` FK repoint, a sync batch write) times out → ROLLBACK queues behind the still-running statement and also times out → the client is idled in the pool with `BEGIN` still open while the server finishes the mutation inside it. The pool is shared across tenants: the next checkout's `BEGIN` is a no-op warning and its `COMMIT` **durably commits the aborted work**.

The `PoolQueryExecutor` path was never exposed (`pool.query` releases with the error, destroying the client); only the transaction path was.

Fix: the choreography now lives in `runInRollbackSafeTransaction` (`datasource/utils/`). A ROLLBACK failure marks the client for destruction — `release(true)` ends the socket, so Postgres aborts the open transaction — logs a warning, and the original error is rethrown on every path. The util spec pins the BEGIN-failure, COMMIT-failure, ROLLBACK-failure and success choreographies (`release(false)` vs `release(true)`, original-error preservation).

## 2. Turning the flag OFF did not actually roll back

`ORMEntityMetadatas` caches `[]` for `IS_ORM_V2_READ_PATH_ENABLED` workspaces (the EntityMetadata build is skipped on v2, #24219). No feature-flag write invalidated that entry. So:

1. Any metadata migration on a flag-ON workspace recomputes the entry to `[]` under a fresh hash.
2. v2 misbehaves; the flag is turned OFF via the admin panel — the emergency lever.
3. Every v1 query on that workspace now throws `EntityMetadataNotFoundError` (500s) until an unrelated migration happens to recompute the cache.

Two changes, closing two distinct holes:

- **Writer side**: `FeatureFlagService` invalidates `ORMEntityMetadatas` alongside `featureFlagsMap` when the ORM v2 flag is among the changed keys (`getFeatureFlagCacheKeysToInvalidate`, unit-tested). All production flag writes route through this service (admin panel, lab, workspace activation, upgrade commands — verified by enumeration). Scoped to the ORM flag so lab toggles of unrelated public flags don't evict multi-MB ORM graphs fleet-wide.
- **Provider side**: `WorkspaceORMEntityMetadatasCacheService.computeForCache` reads the flag row directly from the database instead of through the cached `featureFlagsMap`. The cached map can be stale for seconds after a flip (100ms local TTL + 10s promise memoizer, neither hash-validated), and an adversarial re-check of the writer-side fix alone found a concrete re-poisoning path: a hash-mismatch recompute on a *non-flipping* pod reads the stale map, computes `[]`, and adopts the freshly minted hash — after which it validates as current indefinitely. Deriving from DB state makes the recompute correct whenever it runs, closing that race and the same-pod invalidation window.

The flag flip in the ON direction also invalidates now, which frees the ~5MB per-workspace EntityMetadata graph that previously lingered until an unrelated invalidation.

## Test plan

- `npx jest src/engine/twenty-orm-v2/datasource src/engine/core-modules/feature-flag/utils` — 10 pass (6 transaction choreography on the util, 4 invalidation-key selection).
- `nx typecheck twenty-server`, `oxlint`, `oxfmt` clean.
- Both fixes re-reviewed adversarially after implementation; the provider-side DB read exists because that second pass refuted the writer-side fix as sufficient on its own.
- Not exercised against a live multi-pod deployment; the pool-poisoning and cache-adoption sequences are traced from the vendored library sources, not reproduced.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


