### PR TITLE
chore: bump version to 2.33.0

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "sideEffects": false,
   "license": "MIT",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "sideEffects": false,
   "bin": {
     "twenty": "dist/cli.cjs"

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
@@ -7,4 +7,4 @@
  *                              |___/
  */
 
-export const TWENTY_CURRENT_VERSION = '2.32.0' as const;
+export const TWENTY_CURRENT_VERSION = '2.33.0' as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
@@ -8,5 +8,5 @@
  */
 
 export const TWENTY_NEXT_VERSIONS = [
-  '2.33.0',
+  '2.34.0',
 ] as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
@@ -43,4 +43,5 @@ export const TWENTY_PREVIOUS_VERSIONS = [
   '2.29.0',
   '2.30.0',
   '2.31.0',
+  '2.32.0',
 ] as const;


### PR DESCRIPTION
## Summary

- Moves current version to previous versions array
- Sets TWENTY_CURRENT_VERSION to the new version
- Updates TWENTY_NEXT_VERSIONS with the next minor version
- Bumps twenty-client-sdk, twenty-sdk, and create-twenty-app to the same version

Replaces #24072, whose branch could not be re-pushed by the staging workflow.

## Checklist

- [ ] Verify version constants are correct
- [ ] Verify npm package versions match

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

