### PR TITLE
fix(date-picker): pass monthDate to header and link navigation to increase/decrease month (#24336)

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePicker.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePicker.tsx
@@ -176,27 +176,31 @@ export const DatePicker = ({
   };
 
   const handleChangeMonth = (month: number) => {
-    const newDate = plainDate?.with({ month: month });
+    const current = plainDate ?? Temporal.Now.plainDateISO();
+    const newDate = current.with({ month });
 
-    onChange?.(newDate?.toString() ?? null);
+    onChange?.(newDate.toString());
   };
 
   const handleAddMonth = () => {
-    const newDate = plainDate?.add({ months: 1 });
+    const current = plainDate ?? Temporal.Now.plainDateISO();
+    const newDate = current.add({ months: 1 });
 
-    onChange?.(newDate?.toString() ?? null);
+    onChange?.(newDate.toString());
   };
 
   const handleSubtractMonth = () => {
-    const newDate = plainDate?.subtract({ months: 1 });
+    const current = plainDate ?? Temporal.Now.plainDateISO();
+    const newDate = current.subtract({ months: 1 });
 
-    onChange?.(newDate?.toString() ?? null);
+    onChange?.(newDate.toString());
   };
 
   const handleChangeYear = (year: number) => {
-    const newDate = plainDate?.with({ year: year });
+    const current = plainDate ?? Temporal.Now.plainDateISO();
+    const newDate = current.with({ year });
 
-    onChange?.(newDate?.toString() ?? null);
+    onChange?.(newDate.toString());
   };
 
   const handleDateChange = (datePicked: Date | null) => {
@@ -293,6 +297,7 @@ export const DatePicker = ({
               ) : (
                 <DatePickerHeader
                   date={plainDate?.toString() ?? null}
+                  monthDate={monthDate}
                   onChange={onChange}
                   onChangeMonth={handleChangeMonth}
                   onChangeYear={handleChangeYear}

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePickerHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePickerHeader.tsx
@@ -36,6 +36,7 @@ const StyledCustomDatePickerHeader = styled.div`
 
 type DatePickerHeaderProps = {
   date: string | null;
+  monthDate?: Date;
   onChange?: (date: string | null) => void;
   onChangeMonth: (month: number) => void;
   onChangeYear: (year: number) => void;
@@ -48,6 +49,7 @@ type DatePickerHeaderProps = {
 
 export const DatePickerHeader = ({
   date,
+  monthDate,
   onChange,
   onChangeMonth,
   onChangeYear,
@@ -60,7 +62,11 @@ export const DatePickerHeader = ({
   const currentWorkspaceMember = useAtomStateValue(currentWorkspaceMemberState);
   const userLocale = currentWorkspaceMember?.locale ?? SOURCE_LOCALE;
 
-  const dateParsed = isDefined(date) ? Temporal.PlainDate.from(date) : null;
+  const dateParsed = isDefined(date)
+    ? Temporal.PlainDate.from(date)
+    : isDefined(monthDate)
+      ? turnJSDateToPlainDate(monthDate)
+      : Temporal.Now.plainDateISO();
 
   return (
     <>


### PR DESCRIPTION
## Summary
Resolves #24336 by passing monthDate from react-datepicker to DatePickerHeader and falling back to monthDate or current date in dateParsed and month navigation handlers, ensuring that month and year labels and dropdowns display properly when opening the date picker on unpopulated date fields.

### Changes
- Updated DatePickerHeader to accept monthDate prop and derive dateParsed from monthDate or current date when date is null.
- Updated handleChangeMonth, handleAddMonth, handleSubtractMonth, and handleChangeYear in DatePicker to fallback to Temporal.Now.plainDateISO() when plainDate is null.
- Passed monthDate into DatePickerHeader in renderCustomHeader.

Closes #24336

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

