### PR TITLE
fix: destroy rawDataSource in setup/truncate DB scripts to prevent process hang

### DIFF
--- a/packages/twenty-server/src/database/scripts/setup-db.ts
+++ b/packages/twenty-server/src/database/scripts/setup-db.ts
@@ -5,85 +5,98 @@ import { camelToSnakeCase, performQuery } from './setup-db-utils';
 rawDataSource
   .initialize()
   .then(async () => {
-    await performQuery(
-      'CREATE SCHEMA IF NOT EXISTS "public"',
-      'create schema "public"',
-    );
-    await performQuery(
-      'CREATE SCHEMA IF NOT EXISTS "core"',
-      'create schema "core"',
-    );
+    try {
+      await performQuery(
+        'CREATE SCHEMA IF NOT EXISTS "public"',
+        'create schema "public"',
+      );
+      await performQuery(
+        'CREATE SCHEMA IF NOT EXISTS "core"',
+        'create schema "core"',
+      );
 
-    await performQuery(
-      'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"',
-      'create extension "uuid-ossp"',
-    );
+      await performQuery(
+        'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"',
+        'create extension "uuid-ossp"',
+      );
 
-    await performQuery(
-      'CREATE EXTENSION IF NOT EXISTS "unaccent"',
-      'create extension "unaccent"',
-    );
+      await performQuery(
+        'CREATE EXTENSION IF NOT EXISTS "unaccent"',
+        'create extension "unaccent"',
+      );
 
-    await performQuery(
-      `CREATE OR REPLACE FUNCTION public.unaccent_immutable(input text)
+      await performQuery(
+        `CREATE OR REPLACE FUNCTION public.unaccent_immutable(input text)
     RETURNS text
     LANGUAGE sql
     IMMUTABLE
 AS $$
 SELECT public.unaccent('public.unaccent'::regdictionary, input)
 $$;`,
-      'create immutable unaccent wrapper function',
-    );
+        'create immutable unaccent wrapper function',
+      );
 
-    // We paused the work on FDW
-    if (process.env.IS_FDW_ENABLED !== 'true') {
-      return;
-    }
-
-    await performQuery(
-      'CREATE EXTENSION IF NOT EXISTS "postgres_fdw"',
-      'create extension "postgres_fdw"',
-    );
-
-    await performQuery(
-      'CREATE EXTENSION IF NOT EXISTS "wrappers"',
-      'create extension "wrappers"',
-    );
-
-    await performQuery(
-      'CREATE EXTENSION IF NOT EXISTS "mysql_fdw"',
-      'create extension "mysql_fdw"',
-    );
-
-    const supabaseWrappers = [
-      'airtable',
-      'bigQuery',
-      'clickHouse',
-      'firebase',
-      'logflare',
-      's3',
-      'stripe',
-    ]; // See https://supabase.github.io/wrappers/
-
-    for (const wrapper of supabaseWrappers) {
-      if (await checkForeignDataWrapperExists(`${wrapper.toLowerCase()}_fdw`)) {
-        continue;
+      // We paused the work on FDW
+      if (process.env.IS_FDW_ENABLED !== 'true') {
+        return;
       }
+
       await performQuery(
-        `
+        'CREATE EXTENSION IF NOT EXISTS "postgres_fdw"',
+        'create extension "postgres_fdw"',
+      );
+
+      await performQuery(
+        'CREATE EXTENSION IF NOT EXISTS "wrappers"',
+        'create extension "wrappers"',
+      );
+
+      await performQuery(
+        'CREATE EXTENSION IF NOT EXISTS "mysql_fdw"',
+        'create extension "mysql_fdw"',
+      );
+
+      const supabaseWrappers = [
+        'airtable',
+        'bigQuery',
+        'clickHouse',
+        'firebase',
+        'logflare',
+        's3',
+        'stripe',
+      ]; // See https://supabase.github.io/wrappers/
+
+      for (const wrapper of supabaseWrappers) {
+        if (
+          await checkForeignDataWrapperExists(`${wrapper.toLowerCase()}_fdw`)
+        ) {
+          continue;
+        }
+        await performQuery(
+          `
           CREATE FOREIGN DATA WRAPPER "${wrapper.toLowerCase()}_fdw"
           HANDLER "${camelToSnakeCase(wrapper)}_fdw_handler"
           VALIDATOR "${camelToSnakeCase(wrapper)}_fdw_validator";
           `,
-        `create ${wrapper} "wrappers"`,
-        true,
-        true,
-      );
+          `create ${wrapper} "wrappers"`,
+          true,
+          true,
+        );
+      }
+    } finally {
+      if (rawDataSource.isInitialized) {
+        await rawDataSource.destroy();
+      }
     }
+    process.exit(0);
   })
-  .catch((err) => {
+  .catch(async (err) => {
     // oxlint-disable-next-line no-console
     console.error('Error during Data Source initialization:', err);
+    if (rawDataSource.isInitialized) {
+      await rawDataSource.destroy();
+    }
+    process.exit(1);
   });
 
 async function checkForeignDataWrapperExists(

--- a/packages/twenty-server/src/database/scripts/truncate-db.ts
+++ b/packages/twenty-server/src/database/scripts/truncate-db.ts
@@ -37,7 +37,12 @@ async function dropSchemasSequentially() {
   } catch (err) {
     // oxlint-disable-next-line no-console
     console.error('Error during schema dropping:', err);
+  } finally {
+    if (rawDataSource.isInitialized) {
+      await rawDataSource.destroy();
+    }
   }
+  process.exit(0);
 }
 
 void dropSchemasSequentially();


### PR DESCRIPTION
## Problem

`setup-db.ts` and `truncate-db.ts` initialize a TypeORM `rawDataSource` but never destroy it. An initialized DataSource keeps its connection pool open, which keeps the Node process alive after the script finishes — so the script hangs instead of exiting. In Docker this blocks startup, because the entrypoint runs these scripts and waits for them to terminate.

## Fix

Call `rawDataSource.destroy()` once the work is done, so the connection pool is released and the process can exit:

- `setup-db.ts`: destroy in a `finally` block (this also covers the early-return path when `IS_FDW_ENABLED !== 'true'`) and in the `catch` error handler.
- `truncate-db.ts`: destroy in a `finally` block.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

