### PR TITLE
v1.6.4 — feat(partners): expose marketplace ranking metadata on the list endpoint

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-partners",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/__tests__/marketplace-api.integration-test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/__tests__/marketplace-api.integration-test.ts
@@ -98,6 +98,9 @@ describe('list-available-partners handler', () => {
     );
     expect(partner.serviceCount).toBeGreaterThanOrEqual(0);
     expect(partner.approvedCaseStudyCount).toBeGreaterThanOrEqual(0);
+    expect(partner.approvedCaseStudyWithCoverCount).toBeLessThanOrEqual(
+      partner.approvedCaseStudyCount,
+    );
     expect(partner.rotationKey).toMatch(/^[a-f0-9]{64}$/);
     expect('projectBudgetTypical' in partner).toBe(false);
     expect('profileLinks' in partner).toBe(false);

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/__tests__/marketplace-api.integration-test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/__tests__/marketplace-api.integration-test.ts
@@ -93,6 +93,12 @@ describe('list-available-partners handler', () => {
     expect(partner.name.length).toBeGreaterThan(0);
     expect(partner.introduction.length).toBeGreaterThan(0);
     expect(partner.introduction).not.toMatch(/^##\s/m);
+    expect(['ADVANCED', 'INTERMEDIATE', 'NEW', null]).toContain(
+      partner.partnerTier,
+    );
+    expect(partner.serviceCount).toBeGreaterThanOrEqual(0);
+    expect(partner.approvedCaseStudyCount).toBeGreaterThanOrEqual(0);
+    expect(partner.rotationKey).toMatch(/^[a-f0-9]{64}$/);
     expect('projectBudgetTypical' in partner).toBe(false);
     expect('profileLinks' in partner).toBe(false);
     expect('services' in partner).toBe(false);

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
@@ -24,6 +24,7 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
           introduction: true,
           languagesSpoken: true,
           deploymentExpertise: true,
+          partnerTier: true,
           partnerScope: true,
           region: true,
           calendarLink: { primaryLinkUrl: true },
@@ -38,6 +39,17 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
           skills: true,
           city: true,
           country: true,
+          partnerServices: {
+            edges: { node: { id: true } },
+          },
+          partnerContents: {
+            edges: {
+              node: {
+                contentType: true,
+                status: true,
+              },
+            },
+          },
         },
       },
     },

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
@@ -39,14 +39,15 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
           skills: true,
           city: true,
           country: true,
+          // The server ignores nested relation arguments and caps every
+          // relation read at QUERY_MAX_RECORDS_FROM_RELATION (60), unordered.
+          // A partner holding more than 60 contents would report a truncated
+          // case-study count. Read these at the root and group by partner if
+          // any partner ever approaches that.
           partnerServices: {
             edges: { node: { id: true } },
           },
           partnerContents: {
-            __args: {
-              filter: { status: { eq: 'APPROVED' } },
-              first: 200,
-            },
             edges: {
               node: {
                 contentType: true,

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
@@ -43,6 +43,10 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
             edges: { node: { id: true } },
           },
           partnerContents: {
+            __args: {
+              filter: { status: { eq: 'APPROVED' } },
+              first: 200,
+            },
             edges: {
               node: {
                 contentType: true,

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
@@ -47,6 +47,8 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
               node: {
                 contentType: true,
                 status: true,
+                coverImage: { url: true },
+                coverImageUrl: true,
               },
             },
           },

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper.test.ts
@@ -175,6 +175,29 @@ describe('mapPartnerForMarketplace', () => {
     ]);
   });
 
+  it('falls back to the uploaded file when coverImageUrl is the TEXT default', () => {
+    const node = makeNode();
+    node.partnerContents.edges = [
+      {
+        node: {
+          contentType: ['CASE_STUDY'],
+          status: 'APPROVED',
+          clientName: 'Acme Corp',
+          headline: 'CRM migration',
+          body: { markdown: 'Moved 12 teams to Twenty.' },
+          coverImageUrl: '',
+          coverImage: [{ url: 'https://file.example.com/cover.png' }],
+          caseStudyLink: { primaryLinkUrl: 'https://example.com/case-study' },
+          position: 1,
+        },
+      },
+    ];
+
+    expect(mapPartnerForMarketplace(node, 'profile').portfolio[0].imageUrl).toBe(
+      'https://file.example.com/cover.png',
+    );
+  });
+
   it('prefers the pasted coverImageUrl over the uploaded coverImage file in portfolio', () => {
     const node = makeNode();
     node.partnerContents.edges = [

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper.ts
@@ -2,8 +2,11 @@ import { type CoreSchema } from 'twenty-client-sdk/core';
 
 import { stripMarkdown } from 'src/modules/shared/utils/strip-markdown.util';
 
-import { isCaseStudy } from 'src/modules/partner/utils/content-type';
-import { firstFileUrl, resolvePartnerPictureUrl } from 'src/modules/partner/utils/profile-picture';
+import { isApprovedCaseStudy } from 'src/modules/partner/utils/content-type';
+import {
+  resolveCoverUrl,
+  resolvePartnerPictureUrl,
+} from 'src/modules/partner/utils/profile-picture';
 
 export type MapPartnerDetail = 'list' | 'profile';
 
@@ -202,12 +205,12 @@ const mapPortfolio = (
   edges: ReadonlyArray<PartnerContentEdge>,
 ): MarketplaceProfilePartner['portfolio'] =>
   sortByPositionAscNullsLast(edges)
-    .filter(({ node }) => isCaseStudy(node.contentType) && node.status === 'APPROVED')
+    .filter(({ node }) => isApprovedCaseStudy(node))
     .map(({ node }) => ({
       client: node.clientName ?? '',
       title: node.headline ?? '',
       body: node.body?.markdown ?? '',
-      imageUrl: node.coverImageUrl ?? firstFileUrl(node.coverImage),
+      imageUrl: resolveCoverUrl(node.coverImageUrl, node.coverImage),
       link: node.caseStudyLink?.primaryLinkUrl ?? null,
     }));
 

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
@@ -115,4 +115,51 @@ describe('listAvailablePartners', () => {
     expect(result.partners[0].rotationKey).toMatch(/^[a-f0-9]{64}$/);
     expect(result.partners[0].rotationKey).not.toContain('partner-1');
   });
+
+  it('counts zero for a partner with no services and no contents', async () => {
+    queryAvailablePartnersMock.mockResolvedValue({
+      partners: {
+        edges: [
+          {
+            node: {
+              id: 'partner-2',
+              name: 'Fresh',
+              slug: 'fresh',
+              introduction: '',
+              languagesSpoken: [],
+              deploymentExpertise: [],
+              partnerTier: null,
+              partnerScope: [],
+              region: [],
+              calendarLink: { primaryLinkUrl: null },
+              hourlyRate: null,
+              projectBudgetMin: null,
+              linkedin: { primaryLinkUrl: null },
+              website: { primaryLinkUrl: null },
+              profilePicture: { primaryLinkUrl: null },
+              profilePictureFile: [],
+              skills: [],
+              city: null,
+              country: null,
+              partnerServices: null,
+              partnerContents: null,
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const result = await listAvailablePartners();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.partners[0]).toMatchObject({
+      partnerTier: null,
+      serviceCount: 0,
+      approvedCaseStudyCount: 0,
+      approvedCaseStudyWithCoverCount: 0,
+    });
+    expect(result.partners[0].rotationKey).toMatch(/^[a-f0-9]{64}$/);
+  });
 });

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryAvailablePartnersMock } = vi.hoisted(() => ({
+  queryAvailablePartnersMock: vi.fn(),
+}));
+
+vi.mock('twenty-client-sdk/core', () => ({
+  CoreApiClient: vi.fn(),
+}));
+
+vi.mock(
+  'src/modules/partner/marketplace/graphql/queries/list-available-partners',
+  () => ({ queryAvailablePartners: queryAvailablePartnersMock }),
+);
+
+import { listAvailablePartners } from './list-available-partners.service';
+
+describe('listAvailablePartners', () => {
+  beforeEach(() => {
+    queryAvailablePartnersMock.mockReset();
+  });
+
+  it('returns ranking metadata for each partner', async () => {
+    queryAvailablePartnersMock.mockResolvedValue({
+      partners: {
+        edges: [
+          {
+            node: {
+              id: 'partner-1',
+              name: 'Acme',
+              slug: 'acme',
+              introduction: 'A complete implementation partner profile.',
+              languagesSpoken: ['ENGLISH'],
+              deploymentExpertise: ['CLOUD'],
+              partnerTier: 'ADVANCED',
+              partnerScope: ['SOLUTIONING'],
+              region: ['EUROPE'],
+              calendarLink: { primaryLinkUrl: 'https://cal.example.com/acme' },
+              hourlyRate: { amountMicros: 100_000_000, currencyCode: 'USD' },
+              projectBudgetMin: null,
+              linkedin: { primaryLinkUrl: null },
+              website: { primaryLinkUrl: 'https://acme.example.com' },
+              profilePicture: { primaryLinkUrl: null },
+              profilePictureFile: [],
+              skills: ['Migration'],
+              city: 'Paris',
+              country: 'France',
+              partnerServices: {
+                edges: [
+                  { node: { id: 'service-1' } },
+                  { node: { id: 'service-2' } },
+                ],
+              },
+              partnerContents: {
+                edges: [
+                  { node: { contentType: ['CASE_STUDY'], status: 'APPROVED' } },
+                  { node: { contentType: ['CASE_STUDY'], status: 'IN_REVIEW' } },
+                  { node: { contentType: ['BLOG'], status: 'APPROVED' } },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const result = await listAvailablePartners();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.partners[0]).toMatchObject({
+      partnerTier: 'ADVANCED',
+      serviceCount: 2,
+      approvedCaseStudyCount: 1,
+    });
+    expect(result.partners[0].rotationKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.partners[0].rotationKey).not.toContain('partner-1');
+  });
+});

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
@@ -53,9 +53,46 @@ describe('listAvailablePartners', () => {
               },
               partnerContents: {
                 edges: [
-                  { node: { contentType: ['CASE_STUDY'], status: 'APPROVED' } },
-                  { node: { contentType: ['CASE_STUDY'], status: 'IN_REVIEW' } },
-                  { node: { contentType: ['BLOG'], status: 'APPROVED' } },
+                  {
+                    node: {
+                      contentType: ['CASE_STUDY'],
+                      status: 'APPROVED',
+                      coverImageUrl: 'https://cdn.example.com/cover.png',
+                      coverImage: [],
+                    },
+                  },
+                  {
+                    node: {
+                      contentType: ['CASE_STUDY'],
+                      status: 'APPROVED',
+                      coverImageUrl: '',
+                      coverImage: [{ url: 'https://cdn.example.com/file.png' }],
+                    },
+                  },
+                  {
+                    node: {
+                      contentType: ['CASE_STUDY'],
+                      status: 'APPROVED',
+                      coverImageUrl: '   ',
+                      coverImage: [],
+                    },
+                  },
+                  {
+                    node: {
+                      contentType: ['CASE_STUDY'],
+                      status: 'IN_REVIEW',
+                      coverImageUrl: 'https://cdn.example.com/draft.png',
+                      coverImage: [],
+                    },
+                  },
+                  {
+                    node: {
+                      contentType: ['BLOG'],
+                      status: 'APPROVED',
+                      coverImageUrl: 'https://cdn.example.com/blog.png',
+                      coverImage: [],
+                    },
+                  },
                 ],
               },
             },
@@ -72,7 +109,8 @@ describe('listAvailablePartners', () => {
     expect(result.partners[0]).toMatchObject({
       partnerTier: 'ADVANCED',
       serviceCount: 2,
-      approvedCaseStudyCount: 1,
+      approvedCaseStudyCount: 3,
+      approvedCaseStudyWithCoverCount: 2,
     });
     expect(result.partners[0].rotationKey).toMatch(/^[a-f0-9]{64}$/);
     expect(result.partners[0].rotationKey).not.toContain('partner-1');

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
@@ -6,6 +6,7 @@ import {
   type MarketplaceListPartner,
 } from 'src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper';
 import { isCaseStudy } from 'src/modules/partner/utils/content-type';
+import { firstFileUrl } from 'src/modules/partner/utils/profile-picture';
 
 import { createWeeklyRotationKey } from '../utils/create-weekly-rotation-key';
 
@@ -17,12 +18,21 @@ export type MarketplaceRankedListPartner = MarketplaceListPartner & {
   partnerTier: AvailablePartnerRaw['partnerTier'];
   serviceCount: number;
   approvedCaseStudyCount: number;
+  approvedCaseStudyWithCoverCount: number;
   rotationKey: string;
 };
 
 export type ListAvailablePartnersResult =
   | { ok: true; count: number; partners: MarketplaceRankedListPartner[] }
   | { ok: false; reason: string };
+
+// coverImageUrl is TEXT, so an empty string means "no cover", not null.
+const hasCover = (content: {
+  coverImageUrl?: string | null;
+  coverImage?: ReadonlyArray<{ url?: string | null } | null> | null;
+}): boolean =>
+  (content.coverImageUrl ?? '').trim().length > 0 ||
+  firstFileUrl(content.coverImage) !== null;
 
 const mapListPartner = (
   node: AvailablePartnerRaw,
@@ -35,14 +45,19 @@ const mapListPartner = (
     );
   }
 
+  const approvedCaseStudies = (node.partnerContents?.edges ?? []).filter(
+    ({ node: content }) =>
+      isCaseStudy(content.contentType) && content.status === 'APPROVED',
+  );
+
   return {
     ...mapped,
     partnerTier: node.partnerTier,
     serviceCount: node.partnerServices?.edges.length ?? 0,
-    approvedCaseStudyCount: (node.partnerContents?.edges ?? []).filter(
-      ({ node: content }) =>
-        isCaseStudy(content.contentType) && content.status === 'APPROVED',
-    ).length,
+    approvedCaseStudyCount: approvedCaseStudies.length,
+    approvedCaseStudyWithCoverCount:
+      approvedCaseStudies.filter(({ node: content }) => hasCover(content))
+        .length,
     rotationKey: createWeeklyRotationKey(node.id),
   };
 };

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
@@ -5,10 +5,9 @@ import {
   mapPartnerForMarketplace,
   type MarketplaceListPartner,
 } from 'src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper';
-import { isCaseStudy } from 'src/modules/partner/utils/content-type';
-import { firstFileUrl } from 'src/modules/partner/utils/profile-picture';
-
-import { createWeeklyRotationKey } from '../utils/create-weekly-rotation-key';
+import { isApprovedCaseStudy } from 'src/modules/partner/utils/content-type';
+import { resolveCoverUrl } from 'src/modules/partner/utils/profile-picture';
+import { createWeeklyRotationKey } from 'src/modules/partner/marketplace/utils/create-weekly-rotation-key';
 
 type AvailablePartnerRaw = NonNullable<
   Awaited<ReturnType<typeof queryAvailablePartners>>['partners']
@@ -26,14 +25,6 @@ export type ListAvailablePartnersResult =
   | { ok: true; count: number; partners: MarketplaceRankedListPartner[] }
   | { ok: false; reason: string };
 
-// coverImageUrl is TEXT, so an empty string means "no cover", not null.
-const hasCover = (content: {
-  coverImageUrl?: string | null;
-  coverImage?: ReadonlyArray<{ url?: string | null } | null> | null;
-}): boolean =>
-  (content.coverImageUrl ?? '').trim().length > 0 ||
-  firstFileUrl(content.coverImage) !== null;
-
 const mapListPartner = (
   node: AvailablePartnerRaw,
 ): MarketplaceRankedListPartner => {
@@ -46,18 +37,18 @@ const mapListPartner = (
   }
 
   const approvedCaseStudies = (node.partnerContents?.edges ?? []).filter(
-    ({ node: content }) =>
-      isCaseStudy(content.contentType) && content.status === 'APPROVED',
+    ({ node: content }) => isApprovedCaseStudy(content),
   );
 
   return {
     ...mapped,
     partnerTier: node.partnerTier,
-    serviceCount: node.partnerServices?.edges.length ?? 0,
+    serviceCount: (node.partnerServices?.edges ?? []).length,
     approvedCaseStudyCount: approvedCaseStudies.length,
-    approvedCaseStudyWithCoverCount:
-      approvedCaseStudies.filter(({ node: content }) => hasCover(content))
-        .length,
+    approvedCaseStudyWithCoverCount: approvedCaseStudies.filter(
+      ({ node: content }) =>
+        resolveCoverUrl(content.coverImageUrl, content.coverImage) !== null,
+    ).length,
     rotationKey: createWeeklyRotationKey(node.id),
   };
 };

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
@@ -5,16 +5,28 @@ import {
   mapPartnerForMarketplace,
   type MarketplaceListPartner,
 } from 'src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper';
+import { isCaseStudy } from 'src/modules/partner/utils/content-type';
+
+import { createWeeklyRotationKey } from '../utils/create-weekly-rotation-key';
 
 type AvailablePartnerRaw = NonNullable<
   Awaited<ReturnType<typeof queryAvailablePartners>>['partners']
 >['edges'][number]['node'];
 
+export type MarketplaceRankedListPartner = MarketplaceListPartner & {
+  partnerTier: AvailablePartnerRaw['partnerTier'];
+  serviceCount: number;
+  approvedCaseStudyCount: number;
+  rotationKey: string;
+};
+
 export type ListAvailablePartnersResult =
-  | { ok: true; count: number; partners: MarketplaceListPartner[] }
+  | { ok: true; count: number; partners: MarketplaceRankedListPartner[] }
   | { ok: false; reason: string };
 
-const mapListPartner = (node: AvailablePartnerRaw): MarketplaceListPartner => {
+const mapListPartner = (
+  node: AvailablePartnerRaw,
+): MarketplaceRankedListPartner => {
   const mapped = mapPartnerForMarketplace(node, 'list');
 
   if ('projectBudgetTypical' in mapped) {
@@ -23,7 +35,16 @@ const mapListPartner = (node: AvailablePartnerRaw): MarketplaceListPartner => {
     );
   }
 
-  return mapped;
+  return {
+    ...mapped,
+    partnerTier: node.partnerTier,
+    serviceCount: node.partnerServices?.edges.length ?? 0,
+    approvedCaseStudyCount: (node.partnerContents?.edges ?? []).filter(
+      ({ node: content }) =>
+        isCaseStudy(content.contentType) && content.status === 'APPROVED',
+    ).length,
+    rotationKey: createWeeklyRotationKey(node.id),
+  };
 };
 
 export const listAvailablePartners = async (): Promise<ListAvailablePartnersResult> => {

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
@@ -27,6 +27,7 @@ export type ListAvailablePartnersResult =
 
 const mapListPartner = (
   node: AvailablePartnerRaw,
+  rotationDate: Date,
 ): MarketplaceRankedListPartner => {
   const mapped = mapPartnerForMarketplace(node, 'list');
 
@@ -49,7 +50,7 @@ const mapListPartner = (
       ({ node: content }) =>
         resolveCoverUrl(content.coverImageUrl, content.coverImage) !== null,
     ).length,
-    rotationKey: createWeeklyRotationKey(node.id),
+    rotationKey: createWeeklyRotationKey(node.id, rotationDate),
   };
 };
 
@@ -57,8 +58,11 @@ export const listAvailablePartners = async (): Promise<ListAvailablePartnersResu
   try {
     const client = new CoreApiClient();
     const result = await queryAvailablePartners(client);
+    // One clock read for the whole response: a request that straddles the UTC
+    // Monday boundary would otherwise mix keys from two weeks in one sort.
+    const rotationDate = new Date();
     const partners = (result.partners?.edges ?? []).map(({ node }) =>
-      mapListPartner(node),
+      mapListPartner(node, rotationDate),
     );
 
     return { ok: true, count: partners.length, partners };

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { createWeeklyRotationKey } from './create-weekly-rotation-key';
+
+describe('createWeeklyRotationKey', () => {
+  it('keeps a partner stable within one UTC week', () => {
+    expect(
+      createWeeklyRotationKey('partner-1', new Date('2026-08-17T00:00:00Z')),
+    ).toBe(
+      createWeeklyRotationKey('partner-1', new Date('2026-08-23T23:59:59Z')),
+    );
+  });
+
+  it('changes at the next UTC Monday', () => {
+    expect(
+      createWeeklyRotationKey('partner-1', new Date('2026-08-23T23:59:59Z')),
+    ).not.toBe(
+      createWeeklyRotationKey('partner-1', new Date('2026-08-24T00:00:00Z')),
+    );
+  });
+
+  it('gives different partners different keys', () => {
+    const date = new Date('2026-08-19T12:00:00Z');
+
+    expect(createWeeklyRotationKey('partner-1', date)).not.toBe(
+      createWeeklyRotationKey('partner-2', date),
+    );
+  });
+});

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'node:crypto';
+
+const getUtcWeekStart = (date: Date): string => {
+  const weekStart = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const daysSinceMonday = (weekStart.getUTCDay() + 6) % 7;
+  weekStart.setUTCDate(weekStart.getUTCDate() - daysSinceMonday);
+
+  return weekStart.toISOString().slice(0, 10);
+};
+
+export const createWeeklyRotationKey = (
+  partnerId: string,
+  date = new Date(),
+): string =>
+  createHash('sha256')
+    .update(`${partnerId}:${getUtcWeekStart(date)}`)
+    .digest('hex');

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.ts
@@ -10,9 +10,11 @@ const getUtcWeekStart = (date: Date): string => {
   return weekStart.toISOString().slice(0, 10);
 };
 
+// The date is required: a caller reading the clock per partner would mix keys
+// from two weeks whenever a request crosses the UTC Monday boundary.
 export const createWeeklyRotationKey = (
   partnerId: string,
-  date = new Date(),
+  date: Date,
 ): string =>
   createHash('sha256')
     .update(`${partnerId}:${getUtcWeekStart(date)}`)

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/content-type.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/content-type.ts
@@ -5,8 +5,6 @@ export const isCaseStudy = (
     ? contentType.includes('CASE_STUDY')
     : contentType === 'CASE_STUDY';
 
-// A case study only counts once an admin approved it, so a draft never scores
-// and never reaches the public profile.
 export const isApprovedCaseStudy = (content: {
   contentType?: ReadonlyArray<string | undefined> | string | null;
   status?: string | null;

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/content-type.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/content-type.ts
@@ -4,3 +4,11 @@ export const isCaseStudy = (
   Array.isArray(contentType)
     ? contentType.includes('CASE_STUDY')
     : contentType === 'CASE_STUDY';
+
+// A case study only counts once an admin approved it, so a draft never scores
+// and never reaches the public profile.
+export const isApprovedCaseStudy = (content: {
+  contentType?: ReadonlyArray<string | undefined> | string | null;
+  status?: string | null;
+}): boolean =>
+  isCaseStudy(content.contentType) && content.status === 'APPROVED';

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/profile-picture.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/profile-picture.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { firstFileUrl, resolvePartnerPictureUrl } from './profile-picture';
+import {
+  firstFileUrl,
+  resolveCoverUrl,
+  resolvePartnerPictureUrl,
+} from './profile-picture';
 
 describe('firstFileUrl', () => {
   it('returns the first file url', () => {
@@ -34,5 +38,26 @@ describe('resolvePartnerPictureUrl', () => {
     expect(resolvePartnerPictureUrl(null, null)).toBeNull();
     expect(resolvePartnerPictureUrl(undefined, undefined)).toBeNull();
     expect(resolvePartnerPictureUrl([], null)).toBeNull();
+  });
+});
+
+describe('resolveCoverUrl', () => {
+  it('prefers the pasted url over the uploaded file', () => {
+    expect(
+      resolveCoverUrl('https://x/pasted.png', [{ url: 'https://x/file.png' }]),
+    ).toBe('https://x/pasted.png');
+  });
+  it('treats the TEXT default and whitespace as no pasted url', () => {
+    expect(resolveCoverUrl('', [{ url: 'https://x/file.png' }])).toBe(
+      'https://x/file.png',
+    );
+    expect(resolveCoverUrl('   ', [{ url: 'https://x/file.png' }])).toBe(
+      'https://x/file.png',
+    );
+  });
+  it('returns null when neither source has a url', () => {
+    expect(resolveCoverUrl('', null)).toBeNull();
+    expect(resolveCoverUrl(null, [])).toBeNull();
+    expect(resolveCoverUrl(undefined, [{ url: null }])).toBeNull();
   });
 });

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/profile-picture.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/profile-picture.ts
@@ -18,3 +18,14 @@ export function resolvePartnerPictureUrl(
 ): string | null {
   return firstFileUrl(files) ?? legacyLinkUrl ?? null;
 }
+
+// Cover has the same two sources as the picture, in the opposite order: a
+// pasted URL wins over an uploaded file. coverImageUrl is TEXT, so it reads
+// back as '' when unset — `??` would hand that empty string to the caller and
+// hide the uploaded file behind it.
+export function resolveCoverUrl(
+  pastedUrl: string | null | undefined,
+  files: ReadonlyArray<FileItemRead> | null | undefined,
+): string | null {
+  return (pastedUrl ?? '').trim() || firstFileUrl(files);
+}


### PR DESCRIPTION
**Version:** twenty-partners `1.6.4` (the `list-available-partners` logic function returns five extra fields; no schema change, no migration).

Bumped from `1.6.3`, pending in #24414.

## Problem

The marketplace list ranks partners by profile completeness, then alphabetically by name. A partner gamed the tiebreak by renaming itself `#1_novilin` to take the top slot. The list endpoint exposes none of the signals a fair ranking needs.

## Change

`GET /s/partners` returns four extra fields per partner.

| Field | Meaning |
| --- | --- |
| `partnerTier` | `ADVANCED`, `INTERMEDIATE`, `NEW`, or null |
| `serviceCount` | Number of `partnerService` records |
| `approvedCaseStudyCount` | Approved case studies |
| `approvedCaseStudyWithCoverCount` | Approved case studies that carry a cover image |
| `rotationKey` | `sha256(partnerId + UTC week start)` |

`rotationKey` derives from the internal record id and the UTC week, so a partner can influence neither input. The key is stable inside a week and changes every Monday.

A case study counts only once `status` is `APPROVED`, so an unreviewed draft adds nothing. `coverImageUrl` is a TEXT field, so an empty string counts as no cover; an uploaded `coverImage` file also counts.

This PR changes the contract only. The website consumes it in #24460, which sorts on these fields.

`approvedCaseStudyWithCoverCount` lets the website score an illustrated case study above a bare one, so the two counts must stay consistent: the cover count is always a subset of `approvedCaseStudyCount`. The integration test asserts that relation.

## Checks

- 12 unit tests in `twenty-partners`, including the weekly rotation and the field mapping
- `tsc --noEmit`
- `oxlint`
- Live check against a local workspace loaded with the 29 published production partners

## Note for reviewers

Production currently holds **zero** `partnerService` records, so `serviceCount` returns 0 for every partner today. The field is still exposed, because the ranking treats it as an incentive to fill that section.

Production also holds 6 approved case studies across the 29 published partners, and 2 of them carry a cover. Both use the pasted `coverImageUrl`; nobody uses the `coverImage` file upload.
