### PR TITLE
fix(workflow): return empty records result when filter variable is empty (#24042)

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
@@ -72,10 +72,13 @@ export class FindRecordsWorkflowAction implements WorkflowAction {
     if (workflowActionInput.filter?.recordFilters) {
       for (const filter of workflowActionInput.filter.recordFilters) {
         if (!isRecordFilterValueValid(filter)) {
-          throw new WorkflowStepExecutorException(
-            `Filter condition has an empty value after variable resolution. This likely means a workflow variable could not be resolved. Filter field: ${filter.fieldMetadataId}, operand: ${filter.operand}`,
-            WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
-          );
+          return {
+            result: {
+              first: undefined,
+              all: [],
+              totalCount: 0,
+            },
+          };
         }
       }
     }


### PR DESCRIPTION
# Title
fix(workflow): return empty records result when filter variable resolves to empty (#24042)

## Description
- Updates `FindRecordsWorkflowAction` to return an empty result (`first: undefined`, `all: []`, `totalCount: 0`) when a record filter has an empty or unresolved variable instead of throwing a fatal `WorkflowStepExecutorException`.
- Prevents workflows from crashing when filtering by optional relation fields (such as `companyId` on contacts without a company).

Closes #24042


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

