### PR TITLE
feat(page-layout): include open record in widget visibility context

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/types/WidgetVisibilityContext.ts
+++ b/packages/twenty-front/src/modules/page-layout/types/WidgetVisibilityContext.ts
@@ -1,4 +1,5 @@
 export type WidgetVisibilityContext = {
   device: 'MOBILE' | 'DESKTOP';
   selectedRecords: Record<string, unknown>[];
+  record?: Record<string, unknown>;
 };

--- a/packages/twenty-front/src/modules/page-layout/utils/__tests__/buildWidgetVisibilityContext.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/__tests__/buildWidgetVisibilityContext.test.ts
@@ -7,7 +7,11 @@ describe('buildWidgetVisibilityContext', () => {
       isInSidePanel: false,
     });
 
-    expect(result).toEqual({ device: 'MOBILE', selectedRecords: [] });
+    expect(result).toEqual({
+      device: 'MOBILE',
+      selectedRecords: [],
+      record: undefined,
+    });
   });
 
   it('should return MOBILE device when isInSidePanel is true', () => {
@@ -16,7 +20,11 @@ describe('buildWidgetVisibilityContext', () => {
       isInSidePanel: true,
     });
 
-    expect(result).toEqual({ device: 'MOBILE', selectedRecords: [] });
+    expect(result).toEqual({
+      device: 'MOBILE',
+      selectedRecords: [],
+      record: undefined,
+    });
   });
 
   it('should return MOBILE device when both isMobile and isInSidePanel are true', () => {
@@ -25,7 +33,11 @@ describe('buildWidgetVisibilityContext', () => {
       isInSidePanel: true,
     });
 
-    expect(result).toEqual({ device: 'MOBILE', selectedRecords: [] });
+    expect(result).toEqual({
+      device: 'MOBILE',
+      selectedRecords: [],
+      record: undefined,
+    });
   });
 
   it('should return DESKTOP device when both are false', () => {
@@ -34,10 +46,14 @@ describe('buildWidgetVisibilityContext', () => {
       isInSidePanel: false,
     });
 
-    expect(result).toEqual({ device: 'DESKTOP', selectedRecords: [] });
+    expect(result).toEqual({
+      device: 'DESKTOP',
+      selectedRecords: [],
+      record: undefined,
+    });
   });
 
-  it('should expose the target record as a single-record selection', () => {
+  it('should expose the target record as both record and single-record selection', () => {
     const result = buildWidgetVisibilityContext({
       isMobile: false,
       isInSidePanel: false,
@@ -47,10 +63,11 @@ describe('buildWidgetVisibilityContext', () => {
     expect(result).toEqual({
       device: 'DESKTOP',
       selectedRecords: [{ id: 'a', status: 'DRAFT' }],
+      record: { id: 'a', status: 'DRAFT' },
     });
   });
 
-  it('should expose an empty selection when there is no target record', () => {
+  it('should expose an empty selection and undefined record when there is no target record', () => {
     const result = buildWidgetVisibilityContext({
       isMobile: false,
       isInSidePanel: false,
@@ -58,5 +75,6 @@ describe('buildWidgetVisibilityContext', () => {
     });
 
     expect(result.selectedRecords).toEqual([]);
+    expect(result.record).toBeUndefined();
   });
 });

--- a/packages/twenty-front/src/modules/page-layout/utils/__tests__/evaluateWidgetVisibility.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/__tests__/evaluateWidgetVisibility.test.ts
@@ -258,4 +258,66 @@ describe('evaluateWidgetVisibility', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('evaluating record in conditionalDisplay', () => {
+    it('should evaluate conditionalDisplay rules referencing record properties on record pages', () => {
+      const conditionalDisplay: RulesLogic = {
+        '===': [{ var: 'record.profile' }, 'A'],
+      };
+
+      const matchingResult = evaluateWidgetVisibility({
+        conditionalAvailabilityExpression: undefined,
+        conditionalDisplay,
+        context: {
+          device: 'DESKTOP',
+          selectedRecords: [{ id: 'rec-1', profile: 'A' }],
+          record: { id: 'rec-1', profile: 'A' },
+        },
+      });
+
+      expect(matchingResult).toBe(true);
+
+      const nonMatchingResult = evaluateWidgetVisibility({
+        conditionalAvailabilityExpression: undefined,
+        conditionalDisplay,
+        context: {
+          device: 'DESKTOP',
+          selectedRecords: [{ id: 'rec-2', profile: 'B' }],
+          record: { id: 'rec-2', profile: 'B' },
+        },
+      });
+
+      expect(nonMatchingResult).toBe(false);
+    });
+
+    it('should evaluate truthiness of record id when record is present', () => {
+      const conditionalDisplay: RulesLogic = {
+        '!!': [{ var: 'record.id' }],
+      };
+
+      const withRecordResult = evaluateWidgetVisibility({
+        conditionalAvailabilityExpression: undefined,
+        conditionalDisplay,
+        context: {
+          device: 'DESKTOP',
+          selectedRecords: [{ id: 'rec-1' }],
+          record: { id: 'rec-1' },
+        },
+      });
+
+      expect(withRecordResult).toBe(true);
+
+      const withoutRecordResult = evaluateWidgetVisibility({
+        conditionalAvailabilityExpression: undefined,
+        conditionalDisplay,
+        context: {
+          device: 'DESKTOP',
+          selectedRecords: [],
+          record: undefined,
+        },
+      });
+
+      expect(withoutRecordResult).toBe(false);
+    });
+  });
 });

--- a/packages/twenty-front/src/modules/page-layout/utils/buildWidgetVisibilityContext.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/buildWidgetVisibilityContext.ts
@@ -24,5 +24,6 @@ export const buildWidgetVisibilityContext = ({
     // are false — so a widget gated on the record stays hidden until it loads
     // rather than appearing and being taken away.
     selectedRecords: isDefined(targetRecord) ? [targetRecord] : [],
+    record: targetRecord,
   };
 };


### PR DESCRIPTION
### Problem
On record pages, `PageLayoutWidget.conditionalDisplay` rules and visibility evaluations cannot condition widgets/tabs on the open record's own field values because the evaluation context only carries `{ device, selectedRecords }`, and `selectedRecords` is empty on record pages. This prevents conditional display logic such as `{"===": [{"var": "record.profile"}, "A"]}` or `{"!!": [{"var": "record.id"}]}` from working on record pages.

### Root cause
In `packages/twenty-front/src/modules/page-layout/utils/buildWidgetVisibilityContext.ts`, `targetRecord` was mapped to `selectedRecords: isDefined(targetRecord) ? [targetRecord] : []`, but was not exposed directly under `record`. Additionally, `WidgetVisibilityContext` type in `packages/twenty-front/src/modules/page-layout/types/WidgetVisibilityContext.ts` did not include the `record` property.

### Change
1. Updated `WidgetVisibilityContext` in `packages/twenty-front/src/modules/page-layout/types/WidgetVisibilityContext.ts` to include optional `record?: Record<string, unknown>`.
2. Updated `buildWidgetVisibilityContext` in `packages/twenty-front/src/modules/page-layout/utils/buildWidgetVisibilityContext.ts` to return `record: targetRecord` alongside `selectedRecords`.
3. Updated unit tests in `buildWidgetVisibilityContext.test.ts` and added unit tests in `evaluateWidgetVisibility.test.ts` verifying that `record` fields and truthiness evaluate correctly under `conditionalDisplay` rules.

### Verification
- Added test coverage in `packages/twenty-front/src/modules/page-layout/utils/__tests__/buildWidgetVisibilityContext.test.ts` verifying `record` property is present when target record is defined and undefined when absent.
- Added test coverage in `packages/twenty-front/src/modules/page-layout/utils/__tests__/evaluateWidgetVisibility.test.ts` verifying conditional display rules referencing `record.profile` and `record.id`.

Closes #24028


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

