### PR TITLE
fix(billing) - unblock resource credit upgrades rejected by Stripe

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
@@ -2,6 +2,8 @@
 
 import { Injectable, Logger } from '@nestjs/common';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import type Stripe from 'stripe';
 
 import {
@@ -62,18 +64,22 @@ export class StripeInvoiceService {
       customer: stripeCustomerId,
       subscription: stripeSubscriptionId,
     });
-    const invoiceItem = await this.stripe.invoiceItems.create({
-      customer: stripeCustomerId,
-      subscription: stripeSubscriptionId,
-      invoice: invoice.id,
-      amount: diffAmountInCents,
-      currency,
-      description,
-    });
 
     let finalizedInvoice: Stripe.Invoice;
+    let invoiceItemId: string | undefined;
 
     try {
+      const invoiceItem = await this.stripe.invoiceItems.create({
+        customer: stripeCustomerId,
+        subscription: stripeSubscriptionId,
+        invoice: invoice.id,
+        amount: diffAmountInCents,
+        currency,
+        description,
+      });
+
+      invoiceItemId = invoiceItem.id;
+
       finalizedInvoice = await this.stripe.invoices.finalizeInvoice(
         invoice.id,
         {
@@ -83,7 +89,7 @@ export class StripeInvoiceService {
     } catch (error) {
       await this.deleteDraftUpgradeInvoice({
         invoiceId: invoice.id,
-        invoiceItemId: invoiceItem.id,
+        invoiceItemId,
       });
 
       throw error;
@@ -151,7 +157,7 @@ export class StripeInvoiceService {
     invoiceItemId,
   }: {
     invoiceId: string;
-    invoiceItemId: string;
+    invoiceItemId?: string;
   }): Promise<void> {
     try {
       await this.stripe.invoices.del(invoiceId);
@@ -159,6 +165,10 @@ export class StripeInvoiceService {
       this.logger.error(
         `Failed to delete draft upgrade invoice ${invoiceId}: ${this.getErrorMessage(deleteError)}`,
       );
+    }
+
+    if (!isDefined(invoiceItemId)) {
+      return;
     }
 
     try {

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
@@ -61,21 +61,19 @@ export class StripeInvoiceService {
     const invoice = await this.stripe.invoices.create({
       customer: stripeCustomerId,
       subscription: stripeSubscriptionId,
-      pending_invoice_items_behavior: 'exclude',
+    });
+    const invoiceItem = await this.stripe.invoiceItems.create({
+      customer: stripeCustomerId,
+      subscription: stripeSubscriptionId,
+      invoice: invoice.id,
+      amount: diffAmountInCents,
+      currency,
+      description,
     });
 
     let finalizedInvoice: Stripe.Invoice;
 
     try {
-      await this.stripe.invoiceItems.create({
-        customer: stripeCustomerId,
-        subscription: stripeSubscriptionId,
-        invoice: invoice.id,
-        amount: diffAmountInCents,
-        currency,
-        description,
-      });
-
       finalizedInvoice = await this.stripe.invoices.finalizeInvoice(
         invoice.id,
         {
@@ -83,7 +81,7 @@ export class StripeInvoiceService {
         },
       );
     } catch (error) {
-      await this.deleteDraftUpgradeInvoice(invoice.id);
+      await this.deleteDraftUpgradeInvoice(invoice.id, invoiceItem.id);
 
       throw error;
     }
@@ -145,12 +143,23 @@ export class StripeInvoiceService {
     );
   }
 
-  private async deleteDraftUpgradeInvoice(invoiceId: string): Promise<void> {
+  private async deleteDraftUpgradeInvoice(
+    invoiceId: string,
+    invoiceItemId: string,
+  ): Promise<void> {
     try {
       await this.stripe.invoices.del(invoiceId);
     } catch (deleteError) {
       this.logger.error(
         `Failed to delete draft upgrade invoice ${invoiceId}: ${this.getErrorMessage(deleteError)}`,
+      );
+    }
+
+    try {
+      await this.stripe.invoiceItems.del(invoiceItemId);
+    } catch (deleteError) {
+      this.logger.error(
+        `Failed to delete upgrade invoice item ${invoiceItemId}: ${this.getErrorMessage(deleteError)}`,
       );
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
@@ -81,7 +81,10 @@ export class StripeInvoiceService {
         },
       );
     } catch (error) {
-      await this.deleteDraftUpgradeInvoice(invoice.id, invoiceItem.id);
+      await this.deleteDraftUpgradeInvoice({
+        invoiceId: invoice.id,
+        invoiceItemId: invoiceItem.id,
+      });
 
       throw error;
     }
@@ -143,10 +146,13 @@ export class StripeInvoiceService {
     );
   }
 
-  private async deleteDraftUpgradeInvoice(
-    invoiceId: string,
-    invoiceItemId: string,
-  ): Promise<void> {
+  private async deleteDraftUpgradeInvoice({
+    invoiceId,
+    invoiceItemId,
+  }: {
+    invoiceId: string;
+    invoiceItemId: string;
+  }): Promise<void> {
     try {
       await this.stripe.invoices.del(invoiceId);
     } catch (deleteError) {


### PR DESCRIPTION
## Problem
Introduce regression in `v2.32.0`. `SetResourceCreditSubscriptionPrice` returns a 500 and the upgrade never applies:

    InternalServerError: You may only specify one of these parameters:
    pending_invoice_items_behavior, subscription.

#24264 added `pending_invoice_items_behavior: 'exclude'` to a `stripe.invoices.create` call that already passed `subscription`. Stripe treats the two as mutually exclusive and rejects the request with a 400, so the invoice is never created.
## Fix

Drop `pending_invoice_items_behavior`, keep `subscription`.

Dropping `subscription` instead was not viable: `processInvoicePaid` throws `Invalid invoice paid event data` when a paid invoice carries no subscription id, so an unlinked upgrade invoice would turn every successful upgrade payment into an error.

One gap did rest on the flag. On failure, `deleteDraftUpgradeInvoice` deletes the draft but its item does not go with it, and a pending item is swept onto whatever invoice comes next, charging the diff twice. So the item id is threaded through and deleted alongside the draft.

## Tests

No unit spec. `stripe-invoice.service.spec.ts` was removed in #24094, and this is Stripe I/O orchestration with no pure part to extract. A mock-based test would assert the very params the API rejects, which is how this shipped in the first place.

Verified against Stripe test mode end to end (create, attach item, finalize with `auto_advance: false`, pay, `status: paid`), plus `nx typecheck twenty-server` and oxlint/oxfmt on the changed file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

