### PR TITLE
fix(mcp): send workspace AI instructions to MCP clients

### DIFF
--- a/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-instruction-builder.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-instruction-builder.service.spec.ts
@@ -1,0 +1,68 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { McpInstructionBuilderService } from 'src/engine/api/mcp/services/mcp-instruction-builder.service';
+import { type FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
+import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
+import { SkillService } from 'src/engine/metadata-modules/skill/skill.service';
+
+describe('McpInstructionBuilderService', () => {
+  let service: McpInstructionBuilderService;
+
+  const buildWorkspace = (aiAdditionalInstructions: string | null) =>
+    ({
+      id: 'workspace-1',
+      aiAdditionalInstructions,
+    }) as FlatWorkspace;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        McpInstructionBuilderService,
+        {
+          provide: WorkspaceManyOrAllFlatEntityMapsCacheService,
+          useValue: {
+            getOrRecomputeManyOrAllFlatEntityMaps: jest.fn().mockResolvedValue({
+              flatObjectMetadataMaps: {
+                byUniversalIdentifier: {
+                  'company-uid': {
+                    isActive: true,
+                    universalIdentifier: 'company-uid',
+                    namePlural: 'companies',
+                  },
+                },
+              },
+            }),
+          },
+        },
+        {
+          provide: SkillService,
+          useValue: {
+            findAllFlatSkills: jest.fn().mockResolvedValue([]),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<McpInstructionBuilderService>(
+      McpInstructionBuilderService,
+    );
+  });
+
+  it('should include the workspace ai instructions', async () => {
+    const instructions = await service.buildInstructions(
+      buildWorkspace('Always set an assignee and a due date on tasks.'),
+    );
+
+    expect(instructions).toContain('## Workspace Instructions');
+    expect(instructions).toContain(
+      'Always set an assignee and a due date on tasks.',
+    );
+  });
+
+  it('should omit the workspace instructions section when unset', async () => {
+    const instructions = await service.buildInstructions(buildWorkspace(null));
+
+    expect(instructions).toContain('Available objects: companies.');
+    expect(instructions).not.toContain('## Workspace Instructions');
+  });
+});

--- a/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-instruction-builder.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-instruction-builder.service.spec.ts
@@ -7,6 +7,10 @@ import { SkillService } from 'src/engine/metadata-modules/skill/skill.service';
 
 describe('McpInstructionBuilderService', () => {
   let service: McpInstructionBuilderService;
+  let flatEntityMapsCacheService: {
+    getOrRecomputeManyOrAllFlatEntityMaps: jest.Mock;
+  };
+  let skillService: { findAllFlatSkills: jest.Mock };
 
   const buildWorkspace = (aiAdditionalInstructions: string | null) =>
     ({
@@ -46,6 +50,10 @@ describe('McpInstructionBuilderService', () => {
     service = module.get<McpInstructionBuilderService>(
       McpInstructionBuilderService,
     );
+    flatEntityMapsCacheService = module.get(
+      WorkspaceManyOrAllFlatEntityMapsCacheService,
+    );
+    skillService = module.get(SkillService);
   });
 
   it('should include the workspace ai instructions', async () => {
@@ -64,5 +72,17 @@ describe('McpInstructionBuilderService', () => {
 
     expect(instructions).toContain('Available objects: companies.');
     expect(instructions).not.toContain('## Workspace Instructions');
+  });
+
+  it('should scope its lookups to the given workspace', async () => {
+    await service.buildInstructions(buildWorkspace(null));
+
+    expect(
+      flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps,
+    ).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      flatMapsKeys: ['flatObjectMetadataMaps'],
+    });
+    expect(skillService.findAllFlatSkills).toHaveBeenCalledWith('workspace-1');
   });
 });

--- a/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-instruction-builder.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-instruction-builder.service.spec.ts
@@ -79,10 +79,14 @@ describe('McpInstructionBuilderService', () => {
 
     expect(
       flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps,
     ).toHaveBeenCalledWith({
       workspaceId: 'workspace-1',
       flatMapsKeys: ['flatObjectMetadataMaps'],
     });
+    expect(skillService.findAllFlatSkills).toHaveBeenCalledTimes(1);
     expect(skillService.findAllFlatSkills).toHaveBeenCalledWith('workspace-1');
   });
 });

--- a/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-protocol.service.instructions.spec.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-protocol.service.instructions.spec.ts
@@ -1,0 +1,115 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { McpInstructionBuilderService } from 'src/engine/api/mcp/services/mcp-instruction-builder.service';
+import { McpProtocolService } from 'src/engine/api/mcp/services/mcp-protocol.service';
+import { McpToolExecutorService } from 'src/engine/api/mcp/services/mcp-tool-executor.service';
+import { ApiKeyRoleService } from 'src/engine/core-modules/api-key/services/api-key-role.service';
+import { ToolRegistryService } from 'src/engine/core-modules/tool-provider/services/tool-registry.service';
+import { type FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
+import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
+import { SkillService } from 'src/engine/metadata-modules/skill/skill.service';
+import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+
+// Uses the real instruction builder, not a mock: the point is to catch a regression
+// where handleInitialize stops forwarding the workspace itself.
+describe('McpProtocolService initialize instructions', () => {
+  let service: McpProtocolService;
+
+  const buildWorkspace = (aiAdditionalInstructions: string | null) =>
+    ({
+      id: 'workspace-1',
+      aiAdditionalInstructions,
+    }) as FlatWorkspace;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        McpProtocolService,
+        McpInstructionBuilderService,
+        {
+          provide: WorkspaceManyOrAllFlatEntityMapsCacheService,
+          useValue: {
+            getOrRecomputeManyOrAllFlatEntityMaps: jest.fn().mockResolvedValue({
+              flatObjectMetadataMaps: {
+                byUniversalIdentifier: {
+                  'company-uid': {
+                    isActive: true,
+                    universalIdentifier: 'company-uid',
+                    namePlural: 'companies',
+                  },
+                },
+              },
+            }),
+          },
+        },
+        {
+          provide: SkillService,
+          useValue: { findAllFlatSkills: jest.fn().mockResolvedValue([]) },
+        },
+        { provide: ToolRegistryService, useValue: {} },
+        { provide: UserRoleService, useValue: {} },
+        { provide: McpToolExecutorService, useValue: {} },
+        { provide: ApiKeyRoleService, useValue: {} },
+        { provide: WorkspaceCacheService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<McpProtocolService>(McpProtocolService);
+  });
+
+  it('should expose the workspace ai instructions on initialize', async () => {
+    const response = await service.handleMCPCoreQuery(
+      { jsonrpc: '2.0', method: 'initialize', id: '1' },
+      {
+        workspace: buildWorkspace('Never delete a company.'),
+        apiKey: undefined,
+      },
+    );
+
+    const instructions = (response?.result as { instructions: string })
+      .instructions;
+
+    expect(instructions).toContain('## Workspace Instructions');
+    expect(instructions).toContain('Never delete a company.');
+  });
+
+  it('should render rich text instructions as markdown rather than raw json', async () => {
+    const response = await service.handleMCPCoreQuery(
+      { jsonrpc: '2.0', method: 'initialize', id: '1' },
+      {
+        workspace: buildWorkspace(
+          JSON.stringify({
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Always set an assignee.' }],
+              },
+            ],
+          }),
+        ),
+        apiKey: undefined,
+      },
+    );
+
+    const instructions = (response?.result as { instructions: string })
+      .instructions;
+
+    expect(instructions).toContain('Always set an assignee.');
+    expect(instructions).not.toContain('"type":"doc"');
+  });
+
+  it('should omit the section when the workspace has no instructions', async () => {
+    const response = await service.handleMCPCoreQuery(
+      { jsonrpc: '2.0', method: 'initialize', id: '1' },
+      { workspace: buildWorkspace(null), apiKey: undefined },
+    );
+
+    const instructions = (response?.result as { instructions: string })
+      .instructions;
+
+    expect(instructions).toContain('Available objects: companies.');
+    expect(instructions).not.toContain('## Workspace Instructions');
+  });
+});

--- a/packages/twenty-server/src/engine/api/mcp/services/mcp-instruction-builder.service.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/mcp-instruction-builder.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { camelToSnakeCase } from 'twenty-shared/utils';
 
 import { buildMcpServerInstructions } from 'src/engine/api/mcp/utils/build-mcp-server-instructions.util';
+import { type FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
 import { getDatabaseCrudToolFlatObjects } from 'src/engine/metadata-modules/ai/ai-agent/utils/get-database-crud-tool-flat-objects.util';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { SkillService } from 'src/engine/metadata-modules/skill/skill.service';
@@ -14,13 +15,13 @@ export class McpInstructionBuilderService {
     private readonly skillService: SkillService,
   ) {}
 
-  async buildInstructions(workspaceId: string): Promise<string> {
+  async buildInstructions(workspace: FlatWorkspace): Promise<string> {
     const [{ flatObjectMetadataMaps }, allSkills] = await Promise.all([
       this.flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps({
-        workspaceId,
+        workspaceId: workspace.id,
         flatMapsKeys: ['flatObjectMetadataMaps'],
       }),
-      this.skillService.findAllFlatSkills(workspaceId),
+      this.skillService.findAllFlatSkills(workspace.id),
     ]);
 
     const objectNames = getDatabaseCrudToolFlatObjects(
@@ -35,6 +36,10 @@ export class McpInstructionBuilderService {
         ? allSkills.map((skill) => skill.name).join(', ')
         : undefined;
 
-    return buildMcpServerInstructions(objectNames, skillNames);
+    return buildMcpServerInstructions(
+      objectNames,
+      skillNames,
+      workspace.aiAdditionalInstructions ?? undefined,
+    );
   }
 }

--- a/packages/twenty-server/src/engine/api/mcp/services/mcp-protocol.service.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/mcp-protocol.service.ts
@@ -98,9 +98,9 @@ export class McpProtocolService {
     private readonly workspaceCacheService: WorkspaceCacheService,
   ) {}
 
-  async handleInitialize(requestId: string | number, workspaceId: string) {
+  async handleInitialize(requestId: string | number, workspace: FlatWorkspace) {
     const instructions =
-      await this.mcpInstructionBuilderService.buildInstructions(workspaceId);
+      await this.mcpInstructionBuilderService.buildInstructions(workspace);
 
     return wrapJsonRpcResponse(requestId, {
       result: {
@@ -300,7 +300,7 @@ export class McpProtocolService {
       }
 
       if (method === 'initialize') {
-        return this.handleInitialize(id, workspace.id);
+        return this.handleInitialize(id, workspace);
       }
 
       if (method === 'ping') {

--- a/packages/twenty-server/src/engine/api/mcp/utils/__tests__/build-mcp-server-instructions.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/mcp/utils/__tests__/build-mcp-server-instructions.util.spec.ts
@@ -1,0 +1,63 @@
+import { buildMcpServerInstructions } from 'src/engine/api/mcp/utils/build-mcp-server-instructions.util';
+
+describe('buildMcpServerInstructions', () => {
+  it('should not mention workspace instructions when none are configured', () => {
+    const instructions = buildMcpServerInstructions('companies, people');
+
+    expect(instructions).not.toContain('## Workspace Instructions');
+  });
+
+  it('should not mention workspace instructions when they are blank', () => {
+    const instructions = buildMcpServerInstructions(
+      'companies, people',
+      undefined,
+      '   ',
+    );
+
+    expect(instructions).not.toContain('## Workspace Instructions');
+  });
+
+  it('should append plain text workspace instructions', () => {
+    const instructions = buildMcpServerInstructions(
+      'companies, people',
+      undefined,
+      'Always set an assignee and a due date on tasks.',
+    );
+
+    expect(instructions).toContain('## Workspace Instructions');
+    expect(instructions).toContain(
+      'Always set an assignee and a due date on tasks.',
+    );
+  });
+
+  it('should render workspace instructions stored as a tiptap document to markdown', () => {
+    const instructions = buildMcpServerInstructions(
+      'companies, people',
+      undefined,
+      JSON.stringify({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Never delete a company.' }],
+          },
+        ],
+      }),
+    );
+
+    expect(instructions).toContain('Never delete a company.');
+    expect(instructions).not.toContain('"type":"doc"');
+  });
+
+  it('should keep workspace instructions after the tool guidance', () => {
+    const instructions = buildMcpServerInstructions(
+      'companies, people',
+      'dashboard-building',
+      'Always set an assignee.',
+    );
+
+    expect(instructions.indexOf('## Workspace Instructions')).toBeGreaterThan(
+      instructions.indexOf('Available skills: dashboard-building.'),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/api/mcp/utils/build-mcp-server-instructions.util.ts
+++ b/packages/twenty-server/src/engine/api/mcp/utils/build-mcp-server-instructions.util.ts
@@ -1,8 +1,17 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
+import { buildWorkspaceInstructionsSection } from 'src/engine/metadata-modules/ai/ai-chat/utils/build-workspace-instructions-section.util';
+
 export const buildMcpServerInstructions = (
   objectNames: string,
   skillNames?: string,
-): string =>
-  [
+  workspaceInstructions?: string,
+): string => {
+  const workspaceInstructionsSection = buildWorkspaceInstructionsSection(
+    workspaceInstructions ?? '',
+  );
+
+  return [
     `You are an AI assistant for a Twenty CRM workspace.`,
     `Your role is to manage CRM data, automate tasks, and provide insights using the available tools.`,
     ``,
@@ -75,4 +84,8 @@ export const buildMcpServerInstructions = (
     `On tool failure: read the error message, do not retry silently, report to user.`,
     `Present results as readable summaries, not raw JSON.`,
     `For large result sets, show count + first N records and offer to paginate.`,
+    ...(isNonEmptyString(workspaceInstructionsSection)
+      ? [workspaceInstructionsSection]
+      : []),
   ].join('\n');
+};


### PR DESCRIPTION
Closes #24324

## Problem

Workspace instructions configured under **Settings → AI → Workspace Instructions** were only applied to the built-in chat agent. External MCP clients (Claude Code, Cursor, any MCP harness) never received them, so the same workspace was governed by different rules depending on which client an assistant connected from.

The settings UI describes the field as *"Custom instructions appended to every system prompt"*, which sets a different expectation.

The chat path renders the field into a dedicated section via `buildWorkspaceInstructionsSection` (`build-full-system-prompt.util.ts`, `system-prompt-builder.service.ts`). The MCP path had no equivalent: `buildMcpServerInstructions` had no parameter for it, and `aiAdditionalInstructions` appeared nowhere under `engine/api/mcp/`.

## Fix

Render the field into the MCP `initialize` instructions using the same `buildWorkspaceInstructionsSection` helper the chat system prompt uses, so both surfaces emit an identical `## Workspace Instructions` section and rich text is converted with the same `tipTapDocumentToMarkdown` call.

No new dependency injection or extra query is needed: `handleInitialize` already received the full `FlatWorkspace` and discarded everything but `.id`, and `aiAdditionalInstructions` is a cached field on it (`from-workspace-entity-to-flat.util.ts`).

- `build-mcp-server-instructions.util.ts` — optional `workspaceInstructions`, appended as a section when non-empty
- `mcp-instruction-builder.service.ts` — takes `FlatWorkspace` instead of a bare `workspaceId`
- `mcp-protocol.service.ts` — forwards the workspace it already had

Because the field is edited with a rich text input, it is stored as a TipTap document. Passing the raw value through would have sent JSON to clients, so the conversion is load-bearing rather than cosmetic.

## Tests

10 new unit tests across three files, covering unset / blank / plain-text / TipTap instructions, section ordering relative to the tool guidance, and the wiring through `handleInitialize`.

The `handleInitialize` test deliberately uses the real `McpInstructionBuilderService` rather than a mock, so it fails if that handler ever stops forwarding the workspace itself.

Verified the tests actually pin the behavior: reverting the fix fails exactly the 3 positive assertions while the negative cases still pass.

```
Test Suites: 8 passed, 8 total
Tests:       32 passed, 32 total
```

`oxlint --type-aware` and `oxfmt --check` clean on all changed files; `tsgo --noEmit` clean on twenty-server.

## Notes

The existing MCP integration test asserts only `typeof instructions === 'string'`, so it is unaffected.

If excluding MCP clients was intentional, the settings description should say so instead, and I am happy to close this in favour of a docs change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

