### PR TITLE
fix(front): keep empty values at the bottom for ascending sorts

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/__tests__/turnSortsIntoOrderBy.test.ts
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/__tests__/turnSortsIntoOrderBy.test.ts
@@ -98,7 +98,7 @@ const turnSortsIntoOrderByTestUseCases: TurnSortsIntoOrderTestContext[] = [
           direction: ViewSortDirection.ASC,
         },
       ],
-      expected: [{ field1: 'AscNullsFirst' }, { position: 'AscNullsFirst' }],
+      expected: [{ field1: 'AscNullsLast' }, { position: 'AscNullsFirst' }],
     },
   },
   {
@@ -121,7 +121,7 @@ const turnSortsIntoOrderByTestUseCases: TurnSortsIntoOrderTestContext[] = [
         },
       ],
       expected: [
-        { field1: 'AscNullsFirst' },
+        { field1: 'AscNullsLast' },
         { field2: 'DescNullsLast' },
         { position: 'AscNullsFirst' },
       ],
@@ -281,7 +281,7 @@ describe('turnSortsIntoOrderBy', () => {
       ]);
 
       expect(result).toEqual([
-        { company: { name: 'AscNullsFirst' } },
+        { company: { name: 'AscNullsLast' } },
         { position: 'AscNullsFirst' },
       ]);
     });
@@ -317,7 +317,7 @@ describe('turnSortsIntoOrderBy', () => {
       const result = turnSortsIntoOrderBy(personObjectMetadataItem, sorts, []);
 
       expect(result).toEqual([
-        { companyId: 'AscNullsFirst' },
+        { companyId: 'AscNullsLast' },
         { position: 'AscNullsFirst' },
       ]);
     });

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
@@ -36,9 +36,7 @@ export const turnSortsIntoOrderBy = (
         return undefined;
       }
 
-      // Empty values stay at the bottom in both directions: sorting is about
-      // seeing values, so a sparsely-filled column must not start with a wall
-      // of empty rows when sorted ascending
+      // Nulls last in both directions so a sparse column doesn't open with a wall of empty rows
       const direction: OrderBy =
         sort.direction === ViewSortDirection.ASC
           ? 'AscNullsLast'

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
@@ -36,9 +36,12 @@ export const turnSortsIntoOrderBy = (
         return undefined;
       }
 
+      // Empty values stay at the bottom in both directions: sorting is about
+      // seeing values, so a sparsely-filled column must not start with a wall
+      // of empty rows when sorted ascending
       const direction: OrderBy =
         sort.direction === ViewSortDirection.ASC
-          ? 'AscNullsFirst'
+          ? 'AscNullsLast'
           : 'DescNullsLast';
 
       if (correspondingField.type === FieldMetadataType.RELATION) {


### PR DESCRIPTION
## Description

Ascending sorts mapped to `AscNullsFirst` while descending mapped to `DescNullsLast`, so sorting ascending by a sparsely-filled field (e.g. a date only 10% of records have) started the list with a wall of empty rows before any value appeared. Descending already showed values first.

Empty values now stay at the bottom in **both** directions (`AscNullsLast` / `DescNullsLast`), matching the spreadsheet convention (Excel, Airtable): sorting is about seeing values. The trade-off is that toggling a sort mirrors the non-empty values but keeps empties pinned at the bottom, rather than being a perfect list reversal.

One-line mapping change in `turnSortsIntoOrderBy`; the internal `position` tie-break (`AscNullsFirst`) is unchanged, as are explicit defaults elsewhere.

## Notes

- Independent of the #24354/#24356 pagination stack — the server handles either placement correctly. Pairs best with #24354: on current `main`, `AscNullsLast` sorts still hit the pre-existing null-tail cursor truncation that stack fixes (before this change, `AscNullsFirst` hit it even harder, stalling after one page).
- Sort direction toggling UX discussed with @FelixMalfait; empties-at-bottom chosen as the common-case-friendly convention.

## Test Plan

`turnSortsIntoOrderBy` unit tests updated for the new mapping (internal position tie-break expectations untouched); suite passes, `twenty-front` typecheck, oxlint, and oxfmt clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WExW8V4qrP4RYTyfjfwCJG)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

