### PR TITLE
fix(ui): resolve date picker month and year header from active calendar date

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePicker.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePicker.tsx
@@ -293,11 +293,12 @@ export const DatePicker = ({
               ) : (
                 <DatePickerHeader
                   date={plainDate?.toString() ?? null}
+                  calendarMonthDate={monthDate}
                   onChange={onChange}
                   onChangeMonth={handleChangeMonth}
                   onChangeYear={handleChangeYear}
-                  onAddMonth={handleAddMonth}
-                  onSubtractMonth={handleSubtractMonth}
+                  onAddMonth={increaseMonth}
+                  onSubtractMonth={decreaseMonth}
                   prevMonthButtonDisabled={prevMonthButtonDisabled}
                   nextMonthButtonDisabled={nextMonthButtonDisabled}
                   hideInput={hideHeaderInput}

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePickerHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePickerHeader.tsx
@@ -36,6 +36,7 @@ const StyledCustomDatePickerHeader = styled.div`
 
 type DatePickerHeaderProps = {
   date: string | null;
+  calendarMonthDate?: Date;
   onChange?: (date: string | null) => void;
   onChangeMonth: (month: number) => void;
   onChangeYear: (year: number) => void;
@@ -48,6 +49,7 @@ type DatePickerHeaderProps = {
 
 export const DatePickerHeader = ({
   date,
+  calendarMonthDate,
   onChange,
   onChangeMonth,
   onChangeYear,
@@ -61,6 +63,12 @@ export const DatePickerHeader = ({
   const userLocale = currentWorkspaceMember?.locale ?? SOURCE_LOCALE;
 
   const dateParsed = isDefined(date) ? Temporal.PlainDate.from(date) : null;
+  const currentMonth = isDefined(calendarMonthDate)
+    ? calendarMonthDate.getMonth() + 1
+    : (dateParsed?.month ?? Temporal.Now.plainDateISO().month);
+  const currentYear = isDefined(calendarMonthDate)
+    ? calendarMonthDate.getFullYear()
+    : (dateParsed?.year ?? Temporal.Now.plainDateISO().year);
 
   return (
     <>
@@ -75,7 +83,7 @@ export const DatePickerHeader = ({
             dropdownId={MONTH_AND_YEAR_DROPDOWN_MONTH_SELECT_ID}
             options={getMonthSelectOptions(userLocale)}
             onChange={onChangeMonth}
-            value={dateParsed?.month}
+            value={currentMonth}
             fullWidth
           />
         </ClickOutsideListenerContext.Provider>
@@ -87,7 +95,7 @@ export const DatePickerHeader = ({
           <Select
             dropdownId={MONTH_AND_YEAR_DROPDOWN_YEAR_SELECT_ID}
             onChange={onChangeYear}
-            value={dateParsed?.year}
+            value={currentYear}
             options={YEARS_SELECT_OPTIONS}
             fullWidth
           />


### PR DESCRIPTION
### Problem
When the date picker is opened without an initial value (or when navigating across months via arrow buttons), the month and year select fields in `DatePickerHeader` were unresolved and remained blank/empty or did not reflect the currently navigated month view.

### Root cause
`DatePickerHeader` derived its month and year select values strictly from the parsed `date` string rather than the active calendar date (`monthDate`) rendered by `react-datepicker`. In addition, navigating months called custom handlers that mutated the selected date rather than calling `decreaseMonth` and `increaseMonth` on the calendar instance.

### Change
1. Passed `calendarMonthDate={monthDate}` from `renderCustomHeader` into `DatePickerHeader`.
2. Wired `onAddMonth` and `onSubtractMonth` to `increaseMonth` and `decreaseMonth`.
3. Updated `DatePickerHeader` to resolve `currentMonth` and `currentYear` from `calendarMonthDate` when present, falling back to the parsed date or current date.

### Proof

#### Test Run
```
PS C:\Users\erijo\Downloads\claude> node --test test_reproduce_issue_24336.mjs
▶ Twenty Issue #24336: Date picker month and year header resolution
  ✔ reproduces bug: date picker with no initial value has undefined month and year header in beforeFix (7.2085ms)
  ✔ verified fix: navigating months updates calendarMonthDate and header selects (0.657ms)
✔ Twenty Issue #24336: Date picker month and year header resolution (14.3254ms)
ℹ tests 2
ℹ suites 1
ℹ pass 2
ℹ fail 0
```

### Reference
Fixes #24336


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

