### PR TITLE
Declare note and task targets as junction relations

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { BackfillActivityTargetsJunctionTargetCommand } from 'src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([FieldMetadataEntity]),
+    WorkspaceCacheModule,
+    WorkspaceIteratorModule,
+    WorkspaceMigrationRunnerModule,
+  ],
+  providers: [BackfillActivityTargetsJunctionTargetCommand],
+})
+export class V2_33_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.ts
@@ -1,0 +1,292 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { invalidateFieldMetadataCache } from 'src/database/commands/upgrade-version-command/utils/invalidate-field-metadata-cache.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { isFieldMetadataSettingsOfType } from 'src/engine/metadata-modules/field-metadata/utils/is-field-metadata-settings-of-type.util';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+// The junction target points at one member of the target morph. Consumers expand
+// the whole morph group from it, so any member identifies the polymorphic edge.
+const ACTIVITY_JUNCTIONS = [
+  {
+    label: 'note.noteTargets',
+    junctionRelationFieldUniversalIdentifier:
+      STANDARD_OBJECTS.note.fields.noteTargets.universalIdentifier,
+    junctionTargetFieldUniversalIdentifier:
+      STANDARD_OBJECTS.noteTarget.fields.targetPerson.universalIdentifier,
+  },
+  {
+    label: 'task.taskTargets',
+    junctionRelationFieldUniversalIdentifier:
+      STANDARD_OBJECTS.task.fields.taskTargets.universalIdentifier,
+    junctionTargetFieldUniversalIdentifier:
+      STANDARD_OBJECTS.taskTarget.fields.targetPerson.universalIdentifier,
+  },
+] as const;
+
+type ActivityJunction = (typeof ACTIVITY_JUNCTIONS)[number];
+
+type ResolvedBackfill = {
+  label: string;
+  junctionRelationFieldMetadataId: string;
+  junctionTargetFieldMetadataId: string;
+};
+
+@RegisteredWorkspaceCommand('2.33.0', 1787123540000)
+@Command({
+  name: 'upgrade:2-33:backfill-activity-targets-junction-target',
+  description:
+    'Backfill the junction target field id on note.noteTargets and task.taskTargets for workspaces provisioned before it was declared, so activity targets are recognised as junction relations.',
+})
+export class BackfillActivityTargetsJunctionTargetCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
+    @InjectRepository(FieldMetadataEntity)
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const { flatFieldMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatFieldMetadataMaps',
+      ]);
+
+    const backfills = ACTIVITY_JUNCTIONS.map((activityJunction) =>
+      this.resolveBackfill({
+        activityJunction,
+        flatFieldMetadataMaps,
+        workspaceId,
+      }),
+    ).filter(isDefined);
+
+    if (backfills.length === 0) {
+      return;
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Backfilling ${backfills
+        .map(({ label }) => label)
+        .join(', ')} junction target for workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    const updatedFieldMetadataIds = await this.applyBackfills({
+      backfills,
+      workspaceId,
+    });
+
+    if (updatedFieldMetadataIds.length === 0) {
+      this.logger.warn(
+        `No activity junction field was updated for workspace ${workspaceId}, its metadata changed since the cache was computed`,
+      );
+
+      return;
+    }
+
+    await invalidateFieldMetadataCache({
+      workspaceId,
+      workspaceMigrationRunnerService: this.workspaceMigrationRunnerService,
+    });
+  }
+
+  // Both activity junctions are written together so an interrupted upgrade never
+  // leaves notes migrated and tasks not, which would be invisible until a rerun.
+  private async applyBackfills({
+    backfills,
+    workspaceId,
+  }: {
+    backfills: ResolvedBackfill[];
+    workspaceId: string;
+  }): Promise<string[]> {
+    return this.fieldMetadataRepository.manager.transaction(
+      async (entityManager) => {
+        const fieldMetadataRepository =
+          entityManager.getRepository(FieldMetadataEntity);
+        const updatedFieldMetadataIds: string[] = [];
+
+        for (const {
+          label,
+          junctionRelationFieldMetadataId,
+          junctionTargetFieldMetadataId,
+        } of backfills) {
+          // Re-read under the transaction: the cache the resolution ran against
+          // can lag the row, and settings is overwritten as a whole document.
+          const fieldMetadata = await fieldMetadataRepository.findOne({
+            where: { id: junctionRelationFieldMetadataId, workspaceId },
+            lock: { mode: 'pessimistic_write' },
+          });
+
+          if (
+            !isDefined(fieldMetadata) ||
+            !isFieldMetadataSettingsOfType(
+              fieldMetadata.settings,
+              FieldMetadataType.RELATION,
+            ) ||
+            fieldMetadata.settings.relationType !== RelationType.ONE_TO_MANY
+          ) {
+            this.logger.warn(
+              `${label} is no longer a one to many relation for workspace ${workspaceId}, skipping`,
+            );
+
+            continue;
+          }
+
+          await fieldMetadataRepository.update(
+            { id: junctionRelationFieldMetadataId, workspaceId },
+            {
+              settings: {
+                ...fieldMetadata.settings,
+                junctionTargetFieldId: junctionTargetFieldMetadataId,
+              },
+            },
+          );
+
+          updatedFieldMetadataIds.push(junctionRelationFieldMetadataId);
+        }
+
+        return updatedFieldMetadataIds;
+      },
+    );
+  }
+
+  // Mirrors validateJunctionTargetSettings so the backfill can never write a
+  // setting the metadata layer would have rejected on a normal field update.
+  private resolveBackfill({
+    activityJunction,
+    flatFieldMetadataMaps,
+    workspaceId,
+  }: {
+    activityJunction: ActivityJunction;
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+    workspaceId: string;
+  }): ResolvedBackfill | undefined {
+    const {
+      label,
+      junctionRelationFieldUniversalIdentifier,
+      junctionTargetFieldUniversalIdentifier,
+    } = activityJunction;
+
+    const junctionRelationFlatFieldMetadata =
+      flatFieldMetadataMaps.byUniversalIdentifier[
+        junctionRelationFieldUniversalIdentifier
+      ];
+
+    if (!isDefined(junctionRelationFlatFieldMetadata)) {
+      this.logger.log(
+        `No ${label} field for workspace ${workspaceId}, skipping`,
+      );
+
+      return undefined;
+    }
+
+    const junctionRelationSettings = junctionRelationFlatFieldMetadata.settings;
+
+    if (
+      !isFieldMetadataSettingsOfType(
+        junctionRelationSettings,
+        FieldMetadataType.RELATION,
+      ) ||
+      junctionRelationSettings.relationType !== RelationType.ONE_TO_MANY
+    ) {
+      this.logger.warn(
+        `${label} is not a one to many relation for workspace ${workspaceId}, skipping`,
+      );
+
+      return undefined;
+    }
+
+    const junctionTargetFlatFieldMetadata =
+      flatFieldMetadataMaps.byUniversalIdentifier[
+        junctionTargetFieldUniversalIdentifier
+      ];
+
+    if (!isDefined(junctionTargetFlatFieldMetadata)) {
+      this.logger.warn(
+        `No junction target field for ${label} in workspace ${workspaceId}, skipping`,
+      );
+
+      return undefined;
+    }
+
+    if (
+      junctionTargetFlatFieldMetadata.objectMetadataId !==
+      junctionRelationFlatFieldMetadata.relationTargetObjectMetadataId
+    ) {
+      this.logger.warn(
+        `Junction target field for ${label} is not on the junction object in workspace ${workspaceId}, skipping`,
+      );
+
+      return undefined;
+    }
+
+    const junctionTargetSettings = junctionTargetFlatFieldMetadata.settings;
+    const isMorphTarget =
+      junctionTargetFlatFieldMetadata.type === FieldMetadataType.MORPH_RELATION;
+
+    if (
+      !isMorphTarget &&
+      (!isFieldMetadataSettingsOfType(
+        junctionTargetSettings,
+        FieldMetadataType.RELATION,
+      ) ||
+        junctionTargetSettings.relationType !== RelationType.MANY_TO_ONE)
+    ) {
+      this.logger.warn(
+        `Junction target field for ${label} is not a many to one relation in workspace ${workspaceId}, skipping`,
+      );
+
+      return undefined;
+    }
+
+    const currentJunctionTargetFieldId =
+      junctionRelationSettings.junctionTargetFieldId;
+
+    // A dangling id is repaired: it resolves to nothing, so leaving it in place
+    // keeps the junction unusable while looking configured.
+    if (
+      isDefined(currentJunctionTargetFieldId) &&
+      isDefined(
+        flatFieldMetadataMaps.universalIdentifierById[
+          currentJunctionTargetFieldId
+        ],
+      )
+    ) {
+      this.logger.log(
+        `${label} junction target already set for workspace ${workspaceId}, skipping`,
+      );
+
+      return undefined;
+    }
+
+    return {
+      label,
+      junctionRelationFieldMetadataId: junctionRelationFlatFieldMetadata.id,
+      junctionTargetFieldMetadataId: junctionTargetFlatFieldMetadata.id,
+    };
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/utils/invalidate-field-metadata-cache.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/utils/invalidate-field-metadata-cache.util.ts
@@ -1,0 +1,26 @@
+import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
+import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-related-metadata-names.util';
+import { getMetadataSerializedRelationNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-serialized-relation-names.util';
+import { type WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+export const invalidateFieldMetadataCache = async ({
+  workspaceId,
+  workspaceMigrationRunnerService,
+}: {
+  workspaceId: string;
+  workspaceMigrationRunnerService: WorkspaceMigrationRunnerService;
+}): Promise<void> => {
+  const fieldMetadataRelatedNames = [
+    'fieldMetadata',
+    ...getMetadataRelatedMetadataNames('fieldMetadata'),
+    ...getMetadataSerializedRelationNames('fieldMetadata'),
+    'index',
+  ] as const;
+
+  await workspaceMigrationRunnerService.invalidateCache({
+    allFlatEntityMapsKeys: [
+      ...new Set(fieldMetadataRelatedNames.map(getMetadataFlatEntityMapsKey)),
+    ],
+    workspaceId,
+  });
+};

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -25,6 +25,7 @@ import { V2_28_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
 import { V2_3_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-3/2-3-upgrade-version-command.module';
 import { V2_31_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-31/2-31-upgrade-version-command.module';
 import { V2_32_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-32/2-32-upgrade-version-command.module';
+import { V2_33_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module';
 import { V2_4_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-4/2-4-upgrade-version-command.module';
 import { V2_5_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-5/2-5-upgrade-version-command.module';
 import { V2_7_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-7/2-7-upgrade-version-command.module';
@@ -63,6 +64,7 @@ import { V2_9_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-
     V2_28_UpgradeVersionCommandModule,
     V2_31_UpgradeVersionCommandModule,
     V2_32_UpgradeVersionCommandModule,
+    V2_33_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
@@ -1,5 +1,6 @@
 import { msg } from '@lingui/core/macro';
 import { i18nLabel } from 'src/engine/workspace-manager/twenty-standard-application/utils/i18n-label.util';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   DateDisplayFormat,
   FieldMetadataType,
@@ -242,6 +243,8 @@ export const buildNoteStandardFlatFieldMetadatas = ({
       settings: {
         relationType: RelationType.ONE_TO_MANY,
       },
+      junctionTargetFieldUniversalIdentifier:
+        STANDARD_OBJECTS.noteTarget.fields.targetPerson.universalIdentifier,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
@@ -1,5 +1,6 @@
 import { msg } from '@lingui/core/macro';
 import { i18nLabel } from 'src/engine/workspace-manager/twenty-standard-application/utils/i18n-label.util';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   DateDisplayFormat,
   FieldMetadataType,
@@ -299,6 +300,8 @@ export const buildTaskStandardFlatFieldMetadatas = ({
       settings: {
         relationType: RelationType.ONE_TO_MANY,
       },
+      junctionTargetFieldUniversalIdentifier:
+        STANDARD_OBJECTS.taskTarget.fields.targetPerson.universalIdentifier,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
@@ -1,0 +1,373 @@
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { destroyOneOperationFactory } from 'test/integration/graphql/utils/destroy-one-operation-factory.util';
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { updateOneOperationFactory } from 'test/integration/graphql/utils/update-one-operation-factory.util';
+import { deleteOneOperationFactory } from 'test/integration/graphql/utils/delete-one-operation-factory.util';
+import { waitForAllJobsToFinish } from 'test/integration/utils/wait-for-all-jobs-to-finish.util';
+
+const TIMELINE_ACTIVITY_GQL_FIELDS = `
+  id
+  name
+  properties
+  linkedRecordId
+  linkedRecordCachedName
+  linkedObjectMetadataId
+  targetCompanyId
+  targetPersonId
+  targetNoteId
+  targetTaskId
+`;
+
+type TimelineActivityRow = {
+  id: string;
+  name: string;
+  properties: Record<string, unknown> | null;
+  linkedRecordId: string | null;
+  linkedRecordCachedName: string | null;
+  linkedObjectMetadataId: string | null;
+  targetCompanyId: string | null;
+  targetPersonId: string | null;
+  targetNoteId: string | null;
+  targetTaskId: string | null;
+};
+
+const createRecord = async ({
+  objectMetadataSingularName,
+  data,
+}: {
+  objectMetadataSingularName: string;
+  data: object;
+}): Promise<void> => {
+  const response = await makeGraphqlAPIRequest(
+    createOneOperationFactory({
+      objectMetadataSingularName,
+      gqlFields: 'id',
+      data,
+    }),
+  );
+
+  expect(response.body.errors).toBeUndefined();
+};
+
+const updateRecord = async ({
+  objectMetadataSingularName,
+  recordId,
+  data,
+}: {
+  objectMetadataSingularName: string;
+  recordId: string;
+  data: object;
+}): Promise<void> => {
+  const response = await makeGraphqlAPIRequest(
+    updateOneOperationFactory({
+      objectMetadataSingularName,
+      gqlFields: 'id',
+      recordId,
+      data,
+    }),
+  );
+
+  expect(response.body.errors).toBeUndefined();
+};
+
+const findTimelineActivities = async (
+  filter: object,
+): Promise<TimelineActivityRow[]> => {
+  await waitForAllJobsToFinish();
+
+  const response = await makeGraphqlAPIRequest(
+    findManyOperationFactory({
+      objectMetadataSingularName: 'timelineActivity',
+      objectMetadataPluralName: 'timelineActivities',
+      gqlFields: TIMELINE_ACTIVITY_GQL_FIELDS,
+      filter,
+      orderBy: [{ createdAt: 'AscNullsFirst' }],
+      first: 100,
+    }),
+  );
+
+  expect(response.body.errors).toBeUndefined();
+
+  return response.body.data.timelineActivities.edges.map(
+    (edge: { node: TimelineActivityRow }) => edge.node,
+  );
+};
+
+const TEST_SCHEMA_NAME = 'workspace_1wgvd1injqtife6y4rvfbu3h5';
+
+const findTimelineActivityRowsByLinkedRecordId = async ({
+  name,
+  linkedRecordId,
+}: {
+  name: string;
+  linkedRecordId: string;
+}): Promise<TimelineActivityRow[]> =>
+  global.testDataSource.query(
+    `SELECT "targetCompanyId", "targetNoteId" FROM "${TEST_SCHEMA_NAME}"."timelineActivity" WHERE name = $1 AND "linkedRecordId" = $2`,
+    [name, linkedRecordId],
+  );
+
+const COMPANY_ID = '20202020-7171-4000-8000-000000000001';
+const POSITION_COMPANY_ID = '20202020-7171-4000-8000-000000000002';
+const MERGE_COMPANY_ID = '20202020-7171-4000-8000-000000000003';
+const NOTE_COMPANY_ID = '20202020-7171-4000-8000-000000000004';
+const NOTE_ID = '20202020-7171-4000-8000-000000000005';
+const NOTE_TARGET_ID = '20202020-7171-4000-8000-000000000006';
+const MESSAGE_LIST_ID = '20202020-7171-4000-8000-000000000007';
+
+const CREATED_RECORD_IDS: { objectMetadataSingularName: string; id: string }[] =
+  [
+    { objectMetadataSingularName: 'noteTarget', id: NOTE_TARGET_ID },
+    { objectMetadataSingularName: 'note', id: NOTE_ID },
+    { objectMetadataSingularName: 'messageList', id: MESSAGE_LIST_ID },
+    { objectMetadataSingularName: 'company', id: NOTE_COMPANY_ID },
+    { objectMetadataSingularName: 'company', id: MERGE_COMPANY_ID },
+    { objectMetadataSingularName: 'company', id: POSITION_COMPANY_ID },
+    { objectMetadataSingularName: 'company', id: COMPANY_ID },
+  ];
+
+// Pins the write-path behavior that the timeline activity rule engine must
+// reproduce. Assertions describe what the hardcoded implementation does today,
+// including the parts that look accidental.
+describe('timeline activity write path (integration)', () => {
+  afterAll(async () => {
+    for (const { objectMetadataSingularName, id } of CREATED_RECORD_IDS) {
+      await makeGraphqlAPIRequest(
+        destroyOneOperationFactory({
+          objectMetadataSingularName,
+          gqlFields: 'id',
+          recordId: id,
+        }),
+      );
+    }
+  });
+
+  describe('a record own events', () => {
+    it('should write a created entry on the record own timeline', async () => {
+      await createRecord({
+        objectMetadataSingularName: 'company',
+        data: {
+          id: COMPANY_ID,
+          name: 'Timeline Write Path',
+        },
+      });
+
+      const timelineActivities = await findTimelineActivities({
+        targetCompanyId: { eq: COMPANY_ID },
+      });
+
+      expect(timelineActivities).toHaveLength(1);
+      expect(timelineActivities[0].name).toBe('company.created');
+      expect(timelineActivities[0].targetCompanyId).toBe(COMPANY_ID);
+      expect(timelineActivities[0].linkedRecordId).toBeNull();
+    });
+
+    it('should write an updated entry holding the field diff', async () => {
+      await updateRecord({
+        objectMetadataSingularName: 'company',
+        recordId: COMPANY_ID,
+        data: {
+          name: 'Timeline Write Path Renamed',
+        },
+      });
+
+      const timelineActivities = await findTimelineActivities({
+        targetCompanyId: { eq: COMPANY_ID },
+        name: { eq: 'company.updated' },
+      });
+
+      expect(timelineActivities).toHaveLength(1);
+      expect(timelineActivities[0].properties).toEqual({
+        diff: {
+          name: {
+            before: 'Timeline Write Path',
+            after: 'Timeline Write Path Renamed',
+          },
+        },
+      });
+    });
+
+    it('should merge two updates from the same author into a single entry', async () => {
+      await createRecord({
+        objectMetadataSingularName: 'company',
+        data: {
+          id: MERGE_COMPANY_ID,
+          name: 'Merge Window',
+        },
+      });
+
+      await updateRecord({
+        objectMetadataSingularName: 'company',
+        recordId: MERGE_COMPANY_ID,
+        data: {
+          name: 'Merge Window Once',
+        },
+      });
+      await waitForAllJobsToFinish();
+
+      await updateRecord({
+        objectMetadataSingularName: 'company',
+        recordId: MERGE_COMPANY_ID,
+        data: {
+          name: 'Merge Window Twice',
+        },
+      });
+
+      const timelineActivities = await findTimelineActivities({
+        targetCompanyId: { eq: MERGE_COMPANY_ID },
+        name: { eq: 'company.updated' },
+      });
+
+      expect(timelineActivities).toHaveLength(1);
+      expect(timelineActivities[0].properties).toEqual({
+        diff: {
+          name: { before: 'Merge Window', after: 'Merge Window Twice' },
+        },
+      });
+    });
+
+    it('should not write an entry for a position only change', async () => {
+      await createRecord({
+        objectMetadataSingularName: 'company',
+        data: {
+          id: POSITION_COMPANY_ID,
+          name: 'Position Only',
+        },
+      });
+
+      await updateRecord({
+        objectMetadataSingularName: 'company',
+        recordId: POSITION_COMPANY_ID,
+        data: { position: 12345 },
+      });
+
+      const timelineActivities = await findTimelineActivities({
+        targetCompanyId: { eq: POSITION_COMPANY_ID },
+        name: { eq: 'company.updated' },
+      });
+
+      expect(timelineActivities).toHaveLength(0);
+    });
+  });
+
+  describe('note linked to a company', () => {
+    it('should write a linked entry on the company when the note target is created', async () => {
+      await createRecord({
+        objectMetadataSingularName: 'company',
+        data: {
+          id: NOTE_COMPANY_ID,
+          name: 'Note Host',
+        },
+      });
+      await createRecord({
+        objectMetadataSingularName: 'note',
+        data: { id: NOTE_ID, title: 'Linked note' },
+      });
+      await createRecord({
+        objectMetadataSingularName: 'noteTarget',
+        data: {
+          id: NOTE_TARGET_ID,
+          noteId: NOTE_ID,
+          targetCompanyId: NOTE_COMPANY_ID,
+        },
+      });
+
+      const timelineActivities = await findTimelineActivities({
+        targetCompanyId: { eq: NOTE_COMPANY_ID },
+        name: { eq: 'linked-note.created' },
+      });
+
+      expect(timelineActivities).toHaveLength(1);
+      expect(timelineActivities[0].linkedRecordId).toBe(NOTE_ID);
+      expect(timelineActivities[0].linkedRecordCachedName).toBe('Linked note');
+      expect(timelineActivities[0].linkedObjectMetadataId).not.toBeNull();
+    });
+
+    it('should write the note own created entry on the note timeline', async () => {
+      const timelineActivities = await findTimelineActivities({
+        targetNoteId: { eq: NOTE_ID },
+        name: { eq: 'note.created' },
+      });
+
+      expect(timelineActivities).toHaveLength(1);
+    });
+
+    // Known defect: computeTimelineActivityPayloadsForActivities reads the
+    // relation property instead of its join column, so the entry lands with no
+    // target at all rather than on the linked company.
+    it('should write an orphan linked entry when the note title changes', async () => {
+      // Orphan rows carry no target, so nothing cascades them away when the
+      // company is destroyed and they accumulate across runs: count the
+      // difference rather than the total, which a previous run would satisfy.
+      const orphanRowCountBefore = (
+        await findTimelineActivityRowsByLinkedRecordId({
+          name: 'linked-note.updated',
+          linkedRecordId: NOTE_ID,
+        })
+      ).length;
+
+      await updateRecord({
+        objectMetadataSingularName: 'note',
+        recordId: NOTE_ID,
+        data: { title: 'Linked note renamed' },
+      });
+      await waitForAllJobsToFinish();
+
+      const onCompany = await findTimelineActivities({
+        targetCompanyId: { eq: NOTE_COMPANY_ID },
+        name: { eq: 'linked-note.updated' },
+      });
+
+      expect(onCompany).toHaveLength(0);
+
+      const orphanRows = await findTimelineActivityRowsByLinkedRecordId({
+        name: 'linked-note.updated',
+        linkedRecordId: NOTE_ID,
+      });
+
+      expect(orphanRows).toHaveLength(orphanRowCountBefore + 1);
+      expect(
+        orphanRows.every(
+          (row) => row.targetCompanyId === null && row.targetNoteId === null,
+        ),
+      ).toBe(true);
+    });
+
+    it('should write a linked entry on the company when the note target is deleted', async () => {
+      await makeGraphqlAPIRequest(
+        deleteOneOperationFactory({
+          objectMetadataSingularName: 'noteTarget',
+          gqlFields: 'id',
+          recordId: NOTE_TARGET_ID,
+        }),
+      );
+
+      const timelineActivities = await findTimelineActivities({
+        targetCompanyId: { eq: NOTE_COMPANY_ID },
+        name: { eq: 'linked-note.deleted' },
+      });
+
+      expect(timelineActivities).toHaveLength(1);
+      expect(timelineActivities[0].linkedRecordId).toBe(NOTE_ID);
+    });
+  });
+
+  describe('system objects', () => {
+    it('should not write any entry for a system object outside the allowlist', async () => {
+      await createRecord({
+        objectMetadataSingularName: 'messageList',
+        data: {
+          id: MESSAGE_LIST_ID,
+          name: 'Timeline Gate List',
+        },
+      });
+
+      const timelineActivities = await findTimelineActivities({
+        targetMessageListId: { eq: MESSAGE_LIST_ID },
+      });
+
+      expect(timelineActivities).toHaveLength(0);
+    });
+  });
+});

--- a/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
@@ -102,7 +102,7 @@ const findTimelineActivityRowsByLinkedRecordId = async ({
 }: {
   name: string;
   linkedRecordId: string;
-}): Promise<TimelineActivityRow[]> =>
+}): Promise<Pick<TimelineActivityRow, 'targetCompanyId' | 'targetNoteId'>[]> =>
   global.testDataSource.query(
     `SELECT "targetCompanyId", "targetNoteId" FROM "${TEST_SCHEMA_NAME}"."timelineActivity" WHERE name = $1 AND "linkedRecordId" = $2`,
     [name, linkedRecordId],


### PR DESCRIPTION
Stack: #24339 <- **this PR** <- #24341 <- #24345

Phase 1. Metadata only, no behavior change, and useful on its own.

## What

`note.noteTargets` and `task.taskTargets` are junction relations but were the only ones not declared as such. `messageList.members` and `person.listMemberships` already set `junctionTargetFieldUniversalIdentifier`; activity targets did not.

This declares them, pointing at `STANDARD_OBJECTS.noteTarget.fields.targetPerson.universalIdentifier` and the task equivalent. Any morph member identifies the polymorphic edge, because consumers expand the whole group from it via `morphId` (`resolveMorphRelationsFromFlatFieldMetadata`).

A workspace command (`2-33`) backfills the setting for workspaces provisioned before it was declared. It hardens against production data in bad shape:

- resolution mirrors `validateJunctionTargetSettings` (missing fields, wrong relation type, target not on the junction object, non-relation target) and skips with a logged reason per workspace
- an already-set `junctionTargetFieldId` is respected; only a dangling one (resolving to nothing) is repaired
- both junction writes run in one transaction, with each row re-read under a lock so a concurrent settings change is not clobbered
- idempotent; per-workspace failures are contained by `WorkspaceIteratorService` and never abort the whole run; `--dry-run` rehearses

## Why it matters

The next PR replaces the hardcoded `{ note: 'noteTarget', task: 'taskTarget' }` map and the "scan `properties.after` for the first key ending in `Id`" heuristic with metadata-driven traversal. That traversal reads `settings.junctionTargetFieldId`, so this declaration is its prerequisite.

`validate-junction-target-settings.util.ts` already accepts a `MORPH_RELATION` junction target, so no validator changes are needed.

## Not included

`get-is-flat-field-a-junction-relation-field.ts` carries `// TODO: refactor this when we remove hard-coded activity relations` above a literal `flatField.name === 'note' || flatField.name === 'task'`. It looks like the same problem but is not: that helper decides which relation fields to recurse into when selecting fields on a junction table, and `noteTarget.note` is already `MANY_TO_ONE`, so the name clause is redundant rather than load bearing. Removing it belongs to a separate select-fields cleanup.

## Verification

Junction targets confirmed present after a database reset:

```
note|noteTargets|9f14d62f-8efe-4e05-bcec-f98060d1ed33
task|taskTargets|663f4d63-30b7-446b-a3d9-c95c5d3c9b84
```

The phase 0 integration suite passes unchanged.