### PR TITLE
Stop reporting contact creation duplicate key conflicts to Sentry

### DIFF
--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
@@ -17,6 +17,10 @@ import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handl
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CONTACTS_CREATION_BATCH_SIZE } from 'src/modules/contact-creation-manager/constants/contacts-creation-batch-size.constant';
@@ -32,6 +36,10 @@ import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/perso
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 import { computeDisplayName } from 'src/utils/compute-display-name';
 import { isWorkDomain, isWorkEmail } from 'src/utils/is-work-email';
+
+const isDuplicateEntryError = (error: unknown) =>
+  error instanceof TwentyORMException &&
+  error.code === TwentyORMExceptionCode.DUPLICATE_ENTRY_DETECTED;
 
 @Injectable()
 export class CreateCompanyAndPersonService {
@@ -224,6 +232,13 @@ export class CreateCompanyAndPersonService {
           accountOwner,
         );
       } catch (error) {
+        // Concurrent imports for the same workspace can insert the same company
+        // domain or person email, and the loser hits the unique index. The
+        // record it wanted exists either way.
+        if (isDuplicateEntryError(error)) {
+          continue;
+        }
+
         this.exceptionHandlerService.captureExceptions([error], {
           workspace: {
             id: workspaceId,


### PR DESCRIPTION
## Problem

`CreateCompanyAndContactJob` is enqueued per sync batch, one per message channel and per calendar channel, and prod runs many worker pods. Several imports for the same workspace therefore run at once, and they routinely overlap: two teammates email the same customer, or two contacts share a company domain.

Each import looks up the companies and people it needs and then inserts the ones it did not find. The lookups happen before either insert, so both imports try to create the same record and the loser hits a unique index on `company."domainNamePrimaryLinkUrl"` or `person."emailsPrimaryEmail"`.

The loser reports the failure to Sentry, which is the bulk of what remains in the "Duplicate Entry Detected" group after #24154 (124 company and 7 person events on v2.32.0 over 7 days, spread across 15+ workspaces and every worker pod).

## Change

Losing that race is not actionable: the company or person the import wanted exists, created by the import that won. Skip the batch instead of reporting the exception. Every other failure still reports.

This does not make the write idempotent. Doing that properly means `INSERT ... ON CONFLICT DO NOTHING`, which the workspace ORM does not expose today: v1 never surfaces TypeORM's `orIgnore`, and v2 emits no `ON CONFLICT` at all (its `upsert` is a select-then-write inside a transaction, which races the same way). That is a separate change to the shared write path.
