### PR TITLE
Fix AI FAQ: self-hosted custom models don't need an Organization license

### DIFF
--- a/packages/twenty-docs/user-guide/ai/how-tos/ai-faq.mdx
+++ b/packages/twenty-docs/user-guide/ai/how-tos/ai-faq.mdx
@@ -21,7 +21,7 @@ description: Frequently asked questions about AI features in Twenty.
   </Accordion>
 
   <Accordion title="Can I use my own AI models?">
-    On cloud, you can use only AI models provided by Twenty. On your self-hosted instance, you can use your own AI models after obtaining an Organization license.
+    On cloud, you can use only AI models provided by Twenty. On your self-hosted instance, you can add your own providers and models.
   </Accordion>
 
   <Accordion title="I don't see a role I assigned to an AI agent, where is it?">


### PR DESCRIPTION
The AI FAQ claimed self-hosters need an Organization license to use their own AI models. Nothing in the code enforces that:

- Custom providers/models live in the `AI_PROVIDERS` config variable, resolved in `provider-config.service.ts` with no license check, and settable straight from the environment.
- The admin panel mutations (`addAiProvider`, `addModelToProvider`, ...) are guarded by `AdminPanelGuard` only, never by `EnterpriseFeaturesEnabledGuard` or `enterprisePlanService.isValid()`.
- The only enterprise gate on that screen is cross-workspace AI usage analytics.
- None of the AI provider/model files carry the `/* @license Enterprise */` header, unlike SSO or row-level permissions.

Updated the answer to describe what actually works: add providers and models from the admin panel or via `AI_PROVIDERS`. The cloud sentence is unchanged.

If the intent is to gate this behind a license, that is a code change (guard on the provider mutations plus enterprise headers on those files), and the doc should be corrected until then.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

