### PR TITLE
Tag chat error events with their chat kind

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -79,6 +79,7 @@ import {
   injectCacheBreakpoint,
 } from 'src/engine/metadata-modules/ai/ai-chat/utils/provider-options.util';
 import { replaceUnsupportedFileParts } from 'src/engine/metadata-modules/ai/ai-chat/utils/replace-unsupported-file-parts.util';
+import { tagAiChatKindScope } from 'src/engine/metadata-modules/ai/ai-chat/utils/tag-ai-chat-kind-scope.util';
 import { buildAiTelemetry } from 'src/engine/metadata-modules/ai/ai-models/utils/build-ai-telemetry.util';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
 import { NativeToolBinderService } from 'src/engine/metadata-modules/ai/ai-models/services/native-tool-binder.service';
@@ -224,6 +225,8 @@ export class ChatExecutionService {
           userWorkspaceId,
         }) &&
       !hasSucceededWorkspaceSetupCompletion(messages);
+
+    tagAiChatKindScope({ isWorkspaceSetupThread });
 
     const preloadedToolNames = [
       ...Object.keys(preloadedTools),

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/tag-ai-chat-kind-scope.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/tag-ai-chat-kind-scope.util.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/node';
+
+import { AI_CHAT_STREAM_FUNCTION_ID } from 'src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-stream-function-id.constant';
+import { AI_CHAT_WORKSPACE_SETUP_STREAM_FUNCTION_ID } from 'src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-workspace-setup-stream-function-id.constant';
+
+export const tagAiChatKindScope = ({
+  isWorkspaceSetupThread,
+}: {
+  isWorkspaceSetupThread: boolean;
+}) => {
+  Sentry.getCurrentScope().setTag(
+    'chatKind',
+    isWorkspaceSetupThread
+      ? AI_CHAT_WORKSPACE_SETUP_STREAM_FUNCTION_ID
+      : AI_CHAT_STREAM_FUNCTION_ID,
+  );
+};


### PR DESCRIPTION
Follow-up to #24353, which split the workspace-setup chat's telemetry functionId but only on spans. Chat stream failures are captured as Sentry error events, and those carry no segment marker, so the ai-digest pipeline in twenty-factory cannot split error counts the way it splits spans.

This sets a `chatKind` Sentry scope tag in `streamChat` with the same values as the functionId split (`ai-chat-workspace-setup-stream` / `ai-chat-stream`), so captured error events segment onboarding-vs-general exactly like spans do.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

