### PR TITLE
fix(oauth): return iss parameter in authorization response for RFC 9207 compliance (#24153)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -73,6 +73,7 @@ import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/worksp
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
+import { cleanServerUrl } from 'src/utils/clean-server-url';
 import { getDomainFromEmail } from 'src/utils/get-domain-from-email';
 
 @Injectable()
@@ -648,6 +649,11 @@ export class AuthService {
         authorizeAppInput.state,
       );
     }
+
+    const issuer = cleanServerUrl(
+      this.domainServerConfigService.getBaseUrl().toString(),
+    );
+    redirectUriValidation.parsed.searchParams.set('iss', issuer);
 
     return { redirectUrl: redirectUriValidation.parsed.toString() };
   }


### PR DESCRIPTION
# Title
fix(oauth): return iss parameter in authorization response for RFC 9207 compliance (#24153)

## Description
- Appends `iss` parameter (using canonical server base URL) to the redirect URL in `authorizeApp`.
- Ensures full compliance with RFC 9207 and OAuth 2.1 security BCP, resolving fresh login failures with strict MCP clients like Claude Code.

Closes #24153


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

