### PR TITLE
feat(front) - filter the record timeline by event type

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/TimelineCard.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/TimelineCard.tsx
@@ -1,9 +1,12 @@
 import { styled } from '@linaria/react';
+import { useState } from 'react';
 
 import { CustomResolverFetchMoreLoader } from '@/activities/components/CustomResolverFetchMoreLoader';
 import { SkeletonLoader } from '@/activities/components/SkeletonLoader';
 import { EventList } from '@/activities/timeline-activities/components/EventList';
+import { TimelineScopeFilter } from '@/activities/timeline-activities/components/TimelineScopeFilter';
 import { useTimelineActivities } from '@/activities/timeline-activities/hooks/useTimelineActivities';
+import { type TimelineActivityScope } from '@/activities/timeline-activities/types/TimelineActivityScope';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { useTargetRecord } from '@/ui/layout/contexts/useTargetRecord';
 import { t } from '@lingui/core/macro';
@@ -47,12 +50,13 @@ const StyledSidePanelPlaceholderWrapper = styled.div`
 export const TimelineCard = () => {
   const targetRecord = useTargetRecord();
   const { isInSidePanel } = useLayoutRenderingContext();
+  const [scope, setScope] = useState<TimelineActivityScope>('all');
   const {
     timelineActivities,
     firstQueryLoading,
     loadingMore,
     fetchMoreRecords,
-  } = useTimelineActivities(targetRecord);
+  } = useTimelineActivities(targetRecord, scope);
 
   const isTimelineActivitiesEmpty = timelineActivities.length === 0;
 
@@ -60,7 +64,9 @@ export const TimelineCard = () => {
     return <SkeletonLoader withSubSections />;
   }
 
-  if (isTimelineActivitiesEmpty) {
+  // An unfiltered empty timeline has nothing to offer, but a filtered one has
+  // to keep the control on screen or the filter cannot be cleared.
+  if (isTimelineActivitiesEmpty && scope === 'all') {
     const placeholderContent = (
       <AnimatedPlaceholderEmptyContainer>
         <AnimatedPlaceholder type="emptyTimeline" />
@@ -86,15 +92,28 @@ export const TimelineCard = () => {
 
   return (
     <StyledMainContainer>
-      <EventList
-        targetableObject={targetRecord}
-        title={t`All`}
-        events={timelineActivities ?? []}
-      />
-      <CustomResolverFetchMoreLoader
-        loading={loadingMore}
-        onLastRowVisible={fetchMoreRecords}
-      />
+      <TimelineScopeFilter scope={scope} onChange={setScope} />
+      {isTimelineActivitiesEmpty ? (
+        <AnimatedPlaceholderEmptyTextContainer>
+          <AnimatedPlaceholderEmptySubTitle>
+            {scope === 'activity'
+              ? t`No linked activity on this record.`
+              : t`No field changes recorded on this record.`}
+          </AnimatedPlaceholderEmptySubTitle>
+        </AnimatedPlaceholderEmptyTextContainer>
+      ) : (
+        <>
+          <EventList
+            targetableObject={targetRecord}
+            title={t`All`}
+            events={timelineActivities ?? []}
+          />
+          <CustomResolverFetchMoreLoader
+            loading={loadingMore}
+            onLastRowVisible={fetchMoreRecords}
+          />
+        </>
+      )}
     </StyledMainContainer>
   );
 };

--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/TimelineScopeFilter.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/TimelineScopeFilter.tsx
@@ -1,0 +1,29 @@
+import { type TimelineActivityScope } from '@/activities/timeline-activities/types/TimelineActivityScope';
+import { useLingui } from '@lingui/react/macro';
+import { SegmentedControl } from 'twenty-ui/input';
+
+type TimelineScopeFilterProps = {
+  scope: TimelineActivityScope;
+  onChange: (scope: TimelineActivityScope) => void;
+};
+
+export const TimelineScopeFilter = ({
+  scope,
+  onChange,
+}: TimelineScopeFilterProps) => {
+  const { t } = useLingui();
+
+  return (
+    <SegmentedControl<TimelineActivityScope>
+      ariaLabel={t`Filter timeline`}
+      value={scope}
+      onChange={onChange}
+      itemWidth="content"
+      options={[
+        { value: 'all', label: t`All` },
+        { value: 'activity', label: t`Activity` },
+        { value: 'history', label: t`History` },
+      ]}
+    />
+  );
+};

--- a/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useTimelineActivities.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useTimelineActivities.ts
@@ -3,6 +3,8 @@ import { useCallback, useMemo } from 'react';
 import { useLinkedObjectsTitle } from '@/activities/timeline-activities/hooks/useLinkedObjectsTitle';
 import { type TimelineActivity } from '@/activities/timeline-activities/types/TimelineActivity';
 import { getTimelineActivityRecordGqlFields } from '@/activities/timeline-activities/utils/getTimelineActivityRecordGqlFields';
+import { type TimelineActivityScope } from '@/activities/timeline-activities/types/TimelineActivityScope';
+import { getTimelineActivityScopeFilter } from '@/activities/timeline-activities/utils/getTimelineActivityScopeFilter';
 import { getTimelineActivityTargetObjectMetadataList } from '@/activities/timeline-activities/utils/getTimelineActivityTargetObjectMetadataList';
 import { type ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
 import { useListenToObjectRecordOperationBrowserEvent } from '@/browser-event/hooks/useListenToObjectRecordOperationBrowserEvent';
@@ -19,6 +21,7 @@ import { capitalize, isDefined } from 'twenty-shared/utils';
 
 export const useTimelineActivities = (
   targetableObject: ActivityTargetableObject,
+  scope: TimelineActivityScope = 'all',
 ) => {
   const targetableObjectFieldIdName = `target${capitalize(targetableObject.targetObjectNameSingular)}Id`;
 
@@ -27,8 +30,9 @@ export const useTimelineActivities = (
       [targetableObjectFieldIdName]: {
         eq: targetableObject.id,
       },
+      ...getTimelineActivityScopeFilter(scope),
     }),
-    [targetableObjectFieldIdName, targetableObject.id],
+    [targetableObjectFieldIdName, targetableObject.id, scope],
   );
 
   const { objectMetadataItem: timelineActivityMetadata } =
@@ -96,7 +100,7 @@ export const useTimelineActivities = (
   );
 
   useListenToEventsForQuery({
-    queryId: `timeline-activities-${targetableObject.targetObjectNameSingular}-${targetableObject.id}`,
+    queryId: `timeline-activities-${targetableObject.targetObjectNameSingular}-${targetableObject.id}-${scope}`,
     operationSignature,
     skip: !hasTimelineActivityField,
   });

--- a/packages/twenty-front/src/modules/activities/timeline-activities/types/TimelineActivityScope.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/types/TimelineActivityScope.ts
@@ -1,0 +1,1 @@
+export type TimelineActivityScope = 'all' | 'activity' | 'history';

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/getTimelineActivityScopeFilter.test.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/getTimelineActivityScopeFilter.test.ts
@@ -1,0 +1,30 @@
+import { getTimelineActivityScopeFilter } from '@/activities/timeline-activities/utils/getTimelineActivityScopeFilter';
+
+describe('getTimelineActivityScopeFilter', () => {
+  it('should not constrain the query when the scope is all', () => {
+    expect(getTimelineActivityScopeFilter('all')).toEqual({});
+  });
+
+  it('should keep only link events when the scope is activity', () => {
+    expect(getTimelineActivityScopeFilter('activity')).toEqual({
+      action: { in: ['linked', 'unlinked'] },
+    });
+  });
+
+  it('should keep only record changes when the scope is history', () => {
+    expect(getTimelineActivityScopeFilter('history')).toEqual({
+      action: { in: ['created', 'updated', 'deleted', 'restored'] },
+    });
+  });
+
+  it('should split every action across the two scopes without overlap', () => {
+    const activityActions =
+      getTimelineActivityScopeFilter('activity').action?.in ?? [];
+    const historyActions =
+      getTimelineActivityScopeFilter('history').action?.in ?? [];
+
+    expect(
+      activityActions.filter((action) => historyActions.includes(action)),
+    ).toEqual([]);
+  });
+});

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/getTimelineActivityScopeFilter.test.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/getTimelineActivityScopeFilter.test.ts
@@ -1,4 +1,5 @@
 import { getTimelineActivityScopeFilter } from '@/activities/timeline-activities/utils/getTimelineActivityScopeFilter';
+import { TIMELINE_ACTIVITY_ACTIONS } from 'twenty-shared/timeline';
 
 describe('getTimelineActivityScopeFilter', () => {
   it('should not constrain the query when the scope is all', () => {
@@ -17,14 +18,14 @@ describe('getTimelineActivityScopeFilter', () => {
     });
   });
 
-  it('should split every action across the two scopes without overlap', () => {
-    const activityActions =
-      getTimelineActivityScopeFilter('activity').action?.in ?? [];
-    const historyActions =
-      getTimelineActivityScopeFilter('history').action?.in ?? [];
+  it('should account for every known action across the two scopes exactly once', () => {
+    const scopedActions = [
+      ...(getTimelineActivityScopeFilter('activity').action?.in ?? []),
+      ...(getTimelineActivityScopeFilter('history').action?.in ?? []),
+    ];
 
-    expect(
-      activityActions.filter((action) => historyActions.includes(action)),
-    ).toEqual([]);
+    expect(scopedActions.toSorted()).toEqual(
+      TIMELINE_ACTIVITY_ACTIONS.toSorted(),
+    );
   });
 });

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityScopeFilter.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityScopeFilter.ts
@@ -1,0 +1,19 @@
+import { type TimelineActivityScope } from '@/activities/timeline-activities/types/TimelineActivityScope';
+import { type TimelineActivityAction } from 'twenty-shared/timeline';
+import { type RecordGqlOperationFilter } from 'twenty-shared/types';
+
+const SCOPE_ACTIONS: Record<
+  Exclude<TimelineActivityScope, 'all'>,
+  TimelineActivityAction[]
+> = {
+  activity: ['linked', 'unlinked'],
+  history: ['created', 'updated', 'deleted', 'restored'],
+};
+
+// Filtering runs in SQL on the action column, so it cannot apply the name
+// fallback the read path uses. Rows written before the column existed and left
+// unbackfilled carry no action and only appear under the unfiltered scope.
+export const getTimelineActivityScopeFilter = (
+  scope: TimelineActivityScope,
+): RecordGqlOperationFilter =>
+  scope === 'all' ? {} : { action: { in: SCOPE_ACTIONS[scope] } };

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityScopeFilter.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityScopeFilter.ts
@@ -1,6 +1,9 @@
 import { type TimelineActivityScope } from '@/activities/timeline-activities/types/TimelineActivityScope';
 import { type TimelineActivityAction } from 'twenty-shared/timeline';
-import { type RecordGqlOperationFilter } from 'twenty-shared/types';
+
+export type TimelineActivityScopeFilter = {
+  action?: { in: TimelineActivityAction[] };
+};
 
 const SCOPE_ACTIONS: Record<
   Exclude<TimelineActivityScope, 'all'>,
@@ -15,5 +18,5 @@ const SCOPE_ACTIONS: Record<
 // unbackfilled carry no action and only appear under the unfiltered scope.
 export const getTimelineActivityScopeFilter = (
   scope: TimelineActivityScope,
-): RecordGqlOperationFilter =>
+): TimelineActivityScopeFilter =>
   scope === 'all' ? {} : { action: { in: SCOPE_ACTIONS[scope] } };


### PR DESCRIPTION
Stack: #24341 &lt;- #24345 &lt;- #24385 &lt;- #24386 &lt;- **this PR**

Sits beside the rule configuration stack rather than inside it: it needs the engine and the structured columns, nothing above them. #24393 and later stay based on #24386, so this can merge independently.

The record timeline interleaves a record's own field changes with every note, task and message linked to it. On a busy record the field changes bury everything else, which is the "polluted record" complaint. Salesforce keeps field history in a separate History related list and HubSpot keeps property history in a sidebar panel; neither interleaves them with the activity stream. This adds the same separation as a filter rather than a second surface.

## Behaviour

Three scopes above the timeline:

- **All**, no predicate, the current behaviour.
- **Activity**, `action in (linked, unlinked)`, the notes, tasks and other records attached to this one.
- **History**, `action in (created, updated, deleted, restored)`, the record's own changes.

## Why it is cheap

The timeline already goes through the standard generated `findMany`, so this is one more key in the filter variable and no server change. It rides on the `action` column from #24345 rather than parsing the legacy name, which is what makes an indexable SQL predicate possible at all.

The predicate goes into the query rather than filtering the fetched page. `filterOutInvalidTimelineActivities` already drops rows after a 60 row cursor page, which is why pages can render short; doing the same for a user filter would routinely show an empty timeline while matching rows sat further down the cursor.

Filtering into an empty result keeps the control on screen with a scope-specific message, otherwise the filter cannot be cleared.

## Note on unbackfilled rows

A SQL predicate cannot apply the name fallback that `getTimelineActivityAction` uses at read time, so a row with a null `action` only appears under All. #24345 now backfills that column, so this only affects rows whose legacy name carries no recognisable action.

## Verification

Against a seeded workspace, on a company carrying 661 link rows and 1 creation row:

| Scope | Filter sent | totalCount |
|---|---|---|
| All | `targetCompanyId` only | 662 |
| Activity | `+ action in (linked, unlinked)` | 661 |
| History | `+ action in (created, updated, deleted, restored)` | 1 |

Counts match the database exactly, and the predicate is in the GraphQL variables rather than applied client side. Checked in the browser that the control renders above the timeline and that History shows only the creation row.

Unit tests cover each scope and assert the two scopes partition the actions without overlap. Typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

