### PR TITLE
perf(record-index): memoize records gql fields and size the table skeleton to the viewport

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/hooks/useRelevantRecordsGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/hooks/useRelevantRecordsGqlFields.ts
@@ -13,6 +13,7 @@ import { useRecordIndexContextOrThrow } from '@/object-record/record-index/conte
 
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useMemo } from 'react';
 import { filterDuplicatesById, isDefined } from 'twenty-shared/utils';
 
 type UseRecordsUsefulGqlFields = {
@@ -37,74 +38,86 @@ export const useRelevantRecordsGqlFields = ({
 
   const { objectMetadataItems } = useObjectMetadataItems();
 
-  const visibleRecordFieldMetadataItems = visibleRecordFields
-    .map(
-      (field) =>
-        fieldMetadataItemByFieldMetadataItemId[field.fieldMetadataItemId],
-    )
-    .filter(isDefined);
+  const additionalFieldMetadataIdsKey = additionalFieldMetadataIds.join(',');
 
-  const recordFilterFields = currentRecordFilters
-    .map((recordFilter) =>
-      objectMetadataItem.fields.find(
-        (field) => field.id === recordFilter.fieldMetadataId,
-      ),
-    )
-    .filter(isDefined);
+  return useMemo(() => {
+    const visibleRecordFieldMetadataItems = visibleRecordFields
+      .map(
+        (field) =>
+          fieldMetadataItemByFieldMetadataItemId[field.fieldMetadataItemId],
+      )
+      .filter(isDefined);
 
-  const additionalFieldMetadataItems = additionalFieldMetadataIds
-    .filter(isDefined)
-    .map(
-      (fieldMetadataId) =>
-        fieldMetadataItemByFieldMetadataItemId[fieldMetadataId],
-    )
-    .filter(isDefined);
+    const recordFilterFields = currentRecordFilters
+      .map((recordFilter) =>
+        objectMetadataItem.fields.find(
+          (field) => field.id === recordFilter.fieldMetadataId,
+        ),
+      )
+      .filter(isDefined);
 
-  const fieldMetadataItemsToUse = [
-    ...visibleRecordFieldMetadataItems,
-    ...(recordFilterFields ?? []),
-    ...additionalFieldMetadataItems,
-  ].filter(filterDuplicatesById);
+    const additionalFieldMetadataItems = additionalFieldMetadataIdsKey
+      .split(',')
+      .filter((fieldMetadataId) => fieldMetadataId !== '')
+      .map(
+        (fieldMetadataId) =>
+          fieldMetadataItemByFieldMetadataItemId[fieldMetadataId],
+      )
+      .filter(isDefined);
 
-  const allDepthOneGqlFields = generateDepthRecordGqlFieldsFromFields({
+    const fieldMetadataItemsToUse = [
+      ...visibleRecordFieldMetadataItems,
+      ...recordFilterFields,
+      ...additionalFieldMetadataItems,
+    ].filter(filterDuplicatesById);
+
+    const allDepthOneGqlFields = generateDepthRecordGqlFieldsFromFields({
+      objectMetadataItems,
+      fields: fieldMetadataItemsToUse,
+      depth: 1,
+    });
+
+    const labelIdentifierFieldMetadataItem =
+      getLabelIdentifierFieldMetadataItem(objectMetadataItem);
+    const imageIdentifierFieldMetadataItem =
+      getImageIdentifierFieldMetadataItem(objectMetadataItem);
+
+    const hasPosition = hasObjectMetadataItemPositionField(objectMetadataItem);
+
+    const isObjectAnActivity =
+      objectMetadataItem.nameSingular === CoreObjectNameSingular.Note ||
+      objectMetadataItem.nameSingular === CoreObjectNameSingular.Task;
+
+    return {
+      id: true,
+      ...(isDefined(labelIdentifierFieldMetadataItem)
+        ? { [labelIdentifierFieldMetadataItem.name]: true }
+        : {}),
+      ...(isDefined(imageIdentifierFieldMetadataItem)
+        ? { [imageIdentifierFieldMetadataItem.name]: true }
+        : {}),
+      ...(hasPosition ? { position: true } : {}),
+      ...allDepthOneGqlFields,
+      createdAt: true,
+      updatedAt: true,
+      deletedAt: true,
+      noteTargets: generateActivityTargetGqlFields({
+        activityObjectNameSingular: CoreObjectNameSingular.Note,
+        objectMetadataItems,
+        loadRelations: isObjectAnActivity ? 'relations' : 'activity',
+      }),
+      taskTargets: generateActivityTargetGqlFields({
+        activityObjectNameSingular: CoreObjectNameSingular.Task,
+        objectMetadataItems,
+        loadRelations: isObjectAnActivity ? 'relations' : 'activity',
+      }),
+    };
+  }, [
+    visibleRecordFields,
+    currentRecordFilters,
+    fieldMetadataItemByFieldMetadataItemId,
+    objectMetadataItem,
     objectMetadataItems,
-    fields: fieldMetadataItemsToUse,
-    depth: 1,
-  });
-
-  const labelIdentifierFieldMetadataItem =
-    getLabelIdentifierFieldMetadataItem(objectMetadataItem);
-  const imageIdentifierFieldMetadataItem =
-    getImageIdentifierFieldMetadataItem(objectMetadataItem);
-
-  const hasPosition = hasObjectMetadataItemPositionField(objectMetadataItem);
-
-  const isObjectAnActivity =
-    objectMetadataItem.nameSingular === CoreObjectNameSingular.Note ||
-    objectMetadataItem.nameSingular === CoreObjectNameSingular.Task;
-
-  return {
-    id: true,
-    ...(isDefined(labelIdentifierFieldMetadataItem)
-      ? { [labelIdentifierFieldMetadataItem.name]: true }
-      : {}),
-    ...(isDefined(imageIdentifierFieldMetadataItem)
-      ? { [imageIdentifierFieldMetadataItem.name]: true }
-      : {}),
-    ...(hasPosition ? { position: true } : {}),
-    ...allDepthOneGqlFields,
-    createdAt: true,
-    updatedAt: true,
-    deletedAt: true,
-    noteTargets: generateActivityTargetGqlFields({
-      activityObjectNameSingular: CoreObjectNameSingular.Note,
-      objectMetadataItems,
-      loadRelations: isObjectAnActivity ? 'relations' : 'activity',
-    }),
-    taskTargets: generateActivityTargetGqlFields({
-      activityObjectNameSingular: CoreObjectNameSingular.Task,
-      objectMetadataItems,
-      loadRelations: isObjectAnActivity ? 'relations' : 'activity',
-    }),
-  };
+    additionalFieldMetadataIdsKey,
+  ]);
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyLoading.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyLoading.tsx
@@ -11,9 +11,16 @@ import { RecordTableCellLoading } from '@/object-record/record-table/record-tabl
 import { RecordTableLastEmptyCell } from '@/object-record/record-table/record-table-cell/components/RecordTableLastEmptyCell';
 import { RecordTablePlusButtonCellPlaceholder } from '@/object-record/record-table/record-table-cell/components/RecordTablePlusButtonCellPlaceholder';
 import { RecordTableTr } from '@/object-record/record-table/record-table-row/components/RecordTableTr';
+import { RECORD_TABLE_ROW_HEIGHT } from '@/object-record/record-table/constants/RecordTableRowHeight';
+
+const LOADING_ROWS_BUFFER = 2;
 
 export const RecordTableBodyLoading = () => {
   const { visibleRecordFields } = useRecordTableContextOrThrow();
+
+  const numberOfLoadingRows =
+    Math.ceil(window.innerHeight / RECORD_TABLE_ROW_HEIGHT) +
+    LOADING_ROWS_BUFFER;
 
   const isRecordTableDragColumnHidden = useAtomComponentStateValue(
     isRecordTableDragColumnHiddenComponentState,
@@ -24,7 +31,7 @@ export const RecordTableBodyLoading = () => {
 
   return (
     <RecordTableBody>
-      {Array.from({ length: 80 }).map((_, rowIndex) => (
+      {Array.from({ length: numberOfLoadingRows }).map((_, rowIndex) => (
         <RecordTableRowContextProvider
           key={rowIndex}
           value={{


### PR DESCRIPTION
Supersedes #23911 by @rollecode, keeping the two commits from it that stand on their own. Both commits keep their original authorship.

## What this keeps

**Memoize the relevant records gql fields.** `useRelevantRecordsGqlFields` returned a fresh object literal on every render, which is a dependency of the `useMemo` in `useFindManyRecordsQuery`. The GraphQL document was therefore regenerated on every render of the record index, across all six callers of the hook.

**Size the table loading skeleton to the viewport.** `RecordTableBodyLoading` mounted 80 rows times every visible column while the virtualizer shows about 15. It now mounts what fits the viewport plus a small buffer: 31 rows at 900px instead of 80.

## What this drops from #23911

- **Keeping rows on screen during the initial load.** Moving the row wipe after the await leaves the table mounted and interactive while the fetch is in flight, so a record created from the "+" row in that window is swept into the clear set and replaced by a response that predates it. The virtualized row treadmill is also reset before the await while the scroll reset happens after, so a scrolled table remaps its kept rows to the top for the duration.
- **Scoping the load guards to their own component instance.** The record table instance id already contains the view id, so this turns the view-change branch into dead code and a view fetches once per tab, never refetching on revisit. SSE is unsubscribed while the table is unmounted, so that is a data freshness decision to make on its own rather than inside a perf PR.
- **Showing the board column skeleton only when the column is empty.** `recordBoardShouldFetchMoreInColumn` defaults to true and clears once a column is fully loaded, so those skeletons are the "more pages below" indicator while paginating, not a spurious loader.

## Test plan

- [x] Companies (608) and People (1202) record tables load with every column populated
- [x] Opportunities `By Stage` kanban renders all columns and card fields, covering the `additionalFieldMetadataIds` path
- [x] Loading skeleton renders 31 rows at a 900px viewport, matching `ceil(innerHeight / 32) + 2`
- [x] No JS exceptions and no GraphQL errors across table, board and view switching

Not measured: the render-count improvement itself. The memo is correct but unprofiled, and it still recomputes whenever the record index provider re-renders, because `fieldMetadataItemByFieldMetadataItemId` is rebuilt with `Object.fromEntries` in `useRecordIndexFieldMetadataDerivedStates`. Memoizing that map at the source is the natural follow-up.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

