### PR TITLE
fix(mcp) - hydrate relation fields selected by name in MCP find tools

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-select-fields/common-select-fields-helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-select-fields/common-select-fields-helper.ts
@@ -1,23 +1,14 @@
 import { Injectable } from '@nestjs/common';
 
-import { FieldMetadataType, ObjectsPermissions } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
+import { ObjectsPermissions } from 'twenty-shared/types';
 
 import { getAllSelectableFields } from 'src/engine/api/common/common-select-fields/utils/get-all-selectable-fields.util';
-import { getIsFlatFieldAJoinColumn } from 'src/engine/api/common/common-select-fields/utils/get-is-flat-field-a-join-column.util';
-import { getIsFlatFieldAJunctionRelationField } from 'src/engine/api/common/common-select-fields/utils/get-is-flat-field-a-junction-relation-field';
+import { getRelationsSelectFields } from 'src/engine/api/common/common-select-fields/utils/get-relations-select-fields.util';
 import { CommonSelectedFields } from 'src/engine/api/common/types/common-selected-fields-result.type';
-import { MAX_DEPTH } from 'src/engine/api/rest/input-request-parsers/constants/max-depth.constant';
 import { Depth } from 'src/engine/api/rest/input-request-parsers/types/depth.type';
 import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-
-type SelectFields = {
-  [key: string]: boolean | SelectFields;
-};
 
 @Injectable()
 export class CommonSelectFieldsHelper {
@@ -41,7 +32,7 @@ export class CommonSelectFieldsHelper {
     const restrictedFields =
       objectsPermissions[flatObjectMetadata.id].restrictedFields;
 
-    const relationsSelectFields = this.getRelationsAndRelationsSelectFields({
+    const relationsSelectFields = getRelationsSelectFields({
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,
       flatObjectMetadata,
@@ -62,110 +53,4 @@ export class CommonSelectFieldsHelper {
       ...relationsSelectFields,
     };
   };
-
-  private getRelationsAndRelationsSelectFields({
-    flatObjectMetadataMaps,
-    flatFieldMetadataMaps,
-    flatObjectMetadata,
-    objectsPermissions,
-    depth,
-    onlyUseLabelIdentifierFieldsInRelations = false,
-    currentDepthLevelIsAJunctionTable = false,
-    recurseIntoJunctionTableRelations = false,
-  }: {
-    flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
-    flatObjectMetadata: FlatObjectMetadata;
-    objectsPermissions: ObjectsPermissions;
-    depth: Depth | undefined;
-    onlyUseLabelIdentifierFieldsInRelations?: boolean;
-    currentDepthLevelIsAJunctionTable?: boolean;
-    recurseIntoJunctionTableRelations?: boolean;
-  }) {
-    if (!isDefined(depth) || depth === 0) return {};
-
-    let relationsSelectFields: SelectFields = {};
-
-    for (const fieldId of flatObjectMetadata.fieldIds) {
-      const flatField = findFlatEntityByIdInFlatEntityMapsOrThrow({
-        flatEntityMaps: flatFieldMetadataMaps,
-        flatEntityId: fieldId,
-      });
-
-      if (
-        !isFlatFieldMetadataOfType(flatField, FieldMetadataType.RELATION) &&
-        !isFlatFieldMetadataOfType(flatField, FieldMetadataType.MORPH_RELATION)
-      ) {
-        continue;
-      }
-
-      if (currentDepthLevelIsAJunctionTable) {
-        const fieldIsJunctionRelation = getIsFlatFieldAJunctionRelationField({
-          flatField,
-        });
-
-        if (!fieldIsJunctionRelation) {
-          continue;
-        }
-      }
-
-      const relationTargetObjectMetadata =
-        findFlatEntityByIdInFlatEntityMapsOrThrow({
-          flatEntityMaps: flatObjectMetadataMaps,
-          flatEntityId: flatField.relationTargetObjectMetadataId,
-        });
-
-      if (
-        !objectsPermissions[relationTargetObjectMetadata.id]
-          ?.canReadObjectRecords
-      ) {
-        continue;
-      }
-
-      const relationFieldSelectFields = getAllSelectableFields({
-        restrictedFields:
-          objectsPermissions[relationTargetObjectMetadata.id].restrictedFields,
-        flatObjectMetadata: relationTargetObjectMetadata,
-        flatFieldMetadataMaps,
-        onlyUseLabelIdentifierFieldsInRelations,
-      });
-
-      if (Object.keys(relationFieldSelectFields).length === 0) continue;
-
-      const flatFieldIsJoinColumn = getIsFlatFieldAJoinColumn({ flatField });
-
-      const isFirstDepthLevel =
-        depth === MAX_DEPTH &&
-        isDefined(flatField.relationTargetObjectMetadataId);
-
-      const shouldRecurseIntoRelation =
-        isFirstDepthLevel ||
-        (flatFieldIsJoinColumn && recurseIntoJunctionTableRelations);
-
-      const nextLevelIsAJunctionTable = flatFieldIsJoinColumn;
-
-      if (shouldRecurseIntoRelation) {
-        const nestedRelationFieldSelectFields =
-          this.getRelationsAndRelationsSelectFields({
-            flatObjectMetadataMaps,
-            flatFieldMetadataMaps,
-            flatObjectMetadata: relationTargetObjectMetadata,
-            objectsPermissions,
-            depth: 1,
-            onlyUseLabelIdentifierFieldsInRelations,
-            currentDepthLevelIsAJunctionTable: nextLevelIsAJunctionTable,
-            recurseIntoJunctionTableRelations,
-          });
-
-        relationsSelectFields[flatField.name] = {
-          ...relationFieldSelectFields,
-          ...nestedRelationFieldSelectFields,
-        };
-      } else {
-        relationsSelectFields[flatField.name] = relationFieldSelectFields;
-      }
-    }
-
-    return relationsSelectFields;
-  }
 }

--- a/packages/twenty-server/src/engine/api/common/common-select-fields/utils/get-relations-select-fields.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-select-fields/utils/get-relations-select-fields.util.ts
@@ -49,6 +49,13 @@ export const getRelationsSelectFields = ({
       continue;
     }
 
+    if (
+      objectsPermissions[flatObjectMetadata.id]?.restrictedFields[flatField.id]
+        ?.canRead === false
+    ) {
+      continue;
+    }
+
     if (currentDepthLevelIsAJunctionTable) {
       const fieldIsJunctionRelation = getIsFlatFieldAJunctionRelationField({
         flatField,

--- a/packages/twenty-server/src/engine/api/common/common-select-fields/utils/get-relations-select-fields.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-select-fields/utils/get-relations-select-fields.util.ts
@@ -1,0 +1,118 @@
+import { FieldMetadataType, ObjectsPermissions } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { getAllSelectableFields } from 'src/engine/api/common/common-select-fields/utils/get-all-selectable-fields.util';
+import { getIsFlatFieldAJoinColumn } from 'src/engine/api/common/common-select-fields/utils/get-is-flat-field-a-join-column.util';
+import { getIsFlatFieldAJunctionRelationField } from 'src/engine/api/common/common-select-fields/utils/get-is-flat-field-a-junction-relation-field';
+import { CommonSelectedFields } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { MAX_DEPTH } from 'src/engine/api/rest/input-request-parsers/constants/max-depth.constant';
+import { Depth } from 'src/engine/api/rest/input-request-parsers/types/depth.type';
+import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
+import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+
+export const getRelationsSelectFields = ({
+  flatObjectMetadataMaps,
+  flatFieldMetadataMaps,
+  flatObjectMetadata,
+  objectsPermissions,
+  depth,
+  onlyUseLabelIdentifierFieldsInRelations = false,
+  currentDepthLevelIsAJunctionTable = false,
+  recurseIntoJunctionTableRelations = false,
+}: {
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatObjectMetadata: FlatObjectMetadata;
+  objectsPermissions: ObjectsPermissions;
+  depth: Depth | undefined;
+  onlyUseLabelIdentifierFieldsInRelations?: boolean;
+  currentDepthLevelIsAJunctionTable?: boolean;
+  recurseIntoJunctionTableRelations?: boolean;
+}): CommonSelectedFields => {
+  if (!isDefined(depth) || depth === 0) return {};
+
+  const relationsSelectFields: CommonSelectedFields = {};
+
+  for (const fieldId of flatObjectMetadata.fieldIds) {
+    const flatField = findFlatEntityByIdInFlatEntityMapsOrThrow({
+      flatEntityMaps: flatFieldMetadataMaps,
+      flatEntityId: fieldId,
+    });
+
+    if (
+      !isFlatFieldMetadataOfType(flatField, FieldMetadataType.RELATION) &&
+      !isFlatFieldMetadataOfType(flatField, FieldMetadataType.MORPH_RELATION)
+    ) {
+      continue;
+    }
+
+    if (currentDepthLevelIsAJunctionTable) {
+      const fieldIsJunctionRelation = getIsFlatFieldAJunctionRelationField({
+        flatField,
+      });
+
+      if (!fieldIsJunctionRelation) {
+        continue;
+      }
+    }
+
+    const relationTargetObjectMetadata =
+      findFlatEntityByIdInFlatEntityMapsOrThrow({
+        flatEntityMaps: flatObjectMetadataMaps,
+        flatEntityId: flatField.relationTargetObjectMetadataId,
+      });
+
+    if (
+      !objectsPermissions[relationTargetObjectMetadata.id]?.canReadObjectRecords
+    ) {
+      continue;
+    }
+
+    const relationFieldSelectFields = getAllSelectableFields({
+      restrictedFields:
+        objectsPermissions[relationTargetObjectMetadata.id].restrictedFields,
+      flatObjectMetadata: relationTargetObjectMetadata,
+      flatFieldMetadataMaps,
+      onlyUseLabelIdentifierFieldsInRelations,
+    });
+
+    if (Object.keys(relationFieldSelectFields).length === 0) continue;
+
+    const flatFieldIsJoinColumn = getIsFlatFieldAJoinColumn({ flatField });
+
+    const isFirstDepthLevel =
+      depth === MAX_DEPTH &&
+      isDefined(flatField.relationTargetObjectMetadataId);
+
+    const shouldRecurseIntoRelation =
+      isFirstDepthLevel ||
+      (flatFieldIsJoinColumn && recurseIntoJunctionTableRelations);
+
+    const nextLevelIsAJunctionTable = flatFieldIsJoinColumn;
+
+    if (shouldRecurseIntoRelation) {
+      const nestedRelationFieldSelectFields = getRelationsSelectFields({
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        flatObjectMetadata: relationTargetObjectMetadata,
+        objectsPermissions,
+        depth: 1,
+        onlyUseLabelIdentifierFieldsInRelations,
+        currentDepthLevelIsAJunctionTable: nextLevelIsAJunctionTable,
+        recurseIntoJunctionTableRelations,
+      });
+
+      relationsSelectFields[flatField.name] = {
+        ...relationFieldSelectFields,
+        ...nestedRelationFieldSelectFields,
+      };
+    } else {
+      relationsSelectFields[flatField.name] = relationFieldSelectFields;
+    }
+  }
+
+  return relationsSelectFields;
+};

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/__tests__/graphql-selected-fields-relation.parser.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/__tests__/graphql-selected-fields-relation.parser.spec.ts
@@ -1,0 +1,129 @@
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { GraphqlQuerySelectedFieldsParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+
+const createMockField = (
+  overrides: Partial<FlatFieldMetadata> & {
+    id: string;
+    name: string;
+    type: FieldMetadataType;
+  },
+): FlatFieldMetadata =>
+  ({
+    workspaceId: 'workspace-id',
+    universalIdentifier: overrides.id,
+    label: overrides.name,
+    ...overrides,
+  }) as FlatFieldMetadata;
+
+const buildFieldMaps = (
+  fields: FlatFieldMetadata[],
+): FlatEntityMaps<FlatFieldMetadata> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    fields.map((field) => [field.universalIdentifier, field]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    fields.map((field) => [field.id, field.universalIdentifier]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+const createMockObject = (
+  overrides: Partial<FlatObjectMetadata> & {
+    id: string;
+    nameSingular: string;
+    fieldIds: string[];
+  },
+): FlatObjectMetadata =>
+  ({
+    workspaceId: 'workspace-id',
+    universalIdentifier: overrides.id,
+    ...overrides,
+  }) as FlatObjectMetadata;
+
+const buildObjectMaps = (
+  objects: FlatObjectMetadata[],
+): FlatEntityMaps<FlatObjectMetadata> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    objects.map((object) => [object.universalIdentifier, object]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    objects.map((object) => [object.id, object.universalIdentifier]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+describe('GraphqlQuerySelectedFieldsParser relation fields', () => {
+  const leadIdField = createMockField({
+    id: 'lead-id-field',
+    name: 'id',
+    type: FieldMetadataType.UUID,
+  });
+  const fundField = createMockField({
+    id: 'fund-field',
+    name: 'fund',
+    type: FieldMetadataType.RELATION,
+    settings: { relationType: RelationType.ONE_TO_MANY },
+    relationTargetObjectMetadataId: 'company-object-id',
+  } as Partial<FlatFieldMetadata> & {
+    id: string;
+    name: string;
+    type: FieldMetadataType;
+  });
+  const companyIdField = createMockField({
+    id: 'company-id-field',
+    name: 'id',
+    type: FieldMetadataType.UUID,
+  });
+  const companyNameField = createMockField({
+    id: 'company-name-field',
+    name: 'name',
+    type: FieldMetadataType.TEXT,
+  });
+
+  const investorLeadObject = createMockObject({
+    id: 'investor-lead-object-id',
+    nameSingular: 'investorLead',
+    fieldIds: ['lead-id-field', 'fund-field'],
+  });
+  const companyObject = createMockObject({
+    id: 'company-object-id',
+    nameSingular: 'company',
+    fieldIds: ['company-id-field', 'company-name-field'],
+  });
+
+  const fieldMaps = buildFieldMaps([
+    leadIdField,
+    fundField,
+    companyIdField,
+    companyNameField,
+  ]);
+  const objectMaps = buildObjectMaps([investorLeadObject, companyObject]);
+
+  it('should ignore a relation selected as a boolean', () => {
+    // Boolean selections carry no sub-fields; only the object form hydrates
+    const parser = new GraphqlQuerySelectedFieldsParser(objectMaps, fieldMaps);
+
+    const result = parser.parse({ id: true, fund: true }, investorLeadObject);
+
+    expect(result.select).toEqual({ id: true });
+    expect(result.relations).toEqual({});
+    expect(result.relationFieldsCount).toBe(0);
+  });
+
+  it('should hydrate a relation selected as a nested object', () => {
+    const parser = new GraphqlQuerySelectedFieldsParser(objectMaps, fieldMaps);
+
+    const result = parser.parse(
+      { id: true, fund: { id: true, name: true } },
+      investorLeadObject,
+    );
+
+    expect(result.select.fund).toEqual({ id: true, name: true });
+    expect(result.relations.fund).toEqual({});
+    expect(result.relationFieldsCount).toBe(1);
+  });
+});

--- a/packages/twenty-server/src/engine/api/rest/core/rest-to-common-args-handlers/__tests__/selected-fields-handler.spec.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/rest-to-common-args-handlers/__tests__/selected-fields-handler.spec.ts
@@ -366,6 +366,64 @@ describe('RestToCommonSelectedFieldsHandler', () => {
       });
     });
 
+    it('should not include the relation when the relation field itself is restricted', () => {
+      const companyRelationField = createMockField({
+        id: 'field-1',
+        name: 'company',
+        type: FieldMetadataType.RELATION,
+        objectMetadataId: 'person-id',
+        settings: {
+          relationType: RelationType.ONE_TO_MANY,
+        },
+        relationTargetObjectMetadataId: 'company-id',
+      });
+      const companyNameField = createMockField({
+        id: 'field-2',
+        name: 'name',
+        type: FieldMetadataType.TEXT,
+        objectMetadataId: 'company-id',
+      });
+
+      const personObject = createMockObjectMetadata({
+        id: 'person-id',
+        nameSingular: 'person',
+        fieldIds: ['field-1'],
+      });
+      const companyObject = createMockObjectMetadata({
+        id: 'company-id',
+        nameSingular: 'company',
+        fieldIds: ['field-2'],
+      });
+
+      const flatFieldMetadataMaps = buildFlatFieldMetadataMaps([
+        companyRelationField,
+        companyNameField,
+      ]);
+      const flatObjectMetadataMaps = buildFlatObjectMetadataMaps([
+        personObject,
+        companyObject,
+      ]);
+
+      const objectsPermissions = createObjectsPermissions([
+        'person-id',
+        'company-id',
+      ]);
+
+      objectsPermissions['person-id'].restrictedFields = {
+        'field-1': { canRead: false, canUpdate: false },
+      };
+
+      const result = handler.computeFromDepth({
+        objectsPermissions,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        flatObjectMetadata: personObject,
+        depth: 1,
+      });
+
+      expect(result).toEqual({});
+    });
+
     it('should handle nested relations up to MAX_DEPTH', () => {
       const personCompanyRelation = createMockField({
         id: 'field-1',

--- a/packages/twenty-server/src/engine/core-modules/record-crud/services/find-records.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/services/find-records.service.ts
@@ -73,6 +73,7 @@ export class FindRecordsService {
               flatFieldMetadataMaps,
               flatObjectMetadataMaps,
               selectedFields: allSelectableFields,
+              objectsPermissions,
               selectableRelationFields: getRelationsSelectFields({
                 flatObjectMetadataMaps,
                 flatFieldMetadataMaps,

--- a/packages/twenty-server/src/engine/core-modules/record-crud/services/find-records.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/services/find-records.service.ts
@@ -7,6 +7,7 @@ import { type ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query
 
 import { isNonEmptyArray } from '@sniptt/guards';
 import { CommonFindManyQueryRunnerService } from 'src/engine/api/common/common-query-runners/common-find-many-query-runner.service';
+import { getRelationsSelectFields } from 'src/engine/api/common/common-select-fields/utils/get-relations-select-fields.util';
 import { CommonApiContextBuilderService } from 'src/engine/core-modules/record-crud/services/common-api-context-builder.service';
 import { type FindRecordsParams } from 'src/engine/core-modules/record-crud/types/find-records-params.type';
 import { type FindRecordsResult } from 'src/engine/core-modules/record-crud/types/find-records-result.type';
@@ -52,7 +53,9 @@ export class FindRecordsService {
         queryRunnerContext,
         selectedFields: allSelectableFields,
         flatObjectMetadata,
+        flatObjectMetadataMaps,
         flatFieldMetadataMaps,
+        objectsPermissions,
       } = await this.commonApiContextBuilder.build({
         authContext,
         objectName,
@@ -68,7 +71,16 @@ export class FindRecordsService {
               objectName,
               flatObjectMetadata,
               flatFieldMetadataMaps,
+              flatObjectMetadataMaps,
               selectedFields: allSelectableFields,
+              selectableRelationFields: getRelationsSelectFields({
+                flatObjectMetadataMaps,
+                flatFieldMetadataMaps,
+                flatObjectMetadata,
+                objectsPermissions,
+                depth: 1,
+                onlyUseLabelIdentifierFieldsInRelations: true,
+              }),
             })
           : { effectiveSelectedFields: allSelectableFields, warnings: [] };
 

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
@@ -386,11 +386,17 @@ describe('buildEffectiveSelectedFields', () => {
       universalIdentifiersByApplicationId: {},
     } as unknown as FlatEntityMaps<FlatObjectMetadata>;
 
-    const buildObjectsPermissions = (canReadCompany: boolean) =>
+    const buildObjectsPermissions = ({
+      canReadCompany = true,
+      sourceRestrictedFields = {},
+    }: {
+      canReadCompany?: boolean;
+      sourceRestrictedFields?: Record<string, { canRead: boolean }>;
+    }) =>
       ({
         'investor-lead-object-id': {
           canReadObjectRecords: true,
-          restrictedFields: {},
+          restrictedFields: sourceRestrictedFields,
         },
         'company-object-id': {
           canReadObjectRecords: canReadCompany,
@@ -398,12 +404,14 @@ describe('buildEffectiveSelectedFields', () => {
         },
       }) as unknown as ObjectsPermissions;
 
-    const buildSelectableRelationFields = (canReadCompany: boolean) =>
+    const buildSelectableRelationFields = (
+      objectsPermissions: ObjectsPermissions,
+    ) =>
       getRelationsSelectFields({
         flatObjectMetadataMaps: relationObjectMaps,
         flatFieldMetadataMaps: relationFieldMaps,
         flatObjectMetadata: investorLeadObjectMetadata,
-        objectsPermissions: buildObjectsPermissions(canReadCompany),
+        objectsPermissions,
         depth: 1,
         onlyUseLabelIdentifierFieldsInRelations: true,
       });
@@ -419,7 +427,9 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: investorLeadObjectMetadata,
           flatFieldMetadataMaps: relationFieldMaps,
           selectedFields: { id: true, name: true, fund: true },
-          selectableRelationFields: buildSelectableRelationFields(true),
+          selectableRelationFields: buildSelectableRelationFields(
+            buildObjectsPermissions({}),
+          ),
         });
 
       expect(warnings).toEqual([]);
@@ -441,7 +451,9 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: investorLeadObjectMetadata,
           flatFieldMetadataMaps: relationFieldMaps,
           selectedFields: { id: true, name: true, fund: true },
-          selectableRelationFields: buildSelectableRelationFields(true),
+          selectableRelationFields: buildSelectableRelationFields(
+            buildObjectsPermissions({}),
+          ),
         });
 
       expect(warnings).toEqual([]);
@@ -463,7 +475,33 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: investorLeadObjectMetadata,
           flatFieldMetadataMaps: relationFieldMaps,
           selectedFields: { id: true, name: true, fund: true },
-          selectableRelationFields: buildSelectableRelationFields(false),
+          selectableRelationFields: buildSelectableRelationFields(
+            buildObjectsPermissions({ canReadCompany: false }),
+          ),
+        });
+
+      expect(effectiveSelectedFields).toEqual({ id: true, name: true });
+      expect(warnings).toEqual([
+        "Field 'fund' on investorLead cannot be selected because you do not have read access to company.",
+      ]);
+    });
+
+    it('should not hydrate a relation whose source field is restricted', () => {
+      const { effectiveSelectedFields, warnings } =
+        buildEffectiveSelectedFields({
+          select: ['name', 'fund'],
+          filter: undefined,
+          orderBy: undefined,
+          objectName: 'investorLead',
+          flatObjectMetadataMaps: relationObjectMaps,
+          flatObjectMetadata: investorLeadObjectMetadata,
+          flatFieldMetadataMaps: relationFieldMaps,
+          selectedFields: { id: true, name: true, fund: true },
+          selectableRelationFields: buildSelectableRelationFields(
+            buildObjectsPermissions({
+              sourceRestrictedFields: { 'fund-field': { canRead: false } },
+            }),
+          ),
         });
 
       expect(effectiveSelectedFields).toEqual({ id: true, name: true });
@@ -482,7 +520,9 @@ describe('buildEffectiveSelectedFields', () => {
         flatObjectMetadata: investorLeadObjectMetadata,
         flatFieldMetadataMaps: relationFieldMaps,
         selectedFields: { id: true, name: true, fund: true },
-        selectableRelationFields: buildSelectableRelationFields(true),
+        selectableRelationFields: buildSelectableRelationFields(
+          buildObjectsPermissions({}),
+        ),
       });
 
       expect(warnings).toHaveLength(1);

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
@@ -462,6 +462,32 @@ describe('buildEffectiveSelectedFields', () => {
       });
     });
 
+    it('should hydrate a selected relation that also appears in orderBy', () => {
+      const objectsPermissions = buildObjectsPermissions({});
+
+      const { effectiveSelectedFields, warnings } =
+        buildEffectiveSelectedFields({
+          select: ['name', 'fund'],
+          filter: undefined,
+          orderBy: [{ fund: 'AscNullsLast' }],
+          objectName: 'investorLead',
+          flatObjectMetadataMaps: relationObjectMaps,
+          flatObjectMetadata: investorLeadObjectMetadata,
+          flatFieldMetadataMaps: relationFieldMaps,
+          selectedFields: { id: true, name: true, fund: true },
+          selectableRelationFields:
+            buildSelectableRelationFields(objectsPermissions),
+          objectsPermissions,
+        });
+
+      expect(warnings).toEqual([]);
+      expect(effectiveSelectedFields).toEqual({
+        id: true,
+        name: true,
+        fund: { id: true, name: true },
+      });
+    });
+
     it('should hydrate readable relations in wildcard selection', () => {
       const objectsPermissions = buildObjectsPermissions({});
 
@@ -514,7 +540,7 @@ describe('buildEffectiveSelectedFields', () => {
       ]);
     });
 
-    it('should not hydrate a relation whose source field is restricted', () => {
+    it('should warn when the relation field itself is restricted for the role', () => {
       const objectsPermissions = buildObjectsPermissions({
         sourceRestrictedFields: { 'fund-field': { canRead: false } },
       });

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
@@ -98,6 +98,8 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: defaultFlatObjectMetadata,
           flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
           selectedFields: defaultSelectedFields,
+          selectableRelationFields: {},
+          objectsPermissions: {},
         });
 
       expect(warnings).toEqual([]);
@@ -120,6 +122,8 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: defaultFlatObjectMetadata,
           flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
           selectedFields: defaultSelectedFields,
+          selectableRelationFields: {},
+          objectsPermissions: {},
         });
 
       expect(warnings).toEqual([]);
@@ -139,6 +143,8 @@ describe('buildEffectiveSelectedFields', () => {
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
+        selectableRelationFields: {},
+        objectsPermissions: {},
       });
 
       expect(effectiveSelectedFields).toHaveProperty('id');
@@ -156,6 +162,8 @@ describe('buildEffectiveSelectedFields', () => {
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
+        selectableRelationFields: {},
+        objectsPermissions: {},
       });
 
       expect(warnings).toHaveLength(1);
@@ -173,6 +181,8 @@ describe('buildEffectiveSelectedFields', () => {
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
+        selectableRelationFields: {},
+        objectsPermissions: {},
       });
 
       expect(warnings).toHaveLength(1);
@@ -192,6 +202,8 @@ describe('buildEffectiveSelectedFields', () => {
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
+        selectableRelationFields: {},
+        objectsPermissions: {},
       });
 
       expect(warnings).toHaveLength(2);
@@ -209,6 +221,8 @@ describe('buildEffectiveSelectedFields', () => {
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
+        selectableRelationFields: {},
+        objectsPermissions: {},
       });
 
       expect(effectiveSelectedFields).not.toHaveProperty('searchVector');
@@ -225,6 +239,8 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: defaultFlatObjectMetadata,
           flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
           selectedFields: defaultSelectedFields,
+          selectableRelationFields: {},
+          objectsPermissions: {},
         });
 
       expect(warnings).toHaveLength(1);
@@ -247,6 +263,8 @@ describe('buildEffectiveSelectedFields', () => {
           id: true,
           richText: { blocknote: true, markdown: true },
         },
+        selectableRelationFields: {},
+        objectsPermissions: {},
       });
 
       const richTextFields =
@@ -283,6 +301,8 @@ describe('buildEffectiveSelectedFields', () => {
           name: true,
           richText: { blocknote: true, markdown: true },
         },
+        selectableRelationFields: {},
+        objectsPermissions: {},
       });
 
       const richTextFields =
@@ -417,6 +437,8 @@ describe('buildEffectiveSelectedFields', () => {
       });
 
     it('should hydrate a selected one-to-many relation instead of its unresolvable boolean entry', () => {
+      const objectsPermissions = buildObjectsPermissions({});
+
       const { effectiveSelectedFields, warnings } =
         buildEffectiveSelectedFields({
           select: ['name', 'fund'],
@@ -427,9 +449,9 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: investorLeadObjectMetadata,
           flatFieldMetadataMaps: relationFieldMaps,
           selectedFields: { id: true, name: true, fund: true },
-          selectableRelationFields: buildSelectableRelationFields(
-            buildObjectsPermissions({}),
-          ),
+          selectableRelationFields:
+            buildSelectableRelationFields(objectsPermissions),
+          objectsPermissions,
         });
 
       expect(warnings).toEqual([]);
@@ -441,6 +463,8 @@ describe('buildEffectiveSelectedFields', () => {
     });
 
     it('should hydrate readable relations in wildcard selection', () => {
+      const objectsPermissions = buildObjectsPermissions({});
+
       const { effectiveSelectedFields, warnings } =
         buildEffectiveSelectedFields({
           select: ['*'],
@@ -451,9 +475,9 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: investorLeadObjectMetadata,
           flatFieldMetadataMaps: relationFieldMaps,
           selectedFields: { id: true, name: true, fund: true },
-          selectableRelationFields: buildSelectableRelationFields(
-            buildObjectsPermissions({}),
-          ),
+          selectableRelationFields:
+            buildSelectableRelationFields(objectsPermissions),
+          objectsPermissions,
         });
 
       expect(warnings).toEqual([]);
@@ -465,6 +489,10 @@ describe('buildEffectiveSelectedFields', () => {
     });
 
     it('should warn when selecting a relation whose target is not readable', () => {
+      const objectsPermissions = buildObjectsPermissions({
+        canReadCompany: false,
+      });
+
       const { effectiveSelectedFields, warnings } =
         buildEffectiveSelectedFields({
           select: ['fund'],
@@ -475,9 +503,9 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: investorLeadObjectMetadata,
           flatFieldMetadataMaps: relationFieldMaps,
           selectedFields: { id: true, name: true, fund: true },
-          selectableRelationFields: buildSelectableRelationFields(
-            buildObjectsPermissions({ canReadCompany: false }),
-          ),
+          selectableRelationFields:
+            buildSelectableRelationFields(objectsPermissions),
+          objectsPermissions,
         });
 
       expect(effectiveSelectedFields).toEqual({ id: true, name: true });
@@ -513,6 +541,8 @@ describe('buildEffectiveSelectedFields', () => {
     });
 
     it('should suggest relation field names for near-miss selections', () => {
+      const objectsPermissions = buildObjectsPermissions({});
+
       const { warnings } = buildEffectiveSelectedFields({
         select: ['fundd'],
         filter: undefined,
@@ -522,9 +552,9 @@ describe('buildEffectiveSelectedFields', () => {
         flatObjectMetadata: investorLeadObjectMetadata,
         flatFieldMetadataMaps: relationFieldMaps,
         selectedFields: { id: true, name: true, fund: true },
-        selectableRelationFields: buildSelectableRelationFields(
-          buildObjectsPermissions({}),
-        ),
+        selectableRelationFields:
+          buildSelectableRelationFields(objectsPermissions),
+        objectsPermissions,
       });
 
       expect(warnings).toHaveLength(1);

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
@@ -487,6 +487,10 @@ describe('buildEffectiveSelectedFields', () => {
     });
 
     it('should not hydrate a relation whose source field is restricted', () => {
+      const objectsPermissions = buildObjectsPermissions({
+        sourceRestrictedFields: { 'fund-field': { canRead: false } },
+      });
+
       const { effectiveSelectedFields, warnings } =
         buildEffectiveSelectedFields({
           select: ['name', 'fund'],
@@ -497,16 +501,14 @@ describe('buildEffectiveSelectedFields', () => {
           flatObjectMetadata: investorLeadObjectMetadata,
           flatFieldMetadataMaps: relationFieldMaps,
           selectedFields: { id: true, name: true, fund: true },
-          selectableRelationFields: buildSelectableRelationFields(
-            buildObjectsPermissions({
-              sourceRestrictedFields: { 'fund-field': { canRead: false } },
-            }),
-          ),
+          selectableRelationFields:
+            buildSelectableRelationFields(objectsPermissions),
+          objectsPermissions,
         });
 
       expect(effectiveSelectedFields).toEqual({ id: true, name: true });
       expect(warnings).toEqual([
-        "Field 'fund' on investorLead cannot be selected because you do not have read access to company.",
+        "Field 'fund' on investorLead cannot be selected because your role restricts access to this field.",
       ]);
     });
 

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/__tests__/build-effective-selected-fields.util.spec.ts
@@ -1,5 +1,10 @@
-import { FieldMetadataType } from 'twenty-shared/types';
+import {
+  FieldMetadataType,
+  type ObjectsPermissions,
+  RelationType,
+} from 'twenty-shared/types';
 
+import { getRelationsSelectFields } from 'src/engine/api/common/common-select-fields/utils/get-relations-select-fields.util';
 import { type CommonSelectedFields } from 'src/engine/api/common/types/common-selected-fields-result.type';
 import { buildEffectiveSelectedFields } from 'src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -36,6 +41,12 @@ const buildFlatObjectMetadata = (
     labelIdentifierFieldMetadataId,
     fieldIds,
   }) as unknown as FlatObjectMetadata;
+
+const emptyFlatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata> = {
+  byUniversalIdentifier: {},
+  universalIdentifierById: {},
+  universalIdentifiersByApplicationId: {},
+};
 
 const FIELD_IDS = {
   name: 'field-id-name',
@@ -83,6 +94,7 @@ describe('buildEffectiveSelectedFields', () => {
           filter: undefined,
           orderBy: undefined,
           objectName: 'person',
+          flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
           flatObjectMetadata: defaultFlatObjectMetadata,
           flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
           selectedFields: defaultSelectedFields,
@@ -104,6 +116,7 @@ describe('buildEffectiveSelectedFields', () => {
           filter: undefined,
           orderBy: undefined,
           objectName: 'person',
+          flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
           flatObjectMetadata: defaultFlatObjectMetadata,
           flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
           selectedFields: defaultSelectedFields,
@@ -122,6 +135,7 @@ describe('buildEffectiveSelectedFields', () => {
         filter: undefined,
         orderBy: undefined,
         objectName: 'person',
+        flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
@@ -138,6 +152,7 @@ describe('buildEffectiveSelectedFields', () => {
         filter: undefined,
         orderBy: undefined,
         objectName: 'person',
+        flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
@@ -154,6 +169,7 @@ describe('buildEffectiveSelectedFields', () => {
         filter: undefined,
         orderBy: undefined,
         objectName: 'person',
+        flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
@@ -172,6 +188,7 @@ describe('buildEffectiveSelectedFields', () => {
         filter: undefined,
         orderBy: undefined,
         objectName: 'person',
+        flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
@@ -188,6 +205,7 @@ describe('buildEffectiveSelectedFields', () => {
         filter: undefined,
         orderBy: undefined,
         objectName: 'person',
+        flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: defaultSelectedFields,
@@ -203,6 +221,7 @@ describe('buildEffectiveSelectedFields', () => {
           filter: undefined,
           orderBy: undefined,
           objectName: 'person',
+          flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
           flatObjectMetadata: defaultFlatObjectMetadata,
           flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
           selectedFields: defaultSelectedFields,
@@ -221,6 +240,7 @@ describe('buildEffectiveSelectedFields', () => {
         filter: undefined,
         orderBy: undefined,
         objectName: 'person',
+        flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
         flatObjectMetadata: defaultFlatObjectMetadata,
         flatFieldMetadataMaps: defaultFlatFieldMetadataMaps,
         selectedFields: {
@@ -255,6 +275,7 @@ describe('buildEffectiveSelectedFields', () => {
         filter: undefined,
         orderBy: undefined,
         objectName: 'person',
+        flatObjectMetadataMaps: emptyFlatObjectMetadataMaps,
         flatObjectMetadata: nonRichTextObjectMetadata,
         flatFieldMetadataMaps: nonRichTextMaps,
         selectedFields: {
@@ -269,6 +290,203 @@ describe('buildEffectiveSelectedFields', () => {
 
       expect(richTextFields).toHaveProperty('blocknote');
       expect(richTextFields).toHaveProperty('markdown');
+    });
+  });
+
+  describe('relation field hydration', () => {
+    const leadNameField = {
+      id: FIELD_IDS.name,
+      universalIdentifier: `uid-${FIELD_IDS.name}`,
+      name: 'name',
+      type: FieldMetadataType.TEXT,
+    } as unknown as FlatFieldMetadata;
+    const fundField = {
+      id: 'fund-field',
+      universalIdentifier: 'uid-fund-field',
+      name: 'fund',
+      type: FieldMetadataType.RELATION,
+      settings: { relationType: RelationType.ONE_TO_MANY },
+      relationTargetObjectMetadataId: 'company-object-id',
+      relationTargetFieldMetadataId: 'investor-pipeline-field',
+    } as unknown as FlatFieldMetadata;
+    const companyIdField = {
+      id: 'company-id-field',
+      universalIdentifier: 'uid-company-id-field',
+      name: 'id',
+      type: FieldMetadataType.UUID,
+    } as unknown as FlatFieldMetadata;
+    const companyNameField = {
+      id: 'company-name-field',
+      universalIdentifier: 'uid-company-name-field',
+      name: 'name',
+      type: FieldMetadataType.TEXT,
+    } as unknown as FlatFieldMetadata;
+    const investorPipelineField = {
+      id: 'investor-pipeline-field',
+      universalIdentifier: 'uid-investor-pipeline-field',
+      name: 'investorPipeline',
+      type: FieldMetadataType.RELATION,
+      settings: { relationType: RelationType.MANY_TO_ONE },
+      relationTargetObjectMetadataId: 'investor-lead-object-id',
+      relationTargetFieldMetadataId: 'fund-field',
+    } as unknown as FlatFieldMetadata;
+
+    const relationFieldMaps = {
+      byUniversalIdentifier: Object.fromEntries(
+        [
+          leadNameField,
+          fundField,
+          companyIdField,
+          companyNameField,
+          investorPipelineField,
+        ].map((field) => [field.universalIdentifier, field]),
+      ),
+      universalIdentifierById: Object.fromEntries(
+        [
+          leadNameField,
+          fundField,
+          companyIdField,
+          companyNameField,
+          investorPipelineField,
+        ].map((field) => [field.id, field.universalIdentifier]),
+      ),
+      universalIdentifiersByApplicationId: {},
+    } as unknown as FlatEntityMaps<FlatFieldMetadata>;
+
+    const investorLeadObjectMetadata = {
+      id: 'investor-lead-object-id',
+      universalIdentifier: 'uid-investor-lead-object-id',
+      nameSingular: 'investorLead',
+      labelIdentifierFieldMetadataId: FIELD_IDS.name,
+      fieldIds: [FIELD_IDS.name, 'fund-field'],
+    } as unknown as FlatObjectMetadata;
+    const companyObjectMetadata = {
+      id: 'company-object-id',
+      universalIdentifier: 'uid-company-object-id',
+      nameSingular: 'company',
+      labelIdentifierFieldMetadataId: 'company-name-field',
+      fieldIds: [
+        'company-id-field',
+        'company-name-field',
+        'investor-pipeline-field',
+      ],
+    } as unknown as FlatObjectMetadata;
+
+    const relationObjectMaps = {
+      byUniversalIdentifier: {
+        [investorLeadObjectMetadata.universalIdentifier]:
+          investorLeadObjectMetadata,
+        [companyObjectMetadata.universalIdentifier]: companyObjectMetadata,
+      },
+      universalIdentifierById: {
+        [investorLeadObjectMetadata.id]:
+          investorLeadObjectMetadata.universalIdentifier,
+        [companyObjectMetadata.id]: companyObjectMetadata.universalIdentifier,
+      },
+      universalIdentifiersByApplicationId: {},
+    } as unknown as FlatEntityMaps<FlatObjectMetadata>;
+
+    const buildObjectsPermissions = (canReadCompany: boolean) =>
+      ({
+        'investor-lead-object-id': {
+          canReadObjectRecords: true,
+          restrictedFields: {},
+        },
+        'company-object-id': {
+          canReadObjectRecords: canReadCompany,
+          restrictedFields: {},
+        },
+      }) as unknown as ObjectsPermissions;
+
+    const buildSelectableRelationFields = (canReadCompany: boolean) =>
+      getRelationsSelectFields({
+        flatObjectMetadataMaps: relationObjectMaps,
+        flatFieldMetadataMaps: relationFieldMaps,
+        flatObjectMetadata: investorLeadObjectMetadata,
+        objectsPermissions: buildObjectsPermissions(canReadCompany),
+        depth: 1,
+        onlyUseLabelIdentifierFieldsInRelations: true,
+      });
+
+    it('should hydrate a selected one-to-many relation instead of its unresolvable boolean entry', () => {
+      const { effectiveSelectedFields, warnings } =
+        buildEffectiveSelectedFields({
+          select: ['name', 'fund'],
+          filter: undefined,
+          orderBy: undefined,
+          objectName: 'investorLead',
+          flatObjectMetadataMaps: relationObjectMaps,
+          flatObjectMetadata: investorLeadObjectMetadata,
+          flatFieldMetadataMaps: relationFieldMaps,
+          selectedFields: { id: true, name: true, fund: true },
+          selectableRelationFields: buildSelectableRelationFields(true),
+        });
+
+      expect(warnings).toEqual([]);
+      expect(effectiveSelectedFields).toEqual({
+        id: true,
+        name: true,
+        fund: { id: true, name: true },
+      });
+    });
+
+    it('should hydrate readable relations in wildcard selection', () => {
+      const { effectiveSelectedFields, warnings } =
+        buildEffectiveSelectedFields({
+          select: ['*'],
+          filter: undefined,
+          orderBy: undefined,
+          objectName: 'investorLead',
+          flatObjectMetadataMaps: relationObjectMaps,
+          flatObjectMetadata: investorLeadObjectMetadata,
+          flatFieldMetadataMaps: relationFieldMaps,
+          selectedFields: { id: true, name: true, fund: true },
+          selectableRelationFields: buildSelectableRelationFields(true),
+        });
+
+      expect(warnings).toEqual([]);
+      expect(effectiveSelectedFields).toEqual({
+        id: true,
+        name: true,
+        fund: { id: true, name: true },
+      });
+    });
+
+    it('should warn when selecting a relation whose target is not readable', () => {
+      const { effectiveSelectedFields, warnings } =
+        buildEffectiveSelectedFields({
+          select: ['fund'],
+          filter: undefined,
+          orderBy: undefined,
+          objectName: 'investorLead',
+          flatObjectMetadataMaps: relationObjectMaps,
+          flatObjectMetadata: investorLeadObjectMetadata,
+          flatFieldMetadataMaps: relationFieldMaps,
+          selectedFields: { id: true, name: true, fund: true },
+          selectableRelationFields: buildSelectableRelationFields(false),
+        });
+
+      expect(effectiveSelectedFields).toEqual({ id: true, name: true });
+      expect(warnings).toEqual([
+        "Field 'fund' on investorLead cannot be selected because you do not have read access to company.",
+      ]);
+    });
+
+    it('should suggest relation field names for near-miss selections', () => {
+      const { warnings } = buildEffectiveSelectedFields({
+        select: ['fundd'],
+        filter: undefined,
+        orderBy: undefined,
+        objectName: 'investorLead',
+        flatObjectMetadataMaps: relationObjectMaps,
+        flatObjectMetadata: investorLeadObjectMetadata,
+        flatFieldMetadataMaps: relationFieldMaps,
+        selectedFields: { id: true, name: true, fund: true },
+        selectableRelationFields: buildSelectableRelationFields(true),
+      });
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("'fund'");
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util.ts
@@ -1,5 +1,8 @@
 import Fuse from 'fuse.js';
-import { FieldMetadataType } from 'twenty-shared/types';
+import {
+  FieldMetadataType,
+  type ObjectsPermissions,
+} from 'twenty-shared/types';
 
 import { isNull, isObject } from '@sniptt/guards';
 import { type CommonSelectedFields } from 'src/engine/api/common/types/common-selected-fields-result.type';
@@ -169,6 +172,7 @@ export const buildEffectiveSelectedFields = ({
   flatObjectMetadataMaps,
   selectedFields,
   selectableRelationFields = {},
+  objectsPermissions,
 }: {
   select: string[];
   filter?:
@@ -183,6 +187,7 @@ export const buildEffectiveSelectedFields = ({
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
   selectedFields: CommonSelectedFields;
   selectableRelationFields?: CommonSelectedFields;
+  objectsPermissions?: ObjectsPermissions;
 }): { effectiveSelectedFields: CommonSelectedFields; warnings: string[] } => {
   const filterFieldNames = extractFilterFieldNames(filter);
   const orderByFieldNames = extractOrderByFieldNames(orderBy);
@@ -203,6 +208,7 @@ export const buildEffectiveSelectedFields = ({
       flatFieldMetadataMaps,
       flatObjectMetadataMaps,
       selectableRelationFields,
+      objectsPermissions,
     });
 
   const {

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util.ts
@@ -171,7 +171,7 @@ export const buildEffectiveSelectedFields = ({
   flatFieldMetadataMaps,
   flatObjectMetadataMaps,
   selectedFields,
-  selectableRelationFields = {},
+  selectableRelationFields,
   objectsPermissions,
 }: {
   select: string[];
@@ -186,8 +186,8 @@ export const buildEffectiveSelectedFields = ({
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
   selectedFields: CommonSelectedFields;
-  selectableRelationFields?: CommonSelectedFields;
-  objectsPermissions?: ObjectsPermissions;
+  selectableRelationFields: CommonSelectedFields;
+  objectsPermissions: ObjectsPermissions;
 }): { effectiveSelectedFields: CommonSelectedFields; warnings: string[] } => {
   const filterFieldNames = extractFilterFieldNames(filter);
   const orderByFieldNames = extractOrderByFieldNames(orderBy);

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util.ts
@@ -4,6 +4,7 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { isNull, isObject } from '@sniptt/guards';
 import { type CommonSelectedFields } from 'src/engine/api/common/types/common-selected-fields-result.type';
 import { ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+import { buildUnselectableRelationWarningsByFieldName } from 'src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
@@ -19,14 +20,25 @@ const SUB_FIELDS_TO_EXCLUDE_BY_FIELD_TYPE: Partial<
   [FieldMetadataType.RICH_TEXT]: new Set(['blocknote']),
 };
 
-const buildSelectedField = (
-  rawSelect: string[],
-  filterFieldNames: string[],
-  orderByFieldNames: string[],
-  allSelectableFieldNames: string[],
-  labelIdentifierFieldName: string,
-  objectName: string,
-): { select: string[]; warnings: string[] } => {
+const buildSelectedField = ({
+  rawSelect,
+  filterFieldNames,
+  orderByFieldNames,
+  allSelectableFieldNames,
+  labelIdentifierFieldName,
+  objectName,
+  selectableRelationFieldNames,
+  unselectableRelationWarningsByFieldName,
+}: {
+  rawSelect: string[];
+  filterFieldNames: string[];
+  orderByFieldNames: string[];
+  allSelectableFieldNames: string[];
+  labelIdentifierFieldName: string;
+  objectName: string;
+  selectableRelationFieldNames: string[];
+  unselectableRelationWarningsByFieldName: Map<string, string>;
+}): { select: string[]; relationSelect: string[]; warnings: string[] } => {
   const cleanFieldNames = allSelectableFieldNames.filter(
     (name) => name !== SEARCH_VECTOR_FIELD,
   );
@@ -39,33 +51,61 @@ const buildSelectedField = (
   ].filter((name) => cleanFieldNames.includes(name));
 
   if (rawSelect.includes('*')) {
-    return { select: cleanFieldNames, warnings: [] };
+    return {
+      select: cleanFieldNames,
+      relationSelect: selectableRelationFieldNames,
+      warnings: [],
+    };
   }
 
   const warnings: string[] = [];
   const validFields: string[] = [...implicitFields];
+  const relationSelect: string[] = [];
 
   for (const requestedName of rawSelect) {
     if (implicitFields.includes(requestedName)) {
       continue;
     }
 
+    // Relation names are checked before scalars: ONE_TO_MANY fields are also
+    // listed as selectable booleans, which the query parser cannot resolve
+    if (selectableRelationFieldNames.includes(requestedName)) {
+      relationSelect.push(requestedName);
+      continue;
+    }
+
+    const unselectableRelationWarning =
+      unselectableRelationWarningsByFieldName.get(requestedName);
+
+    if (isDefined(unselectableRelationWarning)) {
+      warnings.push(unselectableRelationWarning);
+      continue;
+    }
+
     if (cleanFieldNames.includes(requestedName)) {
       validFields.push(requestedName);
-    } else {
-      const suggestions = findSimilarFieldNames(requestedName, cleanFieldNames);
-      const hint =
-        suggestions.length > 0
-          ? ` Did you mean: ${suggestions.map((s) => `'${s}'`).join(', ')}?`
-          : '';
-
-      warnings.push(
-        `Field '${requestedName}' not found on ${objectName}.${hint}`,
-      );
+      continue;
     }
+
+    const suggestions = findSimilarFieldNames(requestedName, [
+      ...cleanFieldNames,
+      ...selectableRelationFieldNames,
+    ]);
+    const hint =
+      suggestions.length > 0
+        ? ` Did you mean: ${suggestions.map((s) => `'${s}'`).join(', ')}?`
+        : '';
+
+    warnings.push(
+      `Field '${requestedName}' not found on ${objectName}.${hint}`,
+    );
   }
 
-  return { select: [...new Set(validFields)], warnings };
+  return {
+    select: [...new Set(validFields)],
+    relationSelect: [...new Set(relationSelect)],
+    warnings,
+  };
 };
 
 const extractFilterFieldNames = (
@@ -126,7 +166,9 @@ export const buildEffectiveSelectedFields = ({
   objectName,
   flatObjectMetadata,
   flatFieldMetadataMaps,
+  flatObjectMetadataMaps,
   selectedFields,
+  selectableRelationFields = {},
 }: {
   select: string[];
   filter?:
@@ -138,7 +180,9 @@ export const buildEffectiveSelectedFields = ({
   objectName: string;
   flatObjectMetadata: FlatObjectMetadata;
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
   selectedFields: CommonSelectedFields;
+  selectableRelationFields?: CommonSelectedFields;
 }): { effectiveSelectedFields: CommonSelectedFields; warnings: string[] } => {
   const filterFieldNames = extractFilterFieldNames(filter);
   const orderByFieldNames = extractOrderByFieldNames(orderBy);
@@ -152,26 +196,54 @@ export const buildEffectiveSelectedFields = ({
 
   const labelIdentifierFieldName = labelIdentifierField?.name ?? 'id';
 
-  const { select: cleanSelect, warnings } = buildSelectedField(
-    select,
+  const unselectableRelationWarningsByFieldName =
+    buildUnselectableRelationWarningsByFieldName({
+      objectName,
+      flatObjectMetadata,
+      flatFieldMetadataMaps,
+      flatObjectMetadataMaps,
+      selectableRelationFields,
+    });
+
+  const {
+    select: cleanSelect,
+    relationSelect,
+    warnings,
+  } = buildSelectedField({
+    rawSelect: select,
     filterFieldNames,
     orderByFieldNames,
-    Object.keys(selectedFields),
+    allSelectableFieldNames: Object.keys(selectedFields),
     labelIdentifierFieldName,
     objectName,
-  );
+    selectableRelationFieldNames: Object.keys(selectableRelationFields),
+    unselectableRelationWarningsByFieldName,
+  });
 
   const fieldNameToType = buildFieldNameToTypeMap(
     flatObjectMetadata,
     flatFieldMetadataMaps,
   );
 
+  const selectedRelationFields: CommonSelectedFields = {};
+
+  for (const fieldName of relationSelect) {
+    const fieldValue = selectableRelationFields[fieldName];
+
+    if (isDefined(fieldValue)) {
+      selectedRelationFields[fieldName] = fieldValue;
+    }
+  }
+
   return {
-    effectiveSelectedFields: buildSelectedFieldsOverride(
-      cleanSelect,
-      selectedFields,
-      fieldNameToType,
-    ),
+    effectiveSelectedFields: {
+      ...buildSelectedFieldsOverride(
+        cleanSelect,
+        selectedFields,
+        fieldNameToType,
+      ),
+      ...selectedRelationFields,
+    },
     warnings,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-effective-selected-fields.util.ts
@@ -51,7 +51,11 @@ const buildSelectedField = ({
     labelIdentifierFieldName,
     ...filterFieldNames,
     ...orderByFieldNames,
-  ].filter((name) => cleanFieldNames.includes(name));
+  ].filter(
+    (name) =>
+      cleanFieldNames.includes(name) &&
+      !selectableRelationFieldNames.includes(name),
+  );
 
   if (rawSelect.includes('*')) {
     return {

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util.ts
@@ -1,10 +1,8 @@
-import { FieldMetadataType } from 'twenty-shared/types';
-
 import { type CommonSelectedFields } from 'src/engine/api/common/types/common-selected-fields-result.type';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -33,11 +31,10 @@ export const buildUnselectableRelationWarningsByFieldName = ({
       continue;
     }
 
-    const isRelationField =
-      isFlatFieldMetadataOfType(field, FieldMetadataType.RELATION) ||
-      isFlatFieldMetadataOfType(field, FieldMetadataType.MORPH_RELATION);
-
-    if (!isRelationField || isDefined(selectableRelationFields[field.name])) {
+    if (
+      !isMorphOrRelationFlatFieldMetadata(field) ||
+      isDefined(selectableRelationFields[field.name])
+    ) {
       continue;
     }
 

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util.ts
@@ -1,0 +1,57 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type CommonSelectedFields } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { isDefined } from 'twenty-shared/utils';
+
+export const buildUnselectableRelationWarningsByFieldName = ({
+  objectName,
+  flatObjectMetadata,
+  flatFieldMetadataMaps,
+  flatObjectMetadataMaps,
+  selectableRelationFields,
+}: {
+  objectName: string;
+  flatObjectMetadata: FlatObjectMetadata;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+  selectableRelationFields: CommonSelectedFields;
+}): Map<string, string> => {
+  const warningsByFieldName = new Map<string, string>();
+
+  for (const fieldId of flatObjectMetadata.fieldIds) {
+    const field = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: fieldId,
+      flatEntityMaps: flatFieldMetadataMaps,
+    });
+
+    if (!isDefined(field)) {
+      continue;
+    }
+
+    const isRelationField =
+      isFlatFieldMetadataOfType(field, FieldMetadataType.RELATION) ||
+      isFlatFieldMetadataOfType(field, FieldMetadataType.MORPH_RELATION);
+
+    if (!isRelationField || isDefined(selectableRelationFields[field.name])) {
+      continue;
+    }
+
+    const targetObject = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: field.relationTargetObjectMetadataId,
+      flatEntityMaps: flatObjectMetadataMaps,
+    });
+
+    const warning = isDefined(targetObject)
+      ? `Field '${field.name}' on ${objectName} cannot be selected because you do not have read access to ${targetObject.nameSingular}.`
+      : `Field '${field.name}' on ${objectName} cannot be selected.`;
+
+    warningsByFieldName.set(field.name, warning);
+  }
+
+  return warningsByFieldName;
+};

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util.ts
@@ -21,7 +21,7 @@ export const buildUnselectableRelationWarningsByFieldName = ({
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
   selectableRelationFields: CommonSelectedFields;
-  objectsPermissions?: ObjectsPermissions;
+  objectsPermissions: ObjectsPermissions;
 }): Map<string, string> => {
   const warningsByFieldName = new Map<string, string>();
 
@@ -43,7 +43,7 @@ export const buildUnselectableRelationWarningsByFieldName = ({
     }
 
     const isSourceFieldRestricted =
-      objectsPermissions?.[flatObjectMetadata.id]?.restrictedFields[field.id]
+      objectsPermissions[flatObjectMetadata.id]?.restrictedFields[field.id]
         ?.canRead === false;
 
     if (isSourceFieldRestricted) {

--- a/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/utils/build-unselectable-relation-warnings.util.ts
@@ -1,3 +1,5 @@
+import { type ObjectsPermissions } from 'twenty-shared/types';
+
 import { type CommonSelectedFields } from 'src/engine/api/common/types/common-selected-fields-result.type';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
@@ -12,12 +14,14 @@ export const buildUnselectableRelationWarningsByFieldName = ({
   flatFieldMetadataMaps,
   flatObjectMetadataMaps,
   selectableRelationFields,
+  objectsPermissions,
 }: {
   objectName: string;
   flatObjectMetadata: FlatObjectMetadata;
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
   selectableRelationFields: CommonSelectedFields;
+  objectsPermissions?: ObjectsPermissions;
 }): Map<string, string> => {
   const warningsByFieldName = new Map<string, string>();
 
@@ -35,6 +39,18 @@ export const buildUnselectableRelationWarningsByFieldName = ({
       !isMorphOrRelationFlatFieldMetadata(field) ||
       isDefined(selectableRelationFields[field.name])
     ) {
+      continue;
+    }
+
+    const isSourceFieldRestricted =
+      objectsPermissions?.[flatObjectMetadata.id]?.restrictedFields[field.id]
+        ?.canRead === false;
+
+    if (isSourceFieldRestricted) {
+      warningsByFieldName.set(
+        field.name,
+        `Field '${field.name}' on ${objectName} cannot be selected because your role restricts access to this field.`,
+      );
       continue;
     }
 

--- a/packages/twenty-server/src/engine/core-modules/record-crud/zod-schemas/find-one-tool.zod-schema.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/zod-schemas/find-one-tool.zod-schema.ts
@@ -8,7 +8,9 @@ export const FindOneToolInputSchema = z.object({
     .describe(
       'Fields to include in the response. Required. ' +
         "Use '*' to return all fields. " +
-        ' MANY_TO_ONE relations are referenced by their FK column (e.g. companyId).',
+        'Relation fields resolve to related records as {id, label} summaries: ' +
+        'MANY_TO_ONE returns a single object (or select the <name>Id FK column for just the id), ' +
+        'ONE_TO_MANY returns up to 60 related records.',
     ),
 });
 

--- a/packages/twenty-server/src/engine/core-modules/record-crud/zod-schemas/find-tool.zod-schema.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/zod-schemas/find-tool.zod-schema.ts
@@ -42,7 +42,10 @@ export const generateFindToolInputSchema = (
       .describe(
         `Fields to include in the response. Required. ` +
           `Use '*' to return all fields, or list specific field names. ` +
-          `MANY_TO_ONE relations are referenced by their FK column (e.g. 'companyId'). `,
+          `Relation fields resolve to related records as {id, label} summaries: ` +
+          `MANY_TO_ONE returns a single object (or select the '<name>Id' FK column for just the id), ` +
+          `ONE_TO_MANY returns up to 60 related records. ` +
+          `For more fields or more records, query the related object directly. `,
       ),
     ...filterShape,
     or: z

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/tools/field-metadata-tools.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/tools/field-metadata-tools.factory.ts
@@ -29,6 +29,27 @@ const FIELD_STRIP_WHEN_FALSE = ['isLabelSyncedWithName'];
 // isUIEditable defaults to true, so only the non-default false value is informative
 const FIELD_STRIP_WHEN_TRUE = ['isUIEditable'];
 
+const RELATION_TYPE_DESCRIPTION =
+  'Relation direction from the perspective of the object the field is created on. ' +
+  "MANY_TO_ONE: the field points to a single target record; this object owns the foreign key and gets a writable '<fieldName>Id' on its create/update inputs. Use it for 'belongs to one' fields. " +
+  "ONE_TO_MANY: the field is a read-only collection of target records; records are linked by writing the inverse '<fieldName>Id' on the target object.";
+
+const RelationCreationPayloadSchema = z.object({
+  type: z.nativeEnum(RelationType).describe(RELATION_TYPE_DESCRIPTION),
+  targetObjectMetadataId: z.string().uuid().describe('Target object ID'),
+  targetFieldLabel: z
+    .string()
+    .describe(
+      'Display label of the inverse relation field created on the target object',
+    ),
+  targetFieldIcon: z
+    .string()
+    .optional()
+    .describe(
+      'Tabler icon name for the inverse field (e.g. IconBuildingSkyscraper). Falls back to the relation default.',
+    ),
+});
+
 const GetFieldMetadataInputSchema = z.object({
   id: z.uuid().optional().describe('Field ID. Returns one field if set.'),
   objectMetadataId: z.uuid().optional().describe('Filter by object ID.'),
@@ -75,10 +96,9 @@ const CreateFieldMetadataInputSchema = z.object({
     .optional()
     .describe('Sync label with name'),
   isRemoteCreation: z.boolean().optional().describe('Remote field creation'),
-  relationCreationPayload: z
-    .unknown()
-    .optional()
-    .describe('Relation creation payload'),
+  relationCreationPayload: RelationCreationPayloadSchema.optional().describe(
+    'Required when type is RELATION. Defines the relation direction and the inverse field created on the target object.',
+  ),
 });
 
 const UpdateFieldMetadataInputSchema = z.object({
@@ -134,7 +154,7 @@ const CreateManyRelationFieldsInputSchema = z.object({
           .string()
           .optional()
           .describe('Tabler icon name for the relation field (e.g. IconUsers)'),
-        type: z.nativeEnum(RelationType).describe('MANY_TO_ONE or ONE_TO_MANY'),
+        type: z.nativeEnum(RelationType).describe(RELATION_TYPE_DESCRIPTION),
         targetObjectMetadataId: z.string().uuid().describe('Target object ID'),
         targetFieldLabel: z.string().describe('Inverse field label'),
         targetFieldIcon: z

--- a/packages/twenty-server/test/integration/ai/suites/mcp-find-tools-relation-select.integration-spec.ts
+++ b/packages/twenty-server/test/integration/ai/suites/mcp-find-tools-relation-select.integration-spec.ts
@@ -1,0 +1,244 @@
+import { randomUUID } from 'node:crypto';
+
+import request from 'supertest';
+
+import { deleteRecordsByIds } from 'test/integration/utils/delete-records-by-ids';
+
+const TOOL_NAMES = {
+  createCompany: 'create_one_company',
+  createOpportunity: 'create_one_opportunity',
+  findManyCompanies: 'find_many_companies',
+  findOneCompany: 'find_one_company',
+  findOneOpportunity: 'find_one_opportunity',
+} as const;
+
+type McpToolCallResult = {
+  content?: Array<{ type: string; text: string }>;
+  isError?: boolean;
+};
+
+type DatabaseToolPayload<TResult> = {
+  success: boolean;
+  message: string;
+  result: TResult;
+  warnings?: string[];
+  error?: string;
+};
+
+type CreatedRecord = { id: string };
+
+type FindRecordsResult = {
+  records: Array<Record<string, unknown>>;
+  count: string | number;
+  hasNextPage: boolean;
+};
+
+const baseUrl = `http://localhost:${APP_PORT}`;
+const endpoint = '/mcp';
+
+const postMcp = (body: Record<string, unknown>) =>
+  request(baseUrl)
+    .post(endpoint)
+    .set('Authorization', `Bearer ${API_KEY_ACCESS_TOKEN}`)
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .send(JSON.stringify(body));
+
+const callMcpTool = async (
+  name: string,
+  args: Record<string, unknown>,
+  id: string = `call-${randomUUID()}`,
+): Promise<McpToolCallResult> => {
+  const res = await postMcp({
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    id,
+    params: { name, arguments: args },
+  }).expect(200);
+
+  expect(res.body.id).toBe(id);
+  expect(res.body.jsonrpc).toBe('2.0');
+  expect(res.body.error).toBeUndefined();
+
+  return res.body.result as McpToolCallResult;
+};
+
+const parseToolPayload = <T>(result: McpToolCallResult): T => {
+  expect(result.isError).toBe(false);
+  expect(result.content?.[0]?.type).toBe('text');
+
+  const raw = result.content?.[0]?.text;
+
+  expect(raw).toBeDefined();
+
+  return JSON.parse(raw as string) as T;
+};
+
+const executeWorkspaceTool = async <TResult>(
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<DatabaseToolPayload<TResult>> => {
+  const mcpResult = await callMcpTool('execute_tool', {
+    toolName,
+    arguments: args,
+  });
+  const payload = parseToolPayload<DatabaseToolPayload<TResult>>(mcpResult);
+
+  expect(payload.success).toBe(true);
+  expect(payload.result).toBeDefined();
+
+  return payload;
+};
+
+describe('MCP find tools relation selection (integration)', () => {
+  let companyId: string;
+  let opportunityAId: string;
+  let opportunityBId: string;
+
+  const companyName = `mcp-relation-select-company-${randomUUID()}`;
+  const opportunityAName = `mcp-relation-select-opportunity-a-${randomUUID()}`;
+  const opportunityBName = `mcp-relation-select-opportunity-b-${randomUUID()}`;
+
+  beforeAll(async () => {
+    const company = await executeWorkspaceTool<CreatedRecord>(
+      TOOL_NAMES.createCompany,
+      { name: companyName },
+    );
+
+    companyId = company.result.id;
+
+    const opportunityA = await executeWorkspaceTool<CreatedRecord>(
+      TOOL_NAMES.createOpportunity,
+      { name: opportunityAName, companyId },
+    );
+
+    opportunityAId = opportunityA.result.id;
+
+    const opportunityB = await executeWorkspaceTool<CreatedRecord>(
+      TOOL_NAMES.createOpportunity,
+      { name: opportunityBName, companyId },
+    );
+
+    opportunityBId = opportunityB.result.id;
+  });
+
+  afterAll(async () => {
+    await deleteRecordsByIds(
+      'opportunity',
+      [opportunityAId, opportunityBId].filter(Boolean),
+    );
+    await deleteRecordsByIds('company', [companyId].filter(Boolean));
+  });
+
+  it('should hydrate a one-to-many relation selected by name in find_many', async () => {
+    const payload = await executeWorkspaceTool<FindRecordsResult>(
+      TOOL_NAMES.findManyCompanies,
+      {
+        id: { eq: companyId },
+        select: ['id', 'name', 'opportunities'],
+        limit: 1,
+      },
+    );
+
+    expect(payload.warnings).toBeUndefined();
+    expect(payload.result.records).toHaveLength(1);
+
+    const record = payload.result.records[0];
+
+    expect(record.id).toBe(companyId);
+    expect(record.name).toBe(companyName);
+
+    const opportunities = record.opportunities as Array<
+      Record<string, unknown>
+    >;
+
+    expect(Array.isArray(opportunities)).toBe(true);
+    expect(opportunities).toHaveLength(2);
+    expect(opportunities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: opportunityAId,
+          name: opportunityAName,
+        }),
+        expect.objectContaining({
+          id: opportunityBId,
+          name: opportunityBName,
+        }),
+      ]),
+    );
+  });
+
+  it('should hydrate a one-to-many relation selected by name in find_one', async () => {
+    const payload = await executeWorkspaceTool<FindRecordsResult>(
+      TOOL_NAMES.findOneCompany,
+      {
+        id: companyId,
+        select: ['id', 'name', 'opportunities'],
+      },
+    );
+
+    const record = payload.result.records[0];
+
+    const opportunities = record.opportunities as Array<
+      Record<string, unknown>
+    >;
+
+    expect(opportunities).toHaveLength(2);
+  });
+
+  it('should hydrate a many-to-one relation selected by name as a single record', async () => {
+    const payload = await executeWorkspaceTool<FindRecordsResult>(
+      TOOL_NAMES.findOneOpportunity,
+      {
+        id: opportunityAId,
+        select: ['id', 'name', 'company'],
+      },
+    );
+
+    const record = payload.result.records[0];
+
+    expect(record.id).toBe(opportunityAId);
+    expect(record.company).toEqual(
+      expect.objectContaining({
+        id: companyId,
+        name: companyName,
+      }),
+    );
+  });
+
+  it('should hydrate relation fields in wildcard selection', async () => {
+    const payload = await executeWorkspaceTool<FindRecordsResult>(
+      TOOL_NAMES.findOneCompany,
+      {
+        id: companyId,
+        select: ['*'],
+      },
+    );
+
+    const record = payload.result.records[0];
+
+    expect(record.name).toBe(companyName);
+
+    const opportunities = record.opportunities as Array<
+      Record<string, unknown>
+    >;
+
+    expect(opportunities).toHaveLength(2);
+  });
+
+  it('should suggest the relation field for a near-miss selection', async () => {
+    const payload = await executeWorkspaceTool<FindRecordsResult>(
+      TOOL_NAMES.findManyCompanies,
+      {
+        id: { eq: companyId },
+        select: ['name', 'opportunitiez'],
+        limit: 1,
+      },
+    );
+
+    expect(payload.warnings).toEqual([
+      expect.stringContaining("'opportunities'"),
+    ]);
+    expect(payload.result.records[0]).not.toHaveProperty('opportunities');
+  });
+});

--- a/packages/twenty-server/test/integration/rest/suites/rest-api-depth-relation-field-permissions.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/rest-api-depth-relation-field-permissions.integration-spec.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from 'crypto';
+
+import gql from 'graphql-tag';
+import request from 'supertest';
+import { createCustomRoleWithObjectPermissions } from 'test/integration/graphql/utils/create-custom-role-with-object-permissions.util';
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { deleteRole } from 'test/integration/graphql/utils/delete-one-role.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { updateWorkspaceMemberRole } from 'test/integration/graphql/utils/update-workspace-member-role.util';
+import { upsertFieldPermissions } from 'test/integration/graphql/utils/upsert-field-permissions.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { makeRestAPIRequest } from 'test/integration/rest/utils/make-rest-api-request.util';
+import { deleteRecordsByIds } from 'test/integration/utils/delete-records-by-ids';
+
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+const client = request(`http://localhost:${APP_PORT}`);
+
+describe('REST depth=1 with a restricted relation field', () => {
+  let companyId: string;
+  let personId: string;
+  let customRoleId: string;
+  let companyObjectId: string;
+  let peopleFieldId: string;
+  let originalMemberRoleId: string;
+
+  beforeAll(async () => {
+    const rolesResponse = await client
+      .post('/metadata')
+      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+      .send({
+        query: `
+          query GetRoles {
+            getRoles {
+              id
+              label
+            }
+          }
+        `,
+      });
+
+    originalMemberRoleId = rolesResponse.body.data.getRoles.find(
+      (role: { label: string }) => role.label === 'Member',
+    ).id;
+
+    companyId = randomUUID();
+    personId = randomUUID();
+
+    await makeGraphqlAPIRequest(
+      createOneOperationFactory({
+        objectMetadataSingularName: 'company',
+        gqlFields: 'id name',
+        data: { id: companyId, name: 'RestDepthPermissionCompany' },
+      }),
+    );
+
+    await makeGraphqlAPIRequest(
+      createOneOperationFactory({
+        objectMetadataSingularName: 'person',
+        gqlFields: 'id',
+        data: { id: personId, companyId },
+      }),
+    );
+
+    const objectMetadataResponse = await makeMetadataAPIRequest({
+      query: gql`
+        query {
+          objects(paging: { first: 1000 }) {
+            edges {
+              node {
+                id
+                nameSingular
+              }
+            }
+          }
+        }
+      `,
+    });
+
+    companyObjectId = objectMetadataResponse.body.data.objects.edges.find(
+      (edge: { node: { nameSingular: string } }) =>
+        edge.node.nameSingular === 'company',
+    ).node.id;
+
+    const fieldMetadataResponse = await makeMetadataAPIRequest({
+      query: gql`
+        query {
+          fields(paging: { first: 1000 }) {
+            edges {
+              node {
+                id
+                name
+                object {
+                  nameSingular
+                }
+              }
+            }
+          }
+        }
+      `,
+    });
+
+    peopleFieldId = fieldMetadataResponse.body.data.fields.edges.find(
+      (edge: { node: { name: string; object: { nameSingular: string } } }) =>
+        edge.node.name === 'people' &&
+        edge.node.object.nameSingular === 'company',
+    ).node.id;
+  });
+
+  afterAll(async () => {
+    await deleteRecordsByIds('person', [personId]);
+    await deleteRecordsByIds('company', [companyId]);
+  });
+
+  beforeEach(async () => {
+    const { roleId } = await createCustomRoleWithObjectPermissions({
+      label: 'RestDepthRelationRole',
+      canReadCompany: true,
+      canReadPerson: true,
+    });
+
+    customRoleId = roleId;
+
+    await updateWorkspaceMemberRole({
+      client,
+      roleId: customRoleId,
+      workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+    });
+  });
+
+  afterEach(async () => {
+    await updateWorkspaceMemberRole({
+      client,
+      roleId: originalMemberRoleId,
+      workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+    });
+
+    if (customRoleId) {
+      await deleteRole(client, customRoleId);
+      customRoleId = '';
+    }
+  });
+
+  it('should omit the entire relation when the relation field is restricted for the requesting role', async () => {
+    await upsertFieldPermissions({
+      roleId: customRoleId,
+      fieldPermissions: [
+        {
+          objectMetadataId: companyObjectId,
+          fieldMetadataId: peopleFieldId,
+          canReadFieldValue: false,
+        },
+      ],
+    });
+
+    const response = await makeRestAPIRequest({
+      method: 'get',
+      path: `/companies/${companyId}?depth=1`,
+      bearer: APPLE_JONY_MEMBER_ACCESS_TOKEN,
+    }).expect(200);
+
+    const company = response.body.data.company;
+
+    expect(company.id).toBe(companyId);
+    expect(company).not.toHaveProperty('people');
+  });
+
+  it('should include related records when the relation field is not restricted', async () => {
+    const response = await makeRestAPIRequest({
+      method: 'get',
+      path: `/companies/${companyId}?depth=1`,
+      bearer: APPLE_JONY_MEMBER_ACCESS_TOKEN,
+    }).expect(200);
+
+    const company = response.body.data.company;
+
+    expect(company.id).toBe(companyId);
+    expect(company.people).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: personId })]),
+    );
+  });
+});


### PR DESCRIPTION
## Context

MCP find tools could only return scalar columns and MANY_TO_ONE FK columns. ONE_TO_MANY relation fields were accepted in `select` but silently absent from responses: the selectable-fields map lists them as booleans, which the query parser cannot resolve, while the same data was correctly returned by GraphQL and REST `depth=1`. 

The same issue showed the relation creation MCP tools gave agents no way to pick the right relation direction: `relationCreationPayload` was typed `z.unknown()` with no documentation, so AI clients guessed, and a wrong guess (ONE_TO_MANY instead of MANY_TO_ONE) produces exactly the "relation not writable, reads return null" experience reported.

## What this does

**Relation hydration in find tools (mirrors REST depth=1)**

- Selecting a relation field by name, or `'*'`, returns related records inline as a label-identifier projection: ONE_TO_MANY returns up to 60 `{id, label}` records (`QUERY_MAX_RECORDS_FROM_RELATION`), MANY_TO_ONE returns a single `{id, label}` object (the FK column stays available for id-only reads)
- Relation names are resolved before their unresolvable boolean entries in the selectable-fields map, and selecting a relation whose target object is not readable emits an explicit warning instead of silently omitting the field; near-miss selections suggest relation names too
- Extracts the relation select builder from `CommonSelectFieldsHelper` into a shared util so the REST depth path and the find tools apply identical permission checks (`canReadObjectRecords`, restricted fields); the find service decides the projection (depth 1, label identifiers) on its side
- Updates the `select` descriptions on find tools so agents learn the pattern up front

**Relation creation guidance in metadata tools**

- Types `relationCreationPayload` properly (was `z.unknown()`) and documents direction semantics on all relation-creating tools: MANY_TO_ONE = this object owns the FK and gets a writable `<fieldName>Id` (use for "belongs to one"), ONE_TO_MANY = read-only collection written from the target side

**Tests**

- Integration: MCP end-to-end suite covering the #23780 scenario against the booted app — one-to-many and many-to-one hydration through find_many/find_one, wildcard hydration, and near-miss relation name suggestions
- Parser regression spec covering the silent drop (boolean form ignored, object form hydrated)
- Unit specs for hydration precedence over boolean entries, permissions, and wildcard

Known trade-off: tool outputs pass through `compactToolOutput`, which strips empty arrays globally, so a hydrated relation with zero linked records comes back absent rather than `[]` (consistent with how all tool outputs behave today).

Out of scope, tracked separately: appending generated direction hints to GraphQL relation field descriptions in the schema builder.

## NOTE

The source-field canRead guard is a deliberate behavior change beyond the extraction, restricted relation fields, which already disappeared from scalar selections, now also disappear from REST depth=1 responses and webhook payloads for restricted roles. Previously they leaked. Covered by a computeFromDepth unit case and a REST integration test.

Closes #23780

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

