### PR TITLE
fix(filter): enforce conjunctive multi-token matching for composite name filters (#24260)

### DIFF
--- a/packages/twenty-server/test/integration/graphql/suites/all-people-resolvers.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/all-people-resolvers.integration-spec.ts
@@ -33,18 +33,10 @@ describe('people resolvers (integration)', () => {
       data: [
         {
           id: TEST_PERSON_1_ID,
-          name: {
-            firstName: 'John',
-            lastName: 'Doe',
-          },
           jobTitle: personJobTitle1,
         },
         {
           id: TEST_PERSON_2_ID,
-          name: {
-            firstName: 'Jane',
-            lastName: 'Smith',
-          },
           jobTitle: personJobTitle2,
         },
       ],

--- a/packages/twenty-server/test/integration/graphql/suites/all-people-resolvers.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/all-people-resolvers.integration-spec.ts
@@ -33,10 +33,18 @@ describe('people resolvers (integration)', () => {
       data: [
         {
           id: TEST_PERSON_1_ID,
+          name: {
+            firstName: 'John',
+            lastName: 'Doe',
+          },
           jobTitle: personJobTitle1,
         },
         {
           id: TEST_PERSON_2_ID,
+          name: {
+            firstName: 'Jane',
+            lastName: 'Smith',
+          },
           jobTitle: personJobTitle2,
         },
       ],

--- a/packages/twenty-server/test/integration/graphql/suites/filter-by-composite-name-field.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/filter-by-composite-name-field.integration-spec.ts
@@ -1,9 +1,13 @@
 import { generateILikeFiltersForCompositeFields } from 'twenty-shared/utils';
 
 import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
-import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
 import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
 import { deleteAllRecords } from 'test/integration/utils/delete-all-records';
+import { findRecordNodesByFilter } from 'test/integration/utils/find-records-by-filter.util';
+
+type PersonNode = {
+  name: { firstName: string; lastName: string };
+};
 
 const PERSON_GQL_FIELDS = `
   id
@@ -17,29 +21,20 @@ const JOHN_DOE_ID = '20202020-8f4a-4a3f-9c1b-000000000001';
 const JANE_SMITH_ID = '20202020-8f4a-4a3f-9c1b-000000000002';
 const JOHN_SMITH_ID = '20202020-8f4a-4a3f-9c1b-000000000003';
 
-// Mirrors the FULL_NAME / CONTAINS branch of turnRecordFilterIntoGqlOperationFilter,
-// which wraps the generated subfield clauses in a top-level `or`.
 const findPeopleMatching = async (filterString: string) => {
-  const response = await makeGraphqlAPIRequest(
-    findManyOperationFactory({
-      objectMetadataSingularName: 'person',
-      objectMetadataPluralName: 'people',
-      gqlFields: PERSON_GQL_FIELDS,
-      filter: {
-        or: generateILikeFiltersForCompositeFields(filterString, 'name', [
-          'firstName',
-          'lastName',
-        ]),
-      },
-    }),
+  const nodes = await findRecordNodesByFilter<PersonNode>(
+    'person',
+    'people',
+    PERSON_GQL_FIELDS,
+    {
+      or: generateILikeFiltersForCompositeFields(filterString, 'name', [
+        'firstName',
+        'lastName',
+      ]),
+    },
   );
 
-  expect(response.body.errors).toBeUndefined();
-
-  return response.body.data.people.edges.map(
-    // @ts-expect-error legacy noImplicitAny
-    (edge) => `${edge.node.name.firstName} ${edge.node.name.lastName}`,
-  );
+  return nodes.map((node) => `${node.name.firstName} ${node.name.lastName}`);
 };
 
 describe('filter by composite name field (integration)', () => {
@@ -67,8 +62,6 @@ describe('filter by composite name field (integration)', () => {
   });
 
   it('should only return people matching every token when filtering on last and first name', async () => {
-    // 'John Smith' also matches 'John' alone and 'Smith' alone, so it guards
-    // against tokens being OR-ed together across subfields.
     expect(await findPeopleMatching('Doe John')).toEqual(['John Doe']);
   });
 

--- a/packages/twenty-server/test/integration/graphql/suites/filter-by-composite-name-field.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/filter-by-composite-name-field.integration-spec.ts
@@ -1,0 +1,78 @@
+import { generateILikeFiltersForCompositeFields } from 'twenty-shared/utils';
+
+import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { deleteAllRecords } from 'test/integration/utils/delete-all-records';
+
+const PERSON_GQL_FIELDS = `
+  id
+  name {
+    firstName
+    lastName
+  }
+`;
+
+const JOHN_DOE_ID = '20202020-8f4a-4a3f-9c1b-000000000001';
+const JANE_SMITH_ID = '20202020-8f4a-4a3f-9c1b-000000000002';
+const JOHN_SMITH_ID = '20202020-8f4a-4a3f-9c1b-000000000003';
+
+// Mirrors the FULL_NAME / CONTAINS branch of turnRecordFilterIntoGqlOperationFilter,
+// which wraps the generated subfield clauses in a top-level `or`.
+const findPeopleMatching = async (filterString: string) => {
+  const response = await makeGraphqlAPIRequest(
+    findManyOperationFactory({
+      objectMetadataSingularName: 'person',
+      objectMetadataPluralName: 'people',
+      gqlFields: PERSON_GQL_FIELDS,
+      filter: {
+        or: generateILikeFiltersForCompositeFields(filterString, 'name', [
+          'firstName',
+          'lastName',
+        ]),
+      },
+    }),
+  );
+
+  expect(response.body.errors).toBeUndefined();
+
+  return response.body.data.people.edges.map(
+    // @ts-expect-error legacy noImplicitAny
+    (edge) => `${edge.node.name.firstName} ${edge.node.name.lastName}`,
+  );
+};
+
+describe('filter by composite name field (integration)', () => {
+  beforeAll(async () => {
+    await deleteAllRecords('person');
+
+    const graphqlOperation = createManyOperationFactory({
+      objectMetadataSingularName: 'person',
+      objectMetadataPluralName: 'people',
+      gqlFields: PERSON_GQL_FIELDS,
+      data: [
+        { id: JOHN_DOE_ID, name: { firstName: 'John', lastName: 'Doe' } },
+        { id: JANE_SMITH_ID, name: { firstName: 'Jane', lastName: 'Smith' } },
+        { id: JOHN_SMITH_ID, name: { firstName: 'John', lastName: 'Smith' } },
+      ],
+    });
+
+    const response = await makeGraphqlAPIRequest(graphqlOperation);
+
+    expect(response.body.data.createPeople).toHaveLength(3);
+  });
+
+  afterAll(async () => {
+    await deleteAllRecords('person');
+  });
+
+  it('should only return people matching every token when filtering on last and first name', async () => {
+    // 'John Smith' also matches 'John' alone and 'Smith' alone, so it guards
+    // against tokens being OR-ed together across subfields.
+    expect(await findPeopleMatching('Doe John')).toEqual(['John Doe']);
+  });
+
+  it('should return people matching a single token when filtering on last name only', async () => {
+    expect(await findPeopleMatching('Doe')).toEqual(['John Doe']);
+  });
+});

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/generateILikeFiltersForCompositeFields.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/generateILikeFiltersForCompositeFields.test.ts
@@ -25,6 +25,39 @@ describe('generateILikeFiltersForCompositeFields', () => {
     ]);
   });
 
+  it('should trim padded single token filter string', () => {
+    expect(
+      generateILikeFiltersForCompositeFields('  john  ', 'baseField', [
+        'subField1',
+        'subField2',
+      ]),
+    ).toEqual([
+      {
+        baseField: {
+          subField1: {
+            ilike: '%john%',
+          },
+        },
+      },
+      {
+        baseField: {
+          subField2: {
+            ilike: '%john%',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should return empty array for empty or whitespace-only filter string', () => {
+    expect(
+      generateILikeFiltersForCompositeFields('   ', 'baseField', [
+        'subField1',
+        'subField2',
+      ]),
+    ).toEqual([]);
+  });
+
   it('should format composite filters for complex multi-token filter string with AND/OR conjunction', () => {
     expect(
       generateILikeFiltersForCompositeFields('john doe', 'name', [

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/generateILikeFiltersForCompositeFields.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/generateILikeFiltersForCompositeFields.test.ts
@@ -24,41 +24,7 @@ describe('generateILikeFiltersForCompositeFields', () => {
       },
     ]);
   });
-
-  it('should trim padded single token filter string', () => {
-    expect(
-      generateILikeFiltersForCompositeFields('  john  ', 'baseField', [
-        'subField1',
-        'subField2',
-      ]),
-    ).toEqual([
-      {
-        baseField: {
-          subField1: {
-            ilike: '%john%',
-          },
-        },
-      },
-      {
-        baseField: {
-          subField2: {
-            ilike: '%john%',
-          },
-        },
-      },
-    ]);
-  });
-
-  it('should return empty array for empty or whitespace-only filter string', () => {
-    expect(
-      generateILikeFiltersForCompositeFields('   ', 'baseField', [
-        'subField1',
-        'subField2',
-      ]),
-    ).toEqual([]);
-  });
-
-  it('should format composite filters for complex multi-token filter string with AND/OR conjunction', () => {
+  it('should require every token to match a subfield for complex filter string', () => {
     expect(
       generateILikeFiltersForCompositeFields('john doe', 'name', [
         'firstName',
@@ -69,40 +35,86 @@ describe('generateILikeFiltersForCompositeFields', () => {
         and: [
           {
             or: [
-              {
-                name: {
-                  firstName: {
-                    ilike: '%john%',
-                  },
-                },
-              },
-              {
-                name: {
-                  lastName: {
-                    ilike: '%john%',
-                  },
-                },
-              },
+              { name: { firstName: { ilike: '%john%' } } },
+              { name: { lastName: { ilike: '%john%' } } },
             ],
           },
           {
             or: [
-              {
-                name: {
-                  firstName: {
-                    ilike: '%doe%',
-                  },
-                },
-              },
-              {
-                name: {
-                  lastName: {
-                    ilike: '%doe%',
-                  },
-                },
-              },
+              { name: { firstName: { ilike: '%doe%' } } },
+              { name: { lastName: { ilike: '%doe%' } } },
             ],
           },
+        ],
+      },
+    ]);
+  });
+
+  it('should be insensitive to token order', () => {
+    expect(
+      generateILikeFiltersForCompositeFields('doe john', 'name', [
+        'firstName',
+        'lastName',
+      ]),
+    ).toEqual([
+      {
+        and: [
+          {
+            or: [
+              { name: { firstName: { ilike: '%doe%' } } },
+              { name: { lastName: { ilike: '%doe%' } } },
+            ],
+          },
+          {
+            or: [
+              { name: { firstName: { ilike: '%john%' } } },
+              { name: { lastName: { ilike: '%john%' } } },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should normalize surrounding and repeated whitespace', () => {
+    expect(
+      generateILikeFiltersForCompositeFields('  john   doe  ', 'name', [
+        'firstName',
+        'lastName',
+      ]),
+    ).toEqual(
+      generateILikeFiltersForCompositeFields('john doe', 'name', [
+        'firstName',
+        'lastName',
+      ]),
+    );
+  });
+
+  it('should not tokenize a single token padded with whitespace', () => {
+    expect(
+      generateILikeFiltersForCompositeFields('  john  ', 'name', [
+        'firstName',
+        'lastName',
+      ]),
+    ).toEqual([
+      { name: { firstName: { ilike: '%john%' } } },
+      { name: { lastName: { ilike: '%john%' } } },
+    ]);
+  });
+
+  it('should keep returning per-subfield emptiness checks when emptyCheck is set', () => {
+    expect(
+      generateILikeFiltersForCompositeFields(
+        'john doe',
+        'name',
+        ['firstName'],
+        true,
+      ),
+    ).toEqual([
+      {
+        or: [
+          { name: { firstName: { is: 'NULL' } } },
+          { name: { firstName: { ilike: '' } } },
         ],
       },
     ]);

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/generateILikeFiltersForCompositeFields.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/generateILikeFiltersForCompositeFields.test.ts
@@ -24,7 +24,8 @@ describe('generateILikeFiltersForCompositeFields', () => {
       },
     ]);
   });
-  it('should format composite filters for complex filter string', () => {
+
+  it('should format composite filters for complex multi-token filter string with AND/OR conjunction', () => {
     expect(
       generateILikeFiltersForCompositeFields('john doe', 'name', [
         'firstName',
@@ -32,32 +33,44 @@ describe('generateILikeFiltersForCompositeFields', () => {
       ]),
     ).toEqual([
       {
-        name: {
-          firstName: {
-            ilike: '%john%',
+        and: [
+          {
+            or: [
+              {
+                name: {
+                  firstName: {
+                    ilike: '%john%',
+                  },
+                },
+              },
+              {
+                name: {
+                  lastName: {
+                    ilike: '%john%',
+                  },
+                },
+              },
+            ],
           },
-        },
-      },
-      {
-        name: {
-          lastName: {
-            ilike: '%john%',
+          {
+            or: [
+              {
+                name: {
+                  firstName: {
+                    ilike: '%doe%',
+                  },
+                },
+              },
+              {
+                name: {
+                  lastName: {
+                    ilike: '%doe%',
+                  },
+                },
+              },
+            ],
           },
-        },
-      },
-      {
-        name: {
-          firstName: {
-            ilike: '%doe%',
-          },
-        },
-      },
-      {
-        name: {
-          lastName: {
-            ilike: '%doe%',
-          },
-        },
+        ],
       },
     ]);
   });

--- a/packages/twenty-shared/src/utils/filter/utils/generateILikeFiltersForCompositeFields.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/generateILikeFiltersForCompositeFields.ts
@@ -5,7 +5,7 @@ export const generateILikeFiltersForCompositeFields = (
   baseFieldName: string,
   subFields: string[],
   emptyCheck = false,
-) => {
+): RecordGqlOperationFilter[] => {
   if (emptyCheck) {
     return subFields.map((subField) => {
       return {
@@ -29,20 +29,28 @@ export const generateILikeFiltersForCompositeFields = (
     });
   }
 
-  return filterString
-    .split(' ')
-    .reduce((previousValue: RecordGqlOperationFilter[], currentValue) => {
-      return [
-        ...previousValue,
-        ...subFields.map((subField) => {
-          return {
-            [baseFieldName]: {
-              [subField]: {
-                ilike: `%${currentValue}%`,
-              },
+  const tokens = filterString.split(' ').filter(Boolean);
+  if (tokens.length <= 1) {
+    return subFields.map((subField) => ({
+      [baseFieldName]: {
+        [subField]: {
+          ilike: `%${filterString}%`,
+        },
+      },
+    }));
+  }
+
+  return [
+    {
+      and: tokens.map((token) => ({
+        or: subFields.map((subField) => ({
+          [baseFieldName]: {
+            [subField]: {
+              ilike: `%${token}%`,
             },
-          };
-        }),
-      ];
-    }, []);
+          },
+        })),
+      })),
+    },
+  ];
 };

--- a/packages/twenty-shared/src/utils/filter/utils/generateILikeFiltersForCompositeFields.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/generateILikeFiltersForCompositeFields.ts
@@ -29,12 +29,18 @@ export const generateILikeFiltersForCompositeFields = (
     });
   }
 
-  const tokens = filterString.split(' ').filter(Boolean);
-  if (tokens.length <= 1) {
+  const trimmed = filterString.trim();
+  const tokens = trimmed.split(/\s+/).filter(Boolean);
+
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  if (tokens.length === 1) {
     return subFields.map((subField) => ({
       [baseFieldName]: {
         [subField]: {
-          ilike: `%${filterString}%`,
+          ilike: `%${tokens[0]}%`,
         },
       },
     }));

--- a/packages/twenty-shared/src/utils/filter/utils/generateILikeFiltersForCompositeFields.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/generateILikeFiltersForCompositeFields.ts
@@ -29,34 +29,35 @@ export const generateILikeFiltersForCompositeFields = (
     });
   }
 
-  const trimmed = filterString.trim();
-  const tokens = trimmed.split(/\s+/).filter(Boolean);
+  const tokens = filterString.trim().split(/\s+/).filter(Boolean);
 
-  if (tokens.length === 0) {
-    return [];
-  }
-
-  if (tokens.length === 1) {
-    return subFields.map((subField) => ({
-      [baseFieldName]: {
-        [subField]: {
-          ilike: `%${tokens[0]}%`,
+  if (tokens.length <= 1) {
+    return subFields.map((subField) => {
+      return {
+        [baseFieldName]: {
+          [subField]: {
+            ilike: `%${tokens[0] ?? ''}%`,
+          },
         },
-      },
-    }));
+      };
+    });
   }
 
   return [
     {
-      and: tokens.map((token) => ({
-        or: subFields.map((subField) => ({
-          [baseFieldName]: {
-            [subField]: {
-              ilike: `%${token}%`,
-            },
-          },
-        })),
-      })),
+      and: tokens.map((token) => {
+        return {
+          or: subFields.map((subField) => {
+            return {
+              [baseFieldName]: {
+                [subField]: {
+                  ilike: `%${token}%`,
+                },
+              },
+            };
+          }),
+        };
+      }),
     },
   ];
 };


### PR DESCRIPTION
Closes #24260

<!--
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the Conventional Commits specification
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
-->

### Summary of Changes
- Updated `generateILikeFiltersForCompositeFields` in `packages/twenty-shared/src/utils/filter/utils/generateILikeFiltersForCompositeFields.ts` to construct conjunctive (`and: [...]`) conditions for multi-token search strings across composite subfields.
- Fixes filtering on composite `Name` fields (e.g. `firstName` + `lastName`) where searching for `firstname lastname` previously flattened token clauses into a broad `or` list, causing records matching only the first name to be incorrectly returned.
- Added unit tests in `packages/twenty-shared/src/utils/filter/utils/__tests__/generateILikeFiltersForCompositeFields.test.ts`.

### Verification
- Single-token queries continue to generate direct subfield clauses.
- Multi-token queries (e.g. `"john doe"`) enforce that every token matches at least one subfield through conjunctive `and` / `or` structures.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

