### PR TITLE
refactor(server): compile SQL order clauses from the resolved orderBy leaves

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/__tests__/graphql-query-order.parser.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/__tests__/graphql-query-order.parser.spec.ts
@@ -1,0 +1,247 @@
+import { FieldMetadataType, OrderByDirection } from 'twenty-shared/types';
+
+import { GraphqlQueryOrderFieldParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/graphql-query-order.parser';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+
+describe('GraphqlQueryOrderFieldParser', () => {
+  const workspaceId = 'workspace-id';
+  const objectMetadataId = 'object-id';
+
+  const createMockField = (
+    overrides: Partial<FlatFieldMetadata> & {
+      id: string;
+      name: string;
+      type: FieldMetadataType;
+    },
+  ): FlatFieldMetadata =>
+    ({
+      workspaceId,
+      objectMetadataId,
+      isNullable: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      universalIdentifier: overrides.id,
+      label: overrides.name,
+      ...overrides,
+    }) as FlatFieldMetadata;
+
+  const closeDateField = createMockField({
+    id: 'closedate-id',
+    type: FieldMetadataType.DATE_TIME,
+    name: 'closeDate',
+  });
+
+  const stageField = createMockField({
+    id: 'stage-id',
+    type: FieldMetadataType.TEXT,
+    name: 'stage',
+  });
+
+  const fullNameField = createMockField({
+    id: 'fullname-id',
+    type: FieldMetadataType.FULL_NAME,
+    name: 'fullName',
+  });
+
+  const companyField = createMockField({
+    id: 'company-id',
+    type: FieldMetadataType.RELATION,
+    name: 'company',
+    relationTargetObjectMetadataId: 'company-object-id',
+    settings: {
+      relationType: 'MANY_TO_ONE',
+      joinColumnName: 'companyId',
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any,
+  });
+
+  const companyNameField = createMockField({
+    id: 'company-name-id',
+    type: FieldMetadataType.TEXT,
+    name: 'name',
+    objectMetadataId: 'company-object-id',
+  });
+
+  const companyContactNameField = createMockField({
+    id: 'company-contactname-id',
+    type: FieldMetadataType.FULL_NAME,
+    name: 'contactName',
+    objectMetadataId: 'company-object-id',
+  });
+
+  const rootFields = [closeDateField, stageField, fullNameField, companyField];
+  const fields = [...rootFields, companyNameField, companyContactNameField];
+
+  const flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata> = {
+    byUniversalIdentifier: Object.fromEntries(
+      fields.map((field) => [field.universalIdentifier, field]),
+    ),
+    universalIdentifierById: Object.fromEntries(
+      fields.map((field) => [field.id, field.universalIdentifier]),
+    ),
+    universalIdentifiersByApplicationId: {},
+  };
+
+  const flatObjectMetadata = {
+    id: objectMetadataId,
+    workspaceId,
+    nameSingular: 'opportunity',
+    fieldIds: rootFields.map((field) => field.id),
+  } as unknown as FlatObjectMetadata;
+
+  const companyObjectMetadata = {
+    id: 'company-object-id',
+    universalIdentifier: 'company-object-id',
+    workspaceId,
+    nameSingular: 'company',
+    fieldIds: ['company-name-id', 'company-contactname-id'],
+  } as unknown as FlatObjectMetadata;
+
+  const flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata> = {
+    byUniversalIdentifier: {
+      [objectMetadataId]: flatObjectMetadata,
+      'company-object-id': companyObjectMetadata,
+    },
+    universalIdentifierById: {
+      [objectMetadataId]: objectMetadataId,
+      'company-object-id': 'company-object-id',
+    },
+    universalIdentifiersByApplicationId: {},
+  };
+
+  const parser = new GraphqlQueryOrderFieldParser(
+    flatObjectMetadata,
+    flatObjectMetadataMaps,
+    flatFieldMetadataMaps,
+  );
+
+  it('should compile scalar, composite and relation leaves to their columns', () => {
+    const result = parser.parse(
+      [
+        { closeDate: OrderByDirection.DescNullsLast },
+        { fullName: { firstName: OrderByDirection.AscNullsLast } },
+        { company: { name: OrderByDirection.AscNullsLast } },
+        // oxlint-disable-next-line typescript/no-explicit-any
+      ] as any,
+      'opportunity',
+    );
+
+    expect(result.orderBy).toEqual({
+      'opportunity.closeDate': {
+        order: 'DESC',
+        nulls: 'NULLS LAST',
+        useLower: false,
+        castToText: false,
+      },
+      'opportunity.fullNameFirstName': {
+        order: 'ASC',
+        nulls: 'NULLS LAST',
+        useLower: true,
+        castToText: false,
+      },
+      'company.name': {
+        order: 'ASC',
+        nulls: 'NULLS LAST',
+        useLower: true,
+        castToText: false,
+      },
+    });
+    expect(result.relationJoins).toEqual([{ joinAlias: 'company' }]);
+  });
+
+  it('should compile a composite target field of a relation onto the join alias', () => {
+    const result = parser.parse(
+      [
+        {
+          company: {
+            contactName: { firstName: OrderByDirection.AscNullsLast },
+          },
+        },
+        {
+          company: { contactName: { lastName: OrderByDirection.AscNullsLast } },
+        },
+        // oxlint-disable-next-line typescript/no-explicit-any
+      ] as any,
+      'opportunity',
+    );
+
+    expect(Object.keys(result.orderBy)).toEqual([
+      'company.contactNameFirstName',
+      'company.contactNameLastName',
+    ]);
+    // Two leaves through the same relation share one join
+    expect(result.relationJoins).toEqual([{ joinAlias: 'company' }]);
+  });
+
+  it('should treat a join column access as a scalar of the root object', () => {
+    const result = parser.parse(
+      [{ companyId: OrderByDirection.AscNullsFirst }],
+      'opportunity',
+    );
+
+    expect(result.orderBy).toEqual({
+      'opportunity.companyId': {
+        order: 'ASC',
+        nulls: 'NULLS FIRST',
+        useLower: false,
+        castToText: false,
+      },
+    });
+    expect(result.relationJoins).toEqual([]);
+  });
+
+  it('should reverse direction and NULLS placement for backward pagination', () => {
+    const result = parser.parse(
+      [{ stage: OrderByDirection.AscNullsLast }],
+      'opportunity',
+      false,
+    );
+
+    expect(result.orderBy['opportunity.stage']).toMatchObject({
+      order: 'DESC',
+      nulls: 'NULLS FIRST',
+    });
+  });
+
+  it('should keep the first direction when the same field is ordered twice', () => {
+    const result = parser.parse(
+      [
+        { stage: OrderByDirection.AscNullsLast },
+        { stage: OrderByDirection.DescNullsFirst },
+      ],
+      'opportunity',
+    );
+
+    expect(result.orderBy['opportunity.stage']).toMatchObject({
+      order: 'ASC',
+      nulls: 'NULLS LAST',
+    });
+  });
+
+  it('should reject ordering by a field the role cannot read', () => {
+    expect(() =>
+      parser.parse(
+        [{ stage: OrderByDirection.AscNullsLast }],
+        'opportunity',
+        true,
+        {
+          [objectMetadataId]: {
+            restrictedFields: { 'stage-id': { canRead: false } },
+            // oxlint-disable-next-line typescript/no-explicit-any
+          } as any,
+        },
+      ),
+    ).toThrow('does not have permission');
+  });
+
+  it('should reject unknown fields', () => {
+    expect(() =>
+      parser.parse(
+        [{ unknownField: OrderByDirection.AscNullsLast }],
+        'opportunity',
+      ),
+    ).toThrow('does not exist or is not sortable');
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/graphql-query-order.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/graphql-query-order.parser.ts
@@ -1,29 +1,18 @@
-import { isObject } from 'class-validator';
 import { type ObjectsPermissions } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
-import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
-import {
-  GraphqlQueryRunnerException,
-  GraphqlQueryRunnerExceptionCode,
-} from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
-import { assertFieldIsReadableOrThrow } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/assert-field-is-readable-or-throw.util';
 import {
   buildOrderByColumnExpression,
   shouldCastToText,
   shouldUseCaseInsensitiveOrder,
 } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/build-order-by-column-expression.util';
 import { convertOrderByToFindOptionsOrder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/convert-order-by-to-find-options-order';
-import { isOrderByDirection } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/is-order-by-direction.util';
-import { parseCompositeFieldForOrder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/parse-composite-field-for-order.util';
-import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
+import { computeOrderByLeafColumn } from 'src/engine/api/utils/compute-order-by-leaf-column.util';
+import { resolveOrderByLeaves } from 'src/engine/api/utils/resolve-order-by-leaves.utils';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
-import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 import { type OrderByClause } from './types/order-by-condition.type';
@@ -33,12 +22,14 @@ import { type RelationJoinInfo } from './types/relation-join-info.type';
 // Re-export types for backward compatibility
 export { OrderByClause, ParseOrderByResult, RelationJoinInfo };
 
+// Compiles SQL ORDER BY clauses from the resolved orderBy leaves: walking,
+// validation and permission checks live in resolveOrderByLeaves, shared with
+// column selection and the cursor utilities, so the scan order can never
+// diverge from what cursors continue.
 export class GraphqlQueryOrderFieldParser {
   private flatObjectMetadata: FlatObjectMetadata;
   private flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
   private flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
-  private fieldIdByName: Record<string, string>;
-  private fieldIdByJoinColumnName: Record<string, string>;
 
   constructor(
     flatObjectMetadata: FlatObjectMetadata,
@@ -48,14 +39,6 @@ export class GraphqlQueryOrderFieldParser {
     this.flatObjectMetadata = flatObjectMetadata;
     this.flatObjectMetadataMaps = flatObjectMetadataMaps;
     this.flatFieldMetadataMaps = flatFieldMetadataMaps;
-
-    const fieldMaps = buildFieldMapsFromFlatObjectMetadata(
-      flatFieldMetadataMaps,
-      flatObjectMetadata,
-    );
-
-    this.fieldIdByName = fieldMaps.fieldIdByName;
-    this.fieldIdByJoinColumnName = fieldMaps.fieldIdByJoinColumnName;
   }
 
   parse(
@@ -68,239 +51,51 @@ export class GraphqlQueryOrderFieldParser {
     const relationJoins: RelationJoinInfo[] = [];
     const addedJoinAliases = new Set<string>();
 
-    for (const item of orderBy) {
-      for (const [fieldName, orderByDirection] of Object.entries(item)) {
-        // Check if accessed by relation name (company) vs FK name (companyId)
-        const isAccessedByRelationName = !!this.fieldIdByName[fieldName];
-        const fieldMetadataId =
-          this.fieldIdByName[fieldName] ||
-          this.fieldIdByJoinColumnName[fieldName];
-        const fieldMetadata = findFlatEntityByIdInFlatEntityMaps({
-          flatEntityId: fieldMetadataId,
-          flatEntityMaps: this.flatFieldMetadataMaps,
-        });
+    const orderByLeaves = resolveOrderByLeaves({
+      orderBy,
+      flatObjectMetadata: this.flatObjectMetadata,
+      flatObjectMetadataMaps: this.flatObjectMetadataMaps,
+      flatFieldMetadataMaps: this.flatFieldMetadataMaps,
+      strictValidation: true,
+      objectsPermissions,
+    });
 
-        if (!fieldMetadata || orderByDirection === undefined) {
-          throw new GraphqlQueryRunnerException(
-            `Field "${fieldName}" does not exist or is not sortable`,
-            GraphqlQueryRunnerExceptionCode.FIELD_NOT_FOUND,
-            { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
-          );
-        }
+    for (const orderByLeaf of orderByLeaves) {
+      const leafColumn = computeOrderByLeafColumn(
+        orderByLeaf,
+        objectNameSingular,
+      );
 
-        assertFieldIsReadableOrThrow({
-          objectsPermissions,
-          objectMetadataId: this.flatObjectMetadata.id,
-          fieldMetadataId: fieldMetadata.id,
-        });
-
-        // Only treat as relation if accessed by relation name (not FK like companyId)
-        if (
-          isAccessedByRelationName &&
-          isMorphOrRelationFlatFieldMetadata(fieldMetadata)
-        ) {
-          if (!isObject(orderByDirection)) {
-            throw new GraphqlQueryRunnerException(
-              `Relation field "${fieldName}" requires nested field ordering (e.g., { ${fieldName}: { fieldName: 'AscNullsFirst' } })`,
-              GraphqlQueryRunnerExceptionCode.INVALID_QUERY_INPUT,
-              { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
-            );
-          }
-
-          const relationOrderResult = this.parseRelationFieldOrder({
-            fieldMetadata,
-            orderByDirection: orderByDirection as Record<string, unknown>,
-            isForwardPagination,
-            objectsPermissions,
-          });
-
-          if (relationOrderResult) {
-            Object.assign(orderByConditions, relationOrderResult.orderBy);
-
-            if (!addedJoinAliases.has(relationOrderResult.joinInfo.joinAlias)) {
-              relationJoins.push(relationOrderResult.joinInfo);
-              addedJoinAliases.add(relationOrderResult.joinInfo.joinAlias);
-            }
-          }
-        } else if (isCompositeFieldMetadataType(fieldMetadata.type)) {
-          if (!isObject(orderByDirection)) {
-            throw new GraphqlQueryRunnerException(
-              `Composite field "${fieldName}" requires subfield ordering (e.g., { ${fieldName}: { subFieldName: 'AscNullsFirst' } })`,
-              GraphqlQueryRunnerExceptionCode.INVALID_QUERY_INPUT,
-              { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
-            );
-          }
-
-          const compositeOrder = parseCompositeFieldForOrder(
-            fieldMetadata,
-            orderByDirection as Record<string, unknown>,
-            objectNameSingular,
-            isForwardPagination,
-          );
-
-          Object.assign(orderByConditions, compositeOrder);
-        } else {
-          if (!isOrderByDirection(orderByDirection)) {
-            throw new GraphqlQueryRunnerException(
-              `Scalar field "${fieldName}" requires a direction value (AscNullsFirst, AscNullsLast, DescNullsFirst, DescNullsLast)`,
-              GraphqlQueryRunnerExceptionCode.INVALID_QUERY_INPUT,
-              { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
-            );
-          }
-
-          const columnExpression = buildOrderByColumnExpression(
-            objectNameSingular,
-            fieldName,
-          );
-
-          orderByConditions[columnExpression] = {
-            ...convertOrderByToFindOptionsOrder(
-              orderByDirection,
-              isForwardPagination,
-            ),
-            useLower: shouldUseCaseInsensitiveOrder(fieldMetadata.type),
-            castToText: shouldCastToText(fieldMetadata.type),
-          };
-        }
+      if (!isDefined(leafColumn)) {
+        continue;
       }
+
+      if (
+        orderByLeaf.kind === 'relation' &&
+        !addedJoinAliases.has(leafColumn.tableAlias)
+      ) {
+        relationJoins.push({ joinAlias: leafColumn.tableAlias });
+        addedJoinAliases.add(leafColumn.tableAlias);
+      }
+
+      orderByConditions[
+        buildOrderByColumnExpression(
+          leafColumn.tableAlias,
+          leafColumn.columnName,
+        )
+      ] = {
+        ...convertOrderByToFindOptionsOrder(
+          orderByLeaf.direction,
+          isForwardPagination,
+        ),
+        useLower: shouldUseCaseInsensitiveOrder(leafColumn.columnType),
+        castToText: shouldCastToText(leafColumn.columnType),
+      };
     }
 
     return {
       orderBy: orderByConditions,
       relationJoins,
     };
-  }
-
-  private parseRelationFieldOrder({
-    fieldMetadata,
-    orderByDirection,
-    isForwardPagination,
-    objectsPermissions,
-  }: {
-    fieldMetadata: FlatFieldMetadata;
-    orderByDirection: Record<string, unknown>;
-    isForwardPagination: boolean;
-    objectsPermissions?: ObjectsPermissions;
-  }): {
-    orderBy: Record<string, OrderByClause>;
-    joinInfo: RelationJoinInfo;
-  } | null {
-    if (!isDefined(fieldMetadata.relationTargetObjectMetadataId)) {
-      return null;
-    }
-
-    const targetObjectMetadata = findFlatEntityByIdInFlatEntityMaps({
-      flatEntityId: fieldMetadata.relationTargetObjectMetadataId,
-      flatEntityMaps: this.flatObjectMetadataMaps,
-    });
-
-    if (!isDefined(targetObjectMetadata)) {
-      return null;
-    }
-
-    const nestedFieldNames = Object.keys(orderByDirection);
-
-    // Cursor continuation carries exactly one sub-field value per relation, so
-    // reject ambiguous input here instead of silently ordering by the first key
-    if (nestedFieldNames.length !== 1) {
-      throw new GraphqlQueryRunnerException(
-        `Relation field "${fieldMetadata.name}" supports ordering by exactly one field of the related object`,
-        GraphqlQueryRunnerExceptionCode.INVALID_QUERY_INPUT,
-        { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
-      );
-    }
-
-    const [nestedFieldName] = nestedFieldNames;
-    const nestedFieldOrderByValue = orderByDirection[nestedFieldName];
-
-    if (!isDefined(nestedFieldOrderByValue)) {
-      return null;
-    }
-
-    const { fieldIdByName: targetFieldIdByName } =
-      buildFieldMapsFromFlatObjectMetadata(
-        this.flatFieldMetadataMaps,
-        targetObjectMetadata,
-      );
-
-    const nestedFieldMetadataId = targetFieldIdByName[nestedFieldName];
-
-    if (!isDefined(nestedFieldMetadataId)) {
-      throw new GraphqlQueryRunnerException(
-        `Nested field "${nestedFieldName}" not found in target object "${targetObjectMetadata.nameSingular}"`,
-        GraphqlQueryRunnerExceptionCode.FIELD_NOT_FOUND,
-        { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
-      );
-    }
-
-    const nestedFieldMetadata = findFlatEntityByIdInFlatEntityMaps({
-      flatEntityId: nestedFieldMetadataId,
-      flatEntityMaps: this.flatFieldMetadataMaps,
-    });
-
-    if (!isDefined(nestedFieldMetadata)) {
-      return null;
-    }
-
-    assertFieldIsReadableOrThrow({
-      objectsPermissions,
-      objectMetadataId: targetObjectMetadata.id,
-      fieldMetadataId: nestedFieldMetadata.id,
-    });
-
-    const joinAlias = fieldMetadata.name;
-
-    const joinInfo: RelationJoinInfo = {
-      joinAlias,
-    };
-
-    if (isCompositeFieldMetadataType(nestedFieldMetadata.type)) {
-      if (!isObject(nestedFieldOrderByValue)) {
-        throw new GraphqlQueryRunnerException(
-          `Composite field "${nestedFieldMetadata.name}" requires a subfield to be specified`,
-          GraphqlQueryRunnerExceptionCode.INVALID_QUERY_INPUT,
-          { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
-        );
-      }
-
-      const compositeOrder = parseCompositeFieldForOrder(
-        nestedFieldMetadata,
-        nestedFieldOrderByValue as Record<string, unknown>,
-        joinAlias,
-        isForwardPagination,
-      );
-
-      if (Object.keys(compositeOrder).length === 0) {
-        return null;
-      }
-
-      return {
-        orderBy: compositeOrder,
-        joinInfo,
-      };
-    }
-
-    if (isOrderByDirection(nestedFieldOrderByValue)) {
-      const columnExpression = buildOrderByColumnExpression(
-        joinAlias,
-        nestedFieldMetadata.name,
-      );
-
-      return {
-        orderBy: {
-          [columnExpression]: {
-            ...convertOrderByToFindOptionsOrder(
-              nestedFieldOrderByValue,
-              isForwardPagination,
-            ),
-            useLower: shouldUseCaseInsensitiveOrder(nestedFieldMetadata.type),
-            castToText: shouldCastToText(nestedFieldMetadata.type),
-          },
-        },
-        joinInfo,
-      };
-    }
-
-    return null;
   }
 }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
@@ -178,12 +178,12 @@ export class GraphqlQueryParser {
   }
 
   public getOrderByRawSQL(
-    orderBy: ObjectRecordOrderBy | OrderByWithGroupBy,
+    orderBy: ObjectRecordOrderBy,
     objectNameSingular: string,
     isForwardPagination = true,
   ): { orderByRawSQL: string; relationJoins: RelationJoinInfo[] } {
     const parseResult = this.orderFieldParser.parse(
-      orderBy as ObjectRecordOrderBy,
+      orderBy,
       objectNameSingular,
       isForwardPagination,
     );

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/build-order-by-columns-to-select.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/build-order-by-columns-to-select.ts
@@ -1,10 +1,10 @@
 import { type ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
+import { computeOrderByLeafColumn } from 'src/engine/api/utils/compute-order-by-leaf-column.util';
 import {
   checkIfLeafCanCarryCursorValue,
   resolveOrderByLeaves,
 } from 'src/engine/api/utils/resolve-order-by-leaves.utils';
-import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
@@ -35,11 +35,14 @@ export const buildOrderByColumnsToSelect = ({
       continue;
     }
 
-    columnsToSelect[
-      leaf.kind === 'composite'
-        ? computeCompositeColumnName(leaf.path[0], leaf.compositeProperty)
-        : leaf.path[0]
-    ] = true;
+    const leafColumn = computeOrderByLeafColumn(
+      leaf,
+      flatObjectMetadata.nameSingular,
+    );
+
+    if (leafColumn) {
+      columnsToSelect[leafColumn.columnName] = true;
+    }
   }
 
   return columnsToSelect;

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/build-order-by-columns-to-select.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/build-order-by-columns-to-select.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { type ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { computeOrderByLeafColumn } from 'src/engine/api/utils/compute-order-by-leaf-column.util';
@@ -40,7 +42,7 @@ export const buildOrderByColumnsToSelect = ({
       flatObjectMetadata.nameSingular,
     );
 
-    if (leafColumn) {
+    if (isDefined(leafColumn)) {
       columnsToSelect[leafColumn.columnName] = true;
     }
   }

--- a/packages/twenty-server/src/engine/api/utils/__tests__/resolve-order-by-leaves.utils.spec.ts
+++ b/packages/twenty-server/src/engine/api/utils/__tests__/resolve-order-by-leaves.utils.spec.ts
@@ -350,6 +350,57 @@ describe('resolveOrderByLeaves', () => {
     });
   });
 
+  describe('field read permissions', () => {
+    const permissionsRestricting = (
+      fieldMetadataId: string,
+      objectId: string,
+    ) => ({
+      [objectId]: {
+        canReadObjectRecords: true,
+        canUpdateObjectRecords: true,
+        canSoftDeleteObjectRecords: true,
+        canDestroyObjectRecords: true,
+        restrictedFields: { [fieldMetadataId]: { canRead: false } },
+        // oxlint-disable-next-line typescript/no-explicit-any
+      } as any,
+    });
+
+    it('should reject ordering by a role-restricted root field', () => {
+      expect(() =>
+        resolveOrderByLeaves({
+          orderBy: [{ closeDate: OrderByDirection.AscNullsLast }],
+          flatObjectMetadata,
+          flatFieldMetadataMaps,
+          objectsPermissions: permissionsRestricting(
+            'closedate-id',
+            objectMetadataId,
+          ),
+        }),
+      ).toThrow('does not have permission');
+    });
+
+    it('should reject ordering by a role-restricted relation target field', () => {
+      expect(() =>
+        resolveOrderByLeaves({
+          orderBy: [{ company: { name: OrderByDirection.AscNullsLast } }],
+          flatObjectMetadata,
+          flatObjectMetadataMaps,
+          flatFieldMetadataMaps,
+          objectsPermissions: permissionsRestricting(
+            'company-name-id',
+            'company-object-id',
+          ),
+        }),
+      ).toThrow('does not have permission');
+    });
+  });
+
+  it('should reject a relation entry with no valid nested direction in strict mode', () => {
+    expect(() => resolve([{ company: { name: 5 } }], true)).toThrow(
+      'requires nested field ordering',
+    );
+  });
+
   describe('getCursorValueForLeaf', () => {
     const firstNameLeaf = resolve([
       { fullName: { firstName: OrderByDirection.AscNullsLast } },

--- a/packages/twenty-server/src/engine/api/utils/build-order-by-values-by-record-id.util.ts
+++ b/packages/twenty-server/src/engine/api/utils/build-order-by-values-by-record-id.util.ts
@@ -1,37 +1,13 @@
 import { type ObjectRecord } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
+import { computeOrderByLeafColumn } from 'src/engine/api/utils/compute-order-by-leaf-column.util';
 import {
   checkIfLeafCanCarryCursorValue,
   type OrderByLeaf,
 } from 'src/engine/api/utils/resolve-order-by-leaves.utils';
-import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 
 export type OrderByValuesByRecordId = Record<string, Record<string, unknown>>;
-
-const computeRawColumnAlias = (
-  leaf: OrderByLeaf,
-  objectNameSingular: string,
-): string => {
-  switch (leaf.kind) {
-    // The relation ordering always selects its joined columns under the
-    // deterministic "<joinAlias>_<column>" raw alias, whatever the client
-    // selected (see addRelationOrderColumnsToBuilder)
-    case 'relation':
-      return `${leaf.path[0]}_${
-        isDefined(leaf.targetCompositeProperty)
-          ? computeCompositeColumnName(
-              leaf.path[1],
-              leaf.targetCompositeProperty,
-            )
-          : leaf.path[1]
-      }`;
-    case 'composite':
-      return `${objectNameSingular}_${computeCompositeColumnName(leaf.path[0], leaf.compositeProperty)}`;
-    case 'scalar':
-      return `${objectNameSingular}_${leaf.path[0]}`;
-  }
-};
 
 // Cursors are encoded from the raw rows of the scan rather than from the
 // formatted records: result formatting presents SQL NULLs of TEXT-like columns
@@ -82,7 +58,17 @@ export const buildOrderByValuesByRecordId = ({
     const orderByValues: Record<string, unknown> = {};
 
     for (const leaf of cursorLeaves) {
-      const rawValue = rawRow[computeRawColumnAlias(leaf, objectNameSingular)];
+      const leafColumn = computeOrderByLeafColumn(leaf, objectNameSingular);
+
+      if (!isDefined(leafColumn)) {
+        continue;
+      }
+
+      // Every ordered column is selected under this raw alias, by the find
+      // options for root columns and by addRelationOrderColumnsToBuilder for
+      // joined ones
+      const rawValue =
+        rawRow[`${leafColumn.tableAlias}_${leafColumn.columnName}`];
 
       let container = orderByValues;
 

--- a/packages/twenty-server/src/engine/api/utils/compute-order-by-leaf-column.util.ts
+++ b/packages/twenty-server/src/engine/api/utils/compute-order-by-leaf-column.util.ts
@@ -1,0 +1,58 @@
+import { type FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type OrderByLeaf } from 'src/engine/api/utils/resolve-order-by-leaves.utils';
+import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
+
+export type OrderByLeafColumn = {
+  // The SQL alias the column lives on: the root object for scalar and
+  // composite leaves, the relation's join alias for relation leaves
+  tableAlias: string;
+  columnName: string;
+  columnType: FieldMetadataType;
+};
+
+// The one mapping from an orderBy leaf to the column its values live in. The
+// SQL ORDER BY expression, the hidden column selection and the raw-row alias
+// the cursor side channel reads back (`"<tableAlias>_<columnName>"`) all
+// derive from it, so they cannot drift apart.
+export const computeOrderByLeafColumn = (
+  leaf: OrderByLeaf,
+  objectNameSingular: string,
+): OrderByLeafColumn | null => {
+  switch (leaf.kind) {
+    case 'relation': {
+      if (!isDefined(leaf.targetFieldMetadata)) {
+        // A relation without a resolvable target contributes no ordering
+        return null;
+      }
+
+      return {
+        tableAlias: leaf.path[0],
+        columnName: isDefined(leaf.targetCompositeProperty)
+          ? computeCompositeColumnName(
+              leaf.path[1],
+              leaf.targetCompositeProperty,
+            )
+          : leaf.path[1],
+        columnType: (leaf.targetCompositeProperty ?? leaf.targetFieldMetadata)
+          .type,
+      };
+    }
+    case 'composite':
+      return {
+        tableAlias: objectNameSingular,
+        columnName: computeCompositeColumnName(
+          leaf.path[0],
+          leaf.compositeProperty,
+        ),
+        columnType: leaf.compositeProperty.type,
+      };
+    case 'scalar':
+      return {
+        tableAlias: objectNameSingular,
+        columnName: leaf.path[0],
+        columnType: leaf.fieldMetadata.type,
+      };
+  }
+};

--- a/packages/twenty-server/src/engine/api/utils/resolve-order-by-leaves.utils.ts
+++ b/packages/twenty-server/src/engine/api/utils/resolve-order-by-leaves.utils.ts
@@ -1,6 +1,7 @@
 import {
   type CompositeProperty,
   FieldMetadataType,
+  type ObjectsPermissions,
   type OrderByDirection,
   compositeTypeDefinitions,
 } from 'twenty-shared/types';
@@ -13,6 +14,7 @@ import {
   GraphqlQueryRunnerException,
   GraphqlQueryRunnerExceptionCode,
 } from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
+import { assertFieldIsReadableOrThrow } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/assert-field-is-readable-or-throw.util';
 import { isOrderByDirection } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/is-order-by-direction.util';
 import { resolveFilterKeyFieldMetadata } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/resolve-filter-key-field-metadata.util';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
@@ -77,8 +79,6 @@ const flattenNestedOrderByValue = (
       );
     }
 
-    // The SQL order parser silently ignores relation entries whose nested
-    // value is not a direction; mirror that here so both stay aligned
     return isOrderByDirection(nestedValue)
       ? [{ path: [key], direction: nestedValue }]
       : [];
@@ -95,6 +95,7 @@ const resolveRelationLeaf = ({
   flatObjectMetadataMaps,
   flatFieldMetadataMaps,
   strictValidation,
+  objectsPermissions,
 }: {
   fieldMetadata: FlatFieldMetadata;
   path: string[];
@@ -102,6 +103,7 @@ const resolveRelationLeaf = ({
   flatObjectMetadataMaps?: FlatEntityMaps<FlatObjectMetadata>;
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
   strictValidation: boolean;
+  objectsPermissions?: ObjectsPermissions;
 }): OrderByLeaf | null => {
   const targetObjectMetadata =
     isDefined(flatObjectMetadataMaps) &&
@@ -139,6 +141,12 @@ const resolveRelationLeaf = ({
 
     return null;
   }
+
+  assertFieldIsReadableOrThrow({
+    objectsPermissions,
+    objectMetadataId: targetObjectMetadata.id,
+    fieldMetadataId: targetFieldMetadata.id,
+  });
 
   if (isCompositeFieldMetadataType(targetFieldMetadata.type)) {
     const targetCompositeProperty = compositeTypeDefinitions
@@ -185,20 +193,22 @@ const resolveRelationLeaf = ({
 };
 
 // Single source of truth for walking an orderBy: every entry is flattened into
-// ordered leaves that carry their own direction, so the SQL ordering, column
+// ordered leaves that carry their own direction, and the SQL order parser
+// compiles its clauses from these leaves, so the SQL ordering, column
 // selection, cursor encoding, cursor validation and keyset conditions all
 // consume the same list and cannot drift apart. Duplicated leaves keep their
 // first occurrence, which lets callers append the id tie-breaker untouched: a
 // caller-provided id ordering wins over the appended default.
-// Strict validation rejects unknown or malformed entries the way the SQL order
-// parser does; the lenient mode skips them instead, for callers that re-walk an
-// already-validated orderBy against another object (e.g. nested connections).
+// Strict validation rejects unknown or malformed entries; the lenient mode
+// skips them instead, for callers that re-walk an already-validated orderBy
+// against another object (e.g. nested connections).
 export const resolveOrderByLeaves = ({
   orderBy,
   flatObjectMetadata,
   flatObjectMetadataMaps,
   flatFieldMetadataMaps,
   strictValidation = false,
+  objectsPermissions,
 }: {
   orderBy: ObjectRecordOrderBy | undefined;
   flatObjectMetadata: FlatObjectMetadata;
@@ -207,6 +217,9 @@ export const resolveOrderByLeaves = ({
   flatObjectMetadataMaps?: FlatEntityMaps<FlatObjectMetadata>;
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
   strictValidation?: boolean;
+  // Sort values embed into cursors, so ordering by a field the role cannot
+  // read is rejected like filtering by one is
+  objectsPermissions?: ObjectsPermissions;
 }): OrderByLeaf[] => {
   if (!isDefined(orderBy) || !isNonEmptyArray(orderBy)) {
     return [];
@@ -252,6 +265,12 @@ export const resolveOrderByLeaves = ({
         continue;
       }
 
+      assertFieldIsReadableOrThrow({
+        objectsPermissions,
+        objectMetadataId: flatObjectMetadata.id,
+        fieldMetadataId: fieldMetadata.id,
+      });
+
       if (
         isReferencedByFieldName &&
         isMorphOrRelationFlatFieldMetadata(fieldMetadata)
@@ -265,9 +284,17 @@ export const resolveOrderByLeaves = ({
           continue;
         }
 
-        for (const { path, direction } of flattenNestedOrderByValue(
-          orderByValue,
-        )) {
+        const flattenedRelationPaths = flattenNestedOrderByValue(orderByValue);
+
+        // An entry whose nested values are no directions at all would
+        // otherwise order by nothing without telling the caller
+        if (flattenedRelationPaths.length === 0 && strictValidation) {
+          throwInvalidOrderByInput(
+            `Relation field "${fieldName}" requires nested field ordering (e.g., { ${fieldName}: { fieldName: 'AscNullsFirst' } })`,
+          );
+        }
+
+        for (const { path, direction } of flattenedRelationPaths) {
           const relationLeaf = resolveRelationLeaf({
             fieldMetadata,
             path: [fieldName, ...path],
@@ -275,6 +302,7 @@ export const resolveOrderByLeaves = ({
             flatObjectMetadataMaps,
             flatFieldMetadataMaps,
             strictValidation,
+            objectsPermissions,
           });
 
           if (isDefined(relationLeaf)) {


### PR DESCRIPTION
Follow-up to the #24333 stack (#24354, #24356, #24364), finishing the "normalize once" consolidation.

## Description

`GraphqlQueryOrderFieldParser` was still a second, parallel walker of orderBy next to `resolveOrderByLeaves`: it re-resolved field metadata, re-detected composite and relation shapes with its own target-object lookup, and carried validation branches the runner's canonicalized input could no longer reach (the relation arity throw, the silent-null returns for malformed nested directions). Its error messages were literal copies of the leaf resolver's strings, guaranteed to drift.

Now:

- **The parser compiles clauses from the shared leaves.** `parse()` calls `resolveOrderByLeaves` (strict) and maps each leaf to a column expression plus `order/nulls/useLower/castToText`, deduplicating relation joins. 306 lines become 101, and `parseRelationFieldOrder` is gone (`parseCompositeFieldForOrder` stays: the group-by parser still uses it for its own shapes).
- **The field-readability assertion moves into leaf resolution** (root fields and relation target fields). Every strict consumer now enforces it structurally instead of relying on the parser running after normalization; lenient callers (cursor encoding on results) pass no permissions and are unaffected.
- **`computeOrderByLeafColumn` is the one leaf-to-column mapping**, shared by the ORDER BY expression, the hidden orderBy column selection, and the raw-row alias the cursor side channel reads back (`"<tableAlias>_<columnName>"`). Previously that alias contract was encoded independently on the select side and the read side, so a change to one would have broken cursors at the next page boundary instead of visibly.
- `getOrderByRawSQL` narrows to `ObjectRecordOrderBy` (both group-by callers already pass exactly that) and drops its cast.

Two small behavior refinements, both stricter or more capable, never silently different:

- A relation orderBy entry whose nested values contain no valid direction (e.g. `{ company: { name: 5 } }`) now errors with `INVALID_QUERY_INPUT` instead of silently ordering by nothing.
- A relation entry ordering several target fields at once (e.g. `{ company: { name: Asc, employees: Desc } }`) now orders by all of them, consistent with what cursor continuation already supports, instead of throwing the arity error on the find-many path and silently using the first key on the group-by path.

## Test Plan

- New `graphql-query-order.parser.spec.ts` (7 tests): scalar/composite/relation/relation-composite compilation, join dedupe, join-column access as root scalar without case-insensitive collation, backward NULLS reversal, first-direction-wins, permission rejection, unknown-field rejection.
- Leaf resolver spec extended: role-restricted root and relation-target fields are rejected, and the no-valid-direction relation entry errors in strict mode (15 tests).
- Full server unit suite passes; `cursor-pagination-order-by`, `order-by-relation-field`, `rest-api-core-find-many` and the morph cursor suite pass against a live database (the two known collation-dependent case-insensitivity tests fail identically on unmodified main in this environment).
- Typecheck, oxlint, and oxfmt clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WExW8V4qrP4RYTyfjfwCJG)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

