### PR TITLE
fix(server): timeline calendar events denied on the ORM v2 read path

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -322,7 +322,7 @@ jobs:
       # the 16-way split the unflagged shards use.
       ORM_V2_SHARD_COUNTER: 5
       TEST_FORCED_FEATURE_FLAGS: ${{ matrix.orm-v2 && 'IS_ORM_V2_READ_PATH_ENABLED' || '' }}
-      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls|object-records-permissions|merge-many|mutate-by-relation-field|mutation-relation-filter-rls|upsert|unique-field|object-generated|files-field)'
+      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls|object-records-permissions|merge-many|mutate-by-relation-field|mutation-relation-filter-rls|upsert|unique-field|object-generated|files-field|timeline-from-object-record)'
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -58,9 +58,10 @@ export class TimelineCalendarEventService {
         // this the participant relations (person, workspaceMember) are read with
         // empty permissions and denied for everyone. Channel-level redaction of
         // title and description below is what gates the caller's access.
-        // TODO: run under the caller's role via resolveRolePermissionConfig
-        // instead of bypassing, once roles that cannot read person degrade to a
-        // redacted timeline rather than a denied one.
+        // TODO run under the caller's role via resolveRolePermissionConfig instead
+        // of bypassing, once roles that cannot read person degrade to a redacted
+        // timeline rather than a denied one
+        // https://github.com/twentyhq/core-team-issues/issues/2777
         const calendarEventRepository =
           await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
             workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -54,9 +54,10 @@ export class TimelineCalendarEventService {
       async () => {
         const offset = (page - 1) * pageSize;
 
-        // Runs under a system auth context: the timeline loads participants
-        // (person, workspaceMember) the caller's role may not be able to read,
-        // then redacts each event itself through `visibility` below.
+        // Runs under a system auth context, which resolves no role, so without
+        // this the participant relations (person, workspaceMember) are read with
+        // empty permissions and denied for everyone. Channel-level redaction of
+        // title and description below is what gates the caller's access.
         const calendarEventRepository =
           await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
             workspaceId,
@@ -118,7 +119,6 @@ export class TimelineCalendarEventService {
           await this.globalWorkspaceOrmManager.getRepository<CallRecordingWorkspaceEntity>(
             workspaceId,
             'callRecording',
-            { shouldBypassPermissionChecks: true },
           );
 
         const callRecordings = await callRecordingRepository.find({

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -54,10 +54,14 @@ export class TimelineCalendarEventService {
       async () => {
         const offset = (page - 1) * pageSize;
 
+        // Runs under a system auth context: the timeline loads participants
+        // (person, workspaceMember) the caller's role may not be able to read,
+        // then redacts each event itself through `visibility` below.
         const calendarEventRepository =
           await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
             workspaceId,
             'calendarEvent',
+            { shouldBypassPermissionChecks: true },
           );
 
         const totalNumberOfCalendarEvents = await calendarEventRepository.count(
@@ -114,6 +118,7 @@ export class TimelineCalendarEventService {
           await this.globalWorkspaceOrmManager.getRepository<CallRecordingWorkspaceEntity>(
             workspaceId,
             'callRecording',
+            { shouldBypassPermissionChecks: true },
           );
 
         const callRecordings = await callRecordingRepository.find({

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -58,6 +58,9 @@ export class TimelineCalendarEventService {
         // this the participant relations (person, workspaceMember) are read with
         // empty permissions and denied for everyone. Channel-level redaction of
         // title and description below is what gates the caller's access.
+        // TODO: run under the caller's role via resolveRolePermissionConfig
+        // instead of bypassing, once roles that cannot read person degrade to a
+        // redacted timeline rather than a denied one.
         const calendarEventRepository =
           await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
             workspaceId,


### PR DESCRIPTION
`getTimelineCalendarEventsFromObjectRecord` returns `PERMISSION_DENIED` for every user, admins included, on any record that has calendar events, in workspaces where `IS_ORM_V2_READ_PATH_ENABLED` is on.

```json
{
  "message": "Entity performing the request does not have permission",
  "extensions": { "subCode": "PERMISSION_DENIED", "code": "FORBIDDEN" }
}
```

## Cause

`TimelineCalendarEventService` runs under a system auth context but built its calendar event repository without a `RolePermissionConfig`:

```ts
getRepository<CalendarEventWorkspaceEntity>(workspaceId, 'calendarEvent')
```

With no config the repository gets `objectRecordsPermissions = {}` **and** `shouldBypassPermissionChecks = false`. That is not "the caller's permissions" — a system auth context resolves no role at all, so there is nothing to check against and every non-system object is denied. `calendarEvent` and `calendarEventParticipant` are unaffected because they are `isSystem: true` and get an early return in `validateOperationIsPermittedOrThrow`. The participant relations are not: `person` is a regular object and `workspaceMember` is explicitly excluded from the system bypass.

On the v1 read path this never surfaced. Relation joins added by `find({ relations })` are emitted as bare alias selects, which the join check in `permissions.utils.ts` cannot match, so those relations were never validated. On the v2 read path each relation is loaded through a separate `find()` on the target repository, inheriting the same empty permissions, and that select is validated.

Only records that actually have calendar events are affected; empty timelines return before the relation load.

## Fix

Pass `{ shouldBypassPermissionChecks: true }` to the calendar event repository, which is what `resolveRolePermissionConfig` already returns for a system auth context, and what the `workspaceMember` lookup in this same function already does. No-op on the v1 path.

A `TODO` records the better long-term shape — running under the caller's role instead of bypassing — which needs a redaction path first, since a role that cannot read `person` would otherwise go from a full timeline to a hard denial.

## Coverage

The ORM v2 CI leg only runs suites named in `ORM_V2_TEST_PATH_PATTERN`, and `timeline-from-object-record` was not one of them, which is why this reached production. The suite already seeds a calendar event with a person participant, so it catches this once it runs; it is added to the pattern here.

## Verification

Ran `timeline-from-object-record.integration-spec.ts` against a database reset with `TEST_FORCED_FEATURE_FLAGS=IS_ORM_V2_READ_PATH_ENABLED`:

- before: 3 failed, 5 passed, each failure carrying the exact `PERMISSION_DENIED` payload above
- after: 8 passed

The messaging half of the timeline is not affected. Its participant query joins `person` and `workspaceMember` too, and `getThreadParticipantsByThreadId` runs on every request regardless of the GraphQL selection, but those tests pass under the flag both before and after this change — explicit joins take a different validation path than find-options relations.

## Follow-ups

twentyhq/core-team-issues#2777 collects what this turned up and deliberately leaves out of scope: joined aliases going unvalidated on the v2 path (which the messaging timeline currently depends on), config-less `getRepository` silently meaning deny-all, and `location` / `conferenceSolution` / `callRecordings` being returned ungated for `METADATA`-visibility events on `main` today.