### PR TITLE
Fix dashboard duplication rejecting relation-traversal chart filters

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/dashboard/components/DuplicateDashboardSingleRecordCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/dashboard/components/DuplicateDashboardSingleRecordCommand.tsx
@@ -14,7 +14,7 @@ export const DuplicateDashboardSingleRecordCommand = () => {
   const recordId = selectedRecords[0]?.id;
   const { duplicateDashboard } = useDuplicateDashboard();
   const navigate = useNavigateApp();
-  const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
+  const { enqueueSuccessSnackBar } = useSnackBar();
   const { t } = useLingui();
 
   if (!isDefined(recordId)) {
@@ -32,10 +32,6 @@ export const DuplicateDashboardSingleRecordCommand = () => {
       navigate(AppPath.RecordShowPage, {
         objectNameSingular: CoreObjectNameSingular.Dashboard,
         objectRecordId: result.id,
-      });
-    } else {
-      enqueueErrorSnackBar({
-        message: t`Failed to duplicate dashboard`,
       });
     }
   };

--- a/packages/twenty-front/src/modules/dashboards/hooks/useDuplicateDashboard.ts
+++ b/packages/twenty-front/src/modules/dashboards/hooks/useDuplicateDashboard.ts
@@ -1,15 +1,19 @@
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
+import { useMetadataErrorHandler } from '@/metadata-error-handler/hooks/useMetadataErrorHandler';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { useCreateOneRecordInCache } from '@/object-record/cache/hooks/useCreateOneRecordInCache';
 import { getObjectTypename } from '@/object-record/cache/utils/getObjectTypename';
 import { getRecordNodeFromRecord } from '@/object-record/cache/utils/getRecordNodeFromRecord';
 import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
 import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
-import { isDefined } from 'twenty-shared/utils';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
+import { CoreObjectNameSingular, CrudOperationType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 import { DuplicateDashboardDocument } from '~/generated-metadata/graphql';
 
 export const useDuplicateDashboard = () => {
@@ -27,42 +31,58 @@ export const useDuplicateDashboard = () => {
 
   const [mutate] = useMutation(DuplicateDashboardDocument);
 
+  const { handleMetadataError } = useMetadataErrorHandler();
+  const { enqueueErrorSnackBar } = useSnackBar();
+
   const duplicateDashboard = async (dashboardId: string) => {
-    const result = await mutate({
-      variables: { id: dashboardId },
-      update: (cache, { data }) => {
-        const record = data?.duplicateDashboard;
+    try {
+      const result = await mutate({
+        variables: { id: dashboardId },
+        update: (cache, { data }) => {
+          const record = data?.duplicateDashboard;
 
-        if (!isDefined(record)) return;
+          if (!isDefined(record)) return;
 
-        const createdRecord: ObjectRecord = {
-          ...record,
-          __typename: getObjectTypename(CoreObjectNameSingular.Dashboard),
-        };
+          const createdRecord: ObjectRecord = {
+            ...record,
+            __typename: getObjectTypename(CoreObjectNameSingular.Dashboard),
+          };
 
-        createOneRecordInCache(createdRecord);
+          createOneRecordInCache(createdRecord);
 
-        const recordNode = getRecordNodeFromRecord({
-          objectMetadataItem,
-          objectMetadataItems,
-          record: createdRecord,
-          computeReferences: false,
-        });
-
-        if (isDefined(recordNode)) {
-          triggerCreateRecordsOptimisticEffect({
-            cache,
+          const recordNode = getRecordNodeFromRecord({
             objectMetadataItem,
-            recordsToCreate: [recordNode],
             objectMetadataItems,
-            objectPermissionsByObjectMetadataId,
-            upsertRecordsInStore,
+            record: createdRecord,
+            computeReferences: false,
           });
-        }
-      },
-    });
 
-    return result?.data?.duplicateDashboard;
+          if (isDefined(recordNode)) {
+            triggerCreateRecordsOptimisticEffect({
+              cache,
+              objectMetadataItem,
+              recordsToCreate: [recordNode],
+              objectMetadataItems,
+              objectPermissionsByObjectMetadataId,
+              upsertRecordsInStore,
+            });
+          }
+        },
+      });
+
+      return result?.data?.duplicateDashboard;
+    } catch (error) {
+      if (CombinedGraphQLErrors.is(error)) {
+        handleMetadataError(error, {
+          primaryMetadataName: 'pageLayoutWidget',
+          operationType: CrudOperationType.CREATE,
+        });
+      } else {
+        enqueueErrorSnackBar({ message: t`Failed to duplicate dashboard` });
+      }
+
+      return undefined;
+    }
   };
 
   return {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/utils/__tests__/from-page-layout-widget-configuration-to-universal-configuration.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/utils/__tests__/from-page-layout-widget-configuration-to-universal-configuration.util.spec.ts
@@ -1,0 +1,87 @@
+import {
+  type UniversalChartFilter,
+  ViewFilterOperand,
+} from 'twenty-shared/types';
+
+import { fromPageLayoutWidgetConfigurationToUniversalConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/utils/from-page-layout-widget-configuration-to-universal-configuration.util';
+import { type PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+
+const RELATION_FIELD_ID = '11111111-1111-4111-8111-000000000001';
+const RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-1111-4111-8111-000000000001';
+const TARGET_TEXT_FIELD_ID = '11111111-2222-4222-8222-000000000002';
+const TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-2222-4222-8222-000000000002';
+const AGGREGATE_FIELD_ID = '11111111-3333-4333-8333-000000000003';
+const AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-3333-4333-8333-000000000003';
+const DELETED_FIELD_ID = '11111111-9999-4999-8999-000000000009';
+
+const fieldMetadataUniversalIdentifierById = {
+  [RELATION_FIELD_ID]: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+  [TARGET_TEXT_FIELD_ID]: TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+  [AGGREGATE_FIELD_ID]: AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER,
+};
+
+const getUniversalRecordFilters = (
+  recordFilters: {
+    fieldMetadataId: string;
+    relationTargetFieldMetadataId?: string;
+    operand: string;
+    value: string;
+  }[],
+) => {
+  const universalConfiguration =
+    fromPageLayoutWidgetConfigurationToUniversalConfiguration({
+      configuration: {
+        configurationType: WidgetConfigurationType.AGGREGATE_CHART,
+        aggregateFieldMetadataId: AGGREGATE_FIELD_ID,
+        aggregateOperation: 'SUM',
+        displayType: 'number',
+        filter: { recordFilters },
+      } as unknown as PageLayoutWidgetEntity['configuration'],
+      fieldMetadataUniversalIdentifierById,
+    });
+
+  return (universalConfiguration as unknown as { filter: UniversalChartFilter })
+    .filter.recordFilters;
+};
+
+describe('fromPageLayoutWidgetConfigurationToUniversalConfiguration', () => {
+  it('should convert the relation target field id of a relation-traversal chart filter to its universal identifier', () => {
+    const recordFilters = getUniversalRecordFilters([
+      {
+        fieldMetadataId: RELATION_FIELD_ID,
+        relationTargetFieldMetadataId: TARGET_TEXT_FIELD_ID,
+        operand: ViewFilterOperand.DOES_NOT_CONTAIN,
+        value: 'foo',
+      },
+    ]);
+
+    expect(recordFilters).toEqual([
+      {
+        fieldMetadataUniversalIdentifier: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+        relationTargetFieldMetadataUniversalIdentifier:
+          TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.DOES_NOT_CONTAIN,
+        value: 'foo',
+      },
+    ]);
+  });
+
+  it('should resolve a deleted relation target field to null instead of throwing', () => {
+    const recordFilters = getUniversalRecordFilters([
+      {
+        fieldMetadataId: RELATION_FIELD_ID,
+        relationTargetFieldMetadataId: DELETED_FIELD_ID,
+        operand: ViewFilterOperand.DOES_NOT_CONTAIN,
+        value: 'foo',
+      },
+    ]);
+
+    expect(
+      recordFilters?.[0].relationTargetFieldMetadataUniversalIdentifier,
+    ).toBeNull();
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/utils/__tests__/from-page-layout-widget-configuration-to-universal-configuration.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/utils/__tests__/from-page-layout-widget-configuration-to-universal-configuration.util.spec.ts
@@ -1,10 +1,11 @@
 import {
+  AggregateOperations,
+  type ChartFilter,
   type UniversalChartFilter,
   ViewFilterOperand,
 } from 'twenty-shared/types';
 
 import { fromPageLayoutWidgetConfigurationToUniversalConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/utils/from-page-layout-widget-configuration-to-universal-configuration.util';
-import { type PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 
 const RELATION_FIELD_ID = '11111111-1111-4111-8111-000000000001';
@@ -25,27 +26,27 @@ const fieldMetadataUniversalIdentifierById = {
 };
 
 const getUniversalRecordFilters = (
-  recordFilters: {
-    fieldMetadataId: string;
-    relationTargetFieldMetadataId?: string;
-    operand: string;
-    value: string;
-  }[],
-) => {
+  recordFilters: NonNullable<ChartFilter['recordFilters']>,
+): UniversalChartFilter['recordFilters'] => {
   const universalConfiguration =
     fromPageLayoutWidgetConfigurationToUniversalConfiguration({
       configuration: {
         configurationType: WidgetConfigurationType.AGGREGATE_CHART,
         aggregateFieldMetadataId: AGGREGATE_FIELD_ID,
-        aggregateOperation: 'SUM',
-        displayType: 'number',
+        aggregateOperation: AggregateOperations.SUM,
         filter: { recordFilters },
-      } as unknown as PageLayoutWidgetEntity['configuration'],
+      },
       fieldMetadataUniversalIdentifierById,
     });
 
-  return (universalConfiguration as unknown as { filter: UniversalChartFilter })
-    .filter.recordFilters;
+  if (
+    universalConfiguration.configurationType !==
+    WidgetConfigurationType.AGGREGATE_CHART
+  ) {
+    throw new Error('Expected an aggregate chart universal configuration');
+  }
+
+  return universalConfiguration.filter?.recordFilters;
 };
 
 describe('fromPageLayoutWidgetConfigurationToUniversalConfiguration', () => {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/utils/from-page-layout-widget-configuration-to-universal-configuration.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/utils/from-page-layout-widget-configuration-to-universal-configuration.util.ts
@@ -58,13 +58,23 @@ const convertChartFilterToUniversalFilter = ({
   return {
     ...filter,
     recordFilters: filter.recordFilters?.map(
-      ({ fieldMetadataId, ...rest }) => ({
+      ({ fieldMetadataId, relationTargetFieldMetadataId, ...rest }) => ({
         ...rest,
         fieldMetadataUniversalIdentifier: getFieldMetadataUniversalIdentifier({
           fieldMetadataId,
           fieldMetadataUniversalIdentifierById,
           shouldThrowOnMissingIdentifier: false,
         }),
+        ...(isDefined(relationTargetFieldMetadataId)
+          ? {
+              relationTargetFieldMetadataUniversalIdentifier:
+                getFieldMetadataUniversalIdentifier({
+                  fieldMetadataId: relationTargetFieldMetadataId,
+                  fieldMetadataUniversalIdentifierById,
+                  shouldThrowOnMissingIdentifier: false,
+                }),
+            }
+          : {}),
       }),
     ),
   };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
@@ -16,6 +16,7 @@ const MORPH_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
   '20202020-4444-4444-8444-000000000004';
 const RICH_TEXT_FIELD_UNIVERSAL_IDENTIFIER =
   '20202020-5555-4555-8555-000000000005';
+const TEXT_FIELD_UNIVERSAL_IDENTIFIER = '20202020-6666-4666-8666-000000000006';
 const UNKNOWN_FIELD_UNIVERSAL_IDENTIFIER =
   '20202020-9999-4999-8999-000000000009';
 
@@ -50,6 +51,10 @@ const flatFieldMetadataMaps = {
     [RICH_TEXT_FIELD_UNIVERSAL_IDENTIFIER]: flatFieldMetadata(
       RICH_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
       FieldMetadataType.RICH_TEXT,
+    ),
+    [TEXT_FIELD_UNIVERSAL_IDENTIFIER]: flatFieldMetadata(
+      TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+      FieldMetadataType.TEXT,
     ),
   },
 } as unknown as MetadataUniversalFlatEntityMaps<'fieldMetadata'>;
@@ -140,6 +145,20 @@ describe('validateChartFilter', () => {
       expect(errors[0].message).toContain('DATE');
     },
   );
+
+  it('should accept a text operand on a RELATION field whose target field is a TEXT field', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+        relationTargetFieldMetadataUniversalIdentifier:
+          TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.DOES_NOT_CONTAIN,
+        value: 'foo',
+      },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
 
   it('should validate a MORPH_RELATION filter without a target against relation operands', () => {
     const errors = validateFilter([

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/__tests__/from-universal-configuration-to-flat-page-layout-widget-configuration.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/__tests__/from-universal-configuration-to-flat-page-layout-widget-configuration.util.spec.ts
@@ -1,13 +1,18 @@
 import {
   AggregateOperations,
+  FieldMetadataType,
   type UniversalChartFilter,
   ViewFilterOperand,
 } from 'twenty-shared/types';
 
-import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/from-universal-configuration-to-flat-page-layout-widget-configuration.util';
 
+const OBJECT_METADATA_ID = '00000000-0000-4000-8000-000000000000';
 const RELATION_FIELD_ID = '11111111-1111-4111-8111-000000000001';
 const RELATION_FIELD_UNIVERSAL_IDENTIFIER =
   '20202020-1111-4111-8111-000000000001';
@@ -18,24 +23,44 @@ const AGGREGATE_FIELD_ID = '11111111-3333-4333-8333-000000000003';
 const AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER =
   '20202020-3333-4333-8333-000000000003';
 
-const flatFieldMetadataMaps = {
-  byUniversalIdentifier: {
-    [RELATION_FIELD_UNIVERSAL_IDENTIFIER]: {
-      id: RELATION_FIELD_ID,
-      universalIdentifier: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
-    },
-    [TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER]: {
-      id: TARGET_TEXT_FIELD_ID,
-      universalIdentifier: TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
-    },
-    [AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER]: {
-      id: AGGREGATE_FIELD_ID,
-      universalIdentifier: AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER,
-    },
-  },
-} as unknown as MetadataFlatEntityMaps<'fieldMetadata'>;
+const buildFlatFieldMetadataMaps = (
+  flatFieldMetadatas: FlatFieldMetadata[],
+): FlatEntityMaps<FlatFieldMetadata> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    flatFieldMetadatas.map((flatFieldMetadata) => [
+      flatFieldMetadata.universalIdentifier,
+      flatFieldMetadata,
+    ]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    flatFieldMetadatas.map((flatFieldMetadata) => [
+      flatFieldMetadata.id,
+      flatFieldMetadata.universalIdentifier,
+    ]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
 
-const emptyMaps = { byUniversalIdentifier: {} };
+const flatFieldMetadataMaps = buildFlatFieldMetadataMaps([
+  getFlatFieldMetadataMock({
+    id: RELATION_FIELD_ID,
+    universalIdentifier: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+    objectMetadataId: OBJECT_METADATA_ID,
+    type: FieldMetadataType.RELATION,
+  }),
+  getFlatFieldMetadataMock({
+    id: TARGET_TEXT_FIELD_ID,
+    universalIdentifier: TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+    objectMetadataId: OBJECT_METADATA_ID,
+    type: FieldMetadataType.TEXT,
+  }),
+  getFlatFieldMetadataMock({
+    id: AGGREGATE_FIELD_ID,
+    universalIdentifier: AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER,
+    objectMetadataId: OBJECT_METADATA_ID,
+    type: FieldMetadataType.NUMBER,
+  }),
+]);
 
 const getChartRecordFilters = (
   recordFilters: NonNullable<UniversalChartFilter['recordFilters']>,
@@ -50,11 +75,9 @@ const getChartRecordFilters = (
         filter: { recordFilters },
       },
       flatFieldMetadataMaps,
-      flatFrontComponentMaps:
-        emptyMaps as MetadataFlatEntityMaps<'frontComponent'>,
-      flatViewMaps: emptyMaps as MetadataFlatEntityMaps<'view'>,
-      flatViewFieldGroupMaps:
-        emptyMaps as MetadataFlatEntityMaps<'viewFieldGroup'>,
+      flatFrontComponentMaps: createEmptyFlatEntityMaps(),
+      flatViewMaps: createEmptyFlatEntityMaps(),
+      flatViewFieldGroupMaps: createEmptyFlatEntityMaps(),
     });
 
   if (

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/__tests__/from-universal-configuration-to-flat-page-layout-widget-configuration.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/__tests__/from-universal-configuration-to-flat-page-layout-widget-configuration.util.spec.ts
@@ -1,0 +1,78 @@
+import { type ChartFilter, ViewFilterOperand } from 'twenty-shared/types';
+
+import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
+import { type FlatPageLayoutWidget } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget.type';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/from-universal-configuration-to-flat-page-layout-widget-configuration.util';
+
+const RELATION_FIELD_ID = '11111111-1111-4111-8111-000000000001';
+const RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-1111-4111-8111-000000000001';
+const TARGET_TEXT_FIELD_ID = '11111111-2222-4222-8222-000000000002';
+const TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-2222-4222-8222-000000000002';
+const AGGREGATE_FIELD_ID = '11111111-3333-4333-8333-000000000003';
+const AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-3333-4333-8333-000000000003';
+
+const flatFieldMetadataMaps = {
+  byUniversalIdentifier: {
+    [RELATION_FIELD_UNIVERSAL_IDENTIFIER]: {
+      id: RELATION_FIELD_ID,
+      universalIdentifier: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+    },
+    [TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER]: {
+      id: TARGET_TEXT_FIELD_ID,
+      universalIdentifier: TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+    },
+    [AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER]: {
+      id: AGGREGATE_FIELD_ID,
+      universalIdentifier: AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER,
+    },
+  },
+} as unknown as MetadataFlatEntityMaps<'fieldMetadata'>;
+
+const emptyMaps = { byUniversalIdentifier: {} };
+
+describe('fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration', () => {
+  it('should resolve the relation target universal identifier of a relation-traversal chart filter back to a field metadata id', () => {
+    const configuration =
+      fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration({
+        universalConfiguration: {
+          configurationType: WidgetConfigurationType.AGGREGATE_CHART,
+          aggregateFieldMetadataUniversalIdentifier:
+            AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER,
+          filter: {
+            recordFilters: [
+              {
+                fieldMetadataUniversalIdentifier:
+                  RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+                relationTargetFieldMetadataUniversalIdentifier:
+                  TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+                operand: ViewFilterOperand.DOES_NOT_CONTAIN,
+                value: 'foo',
+              },
+            ],
+          },
+        } as unknown as FlatPageLayoutWidget['universalConfiguration'],
+        flatFieldMetadataMaps,
+        flatFrontComponentMaps:
+          emptyMaps as MetadataFlatEntityMaps<'frontComponent'>,
+        flatViewMaps: emptyMaps as MetadataFlatEntityMaps<'view'>,
+        flatViewFieldGroupMaps:
+          emptyMaps as MetadataFlatEntityMaps<'viewFieldGroup'>,
+      });
+
+    expect(
+      (configuration as unknown as { filter: ChartFilter }).filter
+        .recordFilters,
+    ).toEqual([
+      {
+        fieldMetadataId: RELATION_FIELD_ID,
+        relationTargetFieldMetadataId: TARGET_TEXT_FIELD_ID,
+        operand: ViewFilterOperand.DOES_NOT_CONTAIN,
+        value: 'foo',
+      },
+    ]);
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/__tests__/from-universal-configuration-to-flat-page-layout-widget-configuration.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/__tests__/from-universal-configuration-to-flat-page-layout-widget-configuration.util.spec.ts
@@ -1,7 +1,10 @@
-import { type ChartFilter, ViewFilterOperand } from 'twenty-shared/types';
+import {
+  AggregateOperations,
+  type UniversalChartFilter,
+  ViewFilterOperand,
+} from 'twenty-shared/types';
 
 import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
-import { type FlatPageLayoutWidget } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget.type';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/from-universal-configuration-to-flat-page-layout-widget-configuration.util';
 
@@ -34,39 +37,48 @@ const flatFieldMetadataMaps = {
 
 const emptyMaps = { byUniversalIdentifier: {} };
 
+const getChartRecordFilters = (
+  recordFilters: NonNullable<UniversalChartFilter['recordFilters']>,
+) => {
+  const configuration =
+    fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration({
+      universalConfiguration: {
+        configurationType: WidgetConfigurationType.AGGREGATE_CHART,
+        aggregateFieldMetadataUniversalIdentifier:
+          AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER,
+        aggregateOperation: AggregateOperations.SUM,
+        filter: { recordFilters },
+      },
+      flatFieldMetadataMaps,
+      flatFrontComponentMaps:
+        emptyMaps as MetadataFlatEntityMaps<'frontComponent'>,
+      flatViewMaps: emptyMaps as MetadataFlatEntityMaps<'view'>,
+      flatViewFieldGroupMaps:
+        emptyMaps as MetadataFlatEntityMaps<'viewFieldGroup'>,
+    });
+
+  if (
+    configuration.configurationType !== WidgetConfigurationType.AGGREGATE_CHART
+  ) {
+    throw new Error('Expected an aggregate chart configuration');
+  }
+
+  return configuration.filter?.recordFilters;
+};
+
 describe('fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration', () => {
   it('should resolve the relation target universal identifier of a relation-traversal chart filter back to a field metadata id', () => {
-    const configuration =
-      fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration({
-        universalConfiguration: {
-          configurationType: WidgetConfigurationType.AGGREGATE_CHART,
-          aggregateFieldMetadataUniversalIdentifier:
-            AGGREGATE_FIELD_UNIVERSAL_IDENTIFIER,
-          filter: {
-            recordFilters: [
-              {
-                fieldMetadataUniversalIdentifier:
-                  RELATION_FIELD_UNIVERSAL_IDENTIFIER,
-                relationTargetFieldMetadataUniversalIdentifier:
-                  TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
-                operand: ViewFilterOperand.DOES_NOT_CONTAIN,
-                value: 'foo',
-              },
-            ],
-          },
-        } as unknown as FlatPageLayoutWidget['universalConfiguration'],
-        flatFieldMetadataMaps,
-        flatFrontComponentMaps:
-          emptyMaps as MetadataFlatEntityMaps<'frontComponent'>,
-        flatViewMaps: emptyMaps as MetadataFlatEntityMaps<'view'>,
-        flatViewFieldGroupMaps:
-          emptyMaps as MetadataFlatEntityMaps<'viewFieldGroup'>,
-      });
+    const recordFilters = getChartRecordFilters([
+      {
+        fieldMetadataUniversalIdentifier: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+        relationTargetFieldMetadataUniversalIdentifier:
+          TARGET_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.DOES_NOT_CONTAIN,
+        value: 'foo',
+      },
+    ]);
 
-    expect(
-      (configuration as unknown as { filter: ChartFilter }).filter
-        .recordFilters,
-    ).toEqual([
+    expect(recordFilters).toEqual([
       {
         fieldMetadataId: RELATION_FIELD_ID,
         relationTargetFieldMetadataId: TARGET_TEXT_FIELD_ID,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/from-universal-configuration-to-flat-page-layout-widget-configuration.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/from-universal-configuration-to-flat-page-layout-widget-configuration.util.ts
@@ -56,12 +56,25 @@ const convertUniversalFilterToChartFilter = ({
   return {
     ...filter,
     recordFilters: filter.recordFilters?.map(
-      ({ fieldMetadataUniversalIdentifier, ...rest }) => ({
+      ({
+        fieldMetadataUniversalIdentifier,
+        relationTargetFieldMetadataUniversalIdentifier,
+        ...rest
+      }) => ({
         ...rest,
         fieldMetadataId: resolveFieldMetadataIdOrThrow({
           fieldMetadataUniversalIdentifier,
           flatFieldMetadataMaps,
         }),
+        ...(isDefined(relationTargetFieldMetadataUniversalIdentifier)
+          ? {
+              relationTargetFieldMetadataId: resolveFieldMetadataIdOrThrow({
+                fieldMetadataUniversalIdentifier:
+                  relationTargetFieldMetadataUniversalIdentifier,
+                flatFieldMetadataMaps,
+              }),
+            }
+          : {}),
       }),
     ),
   };

--- a/packages/twenty-server/test/integration/metadata/suites/dashboard/successful-dashboard-duplication.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/dashboard/successful-dashboard-duplication.integration-spec.ts
@@ -5,15 +5,19 @@ import {
   destroyDashboardWithGraphQL,
 } from 'test/integration/metadata/suites/dashboard/utils/dashboard-graphql.util';
 import { duplicateOneDashboard } from 'test/integration/metadata/suites/dashboard/utils/duplicate-one-dashboard.util';
+import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
 import { createOnePageLayoutTab } from 'test/integration/metadata/suites/page-layout-tab/utils/create-one-page-layout-tab.util';
 import { createOnePageLayoutWidget } from 'test/integration/metadata/suites/page-layout-widget/utils/create-one-page-layout-widget.util';
 import { createOnePageLayout } from 'test/integration/metadata/suites/page-layout/utils/create-one-page-layout.util';
 import { extractRecordIdsAndDatesAsExpectAny } from 'test/utils/extract-record-ids-and-dates-as-expect-any';
+import { jestExpectToBeDefined } from 'test/utils/jest-expect-to-be-defined.util.test';
 import {
   type EachTestingContext,
   eachTestingContextFilter,
 } from 'twenty-shared/testing';
+import { AggregateOperations, ViewFilterOperand } from 'twenty-shared/types';
 
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { WidgetType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-type.enum';
 import { PageLayoutType } from 'src/engine/metadata-modules/page-layout/enums/page-layout-type.enum';
 
@@ -156,4 +160,120 @@ describe('Dashboard duplication should succeed', () => {
       expect(data.duplicateDashboard.title).toContain('(Copy)');
     },
   );
+
+  // Regression test for #24285
+  it('should duplicate a dashboard with a chart widget filtering through a relation target field', async () => {
+    currentTestContextId = 'e7b2f7d1-4c3a-4f5e-9b8d-1a2b3c4d5e6f';
+
+    const { objects } = await findManyObjectMetadata({
+      expectToFail: false,
+      input: {
+        filter: {},
+        paging: { first: 100 },
+      },
+      gqlFields: `
+        id
+        nameSingular
+        fieldsList {
+          id
+          name
+        }
+      `,
+    });
+
+    const companyObject = objects.find(
+      (object) => object.nameSingular === 'company',
+    );
+    const opportunityObject = objects.find(
+      (object) => object.nameSingular === 'opportunity',
+    );
+
+    jestExpectToBeDefined(companyObject);
+    jestExpectToBeDefined(opportunityObject);
+
+    const companyEmployeesField = companyObject.fieldsList?.find(
+      (field) => field.name === 'employees',
+    );
+    const companyOpportunitiesField = companyObject.fieldsList?.find(
+      (field) => field.name === 'opportunities',
+    );
+    const opportunityNameField = opportunityObject.fieldsList?.find(
+      (field) => field.name === 'name',
+    );
+
+    jestExpectToBeDefined(companyEmployeesField);
+    jestExpectToBeDefined(companyOpportunitiesField);
+    jestExpectToBeDefined(opportunityNameField);
+
+    const { data: pageLayoutData } = await createOnePageLayout({
+      expectToFail: false,
+      input: {
+        name: 'Page Layout with relation-traversal chart filter',
+        type: PageLayoutType.DASHBOARD,
+      },
+    });
+
+    testPageLayoutId = pageLayoutData.createPageLayout.id;
+
+    const { data: tabData } = await createOnePageLayoutTab({
+      expectToFail: false,
+      input: {
+        title: 'Test Tab',
+        pageLayoutId: testPageLayoutId,
+      },
+    });
+
+    testPageLayoutTabId = tabData.createPageLayoutTab.id;
+
+    await createOnePageLayoutWidget({
+      expectToFail: false,
+      input: {
+        title: 'Companies without lost opportunities',
+        type: WidgetType.GRAPH,
+        objectMetadataId: companyObject.id,
+        pageLayoutTabId: testPageLayoutTabId,
+        gridPosition: {
+          row: 0,
+          column: 0,
+          rowSpan: 1,
+          columnSpan: 1,
+        },
+        configuration: {
+          configurationType: WidgetConfigurationType.AGGREGATE_CHART,
+          aggregateFieldMetadataId: companyEmployeesField.id,
+          aggregateOperation: AggregateOperations.SUM,
+          filter: {
+            recordFilters: [
+              {
+                fieldMetadataId: companyOpportunitiesField.id,
+                relationTargetFieldMetadataId: opportunityNameField.id,
+                operand: ViewFilterOperand.DOES_NOT_CONTAIN,
+                value: 'lost',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const dashboard = await createTestDashboardWithGraphQL({
+      id: currentTestContextId,
+      title: 'Dashboard with relation-traversal chart filter',
+      pageLayoutId: testPageLayoutId,
+    });
+
+    testDashboardId = dashboard.id;
+
+    const { data, errors } = await duplicateOneDashboard({
+      expectToFail: false,
+      input: { id: testDashboardId },
+    });
+
+    expect(errors).toBeUndefined();
+
+    duplicatedDashboardId = data.duplicateDashboard.id;
+
+    expect(data.duplicateDashboard.id).not.toBe(testDashboardId);
+    expect(data.duplicateDashboard.title).toContain('(Copy)');
+  });
 });


### PR DESCRIPTION
Fixes #24285

## Problem

Duplicating a dashboard fails with `METADATA_VALIDATION_FAILED` when any chart widget carries a relation-traversal filter (e.g. `Company → Name DOES_NOT_CONTAIN "x"`), and the user only sees the generic "Multiple validation errors occurred while duplicating page layout" message.

## Root cause

The page layout widget universal configuration converters map a chart record filter's `fieldMetadataId` to its universal identifier but silently carried `relationTargetFieldMetadataId` through the object spread, so the key the chart filter validator reads (`relationTargetFieldMetadataUniversalIdentifier`) was never produced. Validation then fell back to the `RELATION` field type instead of the target field type and rejected operands like `DOES_NOT_CONTAIN` that are valid for the traversal's target field. Duplication re-creates every widget and revalidates it, so any affected dashboard became impossible to duplicate (and such widgets impossible to create or update through the API).

## Changes

- **Forward converter** (`fromPageLayoutWidgetConfigurationToUniversalConfiguration`): resolves `relationTargetFieldMetadataId` to `relationTargetFieldMetadataUniversalIdentifier`, degrading to `null` when the target field no longer exists, matching the main field's leniency.
- **Reverse converter** (`fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration`, app manifest install path): resolves the universal identifier back to a concrete field metadata id, mirroring the `RECORD_TABLE.viewId` fix from #23634.
- **Frontend**: `useDuplicateDashboard` now routes failures through `useMetadataErrorHandler`, so the per-widget `userFriendlyMessage` reaches the user instead of a generic failure snackbar (the global Apollo error link intentionally swallows `METADATA_VALIDATION_FAILED`, so the call site must render it). The command component no longer double-toasts.
- **No data migration needed**: persisted configurations were always valid; `universalConfiguration` is derived from them, so duplication works as soon as this deploys.

## Tests

- Integration regression test in `successful-dashboard-duplication.integration-spec.ts`: duplicating a dashboard whose chart widget filters through a relation target field succeeds. Verified it fails with the exact error from the issue when the converter fix is reverted.
- Unit tests for both converters (traversal mapping, deleted-target leniency) and a validator case (text operand accepted on a RELATION field with a TEXT target).
- Full dashboard integration suite green (17 tests, 5 suites), `page-layout` unit suites green, `nx typecheck` clean for both packages, oxlint/oxfmt clean.

## Manual E2E QA (local app, seeded workspace)

- Success path: created a dashboard with a chart widget filtering `opportunity.company → company.name DOES_NOT_CONTAIN`; widget renders; "Duplicate Dashboard" from the command menu shows the success snackbar, navigates to the copy, and the copy has its own page layout with the widget and filter intact.
- Error path: reproduced the issue's legacy data shape (operand `DOES_NOT_CONTAIN` on a relation filter without a target field, injected via SQL); duplicating now surfaces the snackbar "Chart filter operand is not supported for this field type" instead of only the generic failure.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

