### PR TITLE
fix(workflow): flag a trigger filter whose field reference is broken

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/filters/components/WorkflowStepFilterFieldSelect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/filters/components/WorkflowStepFilterFieldSelect.tsx
@@ -11,14 +11,17 @@ import { useSearchVariable } from '@/workflow/workflow-variables/hooks/useSearch
 import { type StepOutputSchemaV2 } from '@/workflow/workflow-variables/types/StepOutputSchemaV2';
 
 import { useLingui } from '@lingui/react/macro';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useContext, useState } from 'react';
 import { type StepFilter } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import {
   extractRawVariableNamePart,
+  isStandaloneVariableString,
   TRIGGER_STEP_ID,
 } from 'twenty-shared/workflow';
 import { useIcons } from 'twenty-ui/icon';
+import { InputHint } from 'twenty-ui/input';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 type WorkflowStepFilterFieldSelectProps = {
@@ -92,11 +95,22 @@ export const WorkflowStepFilterFieldSelect = ({
   };
 
   const isSelectedFieldNotFound = !isDefined(variableLabel);
+
+  const isStepOutputKeyBroken =
+    isNonEmptyString(stepFilter.stepOutputKey) &&
+    !isStandaloneVariableString(stepFilter.stepOutputKey);
+
   const label = isSelectedFieldNotFound
     ? currentStepId === TRIGGER_STEP_ID
       ? t`Select a field`
       : t`Select a field from a previous step`
     : variableLabel;
+
+  const brokenFieldReferenceHint = isStepOutputKeyBroken ? (
+    <InputHint danger>
+      {t`Broken field reference. Select the field again to fix this condition.`}
+    </InputHint>
+  ) : null;
 
   const fullRecordIconProps = stepFilter.isFullRecord
     ? isDefined(filterObjectMetadataItem)
@@ -118,62 +132,68 @@ export const WorkflowStepFilterFieldSelect = ({
       : label;
 
     return (
+      <>
+        <Dropdown
+          dropdownId={dropdownId}
+          clickableComponent={
+            <SelectControl
+              selectedOption={{
+                value: stepFilter.stepOutputKey,
+                label: disabledLabel,
+                fullLabel: variablePathLabel,
+                Icon: icon,
+                iconThemeColor,
+              }}
+              isDisabled={true}
+            />
+          }
+          dropdownComponents={[]}
+        />
+        {brokenFieldReferenceHint}
+      </>
+    );
+  }
+
+  return (
+    <>
       <Dropdown
         dropdownId={dropdownId}
         clickableComponent={
           <SelectControl
             selectedOption={{
-              value: stepFilter.stepOutputKey,
-              label: disabledLabel,
+              label,
               fullLabel: variablePathLabel,
+              value: stepFilter.stepOutputKey,
               Icon: icon,
               iconThemeColor,
             }}
-            isDisabled={true}
+            textAccent={isSelectedFieldNotFound ? 'placeholder' : 'default'}
+            isDisabled={readonly}
           />
         }
-        dropdownComponents={[]}
+        dropdownComponents={
+          !isDefined(selectedStep) ? (
+            <WorkflowVariablesDropdownSteps
+              dropdownId={dropdownId}
+              steps={availableVariablesInWorkflowStep}
+              onSelect={handleStepSelect}
+            />
+          ) : (
+            <WorkflowDropdownStepOutputItems
+              stepFilter={stepFilter}
+              step={selectedStep}
+              onSelect={handleSubItemSelect}
+              onBack={handleBack}
+            />
+          )
+        }
+        dropdownPlacement="bottom-end"
+        dropdownOffset={{
+          x: 2,
+          y: 4,
+        }}
       />
-    );
-  }
-
-  return (
-    <Dropdown
-      dropdownId={dropdownId}
-      clickableComponent={
-        <SelectControl
-          selectedOption={{
-            label,
-            fullLabel: variablePathLabel,
-            value: stepFilter.stepOutputKey,
-            Icon: icon,
-            iconThemeColor,
-          }}
-          textAccent={isSelectedFieldNotFound ? 'placeholder' : 'default'}
-          isDisabled={readonly}
-        />
-      }
-      dropdownComponents={
-        !isDefined(selectedStep) ? (
-          <WorkflowVariablesDropdownSteps
-            dropdownId={dropdownId}
-            steps={availableVariablesInWorkflowStep}
-            onSelect={handleStepSelect}
-          />
-        ) : (
-          <WorkflowDropdownStepOutputItems
-            stepFilter={stepFilter}
-            step={selectedStep}
-            onSelect={handleSubItemSelect}
-            onBack={handleBack}
-          />
-        )
-      }
-      dropdownPlacement="bottom-end"
-      dropdownOffset={{
-        x: 2,
-        y: 4,
-      }}
-    />
+      {brokenFieldReferenceHint}
+    </>
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/filters/components/__stories__/WorkflowStepFilterColumn.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/filters/components/__stories__/WorkflowStepFilterColumn.stories.tsx
@@ -1,6 +1,7 @@
 import { WorkflowStepFilterColumn } from '@/workflow/workflow-steps/filters/components/WorkflowStepFilterColumn';
 import { WorkflowStepFilterDecorator } from '@/workflow/workflow-steps/workflow-actions/filter-action/components/decorators/WorkflowStepFilterDecorator';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
 import {
   type StepFilter,
   type StepFilterGroup,
@@ -23,10 +24,15 @@ const STEP_FILTER_GROUP: StepFilterGroup = {
 const TEXT_STEP_FILTER: StepFilter = {
   id: 'filter-1',
   stepFilterGroupId: 'filter-group-1',
-  stepOutputKey: 'company.name',
+  stepOutputKey: '{{company.name}}',
   type: 'text',
   value: 'Acme',
   operand: ViewFilterOperand.CONTAINS,
+};
+
+const BROKEN_FIELD_REFERENCE_STEP_FILTER: StepFilter = {
+  ...TEXT_STEP_FILTER,
+  stepOutputKey: 'company.name',
 };
 
 const meta: Meta<typeof WorkflowStepFilterColumn> = {
@@ -53,4 +59,29 @@ const meta: Meta<typeof WorkflowStepFilterColumn> = {
 export default meta;
 type Story = StoryObj<typeof WorkflowStepFilterColumn>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.queryByText(
+        'Broken field reference. Select the field again to fix this condition.',
+      ),
+    ).toBeNull();
+  },
+};
+
+export const WithBrokenFieldReference: Story = {
+  args: {
+    stepFilter: BROKEN_FIELD_REFERENCE_STEP_FILTER,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      await canvas.findByText(
+        'Broken field reference. Select the field again to fix this condition.',
+      ),
+    ).toBeVisible();
+  },
+};

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/filters/components/__stories__/WorkflowStepFilterOperandSelect.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/filters/components/__stories__/WorkflowStepFilterOperandSelect.stories.tsx
@@ -12,7 +12,7 @@ import { graphqlMocks } from '~/testing/graphqlMocks';
 const DEFAULT_STEP_FILTER: StepFilter = {
   id: 'filter-1',
   stepFilterGroupId: 'filter-group-1',
-  stepOutputKey: 'company.name',
+  stepOutputKey: '{{company.name}}',
   type: 'text',
   operand: ViewFilterOperand.CONTAINS,
   value: '',
@@ -22,7 +22,7 @@ const DEFAULT_STEP_FILTER: StepFilter = {
 const GREATER_THAN_FILTER: StepFilter = {
   id: 'filter-1',
   stepFilterGroupId: 'filter-group-1',
-  stepOutputKey: 'company.employees',
+  stepOutputKey: '{{company.employees}}',
   type: 'number',
   operand: ViewFilterOperand.GREATER_THAN_OR_EQUAL,
   value: '100',

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/filters/components/__stories__/WorkflowStepFilterValueInput.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/filters/components/__stories__/WorkflowStepFilterValueInput.stories.tsx
@@ -13,7 +13,7 @@ import { MemoryRouterDecorator } from '~/testing/decorators/MemoryRouterDecorato
 const TEXT_FILTER: StepFilter = {
   id: 'filter-1',
   stepFilterGroupId: 'filter-group-1',
-  stepOutputKey: 'company.name',
+  stepOutputKey: '{{company.name}}',
   type: 'text',
   operand: ViewFilterOperand.CONTAINS,
   value: 'Acme',
@@ -23,7 +23,7 @@ const TEXT_FILTER: StepFilter = {
 const NUMBER_FILTER: StepFilter = {
   id: 'filter-2',
   stepFilterGroupId: 'filter-group-1',
-  stepOutputKey: 'company.employees',
+  stepOutputKey: '{{company.employees}}',
   type: 'number',
   operand: ViewFilterOperand.GREATER_THAN_OR_EQUAL,
   value: '100',

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/__stories__/WorkflowEditActionFilter.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/__stories__/WorkflowEditActionFilter.stories.tsx
@@ -50,7 +50,7 @@ const CONFIGURED_ACTION: WorkflowFilterAction = {
         {
           id: 'filter-1',
           stepFilterGroupId: 'filter-group-1',
-          stepOutputKey: 'company.name',
+          stepOutputKey: '{{company.name}}',
           operand: ViewFilterOperand.CONTAINS,
           value: 'Acme',
           type: 'string',


### PR DESCRIPTION
A customer reported a workflow that never ran: trigger `Record is updated` on People, listening to a select field, with a condition on that same field. The workflow was Active, the trigger panel looked correct, and no run was ever created. Removing the condition and adding it again fixed it.

## Root cause

The stored filter had its `stepOutputKey` saved as a bare path instead of a variable template:

```json
{
  "type": "SELECT",
  "value": "[\"CUSTOMER\"]",
  "operand": "IS",
  "stepOutputKey": "trigger.properties.after.lifecycleStage"
}
```

`resolveInput` only substitutes `{{...}}` and returns anything else verbatim, so the left operand was the string `"trigger.properties.after.lifecycleStage"` rather than the record's field value. Every comparison ran against that literal, so the trigger was skipped on every event.

The reason nobody could see it: the builder renders such a condition as if it were valid. Brace stripping is a regex replace that no-ops on an unwrapped key, so the path still splits and resolves to a real field, and the panel shows the field name, the operand and the value exactly as it would for a working filter.

Re-adding the condition rewrites the key through `getVariableTemplateFromPath`, which wraps in `{{...}}`. That is why it started working.

## Change

`WorkflowStepFilterFieldSelect` shows an error under the field when the filter's `stepOutputKey` is set but is not a variable template, with the same `InputHint danger` the cron trigger uses for an invalid expression:

> Broken field reference. Select the field again to fix this condition.

The field select itself is untouched — it still shows the field name, which is correct and worth keeping. One file.

Opening the trigger is the first thing you do when a workflow is not firing, and it now points at the condition to fix. It works on workflows that are already Active, which is the state the customer was in.

## Verified

On a local instance holding the customer's payload, on an **Active** workflow:

- the error appears under the field select, with the field name still shown above it
- restoring the key to `{{...}}` removes it

## Not covered

Nothing stops the value being written in the first place, and nothing reaches a user who never opens the trigger. Both are worth doing separately. A server-side guard needs care: `stepFilterSchema` is also used to parse stored `WorkflowRun` state, and tightening it blanks the run view for exactly the affected workflows.
