### PR TITLE
perf(graphql): fast-path single-path leaf filter in buildCursorLeafWhereCondition (#24367)

### DIFF
--- a/packages/twenty-server/src/engine/api/utils/build-cursor-leaf-where-condition.utils.ts
+++ b/packages/twenty-server/src/engine/api/utils/build-cursor-leaf-where-condition.utils.ts
@@ -38,9 +38,11 @@ export function buildCursorLeafWhereCondition({
     isEqualityCondition,
     canFieldHoldNullValue: checkIfLeafCanHoldNullValue(leaf),
     buildLeafCondition: (leafFilter) =>
-      leaf.path.reduceRight<Record<string, unknown>>(
-        (nested, key) => ({ [key]: nested }),
-        leafFilter,
-      ),
+      leaf.path.length === 1
+        ? { [leaf.path[0]]: leafFilter }
+        : leaf.path.reduceRight<Record<string, unknown>>(
+            (nested, key) => ({ [key]: nested }),
+            leafFilter,
+          ),
   });
 }


### PR DESCRIPTION
# Title
perf(graphql): fast-path single-path leaf filters in buildCursorLeafWhereCondition (#24367)

## Description
- Short-circuits `reduceRight` in `buildCursorLeafWhereCondition` when the leaf path contains only 1 segment (the standard scalar case).
- Improves keyset pagination filter construction throughput during high-concurrency API reads.

Closes #24367


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

