### PR TITLE
fix(server): ORM v2 write-path parity - persist workflow step logs, skip undefined values

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -154,6 +154,22 @@ export class WorkspaceRepositoryV2 {
     );
   }
 
+  // TypeORM drops undefined properties before it validates or writes anything;
+  // strip them here so they neither throw on an unknown field nor bind as NULL
+  private formatWriteData(
+    data: Partial<ObjectRecord>,
+  ): Record<string, unknown> {
+    const definedData = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined),
+    );
+
+    return formatData(
+      definedData,
+      this.options.flatObjectMetadata,
+      this.options.internalContext.flatFieldMetadataMaps,
+    );
+  }
+
   applyWriteRowLevelPermissions(
     queryBuilder: WorkspaceSelectQueryBuilderV2,
   ): void {
@@ -972,10 +988,8 @@ export class WorkspaceRepositoryV2 {
     }
 
     for (const [index, input] of inputs.entries()) {
-      const { id: _id, ...setColumns } = formatData(
+      const { id: _id, ...setColumns } = this.formatWriteData(
         dataByInputIndex[index],
-        this.options.flatObjectMetadata,
-        this.options.internalContext.flatFieldMetadataMaps,
       );
 
       this.validateWriteIsPermitted({
@@ -1039,11 +1053,7 @@ export class WorkspaceRepositoryV2 {
     formattedRecords: Record<string, unknown>[];
   } {
     const formattedRecords = records.map((record) =>
-      formatData(
-        record,
-        this.options.flatObjectMetadata,
-        this.options.internalContext.flatFieldMetadataMaps,
-      ),
+      this.formatWriteData(record),
     );
 
     const columnNameSet = new Set<string>();
@@ -1218,11 +1228,7 @@ export class WorkspaceRepositoryV2 {
 
     const setColumns =
       kind === 'update' && isDefined(dataToWrite)
-        ? formatData(
-            dataToWrite,
-            this.options.flatObjectMetadata,
-            this.options.internalContext.flatFieldMetadataMaps,
-          )
+        ? this.formatWriteData(dataToWrite)
         : undefined;
 
     this.validateWriteIsPermitted({

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run-step-log.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run-step-log.workspace-service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
 
 import { type WorkflowRunStepLog } from 'twenty-shared/workflow';
+import { DataSource } from 'typeorm';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
-import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
-import { type WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 
 const MAX_STEP_LOG_BYTES = 256_000;
 
@@ -21,8 +21,10 @@ export class WorkflowRunStepLogWorkspaceService {
   private readonly logger = new Logger(WorkflowRunStepLogWorkspaceService.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    @InjectDataSource()
+    private readonly coreDataSource: DataSource,
   ) {}
+
   async setStepLog({
     workflowRunId,
     workspaceId,
@@ -49,29 +51,11 @@ export class WorkflowRunStepLogWorkspaceService {
       sizeBytes,
     };
 
-    const authContext = buildSystemAuthContext(workspaceId);
+    const schemaName = getWorkspaceSchemaName(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      const workflowRunRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-          workspaceId,
-          'workflowRun',
-          { shouldBypassPermissionChecks: true },
-        );
-
-      await workflowRunRepository
-        .createQueryBuilder()
-        .update()
-        .set({
-          stepLogs: () =>
-            `jsonb_set(COALESCE("stepLogs", '{}'::jsonb), ARRAY[:stepId]::text[], :stepLog::jsonb, true)`,
-        })
-        .where('id = :workflowRunId', { workflowRunId })
-        .setParameters({
-          stepId,
-          stepLog: JSON.stringify(stepLogWithSize),
-        })
-        .execute();
-    }, authContext);
+    await this.coreDataSource.query(
+      `UPDATE ${schemaName}."workflowRun" SET "stepLogs" = jsonb_set(COALESCE("stepLogs", '{}'::jsonb), ARRAY[$1]::text[], $2::jsonb, true) WHERE "id" = $3`,
+      [stepId, JSON.stringify(stepLogWithSize), workflowRunId],
+    );
   }
 }


### PR DESCRIPTION
Two silent-data-loss bugs on ORM v2 workspaces. 2 files, +30/−40, 2 commits.

## 1. Workflow step logs were never written on v2 workspaces

`setStepLog` built its update like this:

```ts
repository.createQueryBuilder()
  .update()
  .set({ stepLogs: () => `jsonb_set(COALESCE("stepLogs",'{}'::jsonb), ARRAY[:stepId]::text[], :stepLog::jsonb, true)` })
  .where('id = :workflowRunId', { workflowRunId })
  .setParameters({ stepId, stepLog: JSON.stringify(stepLogWithSize) })
  .execute();
```

Two things there are TypeORM features. A **function value** in `set()` is inlined as raw SQL, which is how one key gets patched inside the jsonb server-side. And `where()` / `setParameters()` are callable **after** `update()`.

`getRepository()` returns a different class depending on the flag. Flag off gives the TypeORM-backed repository, which supports both. Flag on gives `WorkspaceRepositoryV2`, whose mutation builder exposes only `set`, `returning`, `getQuery`, `getQueryAndParameters`, `execute` — so `.where(...)` is not a function and the chain throws before reaching the database. (Had it got past that, `buildSetClauses` throws `UNSUPPORTED_OPERATION` on function values.)

All three callers wrap `setStepLog` in `try/catch` and `logger.warn`, so the step still succeeded and the log was simply never written, with no error surfaced.

The statement is unchanged and now runs directly on the core DataSource, the pattern `workflow-run-enqueue`, `workflow-handle-staled-runs` and `workflow-clean-workflow-runs` already use against `${schemaName}."workflowRun"`. One statement, row-locked by Postgres, identical on both ORMs.

**What changes alongside, deliberately:**
- **No `updatedAt` stamp per log.** The v1 path went through TypeORM's update-date column handling; the raw UPDATE does not. The only liveness reader is the staled-run cron (1h threshold), and the executor writes `updateWorkflowRunStepInfo` through the repository both before (RUNNING) and after (SUCCESS/FAILED) every step, so `updatedAt` is stamped on both sides of each `setStepLog`. Nothing orders on it.
- **No `UPDATED` event per log.** Same stepInfo writes emit one carrying the full row, so the front's `useWorkflowRunStepLog` still live-updates.
- **Off the workspace ORM context, onto the core pool.** The write no longer joins a surrounding transaction. Today nothing wraps step execution in one; if something does later, the log survives a rollback, which is right for an execution log. One short UPDATE per step on the core pool.

## 2. `undefined` wrote `NULL` on the v2 write path

TypeORM drops undefined properties before it validates or writes anything, and renders `DEFAULT` for undefined insert values. ORM v2 generates its own SQL and serialized them, so a caller passing `undefined` wrote `NULL` where v1 left the column untouched. `restorePeople` sends `{ deletedAt: null, companyId: undefined }` — on a flagged workspace the restore erased the person's company link.

The three v2 write paths (single update, batch update, insert) now strip undefined keys on the **raw input, before `formatData`**, via a private `formatWriteData` on the repository. Two reasons for exactly that placement:
- `formatData` is shared with v1 and also runs on find criteria and duplicate-detection conditions, so it is left untouched.
- `formatData` throws on an unknown field before it could ever skip the value, so an undefined key has to be removed before the lookup — which is the order TypeORM uses.

## Test plan

- `npx jest src/engine/twenty-orm src/engine/twenty-orm-v2 src/modules/workflow` — 1018 pass across 113 suites; typecheck, lint, format clean.
- The `jsonb_set` statement was checked by hand with `PREPARE`/`EXECUTE` against a local workspace schema (merge into null and into existing both produce the expected object).
- No unit spec on either change: the service has no logic to unit-test, and a `WorkspaceRepositoryV2` fixture (flat maps, RLS, events, FilesFieldSync) would dwarf the fix. No integration suite currently runs with the v2 flag on.
- **Verified end to end on a running server** (twenty-2 slot, this branch, `IS_ORM_V2_READ_PATH_ENABLED` on for the Apple workspace), both as A/B against the pre-PR code:
  - **Step logs.** Manual-trigger workflow with one Code step. Flag off: `stepLogs` written (control). Flag on, pre-PR service swapped in: run `COMPLETED`, `stepLogs = {}`, worker log: `WARN [CodeWorkflowAction] Failed to persist step log … .update(...).set(...).where is not a function` — the exact mechanism above, observed. Flag on, this PR: `stepLogs` written, no warning.
  - **undefined → NULL.** Person with a company soft-deleted, then `updateMany([{criteria: id, partialEntity: {deletedAt: null, companyId: undefined}}])` — the exact call `restorePeople` makes — through the real `getRepository` (returned `WorkspaceRepositoryV2`). With `formatWriteData` stripping: restored, `companyId` intact. Strip disabled: restored, `companyId = NULL`.
  - Also re-ran the merged #24299 scenario on the same instance: created a field under flag ON (migration → `ORMEntityMetadatas` recomputed to `[]` on the server), flipped OFF through `FeatureFlagService` from a separate process, then v1 reads and a v1 write on the server succeeded with zero `EntityMetadataNotFoundError` in the log.

