### PR TITLE
Align kanban widget with table widget on read-only surfaces

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board-widget/components/RecordBoardWidget.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board-widget/components/RecordBoardWidget.tsx
@@ -26,6 +26,7 @@ export const RecordBoardWidget = ({
       <RecordBoardWidgetViewSettingsReadOnlyEffect
         recordBoardId={recordIndexId}
         isViewSettingsReadOnly={isReadOnly}
+        isRecordCellsNonEditable={isReadOnly}
       />
       <StyledBoardContainer>
         <RecordBoardContainer

--- a/packages/twenty-front/src/modules/object-record/record-board-widget/components/RecordBoardWidgetViewSettingsReadOnlyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board-widget/components/RecordBoardWidgetViewSettingsReadOnlyEffect.tsx
@@ -1,3 +1,4 @@
+import { isRecordBoardCellsNonEditableComponentState } from '@/object-record/record-board/states/isRecordBoardCellsNonEditableComponentState';
 import { isRecordBoardViewSettingsReadOnlyComponentState } from '@/object-record/record-board/states/isRecordBoardViewSettingsReadOnlyComponentState';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useLayoutEffect } from 'react';
@@ -5,14 +6,21 @@ import { useLayoutEffect } from 'react';
 type RecordBoardWidgetViewSettingsReadOnlyEffectProps = {
   recordBoardId: string;
   isViewSettingsReadOnly: boolean;
+  isRecordCellsNonEditable: boolean;
 };
 
 export const RecordBoardWidgetViewSettingsReadOnlyEffect = ({
   recordBoardId,
   isViewSettingsReadOnly,
+  isRecordCellsNonEditable,
 }: RecordBoardWidgetViewSettingsReadOnlyEffectProps) => {
   const setIsRecordBoardViewSettingsReadOnly = useSetAtomComponentState(
     isRecordBoardViewSettingsReadOnlyComponentState,
+    recordBoardId,
+  );
+
+  const setIsRecordBoardCellsNonEditable = useSetAtomComponentState(
+    isRecordBoardCellsNonEditableComponentState,
     recordBoardId,
   );
 
@@ -20,13 +28,20 @@ export const RecordBoardWidgetViewSettingsReadOnlyEffect = ({
   // briefly accept interaction on) their editable controls.
   useLayoutEffect(() => {
     setIsRecordBoardViewSettingsReadOnly(isViewSettingsReadOnly);
+    setIsRecordBoardCellsNonEditable(isRecordCellsNonEditable);
 
     // Reset to the default on unmount so the flag cannot outlive the
     // widget and leak into a later board mounted on the same instance id.
     return () => {
       setIsRecordBoardViewSettingsReadOnly(false);
+      setIsRecordBoardCellsNonEditable(false);
     };
-  }, [isViewSettingsReadOnly, setIsRecordBoardViewSettingsReadOnly]);
+  }, [
+    isViewSettingsReadOnly,
+    isRecordCellsNonEditable,
+    setIsRecordBoardViewSettingsReadOnly,
+    setIsRecordBoardCellsNonEditable,
+  ]);
 
   return null;
 };

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/anchored-portal/components/RecordBoardCardCellEditModePortal.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/anchored-portal/components/RecordBoardCardCellEditModePortal.tsx
@@ -6,6 +6,7 @@ import { RECORD_BOARD_CARD_INPUT_ID_PREFIX } from '@/object-record/record-board/
 import { RecordBoardCardContext } from '@/object-record/record-board/record-board-card/contexts/RecordBoardCardContext';
 import { useRecordBoardCardMetadataFromPosition } from '@/object-record/record-board/record-board-card/hooks/useRecordBoardCardMetadataFromPosition';
 import { recordBoardCardEditModePositionComponentState } from '@/object-record/record-board/record-board-card/states/recordBoardCardEditModePositionComponentState';
+import { isRecordBoardCellsNonEditableComponentState } from '@/object-record/record-board/states/isRecordBoardCellsNonEditableComponentState';
 import { FieldInput } from '@/object-record/record-field/ui/components/FieldInput';
 import { RecordInlineCellAnchoredPortal } from '@/object-record/record-inline-cell/components/RecordInlineCellAnchoredPortal';
 import { RecordInlineCellEditMode } from '@/object-record/record-inline-cell/components/RecordInlineCellEditMode';
@@ -20,11 +21,16 @@ export const RecordBoardCardCellEditModePortal = () => {
     recordBoardCardEditModePositionComponentState,
   );
 
+  const isRecordBoardCellsNonEditable = useAtomComponentStateValue(
+    isRecordBoardCellsNonEditableComponentState,
+  );
+
   const { editedFieldMetadataItem } = useRecordBoardCardMetadataFromPosition();
 
   if (
     !isDefined(recordBoardCardEditModePosition) ||
-    !isDefined(editedFieldMetadataItem)
+    !isDefined(editedFieldMetadataItem) ||
+    isRecordBoardCellsNonEditable
   ) {
     return null;
   }

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/anchored-portal/components/RecordBoardCardCellHoveredPortalContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/anchored-portal/components/RecordBoardCardCellHoveredPortalContent.tsx
@@ -1,5 +1,6 @@
 import { RECORD_BOARD_CARD_INPUT_ID_PREFIX } from '@/object-record/record-board/record-board-card/constants/RecordBoardCardInputIdPrefix';
 import { recordBoardCardEditModePositionComponentState } from '@/object-record/record-board/record-board-card/states/recordBoardCardEditModePositionComponentState';
+import { isRecordBoardCellsNonEditableComponentState } from '@/object-record/record-board/states/isRecordBoardCellsNonEditableComponentState';
 import { recordBoardCardHoverPositionComponentState } from '@/object-record/record-board/record-board-card/states/recordBoardCardHoverPositionComponentState';
 import { FieldDisplay } from '@/object-record/record-field/ui/components/FieldDisplay';
 import { FieldInput } from '@/object-record/record-field/ui/components/FieldInput';
@@ -11,14 +12,25 @@ import { RecordInlineCellHoveredPortalContent } from '@/object-record/record-inl
 import { useInlineCell } from '@/object-record/record-inline-cell/hooks/useInlineCell';
 import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useContext } from 'react';
 
 export const RecordBoardCardCellHoveredPortalContent = () => {
   const { editModeContentOnly, isCentered } = useRecordInlineCellContext();
 
-  const { isRecordFieldReadOnly, recordId, fieldDefinition } =
-    useContext(FieldContext);
+  const {
+    isRecordFieldReadOnly: isRecordFieldReadOnlyFromFieldContext,
+    recordId,
+    fieldDefinition,
+  } = useContext(FieldContext);
+
+  const isRecordBoardCellsNonEditable = useAtomComponentStateValue(
+    isRecordBoardCellsNonEditableComponentState,
+  );
+
+  const isRecordFieldReadOnly =
+    isRecordFieldReadOnlyFromFieldContext || isRecordBoardCellsNonEditable;
 
   const { openInlineCell } = useInlineCell(
     getRecordFieldInputInstanceId({

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardContextProvider.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardContextProvider.tsx
@@ -7,6 +7,7 @@ import { RecordBoardColumnContext } from '@/object-record/record-board/record-bo
 import { RecordBoardContext } from '@/object-record/record-board/contexts/RecordBoardContext';
 import { RecordBoardCard } from '@/object-record/record-board/record-board-card/components/RecordBoardCard';
 import { isRecordBoardCardFocusedComponentFamilyState } from '@/object-record/record-board/states/isRecordBoardCardFocusedComponentFamilyState';
+import { isRecordBoardCellsNonEditableComponentState } from '@/object-record/record-board/states/isRecordBoardCellsNonEditableComponentState';
 import { isRecordBoardDropProcessingComponentState } from '@/object-record/record-board/states/isRecordBoardDropProcessingComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { RecordBoardCardContext } from '@/object-record/record-board/record-board-card/contexts/RecordBoardCardContext';
@@ -38,10 +39,17 @@ export const RecordBoardCardContextProvider = ({
   const { objectMetadataItem } = useContext(RecordBoardContext);
   const { columnIndex } = useContext(RecordBoardColumnContext);
 
-  const isRecordReadOnly = useIsRecordReadOnly({
+  const isRecordReadOnlyFromPermissions = useIsRecordReadOnly({
     recordId,
     objectMetadataId: objectMetadataItem.id,
   });
+
+  const isRecordBoardCellsNonEditable = useAtomComponentStateValue(
+    isRecordBoardCellsNonEditableComponentState,
+  );
+
+  const isRecordReadOnly =
+    isRecordBoardCellsNonEditable || isRecordReadOnlyFromPermissions;
 
   const isRecordBoardCardFocused = useAtomComponentFamilyStateValue(
     isRecordBoardCardFocusedComponentFamilyState,
@@ -65,10 +73,12 @@ export const RecordBoardCardContextProvider = ({
         group={group}
         type={RECORD_BOARD_CARD_DND_TYPE}
         accept={RECORD_BOARD_CARD_DND_TYPE}
-        disabled={isRecordBoardDropProcessing}
+        disabled={isRecordBoardDropProcessing || isRecordBoardCellsNonEditable}
       >
         <StyledDraggableContainer
-          isDragDisabled={isRecordBoardDropProcessing}
+          isDragDisabled={
+            isRecordBoardDropProcessing || isRecordBoardCellsNonEditable
+          }
           id={`record-board-card-${columnIndex}-${rowIndex}`}
           data-selectable-id={recordId}
           data-select-disable

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeader.tsx
@@ -19,6 +19,7 @@ import { recordIndexAggregateDisplayLabelComponentState } from '@/object-record/
 import { recordIndexAggregateDisplayValueForGroupValueComponentFamilyState } from '@/object-record/record-index/states/recordIndexAggregateDisplayValueForGroupValueComponentFamilyState';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
 import { RecordTableWidgetContext } from '@/object-record/record-table-widget/contexts/RecordTableWidgetContext';
+import { isRecordBoardCellsNonEditableComponentState } from '@/object-record/record-board/states/isRecordBoardCellsNonEditableComponentState';
 import { isRecordBoardViewSettingsReadOnlyComponentState } from '@/object-record/record-board/states/isRecordBoardViewSettingsReadOnlyComponentState';
 import { canCreateRecordsForObjectMetadataItem } from '@/object-record/utils/canCreateRecordsForObjectMetadataItem';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
@@ -146,18 +147,27 @@ export const RecordBoardColumnHeader = () => {
     objectMetadataItem.id,
   );
 
+  const recordTableWidgetContext = useContext(RecordTableWidgetContext);
+
   // Creating in a nested relation widget requires picking the related record
   // to create through, which only the table layout offers today.
-  const nestedRelationCreateThrough = useContext(
-    RecordTableWidgetContext,
-  )?.nestedRelationCreateThrough;
+  const nestedRelationCreateThrough =
+    recordTableWidgetContext?.nestedRelationCreateThrough;
+
+  const isRecordBoardCellsNonEditable = useAtomComponentStateValue(
+    isRecordBoardCellsNonEditableComponentState,
+  );
 
   const canCreateRecords =
     !isDefined(nestedRelationCreateThrough) &&
+    !isRecordBoardCellsNonEditable &&
     canCreateRecordsForObjectMetadataItem({
       objectPermissions,
       objectMetadataItem,
     });
+
+  const isAggregateDropdownNonInteractive =
+    recordTableWidgetContext?.isPageLayoutInEditMode ?? false;
 
   const hasAnySoftDeleteFilterOnView = useAtomComponentSelectorValue(
     hasAnySoftDeleteFilterOnViewComponentSelector,
@@ -234,8 +244,8 @@ export const RecordBoardColumnHeader = () => {
               </StyledDropdownContainer>
 
               <StyledAggregateDropdownContainer
-                isNonInteractive={isRecordBoardViewSettingsReadOnly}
-                inert={isRecordBoardViewSettingsReadOnly || undefined}
+                isNonInteractive={isAggregateDropdownNonInteractive}
+                inert={isAggregateDropdownNonInteractive || undefined}
               >
                 <RecordGroupAggregateDropdown
                   aggregateValue={recordIndexAggregateDisplayValueForGroupValue}

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewRecordButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewRecordButton.tsx
@@ -1,12 +1,14 @@
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { RecordBoardContext } from '@/object-record/record-board/contexts/RecordBoardContext';
 import { RecordBoardColumnContext } from '@/object-record/record-board/record-board-column/contexts/RecordBoardColumnContext';
+import { isRecordBoardCellsNonEditableComponentState } from '@/object-record/record-board/states/isRecordBoardCellsNonEditableComponentState';
 import { hasAnySoftDeleteFilterOnViewComponentSelector } from '@/object-record/record-filter/states/hasAnySoftDeleteFilterOnView';
 import { getFieldMetadataItemGqlFieldName } from '@/object-metadata/utils/getFieldMetadataItemGqlFieldName';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
 import { RecordTableWidgetContext } from '@/object-record/record-table-widget/contexts/RecordTableWidgetContext';
 import { canCreateRecordsForObjectMetadataItem } from '@/object-record/utils/canCreateRecordsForObjectMetadataItem';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
@@ -42,6 +44,10 @@ export const RecordBoardColumnNewRecordButton = () => {
     hasAnySoftDeleteFilterOnViewComponentSelector,
   );
 
+  const isRecordBoardCellsNonEditable = useAtomComponentStateValue(
+    isRecordBoardCellsNonEditableComponentState,
+  );
+
   const objectPermissions = useObjectPermissionsForObject(
     objectMetadataItem.id,
   );
@@ -57,6 +63,10 @@ export const RecordBoardColumnNewRecordButton = () => {
   )?.nestedRelationCreateThrough;
 
   if (isDefined(nestedRelationCreateThrough)) {
+    return null;
+  }
+
+  if (isRecordBoardCellsNonEditable) {
     return null;
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-board/states/isRecordBoardCellsNonEditableComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/states/isRecordBoardCellsNonEditableComponentState.ts
@@ -1,9 +1,9 @@
 import { RecordBoardComponentInstanceContext } from '@/object-record/record-board/states/contexts/RecordBoardComponentInstanceContext';
 import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
 
-export const isRecordBoardViewSettingsReadOnlyComponentState =
+export const isRecordBoardCellsNonEditableComponentState =
   createAtomComponentState<boolean>({
-    key: 'isRecordBoardViewSettingsReadOnlyComponentState',
+    key: 'isRecordBoardCellsNonEditableComponentState',
     defaultValue: false,
     componentInstanceContext: RecordBoardComponentInstanceContext,
   });

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSection.tsx
@@ -22,7 +22,8 @@ import { RECORD_TABLE_LABEL_IDENTIFIER_COLUMN_WIDTH_ON_MOBILE } from '@/object-r
 
 import { recordIndexAggregateDisplayLabelComponentState } from '@/object-record/record-index/states/recordIndexAggregateDisplayLabelComponentState';
 import { recordIndexAggregateDisplayValueForGroupValueComponentFamilyState } from '@/object-record/record-index/states/recordIndexAggregateDisplayValueForGroupValueComponentFamilyState';
-import { isRecordTableCellsNonEditableComponentState } from '@/object-record/record-table/states/isRecordTableCellsNonEditableComponentState';
+import { RecordTableWidgetContext } from '@/object-record/record-table-widget/contexts/RecordTableWidgetContext';
+import { useContext } from 'react';
 import { isRecordGroupTableSectionToggledComponentState } from '@/object-record/record-table/record-table-section/states/isRecordGroupTableSectionToggledComponentState';
 import { useAtomComponentFamilyState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyState';
 import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
@@ -143,9 +144,8 @@ export const RecordTableRecordGroupSection = () => {
     currentRecordGroupId,
   );
 
-  const isRecordTableCellsNonEditable = useAtomComponentStateValue(
-    isRecordTableCellsNonEditableComponentState,
-  );
+  const isAggregateDropdownNonInteractive =
+    useContext(RecordTableWidgetContext)?.isPageLayoutInEditMode ?? false;
 
   const visibleRecordFieldsWithoutLabelIdentifier = visibleRecordFields.filter(
     filterOutByProperty(
@@ -188,8 +188,8 @@ export const RecordTableRecordGroupSection = () => {
           chevronWidth={RECORD_TABLE_COLUMN_CHECKBOX_WIDTH}
         />
         <StyledAggregateDropdownContainer
-          isNonInteractive={isRecordTableCellsNonEditable}
-          inert={isRecordTableCellsNonEditable || undefined}
+          isNonInteractive={isAggregateDropdownNonInteractive}
+          inert={isAggregateDropdownNonInteractive || undefined}
         >
           <RecordGroupAggregateDropdown
             aggregateValue={recordIndexAggregateDisplayValueForGroupValue}

--- a/packages/twenty-front/src/modules/views/hooks/useUpdateViewAggregate.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useUpdateViewAggregate.ts
@@ -1,12 +1,13 @@
 import { contextStoreCurrentViewIdComponentState } from '@/context-store/states/contextStoreCurrentViewIdComponentState';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { useLoadRecordIndexStates } from '@/object-record/record-index/hooks/useLoadRecordIndexStates';
+import { RecordTableWidgetContext } from '@/object-record/record-table-widget/contexts/RecordTableWidgetContext';
 import { type ExtendedAggregateOperations } from '@/object-record/record-table/types/ExtendedAggregateOperations';
 import { convertExtendedAggregateOperationToAggregateOperation } from '@/object-record/utils/convertExtendedAggregateOperationToAggregateOperation';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { usePerformViewAPIUpdate } from '@/views/hooks/internal/usePerformViewAPIUpdate';
 import { useCanPersistViewChanges } from '@/views/hooks/useCanPersistViewChanges';
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { type View as GqlView } from '~/generated-metadata/graphql';
 
@@ -17,6 +18,10 @@ export const useUpdateViewAggregate = () => {
   );
   const { performViewAPIUpdate } = usePerformViewAPIUpdate();
   const { loadRecordIndexStates } = useLoadRecordIndexStates();
+
+  const isInsideRecordTableWidget = isDefined(
+    useContext(RecordTableWidgetContext),
+  );
 
   const updateViewAggregate = useCallback(
     async ({
@@ -60,6 +65,10 @@ export const useUpdateViewAggregate = () => {
           return;
         }
 
+        if (isInsideRecordTableWidget) {
+          return;
+        }
+
         loadRecordIndexStates(updatedView, objectMetadataItem);
       }
     },
@@ -68,6 +77,7 @@ export const useUpdateViewAggregate = () => {
       contextStoreCurrentViewId,
       performViewAPIUpdate,
       loadRecordIndexStates,
+      isInsideRecordTableWidget,
     ],
   );
 


### PR DESCRIPTION
## Context

Record table and kanban widgets (dashboards, record page layouts) share the same `isReadOnly` input, but each layout interpreted it differently, producing two user-facing inconsistencies on dashboards:

1. **Records**: table cells are locked, but kanban cards stayed fully editable — inline cell editing, card drag between columns, and per-column record creation all mutated records on what is meant to be a read-only surface.
2. **Aggregates**: the table footer keeps its aggregate dropdown interactive (widgets own their backing view, so configuring an aggregate in place is safe), but the kanban column header made its aggregate chip inert — since widget views are also created without `kanbanAggregateOperation` and the widget settings panel has no aggregate row, dashboard kanbans had *no way* to show or configure aggregates at all (reported: kanban in dashboard shows no calculated totals while the same view on the index does).

## What this does

**Records are now locked on read-only board widgets, matching the table:**
- New `isRecordBoardCellsNonEditableComponentState`, the board counterpart of `isRecordTableCellsNonEditableComponentState`, set by `RecordBoardWidget` from its `isReadOnly` prop alongside the existing view-settings flag.
- It locks card cell editing through both paths — the card body `FieldContext` and the anchored hover/edit portals, which previously computed readonly from object permissions only — plus card drag and the per-column create buttons.
- Record page relation widgets pass `isReadOnly={false}` outside layout edit mode, so they stay editable.

**Aggregates are now configurable in place on board widgets, matching the table footer:**
- The column header aggregate dropdown is no longer swept into the view-settings lock; it is only inert while a page layout draft is being edited (the widget then renders from a draft snapshot, so a persisted-view update would bypass it). The grouped table section follows the same rule so all three surfaces agree.
- `useUpdateViewAggregate` skips the ambient record index reload when invoked from inside a widget: the metadata store update already re-runs the widget's own view load effect, and the ambient reload would overwrite global index states with the widget view's.

Persistence of in-place aggregate changes still goes through `useCanPersistViewChanges`; widget views are `WORKSPACE`-visibility, so the same VIEWS permission applies as for any shared view.

## How it was verified

Browser-tested against a seeded workspace (index kanban as control group, a dashboard with a kanban widget as subject), with record mutations checked against the database:

- Dashboard: card cell click opens no editor; card drag leaves the record untouched (DB-verified); no create buttons; aggregate chip opens the full dropdown; switching the aggregate (Count, then Sum of Amount) applies in place and persists across reload; chip is inert in layout edit mode; column group chip stays locked.
- Index: cards still editable, drag still updates the record (DB-verified), aggregate dropdown unchanged.
- `nx typecheck twenty-front`, `nx lint:diff-with-main twenty-front`, and the widget renderer unit tests pass.

## Follow-up (separate PR)

Per-widget `isRecordsEditable` configuration so record editability becomes an explicit widget setting (default read-only on dashboards, editable on record pages).

---
_Generated by [Claude Code](https://claude.ai/code/session_018thn4XMwKVUiAdV2pkYCtG)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

