### PR TITLE
Fix the flaky front-sb-test storybook shards

### DIFF
--- a/packages/twenty-front/.storybook/vitest.setup.ts
+++ b/packages/twenty-front/.storybook/vitest.setup.ts
@@ -2,6 +2,7 @@ import { Globals } from '@react-spring/web';
 import { setProjectAnnotations } from '@storybook/react-vite';
 import { MotionGlobalConfig } from 'framer-motion';
 import * as projectAnnotations from './preview';
+import { waitForServiceWorkerToControlPage } from './waitForServiceWorkerToControlPage';
 
 MotionGlobalConfig.skipAnimations = true;
 Globals.assign({ skipAnimation: true });
@@ -14,6 +15,14 @@ disableCssAnimationsStyle.innerHTML = `*, *::before, *::after {
   transition-delay: 0s !important;
 }`;
 document.head.appendChild(disableCssAnimationsStyle);
+
+// msw registers its service worker while ./preview evaluates, and it reloads
+// any page that has a registration without being controlled by it, which
+// vitest reports as "the iframe was reloaded during a test" and which fails
+// the whole shard. Holding every file here until the worker controls its page
+// (including files that run zero tests, which otherwise complete instantly)
+// means no test iframe is ever created while the worker is still activating.
+await waitForServiceWorkerToControlPage();
 
 // Pre-warm the dynamic imports used by lazy() story components so the
 // modules are cached before any test runs (avoids flaky timeouts and Argos

--- a/packages/twenty-front/.storybook/waitForServiceWorkerToControlPage.ts
+++ b/packages/twenty-front/.storybook/waitForServiceWorkerToControlPage.ts
@@ -1,0 +1,38 @@
+import { isDefined } from 'twenty-shared/utils';
+
+// The worker takes tens of seconds to activate on CI, because its script
+// request queues behind the story module transforms. serviceWorker.ready is
+// used rather than getRegistration() because msw registers the worker
+// asynchronously while ./preview evaluates, so the registration may not exist
+// yet when this runs. The backstop covers a worker that never activates.
+const SERVICE_WORKER_CONTROL_BACKSTOP_MS = 60_000;
+
+export const waitForServiceWorkerToControlPage = async () => {
+  if (isDefined(navigator.serviceWorker.controller)) {
+    return;
+  }
+
+  const backstop = new Promise<void>((resolve) => {
+    setTimeout(resolve, SERVICE_WORKER_CONTROL_BACKSTOP_MS);
+  });
+
+  await Promise.race([
+    navigator.serviceWorker.ready.then(() => undefined),
+    backstop,
+  ]);
+
+  if (isDefined(navigator.serviceWorker.controller)) {
+    return;
+  }
+
+  await Promise.race([
+    new Promise<void>((resolve) => {
+      navigator.serviceWorker.addEventListener(
+        'controllerchange',
+        () => resolve(),
+        { once: true },
+      );
+    }),
+    backstop,
+  ]);
+};


### PR DESCRIPTION
`front-sb-test (3, pages)` failed about one run in three with `The iframe for X.stories.tsx was reloaded during a test`, which aborts the whole shard (`retry` cannot help, it is a run-level unhandled error).

msw calls `location.reload()` on any page that has a service worker registration without being controlled by it. It registers that worker while `preview.tsx` evaluates inside a tester iframe, by which point the dev server is busy serving story modules and the worker takes ~45s to activate on CI. Files that run zero tests (skipped stories) complete without awaiting anything, freeing a worker slot inside that window, so the next iframe is created registered-but-uncontrolled and msw reloads it mid-test.

The fix is one await in the storybook vitest setup file, which every test file passes through: after `./preview` has started the worker, wait until it controls the page. Iframes that exist during activation are claimed by `clients.claim()`, and since no file can complete before that, every later iframe starts only once the worker is active and is controlled from birth. `serviceWorker.ready` is used rather than `getRegistration()` because msw registers asynchronously, so the registration may not exist yet when the setup file runs.

Verified against a harness that delays the worker script to force the race: on `main` the reload reproduces; with this change wave-1 iframes hold until claimed and later iframes start controlled, across shuffled orders and CI-like concurrency. All 12 storybook shards pass and the previously flaky shard was re-run repeatedly on CI.