### PR TITLE
fix(messaging): refine isBulkMail detection to prevent dropping valid inbound messages (#24332)

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/is-bulk-mail.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/is-bulk-mail.util.spec.ts
@@ -1,29 +1,9 @@
 import { isBulkMail } from 'src/modules/messaging/message-import-manager/utils/is-bulk-mail.util';
 
 describe('isBulkMail', () => {
-  it('should detect a List-Unsubscribe header regardless of casing', () => {
-    expect(
-      isBulkMail([
-        { name: 'List-Unsubscribe', value: '<https://example.com/unsub>' },
-      ]),
-    ).toBe(true);
-
-    expect(
-      isBulkMail([
-        { name: 'list-unsubscribe', value: '<mailto:unsub@example.com>' },
-      ]),
-    ).toBe(true);
-  });
-
-  it('should detect a List-Id header', () => {
-    expect(
-      isBulkMail([{ name: 'List-Id', value: '<newsletter.example.com>' }]),
-    ).toBe(true);
-  });
-
   it('should detect bulk precedence values only', () => {
     expect(isBulkMail([{ name: 'Precedence', value: 'bulk' }])).toBe(true);
-    expect(isBulkMail([{ name: 'Precedence', value: ' List ' }])).toBe(true);
+    expect(isBulkMail([{ name: 'Precedence', value: 'junk' }])).toBe(true);
     expect(isBulkMail([{ name: 'Precedence', value: 'urgent' }])).toBe(false);
   });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/is-bulk-mail.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/is-bulk-mail.util.ts
@@ -2,24 +2,23 @@ import { isNonEmptyString } from '@sniptt/guards';
 
 import { type MessageHeader } from 'src/modules/messaging/message-import-manager/types/message';
 
-const BULK_LIST_HEADER_NAMES = ['list-unsubscribe', 'list-id'];
-const BULK_PRECEDENCE_VALUES = ['bulk', 'list', 'junk'];
+const BULK_PRECEDENCE_VALUES = ['bulk', 'junk'];
 
 export const isBulkMail = (headers: MessageHeader[]): boolean =>
   headers.some(({ name, value }) => {
     const headerName = name.toLowerCase();
     const headerValue = value.trim().toLowerCase();
 
-    if (BULK_LIST_HEADER_NAMES.includes(headerName)) {
-      return isNonEmptyString(headerValue);
-    }
-
     if (headerName === 'precedence') {
       return BULK_PRECEDENCE_VALUES.includes(headerValue);
     }
 
     if (headerName === 'auto-submitted') {
-      return isNonEmptyString(headerValue) && headerValue !== 'no';
+      return (
+        isNonEmptyString(headerValue) &&
+        headerValue !== 'no' &&
+        headerValue !== 'auto-replied'
+      );
     }
 
     return false;


### PR DESCRIPTION
# Title
fix(messaging): refine isBulkMail detection to prevent dropping valid inbound messages (#24332)

## Description
- Removes overbroad `list-id` and `list-unsubscribe` header check in `isBulkMail`.
- Retains explicit `precedence: bulk/junk` and automated `auto-submitted` markers.
- Fixes issue where valid inbound messages involving mailing lists or ticketing systems were silently skipped during Gmail/IMAP sync.

Closes #24332


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

