### PR TITLE
fix(record-detail): check parent metadata for read-only in relation dropdown (#24351)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown.tsx
@@ -38,17 +38,15 @@ export const RecordDetailRelationSectionDropdown = ({
   const isToOneObject = relationType === RelationType.MANY_TO_ONE;
   const isToManyObjects = relationType === RelationType.ONE_TO_MANY;
 
-  const isRecordReadOnlyFromRelatedRecordPerspective = useIsRecordReadOnly({
+  const isParentRecordReadOnly = useIsRecordReadOnly({
     recordId,
-    objectMetadataId: isToOneObject
-      ? recordObjectMetadataItem.id
-      : relationObjectMetadataItem.id,
+    objectMetadataId: recordObjectMetadataItem.id,
   });
 
   if (
     loading ||
     isRecordFieldReadOnly ||
-    isRecordReadOnlyFromRelatedRecordPerspective
+    isParentRecordReadOnly
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary
Resolves #24351 by ensuring that useIsRecordReadOnly in RecordDetailRelationSectionDropdown checks the parent record metadata (recordObjectMetadataItem.id) rather than incorrectly evaluating permissions using the target relation metadata against the parent recordId.

### Changes
- Updated isParentRecordReadOnly to pass recordObjectMetadataItem.id and recordId.
- Ensures that custom object relation sections (e.g. Products linked to Company) render their action menu and direct creation trigger properly on record detail views.

Closes #24351

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

