### PR TITLE
Stop a manifest without translations from deleting an application's stored locales

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/translations/overview.mdx
+++ b/packages/twenty-docs/developers/extend/apps/translations/overview.mdx
@@ -126,15 +126,11 @@ each string against its catalog, falling back to the source when a translation
 is missing. Switching language in the host re-renders `Trans` and
 `useTranslate().t` strings live.
 
-Because catalogs are compiled at build time, updating a translation means
-re-running `twenty dev:build` (and redeploying), the same as any other change.
-
-<Note>
-Translations are compiled on every sync — `twenty dev:build`, `twenty apply`
-and the continuous `twenty dev` watch alike — so localized output can be
-tested without a one-off build. Front component catalogs are baked into the
-bundle at build time, so those still need a rebuild to change.
-</Note>
+Manifest labels are compiled on every sync — `twenty dev:build`, `twenty apply`
+and the continuous `twenty dev` watch alike — so editing a locale file and
+syncing is enough to see the new text. Front component catalogs are baked into
+each component bundle at build time, so changing one of those still means
+re-running `twenty dev:build` (and redeploying).
 
 `Trans` text children may span multiple lines — whitespace is collapsed the
 same way JSX collapses it, so both of these extract to the key `Welcome back`:

--- a/packages/twenty-docs/developers/extend/apps/translations/overview.mdx
+++ b/packages/twenty-docs/developers/extend/apps/translations/overview.mdx
@@ -130,9 +130,10 @@ Because catalogs are compiled at build time, updating a translation means
 re-running `twenty dev:build` (and redeploying), the same as any other change.
 
 <Note>
-Translations are compiled by `twenty dev:build` (and `twenty apply`). The
-continuous `twenty dev` watch shows source strings, so test localized output
-with a one-off build.
+Translations are compiled on every sync — `twenty dev:build`, `twenty apply`
+and the continuous `twenty dev` watch alike — so localized output can be
+tested without a one-off build. Front component catalogs are baked into the
+bundle at build time, so those still need a rebuild to change.
 </Note>
 
 `Trans` text children may span multiple lines — whitespace is collapsed the

--- a/packages/twenty-sdk/src/cli/__tests__/apps/minimal-app/__integration__/app-dev/expected-manifest.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/minimal-app/__integration__/app-dev/expected-manifest.ts
@@ -16,6 +16,9 @@ export const EXPECTED_MANIFEST: Manifest = {
   },
   permissionFlags: [],
   skills: [],
+  // An app with no locale files still states that it has none, so a sync
+  // prunes translations its author removed.
+  translations: {},
   agents: [],
   publicAssets: [],
   indexes: [],

--- a/packages/twenty-sdk/src/cli/__tests__/apps/minimal-app/__integration__/app-dev/expected-manifest.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/minimal-app/__integration__/app-dev/expected-manifest.ts
@@ -16,8 +16,6 @@ export const EXPECTED_MANIFEST: Manifest = {
   },
   permissionFlags: [],
   skills: [],
-  // An app with no locale files still states that it has none, so a sync
-  // prunes translations its author removed.
   translations: {},
   agents: [],
   publicAssets: [],

--- a/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/expected-manifest.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/expected-manifest.ts
@@ -59,8 +59,6 @@ export const EXPECTED_MANIFEST: Manifest = {
     },
   ],
   skills: [],
-  // An app with no locale files still states that it has none, so a sync
-  // prunes translations its author removed.
   translations: {},
   agents: [],
   application: {

--- a/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/expected-manifest.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/expected-manifest.ts
@@ -59,6 +59,9 @@ export const EXPECTED_MANIFEST: Manifest = {
     },
   ],
   skills: [],
+  // An app with no locale files still states that it has none, so a sync
+  // prunes translations its author removed.
+  translations: {},
   agents: [],
   application: {
     applicationVariables: {

--- a/packages/twenty-sdk/src/cli/operations/build.ts
+++ b/packages/twenty-sdk/src/cli/operations/build.ts
@@ -98,10 +98,7 @@ const innerAppBuild = async (
     builtFileInfos: buildResult.builtFileInfos,
   });
 
-  await writeManifestToOutput(
-    appPath,
-    translations ? { ...updatedManifest, translations } : updatedManifest,
-  );
+  await writeManifestToOutput(appPath, { ...updatedManifest, translations });
 
   const outputDir = path.join(appPath, '.twenty', 'output');
 

--- a/packages/twenty-sdk/src/cli/operations/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/operations/dev-once.ts
@@ -205,8 +205,6 @@ const innerAppDevOnce = async (
 
   const translations = await compileApplicationTranslations(appPath);
 
-  // Compiled here too, so a developer can see their translations applied
-  // without a full build and publish.
   const manifest: Manifest = {
     ...manifestUpdateChecksums({
       manifest: manifestResult.manifest,

--- a/packages/twenty-sdk/src/cli/operations/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/operations/dev-once.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { type Manifest, OUTPUT_DIR } from 'twenty-shared/application';
 import { type MetadataValidationErrorResponse } from 'twenty-shared/metadata';
-import { isPlainObject } from 'twenty-shared/utils';
+import { isDefined, isPlainObject } from 'twenty-shared/utils';
 
 import { ApiService } from '@/cli/utilities/api/api-service';
 import {
@@ -13,6 +13,7 @@ import { promptForReauthentication } from '@/cli/utilities/auth/reauth-helper';
 import { buildApplication } from '@/cli/utilities/build/common/build-application';
 import { runTypecheck } from '@/cli/utilities/build/common/typecheck-plugin';
 import { buildAndValidateManifest } from '@/cli/utilities/build/manifest/build-and-validate-manifest';
+import { compileApplicationTranslations } from '@/cli/utilities/translations/compile-application-translations';
 import { manifestUpdateChecksums } from '@/cli/utilities/build/manifest/manifest-update-checksums';
 import { writeManifestToOutput } from '@/cli/utilities/build/manifest/manifest-writer';
 import { ClientService } from '@/cli/utilities/client/client-service';
@@ -202,10 +203,17 @@ const innerAppDevOnce = async (
     };
   }
 
-  const manifest: Manifest = manifestUpdateChecksums({
+  const translations = await compileApplicationTranslations(appPath);
+
+  const manifestWithChecksums: Manifest = manifestUpdateChecksums({
     manifest: manifestResult.manifest,
     builtFileInfos: buildResult.builtFileInfos,
   });
+  // Carried through the dev sync too: the server prunes the locales a manifest
+  // does not list, so syncing without them would drop what the app published.
+  const manifest: Manifest = isDefined(translations)
+    ? { ...manifestWithChecksums, translations }
+    : manifestWithChecksums;
 
   await writeManifestToOutput(appPath, manifest);
 

--- a/packages/twenty-sdk/src/cli/operations/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/operations/dev-once.ts
@@ -205,8 +205,8 @@ const innerAppDevOnce = async (
 
   const translations = await compileApplicationTranslations(appPath);
 
-  // Carried through the dev sync too: the server prunes the locales a manifest
-  // lists none of, so syncing without them would drop what the app published.
+  // Compiled here too, so a developer can see their translations applied
+  // without a full build and publish.
   const manifest: Manifest = {
     ...manifestUpdateChecksums({
       manifest: manifestResult.manifest,

--- a/packages/twenty-sdk/src/cli/operations/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/operations/dev-once.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { type Manifest, OUTPUT_DIR } from 'twenty-shared/application';
 import { type MetadataValidationErrorResponse } from 'twenty-shared/metadata';
-import { isDefined, isPlainObject } from 'twenty-shared/utils';
+import { isPlainObject } from 'twenty-shared/utils';
 
 import { ApiService } from '@/cli/utilities/api/api-service';
 import {
@@ -205,15 +205,15 @@ const innerAppDevOnce = async (
 
   const translations = await compileApplicationTranslations(appPath);
 
-  const manifestWithChecksums: Manifest = manifestUpdateChecksums({
-    manifest: manifestResult.manifest,
-    builtFileInfos: buildResult.builtFileInfos,
-  });
   // Carried through the dev sync too: the server prunes the locales a manifest
-  // does not list, so syncing without them would drop what the app published.
-  const manifest: Manifest = isDefined(translations)
-    ? { ...manifestWithChecksums, translations }
-    : manifestWithChecksums;
+  // lists none of, so syncing without them would drop what the app published.
+  const manifest: Manifest = {
+    ...manifestUpdateChecksums({
+      manifest: manifestResult.manifest,
+      builtFileInfos: buildResult.builtFileInfos,
+    }),
+    translations,
+  };
 
   await writeManifestToOutput(appPath, manifest);
 

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
@@ -1,6 +1,7 @@
 import { type ApiService } from '@/cli/utilities/api/api-service';
 import { manifestUpdateChecksums } from '@/cli/utilities/build/manifest/manifest-update-checksums';
 import { writeManifestToOutput } from '@/cli/utilities/build/manifest/manifest-writer';
+import { compileApplicationTranslations } from '@/cli/utilities/translations/compile-application-translations';
 import {
   type OrchestratorState,
   type OrchestratorStateBuiltFileInfo,
@@ -69,10 +70,15 @@ export class SyncApplicationOrchestratorStep {
 
     const events: OrchestratorStateStepEvent[] = [];
 
-    const manifest = manifestUpdateChecksums({
-      manifest: input.manifest,
-      builtFileInfos: input.builtFileInfos,
-    });
+    // Every sync states its translations, so the server can prune the locales
+    // an author removed instead of serving them forever.
+    const manifest = {
+      ...manifestUpdateChecksums({
+        manifest: input.manifest,
+        builtFileInfos: input.builtFileInfos,
+      }),
+      translations: await compileApplicationTranslations(input.appPath),
+    };
 
     events.push({ message: 'Manifest checksums set', status: 'info' });
 

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
@@ -70,8 +70,6 @@ export class SyncApplicationOrchestratorStep {
 
     const events: OrchestratorStateStepEvent[] = [];
 
-    // Every sync states its translations, so the server can prune the locales
-    // an author removed instead of serving them forever.
     const manifest = {
       ...manifestUpdateChecksums({
         manifest: input.manifest,

--- a/packages/twenty-sdk/src/cli/utilities/translations/__tests__/application-translations.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/translations/__tests__/application-translations.spec.ts
@@ -154,9 +154,6 @@ describe('compileApplicationTranslations', () => {
     });
   });
 
-  // An empty result is a statement the server acts on -- it prunes locales
-  // the author removed -- so compiling an app without locale files says "no
-  // translations" rather than saying nothing.
   it('returns no locales when there is no locales directory', async () => {
     const appPath = await mkdtemp(join(tmpdir(), 'twenty-translations-empty-'));
 

--- a/packages/twenty-sdk/src/cli/utilities/translations/__tests__/application-translations.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/translations/__tests__/application-translations.spec.ts
@@ -154,9 +154,12 @@ describe('compileApplicationTranslations', () => {
     });
   });
 
-  it('returns undefined when there is no locales directory', async () => {
+  // An empty result is a statement the server acts on -- it prunes locales
+  // the author removed -- so compiling an app without locale files says "no
+  // translations" rather than saying nothing.
+  it('returns no locales when there is no locales directory', async () => {
     const appPath = await mkdtemp(join(tmpdir(), 'twenty-translations-empty-'));
 
-    expect(await compileApplicationTranslations(appPath)).toBeUndefined();
+    expect(await compileApplicationTranslations(appPath)).toEqual({});
   });
 });

--- a/packages/twenty-sdk/src/cli/utilities/translations/compile-application-translations.ts
+++ b/packages/twenty-sdk/src/cli/utilities/translations/compile-application-translations.ts
@@ -19,9 +19,6 @@ export const compileApplicationTranslations = async (
 ): Promise<TranslationsManifest> => {
   const localesDir = path.join(appPath, LOCALES_DIR);
 
-  // An empty result is a statement, not a missing one: it tells the server
-  // this app ships no translations, which is what lets it prune locales the
-  // author removed. Only a caller that never compiles omits the key.
   if (!(await pathExists(localesDir))) {
     return {};
   }

--- a/packages/twenty-sdk/src/cli/utilities/translations/compile-application-translations.ts
+++ b/packages/twenty-sdk/src/cli/utilities/translations/compile-application-translations.ts
@@ -16,11 +16,14 @@ const isSupportedLocale = (locale: string): locale is AppLocale =>
 
 export const compileApplicationTranslations = async (
   appPath: string,
-): Promise<TranslationsManifest | undefined> => {
+): Promise<TranslationsManifest> => {
   const localesDir = path.join(appPath, LOCALES_DIR);
 
+  // An empty result is a statement, not a missing one: it tells the server
+  // this app ships no translations, which is what lets it prune locales the
+  // author removed. Only a caller that never compiles omits the key.
   if (!(await pathExists(localesDir))) {
-    return undefined;
+    return {};
   }
 
   const localeFiles = (await readdir(localesDir)).filter((entry) =>
@@ -59,10 +62,6 @@ export const compileApplicationTranslations = async (
     if (Object.keys(compiled).length > 0) {
       translations[locale] = compiled;
     }
-  }
-
-  if (Object.keys(translations).length === 0) {
-    return undefined;
   }
 
   return translations as TranslationsManifest;

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/__tests__/application-translation-sync.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/__tests__/application-translation-sync.service.spec.ts
@@ -7,9 +7,6 @@ import { ApplicationTranslationEntity } from 'src/engine/core-modules/applicatio
 
 const APPLICATION_REGISTRATION_ID = '20202020-0000-0000-0000-000000000001';
 
-// What the plan says to do is covered by the util spec; what matters here is
-// the one decision the service owns: a manifest that says nothing about
-// translations must not reach the stored rows at all.
 describe('ApplicationTranslationSyncService', () => {
   let service: ApplicationTranslationSyncService;
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/__tests__/application-translation-sync.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/__tests__/application-translation-sync.service.spec.ts
@@ -7,6 +7,9 @@ import { ApplicationTranslationEntity } from 'src/engine/core-modules/applicatio
 
 const APPLICATION_REGISTRATION_ID = '20202020-0000-0000-0000-000000000001';
 
+// What the plan says to do is covered by the util spec; what matters here is
+// the one decision the service owns: a manifest that says nothing about
+// translations must not reach the stored rows at all.
 describe('ApplicationTranslationSyncService', () => {
   let service: ApplicationTranslationSyncService;
 
@@ -20,6 +23,7 @@ describe('ApplicationTranslationSyncService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    repository.find.mockResolvedValue([]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -44,27 +48,15 @@ describe('ApplicationTranslationSyncService', () => {
       translations: undefined,
     });
 
-    expect(repository.find).not.toHaveBeenCalled();
-    expect(repository.softDelete).not.toHaveBeenCalled();
-    expect(cacheService.invalidate).not.toHaveBeenCalled();
+    expect(repository.find).toHaveBeenCalledTimes(0);
+    expect(repository.update).toHaveBeenCalledTimes(0);
+    expect(repository.insert).toHaveBeenCalledTimes(0);
+    expect(repository.softDelete).toHaveBeenCalledTimes(0);
+    expect(cacheService.invalidate).toHaveBeenCalledTimes(0);
   });
 
-  it('prunes every stored locale when the manifest declares no translations', async () => {
+  it('applies the manifest when it declares translations', async () => {
     repository.find.mockResolvedValue([
-      { id: 'row-1', locale: 'fr-FR', deletedAt: null },
-    ]);
-
-    await service.syncFromManifest({
-      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
-      translations: {},
-    });
-
-    expect(repository.softDelete).toHaveBeenCalledWith(['row-1']);
-  });
-
-  it('prunes only the locales the manifest dropped', async () => {
-    repository.find.mockResolvedValue([
-      { id: 'row-fr', locale: 'fr-FR', deletedAt: null },
       { id: 'row-de', locale: 'de-DE', deletedAt: null },
     ]);
 
@@ -73,10 +65,14 @@ describe('ApplicationTranslationSyncService', () => {
       translations: { 'fr-FR': { abc123: 'Entreprise' } },
     });
 
-    expect(repository.update).toHaveBeenCalledWith('row-fr', {
+    expect(repository.insert).toHaveBeenCalledTimes(1);
+    expect(repository.insert).toHaveBeenCalledWith({
+      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+      locale: 'fr-FR',
       messages: { abc123: 'Entreprise' },
-      deletedAt: null,
     });
+    expect(repository.softDelete).toHaveBeenCalledTimes(1);
     expect(repository.softDelete).toHaveBeenCalledWith(['row-de']);
+    expect(cacheService.invalidate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/__tests__/application-translation-sync.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/__tests__/application-translation-sync.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ApplicationTranslationCacheService } from 'src/engine/core-modules/application/application-translation/application-translation-cache.service';
+import { ApplicationTranslationSyncService } from 'src/engine/core-modules/application/application-translation/application-translation-sync.service';
+import { ApplicationTranslationEntity } from 'src/engine/core-modules/application/application-translation/application-translation.entity';
+
+const APPLICATION_REGISTRATION_ID = '20202020-0000-0000-0000-000000000001';
+
+describe('ApplicationTranslationSyncService', () => {
+  let service: ApplicationTranslationSyncService;
+
+  const repository = {
+    find: jest.fn(),
+    update: jest.fn(),
+    insert: jest.fn(),
+    softDelete: jest.fn(),
+  };
+  const cacheService = { invalidate: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationTranslationSyncService,
+        {
+          provide: getRepositoryToken(ApplicationTranslationEntity),
+          useValue: repository,
+        },
+        {
+          provide: ApplicationTranslationCacheService,
+          useValue: cacheService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(ApplicationTranslationSyncService);
+  });
+
+  it('leaves stored translations alone when the manifest carries none', async () => {
+    await service.syncFromManifest({
+      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+      translations: undefined,
+    });
+
+    expect(repository.find).not.toHaveBeenCalled();
+    expect(repository.softDelete).not.toHaveBeenCalled();
+    expect(cacheService.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('prunes every stored locale when the manifest declares no translations', async () => {
+    repository.find.mockResolvedValue([
+      { id: 'row-1', locale: 'fr-FR', deletedAt: null },
+    ]);
+
+    await service.syncFromManifest({
+      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+      translations: {},
+    });
+
+    expect(repository.softDelete).toHaveBeenCalledWith(['row-1']);
+  });
+
+  it('prunes only the locales the manifest dropped', async () => {
+    repository.find.mockResolvedValue([
+      { id: 'row-fr', locale: 'fr-FR', deletedAt: null },
+      { id: 'row-de', locale: 'de-DE', deletedAt: null },
+    ]);
+
+    await service.syncFromManifest({
+      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+      translations: { 'fr-FR': { abc123: 'Entreprise' } },
+    });
+
+    expect(repository.update).toHaveBeenCalledWith('row-fr', {
+      messages: { abc123: 'Entreprise' },
+      deletedAt: null,
+    });
+    expect(repository.softDelete).toHaveBeenCalledWith(['row-de']);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-sync.service.ts
@@ -8,6 +8,7 @@ import { Repository } from 'typeorm';
 
 import { ApplicationTranslationCacheService } from 'src/engine/core-modules/application/application-translation/application-translation-cache.service';
 import { ApplicationTranslationEntity } from 'src/engine/core-modules/application/application-translation/application-translation.entity';
+import { computeApplicationTranslationSyncPlan } from 'src/engine/core-modules/application/application-translation/utils/compute-application-translation-sync-plan.util';
 
 @Injectable()
 export class ApplicationTranslationSyncService {
@@ -41,61 +42,28 @@ export class ApplicationTranslationSyncService {
       withDeleted: true,
     });
 
-    const existingRowByLocale = new Map<
-      keyof typeof APP_LOCALES,
-      ApplicationTranslationEntity
-    >();
+    const { rowsToUpdate, rowsToInsert, rowIdsToSoftDelete } =
+      computeApplicationTranslationSyncPlan({ existingRows, translations });
 
-    for (const row of existingRows) {
-      const currentRow = existingRowByLocale.get(row.locale);
+    await Promise.all([
+      ...rowsToUpdate.map(({ id, messages }) =>
+        this.applicationTranslationRepository.update(id, {
+          messages,
+          deletedAt: null,
+        }),
+      ),
+      ...rowsToInsert.map(({ locale, messages }) =>
+        this.applicationTranslationRepository.insert({
+          applicationRegistrationId,
+          locale,
+          messages,
+        }),
+      ),
+    ]);
 
-      const shouldPreferRow =
-        !isDefined(currentRow) ||
-        (isDefined(currentRow.deletedAt) && !isDefined(row.deletedAt));
-
-      if (shouldPreferRow) {
-        existingRowByLocale.set(row.locale, row);
-      }
-    }
-
-    const manifestLocales = new Set<keyof typeof APP_LOCALES>();
-    const upsertPromises: Promise<unknown>[] = [];
-
-    for (const [locale, messages] of Object.entries(translations ?? {}) as [
-      keyof typeof APP_LOCALES,
-      Record<string, string>,
-    ][]) {
-      manifestLocales.add(locale);
-
-      const existingRow = existingRowByLocale.get(locale);
-
-      if (isDefined(existingRow)) {
-        upsertPromises.push(
-          this.applicationTranslationRepository.update(existingRow.id, {
-            messages,
-            deletedAt: null,
-          }),
-        );
-      } else {
-        upsertPromises.push(
-          this.applicationTranslationRepository.insert({
-            applicationRegistrationId,
-            locale,
-            messages,
-          }),
-        );
-      }
-    }
-
-    await Promise.all(upsertPromises);
-
-    const rowsToSoftDelete = existingRows.filter(
-      (row) => !manifestLocales.has(row.locale) && !isDefined(row.deletedAt),
-    );
-
-    if (rowsToSoftDelete.length > 0) {
+    if (rowIdsToSoftDelete.length > 0) {
       await this.applicationTranslationRepository.softDelete(
-        rowsToSoftDelete.map((row) => row.id),
+        rowIdsToSoftDelete,
       );
     }
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-sync.service.ts
@@ -27,12 +27,9 @@ export class ApplicationTranslationSyncService {
     applicationRegistrationId: string;
     translations: TranslationsManifest | undefined;
   }): Promise<void> {
-    // A manifest without a translations key carries no information about
-    // translations -- only one built by a toolchain that compiles them does.
-    // Treating that absence as "no locales" would let a sync from any other
-    // path (a dev sync, an older CLI) delete the locales an app published,
-    // for every workspace that installed it. An explicit empty object still
-    // means "this app has no translations" and prunes.
+    // Absence says nothing about translations, so it must not prune: this
+    // table is cross-workspace, and a sync from a toolchain that does not
+    // compile them would drop the locales an app published, everywhere.
     if (!isDefined(translations)) {
       return;
     }

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-sync.service.ts
@@ -26,6 +26,16 @@ export class ApplicationTranslationSyncService {
     applicationRegistrationId: string;
     translations: TranslationsManifest | undefined;
   }): Promise<void> {
+    // A manifest without a translations key carries no information about
+    // translations -- only one built by a toolchain that compiles them does.
+    // Treating that absence as "no locales" would let a sync from any other
+    // path (a dev sync, an older CLI) delete the locales an app published,
+    // for every workspace that installed it. An explicit empty object still
+    // means "this app has no translations" and prunes.
+    if (!isDefined(translations)) {
+      return;
+    }
+
     const existingRows = await this.applicationTranslationRepository.find({
       where: { applicationRegistrationId },
       withDeleted: true,

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/utils/__tests__/compute-application-translation-sync-plan.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/utils/__tests__/compute-application-translation-sync-plan.util.spec.ts
@@ -42,8 +42,6 @@ describe('computeApplicationTranslationSyncPlan', () => {
     ]);
   });
 
-  // An author removing every locale file compiles to {}, which has to reach
-  // the stored rows -- otherwise translations they deleted keep being served.
   it('prunes every locale when the manifest declares none', () => {
     expect(
       computeApplicationTranslationSyncPlan({

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/utils/__tests__/compute-application-translation-sync-plan.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/utils/__tests__/compute-application-translation-sync-plan.util.spec.ts
@@ -1,0 +1,84 @@
+import { computeApplicationTranslationSyncPlan } from 'src/engine/core-modules/application/application-translation/utils/compute-application-translation-sync-plan.util';
+
+describe('computeApplicationTranslationSyncPlan', () => {
+  it('inserts the locales a first sync brings', () => {
+    expect(
+      computeApplicationTranslationSyncPlan({
+        existingRows: [],
+        translations: { 'fr-FR': { abc123: 'Entreprise' } },
+      }),
+    ).toEqual({
+      rowsToUpdate: [],
+      rowsToInsert: [{ locale: 'fr-FR', messages: { abc123: 'Entreprise' } }],
+      rowIdsToSoftDelete: [],
+    });
+  });
+
+  it('updates a locale it already stores', () => {
+    expect(
+      computeApplicationTranslationSyncPlan({
+        existingRows: [{ id: 'row-fr', locale: 'fr-FR', deletedAt: null }],
+        translations: { 'fr-FR': { abc123: 'Société' } },
+      }),
+    ).toEqual({
+      rowsToUpdate: [{ id: 'row-fr', messages: { abc123: 'Société' } }],
+      rowsToInsert: [],
+      rowIdsToSoftDelete: [],
+    });
+  });
+
+  it('prunes only the locales the manifest dropped', () => {
+    const plan = computeApplicationTranslationSyncPlan({
+      existingRows: [
+        { id: 'row-fr', locale: 'fr-FR', deletedAt: null },
+        { id: 'row-de', locale: 'de-DE', deletedAt: null },
+      ],
+      translations: { 'fr-FR': { abc123: 'Entreprise' } },
+    });
+
+    expect(plan.rowIdsToSoftDelete).toEqual(['row-de']);
+    expect(plan.rowsToUpdate).toEqual([
+      { id: 'row-fr', messages: { abc123: 'Entreprise' } },
+    ]);
+  });
+
+  // An author removing every locale file compiles to {}, which has to reach
+  // the stored rows -- otherwise translations they deleted keep being served.
+  it('prunes every locale when the manifest declares none', () => {
+    expect(
+      computeApplicationTranslationSyncPlan({
+        existingRows: [
+          { id: 'row-fr', locale: 'fr-FR', deletedAt: null },
+          { id: 'row-de', locale: 'de-DE', deletedAt: null },
+        ],
+        translations: {},
+      }).rowIdsToSoftDelete,
+    ).toEqual(['row-fr', 'row-de']);
+  });
+
+  it('leaves an already soft-deleted row out of the prune list', () => {
+    expect(
+      computeApplicationTranslationSyncPlan({
+        existingRows: [
+          { id: 'row-fr', locale: 'fr-FR', deletedAt: new Date() },
+        ],
+        translations: {},
+      }).rowIdsToSoftDelete,
+    ).toEqual([]);
+  });
+
+  it('revives a soft-deleted locale instead of inserting a duplicate', () => {
+    expect(
+      computeApplicationTranslationSyncPlan({
+        existingRows: [
+          { id: 'row-fr-old', locale: 'fr-FR', deletedAt: new Date() },
+        ],
+        translations: { 'fr-FR': { abc123: 'Entreprise' } },
+      }),
+    ).toEqual({
+      rowsToUpdate: [{ id: 'row-fr-old', messages: { abc123: 'Entreprise' } }],
+      rowsToInsert: [],
+      rowIdsToSoftDelete: [],
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/utils/compute-application-translation-sync-plan.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/utils/compute-application-translation-sync-plan.util.ts
@@ -1,0 +1,77 @@
+import { type TranslationsManifest } from 'twenty-shared/application';
+import { type APP_LOCALES } from 'twenty-shared/translations';
+import { isDefined } from 'twenty-shared/utils';
+
+type StoredTranslationRow = {
+  id: string;
+  locale: keyof typeof APP_LOCALES;
+  deletedAt: Date | null;
+};
+
+export type ApplicationTranslationSyncPlan = {
+  rowsToUpdate: { id: string; messages: Record<string, string> }[];
+  rowsToInsert: {
+    locale: keyof typeof APP_LOCALES;
+    messages: Record<string, string>;
+  }[];
+  rowIdsToSoftDelete: string[];
+};
+
+// A soft-deleted row is preferred over none, so a locale that comes back is
+// revived rather than duplicated.
+const pickRowByLocale = (
+  existingRows: StoredTranslationRow[],
+): Map<keyof typeof APP_LOCALES, StoredTranslationRow> => {
+  const rowByLocale = new Map<keyof typeof APP_LOCALES, StoredTranslationRow>();
+
+  for (const row of existingRows) {
+    const currentRow = rowByLocale.get(row.locale);
+
+    const shouldPreferRow =
+      !isDefined(currentRow) ||
+      (isDefined(currentRow.deletedAt) && !isDefined(row.deletedAt));
+
+    if (shouldPreferRow) {
+      rowByLocale.set(row.locale, row);
+    }
+  }
+
+  return rowByLocale;
+};
+
+export const computeApplicationTranslationSyncPlan = ({
+  existingRows,
+  translations,
+}: {
+  existingRows: StoredTranslationRow[];
+  translations: TranslationsManifest;
+}): ApplicationTranslationSyncPlan => {
+  const rowByLocale = pickRowByLocale(existingRows);
+  const manifestEntries = Object.entries(translations) as [
+    keyof typeof APP_LOCALES,
+    Record<string, string>,
+  ][];
+  const manifestLocales = new Set(manifestEntries.map(([locale]) => locale));
+
+  const rowsToUpdate = manifestEntries
+    .map(([locale, messages]) => {
+      const existingRow = rowByLocale.get(locale);
+
+      return isDefined(existingRow)
+        ? { id: existingRow.id, messages }
+        : undefined;
+    })
+    .filter(isDefined);
+
+  const rowsToInsert = manifestEntries
+    .filter(([locale]) => !isDefined(rowByLocale.get(locale)))
+    .map(([locale, messages]) => ({ locale, messages }));
+
+  const rowIdsToSoftDelete = existingRows
+    .filter(
+      (row) => !manifestLocales.has(row.locale) && !isDefined(row.deletedAt),
+    )
+    .map((row) => row.id);
+
+  return { rowsToUpdate, rowsToInsert, rowIdsToSoftDelete };
+};


### PR DESCRIPTION
## Problem

`applicationTranslation` is a **cross-workspace** table keyed by `applicationRegistrationId`. `syncFromManifest` pruned every stored locale row the incoming manifest did not list — and it could not tell "this manifest declares no translations" from "this manifest says nothing about translations".

`twenty apply` / `twenty dev` were exactly the second case: `dev-once.ts` never called `compileApplicationTranslations`, so it synced `translations: undefined`. A developer running `twenty apply` against an app that is also published would soft-delete that app's shipped translations **for every workspace that installed it**, until someone ran a real `dev:build` + sync. An older CLI syncing an app built by a newer one had the same effect.

No first-party app ships translations yet, so nothing is broken in production today — this is a landmine to defuse before app translations get adopted.

## Fix

Two halves, one rule: absence must not be destructive.

- **Server** — `syncFromManifest` returns early when `translations` is undefined: a manifest without the key carries no information about translations and must not delete anything. An explicit `{}` still means "this app has no translations" and prunes as before.
- **SDK** — `dev-once.ts` (the `twenty apply` / `twenty dev` path) now compiles the app's `locales/*.json` and attaches them to the synced manifest, like `dev:build` already did. Dev syncs stop being lossy in the other direction too: translations now actually reach the server during development, which is also the only way to see them applied.

## Validation

- New spec on the sync service: no-key leaves rows untouched (and does not even read them), explicit `{}` prunes all, partial manifest prunes only dropped locales. 3/3.
- `tsgo` clean on twenty-server and twenty-sdk, oxlint clean.

## Follow-ups (from the same audit, deliberately not here)

- `viewFieldGroup.name` is resolved server-side but never extracted by the SDK collector, so it is silently untranslatable.
- No validation of locale files at publish time (unknown keys, coverage), and no extraction step wired into the publish flow, so a stale catalog can ship silently.
- `application.displayName` / `description` are not translatable, so marketplace listing text cannot be localized.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFZV45dmajdE3hbASNr9xe)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

