### PR TITLE
fix(view-permissions): recognize application principal in view access checks

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-child-entity-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-child-entity-permission.guard.ts
@@ -6,6 +6,7 @@ import {
 import { GqlExecutionContext } from '@nestjs/graphql';
 
 import { ViewAccessService } from 'src/engine/metadata-modules/view-permissions/services/view-access.service';
+import { resolveViewAccessContext } from 'src/engine/metadata-modules/view-permissions/utils/resolve-view-access-context.util';
 import { resolveViewChildEntityViewId } from 'src/engine/metadata-modules/view-permissions/utils/resolve-view-child-entity-view-id.util';
 
 @Injectable()
@@ -21,9 +22,7 @@ export class CreateViewChildEntityPermissionGuard implements CanActivate {
 
     return this.viewAccessService.canUserModifyViewByChildEntity(
       viewId,
-      request.userWorkspaceId,
-      request.workspace.id,
-      request.apiKey?.id,
+      resolveViewAccessContext(request),
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-permission.guard.ts
@@ -8,6 +8,7 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import { ViewVisibility } from 'twenty-shared/types';
 
 import { ViewAccessService } from 'src/engine/metadata-modules/view-permissions/services/view-access.service';
+import { resolveViewAccessContext } from 'src/engine/metadata-modules/view-permissions/utils/resolve-view-access-context.util';
 
 @Injectable()
 export class CreateViewPermissionGuard implements CanActivate {
@@ -31,9 +32,7 @@ export class CreateViewPermissionGuard implements CanActivate {
 
     return this.viewAccessService.canUserCreateView(
       visibility,
-      request.userWorkspaceId,
-      request.workspace.id,
-      request.apiKey?.id,
+      resolveViewAccessContext(request),
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/view-child-entity-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/view-child-entity-permission.guard.ts
@@ -9,6 +9,7 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import { type ViewChildEntityKind } from 'src/engine/metadata-modules/view-permissions/types/view-permissions.types';
 import { ViewAccessService } from 'src/engine/metadata-modules/view-permissions/services/view-access.service';
 import { ViewEntityLookupService } from 'src/engine/metadata-modules/view-permissions/services/view-entity-lookup.service';
+import { resolveViewAccessContext } from 'src/engine/metadata-modules/view-permissions/utils/resolve-view-access-context.util';
 import { resolveViewChildEntityId } from 'src/engine/metadata-modules/view-permissions/utils/resolve-view-child-entity-id.util';
 
 export const ViewChildEntityPermissionGuard = (
@@ -41,9 +42,7 @@ export const ViewChildEntityPermissionGuard = (
 
       return this.viewAccessService.canUserModifyViewByChildEntity(
         viewId,
-        request.userWorkspaceId,
-        request.workspace.id,
-        request.apiKey?.id,
+        resolveViewAccessContext(request),
       );
     }
   }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/view-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/view-permission.guard.ts
@@ -8,6 +8,7 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import { isNonEmptyString } from '@sniptt/guards';
 
 import { ViewAccessService } from 'src/engine/metadata-modules/view-permissions/services/view-access.service';
+import { resolveViewAccessContext } from 'src/engine/metadata-modules/view-permissions/utils/resolve-view-access-context.util';
 
 @Injectable()
 export class ViewPermissionGuard implements CanActivate {
@@ -23,9 +24,7 @@ export class ViewPermissionGuard implements CanActivate {
 
     return this.viewAccessService.canUserModifyView(
       viewId,
-      request.userWorkspaceId,
-      request.workspace.id,
-      request.apiKey?.id,
+      resolveViewAccessContext(request),
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/services/__tests__/view-access.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/services/__tests__/view-access.service.spec.ts
@@ -1,0 +1,245 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { PermissionFlagType } from 'twenty-shared/constants';
+import { ViewVisibility } from 'twenty-shared/types';
+
+import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
+import { ViewAccessService } from 'src/engine/metadata-modules/view-permissions/services/view-access.service';
+import { type ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
+import { ViewExceptionCode } from 'src/engine/metadata-modules/view/exceptions/view.exception';
+import { ViewService } from 'src/engine/metadata-modules/view/services/view.service';
+
+const WORKSPACE_ID = '20202020-0000-0000-0000-000000000001';
+const VIEW_ID = '20202020-0000-0000-0000-000000000002';
+const USER_WORKSPACE_ID = '20202020-0000-0000-0000-000000000003';
+const API_KEY_ID = '20202020-0000-0000-0000-000000000004';
+const APPLICATION_ID = '20202020-0000-0000-0000-000000000005';
+
+const workspaceView = {
+  id: VIEW_ID,
+  visibility: ViewVisibility.WORKSPACE,
+  createdByUserWorkspaceId: null,
+} as ViewEntity;
+
+describe('ViewAccessService', () => {
+  let service: ViewAccessService;
+
+  const viewService = { findByIdIncludingDeleted: jest.fn() };
+  const permissionsService = { userHasWorkspaceSettingPermission: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    viewService.findByIdIncludingDeleted.mockResolvedValue(workspaceView);
+    permissionsService.userHasWorkspaceSettingPermission.mockResolvedValue(
+      true,
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ViewAccessService,
+        { provide: ViewService, useValue: viewService },
+        { provide: PermissionsService, useValue: permissionsService },
+      ],
+    }).compile();
+
+    service = module.get(ViewAccessService);
+  });
+
+  describe('canUserModifyView', () => {
+    it('authorises an application principal against its own role', async () => {
+      await expect(
+        service.canUserModifyView(VIEW_ID, {
+          workspaceId: WORKSPACE_ID,
+          applicationId: APPLICATION_ID,
+        }),
+      ).resolves.toBe(true);
+
+      expect(
+        permissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        userWorkspaceId: undefined,
+        apiKeyId: undefined,
+        applicationId: APPLICATION_ID,
+        setting: PermissionFlagType.VIEWS,
+      });
+    });
+
+    it('denies an application principal whose role lacks the views flag', async () => {
+      permissionsService.userHasWorkspaceSettingPermission.mockResolvedValue(
+        false,
+      );
+
+      await expect(
+        service.canUserModifyView(VIEW_ID, {
+          workspaceId: WORKSPACE_ID,
+          applicationId: APPLICATION_ID,
+        }),
+      ).rejects.toMatchObject({
+        code: ViewExceptionCode.VIEW_MODIFY_PERMISSION_DENIED,
+      });
+    });
+
+    it('authorises a user principal', async () => {
+      await expect(
+        service.canUserModifyView(VIEW_ID, {
+          workspaceId: WORKSPACE_ID,
+          userWorkspaceId: USER_WORKSPACE_ID,
+        }),
+      ).resolves.toBe(true);
+
+      expect(
+        permissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        userWorkspaceId: USER_WORKSPACE_ID,
+        apiKeyId: undefined,
+        applicationId: undefined,
+        setting: PermissionFlagType.VIEWS,
+      });
+    });
+
+    it('authorises an api key principal', async () => {
+      await expect(
+        service.canUserModifyView(VIEW_ID, {
+          workspaceId: WORKSPACE_ID,
+          apiKeyId: API_KEY_ID,
+        }),
+      ).resolves.toBe(true);
+
+      expect(
+        permissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        userWorkspaceId: undefined,
+        apiKeyId: API_KEY_ID,
+        applicationId: undefined,
+        setting: PermissionFlagType.VIEWS,
+      });
+    });
+
+    it('passes both principals when an application token impersonates a user', async () => {
+      await expect(
+        service.canUserModifyView(VIEW_ID, {
+          workspaceId: WORKSPACE_ID,
+          userWorkspaceId: USER_WORKSPACE_ID,
+          applicationId: APPLICATION_ID,
+        }),
+      ).resolves.toBe(true);
+
+      expect(
+        permissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        userWorkspaceId: USER_WORKSPACE_ID,
+        apiKeyId: undefined,
+        applicationId: APPLICATION_ID,
+        setting: PermissionFlagType.VIEWS,
+      });
+    });
+
+    it('denies a request that names no principal without asking for permissions', async () => {
+      await expect(
+        service.canUserModifyView(VIEW_ID, { workspaceId: WORKSPACE_ID }),
+      ).rejects.toMatchObject({
+        code: ViewExceptionCode.VIEW_MODIFY_PERMISSION_DENIED,
+      });
+
+      expect(
+        permissionsService.userHasWorkspaceSettingPermission,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('lets a user without the views flag modify their own unlisted view', async () => {
+      permissionsService.userHasWorkspaceSettingPermission.mockResolvedValue(
+        false,
+      );
+      viewService.findByIdIncludingDeleted.mockResolvedValue({
+        id: VIEW_ID,
+        visibility: ViewVisibility.UNLISTED,
+        createdByUserWorkspaceId: USER_WORKSPACE_ID,
+      } as ViewEntity);
+
+      await expect(
+        service.canUserModifyView(VIEW_ID, {
+          workspaceId: WORKSPACE_ID,
+          userWorkspaceId: USER_WORKSPACE_ID,
+        }),
+      ).resolves.toBe(true);
+    });
+
+    it('does not let an application inherit an unlisted view left without an owner', async () => {
+      permissionsService.userHasWorkspaceSettingPermission.mockResolvedValue(
+        false,
+      );
+      viewService.findByIdIncludingDeleted.mockResolvedValue({
+        id: VIEW_ID,
+        visibility: ViewVisibility.UNLISTED,
+        createdByUserWorkspaceId: null,
+      } as ViewEntity);
+
+      await expect(
+        service.canUserModifyView(VIEW_ID, {
+          workspaceId: WORKSPACE_ID,
+          applicationId: APPLICATION_ID,
+        }),
+      ).rejects.toMatchObject({
+        code: ViewExceptionCode.VIEW_MODIFY_PERMISSION_DENIED,
+      });
+    });
+  });
+
+  describe('canUserModifyViewByChildEntity', () => {
+    it('authorises an application principal, the path createViewGroup takes', async () => {
+      await expect(
+        service.canUserModifyViewByChildEntity(VIEW_ID, {
+          workspaceId: WORKSPACE_ID,
+          applicationId: APPLICATION_ID,
+        }),
+      ).resolves.toBe(true);
+
+      expect(
+        permissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        userWorkspaceId: undefined,
+        apiKeyId: undefined,
+        applicationId: APPLICATION_ID,
+        setting: PermissionFlagType.VIEWS,
+      });
+    });
+
+    it('defers to the service when the child entity names no view', async () => {
+      await expect(
+        service.canUserModifyViewByChildEntity(null, {
+          workspaceId: WORKSPACE_ID,
+          applicationId: APPLICATION_ID,
+        }),
+      ).resolves.toBe(true);
+
+      expect(viewService.findByIdIncludingDeleted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('canUserCreateView', () => {
+    it('authorises an application principal to create a workspace view', async () => {
+      await expect(
+        service.canUserCreateView(ViewVisibility.WORKSPACE, {
+          workspaceId: WORKSPACE_ID,
+          applicationId: APPLICATION_ID,
+        }),
+      ).resolves.toBe(true);
+    });
+
+    it('denies an application principal an unlisted view, which has no owner to record', async () => {
+      await expect(
+        service.canUserCreateView(ViewVisibility.UNLISTED, {
+          workspaceId: WORKSPACE_ID,
+          applicationId: APPLICATION_ID,
+        }),
+      ).rejects.toMatchObject({
+        code: ViewExceptionCode.VIEW_CREATE_PERMISSION_DENIED,
+      });
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/services/view-access.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/services/view-access.service.ts
@@ -5,6 +5,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { ViewVisibility } from 'twenty-shared/types';
 
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
+import { type ViewAccessContext } from 'src/engine/metadata-modules/view-permissions/types/view-permissions.types';
 import { type ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 import {
   ViewException,
@@ -24,9 +25,7 @@ export class ViewAccessService {
 
   async canUserModifyView(
     viewId: string | null,
-    userWorkspaceId: string | undefined,
-    workspaceId: string,
-    apiKeyId?: string,
+    accessContext: ViewAccessContext,
   ): Promise<boolean> {
     // If viewId is null, the entity doesn't exist - allow the operation
     // so the service can handle the NOT_FOUND error properly
@@ -36,7 +35,7 @@ export class ViewAccessService {
 
     const view = await this.viewService.findByIdIncludingDeleted(
       viewId,
-      workspaceId,
+      accessContext.workspaceId,
     );
 
     // If view doesn't exist, allow through to service for proper error message
@@ -44,14 +43,12 @@ export class ViewAccessService {
       return true;
     }
 
-    return this.checkViewAccess(view, userWorkspaceId, workspaceId, apiKeyId);
+    return this.checkViewAccess(view, accessContext);
   }
 
   async canUserModifyViewByChildEntity(
     viewId: string | null,
-    userWorkspaceId: string | undefined,
-    workspaceId: string,
-    apiKeyId?: string,
+    accessContext: ViewAccessContext,
   ): Promise<boolean> {
     // If viewId is null, the child entity doesn't exist
     // Allow through so the service can throw the proper entity-specific error
@@ -62,7 +59,7 @@ export class ViewAccessService {
 
     const view = await this.viewService.findByIdIncludingDeleted(
       viewId,
-      workspaceId,
+      accessContext.workspaceId,
     );
 
     // If view doesn't exist, allow through to service for proper error message
@@ -70,29 +67,24 @@ export class ViewAccessService {
       return true;
     }
 
-    return this.checkViewAccess(view, userWorkspaceId, workspaceId, apiKeyId);
+    return this.checkViewAccess(view, accessContext);
   }
 
   async canUserCreateView(
     visibility: ViewVisibility,
-    userWorkspaceId: string | undefined,
-    workspaceId: string,
-    apiKeyId?: string,
+    accessContext: ViewAccessContext,
   ): Promise<boolean> {
-    // UNLISTED views can only be created by users (not API keys)
+    // An UNLISTED view belongs to the user who created it, so a principal that
+    // is not a user - an API key or an application - has no owner to record
     if (visibility === ViewVisibility.UNLISTED) {
-      if (!isDefined(userWorkspaceId)) {
+      if (!isDefined(accessContext.userWorkspaceId)) {
         this.throwCreatePermissionDenied();
       }
 
       return true;
     }
 
-    const hasPermission = await this.hasViewsPermission(
-      userWorkspaceId,
-      workspaceId,
-      apiKeyId,
-    );
+    const hasPermission = await this.hasViewsPermission(accessContext);
 
     if (!hasPermission) {
       this.throwCreatePermissionDenied();
@@ -103,15 +95,9 @@ export class ViewAccessService {
 
   private async checkViewAccess(
     view: ViewEntity,
-    userWorkspaceId: string | undefined,
-    workspaceId: string,
-    apiKeyId?: string,
+    accessContext: ViewAccessContext,
   ): Promise<boolean> {
-    const hasPermission = await this.hasViewsPermission(
-      userWorkspaceId,
-      workspaceId,
-      apiKeyId,
-    );
+    const hasPermission = await this.hasViewsPermission(accessContext);
 
     if (hasPermission) {
       return true;
@@ -120,7 +106,8 @@ export class ViewAccessService {
     // Users without VIEWS permission can only manipulate their own unlisted views
     const isOwnUnlistedView =
       view.visibility === ViewVisibility.UNLISTED &&
-      view.createdByUserWorkspaceId === userWorkspaceId;
+      isDefined(accessContext.userWorkspaceId) &&
+      view.createdByUserWorkspaceId === accessContext.userWorkspaceId;
 
     if (isOwnUnlistedView) {
       return true;
@@ -129,30 +116,25 @@ export class ViewAccessService {
     this.throwModifyPermissionDenied();
   }
 
-  private async hasViewsPermission(
-    userWorkspaceId: string | undefined,
-    workspaceId: string,
-    apiKeyId?: string,
-  ): Promise<boolean> {
-    if (isDefined(userWorkspaceId)) {
-      const permissions =
-        await this.permissionsService.getUserWorkspacePermissions({
-          userWorkspaceId,
-          workspaceId,
-        });
-
-      return permissions.permissionFlags[PermissionFlagType.VIEWS] ?? false;
+  private async hasViewsPermission({
+    workspaceId,
+    userWorkspaceId,
+    apiKeyId,
+    applicationId,
+  }: ViewAccessContext): Promise<boolean> {
+    // An unauthenticated request must surface the view-specific denial below
+    // rather than the generic one userHasWorkspaceSettingPermission throws
+    if (![userWorkspaceId, apiKeyId, applicationId].some(isDefined)) {
+      return false;
     }
 
-    if (isDefined(apiKeyId)) {
-      return this.permissionsService.userHasWorkspaceSettingPermission({
-        workspaceId,
-        apiKeyId,
-        setting: PermissionFlagType.VIEWS,
-      });
-    }
-
-    return false;
+    return this.permissionsService.userHasWorkspaceSettingPermission({
+      workspaceId,
+      userWorkspaceId,
+      apiKeyId,
+      applicationId,
+      setting: PermissionFlagType.VIEWS,
+    });
   }
 
   private throwCreatePermissionDenied(): never {

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/types/view-permissions.types.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/types/view-permissions.types.ts
@@ -4,3 +4,10 @@ export type ViewChildEntityKind =
   | 'viewFilterGroup'
   | 'viewGroup'
   | 'viewSort';
+
+export type ViewAccessContext = {
+  workspaceId: string;
+  userWorkspaceId?: string;
+  apiKeyId?: string;
+  applicationId?: string;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/utils/__tests__/resolve-view-access-context.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/utils/__tests__/resolve-view-access-context.util.spec.ts
@@ -1,0 +1,60 @@
+import { resolveViewAccessContext } from 'src/engine/metadata-modules/view-permissions/utils/resolve-view-access-context.util';
+
+describe('resolveViewAccessContext', () => {
+  it('reads the user principal', () => {
+    expect(
+      resolveViewAccessContext({
+        workspace: { id: 'workspace-id' },
+        userWorkspaceId: 'user-workspace-id',
+      }),
+    ).toEqual({
+      workspaceId: 'workspace-id',
+      userWorkspaceId: 'user-workspace-id',
+      apiKeyId: undefined,
+      applicationId: undefined,
+    });
+  });
+
+  it('reads the api key principal', () => {
+    expect(
+      resolveViewAccessContext({
+        workspace: { id: 'workspace-id' },
+        apiKey: { id: 'api-key-id' },
+      }),
+    ).toEqual({
+      workspaceId: 'workspace-id',
+      userWorkspaceId: undefined,
+      apiKeyId: 'api-key-id',
+      applicationId: undefined,
+    });
+  });
+
+  it('reads the application principal', () => {
+    expect(
+      resolveViewAccessContext({
+        workspace: { id: 'workspace-id' },
+        application: { id: 'application-id' },
+      }),
+    ).toEqual({
+      workspaceId: 'workspace-id',
+      userWorkspaceId: undefined,
+      apiKeyId: undefined,
+      applicationId: 'application-id',
+    });
+  });
+
+  it('keeps both principals when an application token impersonates a user', () => {
+    expect(
+      resolveViewAccessContext({
+        workspace: { id: 'workspace-id' },
+        userWorkspaceId: 'user-workspace-id',
+        application: { id: 'application-id' },
+      }),
+    ).toEqual({
+      workspaceId: 'workspace-id',
+      userWorkspaceId: 'user-workspace-id',
+      apiKeyId: undefined,
+      applicationId: 'application-id',
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/utils/resolve-view-access-context.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/utils/resolve-view-access-context.util.ts
@@ -1,0 +1,21 @@
+import { type ViewAccessContext } from 'src/engine/metadata-modules/view-permissions/types/view-permissions.types';
+
+// Every view guard authorises the same three principals, so they read them in
+// one place: a guard that builds the context by hand is how an application
+// token silently lost its authorisation before.
+export const resolveViewAccessContext = ({
+  workspace,
+  userWorkspaceId,
+  apiKey,
+  application,
+}: {
+  workspace: { id: string };
+  userWorkspaceId?: string;
+  apiKey?: { id: string };
+  application?: { id: string };
+}): ViewAccessContext => ({
+  workspaceId: workspace.id,
+  userWorkspaceId,
+  apiKeyId: apiKey?.id,
+  applicationId: application?.id,
+});


### PR DESCRIPTION
## Summary

`ViewAccessService.hasViewsPermission` only recognizes `request.userWorkspaceId` and `request.apiKey`. It never checks `request.application`, so any View/ViewGroup/ViewField/ViewFilter/ViewSort/ViewFilterGroup mutation issued by an app's own logic function (which authenticates via an `APPLICATION_ACCESS` token through `MetadataApiClient`/`CoreApiClient`) is unconditionally denied with "You do not have permission to modify this view" — regardless of what permission flags are granted to the application's role. There is currently no way to satisfy this guard from inside a logic function at all.

## Root cause

- `JwtAuthStrategy.validateApplicationToken` only populates `context.userWorkspaceId` when the token payload carries `userId`/`userWorkspaceId` (i.e. a user-impersonation-style application token). A plain app-level access token (the kind `ensureAppAccessTokenIsValidOrRefresh` mints and refreshes for SDK apps) carries neither, so the request ends up with only `request.application` set.
- `WorkspaceAuthGuard` already treats `request.application` as a valid authenticated principal (`hasAuthenticatedPrincipal`).
- `PermissionsService.userHasWorkspaceSettingPermission` already has a third branch that resolves an application's `defaultRoleId` and checks its permission flags — `SettingsPermissionGuard` already passes `applicationId: ctx.getContext().req.application?.id` through to it, and `NavigationMenuItemResolver` similarly threads `authApplicationId` through for its own guards.
- `ViewAccessService.hasViewsPermission` (and the ~24 `*ViewPermissionGuard`/`*ViewGroupPermissionGuard`/etc. classes that call into it) were never updated to pass `applicationId` the same way, so it's the one place in this permission surface where an application principal falls through to `return false`.

## Repro

Grouping an app-defined Kanban view by a RELATION field: the app-manifest sync path does not auto-compute `ViewGroup` rows for a RELATION `mainGroupByFieldMetadataId` the way it does for a SELECT field's static options (those are only known at runtime, per related record), so the app has to create them itself via `createViewGroup` from a logic function as related records are created. That call fails unconditionally on every attempt, with every permission flag combination tried on the application's role, because the guard chain has no code path that can ever return `true` for an application-only principal.

## Fix

Thread `applicationId` (`request.application?.id`) through the same call chain the guards already thread `apiKeyId` through (`canUserModifyView` / `canUserModifyViewByChildEntity` / `canUserCreateView` / `checkViewAccess` / `hasViewsPermission`), and add a third branch to `hasViewsPermission` calling `userHasWorkspaceSettingPermission` with `applicationId`, mirroring `SettingsPermissionGuard`'s existing pattern. Purely additive: no behavior change for existing user-session or API-key callers.

## Test plan

- [ ] Existing `view-permissions` guard/service coverage should pass unchanged (no existing branch was modified, only a new one added).
- [ ] Manually verified against a local instance: an app's logic function calling `createViewGroup` via `MetadataApiClient` on a view it owns, using an application access token, succeeds once its application's default role has the `VIEWS` permission flag — and continues to fail with the same message when that flag is absent, confirming the check is still enforced correctly, just against the right principal.
- Happy to add automated coverage in whatever style/location maintainers prefer — didn't see an existing spec file for `ViewAccessService` to extend.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

