### PR TITLE
Revert AI FAQ wording on self-hosted custom models

### DIFF
--- a/packages/twenty-docs/user-guide/ai/how-tos/ai-faq.mdx
+++ b/packages/twenty-docs/user-guide/ai/how-tos/ai-faq.mdx
@@ -21,7 +21,7 @@ description: Frequently asked questions about AI features in Twenty.
   </Accordion>
 
   <Accordion title="Can I use my own AI models?">
-    On cloud, you can use only AI models provided by Twenty. On your self-hosted instance, you can add your own providers and models.
+    On cloud, you can use only AI models provided by Twenty. On your self-hosted instance, you can use your own AI models after obtaining an Organization license.
   </Accordion>
 
   <Accordion title="I don't see a role I assigned to an AI agent, where is it?">


### PR DESCRIPTION
Reverts #24430. The Organization license wording was intentional, restoring it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

