### PR TITLE
fix(query-runner): match case-insensitive LOWER() in keyset comparisons (#24359)

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-where-condition-parts.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-where-condition-parts.spec.ts
@@ -1,0 +1,32 @@
+import { FieldMetadataType } from "twenty-shared/types";
+import { computeWhereConditionParts } from "../compute-where-condition-parts";
+
+describe("computeWhereConditionParts", () => {
+  it("generates strict equality condition for cursor keyset without null widening", () => {
+    const res = computeWhereConditionParts({
+      operator: "eqStrict",
+      objectNameSingular: "company",
+      key: "name",
+      value: "Acme",
+      fieldMetadataType: FieldMetadataType.TEXT,
+    });
+
+    expect(res.sql).toMatch(/^"company"\."name" = :name[a-f0-9]+$/);
+    expect(res.sql).not.toContain("IS NULL");
+    const paramKey = Object.keys(res.params)[0];
+    expect(res.params[paramKey]).toBe("Acme");
+  });
+
+  it("generates strict IS NULL condition for cursor continuation without fallback", () => {
+    const res = computeWhereConditionParts({
+      operator: "isStrictly",
+      objectNameSingular: "company",
+      key: "domainName",
+      value: "NULL",
+      fieldMetadataType: FieldMetadataType.LINKS,
+    });
+
+    expect(res.sql).toBe('"company"."domainName" IS NULL');
+    expect(Object.keys(res.params).length).toBe(0);
+  });
+});


### PR DESCRIPTION
# Title
fix(query-runner): match case-insensitive LOWER() comparison in keyset range filters for TEXT and SELECT fields (#24359)

## Description
- Updates `computeWhereConditionParts` for range comparisons (`gt`, `gte`, `lt`, `lte`) on `TEXT`, `SELECT`, and `MULTI_SELECT` fields to use `LOWER(field::text)`.
- Aligns cursor keyset predicates with `ORDER BY LOWER(...)` expressions, preventing record skipping or duplication across pagination boundaries.

Closes #24359


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

