### PR TITLE
Add petbee-cadencia Twenty app: régua comercial como app nativo (modo…

### DIFF
--- a/packages/twenty-apps/petbee-cadencia/README.md
+++ b/packages/twenty-apps/petbee-cadencia/README.md
@@ -1,0 +1,77 @@
+# Cadência Petbee (Twenty App)
+
+Motor da régua comercial dentro do próprio Twenty, como aplicativo nativo
+(`twenty-sdk`). Porte 1:1 do workflow n8n "Cadência Twenty (nativa)" v10 —
+mesma régua, mesmas guardas, mesmo algoritmo de reconciliação.
+
+## O que ele faz
+
+- **Régua v2 (9 toques)**: concluir a FUP N cria a FUP N+1, com prazo ancorado
+  na conclusão real (manhã 9h30 / tarde 16h em São Paulo; FUP 2 = +1h30;
+  conclusão da "tarde" após as 16h empurra pra amanhã).
+- **Guarda pós-FUP 9**: card parado em Em Negociação com os 9 toques feitos
+  ganha a task "Decidir: Break ou Perdido? — [nome]" até alguém mover o card.
+- **Break**: agenda a "FUP final (antes do lost)" pra +25 dias, 11h.
+- **Perdido sem motivo**: task-guarda "Preencher motivo da perda" até o motivo entrar.
+- **Ganhou/Perdido/fora do funil**: tasks de régua abertas somem; manuais nunca são tocadas.
+- **Autocura**: dedup de corrida, self-heal do link do WhatsApp (wa.me → inbox),
+  fupNumero sincronizado, órfãs removidas. Vencimento editado à mão é respeitado.
+
+## Arquitetura
+
+```
+src/cadencia/regua.ts      → régua pura (datas, títulos, padrões)   [testada]
+src/cadencia/plan.ts       → computePlan: estado desejado → ops     [testada]
+src/cadencia/reconcile.ts  → lê o CRM (CoreApiClient), executa o plano, alerta falha
+src/logic-functions/
+  tick.ts                    → cron */5min (rede de segurança)
+  on-opportunity-created.ts  → campainha: negócio novo
+  on-opportunity-updated.ts  → campainha: stage/fupNumero/motivo/whatsapp mudou
+  on-task-updated.ts         → campainha: status de task mudou (done → próxima FUP)
+```
+
+Todo gatilho chama a MESMA reconciliação: ler o funil inteiro → calcular o que
+deveria existir → criar/concluir/apagar a diferença. Evento dá velocidade,
+cron dá verdade.
+
+## Variáveis do app
+
+| Variável | Padrão | Papel |
+|---|---|---|
+| `CADENCIA_DRY_RUN` | `"true"` | **Modo sombra**: calcula e loga o plano, não escreve nada. Só vire `"false"` com o motor n8n desligado. |
+| `CADENCIA_ALERT_WEBHOOK_URL` | vazio | Webhook (Slack) avisado quando a reconciliação falha. |
+
+## Testes
+
+```bash
+yarn test        # 21 testes do núcleo puro (datas da régua + plano)
+```
+
+## Deploy (na máquina do Lucas)
+
+```bash
+cd packages/twenty-apps/petbee-cadencia
+yarn install
+yarn twenty remote:add --url https://crm.petbeetools.com.br --api-key $TWENTY_API_KEY --as petbee
+yarn twenty plan     # mostra o que será criado, sem aplicar
+yarn twenty apply    # instala/atualiza o app no workspace
+yarn twenty dev:function:logs -n cadencia-tick   # acompanhar o modo sombra
+```
+
+## Plano de adoção (sem risco)
+
+1. **Sombra** (`CADENCIA_DRY_RUN=true`, padrão): o app roda em paralelo ao motor
+   n8n e apenas LOGA o plano que executaria. Como o n8n mantém o estado
+   reconciliado, o esperado no log é `totalOps: 0` em regime — qualquer op
+   não-vazia persistente é divergência a investigar.
+2. **Paridade provada** (alguns dias de logs limpos): desligar o motor n8n
+   (despublicar o workflow "Cadência Twenty (nativa)" e apagar o webhook
+   campainha do Twenty) e virar `CADENCIA_DRY_RUN=false`.
+3. **Rollback**: virar `CADENCIA_DRY_RUN=true` de volta e republicar o workflow
+   n8n. Os dois nunca escrevem ao mesmo tempo.
+
+## Regra de ouro
+
+Enquanto o n8n for o motor ativo, **qualquer mudança de régua vale nos dois**
+(no jsCode do "Plano de cadência" e em `src/cadencia/`). Depois da adoção, este
+app vira a única fonte da verdade.

--- a/packages/twenty-apps/petbee-cadencia/package.json
+++ b/packages/twenty-apps/petbee-cadencia/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "petbee-cadencia",
+  "version": "0.1.0",
+  "private": true,
+  "license": "UNLICENSED",
+  "type": "module",
+  "engines": {
+    "node": ">=22.6.0",
+    "npm": "please-use-yarn",
+    "yarn": ">=4.0.2"
+  },
+  "packageManager": "yarn@4.9.2",
+  "scripts": {
+    "twenty": "twenty",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "node --experimental-strip-types --test src/cadencia/__tests__/regua.test.ts src/cadencia/__tests__/plan.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.2",
+    "twenty-client-sdk": "^2.14.0",
+    "twenty-sdk": "^2.14.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/twenty-apps/petbee-cadencia/src/application-config.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/application-config.ts
@@ -22,11 +22,12 @@ export default defineApplication({
       value: 'true',
       isSecret: false,
     },
+    // Segredo não carrega valor no código: preencher em Settings → Applications
+    // → Cadência Petbee depois de instalar. Vazio = sem aviso de falha.
     CADENCIA_ALERT_WEBHOOK_URL: {
       universalIdentifier: ALERT_WEBHOOK_VARIABLE_UNIVERSAL_IDENTIFIER,
       description:
         'Webhook (ex.: Slack) que recebe um aviso quando a reconciliação falha. Vazio = sem aviso.',
-      value: '',
       isSecret: true,
     },
   },

--- a/packages/twenty-apps/petbee-cadencia/src/application-config.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/application-config.ts
@@ -1,0 +1,33 @@
+import { defineApplication } from 'twenty-sdk/define';
+
+import {
+  ALERT_WEBHOOK_VARIABLE_UNIVERSAL_IDENTIFIER,
+  APP_DESCRIPTION,
+  APP_DISPLAY_NAME,
+  APPLICATION_UNIVERSAL_IDENTIFIER,
+  DRY_RUN_VARIABLE_UNIVERSAL_IDENTIFIER,
+} from 'src/constants/universal-identifiers';
+
+export default defineApplication({
+  universalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+  displayName: APP_DISPLAY_NAME,
+  description: APP_DESCRIPTION,
+  applicationVariables: {
+    // "true" = modo sombra: calcula e loga o plano, mas não escreve nada.
+    // Trocar para "false" só quando o motor n8n for desligado — nunca os dois escrevendo.
+    CADENCIA_DRY_RUN: {
+      universalIdentifier: DRY_RUN_VARIABLE_UNIVERSAL_IDENTIFIER,
+      description:
+        'Modo sombra: "true" calcula e loga o plano sem escrever; "false" executa as operações no CRM.',
+      value: 'true',
+      isSecret: false,
+    },
+    CADENCIA_ALERT_WEBHOOK_URL: {
+      universalIdentifier: ALERT_WEBHOOK_VARIABLE_UNIVERSAL_IDENTIFIER,
+      description:
+        'Webhook (ex.: Slack) que recebe um aviso quando a reconciliação falha. Vazio = sem aviso.',
+      value: '',
+      isSecret: true,
+    },
+  },
+});

--- a/packages/twenty-apps/petbee-cadencia/src/cadencia/__tests__/plan.test.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/cadencia/__tests__/plan.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { computePlan, type OppDoFunil, type PlanInput, type PlanOp } from '../plan.ts';
+
+const AGORA = new Date('2026-08-19T13:00:00.000Z');
+
+function entrada(parcial: Partial<PlanInput>): PlanInput {
+  return {
+    agora: AGORA,
+    funil: [],
+    abertas: [],
+    perdidasSemMotivo: [],
+    foraDoFunil: {},
+    ...parcial,
+  };
+}
+
+function oppDe(parcial: Partial<OppDoFunil>): OppDoFunil {
+  return {
+    id: 'opp-1',
+    name: 'Luc Test',
+    stage: 'EM_NEGOCIACAO',
+    fupNumero: 0,
+    whatsapp: '+55 41 99999-8888',
+    tarefas: [],
+    ...parcial,
+  };
+}
+
+function criacoes(ops: PlanOp[]): Extract<PlanOp, { kind: 'createTask' }>[] {
+  return ops.filter((op): op is Extract<PlanOp, { kind: 'createTask' }> => op.kind === 'createTask');
+}
+
+test('negócio novo em Em Negociação ganha a FUP 1 imediata, da Vitória, com zap', () => {
+  const ops = computePlan(entrada({ funil: [oppDe({})] }));
+  const criadas = criacoes(ops);
+
+  assert.equal(criadas.length, 1);
+  assert.equal(criadas[0].data.title, 'FUP 1 (abordar agora) — Luc Test');
+  assert.equal(criadas[0].data.dueAt, AGORA.toISOString());
+  assert.equal(criadas[0].data.assigneeId, '69572821-c2f4-4923-9c68-23381b665a49');
+  assert.equal(criadas[0].data.whatsapp?.primaryLinkUrl, 'https://inbox.petbeetools.com.br/');
+});
+
+test('FUP 9 concluída sem mover o card cobra a decisão (guarda pós-régua)', () => {
+  const opp = oppDe({
+    fupNumero: 8,
+    tarefas: [{ id: 't9', title: 'FUP 9 (mensagem, manhã) — Luc Test', status: 'DONE' }],
+  });
+  const ops = computePlan(entrada({ funil: [opp] }));
+
+  assert.ok(
+    ops.find(
+      (op) => op.kind === 'updateOpportunity' && op.data.fupNumero === 9,
+    ),
+    'fupNumero deve sincronizar para 9',
+  );
+
+  const criadas = criacoes(ops);
+
+  assert.equal(criadas.length, 1);
+  assert.equal(criadas[0].data.title, 'Decidir: Break ou Perdido? — Luc Test');
+  assert.ok(criadas[0].data.bodyV2?.markdown.includes('9 toques feitos'));
+});
+
+test('decisão concluída sem mover o card é recriada (guarda insiste)', () => {
+  const opp = oppDe({
+    fupNumero: 9,
+    tarefas: [
+      { id: 'td', title: 'Decidir: Break ou Perdido? — Luc Test', status: 'DONE' },
+    ],
+  });
+  const criadas = criacoes(computePlan(entrada({ funil: [opp] })));
+
+  assert.equal(criadas.length, 1);
+  assert.equal(criadas[0].data.title, 'Decidir: Break ou Perdido? — Luc Test');
+});
+
+test('mover pro Break apaga decisão e FUPs abertas e agenda a FUP final (+25d, 11h SP)', () => {
+  const opp = oppDe({
+    stage: 'BREAK',
+    fupNumero: 9,
+    tarefas: [
+      { id: 'td', title: 'Decidir: Break ou Perdido? — Luc Test', status: 'TODO' },
+      { id: 't9', title: 'FUP 9 (mensagem, manhã) — Luc Test', status: 'TODO' },
+    ],
+  });
+  const ops = computePlan(entrada({ funil: [opp] }));
+
+  assert.deepEqual(
+    ops.filter((op) => op.kind === 'deleteTask').map((op) => op.taskId).sort(),
+    ['t9', 'td'],
+  );
+
+  const criadas = criacoes(ops);
+
+  assert.equal(criadas.length, 1);
+  assert.equal(criadas[0].data.title, 'FUP final (antes do lost) — Luc Test');
+  assert.equal(criadas[0].data.dueAt, '2026-09-13T14:00:00.000Z');
+});
+
+test('duplicata aberta da mesma FUP (corrida) é removida', () => {
+  const opp = oppDe({
+    tarefas: [
+      { id: 'a', title: 'FUP 1 (abordar agora) — Luc Test', status: 'TODO' },
+      { id: 'b', title: 'FUP 1 (abordar agora) — Luc Test', status: 'TODO' },
+    ],
+  });
+  const ops = computePlan(entrada({ funil: [opp] }));
+
+  assert.deepEqual(
+    ops.filter((op) => op.kind === 'deleteTask').map((op) => op.taskId),
+    ['b'],
+  );
+  assert.equal(criacoes(ops).length, 0);
+});
+
+test('task manual (título fora dos padrões) nunca é tocada', () => {
+  const opp = oppDe({
+    fupNumero: 1,
+    tarefas: [
+      { id: 'm', title: 'Ligar pro veterinário parceiro', status: 'TODO' },
+      { id: 't2', title: 'FUP 2 (mensagem, ~1h30 depois) — Luc Test', status: 'TODO' },
+    ],
+  });
+  const ops = computePlan(entrada({ funil: [opp] }));
+
+  assert.ok(!ops.find((op) => op.kind === 'deleteTask' && op.taskId === 'm'));
+  assert.ok(!ops.find((op) => op.kind === 'updateTask' && op.taskId === 'm'));
+});
+
+test('vencimento editado à mão é respeitado (sem updateTask de dueAt)', () => {
+  const opp = oppDe({
+    fupNumero: 1,
+    tarefas: [
+      {
+        id: 't2',
+        title: 'FUP 2 (mensagem, ~1h30 depois) — Luc Test',
+        status: 'TODO',
+        dueAt: '2026-08-25T12:00:00.000Z',
+        whatsapp: { primaryLinkUrl: 'https://inbox.petbeetools.com.br/' },
+      },
+    ],
+  });
+  const ops = computePlan(entrada({ funil: [opp] }));
+
+  assert.deepEqual(ops, []);
+});
+
+test('link wa.me antigo ganha self-heal para o inbox', () => {
+  const opp = oppDe({
+    fupNumero: 1,
+    tarefas: [
+      {
+        id: 't2',
+        title: 'FUP 2 (mensagem, ~1h30 depois) — Luc Test',
+        status: 'TODO',
+        whatsapp: { primaryLinkUrl: 'https://wa.me/5541999998888' },
+      },
+    ],
+  });
+  const ops = computePlan(entrada({ funil: [opp] }));
+
+  assert.equal(ops.length, 1);
+  assert.equal(ops[0].kind, 'updateTask');
+});
+
+test('task gerenciada de negócio que saiu do funil (Ganhou/Perdido) é apagada', () => {
+  const ops = computePlan(
+    entrada({
+      abertas: [
+        { id: 'x', title: 'FUP 3 (ligação + mensagem, manhã) — Fulano', targetOpportunityId: 'opp-won' },
+        { id: 'y', title: 'Decidir: Break ou Perdido? — Fulano', targetOpportunityId: 'opp-won' },
+        { id: 'z', title: 'Task manual solta', targetOpportunityId: 'opp-won' },
+      ],
+      foraDoFunil: { 'opp-won': { id: 'opp-won', stage: 'WON' } },
+    }),
+  );
+
+  assert.deepEqual(
+    ops.filter((op) => op.kind === 'deleteTask').map((op) => op.taskId).sort(),
+    ['x', 'y'],
+  );
+});
+
+test('Perdido sem motivo ganha a guarda; com motivo preenchido a guarda cai', () => {
+  const criando = computePlan(
+    entrada({ perdidasSemMotivo: [{ id: 'opp-lost', name: 'Fulano' }] }),
+  );
+  const criadas = criacoes(criando);
+
+  assert.equal(criadas.length, 1);
+  assert.equal(criadas[0].data.title, 'Preencher motivo da perda — Fulano');
+
+  const limpando = computePlan(
+    entrada({
+      abertas: [
+        { id: 'g', title: 'Preencher motivo da perda — Fulano', targetOpportunityId: 'opp-lost' },
+      ],
+      foraDoFunil: {
+        'opp-lost': { id: 'opp-lost', stage: 'LOST', motivoLost: 'SEM_ORCAMENTO' },
+      },
+    }),
+  );
+
+  assert.deepEqual(
+    limpando.filter((op) => op.kind === 'deleteTask').map((op) => op.taskId),
+    ['g'],
+  );
+});
+
+test('concluir várias FUPs de uma vez agenda só a próxima certa', () => {
+  const opp = oppDe({
+    fupNumero: 0,
+    tarefas: [
+      { id: 't1', title: 'FUP 1 (abordar agora) — Luc Test', status: 'DONE' },
+      { id: 't2', title: 'FUP 2 (mensagem, ~1h30 depois) — Luc Test', status: 'DONE' },
+      { id: 't3', title: 'FUP 3 (ligação + mensagem, manhã) — Luc Test', status: 'DONE' },
+    ],
+  });
+  const ops = computePlan(entrada({ funil: [opp] }));
+  const criadas = criacoes(ops);
+
+  assert.equal(criadas.length, 1);
+  assert.ok(criadas[0].data.title.startsWith('FUP 4 '));
+  assert.ok(
+    ops.find((op) => op.kind === 'updateOpportunity' && op.data.fupNumero === 3),
+  );
+});

--- a/packages/twenty-apps/petbee-cadencia/src/cadencia/__tests__/regua.test.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/cadencia/__tests__/regua.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { horarioSP, proximas, tardeDoDia, zapDe } from '../regua.ts';
+
+// 2026-08-19 10:00 em São Paulo (13:00 UTC).
+const MANHA_SP = new Date('2026-08-19T13:00:00.000Z');
+// 2026-08-19 17:00 em São Paulo (20:00 UTC).
+const FIM_DE_TARDE_SP = new Date('2026-08-19T20:00:00.000Z');
+
+test('FUP 1 vence no instante da qualificação', () => {
+  const [toque] = proximas('Luc Test', 0, MANHA_SP);
+
+  assert.equal(toque.titulo, 'FUP 1 (abordar agora) — Luc Test');
+  assert.equal(toque.dueAt, MANHA_SP.toISOString());
+});
+
+test('FUP 2 vence 1h30 depois da conclusão da FUP 1', () => {
+  const [toque] = proximas('Luc Test', 1, MANHA_SP);
+
+  assert.equal(toque.titulo, 'FUP 2 (mensagem, ~1h30 depois) — Luc Test');
+  assert.equal(toque.dueAt, '2026-08-19T14:30:00.000Z');
+});
+
+test('FUP 3 vence na manhã seguinte às 9h30 de São Paulo', () => {
+  const [toque] = proximas('Luc Test', 2, MANHA_SP);
+
+  assert.equal(toque.dueAt, '2026-08-20T12:30:00.000Z');
+});
+
+test('FUP 4 concluída de manhã vence hoje às 16h de São Paulo', () => {
+  const [toque] = proximas('Luc Test', 3, MANHA_SP);
+
+  assert.equal(toque.dueAt, '2026-08-19T19:00:00.000Z');
+});
+
+test('FUP 4 concluída após as 16h empurra para amanhã às 16h', () => {
+  assert.equal(tardeDoDia(FIM_DE_TARDE_SP), '2026-08-20T19:00:00.000Z');
+});
+
+test('FUP 8 vence no dia seguinte às 16h; FUP 9 na manhã seguinte', () => {
+  assert.equal(proximas('X', 7, MANHA_SP)[0].dueAt, '2026-08-20T19:00:00.000Z');
+  assert.equal(proximas('X', 8, MANHA_SP)[0].dueAt, '2026-08-20T12:30:00.000Z');
+});
+
+test('depois da FUP 9 a régua não agenda mais toques', () => {
+  assert.deepEqual(proximas('X', 9, MANHA_SP), []);
+  assert.deepEqual(proximas('X', 12, MANHA_SP), []);
+});
+
+test('virada de mês: manhã seguinte de 31/08 é 01/09', () => {
+  const fimDeMes = new Date('2026-08-31T13:00:00.000Z');
+
+  assert.equal(horarioSP(fimDeMes, 1, 9, 30), '2026-09-01T12:30:00.000Z');
+});
+
+test('FUP final do Break cai 25 dias depois às 11h de São Paulo', () => {
+  assert.equal(horarioSP(MANHA_SP, 25, 11, 0), '2026-09-13T14:00:00.000Z');
+});
+
+test('zapDe aceita número real e rejeita vazio ou lixo', () => {
+  const zap = zapDe('+55 41 99999-8888');
+
+  assert.ok(zap);
+  assert.equal(zap.label, '+55 41 99999-8888');
+  assert.equal(zap.url, 'https://inbox.petbeetools.com.br/');
+  assert.ok(zap.markdown.includes('abrir inbox'));
+  assert.equal(zapDe(''), null);
+  assert.equal(zapDe('abc'), null);
+  assert.equal(zapDe(null), null);
+});

--- a/packages/twenty-apps/petbee-cadencia/src/cadencia/plan.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/cadencia/plan.ts
@@ -1,0 +1,278 @@
+// Reconciliação de estado desejado — porte fiel do nó "Plano de cadência" (n8n v10).
+// Entrada: fotografia do funil vivo + tasks abertas. Saída: lista de operações que
+// tornam o CRM igual ao estado desejado. Função PURA: nada de rede ou relógio próprio.
+import {
+  markdownDecisao,
+  PADRAO_DECISAO,
+  PADRAO_FUP,
+  PADRAO_MOTIVO,
+  proximas,
+  tituloDecisaoDe,
+  tituloFinalDe,
+  tituloMotivoDe,
+  horarioSP,
+  VITORIA_WORKSPACE_MEMBER_ID,
+  zapDe,
+  type Zap,
+} from './regua.ts';
+
+export type TaskDoFunil = {
+  id: string;
+  title: string;
+  status: string;
+  dueAt?: string | null;
+  whatsapp?: { primaryLinkUrl?: string | null } | null;
+};
+
+export type OppDoFunil = {
+  id: string;
+  name: string;
+  stage: string;
+  fupNumero?: number | null;
+  whatsapp?: string | null;
+  tarefas: TaskDoFunil[];
+};
+
+export type TaskAberta = {
+  id: string;
+  title: string;
+  targetOpportunityId: string | null;
+};
+
+export type OppForaDoFunil = {
+  id: string;
+  stage: string;
+  motivoLost?: string | null;
+};
+
+export type PlanInput = {
+  agora: Date;
+  funil: OppDoFunil[];
+  abertas: TaskAberta[];
+  perdidasSemMotivo: { id: string; name: string }[];
+  // Negócios (fora do funil vivo) que são alvo de alguma task gerenciada aberta, por id.
+  foraDoFunil: Record<string, OppForaDoFunil>;
+};
+
+export type TaskCreateData = {
+  title: string;
+  status: 'TODO';
+  dueAt: string;
+  assigneeId: string;
+  whatsapp?: { primaryLinkLabel: string; primaryLinkUrl: string };
+  bodyV2?: { markdown: string };
+};
+
+export type PlanOp =
+  | { kind: 'createTask'; oppId: string; data: TaskCreateData }
+  | { kind: 'updateTask'; taskId: string; data: Record<string, unknown> }
+  | { kind: 'deleteTask'; taskId: string }
+  | { kind: 'updateOpportunity'; oppId: string; data: { fupNumero: number } };
+
+function camposZap(zap: Zap): {
+  whatsapp: { primaryLinkLabel: string; primaryLinkUrl: string };
+  bodyV2: { markdown: string };
+} {
+  return {
+    whatsapp: { primaryLinkLabel: zap.label, primaryLinkUrl: zap.url },
+    bodyV2: { markdown: zap.markdown },
+  };
+}
+
+function opCreate(
+  oppId: string,
+  titulo: string,
+  dueAt: string,
+  zap: Zap | null,
+  markdown?: string,
+): PlanOp {
+  const data: TaskCreateData = {
+    title: titulo,
+    status: 'TODO',
+    dueAt,
+    assigneeId: VITORIA_WORKSPACE_MEMBER_ID,
+  };
+
+  if (zap) Object.assign(data, camposZap(zap));
+  if (markdown) data.bodyV2 = { markdown };
+
+  return { kind: 'createTask', oppId, data };
+}
+
+function numDe(titulo: string): number | null {
+  const m = titulo.match(/^FUP (\d+) /);
+
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function linkDesatualizado(task: TaskDoFunil): boolean {
+  const url = task.whatsapp?.primaryLinkUrl;
+
+  return !url || url.indexOf('wa.me') !== -1;
+}
+
+export function computePlan(input: PlanInput): PlanOp[] {
+  const { agora, funil, abertas, perdidasSemMotivo, foraDoFunil } = input;
+  const ops: PlanOp[] = [];
+
+  for (const opp of funil) {
+    // Dedup anti-corrida: segunda task gerenciada ABERTA com mesmo título é excluída.
+    const vistos: Record<string, boolean> = {};
+    const tarefas: TaskDoFunil[] = [];
+
+    for (const t of opp.tarefas) {
+      const gerenciadaAberta =
+        t.status !== 'DONE' &&
+        (PADRAO_FUP.test(t.title) || PADRAO_DECISAO.test(t.title));
+
+      if (gerenciadaAberta && vistos[t.title]) {
+        ops.push({ kind: 'deleteTask', taskId: t.id });
+        continue;
+      }
+      if (gerenciadaAberta) vistos[t.title] = true;
+      tarefas.push(t);
+    }
+
+    const feitos = tarefas
+      .filter((t) => t.status === 'DONE')
+      .map((t) => numDe(t.title))
+      .filter((n): n is number => n != null);
+    const maxFeito = feitos.length ? Math.max(...feitos) : 0;
+    const zap = zapDe(opp.whatsapp);
+
+    if (opp.stage === 'EM_NEGOCIACAO') {
+      const fupCampo = opp.fupNumero == null ? 0 : opp.fupNumero;
+      const fupReal = Math.max(fupCampo, maxFeito);
+
+      // fupNumero acompanha o maior FUP realmente concluído (teto 9).
+      if (fupCampo !== Math.min(fupReal, 9)) {
+        ops.push({
+          kind: 'updateOpportunity',
+          oppId: opp.id,
+          data: { fupNumero: Math.min(fupReal, 9) },
+        });
+      }
+
+      const esperadas = proximas(opp.name, fupReal, agora);
+      const titulosEsperados = new Set(esperadas.map((e) => e.titulo));
+
+      // FUP aberta que não é a esperada: nº já alcançado vira DONE, futura órfã é excluída.
+      for (const t of tarefas) {
+        if (
+          t.status === 'DONE' ||
+          !PADRAO_FUP.test(t.title) ||
+          titulosEsperados.has(t.title)
+        )
+          continue;
+
+        const n = numDe(t.title);
+
+        if (n != null && n <= fupReal) {
+          ops.push({ kind: 'updateTask', taskId: t.id, data: { status: 'DONE' } });
+        } else {
+          ops.push({ kind: 'deleteTask', taskId: t.id });
+        }
+      }
+
+      // Esperada faltando é criada; aberta existente só ganha self-heal do link
+      // (vazio ou wa.me) — vencimento editado à mão é respeitado.
+      for (const esperada of esperadas) {
+        const jaTem = tarefas.find((t) => t.title === esperada.titulo);
+
+        if (!jaTem) {
+          ops.push(opCreate(opp.id, esperada.titulo, esperada.dueAt, zap));
+        } else if (jaTem.status !== 'DONE' && zap && linkDesatualizado(jaTem)) {
+          ops.push({ kind: 'updateTask', taskId: jaTem.id, data: camposZap(zap) });
+        }
+      }
+
+      // Guarda pós-FUP 9: card parado em Em Negociação cobra a decisão até mover.
+      const tituloDecisao = tituloDecisaoDe(opp.name);
+
+      for (const t of tarefas) {
+        if (t.status === 'DONE' || !PADRAO_DECISAO.test(t.title)) continue;
+        if (fupReal < 9 || t.title !== tituloDecisao) {
+          ops.push({ kind: 'deleteTask', taskId: t.id });
+        }
+      }
+
+      const decisaoAberta = tarefas.find(
+        (t) => t.title === tituloDecisao && t.status !== 'DONE',
+      );
+
+      if (fupReal >= 9 && !decisaoAberta) {
+        ops.push(
+          opCreate(
+            opp.id,
+            tituloDecisao,
+            agora.toISOString(),
+            zap,
+            markdownDecisao(zap),
+          ),
+        );
+      }
+    } else {
+      // BREAK: só a "FUP final" (+25 dias, 11h SP) fica de pé; decisão e FUPs somem.
+      const tituloFinal = tituloFinalDe(opp.name);
+
+      for (const t of tarefas) {
+        if (t.status === 'DONE') continue;
+
+        const fupIndevida = PADRAO_FUP.test(t.title) && t.title !== tituloFinal;
+
+        if (fupIndevida || PADRAO_DECISAO.test(t.title)) {
+          ops.push({ kind: 'deleteTask', taskId: t.id });
+        }
+      }
+
+      const jaFinal = tarefas.find((t) => t.title === tituloFinal);
+
+      if (!jaFinal) {
+        ops.push(opCreate(opp.id, tituloFinal, horarioSP(agora, 25, 11, 0), zap));
+      } else if (jaFinal.status !== 'DONE' && zap && linkDesatualizado(jaFinal)) {
+        ops.push({ kind: 'updateTask', taskId: jaFinal.id, data: camposZap(zap) });
+      }
+    }
+  }
+
+  // Órfãs: task gerenciada aberta apontando pra negócio que saiu do funil vivo.
+  for (const t of abertas) {
+    if (!PADRAO_FUP.test(t.title) && !PADRAO_DECISAO.test(t.title)) continue;
+    if (!t.targetOpportunityId) continue;
+
+    const opp = foraDoFunil[t.targetOpportunityId];
+
+    if (!opp) continue;
+    if (opp.stage !== 'EM_NEGOCIACAO' && opp.stage !== 'BREAK') {
+      ops.push({ kind: 'deleteTask', taskId: t.id });
+    }
+  }
+
+  // Perdido sem motivo ganha a task-guarda (due imediato, sem zap).
+  for (const perdida of perdidasSemMotivo) {
+    const titulo = tituloMotivoDe(perdida.name);
+
+    if (!abertas.find((t) => t.title === titulo)) {
+      ops.push(opCreate(perdida.id, titulo, agora.toISOString(), null));
+    }
+  }
+
+  // Guarda de motivo some quando o motivo entra (ou o card sai de Perdido); dedup.
+  const vistosMotivo: Record<string, boolean> = {};
+
+  for (const t of abertas) {
+    if (!PADRAO_MOTIVO.test(t.title)) continue;
+    if (!t.targetOpportunityId) continue;
+
+    const opp = foraDoFunil[t.targetOpportunityId];
+
+    if (!opp) continue;
+    if (opp.stage !== 'LOST' || opp.motivoLost || vistosMotivo[t.title]) {
+      ops.push({ kind: 'deleteTask', taskId: t.id });
+    } else {
+      vistosMotivo[t.title] = true;
+    }
+  }
+
+  return ops;
+}

--- a/packages/twenty-apps/petbee-cadencia/src/cadencia/reconcile.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/cadencia/reconcile.ts
@@ -1,0 +1,277 @@
+// Lê a fotografia do CRM, calcula o plano (plan.ts) e — fora do modo sombra — executa.
+// Toda entrada do motor (cron ou evento) passa por aqui; falhas disparam o alerta.
+import { CoreApiClient } from 'twenty-client-sdk/core';
+
+import { PADRAO_DECISAO, PADRAO_FUP, PADRAO_MOTIVO } from './regua.ts';
+import {
+  computePlan,
+  type OppDoFunil,
+  type OppForaDoFunil,
+  type PlanOp,
+  type TaskAberta,
+  type TaskDoFunil,
+} from './plan.ts';
+
+type Edge<T> = { node: T };
+type Conexao<T> = { edges: Edge<T>[] } | null | undefined;
+
+function nodesDe<T>(conexao: Conexao<T>): T[] {
+  return (conexao?.edges ?? []).map((edge) => edge.node);
+}
+
+const GERENCIADA = (titulo: string): boolean =>
+  PADRAO_FUP.test(titulo) || PADRAO_DECISAO.test(titulo) || PADRAO_MOTIVO.test(titulo);
+
+async function carregarFunil(client: CoreApiClient): Promise<OppDoFunil[]> {
+  const resposta = (await client.query({
+    opportunities: {
+      __args: {
+        filter: {
+          or: [{ stage: { eq: 'EM_NEGOCIACAO' } }, { stage: { eq: 'BREAK' } }],
+        },
+        first: 200,
+      },
+      edges: {
+        node: {
+          id: true,
+          name: true,
+          stage: true,
+          fupNumero: true,
+          whatsapp: true,
+          taskTargets: {
+            edges: {
+              node: {
+                task: {
+                  id: true,
+                  title: true,
+                  status: true,
+                  dueAt: true,
+                  whatsapp: { primaryLinkUrl: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })) as {
+    opportunities: Conexao<{
+      id: string;
+      name: string;
+      stage: string;
+      fupNumero?: number | null;
+      whatsapp?: string | null;
+      taskTargets: Conexao<{ task: TaskDoFunil | null }>;
+    }>;
+  };
+
+  return nodesDe(resposta.opportunities).map((opp) => ({
+    id: opp.id,
+    name: opp.name,
+    stage: opp.stage,
+    fupNumero: opp.fupNumero,
+    whatsapp: opp.whatsapp,
+    tarefas: nodesDe(opp.taskTargets)
+      .map((alvo) => alvo.task)
+      .filter((task): task is TaskDoFunil => task != null),
+  }));
+}
+
+async function carregarAbertas(client: CoreApiClient): Promise<TaskAberta[]> {
+  const resposta = (await client.query({
+    tasks: {
+      __args: { filter: { status: { eq: 'TODO' } }, first: 300 },
+      edges: {
+        node: {
+          id: true,
+          title: true,
+          taskTargets: { edges: { node: { targetOpportunityId: true } } },
+        },
+      },
+    },
+  })) as {
+    tasks: Conexao<{
+      id: string;
+      title: string;
+      taskTargets: Conexao<{ targetOpportunityId: string | null }>;
+    }>;
+  };
+
+  return nodesDe(resposta.tasks).map((task) => ({
+    id: task.id,
+    title: task.title,
+    targetOpportunityId:
+      nodesDe(task.taskTargets)[0]?.targetOpportunityId ?? null,
+  }));
+}
+
+async function carregarPerdidasSemMotivo(
+  client: CoreApiClient,
+): Promise<{ id: string; name: string }[]> {
+  const resposta = (await client.query({
+    opportunities: {
+      __args: {
+        filter: { stage: { eq: 'LOST' }, motivoLost: { is: 'NULL' } },
+        first: 50,
+      },
+      edges: { node: { id: true, name: true } },
+    },
+  })) as { opportunities: Conexao<{ id: string; name: string }> };
+
+  return nodesDe(resposta.opportunities);
+}
+
+async function carregarForaDoFunil(
+  client: CoreApiClient,
+  abertas: TaskAberta[],
+  idsDoFunil: Set<string>,
+): Promise<Record<string, OppForaDoFunil>> {
+  const candidatas = new Set<string>();
+
+  for (const task of abertas) {
+    if (!GERENCIADA(task.title)) continue;
+    if (task.targetOpportunityId && !idsDoFunil.has(task.targetOpportunityId)) {
+      candidatas.add(task.targetOpportunityId);
+    }
+  }
+
+  const ids = [...candidatas].slice(0, 100);
+
+  if (!ids.length) return {};
+
+  const resposta = (await client.query({
+    opportunities: {
+      __args: { filter: { id: { in: ids } }, first: 100 },
+      edges: { node: { id: true, stage: true, motivoLost: true } },
+    },
+  })) as { opportunities: Conexao<OppForaDoFunil> };
+
+  const mapa: Record<string, OppForaDoFunil> = {};
+
+  for (const opp of nodesDe(resposta.opportunities)) mapa[opp.id] = opp;
+
+  return mapa;
+}
+
+async function executarOp(client: CoreApiClient, op: PlanOp): Promise<void> {
+  if (op.kind === 'createTask') {
+    const criada = (await client.mutation({
+      createTask: { __args: { data: op.data }, id: true },
+    })) as { createTask: { id: string } };
+
+    await client.mutation({
+      createTaskTarget: {
+        __args: {
+          data: { taskId: criada.createTask.id, targetOpportunityId: op.oppId },
+        },
+        id: true,
+      },
+    });
+
+    return;
+  }
+
+  if (op.kind === 'updateTask') {
+    await client.mutation({
+      updateTask: { __args: { id: op.taskId, data: op.data }, id: true },
+    });
+
+    return;
+  }
+
+  if (op.kind === 'deleteTask') {
+    await client.mutation({ deleteTask: { __args: { id: op.taskId }, id: true } });
+
+    return;
+  }
+
+  await client.mutation({
+    updateOpportunity: { __args: { id: op.oppId, data: op.data }, id: true },
+  });
+}
+
+function resumoDe(op: PlanOp): string {
+  if (op.kind === 'createTask') return `createTask: ${op.data.title}`;
+  if (op.kind === 'updateTask') return `updateTask ${op.taskId}: ${JSON.stringify(op.data)}`;
+  if (op.kind === 'deleteTask') return `deleteTask ${op.taskId}`;
+
+  return `updateOpportunity ${op.oppId}: fupNumero=${op.data.fupNumero}`;
+}
+
+async function avisarFalha(erro: unknown): Promise<void> {
+  const webhook = (process.env.CADENCIA_ALERT_WEBHOOK_URL ?? '').trim();
+
+  if (!webhook) return;
+
+  const mensagem = erro instanceof Error ? erro.message : String(erro);
+
+  try {
+    await fetch(webhook, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        text: `🚨 Cadência Petbee (app): falha na reconciliação — ${mensagem}`,
+      }),
+    });
+  } catch {
+    // O alerta nunca pode mascarar o erro original.
+  }
+}
+
+export type ResultadoReconcile = {
+  gatilho: string;
+  dryRun: boolean;
+  totalOps: number;
+  executadas: number;
+  ops: string[];
+};
+
+export async function reconcile(gatilho: string): Promise<ResultadoReconcile> {
+  // Sombra por padrão: só escreve quando a variável for exatamente "false".
+  const dryRun = (process.env.CADENCIA_DRY_RUN ?? 'true').trim() !== 'false';
+
+  try {
+    const client = new CoreApiClient();
+
+    const funil = await carregarFunil(client);
+    const abertas = await carregarAbertas(client);
+    const perdidasSemMotivo = await carregarPerdidasSemMotivo(client);
+    const foraDoFunil = await carregarForaDoFunil(
+      client,
+      abertas,
+      new Set(funil.map((opp) => opp.id)),
+    );
+
+    const ops = computePlan({
+      agora: new Date(),
+      funil,
+      abertas,
+      perdidasSemMotivo,
+      foraDoFunil,
+    });
+
+    let executadas = 0;
+
+    if (!dryRun) {
+      for (const op of ops) {
+        await executarOp(client, op);
+        executadas += 1;
+      }
+    }
+
+    const resultado: ResultadoReconcile = {
+      gatilho,
+      dryRun,
+      totalOps: ops.length,
+      executadas,
+      ops: ops.map(resumoDe),
+    };
+
+    console.log(`[cadencia] ${JSON.stringify(resultado)}`);
+
+    return resultado;
+  } catch (erro) {
+    await avisarFalha(erro);
+    throw erro;
+  }
+}

--- a/packages/twenty-apps/petbee-cadencia/src/cadencia/regua.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/cadencia/regua.ts
@@ -1,0 +1,128 @@
+// RÉGUA OFICIAL v2 (18/08/2026) — horários America/Sao_Paulo (UTC-3, sem horário de verão desde 2019).
+// 9 toques em ~6 dias: 2/dia nos 3 primeiros, 1/dia depois. Concluir a FUP N cria a N+1,
+// com prazo ancorado na CONCLUSÃO REAL (quem adianta, acelera; quem atrasa, reancora).
+// Toque "tarde do mesmo dia" concluído após as 16h empurra para amanhã às 16h.
+// Fonte da verdade compartilhada com o motor n8n "Cadência Twenty (nativa)" v10 —
+// qualquer mudança de régua precisa ser aplicada nos dois até o n8n ser aposentado.
+
+export const VITORIA_WORKSPACE_MEMBER_ID =
+  '69572821-c2f4-4923-9c68-23381b665a49';
+export const INBOX_URL = 'https://inbox.petbeetools.com.br/';
+
+export const TOQUES: Record<number, string> = {
+  1: 'FUP 1 (abordar agora)',
+  2: 'FUP 2 (mensagem, ~1h30 depois)',
+  3: 'FUP 3 (ligação + mensagem, manhã)',
+  4: 'FUP 4 (ligação + mensagem, tarde)',
+  5: 'FUP 5 (ligação + mensagem, manhã)',
+  6: 'FUP 6 (ligação + mensagem, tarde)',
+  7: 'FUP 7 (mensagem, manhã)',
+  8: 'FUP 8 (ligação, tarde)',
+  9: 'FUP 9 (mensagem, manhã)',
+};
+
+export const PADRAO_FUP = /^FUP (\d+|final) /;
+export const PADRAO_MOTIVO = /^Preencher motivo da perda — /;
+export const PADRAO_DECISAO = /^Decidir: Break ou Perdido\? — /;
+
+const SP_OFFSET_MS = 3 * 3600000;
+
+function spDe(instante: Date): Date {
+  return new Date(instante.getTime() - SP_OFFSET_MS);
+}
+
+// Data/hora de São Paulo (dia de `base` + addDias, às hora:minuto SP) em ISO UTC.
+export function horarioSP(
+  base: Date,
+  addDias: number,
+  hora: number,
+  minuto: number,
+): string {
+  const sp = spDe(base);
+
+  return new Date(
+    Date.UTC(
+      sp.getUTCFullYear(),
+      sp.getUTCMonth(),
+      sp.getUTCDate() + addDias,
+      hora + 3,
+      minuto,
+    ),
+  ).toISOString();
+}
+
+// "Tarde do dia": 16h SP de hoje — a menos que já passem das 16h, aí amanhã 16h.
+export function tardeDoDia(base: Date): string {
+  const sp = spDe(base);
+
+  return sp.getUTCHours() < 16
+    ? horarioSP(base, 0, 16, 0)
+    : horarioSP(base, 1, 16, 0);
+}
+
+export type ToqueEsperado = { titulo: string; dueAt: string };
+
+// Próximo(s) toque(s) esperados dado o último FUP concluído, ancorado em `base`.
+export function proximas(
+  nome: string,
+  fup: number,
+  base: Date,
+): ToqueEsperado[] {
+  const t = (n: number): string => `${TOQUES[n]} — ${nome}`;
+
+  if (fup <= 0) return [{ titulo: t(1), dueAt: base.toISOString() }];
+  if (fup === 1)
+    return [
+      { titulo: t(2), dueAt: new Date(base.getTime() + 90 * 60000).toISOString() },
+    ];
+  if (fup === 2) return [{ titulo: t(3), dueAt: horarioSP(base, 1, 9, 30) }];
+  if (fup === 3) return [{ titulo: t(4), dueAt: tardeDoDia(base) }];
+  if (fup === 4) return [{ titulo: t(5), dueAt: horarioSP(base, 1, 9, 30) }];
+  if (fup === 5) return [{ titulo: t(6), dueAt: tardeDoDia(base) }];
+  if (fup === 6) return [{ titulo: t(7), dueAt: horarioSP(base, 1, 9, 30) }];
+  if (fup === 7) return [{ titulo: t(8), dueAt: horarioSP(base, 1, 16, 0) }];
+  if (fup === 8) return [{ titulo: t(9), dueAt: horarioSP(base, 1, 9, 30) }];
+
+  return [];
+}
+
+export type Zap = { label: string; url: string; markdown: string };
+
+// Dados de WhatsApp do negócio, prontos pros campos da task. null quando não há número usável.
+export function zapDe(whatsappBruto: string | null | undefined): Zap | null {
+  const bruto = String(whatsappBruto ?? '').trim();
+
+  if (!bruto) return null;
+
+  const digitos = bruto.replace(/\D/g, '');
+
+  if (digitos.length < 10) return null;
+
+  return {
+    label: bruto,
+    url: INBOX_URL,
+    markdown: `**WhatsApp:** ${bruto} — [abrir inbox](${INBOX_URL})`,
+  };
+}
+
+export function tituloDecisaoDe(nome: string): string {
+  return `Decidir: Break ou Perdido? — ${nome}`;
+}
+
+export function tituloFinalDe(nome: string): string {
+  return `FUP final (antes do lost) — ${nome}`;
+}
+
+export function tituloMotivoDe(nome: string): string {
+  return `Preencher motivo da perda — ${nome}`;
+}
+
+export function markdownDecisao(zap: Zap | null): string {
+  const corpo =
+    '**9 toques feitos, sem resposta.** Decida o destino deste negócio:\n\n' +
+    '- Arraste o card para **Break** → o motor agenda um FUP final em 25 dias.\n' +
+    '- Arraste para **Perdido** → preencha o **motivo** (obrigatório).\n\n' +
+    'Esta task some sozinha quando o card mudar de coluna.';
+
+  return zap ? `${corpo}\n\n${zap.markdown}` : corpo;
+}

--- a/packages/twenty-apps/petbee-cadencia/src/constants/universal-identifiers.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/constants/universal-identifiers.ts
@@ -1,0 +1,22 @@
+export const APP_DISPLAY_NAME = 'Cadência Petbee';
+export const APP_DESCRIPTION =
+  'Motor da régua comercial Petbee: cria, conclui e remove as tasks de follow-up (FUP 1-9, Break e guardas de decisão/motivo) por reconciliação de estado desejado.';
+
+export const APPLICATION_UNIVERSAL_IDENTIFIER =
+  'b03be720-8b2a-401b-9545-141f42bd8d2b';
+export const DEFAULT_ROLE_UNIVERSAL_IDENTIFIER =
+  '14d47aa0-8d99-4592-9a55-710bffe04aea';
+
+export const DRY_RUN_VARIABLE_UNIVERSAL_IDENTIFIER =
+  '2544f3c1-bea6-48f7-9de0-3bab04ff05ad';
+export const ALERT_WEBHOOK_VARIABLE_UNIVERSAL_IDENTIFIER =
+  'a66d9be7-ccda-418b-a6a4-eebe111b9e9e';
+
+export const TICK_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER =
+  '9b0cfce4-5303-4e23-8ba5-1f7258aef2be';
+export const OPPORTUNITY_CREATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER =
+  '9c8b9c6e-1010-4663-bb9d-0a6905c1bc22';
+export const OPPORTUNITY_UPDATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER =
+  '5dca0c87-ecb3-42f4-b05a-b4813c7d6902';
+export const TASK_UPDATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER =
+  '982d2b46-6cfb-45cb-8181-40b80a7e7f0f';

--- a/packages/twenty-apps/petbee-cadencia/src/default-role.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/default-role.ts
@@ -1,0 +1,17 @@
+import { defineApplicationRole } from 'twenty-sdk/define';
+
+import {
+  APP_DISPLAY_NAME,
+  DEFAULT_ROLE_UNIVERSAL_IDENTIFIER,
+} from 'src/constants/universal-identifiers';
+
+export default defineApplicationRole({
+  universalIdentifier: DEFAULT_ROLE_UNIVERSAL_IDENTIFIER,
+  label: `${APP_DISPLAY_NAME} — papel do motor`,
+  description:
+    'Lê o funil, cria/conclui/remove tasks de cadência e vínculos task-negócio. Sem destroy: remoções são sempre soft delete.',
+  canReadAllObjectRecords: true,
+  canUpdateAllObjectRecords: true,
+  canSoftDeleteAllObjectRecords: true,
+  canDestroyAllObjectRecords: false,
+});

--- a/packages/twenty-apps/petbee-cadencia/src/logic-functions/on-opportunity-created.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/logic-functions/on-opportunity-created.ts
@@ -1,0 +1,21 @@
+import { defineLogicFunction } from 'twenty-sdk/define';
+
+import { OPPORTUNITY_CREATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import { reconcile, type ResultadoReconcile } from 'src/cadencia/reconcile.ts';
+
+// Campainha: negócio novo (ex.: lead da LP já qualificado) ganha a task certa em segundos.
+// O payload não é usado — o reconciliador sempre lê a verdade inteira do CRM.
+const handler = async (): Promise<ResultadoReconcile> => {
+  return reconcile('opportunity.created');
+};
+
+export default defineLogicFunction({
+  universalIdentifier: OPPORTUNITY_CREATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER,
+  name: 'cadencia-on-opportunity-created',
+  description: 'Reconcilia a cadência quando um negócio é criado.',
+  timeoutSeconds: 120,
+  databaseEventTriggerSettings: {
+    eventName: 'opportunity.created',
+  },
+  handler,
+});

--- a/packages/twenty-apps/petbee-cadencia/src/logic-functions/on-opportunity-updated.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/logic-functions/on-opportunity-updated.ts
@@ -1,0 +1,24 @@
+import { defineLogicFunction } from 'twenty-sdk/define';
+
+import { OPPORTUNITY_UPDATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import { reconcile, type ResultadoReconcile } from 'src/cadencia/reconcile.ts';
+
+// Campainha: arrastar o card (stage), corrigir o número (whatsapp), preencher o motivo
+// da perda ou ajustar o fupNumero reconcilia na hora. updatedFields evita disparo em
+// edições irrelevantes (nota, valor etc.).
+const handler = async (): Promise<ResultadoReconcile> => {
+  return reconcile('opportunity.updated');
+};
+
+export default defineLogicFunction({
+  universalIdentifier: OPPORTUNITY_UPDATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER,
+  name: 'cadencia-on-opportunity-updated',
+  description:
+    'Reconcilia a cadência quando etapa, fupNumero, motivo da perda ou WhatsApp de um negócio mudam.',
+  timeoutSeconds: 120,
+  databaseEventTriggerSettings: {
+    eventName: 'opportunity.updated',
+    updatedFields: ['stage', 'fupNumero', 'motivoLost', 'whatsapp'],
+  },
+  handler,
+});

--- a/packages/twenty-apps/petbee-cadencia/src/logic-functions/on-task-updated.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/logic-functions/on-task-updated.ts
@@ -1,0 +1,21 @@
+import { defineLogicFunction } from 'twenty-sdk/define';
+
+import { TASK_UPDATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import { reconcile, type ResultadoReconcile } from 'src/cadencia/reconcile.ts';
+
+// Campainha principal do dia a dia: a Vitória dá done na FUP N e a N+1 nasce em segundos.
+const handler = async (): Promise<ResultadoReconcile> => {
+  return reconcile('task.updated');
+};
+
+export default defineLogicFunction({
+  universalIdentifier: TASK_UPDATED_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER,
+  name: 'cadencia-on-task-updated',
+  description: 'Reconcilia a cadência quando o status de uma task muda.',
+  timeoutSeconds: 120,
+  databaseEventTriggerSettings: {
+    eventName: 'task.updated',
+    updatedFields: ['status'],
+  },
+  handler,
+});

--- a/packages/twenty-apps/petbee-cadencia/src/logic-functions/tick.ts
+++ b/packages/twenty-apps/petbee-cadencia/src/logic-functions/tick.ts
@@ -1,0 +1,22 @@
+import { defineLogicFunction } from 'twenty-sdk/define';
+
+import { TICK_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import { reconcile, type ResultadoReconcile } from 'src/cadencia/reconcile.ts';
+
+// Rede de segurança: mesmo que algum evento se perca, a cada 5 minutos o estado
+// desejado é reconferido do zero — nenhuma task fica faltando ou sobrando por muito tempo.
+const handler = async (): Promise<ResultadoReconcile> => {
+  return reconcile('tick');
+};
+
+export default defineLogicFunction({
+  universalIdentifier: TICK_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER,
+  name: 'cadencia-tick',
+  description:
+    'Reconciliação periódica da régua comercial (rede de segurança da cadência).',
+  timeoutSeconds: 120,
+  cronTriggerSettings: {
+    pattern: '*/5 * * * *',
+  },
+  handler,
+});

--- a/packages/twenty-apps/petbee-cadencia/tsconfig.json
+++ b/packages/twenty-apps/petbee-cadencia/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
+    "allowUnreachableCode": false,
+    "strict": true,
+    "alwaysStrict": true,
+    "noImplicitAny": true,
+    "target": "es2022",
+    "module": "esnext",
+    "lib": ["es2022"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "resolveJsonModule": true,
+    "paths": {
+      "src/*": ["./src/*"],
+      "~/*": ["./*"]
+    }
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

