### PR TITLE
feat(mcp): include workspace AI instructions in MCP server instructions (#24324)

### DIFF
--- a/packages/twenty-server/src/engine/api/mcp/mcp.module.ts
+++ b/packages/twenty-server/src/engine/api/mcp/mcp.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 
 import { McpCoreController } from 'src/engine/api/mcp/controllers/mcp-core.controller';
 import { McpAuthGuard } from 'src/engine/api/mcp/guards/mcp-auth.guard';
@@ -31,6 +33,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     SkillModule,
     TwentyConfigModule,
     WorkspaceCacheModule,
+    TypeOrmModule.forFeature([Workspace], 'core'),
   ],
   controllers: [McpCoreController],
   exports: [McpProtocolService],

--- a/packages/twenty-server/src/engine/api/mcp/services/mcp-instruction-builder.service.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/mcp-instruction-builder.service.ts
@@ -1,9 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
-import { camelToSnakeCase } from 'twenty-shared/utils';
+import { camelToSnakeCase, isNonEmptyString } from 'twenty-shared/utils';
 
 import { buildMcpServerInstructions } from 'src/engine/api/mcp/utils/build-mcp-server-instructions.util';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { getDatabaseCrudToolFlatObjects } from 'src/engine/metadata-modules/ai/ai-agent/utils/get-database-crud-tool-flat-objects.util';
+import { tipTapDocumentToMarkdown } from 'src/engine/metadata-modules/ai/ai-chat/utils/tip-tap-document-to-markdown.util';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { SkillService } from 'src/engine/metadata-modules/skill/skill.service';
 
@@ -12,16 +16,23 @@ export class McpInstructionBuilderService {
   constructor(
     private readonly flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
     private readonly skillService: SkillService,
+    @InjectRepository(Workspace, 'core')
+    private readonly workspaceRepository: Repository<Workspace>,
   ) {}
 
   async buildInstructions(workspaceId: string): Promise<string> {
-    const [{ flatObjectMetadataMaps }, allSkills] = await Promise.all([
-      this.flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps({
-        workspaceId,
-        flatMapsKeys: ['flatObjectMetadataMaps'],
-      }),
-      this.skillService.findAllFlatSkills(workspaceId),
-    ]);
+    const [{ flatObjectMetadataMaps }, allSkills, workspace] =
+      await Promise.all([
+        this.flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps({
+          workspaceId,
+          flatMapsKeys: ['flatObjectMetadataMaps'],
+        }),
+        this.skillService.findAllFlatSkills(workspaceId),
+        this.workspaceRepository.findOne({
+          where: { id: workspaceId },
+          select: { id: true, aiAdditionalInstructions: true },
+        }),
+      ]);
 
     const objectNames = getDatabaseCrudToolFlatObjects(
       flatObjectMetadataMaps.byUniversalIdentifier,
@@ -35,6 +46,14 @@ export class McpInstructionBuilderService {
         ? allSkills.map((skill) => skill.name).join(', ')
         : undefined;
 
-    return buildMcpServerInstructions(objectNames, skillNames);
+    const workspaceInstructions = tipTapDocumentToMarkdown(
+      workspace?.aiAdditionalInstructions ?? '',
+    ).trim();
+
+    return buildMcpServerInstructions(
+      objectNames,
+      skillNames,
+      isNonEmptyString(workspaceInstructions) ? workspaceInstructions : undefined,
+    );
   }
 }

--- a/packages/twenty-server/src/engine/api/mcp/utils/build-mcp-server-instructions.util.ts
+++ b/packages/twenty-server/src/engine/api/mcp/utils/build-mcp-server-instructions.util.ts
@@ -1,6 +1,7 @@
 export const buildMcpServerInstructions = (
   objectNames: string,
   skillNames?: string,
+  workspaceInstructions?: string,
 ): string =>
   [
     `You are an AI assistant for a Twenty CRM workspace.`,
@@ -75,4 +76,12 @@ export const buildMcpServerInstructions = (
     `On tool failure: read the error message, do not retry silently, report to user.`,
     `Present results as readable summaries, not raw JSON.`,
     `For large result sets, show count + first N records and offer to paginate.`,
+    ...(workspaceInstructions
+      ? [
+          ``,
+          `## Workspace Instructions`,
+          `The following are custom instructions provided by the workspace administrator:`,
+          workspaceInstructions,
+        ]
+      : []),
   ].join('\n');


### PR DESCRIPTION
Closes #24324

<!--
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the Conventional Commits specification
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
-->

### Summary of Changes
- Injected workspace `aiAdditionalInstructions` into `McpInstructionBuilderService` (`packages/twenty-server/src/engine/api/mcp/services/mcp-instruction-builder.service.ts`).
- Converted TipTap JSON content to markdown using `tipTapDocumentToMarkdown()`, matching the built-in chat agent prompt builder.
- Appended `## Workspace Instructions` to the generated MCP server instructions in `buildMcpServerInstructions` (`packages/twenty-server/src/engine/api/mcp/utils/build-mcp-server-instructions.util.ts`).
- Registered `TypeOrmModule.forFeature([Workspace], 'core')` in `packages/twenty-server/src/engine/api/mcp/mcp.module.ts`.

### Verification
- Verified that empty / absent workspace instructions do not render extraneous sections in MCP initialization.
- Verified that configured workspace instructions are appended consistently under `## Workspace Instructions`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

