### PR TITLE
Resolve object labels in search results through the shared resolver

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/search/search.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/search.resolver.ts
@@ -1,5 +1,5 @@
 import { UseFilters, UseGuards, UsePipes } from '@nestjs/common';
-import { Args, Query } from '@nestjs/graphql';
+import { Args, Context, Query } from '@nestjs/graphql';
 
 import { isDefined } from 'twenty-shared/utils';
 
@@ -10,7 +10,9 @@ import { SearchArgs } from 'src/engine/core-modules/search/dtos/search-args';
 import { SearchResultConnectionDTO } from 'src/engine/core-modules/search/dtos/search-result-connection.dto';
 import { SearchApiExceptionFilter } from 'src/engine/core-modules/search/filters/search-api-exception.filter';
 import { SearchService } from 'src/engine/core-modules/search/services/search.service';
+import { type I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { CustomPermissionGuard } from 'src/engine/guards/custom-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
@@ -43,6 +45,7 @@ export class SearchResolver {
       excludedObjectNameSingulars,
       after,
     }: SearchArgs,
+    @Context() context: { loaders: IDataloaders } & I18nContext,
   ) {
     const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
       await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
@@ -82,6 +85,8 @@ export class SearchResolver {
       workspaceId: workspace.id,
       limit,
       after,
+      loaders: context.loaders,
+      locale: context.req.locale,
     });
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -16,6 +16,8 @@ import {
 } from 'twenty-shared/utils';
 import { Brackets, type ObjectLiteral } from 'typeorm';
 
+import { type APP_LOCALES } from 'twenty-shared/translations';
+
 import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
@@ -26,6 +28,7 @@ import {
 import { isQueryCanceledError } from 'src/engine/api/graphql/workspace-query-runner/utils/is-query-canceled-error.util';
 import { FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
 import { extractFileIdFromUrl } from 'src/engine/core-modules/file/files-field/utils/extract-file-id-from-url.util';
+import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { STANDARD_OBJECTS_BY_PRIORITY_RANK } from 'src/engine/core-modules/search/constants/standard-objects-by-priority-rank';
 import { type ObjectRecordFilterInput } from 'src/engine/core-modules/search/dtos/object-record-filter-input';
 import { type SearchArgs } from 'src/engine/core-modules/search/dtos/search-args';
@@ -39,6 +42,7 @@ import {
 import { type RecordsWithObjectMetadataItem } from 'src/engine/core-modules/search/types/records-with-object-metadata-item';
 import { formatSearchTerms } from 'src/engine/core-modules/search/utils/format-search-terms';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -47,6 +51,7 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { getEffectiveImageIdentifierFieldMetadataId } from 'src/engine/metadata-modules/object-metadata/utils/get-effective-image-identifier-field-metadata-id.util';
 import { SEARCH_VECTOR_FIELD } from 'src/engine/metadata-modules/search-field-metadata/constants/search-vector-field.constants';
+import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
@@ -70,6 +75,7 @@ export class SearchService {
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
     private readonly fileUrlService: FileUrlService,
     private readonly twentyConfigService: TwentyConfigService,
+    private readonly i18nService: I18nService,
   ) {}
 
   async getAllRecordsWithObjectMetadataItems({
@@ -778,13 +784,44 @@ export class SearchService {
     workspaceId,
     limit,
     after,
+    loaders,
+    locale,
   }: {
     recordsWithObjectMetadataItems: RecordsWithObjectMetadataItem[];
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     workspaceId: string;
     limit: number;
     after?: string;
+    loaders: IDataloaders;
+    locale: keyof typeof APP_LOCALES | undefined;
   }): Promise<SearchResultConnectionDTO> {
+    // Resolved per object rather than per record: the catalog loader is
+    // batched, and a search page holds few objects but many records.
+    const objectLabelSingularByObjectMetadataId = new Map(
+      await Promise.all(
+        recordsWithObjectMetadataItems.map(
+          async ({ objectMetadataItem }) =>
+            [
+              objectMetadataItem.id,
+              resolveEffectiveEntityProperty({
+                metadataName: 'objectMetadata',
+                baseValue: objectMetadataItem.labelSingular,
+                overrides: objectMetadataItem.overrides,
+                property: 'labelSingular',
+                i18nContext:
+                  await this.i18nService.buildEffectiveEntityI18nContext({
+                    applicationId:
+                      objectMetadataItem.applicationId ?? undefined,
+                    loaders,
+                    locale,
+                    workspaceId,
+                  }),
+              }),
+            ] as const,
+        ),
+      ),
+    );
+
     const recordPromises = recordsWithObjectMetadataItems.flatMap(
       ({ objectMetadataItem, records }) => {
         return records.map(async (record) => {
@@ -792,8 +829,9 @@ export class SearchService {
             recordId: record.id,
             objectNameSingular: objectMetadataItem.nameSingular,
             objectLabelSingular:
-              objectMetadataItem.overrides?.labelSingular ??
-              objectMetadataItem.labelSingular,
+              objectLabelSingularByObjectMetadataId.get(
+                objectMetadataItem.id,
+              ) ?? objectMetadataItem.labelSingular,
             label: this.getLabelIdentifierValue(
               record,
               objectMetadataItem,

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -795,8 +795,6 @@ export class SearchService {
     loaders: IDataloaders;
     locale: keyof typeof APP_LOCALES | undefined;
   }): Promise<SearchResultConnectionDTO> {
-    // Resolved per object rather than per record: the catalog loader is
-    // batched, and a search page holds few objects but many records.
     const objectLabelSingularByObjectMetadataId = new Map(
       await Promise.all(
         recordsWithObjectMetadataItems.map(


### PR DESCRIPTION
## Problem

`computeSearchObjectResults` built `objectLabelSingular` as:

```ts
objectMetadataItem.overrides?.labelSingular ?? objectMetadataItem.labelSingular
```

That applies the workspace rename override but skips `resolveEffectiveEntityProperty` entirely, so it consults neither the per-locale workspace translations map nor the shipped standard-label catalog. A French workspace therefore sees French object names everywhere in the app **except** in search results, the record pickers and the `@`-mention menu, which stay English.

The value is consumed as-is by `SingleRecordPickerMenuItem` and `CustomMentionMenu` — `SearchRecordDTO.objectLabelSingular` has no field resolver, so nothing downstream repairs it. This was the most visible remaining incoherence in the metadata-i18n audit.

## Fix

Resolve through `resolveEffectiveEntityProperty` with the request locale, exactly like the object-metadata resolvers do. `SearchResolver` now passes `context.loaders` and `context.req.locale`; `I18nService.buildEffectiveEntityI18nContext` supplies the standard-app flag and the per-application catalog, so app-provided objects resolve against their own catalog too.

Resolution runs once per object rather than per record — a search page holds few objects and many records — and the catalog loader is batched per application, so this adds no query per result row.

## Validation

- `tsgo` clean on twenty-server, oxlint clean.
- Manual check against the seeded French workspace: search results, record picker and mention menu now show the translated object name, matching the rest of the UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFZV45dmajdE3hbASNr9xe)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

