### PR TITLE
fix(record-detail): check parent metadata for read-only in relation dropdown (#24351)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown.tsx
@@ -40,9 +40,7 @@ export const RecordDetailRelationSectionDropdown = ({
 
   const isRecordReadOnlyFromRelatedRecordPerspective = useIsRecordReadOnly({
     recordId,
-    objectMetadataId: isToOneObject
-      ? recordObjectMetadataItem.id
-      : relationObjectMetadataItem.id,
+    objectMetadataId: recordObjectMetadataItem.id,
   });
 
   if (


### PR DESCRIPTION
# Title
fix(record-detail): check parent record object metadata for read-only permission in relation section dropdown (#24351)

## Description
- Updates `RecordDetailRelationSectionDropdown` to pass `recordObjectMetadataItem.id` when calling `useIsRecordReadOnly({ recordId, objectMetadataId })`.
- Prevents mismatched object metadata ID lookups (passing parent `recordId` with target relation object metadata ID), which caused custom object relation section headers to mistakenly evaluate as read-only and hide the inline creation menu trigger.

Closes #24351


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

