### PR TITLE
v1.6.3 — Remove the ranking field from the partner model

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-partners",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/application-intake/__tests__/submit-partner-application.integration-test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/application-intake/__tests__/submit-partner-application.integration-test.ts
@@ -207,7 +207,7 @@ describe('submit-partner-application handler — upsert', () => {
     expect(node?.hourlyRate).toEqual({ amountMicros: 175_000_000, currencyCode: 'USD' });
   });
 
-  it('preserves staff-owned columns (validationStage, ranking, reviewed) on resubmission', async () => {
+  it('preserves staff-owned columns (validationStage, reviewed) on resubmission', async () => {
     const first = await handler(authedEvent(baseInput({ email: 'staff.preserve@example.com' })));
     await trackCreated(first);
     expect(first.ok).toBe(true);
@@ -217,7 +217,7 @@ describe('submit-partner-application handler — upsert', () => {
       updatePartner: {
         __args: {
           id: first.partnerId,
-          data: { validationStage: 'VALIDATED', reviewed: true, ranking: 'RATING_4' },
+          data: { validationStage: 'VALIDATED', reviewed: true },
         },
         id: true,
       },
@@ -232,14 +232,12 @@ describe('submit-partner-application handler — upsert', () => {
         __args: { filter: { id: { eq: second.partnerId } } },
         validationStage: true,
         reviewed: true,
-        ranking: true,
         city: true,
       },
     });
     const node = partner.partner;
     expect(node?.validationStage).toBe('VALIDATED');
     expect(node?.reviewed).toBe(true);
-    expect(node?.ranking).toBe('RATING_4');
     expect(node?.city).toBe('Berlin');
   });
 

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/objects/partner.object.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/objects/partner.object.ts
@@ -53,21 +53,6 @@ export default defineObject({
       isNullable: true,
     },
     {
-      universalIdentifier: '5412e4ca-cc96-4be8-8652-b73dace7673b',
-      type: FieldType.RATING,
-      name: 'ranking',
-      label: 'Ranking',
-      icon: 'IconStar',
-      isNullable: true,
-      options: [
-        { id: 'e4c784f0-7e2b-4eca-94dc-fc447266f252', value: 'RATING_1', label: '1', position: 0 },
-        { id: '79d033bd-4189-4f69-a9d1-a54d7cbbc5bc', value: 'RATING_2', label: '2', position: 1 },
-        { id: '1206bdcc-a804-4649-a3ce-bd001a3abc2c', value: 'RATING_3', label: '3', position: 2 },
-        { id: '1c195738-d823-415e-b4db-44a6cdc09ec5', value: 'RATING_4', label: '4', position: 3 },
-        { id: '92cd3a72-8d5b-4077-a369-ddfe429aa2aa', value: 'RATING_5', label: '5', position: 4 },
-      ],
-    },
-    {
       universalIdentifier: 'd4fa6461-37b6-49ee-9181-dd482e74a70b',
       type: FieldType.SELECT,
       name: 'partnerTier',

--- a/packages/twenty-apps/internal/twenty-partners/src/roles/partner.role.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/roles/partner.role.ts
@@ -312,11 +312,6 @@ export default defineRole({
       canUpdateFieldValue: false,
     },
     {
-      objectUniversalIdentifier: PARTNER_OBJECT_UNIVERSAL_IDENTIFIER,
-      fieldUniversalIdentifier: '5412e4ca-cc96-4be8-8652-b73dace7673b',
-      canUpdateFieldValue: false,
-    },
-    {
       // Partner Tier — read-locked too: admin-only on the record page, hidden from partners.
       objectUniversalIdentifier: PARTNER_OBJECT_UNIVERSAL_IDENTIFIER,
       fieldUniversalIdentifier: 'd4fa6461-37b6-49ee-9181-dd482e74a70b',

--- a/packages/twenty-apps/internal/twenty-partners/src/skills/_shared/partner-api.md
+++ b/packages/twenty-apps/internal/twenty-partners/src/skills/_shared/partner-api.md
@@ -70,7 +70,7 @@ query ListPartners($after: String) {
       id name slug introduction
       languagesSpoken country region city
       deploymentExpertise partnerScope skills typeOfTeam
-      partnerTier ranking
+      partnerTier
       twentyExperience twentyExperienceNotes
       hourlyRate { amountMicros currencyCode }
       projectBudgetMin { amountMicros currencyCode }

--- a/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-shortlist/SKILL.md
+++ b/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-shortlist/SKILL.md
@@ -116,8 +116,8 @@ Rules:
 - Read the partner's **notes** (`noteTargets` filtered by `targetPartnerId`) when there are
   any. A `Partner call recap:` note carries what was actually said on a call, which beats
   self-written copy. About 5 partners have one.
-- `partnerTier` and `ranking` are the user's own past judgements. Report them where set;
-  never let them reorder the list.
+- `partnerTier` is the user's own past judgement. Report it where set; never let it
+  reorder the list.
 
 Head the output with the lead's budget line from the criteria file, usually "not stated".
 Show each partner's rate next to it. Do not compute a verdict from the comparison.

--- a/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-triage/SKILL.md
+++ b/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-triage/SKILL.md
@@ -102,11 +102,9 @@ Rules:
 
 - **Not a gate.** It never moves anyone to `REJECTED` or out of the funnel.
 - **Not a writer.** It never edits a record. Surfacing only.
-- **Not the production cron.** This is the dev surface for the ranking. Once the chase-list is
-  trustworthy, `rank.py` is what gets ported to a daily logic-function cron that writes
-  `ranking` and a tier onto each record so the workspace view sorts itself. The judgment pass
-  stays here, for the runs where a human is in the loop. Build the skill, trust it, port the
-  cheap part. Don't build both.
+- **Not the production cron.** This is the dev surface. The score `rank.py` computes stays
+  local to a run — it is never written back onto a record. The judgment pass stays here, for
+  the runs where a human is in the loop.
 
 ## Self-check
 

--- a/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-triage/SKILL.md
+++ b/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-triage/SKILL.md
@@ -102,7 +102,7 @@ Rules:
 
 - **Not a gate.** It never moves anyone to `REJECTED` or out of the funnel.
 - **Not a writer.** It never edits a record. Surfacing only.
-- **Not the production cron.** This is the dev surface. The score `rank.py` computes stays
+- **Not the production cron.** This is the dev surface for the chase-list. The score `rank.py` computes stays
   local to a run — it is never written back onto a record. The judgment pass stays here, for
   the runs where a human is in the loop.
 

--- a/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-triage/SKILL.md
+++ b/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-triage/SKILL.md
@@ -102,9 +102,8 @@ Rules:
 
 - **Not a gate.** It never moves anyone to `REJECTED` or out of the funnel.
 - **Not a writer.** It never edits a record. Surfacing only.
-- **Not the production cron.** This is the dev surface for the chase-list. The score
-  `rank.py` computes stays local to a run — it is never written back onto a record. The
-  judgment pass stays here, for the runs where a human is in the loop.
+- **Not a background job.** Nothing here is scheduled. The judgment pass stays here, for
+  the runs where a human is in the loop.
 
 ## Self-check
 

--- a/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-triage/SKILL.md
+++ b/packages/twenty-apps/internal/twenty-partners/src/skills/twenty-partner-triage/SKILL.md
@@ -102,9 +102,9 @@ Rules:
 
 - **Not a gate.** It never moves anyone to `REJECTED` or out of the funnel.
 - **Not a writer.** It never edits a record. Surfacing only.
-- **Not the production cron.** This is the dev surface for the chase-list. The score `rank.py` computes stays
-  local to a run — it is never written back onto a record. The judgment pass stays here, for
-  the runs where a human is in the loop.
+- **Not the production cron.** This is the dev surface for the chase-list. The score
+  `rank.py` computes stays local to a run — it is never written back onto a record. The
+  judgment pass stays here, for the runs where a human is in the loop.
 
 ## Self-check
 


### PR DESCRIPTION
Deletes the `ranking` RATING field from the twenty-partners Partner object. Bumps the app to 1.6.3.

Nothing in the app's source read or wrote it: no view, page-layout, service, mapper, connector, or seed script referenced the field or its UUID `5412e4ca-cc96-4be8-8652-b73dace7673b`.

- `partner.object.ts` — field declaration removed
- `partner.role.ts` — field permission entry removed
- `submit-partner-application.integration-test.ts` — the staff-owned-columns test now guards `validationStage` and `reviewed` only
- three bundled skill docs — every mention removed, including the triage doc's plan for a cron that would have written the field back

## Verified against a live workspace

The app was installed with the field present, then the field-less manifest was synced against it. The sync reported:

    Plan: 0 to add, 0 to change, 4 to destroy.
      # fieldMetadata "ranking" will be destroyed
      # viewField "1554fb84-d4d5-5123-81b0-9ac0f41b6415" will be destroyed
      # viewField "52c86084-e640-548b-be1c-fa772bf91314" will be destroyed
      # fieldPermission "828b68a2-9020-54d0-9281-130f7d9b2281" will be destroyed
    Warning: 1 destructive change(s) will permanently delete data.
      - fieldMetadata "ranking" — drops the column and its data

After applying with `--force`, schema introspection returns no `ranking` field and the `fieldMetadata` row is gone. Unit (221) and integration (47) suites pass against the resulting schema.

## Before deploying

- **The destroy cascades beyond the field itself.** It took four objects here: the field metadata, its role permission, and two view fields a workspace creates automatically per list view showing the column. That count is workspace state, not source state — if anyone added the column to another view, or sorted or filtered by it, production's plan will carry more rows. Read the plan output before passing `--force`.
- **The CLI refuses destructive changes non-interactively** and demands `--force`.
- **The rehearsal workspace held no Partner records**, so the column drop ran on an empty table. The DDL is the same, but production drops a column holding real values.
- Existing `ranking` values are dropped with no backup. That is deliberate. Worth a `SELECT count(*) ... WHERE ranking IS NOT NULL` first, so the number of affected records is on record.
