### PR TITLE
Gate twenty-ui interaction handlers on the element being clickable

### DIFF
--- a/packages/twenty-ui/src/data-display/AvatarOrIcon/AvatarOrIcon.tsx
+++ b/packages/twenty-ui/src/data-display/AvatarOrIcon/AvatarOrIcon.tsx
@@ -48,59 +48,53 @@ export const AvatarOrIcon = ({
     );
   }
 
-  const isClickable = isDefined(onClick);
   const accessibleLabel = isNonEmptyString(placeholder)
     ? placeholder
     : 'Avatar';
 
-  if (isIconInverted || isDefined(IconBackgroundColor)) {
-    return (
+  const iconContent =
+    isIconInverted || isDefined(IconBackgroundColor) ? (
       <div
-        className={styles.wrapper}
-        data-clickable={isClickable || undefined}
-        role={isClickable ? 'button' : undefined}
-        tabIndex={isClickable ? 0 : undefined}
-        aria-label={isClickable ? accessibleLabel : undefined}
-        onClick={onClick}
-        onKeyDown={handleClickableElementKeyDown}
+        className={styles.iconWithBackgroundContainer}
+        style={
+          isDefined(IconBackgroundColor)
+            ? ({
+                '--avatar-or-icon-background': IconBackgroundColor,
+              } as React.CSSProperties)
+            : undefined
+        }
       >
-        <div
-          className={styles.iconWithBackgroundContainer}
-          style={
-            isDefined(IconBackgroundColor)
-              ? ({
-                  '--avatar-or-icon-background': IconBackgroundColor,
-                } as React.CSSProperties)
-              : undefined
-          }
-        >
-          <Icon
-            color={theme.font.color.inverted}
-            size={theme.icon.size.sm}
-            stroke={theme.icon.stroke.sm}
-            aria-hidden
-          />
-        </div>
+        <Icon
+          color={theme.font.color.inverted}
+          size={theme.icon.size.sm}
+          stroke={theme.icon.stroke.sm}
+          aria-hidden
+        />
       </div>
-    );
-  }
-
-  return (
-    <div
-      className={styles.wrapper}
-      data-clickable={isClickable || undefined}
-      role={isClickable ? 'button' : undefined}
-      tabIndex={isClickable ? 0 : undefined}
-      aria-label={isClickable ? accessibleLabel : undefined}
-      onClick={onClick}
-      onKeyDown={handleClickableElementKeyDown}
-    >
+    ) : (
       <Icon
         size={theme.icon.size.sm}
         stroke={theme.icon.stroke.sm}
         color={IconColor || 'currentColor'}
         aria-hidden
       />
-    </div>
-  );
+    );
+
+  if (isDefined(onClick)) {
+    return (
+      <div
+        className={styles.wrapper}
+        data-clickable={true}
+        role="button"
+        tabIndex={0}
+        aria-label={accessibleLabel}
+        onClick={onClick}
+        onKeyDown={handleClickableElementKeyDown}
+      >
+        {iconContent}
+      </div>
+    );
+  }
+
+  return <div className={styles.wrapper}>{iconContent}</div>;
 };

--- a/packages/twenty-ui/src/input/ColorSchemeCard/ColorSchemeCard.tsx
+++ b/packages/twenty-ui/src/input/ColorSchemeCard/ColorSchemeCard.tsx
@@ -26,27 +26,42 @@ const ColorSchemeSegment = ({
 }: ColorSchemeSegmentProps) => {
   const grayScale = variant === 'Dark' ? GRAY_SCALE_DARK : GRAY_SCALE_LIGHT;
 
+  const segmentClassName = clsx(styles.colorSchemeBackground, className);
+  const segmentStyle = {
+    '--color-scheme-card-background': grayScale.gray4,
+    '--color-scheme-card-border-color': grayScale.gray5,
+    '--color-scheme-card-content-background': grayScale.gray1,
+    '--color-scheme-card-content-color': grayScale.gray12,
+    ...style,
+  } as React.CSSProperties;
+  const segmentContent = <div className={styles.colorSchemeContent}>Aa</div>;
+
+  if (isDefined(onClick)) {
+    return (
+      <div
+        className={segmentClassName}
+        style={segmentStyle}
+        role="button"
+        tabIndex={0}
+        aria-label={variant}
+        onClick={onClick}
+        onKeyDown={handleClickableElementKeyDown}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        {segmentContent}
+      </div>
+    );
+  }
+
   return (
     <div
-      className={clsx(styles.colorSchemeBackground, className)}
-      style={
-        {
-          '--color-scheme-card-background': grayScale.gray4,
-          '--color-scheme-card-border-color': grayScale.gray5,
-          '--color-scheme-card-content-background': grayScale.gray1,
-          '--color-scheme-card-content-color': grayScale.gray12,
-          ...style,
-        } as React.CSSProperties
-      }
-      role={isDefined(onClick) ? 'button' : undefined}
-      tabIndex={isDefined(onClick) ? 0 : undefined}
-      aria-label={isDefined(onClick) ? variant : undefined}
-      onClick={onClick}
-      onKeyDown={handleClickableElementKeyDown}
+      className={segmentClassName}
+      style={segmentStyle}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <div className={styles.colorSchemeContent}>Aa</div>
+      {segmentContent}
     </div>
   );
 };
@@ -62,26 +77,36 @@ export const ColorSchemeCard = ({
   onClick,
   className,
 }: ColorSchemeCardProps) => {
+  const mixedSegments = (
+    <>
+      <ColorSchemeSegment
+        style={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
+        variant="Light"
+      />
+      <ColorSchemeSegment
+        style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
+        variant="Dark"
+      />
+    </>
+  );
+
   if (variant === 'System') {
     return (
       <div className={clsx(styles.container, className)}>
-        <div
-          className={styles.mixedColorSchemeSegment}
-          role={isDefined(onClick) ? 'button' : undefined}
-          tabIndex={isDefined(onClick) ? 0 : undefined}
-          aria-label={isDefined(onClick) ? variant : undefined}
-          onClick={onClick}
-          onKeyDown={handleClickableElementKeyDown}
-        >
-          <ColorSchemeSegment
-            style={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
-            variant="Light"
-          />
-          <ColorSchemeSegment
-            style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
-            variant="Dark"
-          />
-        </div>
+        {isDefined(onClick) ? (
+          <div
+            className={styles.mixedColorSchemeSegment}
+            role="button"
+            tabIndex={0}
+            aria-label={variant}
+            onClick={onClick}
+            onKeyDown={handleClickableElementKeyDown}
+          >
+            {mixedSegments}
+          </div>
+        ) : (
+          <div className={styles.mixedColorSchemeSegment}>{mixedSegments}</div>
+        )}
         <div
           className={styles.checkmarkContainer}
           data-selected={selected || undefined}

--- a/packages/twenty-ui/src/json-visualizer/components/internal/JsonNodeValue.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/internal/JsonNodeValue.tsx
@@ -21,19 +21,25 @@ export const JsonNodeValue = ({
     onNodeValueClick?.(valueAsString);
   };
 
-  return (
-    <span
-      className={clsx(
-        styles.text,
-        highlighting === 'blue' && styles.blue,
-        highlighting === 'red' && styles.red,
-      )}
-      role={isInteractive ? 'button' : undefined}
-      tabIndex={isInteractive ? 0 : undefined}
-      onClick={isInteractive ? handleClick : undefined}
-      onKeyDown={handleClickableElementKeyDown}
-    >
-      {valueAsString}
-    </span>
+  const valueClassName = clsx(
+    styles.text,
+    highlighting === 'blue' && styles.blue,
+    highlighting === 'red' && styles.red,
   );
+
+  if (isInteractive) {
+    return (
+      <span
+        className={valueClassName}
+        role="button"
+        tabIndex={0}
+        onClick={handleClick}
+        onKeyDown={handleClickableElementKeyDown}
+      >
+        {valueAsString}
+      </span>
+    );
+  }
+
+  return <span className={valueClassName}>{valueAsString}</span>;
 };


### PR DESCRIPTION
`AvatarOrIcon`, `ColorSchemeCard` and `JsonNodeValue` set `role`/`tabIndex`/`aria-label` only when an `onClick` is passed, but attached `onClick` and `onKeyDown` unconditionally. A non-clickable element therefore carried a keydown handler with no role, which is what [jsx-a11y/no-static-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md) flags.

The handlers now attach only in the clickable branch, so the role and the handlers cannot come apart. Rendered output is unchanged in both branches.

Clears 5 of the 6 remaining `no-static-element-interactions` warnings in twenty-ui. The last one is `Avatar`, fixed in #24278.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

