### PR TITLE
fix(server) - index the timelineActivity message targets

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module.ts
@@ -4,8 +4,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { BackfillActivityTargetsJunctionTargetCommand } from 'src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command';
 import { MigrateCommandMenuItemLabelsToPlaceholdersCommand } from 'src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787127900000-migrate-command-menu-item-labels-to-placeholders.command';
+import { CreateTimelineActivityMessageTargetIndexesCommand } from 'src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787128000000-create-timeline-activity-message-target-indexes.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
@@ -16,12 +18,14 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     ApplicationModule,
     WorkspaceCacheModule,
     WorkspaceIteratorModule,
+    WorkspaceSchemaManagerModule,
     WorkspaceMigrationRunnerModule,
     WorkspaceMigrationModule,
   ],
   providers: [
     BackfillActivityTargetsJunctionTargetCommand,
     MigrateCommandMenuItemLabelsToPlaceholdersCommand,
+    CreateTimelineActivityMessageTargetIndexesCommand,
   ],
 })
 export class V2_33_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787128000000-create-timeline-activity-message-target-indexes.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787128000000-create-timeline-activity-message-target-indexes.command.ts
@@ -1,0 +1,223 @@
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
+
+const TIMELINE_ACTIVITY = STANDARD_OBJECTS.timelineActivity;
+
+// The marketing email work added these two targets without declaring their
+// indexes, so they shipped unindexed while the other nine targets were covered.
+const MISSING_INDEXES = [
+  {
+    indexUniversalIdentifier:
+      TIMELINE_ACTIVITY.indexes.messageListIdIndex.universalIdentifier,
+    fieldUniversalIdentifier:
+      TIMELINE_ACTIVITY.fields.targetMessageList.universalIdentifier,
+  },
+  {
+    indexUniversalIdentifier:
+      TIMELINE_ACTIVITY.indexes.messageCampaignIdIndex.universalIdentifier,
+    fieldUniversalIdentifier:
+      TIMELINE_ACTIVITY.fields.targetMessageCampaign.universalIdentifier,
+  },
+];
+
+@RegisteredWorkspaceCommand('2.33.0', 1787128000000)
+@Command({
+  name: 'upgrade:2-33:create-timeline-activity-message-target-indexes',
+  description:
+    'Create the missing BTREE indexes on timelineActivity.targetMessageListId and timelineActivity.targetMessageCampaignId. Indexes are created with CONCURRENTLY so writes are not blocked.',
+})
+export class CreateTimelineActivityMessageTargetIndexesCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceSchemaManagerService: WorkspaceSchemaManagerService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    dataSource,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    if (!isDefined(dataSource)) {
+      this.logger.log(`No data source for workspace ${workspaceId}, skipping`);
+
+      return;
+    }
+
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps, flatIndexMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+        'flatFieldMetadataMaps',
+        'flatIndexMaps',
+      ]);
+
+    const flatObjectMetadata =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier: TIMELINE_ACTIVITY.universalIdentifier,
+      });
+
+    if (!isDefined(flatObjectMetadata)) {
+      this.logger.log(
+        `timelineActivity object does not exist for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    // A workspace that predates the marketing email work has neither the target
+    // field nor a column to index, and the standard sync adds both together.
+    // The join column is read back off the field so a renamed field still
+    // resolves to the column it actually owns.
+    const indexesToCreate = MISSING_INDEXES.map(
+      ({ indexUniversalIdentifier, fieldUniversalIdentifier }) => {
+        const flatFieldMetadata =
+          flatFieldMetadataMaps.byUniversalIdentifier[fieldUniversalIdentifier];
+
+        if (
+          isDefined(
+            flatIndexMaps.byUniversalIdentifier[indexUniversalIdentifier],
+          ) ||
+          !isDefined(flatFieldMetadata)
+        ) {
+          return undefined;
+        }
+
+        return {
+          indexUniversalIdentifier,
+          joinColumnName: computeMorphOrRelationFieldJoinColumnName({
+            name: flatFieldMetadata.name,
+          }),
+        };
+      },
+    ).filter(isDefined);
+
+    if (indexesToCreate.length === 0) {
+      return;
+    }
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        now: new Date().toISOString(),
+        workspaceId,
+        twentyStandardApplicationId: twentyStandardFlatApplication.id,
+      });
+
+    const indexBuildPlans = indexesToCreate.map(
+      ({ indexUniversalIdentifier, joinColumnName }) => {
+        const standardFlatIndexMetadata =
+          findFlatEntityByUniversalIdentifier<FlatIndexMetadata>({
+            flatEntityMaps: standardAllFlatEntityMaps.flatIndexMaps,
+            universalIdentifier: indexUniversalIdentifier,
+          });
+
+        if (!isDefined(standardFlatIndexMetadata)) {
+          throw new Error(
+            `Standard application is missing timelineActivity index ${indexUniversalIdentifier}`,
+          );
+        }
+
+        return { flatIndexMetadata: standardFlatIndexMetadata, joinColumnName };
+      },
+    );
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Creating ${indexBuildPlans
+        .map(({ flatIndexMetadata }) => flatIndexMetadata.name)
+        .join(', ')} for workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    const { schemaName, tableName } = getWorkspaceSchemaContextForMigration({
+      workspaceId,
+      objectMetadata: flatObjectMetadata,
+    });
+
+    const queryRunner = dataSource.createQueryRunner();
+
+    try {
+      await queryRunner.connect();
+
+      for (const { flatIndexMetadata, joinColumnName } of indexBuildPlans) {
+        await this.workspaceSchemaManagerService.indexManager.createIndex({
+          queryRunner,
+          schemaName,
+          tableName,
+          index: {
+            name: flatIndexMetadata.name,
+            columns: [joinColumnName],
+            isUnique: flatIndexMetadata.isUnique,
+            type: flatIndexMetadata.indexType,
+            where: flatIndexMetadata.indexWhereClause ?? undefined,
+          },
+          concurrently: true,
+        });
+      }
+    } finally {
+      await queryRunner.release();
+    }
+
+    const result =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+          allFlatEntityOperationByMetadataName: {
+            index: {
+              flatEntityToCreate: indexBuildPlans.map(
+                ({ flatIndexMetadata }) => flatIndexMetadata,
+              ),
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+        },
+      );
+
+    if (result.status === 'fail') {
+      this.logger.error(
+        `Failed to persist timelineActivity message target index metadata:\n${JSON.stringify(result, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to create timelineActivity message target indexes for workspace ${workspaceId}`,
+      );
+    }
+
+    this.logger.log(
+      `Created ${indexBuildPlans.length} timelineActivity message target index(es) for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/__tests__/polymorphic-standard-object-index-coverage.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/__tests__/polymorphic-standard-object-index-coverage.spec.ts
@@ -1,0 +1,61 @@
+import { DEFAULT_RELATIONS_OBJECTS_STANDARD_IDS } from 'twenty-shared/metadata';
+import { RelationType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+
+const WORKSPACE_ID = '20202020-1111-4111-8111-111111111111';
+const TWENTY_STANDARD_APPLICATION_ID = '20202020-2222-4222-8222-222222222222';
+const NOW = '2024-01-01T00:00:00.000Z';
+
+// Every target join column on these objects is filtered on by the timeline,
+// attachment and activity target queries, and each target is declared by hand
+// in three separate places. Without this guard a new target ships unindexed.
+describe('polymorphic standard object index coverage', () => {
+  const { allFlatEntityMaps } =
+    computeTwentyStandardApplicationAllFlatEntityMaps({
+      now: NOW,
+      workspaceId: WORKSPACE_ID,
+      twentyStandardApplicationId: TWENTY_STANDARD_APPLICATION_ID,
+    });
+
+  const indexedFieldMetadataIds = new Set(
+    Object.values(allFlatEntityMaps.flatIndexMaps.byUniversalIdentifier)
+      .filter(isDefined)
+      .flatMap((flatIndex) =>
+        flatIndex.flatIndexFieldMetadatas.map(
+          (flatIndexFieldMetadata) => flatIndexFieldMetadata.fieldMetadataId,
+        ),
+      ),
+  );
+
+  it.each([...DEFAULT_RELATIONS_OBJECTS_STANDARD_IDS])(
+    'indexes every many to one target join column on %s',
+    (objectNameSingular) => {
+      const flatObjectMetadata = Object.values(
+        allFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier,
+      )
+        .filter(isDefined)
+        .find((candidate) => candidate.nameSingular === objectNameSingular);
+
+      expect(flatObjectMetadata).toBeDefined();
+
+      const unindexedFieldNames = Object.values(
+        allFlatEntityMaps.flatFieldMetadataMaps.byUniversalIdentifier,
+      )
+        .filter(isDefined)
+        .filter(isMorphOrRelationFlatFieldMetadata)
+        .filter(
+          (flatFieldMetadata) =>
+            flatFieldMetadata.objectMetadataId === flatObjectMetadata?.id &&
+            flatFieldMetadata.settings?.relationType ===
+              RelationType.MANY_TO_ONE &&
+            !indexedFieldMetadataIds.has(flatFieldMetadata.id),
+        )
+        .map((flatFieldMetadata) => flatFieldMetadata.name);
+
+      expect(unindexedFieldNames).toEqual([]);
+    },
+  );
+});

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-timeline-activity-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-timeline-activity-standard-flat-index-metadata.util.ts
@@ -136,4 +136,28 @@ export const buildTimelineActivityStandardFlatIndexMetadatas = ({
     twentyStandardApplicationId,
     now,
   }),
+  messageListIdIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'messageListIdIndex',
+      relatedFieldNames: ['targetMessageList'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
+  messageCampaignIdIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'messageCampaignIdIndex',
+      relatedFieldNames: ['targetMessageCampaign'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
 });

--- a/packages/twenty-shared/src/metadata/__tests__/__snapshots__/standardObjectUniversalIdentifiers.test.ts.snap
+++ b/packages/twenty-shared/src/metadata/__tests__/__snapshots__/standardObjectUniversalIdentifiers.test.ts.snap
@@ -2664,6 +2664,12 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       "dashboardIdIndex": {
         "universalIdentifier": "e8821da9-728d-470a-bf5b-5a981fff7880",
       },
+      "messageCampaignIdIndex": {
+        "universalIdentifier": "a6ee9f9a-5ac9-40b6-8046-1ebaa6bb82ff",
+      },
+      "messageListIdIndex": {
+        "universalIdentifier": "78615a19-fb94-4a4e-bc5b-b43754e17cea",
+      },
       "noteIdIndex": {
         "universalIdentifier": "995db1d8-0d3e-40f7-b0eb-5e6897bc9966",
       },

--- a/packages/twenty-shared/src/metadata/constants/standard-object.constant.ts
+++ b/packages/twenty-shared/src/metadata/constants/standard-object.constant.ts
@@ -1061,6 +1061,12 @@ export const STANDARD_OBJECTS = {
       dashboardIdIndex: {
         universalIdentifier: 'e8821da9-728d-470a-bf5b-5a981fff7880',
       },
+      messageListIdIndex: {
+        universalIdentifier: '78615a19-fb94-4a4e-bc5b-b43754e17cea',
+      },
+      messageCampaignIdIndex: {
+        universalIdentifier: 'a6ee9f9a-5ac9-40b6-8046-1ebaa6bb82ff',
+      },
     },
     views: {
       allTimelineActivities: buildStandardObjectIndexView({


### PR DESCRIPTION
`timelineActivity.targetMessageListId` and `timelineActivity.targetMessageCampaignId` have no index. The other nine timeline targets do. Every target join column is what the record timeline query filters on, so those two objects were paying a sequential scan on the largest table in the workspace schema.

## Why it was missed

Adding a timeline target means editing three unrelated places: the field block in `compute-timeline-activity-standard-flat-field-metadata.util.ts`, the index name in `STANDARD_OBJECTS.timelineActivity.indexes`, and the index block in `compute-timeline-activity-standard-flat-index-metadata.util.ts`. Nothing connects the field list to the index list, so adding a target without an index compiles and passes.

The marketing email work (#21173) added both targets and updated the field list, the entity, the shared constants and the view fields, but not the index util. Custom objects hide the gap because their target fields go through `generateIndexForFlatFieldMetadata` and get indexed automatically; only hand declared standard targets can drift.

`upgrade:2-8:backfill-relation-join-column-indexes` is generic enough to have caught this, but it ran at 2.8 and these fields shipped afterwards.

## Changes

- Declare `messageListIdIndex` and `messageCampaignIdIndex`, which fixes every newly provisioned workspace.
- `upgrade:2-33:create-timeline-activity-message-target-indexes` creates them on existing workspaces, `CONCURRENTLY` so writes are not blocked, following the 2-8 precedent. It resolves the join column from the field metadata rather than a hardcoded name, skips a workspace that has the index already, and skips one that predates the target field entirely.
- A test asserting that every many to one target on the four polymorphic standard objects (`timelineActivity`, `attachment`, `noteTarget`, `taskTarget`) is covered by a declared index. This is the part that stops the two lists drifting again.

## Verification

- The guard test passes on all four objects, and fails with `targetMessageList` listed when the declaration is removed, so it is not vacuous.
- Ran the upgrade command against two seeded workspaces provisioned before the declaration existed: both indexes created on each, confirmed present in `pg_indexes` as BTREE on the right columns.
- Re-ran it: no work done, index count unchanged, so it is idempotent.
- `attachment`, `noteTarget` and `taskTarget` were already fully covered, so `timelineActivity` was the only object that had drifted.
- Typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

