### PR TITLE
feat(workflow): rollout command for the core read/dispatch cutover

### DIFF
--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -7,6 +7,7 @@ import { DataSeedWorkspaceCommand } from 'src/database/commands/data-seed-dev-wo
 import { SecretEncryptionRotationModule } from 'src/database/commands/secret-encryption-rotation/secret-encryption-rotation.module';
 import { GenerateInstanceCommandCommand } from 'src/database/commands/generate-instance-command.command';
 import { InstallPreInstalledAppsCommand } from 'src/database/commands/install-pre-installed-apps.command';
+import { MigrateWorkflowReadsToCoreCommand } from 'src/database/commands/migrate-workflow-reads-to-core.command';
 import { InstanceCommandGenerationService } from 'src/database/commands/instance-command-generation.service';
 import { ListOrphanedWorkspaceEntitiesCommand } from 'src/database/commands/list-and-delete-orphaned-workspace-entities.command';
 import { ConfirmationQuestion } from 'src/database/commands/questions/confirmation.question';
@@ -114,6 +115,7 @@ import { WorkflowCoreConsistencyModule } from 'src/modules/workflow/workflow-cor
     UpgradeStatusCommand,
     RebuildApplicationDefaultDepsCommand,
     InstallPreInstalledAppsCommand,
+    MigrateWorkflowReadsToCoreCommand,
     provideWorkspaceScopedRepository(RoleEntity),
   ],
 })

--- a/packages/twenty-server/src/database/commands/migrate-workflow-reads-to-core.command.ts
+++ b/packages/twenty-server/src/database/commands/migrate-workflow-reads-to-core.command.ts
@@ -1,0 +1,104 @@
+import { Command } from 'nest-commander';
+
+import { FeatureFlagKey } from 'twenty-shared/types';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { WorkflowCoreConsistencyService } from 'src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service';
+import { flattenWorkflowCoreDrift } from 'src/modules/workflow/workflow-core-consistency/utils/flatten-workflow-core-drift.util';
+
+const WORKFLOW_CORE_CUTOVER_FLAGS = [
+  FeatureFlagKey.IS_WORKFLOW_VERSION_IN_CORE_ENABLED,
+  FeatureFlagKey.IS_WORKFLOW_DISPATCH_FROM_CORE_ENABLED,
+];
+
+@Command({
+  name: 'workflow:migrate-to-core',
+  description:
+    'Per workspace: verify workspace/core workflow consistency, then enable the core read and dispatch flags. Workspaces with drift are reported and skipped.',
+})
+export class MigrateWorkflowReadsToCoreCommand extends ProvisionedWorkspaceCommandRunner {
+  private readonly migratedWorkspaceIds: string[] = [];
+  private readonly driftedWorkspaceIds: string[] = [];
+
+  constructor(
+    protected override readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workflowCoreConsistencyService: WorkflowCoreConsistencyService,
+    private readonly featureFlagService: FeatureFlagService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    index,
+    total,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const dryRun = options.dryRun ?? false;
+    const prefix = `${dryRun ? '[DRY RUN] ' : ''}(${index + 1}/${total}) workspace ${workspaceId}`;
+
+    const featureFlagsMap =
+      await this.featureFlagService.getWorkspaceFeatureFlagsMap(workspaceId);
+
+    const missingFlags = WORKFLOW_CORE_CUTOVER_FLAGS.filter(
+      (flag) => featureFlagsMap[flag] !== true,
+    );
+
+    if (missingFlags.length === 0) {
+      this.logger.log(`${prefix}: already migrated, skipping`);
+
+      return;
+    }
+
+    const consistencyResult =
+      await this.workflowCoreConsistencyService.checkWorkspace(
+        workspaceId,
+        getWorkspaceSchemaName(workspaceId),
+      );
+
+    const driftEntries = flattenWorkflowCoreDrift(consistencyResult);
+
+    if (driftEntries.length > 0) {
+      this.driftedWorkspaceIds.push(workspaceId);
+      this.logger.warn(
+        `${prefix}: DRIFT detected, skipping (${driftEntries.join(', ')})`,
+      );
+
+      return;
+    }
+
+    if (dryRun) {
+      this.logger.log(
+        `${prefix}: consistent, would enable ${missingFlags.join(', ')}`,
+      );
+
+      return;
+    }
+
+    await this.featureFlagService.enableFeatureFlags(missingFlags, workspaceId);
+
+    this.migratedWorkspaceIds.push(workspaceId);
+    this.logger.log(`${prefix}: migrated (${missingFlags.join(', ')})`);
+  }
+
+  override async run(
+    passedParams: string[],
+    options: Parameters<ProvisionedWorkspaceCommandRunner['run']>[1],
+  ): Promise<void> {
+    await super.run(passedParams, options);
+
+    this.logger.log(
+      `Migration done: ${this.migratedWorkspaceIds.length} migrated, ${this.driftedWorkspaceIds.length} skipped on drift`,
+    );
+
+    if (this.driftedWorkspaceIds.length > 0) {
+      this.logger.warn(
+        `Drifted workspaces needing a resync before retry: ${this.driftedWorkspaceIds.join(', ')}`,
+      );
+    }
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -16,6 +16,12 @@ import {
 
 type DriftCounts = Record<string, number>;
 
+export type WorkflowCoreConsistencyResult = {
+  workflow: DriftCounts;
+  workflowVersion: DriftCounts;
+  automatedTrigger: DriftCounts;
+};
+
 // Detect drift between the workspace source-of-truth records and their core
 // mirror. The dual-write is best-effort (async, not transactional), so core can
 // silently fall out of sync; this quantifies that per workspace as metrics.
@@ -41,7 +47,28 @@ export class WorkflowCoreConsistencyService {
 
     for (const { workspaceId, databaseSchema } of workspaces) {
       try {
-        await this.checkWorkspace(workspaceId, databaseSchema);
+        const result = await this.checkWorkspace(workspaceId, databaseSchema);
+
+        if (isDefined(result)) {
+          this.emitDrift(
+            MetricsKeys.WorkflowCoreConsistencyWorkflowDrift,
+            workspaceId,
+            'workflow',
+            result.workflow,
+          );
+          this.emitDrift(
+            MetricsKeys.WorkflowCoreConsistencyVersionDrift,
+            workspaceId,
+            'workflowVersion',
+            result.workflowVersion,
+          );
+          this.emitDrift(
+            MetricsKeys.WorkflowCoreConsistencyAutomatedTriggerDrift,
+            workspaceId,
+            'automatedTrigger',
+            result.automatedTrigger,
+          );
+        }
       } catch (error) {
         this.exceptionHandlerService.captureExceptions([error], {
           workspace: { id: workspaceId },
@@ -50,10 +77,10 @@ export class WorkflowCoreConsistencyService {
     }
   }
 
-  private async checkWorkspace(
+  async checkWorkspace(
     workspaceId: string,
     schema: string,
-  ): Promise<void> {
+  ): Promise<WorkflowCoreConsistencyResult | null> {
     const [{ shouldCheck }] = await this.coreDataSource.query(
       `SELECT (
          EXISTS (SELECT 1 FROM "${schema}"."workflow" WHERE "deletedAt" IS NULL)
@@ -63,24 +90,29 @@ export class WorkflowCoreConsistencyService {
     );
 
     if (!shouldCheck) {
-      return;
+      return null;
     }
 
-    await this.checkWorkflowSync(workspaceId, schema);
-    await this.checkWorkflowVersionSync(workspaceId, schema);
-    await this.checkAutomatedTriggerSync(workspaceId, schema);
+    return {
+      workflow: await this.checkWorkflowSync(workspaceId, schema),
+      workflowVersion: await this.checkWorkflowVersionSync(workspaceId, schema),
+      automatedTrigger: await this.checkAutomatedTriggerSync(
+        workspaceId,
+        schema,
+      ),
+    };
   }
 
   private async checkWorkflowSync(
     workspaceId: string,
     schema: string,
-  ): Promise<void> {
+  ): Promise<DriftCounts> {
     const [counts] = await this.coreDataSource.query(
       `SELECT
          count(*) FILTER (WHERE wf."coreWorkflowId" IS NULL)::int AS unlinked,
          count(*) FILTER (WHERE wf."coreWorkflowId" IS NOT NULL AND c.id IS NULL)::int AS "missingCore",
          count(*) FILTER (WHERE c.id IS NOT NULL AND (
-           wf.name IS DISTINCT FROM c.name
+           NULLIF(wf.name, '') IS DISTINCT FROM NULLIF(c.name, '')
            OR NULLIF(wf."lastPublishedVersionId", '') IS DISTINCT FROM c."lastPublishedVersionId"::text
          ))::int AS "fieldMismatch"
        FROM "${schema}"."workflow" wf
@@ -100,23 +132,18 @@ export class WorkflowCoreConsistencyService {
       [workspaceId],
     );
 
-    this.emitDrift(
-      MetricsKeys.WorkflowCoreConsistencyWorkflowDrift,
-      workspaceId,
-      'workflow',
-      {
-        unlinked: counts.unlinked,
-        missingCore: counts.missingCore,
-        fieldMismatch: counts.fieldMismatch,
-        orphanCore,
-      },
-    );
+    return {
+      unlinked: counts.unlinked,
+      missingCore: counts.missingCore,
+      fieldMismatch: counts.fieldMismatch,
+      orphanCore,
+    };
   }
 
   private async checkWorkflowVersionSync(
     workspaceId: string,
     schema: string,
-  ): Promise<void> {
+  ): Promise<DriftCounts> {
     const [counts] = await this.coreDataSource.query(
       `SELECT
          count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NULL)::int AS unlinked,
@@ -146,23 +173,18 @@ export class WorkflowCoreConsistencyService {
       [workspaceId],
     );
 
-    this.emitDrift(
-      MetricsKeys.WorkflowCoreConsistencyVersionDrift,
-      workspaceId,
-      'workflowVersion',
-      {
-        unlinked: counts.unlinked,
-        missingCore: counts.missingCore,
-        fieldMismatch: counts.fieldMismatch,
-        orphanCore,
-      },
-    );
+    return {
+      unlinked: counts.unlinked,
+      missingCore: counts.missingCore,
+      fieldMismatch: counts.fieldMismatch,
+      orphanCore,
+    };
   }
 
   private async checkAutomatedTriggerSync(
     workspaceId: string,
     schema: string,
-  ): Promise<void> {
+  ): Promise<DriftCounts> {
     const { workflowAutomatedTriggerMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
         'workflowAutomatedTriggerMaps',
@@ -208,12 +230,7 @@ export class WorkflowCoreConsistencyService {
       }
     }
 
-    this.emitDrift(
-      MetricsKeys.WorkflowCoreConsistencyAutomatedTriggerDrift,
-      workspaceId,
-      'automatedTrigger',
-      { inTableNotCache, inCacheNotTable, mismatch },
-    );
+    return { inTableNotCache, inCacheNotTable, mismatch };
   }
 
   private triggerIdentity(

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/utils/__tests__/flatten-workflow-core-drift.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/utils/__tests__/flatten-workflow-core-drift.util.spec.ts
@@ -1,0 +1,55 @@
+import { flattenWorkflowCoreDrift } from 'src/modules/workflow/workflow-core-consistency/utils/flatten-workflow-core-drift.util';
+
+describe('flattenWorkflowCoreDrift', () => {
+  it('should return no entries for a workspace without workflows', () => {
+    expect(flattenWorkflowCoreDrift(null)).toEqual([]);
+  });
+
+  it('should return no entries when every counter is zero', () => {
+    expect(
+      flattenWorkflowCoreDrift({
+        workflow: {
+          unlinked: 0,
+          missingCore: 0,
+          fieldMismatch: 0,
+          orphanCore: 0,
+        },
+        workflowVersion: {
+          unlinked: 0,
+          missingCore: 0,
+          fieldMismatch: 0,
+          orphanCore: 0,
+        },
+        automatedTrigger: {
+          inTableNotCache: 0,
+          inCacheNotTable: 0,
+          mismatch: 0,
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it('should name every non-zero counter with its entity', () => {
+    expect(
+      flattenWorkflowCoreDrift({
+        workflow: {
+          unlinked: 2,
+          missingCore: 0,
+          fieldMismatch: 0,
+          orphanCore: 0,
+        },
+        workflowVersion: {
+          unlinked: 0,
+          missingCore: 0,
+          fieldMismatch: 1,
+          orphanCore: 0,
+        },
+        automatedTrigger: {
+          inTableNotCache: 0,
+          inCacheNotTable: 0,
+          mismatch: 0,
+        },
+      }),
+    ).toEqual(['workflow.unlinked=2', 'workflowVersion.fieldMismatch=1']);
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/utils/flatten-workflow-core-drift.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/utils/flatten-workflow-core-drift.util.ts
@@ -1,0 +1,17 @@
+import { type WorkflowCoreConsistencyResult } from 'src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service';
+
+// A workspace is safe to cut over only when every drift counter is zero;
+// null means the workspace has no workflows at all, which is also safe
+export const flattenWorkflowCoreDrift = (
+  result: WorkflowCoreConsistencyResult | null,
+): string[] => {
+  if (result === null) {
+    return [];
+  }
+
+  return Object.entries(result).flatMap(([entity, counts]) =>
+    Object.entries(counts)
+      .filter(([, count]) => count > 0)
+      .map(([driftType, count]) => `${entity}.${driftType}=${count}`),
+  );
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/workflow-core-consistency.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/workflow-core-consistency.module.ts
@@ -13,6 +13,6 @@ import { WorkflowCoreConsistencyService } from 'src/modules/workflow/workflow-co
     WorkflowCoreConsistencyCronJob,
     WorkflowCoreConsistencyCronCommand,
   ],
-  exports: [WorkflowCoreConsistencyCronCommand],
+  exports: [WorkflowCoreConsistencyCronCommand, WorkflowCoreConsistencyService],
 })
 export class WorkflowCoreConsistencyModule {}


### PR DESCRIPTION
## What

Adds `workflow:migrate-to-core`, the rollout command for the workflow core read/dispatch cutover, replacing manual per-workspace flag flips.

For each workspace (active or suspended, provisioned):
1. Skip if both flags are already on (idempotent).
2. Run the workflow/workflowVersion/automatedTrigger consistency checks.
3. Zero drift (or no workflows at all): enable `IS_WORKFLOW_VERSION_IN_CORE_ENABLED` + `IS_WORKFLOW_DISPATCH_FROM_CORE_ENABLED` and invalidate the feature-flag cache.
4. Any drift: report the exact counters and skip; the summary lists every skipped workspace for resync + retry.

Inherits the workspace runner options: `--dry-run`, `--workspace-id`, `--start-from-workspace-id`, `--workspace-count-limit`.

```
npx nx command twenty-server -- workflow:migrate-to-core --dry-run
```

## Changes

- `MigrateWorkflowReadsToCoreCommand` (`ProvisionedWorkflowCommandRunner` pattern, like `install-pre-installed-apps`).
- `WorkflowCoreConsistencyService`: the three checks now return their drift counts instead of emitting directly; the cron path emits the same metrics from the returned counts, and `checkWorkspace` is public so the command reuses the exact drift definition that feeds the Grafana dashboard.
- `flattenWorkflowCoreDrift` util + spec: turns a result into `entity.driftType=count` strings; empty means safe to cut over.
- Name comparison normalizes `NULL` and `''`: the mirror writes empty string for unset names, so every workspace with unnamed workflows reported permanent cosmetic drift (4 on the seed workspace) that would have blocked cutover and pages the dashboard for nothing.

## Test

- Dry run against the local instance: seed workspace first reported `workflow.fieldMismatch=4` (the NULL/`''` artifact), clean after normalization; both workspaces then reported "would enable".
- Real run enabled both flags for both workspaces (verified in `core.featureFlag`); second run is a no-op.
- `flattenWorkflowCoreDrift` spec 3/3; server typecheck and lint clean.

## Notes

- The command only reads and flips flags; it repairs nothing. Drifted workspaces need the existing resync path first.
- Rollback is manual (delete the flag rows); not automated on purpose.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

