### PR TITLE
Split onboarding chat spans into their own telemetry functionId

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-stream-function-id.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-stream-function-id.constant.ts
@@ -1,0 +1,1 @@
+export const AI_CHAT_STREAM_FUNCTION_ID = 'ai-chat-stream';

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-workspace-setup-stream-function-id.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-workspace-setup-stream-function-id.constant.ts
@@ -1,0 +1,2 @@
+export const AI_CHAT_WORKSPACE_SETUP_STREAM_FUNCTION_ID =
+  'ai-chat-workspace-setup-stream';

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/workspace-setup-chat-stream-function-id.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/workspace-setup-chat-stream-function-id.constant.ts
@@ -1,4 +1,0 @@
-// Splits onboarding chat traffic in AI telemetry; the ai-digest pipeline in
-// twentyhq/twenty-factory filters Sentry spans on this exact string.
-export const WORKSPACE_SETUP_CHAT_STREAM_FUNCTION_ID =
-  'workspace-setup-chat-stream';

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/workspace-setup-chat-stream-function-id.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/workspace-setup-chat-stream-function-id.constant.ts
@@ -1,0 +1,4 @@
+// Splits onboarding chat traffic in AI telemetry; the ai-digest pipeline in
+// twentyhq/twenty-factory filters Sentry spans on this exact string.
+export const WORKSPACE_SETUP_CHAT_STREAM_FUNCTION_ID =
+  'workspace-setup-chat-stream';

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -55,7 +55,9 @@ import {
   extractCacheCreationTokens,
   extractCacheCreationTokensFromSteps,
 } from 'src/engine/metadata-modules/ai/ai-billing/utils/extract-cache-creation-tokens.util';
+import { AI_CHAT_STREAM_FUNCTION_ID } from 'src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-stream-function-id.constant';
 import { AI_CHAT_TOOL_NAMES_TO_PRELOAD } from 'src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-tool-names-to-preload.const';
+import { WORKSPACE_SETUP_CHAT_STREAM_FUNCTION_ID } from 'src/engine/metadata-modules/ai/ai-chat/constants/workspace-setup-chat-stream-function-id.constant';
 import { MessagePruningService } from 'src/engine/metadata-modules/ai/ai-chat/services/message-pruning.service';
 import { SystemPromptBuilderService } from 'src/engine/metadata-modules/ai/ai-chat/services/system-prompt-builder.service';
 import {
@@ -471,7 +473,9 @@ export class ChatExecutionService {
         hasToolCall(COMPLETE_WORKSPACE_SETUP_TOOL_NAME)(step) ||
         hasNoMoreAvailableCredits,
       experimental_telemetry: buildAiTelemetry({
-        functionId: 'ai-chat-stream',
+        functionId: isWorkspaceSetupThread
+          ? WORKSPACE_SETUP_CHAT_STREAM_FUNCTION_ID
+          : AI_CHAT_STREAM_FUNCTION_ID,
         workspaceId: workspace.id,
         userWorkspaceId,
         threadId,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -57,7 +57,7 @@ import {
 } from 'src/engine/metadata-modules/ai/ai-billing/utils/extract-cache-creation-tokens.util';
 import { AI_CHAT_STREAM_FUNCTION_ID } from 'src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-stream-function-id.constant';
 import { AI_CHAT_TOOL_NAMES_TO_PRELOAD } from 'src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-tool-names-to-preload.const';
-import { WORKSPACE_SETUP_CHAT_STREAM_FUNCTION_ID } from 'src/engine/metadata-modules/ai/ai-chat/constants/workspace-setup-chat-stream-function-id.constant';
+import { AI_CHAT_WORKSPACE_SETUP_STREAM_FUNCTION_ID } from 'src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-workspace-setup-stream-function-id.constant';
 import { MessagePruningService } from 'src/engine/metadata-modules/ai/ai-chat/services/message-pruning.service';
 import { SystemPromptBuilderService } from 'src/engine/metadata-modules/ai/ai-chat/services/system-prompt-builder.service';
 import {
@@ -474,7 +474,7 @@ export class ChatExecutionService {
         hasNoMoreAvailableCredits,
       experimental_telemetry: buildAiTelemetry({
         functionId: isWorkspaceSetupThread
-          ? WORKSPACE_SETUP_CHAT_STREAM_FUNCTION_ID
+          ? AI_CHAT_WORKSPACE_SETUP_STREAM_FUNCTION_ID
           : AI_CHAT_STREAM_FUNCTION_ID,
         workspaceId: workspace.id,
         userWorkspaceId,


### PR DESCRIPTION
The workspace-setup (onboarding) chat and the general chat share one streaming path, so their Sentry spans are indistinguishable. This tags active workspace-setup threads with `functionId: ai-chat-workspace-setup-stream` (general chat keeps `ai-chat-stream`), letting the ai-digest pipeline in twenty-factory report the two separately.

`isWorkspaceSetupThread` was already computed in `streamChat`; once `complete_workspace_setup` succeeds, later turns in the thread count as general again, which is intended. Tool-call child spans carry no functionId in Sentry, so they stay in the general bucket.

Error events are tagged separately in the follow-up #24387.
