### PR TITLE
Dark mode support for the email composer canvas

### DIFF
--- a/packages/twenty-emails/src/utils/email-renderer/email-renderer.tsx
+++ b/packages/twenty-emails/src/utils/email-renderer/email-renderer.tsx
@@ -1,13 +1,70 @@
 import { type ReactNode } from 'react';
 import { Body, Container, Head, Html } from 'react-email';
+import { isNonEmptyString } from '@sniptt/guards';
 import { type JSONContent } from '@tiptap/core';
 import { type CanvasTheme, resolveCanvasTheme } from 'twenty-shared/utils';
 import { mappedNodeContent } from 'src/utils/email-renderer/renderers/render-node';
 
 const BASE_STYLE_RESET = `blockquote,h1,h2,h3,img,li,ol,p,ul{margin-top:0;margin-bottom:0}`;
+const COLOR_SCHEME_DECLARATION = `:root{color-scheme:light dark;supported-color-schemes:light dark}`;
+
+const EMAIL_PAGE_CLASS_NAME = 'email-page';
+const EMAIL_BODY_CLASS_NAME = 'email-body';
+
+const SAFE_CSS_COLOR_PATTERN = /^[#a-zA-Z0-9(),.%\s-]+$/;
+
+const hasBorder = (theme: CanvasTheme) =>
+  isNonEmptyString(theme.borderWidth) && theme.borderWidth !== '0px';
+
+const darkColorSchemeStyle = (theme: CanvasTheme): string => {
+  const pageDeclarations: string[] = [];
+  const bodyDeclarations: string[] = [];
+
+  const addDeclaration = (
+    declarations: string[],
+    property: string,
+    color: string,
+  ) => {
+    if (isNonEmptyString(color) && SAFE_CSS_COLOR_PATTERN.test(color)) {
+      declarations.push(`${property}:${color} !important`);
+    }
+  };
+
+  addDeclaration(
+    pageDeclarations,
+    'background-color',
+    theme.dark.pageBackground,
+  );
+  addDeclaration(pageDeclarations, 'color', theme.dark.textColor);
+  addDeclaration(
+    bodyDeclarations,
+    'background-color',
+    theme.dark.bodyBackground,
+  );
+  addDeclaration(bodyDeclarations, 'color', theme.dark.textColor);
+
+  if (hasBorder(theme)) {
+    addDeclaration(bodyDeclarations, 'border-color', theme.dark.borderColor);
+  }
+
+  const rules: string[] = [];
+
+  if (pageDeclarations.length > 0) {
+    rules.push(`.${EMAIL_PAGE_CLASS_NAME}{${pageDeclarations.join(';')}}`);
+  }
+
+  if (bodyDeclarations.length > 0) {
+    rules.push(`.${EMAIL_BODY_CLASS_NAME}{${bodyDeclarations.join(';')}}`);
+  }
+
+  return rules.length === 0
+    ? ''
+    : `@media (prefers-color-scheme:dark){${rules.join('')}}`;
+};
 
 const themedBody = (theme: CanvasTheme, children: ReactNode) => (
   <Body
+    className={EMAIL_PAGE_CLASS_NAME}
     style={{
       backgroundColor: theme.pageBackground,
       color: theme.textColor,
@@ -16,12 +73,12 @@ const themedBody = (theme: CanvasTheme, children: ReactNode) => (
     }}
   >
     <Container
+      className={EMAIL_BODY_CLASS_NAME}
       style={{
         backgroundColor: theme.bodyBackground || undefined,
-        border:
-          theme.borderWidth !== '' && theme.borderWidth !== '0px'
-            ? `${theme.borderWidth} solid ${theme.borderColor}`
-            : undefined,
+        border: hasBorder(theme)
+          ? `${theme.borderWidth} solid ${theme.borderColor}`
+          : undefined,
         borderRadius: theme.cornerRadius,
         color: theme.textColor,
         maxWidth: theme.width,
@@ -45,9 +102,20 @@ export const reactMarkupFromJSON = (json: JSONContent | string) => {
   return (
     <Html>
       <Head>
+        {/* Declaring a dark scheme stops clients from auto-inverting, so only
+            themed documents (which ship their own dark rules) opt in. */}
+        {canvasTheme !== null && (
+          <>
+            <meta name="color-scheme" content="light dark" />
+            <meta name="supported-color-schemes" content="light dark" />
+          </>
+        )}
         <style
           dangerouslySetInnerHTML={{
-            __html: BASE_STYLE_RESET,
+            __html:
+              canvasTheme !== null
+                ? `${BASE_STYLE_RESET}${COLOR_SCHEME_DECLARATION}${darkColorSchemeStyle(canvasTheme)}`
+                : BASE_STYLE_RESET,
           }}
         />
       </Head>

--- a/packages/twenty-front/src/modules/activities/emails/editor/components/EmailEditorCanvas.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/editor/components/EmailEditorCanvas.tsx
@@ -1,9 +1,17 @@
 import { AdvancedTextEditor } from '@/advanced-text-editor/components/AdvancedTextEditor';
 import { type AdvancedTextEditorComponentProps } from '@/advanced-text-editor/types/AdvancedTextEditorComponentProps';
 import { styled } from '@linaria/react';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useEditorState } from '@tiptap/react';
-import { CANVAS_THEME_DEFAULTS, resolveCanvasTheme } from 'twenty-shared/utils';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
+import {
+  CANVAS_THEME_DEFAULTS,
+  getCanvasThemeForColorScheme,
+  resolveCanvasTheme,
+} from 'twenty-shared/utils';
+import {
+  themeCssVariables,
+  useThemeColorScheme,
+} from 'twenty-ui/theme-constants';
 
 const StyledCanvasBackdrop = styled.div`
   box-sizing: border-box;
@@ -42,7 +50,11 @@ export const EmailEditorCanvas = ({
     selector: ({ editor: currentEditor }) =>
       resolveCanvasTheme(currentEditor.state.doc.attrs.canvasTheme),
   });
-  const canvasTheme = storedCanvasTheme ?? CANVAS_THEME_DEFAULTS;
+  const themeColorScheme = useThemeColorScheme();
+  const canvasTheme = getCanvasThemeForColorScheme(
+    storedCanvasTheme ?? CANVAS_THEME_DEFAULTS,
+    themeColorScheme,
+  );
 
   return (
     <StyledCanvasBackdrop
@@ -55,7 +67,8 @@ export const EmailEditorCanvas = ({
         style={{
           backgroundColor: canvasTheme.bodyBackground || undefined,
           border:
-            canvasTheme.borderWidth !== '' && canvasTheme.borderWidth !== '0px'
+            isNonEmptyString(canvasTheme.borderWidth) &&
+            canvasTheme.borderWidth !== '0px'
               ? `${canvasTheme.borderWidth} solid ${canvasTheme.borderColor}`
               : undefined,
           borderRadius: canvasTheme.cornerRadius,

--- a/packages/twenty-front/src/modules/side-panel/pages/email-block-settings/components/EmailPageStyleSection.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/email-block-settings/components/EmailPageStyleSection.tsx
@@ -3,7 +3,7 @@ import { useLingui } from '@lingui/react/macro';
 import { type Editor } from '@tiptap/core';
 import { useEditorState } from '@tiptap/react';
 import {
-  type CanvasTheme,
+  type CanvasThemeStringProperty,
   isDefined,
   resolveCanvasTheme,
 } from 'twenty-shared/utils';
@@ -102,7 +102,10 @@ export const EmailPageStyleSection = ({
     );
   }
 
-  const setThemeValue = (themeKey: keyof CanvasTheme, value: string) => {
+  const setThemeValue = (
+    themeKey: CanvasThemeStringProperty,
+    value: string,
+  ) => {
     editor
       .chain()
       .command(({ tr }) => {

--- a/packages/twenty-front/src/modules/side-panel/pages/email-block-settings/components/SidePanelEmailBlockSettingsPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/email-block-settings/components/SidePanelEmailBlockSettingsPage.tsx
@@ -3,13 +3,17 @@ import { useLingui } from '@lingui/react/macro';
 import { type Editor } from '@tiptap/core';
 import { useEditorState } from '@tiptap/react';
 import {
+  getCanvasThemeForColorScheme,
   isDefined,
   resolveCanvasTheme,
   TIPTAP_NODE_TYPES,
 } from 'twenty-shared/utils';
 import { IconTrash } from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
+import {
+  themeCssVariables,
+  useThemeColorScheme,
+} from 'twenty-ui/theme-constants';
 
 import { activeEmailEditorState } from '@/activities/emails/states/activeEmailEditorState';
 import { ADVANCED_TEXT_EDITOR_BLOCK_CATALOG } from '@/advanced-text-editor/constants/AdvancedTextEditorBlockCatalog';
@@ -71,6 +75,7 @@ const BOX_FIELD_SIDE_PROPERTIES: Record<
 
 const EmailBlockSettingsContent = ({ editor }: { editor: Editor }) => {
   const { i18n, t } = useLingui();
+  const themeColorScheme = useThemeColorScheme();
   const target = useEditorState({
     editor,
     selector: ({ editor: currentEditor }) =>
@@ -84,7 +89,12 @@ const EmailBlockSettingsContent = ({ editor }: { editor: Editor }) => {
   const blockDefinition = ADVANCED_TEXT_EDITOR_BLOCK_CATALOG[target.nodeType];
   const fields = blockDefinition.settingsFields;
   const styles = getBlockStyle(target.attrs.style);
-  const canvasTheme = resolveCanvasTheme(editor.state.doc.attrs.canvasTheme);
+  const storedCanvasTheme = resolveCanvasTheme(
+    editor.state.doc.attrs.canvasTheme,
+  );
+  const canvasTheme = isDefined(storedCanvasTheme)
+    ? getCanvasThemeForColorScheme(storedCanvasTheme, themeColorScheme)
+    : null;
 
   const displayedStyleValue = (property: string) =>
     styles[property] ??

--- a/packages/twenty-front/src/modules/side-panel/pages/email-block-settings/types/EmailThemeField.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/email-block-settings/types/EmailThemeField.ts
@@ -1,11 +1,11 @@
 import { type MessageDescriptor } from '@lingui/core';
-import { type CanvasTheme } from 'twenty-shared/utils';
+import { type CanvasThemeStringProperty } from 'twenty-shared/utils';
 
 import { type AdvancedTextEditorSettingInput } from '@/advanced-text-editor/types/AdvancedTextEditorBlockCatalog';
 
 export type EmailThemeField = {
   label: MessageDescriptor;
-  property: keyof CanvasTheme;
+  property: CanvasThemeStringProperty;
   input: AdvancedTextEditorSettingInput;
   placeholder?: string;
 };

--- a/packages/twenty-server/src/engine/core-modules/email/utils/__tests__/compile-outbound-email-content.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/email/utils/__tests__/compile-outbound-email-content.util.spec.ts
@@ -156,6 +156,76 @@ describe('compileOutboundEmailContent', () => {
     expect(html).toContain('max-width:600px');
   });
 
+  it('should emit dark color scheme overrides alongside the light inline styles', async () => {
+    const html = await compileDocument({
+      type: 'doc',
+      attrs: {
+        canvasTheme: {
+          pageBackground: '#ffffff',
+          textColor: '#1c1c1c',
+          borderWidth: '1px',
+          borderColor: '#dbdbdb',
+          dark: {
+            pageBackground: '#1c1c1c',
+            textColor: '#ffffff',
+            borderColor: '#424242',
+          },
+        },
+      },
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Adaptive content' }],
+        },
+      ],
+    });
+
+    expect(html).toContain('background-color:#ffffff');
+    expect(html).toContain('@media (prefers-color-scheme:dark)');
+    expect(html).toContain('.email-page{background-color:#1c1c1c !important');
+    expect(html).toContain('border-color:#424242 !important');
+    expect(html).toContain('color-scheme:light dark');
+  });
+
+  it('should drop dark colors that could break out of the stylesheet', async () => {
+    const html = await compileDocument({
+      type: 'doc',
+      attrs: {
+        canvasTheme: {
+          dark: {
+            pageBackground: '#000}</style><script>alert(1)</script>',
+            textColor: '#ffffff',
+          },
+        },
+      },
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Adaptive content' }],
+        },
+      ],
+    });
+
+    expect(html).not.toContain('alert(1)');
+    expect(html).toContain('.email-page{color:#ffffff !important}');
+  });
+
+  it('should not declare a dark color scheme for documents without a theme', async () => {
+    const html = await compileDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Untethered content' }],
+        },
+      ],
+    });
+
+    expect(html).toContain('Untethered content');
+    expect(html).not.toContain('color-scheme');
+    expect(html).not.toContain('prefers-color-scheme');
+  });
+
   it('should keep the bare body for documents without a theme', async () => {
     const html = await compileDocument({
       type: 'doc',

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -220,8 +220,17 @@ export { pascalToKebab } from './strings/pascalToKebab';
 export { stringifySafely } from './strings/stringifySafely';
 export { uncapitalize } from './strings/uncapitalize';
 export { getSubdomainSlugFromDisplayName } from './subdomain/getSubdomainSlugFromDisplayName';
-export type { CanvasTheme } from './tiptap/canvas-theme';
-export { CANVAS_THEME_DEFAULTS } from './tiptap/canvas-theme';
+export type {
+  CanvasThemeColors,
+  CanvasTheme,
+  CanvasThemeColorScheme,
+  CanvasThemeStringProperty,
+} from './tiptap/canvas-theme';
+export {
+  CANVAS_THEME_COLOR_PROPERTIES,
+  CANVAS_THEME_DARK_DEFAULTS,
+  CANVAS_THEME_DEFAULTS,
+} from './tiptap/canvas-theme';
 export type { EmailDocumentMarkType } from './tiptap/email-document-mark-catalog';
 export {
   EMAIL_DOCUMENT_MARK_CATALOG,
@@ -241,6 +250,7 @@ export { EMAIL_DOCUMENT_SCHEMA_VERSION } from './tiptap/email-document-schema-ve
 export type { EmailDocument } from './tiptap/email-document-schema';
 export { emailDocumentSchema } from './tiptap/email-document-schema';
 export type { EmailDocumentStringContext } from './tiptap/email-document-string-context';
+export { getCanvasThemeForColorScheme } from './tiptap/get-canvas-theme-for-color-scheme';
 export { isCanvasTheme } from './tiptap/is-canvas-theme';
 export { isEmailDocumentShape } from './tiptap/is-email-document-shape';
 export type { CampaignVariableDefinition } from './tiptap/list-campaign-variables-for-fields';

--- a/packages/twenty-shared/src/utils/tiptap/__tests__/resolve-canvas-theme.test.ts
+++ b/packages/twenty-shared/src/utils/tiptap/__tests__/resolve-canvas-theme.test.ts
@@ -1,0 +1,57 @@
+import {
+  CANVAS_THEME_DARK_DEFAULTS,
+  CANVAS_THEME_DEFAULTS,
+} from '../canvas-theme';
+import { getCanvasThemeForColorScheme } from '../get-canvas-theme-for-color-scheme';
+import { resolveCanvasTheme } from '../resolve-canvas-theme';
+
+describe('resolveCanvasTheme', () => {
+  it('should fall back to the dark defaults when the document predates dark mode', () => {
+    const theme = resolveCanvasTheme({ pageBackground: '#f4f4f5' });
+
+    expect(theme?.pageBackground).toBe('#f4f4f5');
+    expect(theme?.dark).toEqual(CANVAS_THEME_DARK_DEFAULTS);
+  });
+
+  it('should keep dark defaults for the colors the document does not override', () => {
+    const theme = resolveCanvasTheme({ dark: { textColor: '#eeeeee' } });
+
+    expect(theme?.dark).toEqual({
+      ...CANVAS_THEME_DARK_DEFAULTS,
+      textColor: '#eeeeee',
+    });
+  });
+
+  it('should ignore a dark attribute that is not a color map', () => {
+    expect(resolveCanvasTheme({ dark: 'nope' })?.dark).toEqual(
+      CANVAS_THEME_DARK_DEFAULTS,
+    );
+  });
+
+  it('should return null for non object values', () => {
+    expect(resolveCanvasTheme(null)).toBeNull();
+    expect(resolveCanvasTheme([])).toBeNull();
+  });
+});
+
+describe('getCanvasThemeForColorScheme', () => {
+  it('should apply the dark colors while keeping the shared geometry', () => {
+    const darkTheme = getCanvasThemeForColorScheme(
+      CANVAS_THEME_DEFAULTS,
+      'dark',
+    );
+
+    expect(darkTheme.pageBackground).toBe(
+      CANVAS_THEME_DARK_DEFAULTS.pageBackground,
+    );
+    expect(darkTheme.textColor).toBe(CANVAS_THEME_DARK_DEFAULTS.textColor);
+    expect(darkTheme.width).toBe(CANVAS_THEME_DEFAULTS.width);
+    expect(darkTheme.padding).toBe(CANVAS_THEME_DEFAULTS.padding);
+  });
+
+  it('should leave the theme untouched for the light scheme', () => {
+    expect(getCanvasThemeForColorScheme(CANVAS_THEME_DEFAULTS, 'light')).toBe(
+      CANVAS_THEME_DEFAULTS,
+    );
+  });
+});

--- a/packages/twenty-shared/src/utils/tiptap/canvas-theme.ts
+++ b/packages/twenty-shared/src/utils/tiptap/canvas-theme.ts
@@ -1,25 +1,55 @@
-export type CanvasTheme = {
+export type CanvasThemeColors = {
   pageBackground: string;
-  pagePadding: string;
-  textAlign: 'left' | 'center' | 'right';
   bodyBackground: string;
   textColor: string;
+  borderColor: string;
+};
+
+export type CanvasTheme = CanvasThemeColors & {
+  pagePadding: string;
+  textAlign: 'left' | 'center' | 'right';
   width: string;
   padding: string;
   cornerRadius: string;
   borderWidth: string;
-  borderColor: string;
+  dark: CanvasThemeColors;
+};
+
+export type CanvasThemeColorScheme = 'light' | 'dark';
+
+export type CanvasThemeStringProperty = Exclude<keyof CanvasTheme, 'dark'>;
+
+export const CANVAS_THEME_COLOR_PROPERTIES = [
+  'pageBackground',
+  'bodyBackground',
+  'textColor',
+  'borderColor',
+] as const satisfies readonly (keyof CanvasThemeColors)[];
+
+const WEBSITE_WHITE = '#ffffff';
+const WEBSITE_BLACK = '#1c1c1c';
+const WEBSITE_SILVER = '#dbdbdb';
+const WEBSITE_GRAPHITE = '#424242';
+
+const APP_DARK_SURFACE = '#171717';
+
+export const CANVAS_THEME_DARK_DEFAULTS: CanvasThemeColors = {
+  pageBackground: APP_DARK_SURFACE,
+  bodyBackground: '',
+  textColor: WEBSITE_WHITE,
+  borderColor: WEBSITE_GRAPHITE,
 };
 
 export const CANVAS_THEME_DEFAULTS: CanvasTheme = {
-  pageBackground: '#ffffff',
+  pageBackground: WEBSITE_WHITE,
   pagePadding: '24px',
   textAlign: 'left',
   bodyBackground: '',
-  textColor: '#18181b',
+  textColor: WEBSITE_BLACK,
   width: '600px',
   padding: '24px',
   cornerRadius: '0px',
   borderWidth: '0px',
-  borderColor: '',
+  borderColor: WEBSITE_SILVER,
+  dark: CANVAS_THEME_DARK_DEFAULTS,
 };

--- a/packages/twenty-shared/src/utils/tiptap/email-document-schema.ts
+++ b/packages/twenty-shared/src/utils/tiptap/email-document-schema.ts
@@ -153,17 +153,21 @@ const blockNodeSchema = z.discriminatedUnion('type', [
   htmlNodeSchema,
 ]);
 
-const canvasThemeAttributeSchema = z.looseObject({
+const canvasThemeColorsAttributeSchema = z.looseObject({
   pageBackground: z.string().optional(),
-  pagePadding: z.string().optional(),
-  textAlign: z.enum(['left', 'center', 'right']).optional(),
   bodyBackground: z.string().optional(),
   textColor: z.string().optional(),
+  borderColor: z.string().optional(),
+});
+
+const canvasThemeAttributeSchema = canvasThemeColorsAttributeSchema.extend({
+  pagePadding: z.string().optional(),
+  textAlign: z.enum(['left', 'center', 'right']).optional(),
   width: z.string().optional(),
   padding: z.string().optional(),
   cornerRadius: z.string().optional(),
   borderWidth: z.string().optional(),
-  borderColor: z.string().optional(),
+  dark: canvasThemeColorsAttributeSchema.nullable().optional(),
 });
 
 export const emailDocumentSchema = z.looseObject({

--- a/packages/twenty-shared/src/utils/tiptap/get-canvas-theme-for-color-scheme.ts
+++ b/packages/twenty-shared/src/utils/tiptap/get-canvas-theme-for-color-scheme.ts
@@ -1,0 +1,7 @@
+import { type CanvasTheme, type CanvasThemeColorScheme } from './canvas-theme';
+
+export const getCanvasThemeForColorScheme = (
+  theme: CanvasTheme,
+  colorScheme: CanvasThemeColorScheme,
+): CanvasTheme =>
+  colorScheme === 'dark' ? { ...theme, ...theme.dark } : theme;

--- a/packages/twenty-shared/src/utils/tiptap/index.ts
+++ b/packages/twenty-shared/src/utils/tiptap/index.ts
@@ -3,6 +3,7 @@ export * from './email-document-node';
 export * from './email-document-schema';
 export * from './email-document-schema-version';
 export * from './email-document-string-context';
+export * from './get-canvas-theme-for-color-scheme';
 export * from './is-canvas-theme';
 export * from './list-campaign-variables-for-fields';
 export * from './parse-email-document';

--- a/packages/twenty-shared/src/utils/tiptap/resolve-canvas-theme.ts
+++ b/packages/twenty-shared/src/utils/tiptap/resolve-canvas-theme.ts
@@ -1,5 +1,35 @@
-import { CANVAS_THEME_DEFAULTS, type CanvasTheme } from './canvas-theme';
+import {
+  CANVAS_THEME_COLOR_PROPERTIES,
+  CANVAS_THEME_DARK_DEFAULTS,
+  CANVAS_THEME_DEFAULTS,
+  type CanvasTheme,
+  type CanvasThemeColors,
+} from './canvas-theme';
 import { isCanvasTheme } from './is-canvas-theme';
 
+const resolveDarkCanvasThemeColors = (value: unknown): CanvasThemeColors => {
+  if (!isCanvasTheme(value)) {
+    return CANVAS_THEME_DARK_DEFAULTS;
+  }
+
+  const colors = { ...CANVAS_THEME_DARK_DEFAULTS };
+
+  for (const property of CANVAS_THEME_COLOR_PROPERTIES) {
+    const override = value[property];
+
+    if (typeof override === 'string') {
+      colors[property] = override;
+    }
+  }
+
+  return colors;
+};
+
 export const resolveCanvasTheme = (value: unknown): CanvasTheme | null =>
-  isCanvasTheme(value) ? { ...CANVAS_THEME_DEFAULTS, ...value } : null;
+  isCanvasTheme(value)
+    ? {
+        ...CANVAS_THEME_DEFAULTS,
+        ...value,
+        dark: resolveDarkCanvasThemeColors(value.dark),
+      }
+    : null;


### PR DESCRIPTION
Canvas theme now carries a nested `dark` color set (page/body background, text, border) alongside the light values.

Resolved per color scheme in the editor and emitted as a `prefers-color-scheme` block at render time.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

