### PR TITLE
Rank marketplace partners by evidence instead of by name (needs twenty-partners 1.6.4)

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-partners",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/__tests__/marketplace-api.integration-test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/__tests__/marketplace-api.integration-test.ts
@@ -98,6 +98,9 @@ describe('list-available-partners handler', () => {
     );
     expect(partner.serviceCount).toBeGreaterThanOrEqual(0);
     expect(partner.approvedCaseStudyCount).toBeGreaterThanOrEqual(0);
+    expect(partner.approvedCaseStudyWithCoverCount).toBeLessThanOrEqual(
+      partner.approvedCaseStudyCount,
+    );
     expect(partner.rotationKey).toMatch(/^[a-f0-9]{64}$/);
     expect('projectBudgetTypical' in partner).toBe(false);
     expect('profileLinks' in partner).toBe(false);

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/__tests__/marketplace-api.integration-test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/__tests__/marketplace-api.integration-test.ts
@@ -93,6 +93,12 @@ describe('list-available-partners handler', () => {
     expect(partner.name.length).toBeGreaterThan(0);
     expect(partner.introduction.length).toBeGreaterThan(0);
     expect(partner.introduction).not.toMatch(/^##\s/m);
+    expect(['ADVANCED', 'INTERMEDIATE', 'NEW', null]).toContain(
+      partner.partnerTier,
+    );
+    expect(partner.serviceCount).toBeGreaterThanOrEqual(0);
+    expect(partner.approvedCaseStudyCount).toBeGreaterThanOrEqual(0);
+    expect(partner.rotationKey).toMatch(/^[a-f0-9]{64}$/);
     expect('projectBudgetTypical' in partner).toBe(false);
     expect('profileLinks' in partner).toBe(false);
     expect('services' in partner).toBe(false);

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
@@ -24,6 +24,7 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
           introduction: true,
           languagesSpoken: true,
           deploymentExpertise: true,
+          partnerTier: true,
           partnerScope: true,
           region: true,
           calendarLink: { primaryLinkUrl: true },
@@ -38,6 +39,17 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
           skills: true,
           city: true,
           country: true,
+          partnerServices: {
+            edges: { node: { id: true } },
+          },
+          partnerContents: {
+            edges: {
+              node: {
+                contentType: true,
+                status: true,
+              },
+            },
+          },
         },
       },
     },

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
@@ -39,14 +39,15 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
           skills: true,
           city: true,
           country: true,
+          // The server ignores nested relation arguments and caps every
+          // relation read at QUERY_MAX_RECORDS_FROM_RELATION (60), unordered.
+          // A partner holding more than 60 contents would report a truncated
+          // case-study count. Read these at the root and group by partner if
+          // any partner ever approaches that.
           partnerServices: {
             edges: { node: { id: true } },
           },
           partnerContents: {
-            __args: {
-              filter: { status: { eq: 'APPROVED' } },
-              first: 200,
-            },
             edges: {
               node: {
                 contentType: true,

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
@@ -43,6 +43,10 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
             edges: { node: { id: true } },
           },
           partnerContents: {
+            __args: {
+              filter: { status: { eq: 'APPROVED' } },
+              first: 200,
+            },
             edges: {
               node: {
                 contentType: true,

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/graphql/queries/list-available-partners.ts
@@ -47,6 +47,8 @@ export const queryAvailablePartners = (client: CoreApiClient) =>
               node: {
                 contentType: true,
                 status: true,
+                coverImage: { url: true },
+                coverImageUrl: true,
               },
             },
           },

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper.test.ts
@@ -175,6 +175,29 @@ describe('mapPartnerForMarketplace', () => {
     ]);
   });
 
+  it('falls back to the uploaded file when coverImageUrl is the TEXT default', () => {
+    const node = makeNode();
+    node.partnerContents.edges = [
+      {
+        node: {
+          contentType: ['CASE_STUDY'],
+          status: 'APPROVED',
+          clientName: 'Acme Corp',
+          headline: 'CRM migration',
+          body: { markdown: 'Moved 12 teams to Twenty.' },
+          coverImageUrl: '',
+          coverImage: [{ url: 'https://file.example.com/cover.png' }],
+          caseStudyLink: { primaryLinkUrl: 'https://example.com/case-study' },
+          position: 1,
+        },
+      },
+    ];
+
+    expect(mapPartnerForMarketplace(node, 'profile').portfolio[0].imageUrl).toBe(
+      'https://file.example.com/cover.png',
+    );
+  });
+
   it('prefers the pasted coverImageUrl over the uploaded coverImage file in portfolio', () => {
     const node = makeNode();
     node.partnerContents.edges = [

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper.ts
@@ -2,8 +2,11 @@ import { type CoreSchema } from 'twenty-client-sdk/core';
 
 import { stripMarkdown } from 'src/modules/shared/utils/strip-markdown.util';
 
-import { isCaseStudy } from 'src/modules/partner/utils/content-type';
-import { firstFileUrl, resolvePartnerPictureUrl } from 'src/modules/partner/utils/profile-picture';
+import { isApprovedCaseStudy } from 'src/modules/partner/utils/content-type';
+import {
+  resolveCoverUrl,
+  resolvePartnerPictureUrl,
+} from 'src/modules/partner/utils/profile-picture';
 
 export type MapPartnerDetail = 'list' | 'profile';
 
@@ -202,12 +205,12 @@ const mapPortfolio = (
   edges: ReadonlyArray<PartnerContentEdge>,
 ): MarketplaceProfilePartner['portfolio'] =>
   sortByPositionAscNullsLast(edges)
-    .filter(({ node }) => isCaseStudy(node.contentType) && node.status === 'APPROVED')
+    .filter(({ node }) => isApprovedCaseStudy(node))
     .map(({ node }) => ({
       client: node.clientName ?? '',
       title: node.headline ?? '',
       body: node.body?.markdown ?? '',
-      imageUrl: node.coverImageUrl ?? firstFileUrl(node.coverImage),
+      imageUrl: resolveCoverUrl(node.coverImageUrl, node.coverImage),
       link: node.caseStudyLink?.primaryLinkUrl ?? null,
     }));
 

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
@@ -115,4 +115,51 @@ describe('listAvailablePartners', () => {
     expect(result.partners[0].rotationKey).toMatch(/^[a-f0-9]{64}$/);
     expect(result.partners[0].rotationKey).not.toContain('partner-1');
   });
+
+  it('counts zero for a partner with no services and no contents', async () => {
+    queryAvailablePartnersMock.mockResolvedValue({
+      partners: {
+        edges: [
+          {
+            node: {
+              id: 'partner-2',
+              name: 'Fresh',
+              slug: 'fresh',
+              introduction: '',
+              languagesSpoken: [],
+              deploymentExpertise: [],
+              partnerTier: null,
+              partnerScope: [],
+              region: [],
+              calendarLink: { primaryLinkUrl: null },
+              hourlyRate: null,
+              projectBudgetMin: null,
+              linkedin: { primaryLinkUrl: null },
+              website: { primaryLinkUrl: null },
+              profilePicture: { primaryLinkUrl: null },
+              profilePictureFile: [],
+              skills: [],
+              city: null,
+              country: null,
+              partnerServices: null,
+              partnerContents: null,
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const result = await listAvailablePartners();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.partners[0]).toMatchObject({
+      partnerTier: null,
+      serviceCount: 0,
+      approvedCaseStudyCount: 0,
+      approvedCaseStudyWithCoverCount: 0,
+    });
+    expect(result.partners[0].rotationKey).toMatch(/^[a-f0-9]{64}$/);
+  });
 });

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryAvailablePartnersMock } = vi.hoisted(() => ({
+  queryAvailablePartnersMock: vi.fn(),
+}));
+
+vi.mock('twenty-client-sdk/core', () => ({
+  CoreApiClient: vi.fn(),
+}));
+
+vi.mock(
+  'src/modules/partner/marketplace/graphql/queries/list-available-partners',
+  () => ({ queryAvailablePartners: queryAvailablePartnersMock }),
+);
+
+import { listAvailablePartners } from './list-available-partners.service';
+
+describe('listAvailablePartners', () => {
+  beforeEach(() => {
+    queryAvailablePartnersMock.mockReset();
+  });
+
+  it('returns ranking metadata for each partner', async () => {
+    queryAvailablePartnersMock.mockResolvedValue({
+      partners: {
+        edges: [
+          {
+            node: {
+              id: 'partner-1',
+              name: 'Acme',
+              slug: 'acme',
+              introduction: 'A complete implementation partner profile.',
+              languagesSpoken: ['ENGLISH'],
+              deploymentExpertise: ['CLOUD'],
+              partnerTier: 'ADVANCED',
+              partnerScope: ['SOLUTIONING'],
+              region: ['EUROPE'],
+              calendarLink: { primaryLinkUrl: 'https://cal.example.com/acme' },
+              hourlyRate: { amountMicros: 100_000_000, currencyCode: 'USD' },
+              projectBudgetMin: null,
+              linkedin: { primaryLinkUrl: null },
+              website: { primaryLinkUrl: 'https://acme.example.com' },
+              profilePicture: { primaryLinkUrl: null },
+              profilePictureFile: [],
+              skills: ['Migration'],
+              city: 'Paris',
+              country: 'France',
+              partnerServices: {
+                edges: [
+                  { node: { id: 'service-1' } },
+                  { node: { id: 'service-2' } },
+                ],
+              },
+              partnerContents: {
+                edges: [
+                  { node: { contentType: ['CASE_STUDY'], status: 'APPROVED' } },
+                  { node: { contentType: ['CASE_STUDY'], status: 'IN_REVIEW' } },
+                  { node: { contentType: ['BLOG'], status: 'APPROVED' } },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const result = await listAvailablePartners();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.partners[0]).toMatchObject({
+      partnerTier: 'ADVANCED',
+      serviceCount: 2,
+      approvedCaseStudyCount: 1,
+    });
+    expect(result.partners[0].rotationKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.partners[0].rotationKey).not.toContain('partner-1');
+  });
+});

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.test.ts
@@ -53,9 +53,46 @@ describe('listAvailablePartners', () => {
               },
               partnerContents: {
                 edges: [
-                  { node: { contentType: ['CASE_STUDY'], status: 'APPROVED' } },
-                  { node: { contentType: ['CASE_STUDY'], status: 'IN_REVIEW' } },
-                  { node: { contentType: ['BLOG'], status: 'APPROVED' } },
+                  {
+                    node: {
+                      contentType: ['CASE_STUDY'],
+                      status: 'APPROVED',
+                      coverImageUrl: 'https://cdn.example.com/cover.png',
+                      coverImage: [],
+                    },
+                  },
+                  {
+                    node: {
+                      contentType: ['CASE_STUDY'],
+                      status: 'APPROVED',
+                      coverImageUrl: '',
+                      coverImage: [{ url: 'https://cdn.example.com/file.png' }],
+                    },
+                  },
+                  {
+                    node: {
+                      contentType: ['CASE_STUDY'],
+                      status: 'APPROVED',
+                      coverImageUrl: '   ',
+                      coverImage: [],
+                    },
+                  },
+                  {
+                    node: {
+                      contentType: ['CASE_STUDY'],
+                      status: 'IN_REVIEW',
+                      coverImageUrl: 'https://cdn.example.com/draft.png',
+                      coverImage: [],
+                    },
+                  },
+                  {
+                    node: {
+                      contentType: ['BLOG'],
+                      status: 'APPROVED',
+                      coverImageUrl: 'https://cdn.example.com/blog.png',
+                      coverImage: [],
+                    },
+                  },
                 ],
               },
             },
@@ -72,7 +109,8 @@ describe('listAvailablePartners', () => {
     expect(result.partners[0]).toMatchObject({
       partnerTier: 'ADVANCED',
       serviceCount: 2,
-      approvedCaseStudyCount: 1,
+      approvedCaseStudyCount: 3,
+      approvedCaseStudyWithCoverCount: 2,
     });
     expect(result.partners[0].rotationKey).toMatch(/^[a-f0-9]{64}$/);
     expect(result.partners[0].rotationKey).not.toContain('partner-1');

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
@@ -6,6 +6,7 @@ import {
   type MarketplaceListPartner,
 } from 'src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper';
 import { isCaseStudy } from 'src/modules/partner/utils/content-type';
+import { firstFileUrl } from 'src/modules/partner/utils/profile-picture';
 
 import { createWeeklyRotationKey } from '../utils/create-weekly-rotation-key';
 
@@ -17,12 +18,21 @@ export type MarketplaceRankedListPartner = MarketplaceListPartner & {
   partnerTier: AvailablePartnerRaw['partnerTier'];
   serviceCount: number;
   approvedCaseStudyCount: number;
+  approvedCaseStudyWithCoverCount: number;
   rotationKey: string;
 };
 
 export type ListAvailablePartnersResult =
   | { ok: true; count: number; partners: MarketplaceRankedListPartner[] }
   | { ok: false; reason: string };
+
+// coverImageUrl is TEXT, so an empty string means "no cover", not null.
+const hasCover = (content: {
+  coverImageUrl?: string | null;
+  coverImage?: ReadonlyArray<{ url?: string | null } | null> | null;
+}): boolean =>
+  (content.coverImageUrl ?? '').trim().length > 0 ||
+  firstFileUrl(content.coverImage) !== null;
 
 const mapListPartner = (
   node: AvailablePartnerRaw,
@@ -35,14 +45,19 @@ const mapListPartner = (
     );
   }
 
+  const approvedCaseStudies = (node.partnerContents?.edges ?? []).filter(
+    ({ node: content }) =>
+      isCaseStudy(content.contentType) && content.status === 'APPROVED',
+  );
+
   return {
     ...mapped,
     partnerTier: node.partnerTier,
     serviceCount: node.partnerServices?.edges.length ?? 0,
-    approvedCaseStudyCount: (node.partnerContents?.edges ?? []).filter(
-      ({ node: content }) =>
-        isCaseStudy(content.contentType) && content.status === 'APPROVED',
-    ).length,
+    approvedCaseStudyCount: approvedCaseStudies.length,
+    approvedCaseStudyWithCoverCount:
+      approvedCaseStudies.filter(({ node: content }) => hasCover(content))
+        .length,
     rotationKey: createWeeklyRotationKey(node.id),
   };
 };

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
@@ -5,10 +5,9 @@ import {
   mapPartnerForMarketplace,
   type MarketplaceListPartner,
 } from 'src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper';
-import { isCaseStudy } from 'src/modules/partner/utils/content-type';
-import { firstFileUrl } from 'src/modules/partner/utils/profile-picture';
-
-import { createWeeklyRotationKey } from '../utils/create-weekly-rotation-key';
+import { isApprovedCaseStudy } from 'src/modules/partner/utils/content-type';
+import { resolveCoverUrl } from 'src/modules/partner/utils/profile-picture';
+import { createWeeklyRotationKey } from 'src/modules/partner/marketplace/utils/create-weekly-rotation-key';
 
 type AvailablePartnerRaw = NonNullable<
   Awaited<ReturnType<typeof queryAvailablePartners>>['partners']
@@ -26,14 +25,6 @@ export type ListAvailablePartnersResult =
   | { ok: true; count: number; partners: MarketplaceRankedListPartner[] }
   | { ok: false; reason: string };
 
-// coverImageUrl is TEXT, so an empty string means "no cover", not null.
-const hasCover = (content: {
-  coverImageUrl?: string | null;
-  coverImage?: ReadonlyArray<{ url?: string | null } | null> | null;
-}): boolean =>
-  (content.coverImageUrl ?? '').trim().length > 0 ||
-  firstFileUrl(content.coverImage) !== null;
-
 const mapListPartner = (
   node: AvailablePartnerRaw,
 ): MarketplaceRankedListPartner => {
@@ -46,18 +37,18 @@ const mapListPartner = (
   }
 
   const approvedCaseStudies = (node.partnerContents?.edges ?? []).filter(
-    ({ node: content }) =>
-      isCaseStudy(content.contentType) && content.status === 'APPROVED',
+    ({ node: content }) => isApprovedCaseStudy(content),
   );
 
   return {
     ...mapped,
     partnerTier: node.partnerTier,
-    serviceCount: node.partnerServices?.edges.length ?? 0,
+    serviceCount: (node.partnerServices?.edges ?? []).length,
     approvedCaseStudyCount: approvedCaseStudies.length,
-    approvedCaseStudyWithCoverCount:
-      approvedCaseStudies.filter(({ node: content }) => hasCover(content))
-        .length,
+    approvedCaseStudyWithCoverCount: approvedCaseStudies.filter(
+      ({ node: content }) =>
+        resolveCoverUrl(content.coverImageUrl, content.coverImage) !== null,
+    ).length,
     rotationKey: createWeeklyRotationKey(node.id),
   };
 };

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
@@ -5,16 +5,28 @@ import {
   mapPartnerForMarketplace,
   type MarketplaceListPartner,
 } from 'src/modules/partner/marketplace/mappers/map-partner-for-marketplace.mapper';
+import { isCaseStudy } from 'src/modules/partner/utils/content-type';
+
+import { createWeeklyRotationKey } from '../utils/create-weekly-rotation-key';
 
 type AvailablePartnerRaw = NonNullable<
   Awaited<ReturnType<typeof queryAvailablePartners>>['partners']
 >['edges'][number]['node'];
 
+export type MarketplaceRankedListPartner = MarketplaceListPartner & {
+  partnerTier: AvailablePartnerRaw['partnerTier'];
+  serviceCount: number;
+  approvedCaseStudyCount: number;
+  rotationKey: string;
+};
+
 export type ListAvailablePartnersResult =
-  | { ok: true; count: number; partners: MarketplaceListPartner[] }
+  | { ok: true; count: number; partners: MarketplaceRankedListPartner[] }
   | { ok: false; reason: string };
 
-const mapListPartner = (node: AvailablePartnerRaw): MarketplaceListPartner => {
+const mapListPartner = (
+  node: AvailablePartnerRaw,
+): MarketplaceRankedListPartner => {
   const mapped = mapPartnerForMarketplace(node, 'list');
 
   if ('projectBudgetTypical' in mapped) {
@@ -23,7 +35,16 @@ const mapListPartner = (node: AvailablePartnerRaw): MarketplaceListPartner => {
     );
   }
 
-  return mapped;
+  return {
+    ...mapped,
+    partnerTier: node.partnerTier,
+    serviceCount: node.partnerServices?.edges.length ?? 0,
+    approvedCaseStudyCount: (node.partnerContents?.edges ?? []).filter(
+      ({ node: content }) =>
+        isCaseStudy(content.contentType) && content.status === 'APPROVED',
+    ).length,
+    rotationKey: createWeeklyRotationKey(node.id),
+  };
 };
 
 export const listAvailablePartners = async (): Promise<ListAvailablePartnersResult> => {

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/services/list-available-partners.service.ts
@@ -27,6 +27,7 @@ export type ListAvailablePartnersResult =
 
 const mapListPartner = (
   node: AvailablePartnerRaw,
+  rotationDate: Date,
 ): MarketplaceRankedListPartner => {
   const mapped = mapPartnerForMarketplace(node, 'list');
 
@@ -49,7 +50,7 @@ const mapListPartner = (
       ({ node: content }) =>
         resolveCoverUrl(content.coverImageUrl, content.coverImage) !== null,
     ).length,
-    rotationKey: createWeeklyRotationKey(node.id),
+    rotationKey: createWeeklyRotationKey(node.id, rotationDate),
   };
 };
 
@@ -57,8 +58,11 @@ export const listAvailablePartners = async (): Promise<ListAvailablePartnersResu
   try {
     const client = new CoreApiClient();
     const result = await queryAvailablePartners(client);
+    // One clock read for the whole response: a request that straddles the UTC
+    // Monday boundary would otherwise mix keys from two weeks in one sort.
+    const rotationDate = new Date();
     const partners = (result.partners?.edges ?? []).map(({ node }) =>
-      mapListPartner(node),
+      mapListPartner(node, rotationDate),
     );
 
     return { ok: true, count: partners.length, partners };

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { createWeeklyRotationKey } from './create-weekly-rotation-key';
+
+describe('createWeeklyRotationKey', () => {
+  it('keeps a partner stable within one UTC week', () => {
+    expect(
+      createWeeklyRotationKey('partner-1', new Date('2026-08-17T00:00:00Z')),
+    ).toBe(
+      createWeeklyRotationKey('partner-1', new Date('2026-08-23T23:59:59Z')),
+    );
+  });
+
+  it('changes at the next UTC Monday', () => {
+    expect(
+      createWeeklyRotationKey('partner-1', new Date('2026-08-23T23:59:59Z')),
+    ).not.toBe(
+      createWeeklyRotationKey('partner-1', new Date('2026-08-24T00:00:00Z')),
+    );
+  });
+
+  it('gives different partners different keys', () => {
+    const date = new Date('2026-08-19T12:00:00Z');
+
+    expect(createWeeklyRotationKey('partner-1', date)).not.toBe(
+      createWeeklyRotationKey('partner-2', date),
+    );
+  });
+});

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'node:crypto';
+
+const getUtcWeekStart = (date: Date): string => {
+  const weekStart = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const daysSinceMonday = (weekStart.getUTCDay() + 6) % 7;
+  weekStart.setUTCDate(weekStart.getUTCDate() - daysSinceMonday);
+
+  return weekStart.toISOString().slice(0, 10);
+};
+
+export const createWeeklyRotationKey = (
+  partnerId: string,
+  date = new Date(),
+): string =>
+  createHash('sha256')
+    .update(`${partnerId}:${getUtcWeekStart(date)}`)
+    .digest('hex');

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/marketplace/utils/create-weekly-rotation-key.ts
@@ -10,9 +10,11 @@ const getUtcWeekStart = (date: Date): string => {
   return weekStart.toISOString().slice(0, 10);
 };
 
+// The date is required: a caller reading the clock per partner would mix keys
+// from two weeks whenever a request crosses the UTC Monday boundary.
 export const createWeeklyRotationKey = (
   partnerId: string,
-  date = new Date(),
+  date: Date,
 ): string =>
   createHash('sha256')
     .update(`${partnerId}:${getUtcWeekStart(date)}`)

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/content-type.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/content-type.ts
@@ -5,8 +5,6 @@ export const isCaseStudy = (
     ? contentType.includes('CASE_STUDY')
     : contentType === 'CASE_STUDY';
 
-// A case study only counts once an admin approved it, so a draft never scores
-// and never reaches the public profile.
 export const isApprovedCaseStudy = (content: {
   contentType?: ReadonlyArray<string | undefined> | string | null;
   status?: string | null;

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/content-type.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/content-type.ts
@@ -4,3 +4,11 @@ export const isCaseStudy = (
   Array.isArray(contentType)
     ? contentType.includes('CASE_STUDY')
     : contentType === 'CASE_STUDY';
+
+// A case study only counts once an admin approved it, so a draft never scores
+// and never reaches the public profile.
+export const isApprovedCaseStudy = (content: {
+  contentType?: ReadonlyArray<string | undefined> | string | null;
+  status?: string | null;
+}): boolean =>
+  isCaseStudy(content.contentType) && content.status === 'APPROVED';

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/profile-picture.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/profile-picture.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { firstFileUrl, resolvePartnerPictureUrl } from './profile-picture';
+import {
+  firstFileUrl,
+  resolveCoverUrl,
+  resolvePartnerPictureUrl,
+} from './profile-picture';
 
 describe('firstFileUrl', () => {
   it('returns the first file url', () => {
@@ -34,5 +38,26 @@ describe('resolvePartnerPictureUrl', () => {
     expect(resolvePartnerPictureUrl(null, null)).toBeNull();
     expect(resolvePartnerPictureUrl(undefined, undefined)).toBeNull();
     expect(resolvePartnerPictureUrl([], null)).toBeNull();
+  });
+});
+
+describe('resolveCoverUrl', () => {
+  it('prefers the pasted url over the uploaded file', () => {
+    expect(
+      resolveCoverUrl('https://x/pasted.png', [{ url: 'https://x/file.png' }]),
+    ).toBe('https://x/pasted.png');
+  });
+  it('treats the TEXT default and whitespace as no pasted url', () => {
+    expect(resolveCoverUrl('', [{ url: 'https://x/file.png' }])).toBe(
+      'https://x/file.png',
+    );
+    expect(resolveCoverUrl('   ', [{ url: 'https://x/file.png' }])).toBe(
+      'https://x/file.png',
+    );
+  });
+  it('returns null when neither source has a url', () => {
+    expect(resolveCoverUrl('', null)).toBeNull();
+    expect(resolveCoverUrl(null, [])).toBeNull();
+    expect(resolveCoverUrl(undefined, [{ url: null }])).toBeNull();
   });
 });

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/profile-picture.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/utils/profile-picture.ts
@@ -18,3 +18,14 @@ export function resolvePartnerPictureUrl(
 ): string | null {
   return firstFileUrl(files) ?? legacyLinkUrl ?? null;
 }
+
+// Cover has the same two sources as the picture, in the opposite order: a
+// pasted URL wins over an uploaded file. coverImageUrl is TEXT, so it reads
+// back as '' when unset — `??` would hand that empty string to the caller and
+// hide the uploaded file behind it.
+export function resolveCoverUrl(
+  pastedUrl: string | null | undefined,
+  files: ReadonlyArray<FileItemRead> | null | undefined,
+): string | null {
+  return (pastedUrl ?? '').trim() || firstFileUrl(files);
+}

--- a/packages/twenty-website/src/app/[locale]/(site)/partners/profile/[slug]/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/(site)/partners/profile/[slug]/page.tsx
@@ -6,10 +6,7 @@ import { getCommunityStats } from '@/platform/community';
 import { getRouteI18n } from '@/platform/i18n/get-route-i18n';
 import { getServerI18n } from '@/platform/i18n/get-server-i18n';
 import { resolveLocaleParam } from '@/platform/i18n/resolve-locale-param';
-import {
-  getMarketplacePartnerBySlug,
-  getMarketplacePartners,
-} from '@/partners-marketplace/marketplace-partners-source';
+import { getMarketplacePartnerBySlug } from '@/partners-marketplace/marketplace-partners-source';
 import { PartnerProfile } from '@/partners-marketplace/PartnerProfile';
 import { richTextExcerpt } from '@/partners-marketplace/rich-text-excerpt';
 import { buildBreadcrumbListJsonLd, JsonLd } from '@/platform/seo';
@@ -20,11 +17,6 @@ type PartnerProfileParams = { locale: string; slug: string };
 export const dynamic = 'force-dynamic';
 
 export const dynamicParams = true;
-
-export async function generateStaticParams(): Promise<Array<{ slug: string }>> {
-  const partners = await getMarketplacePartners();
-  return partners.map((partner) => ({ slug: partner.slug }));
-}
 
 export async function generateMetadata({
   params,

--- a/packages/twenty-website/src/partners-marketplace/completeness-score.ts
+++ b/packages/twenty-website/src/partners-marketplace/completeness-score.ts
@@ -7,7 +7,10 @@ export const completenessScore = (
   if (partner.description.trim().length >= 120) s += 2;
   if (partner.profilePictureUrl) s += 1;
   if (partner.serviceCount >= 1) s += 2;
-  s += Math.min(partner.approvedCaseStudyCount, 3) * 2;
+  const countedCaseStudies = Math.min(partner.approvedCaseStudyCount, 3);
+  s +=
+    countedCaseStudies * 2 +
+    Math.min(partner.approvedCaseStudyWithCoverCount, countedCaseStudies);
   if (partner.calendarLink) s += 1;
   if (partner.hourlyRateUsd !== null || partner.projectBudgetMinUsd !== null) {
     s += 1;

--- a/packages/twenty-website/src/partners-marketplace/completeness-score.ts
+++ b/packages/twenty-website/src/partners-marketplace/completeness-score.ts
@@ -9,7 +9,7 @@ export const completenessScore = (
   if (partner.serviceCount >= 1) s += 2;
   const countedCaseStudies = Math.min(partner.approvedCaseStudyCount, 3);
   s +=
-    countedCaseStudies * 2 +
+    countedCaseStudies * 4 +
     Math.min(partner.approvedCaseStudyWithCoverCount, countedCaseStudies);
   if (partner.calendarLink) s += 1;
   if (partner.hourlyRateUsd !== null || partner.projectBudgetMinUsd !== null) {

--- a/packages/twenty-website/src/partners-marketplace/completeness-score.ts
+++ b/packages/twenty-website/src/partners-marketplace/completeness-score.ts
@@ -1,20 +1,36 @@
 import { type RankedMarketplacePartner } from './marketplace-partner';
 
+const MIN_DESCRIPTION_LENGTH = 120;
+const MAX_COUNTED_CASE_STUDIES = 3;
+// An approved case study has to outweigh picture + calendar + rate combined,
+// otherwise three quick form fields beat evidence of delivered client work.
+const POINTS_PER_CASE_STUDY = 4;
+const POINTS_PER_CASE_STUDY_COVER = 1;
+
 export const completenessScore = (
   partner: RankedMarketplacePartner,
 ): number => {
-  let s = 0;
-  if (partner.description.trim().length >= 120) s += 2;
-  if (partner.profilePictureUrl) s += 1;
-  if (partner.serviceCount >= 1) s += 2;
-  const countedCaseStudies = Math.min(partner.approvedCaseStudyCount, 3);
-  s +=
-    countedCaseStudies * 4 +
-    Math.min(partner.approvedCaseStudyWithCoverCount, countedCaseStudies);
-  if (partner.calendarLink) s += 1;
+  const countedCaseStudies = Math.min(
+    partner.approvedCaseStudyCount,
+    MAX_COUNTED_CASE_STUDIES,
+  );
+  const countedCovers = Math.min(
+    partner.approvedCaseStudyWithCoverCount,
+    countedCaseStudies,
+  );
+
+  let score =
+    countedCaseStudies * POINTS_PER_CASE_STUDY +
+    countedCovers * POINTS_PER_CASE_STUDY_COVER;
+
+  if (partner.description.trim().length >= MIN_DESCRIPTION_LENGTH) score += 2;
+  if (partner.serviceCount >= 1) score += 2;
+  if (partner.profilePictureUrl) score += 1;
+  if (partner.calendarLink) score += 1;
   if (partner.hourlyRateUsd !== null || partner.projectBudgetMinUsd !== null) {
-    s += 1;
+    score += 1;
   }
-  if (partner.partnerScope.length >= 1) s += 1;
-  return s;
+  if (partner.partnerScope.length >= 1) score += 1;
+
+  return score;
 };

--- a/packages/twenty-website/src/partners-marketplace/completeness-score.ts
+++ b/packages/twenty-website/src/partners-marketplace/completeness-score.ts
@@ -1,14 +1,17 @@
-import { type MarketplacePartner } from './marketplace-partner';
+import { type RankedMarketplacePartner } from './marketplace-partner';
 
-export const completenessScore = (p: MarketplacePartner): number => {
+export const completenessScore = (
+  partner: RankedMarketplacePartner,
+): number => {
   let s = 0;
-  if (p.description.trim().length >= 120) s += 2;
-  if (p.profilePictureUrl) s += 1;
-  if (p.services.length >= 1) s += 2;
-  if (p.portfolio.length >= 1) s += 2;
-  if (p.clients.length >= 1) s += 1;
-  if (p.calendarLink) s += 1;
-  if (p.hourlyRateUsd != null || p.projectBudgetMinUsd != null) s += 1;
-  if (p.partnerScope.length >= 1) s += 1;
+  if (partner.description.trim().length >= 120) s += 2;
+  if (partner.profilePictureUrl) s += 1;
+  if (partner.serviceCount >= 1) s += 2;
+  s += Math.min(partner.approvedCaseStudyCount, 3) * 2;
+  if (partner.calendarLink) s += 1;
+  if (partner.hourlyRateUsd !== null || partner.projectBudgetMinUsd !== null) {
+    s += 1;
+  }
+  if (partner.partnerScope.length >= 1) s += 1;
   return s;
 };

--- a/packages/twenty-website/src/partners-marketplace/dummy-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/dummy-marketplace-partners.ts
@@ -6,8 +6,9 @@ export const DUMMY_PARTNERS: RankedMarketplacePartner[] = [
     partnerTier: null,
     serviceCount: 4,
     approvedCaseStudyCount: 3,
-    approvedCaseStudyWithCoverCount: 1,
-    rotationKey: 'atelier-sigma',
+    approvedCaseStudyWithCoverCount: 2,
+    rotationKey:
+      '60973a6d38f6a1a042b35e2e547656b8170aff362d6e64544907f2317d8ff5ae',
     name: 'Atelier Sigma',
     description: `**Senior CRM partner for venture-backed teams, with Twenty at the core.**
 
@@ -156,7 +157,8 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     serviceCount: 1,
     approvedCaseStudyCount: 1,
     approvedCaseStudyWithCoverCount: 1,
-    rotationKey: 'northbeam-studio',
+    rotationKey:
+      '4a14150fe472b8ae30f13d804960d398aa3983e3188d744d715fde00a430c12b',
     name: 'Northbeam Studio',
     description:
       'RevOps and reporting for B2B SaaS teams that have outgrown spreadsheets and their first CRM. We turn messy pipelines into forecasts leadership actually trusts, redesign stages and scoring around how reps really sell, wire up the dashboards your board keeps asking for, connect the enrichment and outreach tools your growth team already runs, and document every last piece of it so the system keeps working long after we hand it back over. Based in London, working across the UK and EU in English, and yes this sentence is deliberately far too long to prove the card never breaks no matter how much a partner writes.',
@@ -208,7 +210,8 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     serviceCount: 2,
     approvedCaseStudyCount: 1,
     approvedCaseStudyWithCoverCount: 1,
-    rotationKey: '9-dots-ventures',
+    rotationKey:
+      '8b2cb1cea581b13a5664a71434b204234674084488298db6ea2ce1f3d327b21b',
     name: '9 Dots Ventures',
     description:
       'Boutique CRM implementer for real-estate workflows and WhatsApp automation, with self-hosted Twenty deployments across APAC.',
@@ -268,7 +271,8 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     serviceCount: 2,
     approvedCaseStudyCount: 0,
     approvedCaseStudyWithCoverCount: 0,
-    rotationKey: 'halden-roe',
+    rotationKey:
+      'ce4f7a4b57e3d8be6da3eef9420c78ae6b83d2b94e635b5ddeb7e972f15b134b',
     name: 'Halden & Roe',
     description:
       'Migrations off legacy CRMs for mid-market teams. German and English, with EU data residency by default.',
@@ -309,7 +313,8 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     serviceCount: 2,
     approvedCaseStudyCount: 0,
     approvedCaseStudyWithCoverCount: 0,
-    rotationKey: 'verza-collective',
+    rotationKey:
+      '8a9b0dd87072f7ad5a3d007b4b15c89d78f5015b7f358c8b5ad0486c75709e0f',
     name: 'Verza Collective',
     description:
       'No-code operations and automations for scaling startups. 150 projects shipped across Europe and LATAM, from first pipeline to full RevOps tooling.',
@@ -356,7 +361,8 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     serviceCount: 1,
     approvedCaseStudyCount: 0,
     approvedCaseStudyWithCoverCount: 0,
-    rotationKey: 'kioko-labs',
+    rotationKey:
+      '438cb0009a662ad2c228caf645925fb2dcbfd55d5d9fa737ca28d87a5dd969b9',
     name: 'Kioko Labs',
     description:
       'Self-hosted Twenty deployments and API work for teams across Africa and the Gulf.',
@@ -392,7 +398,8 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     serviceCount: 0,
     approvedCaseStudyCount: 0,
     approvedCaseStudyWithCoverCount: 0,
-    rotationKey: 'tomas-brandt',
+    rotationKey:
+      '2915f4495ee1d953cfdfbcd168d6a0dc6d6b0c7bd22e06797c21a2e099631533',
     name: 'Tomas Brandt',
     description:
       'Independent Twenty consultant, ex-Salesforce admin. Available for short solutioning engagements.',
@@ -422,7 +429,8 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     serviceCount: 0,
     approvedCaseStudyCount: 0,
     approvedCaseStudyWithCoverCount: 0,
-    rotationKey: 'benjamin-reynolds',
+    rotationKey:
+      '1d446fd5709cc17ab3de6771fedc591056498ee55831703cc4d115457b1494df',
     name: 'Benjamin Reynolds',
     description: '',
     calendarLink: '',

--- a/packages/twenty-website/src/partners-marketplace/dummy-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/dummy-marketplace-partners.ts
@@ -1,8 +1,12 @@
-import { type MarketplacePartner } from './marketplace-partner';
+import { type RankedMarketplacePartner } from './marketplace-partner';
 
-export const DUMMY_PARTNERS: MarketplacePartner[] = [
+export const DUMMY_PARTNERS: RankedMarketplacePartner[] = [
   {
     slug: 'atelier-sigma',
+    partnerTier: null,
+    serviceCount: 4,
+    approvedCaseStudyCount: 3,
+    rotationKey: 'atelier-sigma',
     name: 'Atelier Sigma',
     description: `**Senior CRM partner for venture-backed teams, with Twenty at the core.**
 
@@ -147,6 +151,10 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
   },
   {
     slug: 'northbeam-studio',
+    partnerTier: null,
+    serviceCount: 1,
+    approvedCaseStudyCount: 1,
+    rotationKey: 'northbeam-studio',
     name: 'Northbeam Studio',
     description:
       'RevOps and reporting for B2B SaaS teams that have outgrown spreadsheets and their first CRM. We turn messy pipelines into forecasts leadership actually trusts, redesign stages and scoring around how reps really sell, wire up the dashboards your board keeps asking for, connect the enrichment and outreach tools your growth team already runs, and document every last piece of it so the system keeps working long after we hand it back over. Based in London, working across the UK and EU in English, and yes this sentence is deliberately far too long to prove the card never breaks no matter how much a partner writes.',
@@ -194,6 +202,10 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
   },
   {
     slug: '9-dots-ventures',
+    partnerTier: null,
+    serviceCount: 2,
+    approvedCaseStudyCount: 1,
+    rotationKey: '9-dots-ventures',
     name: '9 Dots Ventures',
     description:
       'Boutique CRM implementer for real-estate workflows and WhatsApp automation, with self-hosted Twenty deployments across APAC.',
@@ -249,6 +261,10 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
   },
   {
     slug: 'halden-roe',
+    partnerTier: null,
+    serviceCount: 2,
+    approvedCaseStudyCount: 0,
+    rotationKey: 'halden-roe',
     name: 'Halden & Roe',
     description:
       'Migrations off legacy CRMs for mid-market teams. German and English, with EU data residency by default.',
@@ -285,6 +301,10 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
   },
   {
     slug: 'verza-collective',
+    partnerTier: null,
+    serviceCount: 2,
+    approvedCaseStudyCount: 0,
+    rotationKey: 'verza-collective',
     name: 'Verza Collective',
     description:
       'No-code operations and automations for scaling startups. 150 projects shipped across Europe and LATAM, from first pipeline to full RevOps tooling.',
@@ -327,6 +347,10 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
   },
   {
     slug: 'kioko-labs',
+    partnerTier: null,
+    serviceCount: 1,
+    approvedCaseStudyCount: 0,
+    rotationKey: 'kioko-labs',
     name: 'Kioko Labs',
     description:
       'Self-hosted Twenty deployments and API work for teams across Africa and the Gulf.',
@@ -358,6 +382,10 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
   },
   {
     slug: 'tomas-brandt',
+    partnerTier: null,
+    serviceCount: 0,
+    approvedCaseStudyCount: 0,
+    rotationKey: 'tomas-brandt',
     name: 'Tomas Brandt',
     description:
       'Independent Twenty consultant, ex-Salesforce admin. Available for short solutioning engagements.',
@@ -383,6 +411,10 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
   },
   {
     slug: 'benjamin-reynolds',
+    partnerTier: null,
+    serviceCount: 0,
+    approvedCaseStudyCount: 0,
+    rotationKey: 'benjamin-reynolds',
     name: 'Benjamin Reynolds',
     description: '',
     calendarLink: '',

--- a/packages/twenty-website/src/partners-marketplace/dummy-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/dummy-marketplace-partners.ts
@@ -6,6 +6,7 @@ export const DUMMY_PARTNERS: RankedMarketplacePartner[] = [
     partnerTier: null,
     serviceCount: 4,
     approvedCaseStudyCount: 3,
+    approvedCaseStudyWithCoverCount: 1,
     rotationKey: 'atelier-sigma',
     name: 'Atelier Sigma',
     description: `**Senior CRM partner for venture-backed teams, with Twenty at the core.**
@@ -154,6 +155,7 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     partnerTier: null,
     serviceCount: 1,
     approvedCaseStudyCount: 1,
+    approvedCaseStudyWithCoverCount: 1,
     rotationKey: 'northbeam-studio',
     name: 'Northbeam Studio',
     description:
@@ -205,6 +207,7 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     partnerTier: null,
     serviceCount: 2,
     approvedCaseStudyCount: 1,
+    approvedCaseStudyWithCoverCount: 1,
     rotationKey: '9-dots-ventures',
     name: '9 Dots Ventures',
     description:
@@ -264,6 +267,7 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     partnerTier: null,
     serviceCount: 2,
     approvedCaseStudyCount: 0,
+    approvedCaseStudyWithCoverCount: 0,
     rotationKey: 'halden-roe',
     name: 'Halden & Roe',
     description:
@@ -304,6 +308,7 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     partnerTier: null,
     serviceCount: 2,
     approvedCaseStudyCount: 0,
+    approvedCaseStudyWithCoverCount: 0,
     rotationKey: 'verza-collective',
     name: 'Verza Collective',
     description:
@@ -350,6 +355,7 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     partnerTier: null,
     serviceCount: 1,
     approvedCaseStudyCount: 0,
+    approvedCaseStudyWithCoverCount: 0,
     rotationKey: 'kioko-labs',
     name: 'Kioko Labs',
     description:
@@ -385,6 +391,7 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     partnerTier: null,
     serviceCount: 0,
     approvedCaseStudyCount: 0,
+    approvedCaseStudyWithCoverCount: 0,
     rotationKey: 'tomas-brandt',
     name: 'Tomas Brandt',
     description:
@@ -414,6 +421,7 @@ Twenty is the foundation. Around it we build modular GTM stacks that are structu
     partnerTier: null,
     serviceCount: 0,
     approvedCaseStudyCount: 0,
+    approvedCaseStudyWithCoverCount: 0,
     rotationKey: 'benjamin-reynolds',
     name: 'Benjamin Reynolds',
     description: '',

--- a/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.test.ts
@@ -73,6 +73,60 @@ describe('fetchLiveMarketplacePartners', () => {
     ]);
   });
 
+  const rankablePartner = {
+    name: 'Acme',
+    slug: 'acme',
+    introduction: 'Hi',
+    languagesSpoken: ['ENGLISH'],
+    partnerScope: ['ADVISORY'],
+    region: ['US'],
+    calendarLink: null,
+    hourlyRate: null,
+    projectBudgetMin: null,
+    linkedin: null,
+    website: null,
+    profilePicture: null,
+    skills: null,
+    city: null,
+    country: null,
+    partnerTier: 'ADVANCED',
+    serviceCount: 2,
+    approvedCaseStudyCount: 3,
+    approvedCaseStudyWithCoverCount: 2,
+    rotationKey: 'weekly-key',
+  };
+
+  it.each([
+    ['rotationKey', { rotationKey: '' }],
+    ['serviceCount', { serviceCount: undefined }],
+    ['approvedCaseStudyCount', { approvedCaseStudyCount: null }],
+    [
+      'approvedCaseStudyWithCoverCount',
+      { approvedCaseStudyWithCoverCount: -1 },
+    ],
+  ])(
+    'throws when the payload breaks the ranking contract on %s',
+    async (_field, override) => {
+      mockedFetch.mockResolvedValue({
+        ok: true,
+        partners: [{ ...rankablePartner, ...override }],
+      });
+
+      await expect(fetchLiveMarketplacePartners()).rejects.toThrow('acme');
+    },
+  );
+
+  it('reads an unknown partner tier as unranked', async () => {
+    mockedFetch.mockResolvedValue({
+      ok: true,
+      partners: [{ ...rankablePartner, partnerTier: 'EXPERT' }],
+    });
+
+    const [partner] = await fetchLiveMarketplacePartners();
+
+    expect(partner.partnerTier).toBeNull();
+  });
+
   it('degrades to [] when the fetch throws', async () => {
     const errorSpy = jest
       .spyOn(console, 'error')

--- a/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.test.ts
@@ -31,6 +31,10 @@ describe('fetchLiveMarketplacePartners', () => {
           skills: null,
           city: null,
           country: null,
+          partnerTier: 'ADVANCED',
+          serviceCount: 2,
+          approvedCaseStudyCount: 3,
+          rotationKey: 'weekly-key',
         },
       ],
     });
@@ -59,6 +63,10 @@ describe('fetchLiveMarketplacePartners', () => {
         services: [],
         portfolio: [],
         clients: [],
+        partnerTier: 'ADVANCED',
+        serviceCount: 2,
+        approvedCaseStudyCount: 3,
+        rotationKey: 'weekly-key',
       },
     ]);
   });

--- a/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.test.ts
@@ -106,13 +106,15 @@ describe('fetchLiveMarketplacePartners', () => {
     ],
   ])(
     'throws when the payload breaks the ranking contract on %s',
-    async (_field, override) => {
+    async (field, override) => {
       mockedFetch.mockResolvedValue({
         ok: true,
         partners: [{ ...rankablePartner, ...override }],
       });
 
-      await expect(fetchLiveMarketplacePartners()).rejects.toThrow('acme');
+      await expect(fetchLiveMarketplacePartners()).rejects.toThrow(
+        new RegExp(`${field}.*acme`),
+      );
     },
   );
 

--- a/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.test.ts
@@ -34,6 +34,7 @@ describe('fetchLiveMarketplacePartners', () => {
           partnerTier: 'ADVANCED',
           serviceCount: 2,
           approvedCaseStudyCount: 3,
+          approvedCaseStudyWithCoverCount: 2,
           rotationKey: 'weekly-key',
         },
       ],
@@ -66,6 +67,7 @@ describe('fetchLiveMarketplacePartners', () => {
         partnerTier: 'ADVANCED',
         serviceCount: 2,
         approvedCaseStudyCount: 3,
+        approvedCaseStudyWithCoverCount: 2,
         rotationKey: 'weekly-key',
       },
     ]);

--- a/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.ts
@@ -1,4 +1,4 @@
-import { type MarketplacePartner } from './marketplace-partner';
+import { type RankedMarketplacePartner } from './marketplace-partner';
 import { type CurrencyValue, type LinkValue } from './marketplace-api-types';
 import { linkUrl } from './link-url';
 import { microsToUsd } from './micros-to-usd';
@@ -23,6 +23,10 @@ type ApiPartner = {
   skills: string[] | null;
   city: string | null;
   country: string | null;
+  partnerTier: RankedMarketplacePartner['partnerTier'];
+  serviceCount: number;
+  approvedCaseStudyCount: number;
+  rotationKey: string;
 };
 
 type ApiResponse = {
@@ -34,7 +38,7 @@ type ApiResponse = {
 // to [] on any failure (matching the old getPartners) so the page renders the
 // empty state rather than crashing.
 export async function fetchLiveMarketplacePartners(): Promise<
-  readonly MarketplacePartner[]
+  readonly RankedMarketplacePartner[]
 > {
   try {
     const data = (await partnersApiFetch('/s/partners')) as ApiResponse;
@@ -65,6 +69,10 @@ export async function fetchLiveMarketplacePartners(): Promise<
       services: [],
       portfolio: [],
       clients: [],
+      partnerTier: apiPartner.partnerTier,
+      serviceCount: apiPartner.serviceCount,
+      approvedCaseStudyCount: apiPartner.approvedCaseStudyCount,
+      rotationKey: apiPartner.rotationKey,
     }));
   } catch (error) {
     console.error('[partners-marketplace] live fetch failed:', error);

--- a/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.ts
@@ -26,6 +26,7 @@ type ApiPartner = {
   partnerTier: RankedMarketplacePartner['partnerTier'];
   serviceCount: number;
   approvedCaseStudyCount: number;
+  approvedCaseStudyWithCoverCount: number;
   rotationKey: string;
 };
 
@@ -72,6 +73,8 @@ export async function fetchLiveMarketplacePartners(): Promise<
       partnerTier: apiPartner.partnerTier,
       serviceCount: apiPartner.serviceCount,
       approvedCaseStudyCount: apiPartner.approvedCaseStudyCount,
+      approvedCaseStudyWithCoverCount:
+        apiPartner.approvedCaseStudyWithCoverCount,
       rotationKey: apiPartner.rotationKey,
     }));
   } catch (error) {

--- a/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.ts
@@ -54,7 +54,7 @@ const assertRankingContract = (apiPartner: ApiPartner): void => {
     apiPartner.rotationKey.length === 0
   ) {
     throw new Error(
-      `partners API returned no rotationKey for "${apiPartner.slug}"`,
+      `partners API returned no rotationKey for "${apiPartner.slug}" (${JSON.stringify(apiPartner.rotationKey)})`,
     );
   }
 
@@ -64,7 +64,7 @@ const assertRankingContract = (apiPartner: ApiPartner): void => {
 
   if (invalidCount !== undefined) {
     throw new Error(
-      `partners API returned an invalid ${invalidCount} for "${apiPartner.slug}"`,
+      `partners API returned an invalid ${invalidCount} for "${apiPartner.slug}" (${JSON.stringify(apiPartner[invalidCount])})`,
     );
   }
 };

--- a/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-marketplace-partners.ts
@@ -1,4 +1,8 @@
-import { type RankedMarketplacePartner } from './marketplace-partner';
+import {
+  PARTNER_TIERS,
+  type PartnerTier,
+  type RankedMarketplacePartner,
+} from './marketplace-partner';
 import { type CurrencyValue, type LinkValue } from './marketplace-api-types';
 import { linkUrl } from './link-url';
 import { microsToUsd } from './micros-to-usd';
@@ -23,7 +27,7 @@ type ApiPartner = {
   skills: string[] | null;
   city: string | null;
   country: string | null;
-  partnerTier: RankedMarketplacePartner['partnerTier'];
+  partnerTier: PartnerTier | null;
   serviceCount: number;
   approvedCaseStudyCount: number;
   approvedCaseStudyWithCoverCount: number;
@@ -35,19 +39,72 @@ type ApiResponse = {
   ok?: boolean;
 };
 
+const RANKING_COUNTS = [
+  'serviceCount',
+  'approvedCaseStudyCount',
+  'approvedCaseStudyWithCoverCount',
+] as const;
+
+// The ranking tuple carries no defaults on purpose. A missing count turns the
+// score into NaN, which the comparator silently skips, so a partial payload
+// would seat a partner in a slot it never earned.
+const assertRankingContract = (apiPartner: ApiPartner): void => {
+  if (
+    typeof apiPartner.rotationKey !== 'string' ||
+    apiPartner.rotationKey.length === 0
+  ) {
+    throw new Error(
+      `partners API returned no rotationKey for "${apiPartner.slug}"`,
+    );
+  }
+
+  const invalidCount = RANKING_COUNTS.find(
+    (count) => !Number.isInteger(apiPartner[count]) || apiPartner[count] < 0,
+  );
+
+  if (invalidCount !== undefined) {
+    throw new Error(
+      `partners API returned an invalid ${invalidCount} for "${apiPartner.slug}"`,
+    );
+  }
+};
+
+// partnerTier is a CRM select the API owns, so it can gain values this build
+// never heard of. An unknown one ranks as unset instead of breaking the tier
+// comparison.
+const readPartnerTier = (value: unknown): PartnerTier | null =>
+  PARTNER_TIERS.find((tier) => tier === value) ?? null;
+
 // The live source: normalize the CRM payload into MarketplacePartner. Degrades
-// to [] on any failure (matching the old getPartners) so the page renders the
-// empty state rather than crashing.
+// to [] when the API is unreachable or shapeless (matching the old getPartners)
+// so the page renders the empty state rather than crashing. A payload that
+// breaks the ranking contract throws instead — see assertRankingContract.
 export async function fetchLiveMarketplacePartners(): Promise<
   readonly RankedMarketplacePartner[]
 > {
+  let data: ApiResponse;
+
   try {
-    const data = (await partnersApiFetch('/s/partners')) as ApiResponse;
-    const partners = data.partners;
-    if (!Array.isArray(partners)) {
-      throw new Error('partners API response missing partners array');
-    }
-    return partners.map((apiPartner) => ({
+    data = (await partnersApiFetch('/s/partners')) as ApiResponse;
+  } catch (error) {
+    console.error('[partners-marketplace] live fetch failed:', error);
+    return [];
+  }
+
+  const partners = data.partners;
+
+  if (!Array.isArray(partners)) {
+    console.error(
+      '[partners-marketplace] live fetch failed:',
+      new Error('partners API response missing partners array'),
+    );
+    return [];
+  }
+
+  return partners.map((apiPartner) => {
+    assertRankingContract(apiPartner);
+
+    return {
       slug: apiPartner.slug,
       name: apiPartner.name,
       description: apiPartner.introduction ?? '',
@@ -70,15 +127,12 @@ export async function fetchLiveMarketplacePartners(): Promise<
       services: [],
       portfolio: [],
       clients: [],
-      partnerTier: apiPartner.partnerTier,
+      partnerTier: readPartnerTier(apiPartner.partnerTier),
       serviceCount: apiPartner.serviceCount,
       approvedCaseStudyCount: apiPartner.approvedCaseStudyCount,
       approvedCaseStudyWithCoverCount:
         apiPartner.approvedCaseStudyWithCoverCount,
       rotationKey: apiPartner.rotationKey,
-    }));
-  } catch (error) {
-    console.error('[partners-marketplace] live fetch failed:', error);
-    return [];
-  }
+    };
+  });
 }

--- a/packages/twenty-website/src/partners-marketplace/get-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/get-marketplace-partners.ts
@@ -1,12 +1,12 @@
 import { DUMMY_PARTNERS } from './dummy-marketplace-partners';
 import { fetchLiveMarketplacePartners } from './fetch-live-marketplace-partners';
-import { type MarketplacePartner } from './marketplace-partner';
+import { type RankedMarketplacePartner } from './marketplace-partner';
 import { rankPartners } from './rank-partners';
 
 const useDummy = process.env.NEXT_PUBLIC_USE_DUMMY_PARTNERS === '1';
 
 export const getMarketplacePartners = async (): Promise<
-  MarketplacePartner[]
+  RankedMarketplacePartner[]
 > => {
   const partners = useDummy
     ? DUMMY_PARTNERS

--- a/packages/twenty-website/src/partners-marketplace/get-marketplace-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/get-marketplace-partners.ts
@@ -1,15 +1,30 @@
 import { DUMMY_PARTNERS } from './dummy-marketplace-partners';
 import { fetchLiveMarketplacePartners } from './fetch-live-marketplace-partners';
-import { type RankedMarketplacePartner } from './marketplace-partner';
+import { type MarketplacePartner } from './marketplace-partner';
 import { rankPartners } from './rank-partners';
 
 const useDummy = process.env.NEXT_PUBLIC_USE_DUMMY_PARTNERS === '1';
 
+// The ranked list crosses a client boundary, so React serializes whatever it
+// carries into the page source. The ranking fields are inputs to the order, not
+// page content: partnerTier is an internal classification the UI never renders,
+// and rotationKey is next week's tiebreak seed. Neither belongs in View Source
+// of a page that exists to stop partners from gaming their position.
 export const getMarketplacePartners = async (): Promise<
-  RankedMarketplacePartner[]
+  MarketplacePartner[]
 > => {
   const partners = useDummy
     ? DUMMY_PARTNERS
     : await fetchLiveMarketplacePartners();
-  return rankPartners(partners);
+
+  return rankPartners(partners).map(
+    ({
+      partnerTier: _partnerTier,
+      serviceCount: _serviceCount,
+      approvedCaseStudyCount: _approvedCaseStudyCount,
+      approvedCaseStudyWithCoverCount: _approvedCaseStudyWithCoverCount,
+      rotationKey: _rotationKey,
+      ...partner
+    }) => partner,
+  );
 };

--- a/packages/twenty-website/src/partners-marketplace/marketplace-partner.ts
+++ b/packages/twenty-website/src/partners-marketplace/marketplace-partner.ts
@@ -40,7 +40,9 @@ export type MarketplacePartner = {
   clients: readonly PartnerClient[];
 };
 
-export type PartnerTier = 'ADVANCED' | 'INTERMEDIATE' | 'NEW';
+export const PARTNER_TIERS = ['ADVANCED', 'INTERMEDIATE', 'NEW'] as const;
+
+export type PartnerTier = (typeof PARTNER_TIERS)[number];
 
 export type RankedMarketplacePartner = MarketplacePartner & {
   partnerTier: PartnerTier | null;

--- a/packages/twenty-website/src/partners-marketplace/marketplace-partner.ts
+++ b/packages/twenty-website/src/partners-marketplace/marketplace-partner.ts
@@ -46,5 +46,6 @@ export type RankedMarketplacePartner = MarketplacePartner & {
   partnerTier: PartnerTier | null;
   serviceCount: number;
   approvedCaseStudyCount: number;
+  approvedCaseStudyWithCoverCount: number;
   rotationKey: string;
 };

--- a/packages/twenty-website/src/partners-marketplace/marketplace-partner.ts
+++ b/packages/twenty-website/src/partners-marketplace/marketplace-partner.ts
@@ -39,3 +39,12 @@ export type MarketplacePartner = {
   portfolio: readonly PartnerCaseStudy[];
   clients: readonly PartnerClient[];
 };
+
+export type PartnerTier = 'ADVANCED' | 'INTERMEDIATE' | 'NEW';
+
+export type RankedMarketplacePartner = MarketplacePartner & {
+  partnerTier: PartnerTier | null;
+  serviceCount: number;
+  approvedCaseStudyCount: number;
+  rotationKey: string;
+};

--- a/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
@@ -29,6 +29,7 @@ const base: RankedMarketplacePartner = {
   partnerTier: null,
   serviceCount: 0,
   approvedCaseStudyCount: 0,
+  approvedCaseStudyWithCoverCount: 0,
   rotationKey: 'b',
 };
 
@@ -51,6 +52,40 @@ test('awards two points per approved case study with a six-point cap', () => {
   expect(completenessScore({ ...base, approvedCaseStudyCount: 1 })).toBe(2);
   expect(completenessScore({ ...base, approvedCaseStudyCount: 3 })).toBe(6);
   expect(completenessScore({ ...base, approvedCaseStudyCount: 4 })).toBe(6);
+});
+
+test('awards one extra point per approved case study that has a cover', () => {
+  expect(
+    completenessScore({
+      ...base,
+      approvedCaseStudyCount: 1,
+      approvedCaseStudyWithCoverCount: 1,
+    }),
+  ).toBe(3);
+  expect(
+    completenessScore({
+      ...base,
+      approvedCaseStudyCount: 3,
+      approvedCaseStudyWithCoverCount: 3,
+    }),
+  ).toBe(9);
+  expect(
+    completenessScore({
+      ...base,
+      approvedCaseStudyCount: 3,
+      approvedCaseStudyWithCoverCount: 1,
+    }),
+  ).toBe(7);
+});
+
+test('caps the cover bonus at the three counted case studies', () => {
+  expect(
+    completenessScore({
+      ...base,
+      approvedCaseStudyCount: 5,
+      approvedCaseStudyWithCoverCount: 5,
+    }),
+  ).toBe(9);
 });
 
 test('completeness wins over partner tier', () => {

--- a/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
@@ -92,6 +92,16 @@ test('awards one extra point per approved case study that has a cover', () => {
   ).toBe(13);
 });
 
+test('never counts more covers than counted case studies', () => {
+  expect(
+    completenessScore({
+      ...base,
+      approvedCaseStudyCount: 1,
+      approvedCaseStudyWithCoverCount: 3,
+    }),
+  ).toBe(5);
+});
+
 test('caps the cover bonus at the three counted case studies', () => {
   expect(
     completenessScore({

--- a/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
@@ -1,12 +1,12 @@
-import { type MarketplacePartner } from './marketplace-partner';
 import { completenessScore } from './completeness-score';
 import { isGhost } from './is-ghost-partner';
+import { type RankedMarketplacePartner } from './marketplace-partner';
 import { rankPartners } from './rank-partners';
 
-const base: MarketplacePartner = {
+const base: RankedMarketplacePartner = {
   slug: 'x',
   name: 'X',
-  description: '',
+  description: 'A short description that keeps this partner visible.',
   calendarLink: '',
   partnerScope: [],
   region: [],
@@ -26,45 +26,87 @@ const base: MarketplacePartner = {
   services: [],
   portfolio: [],
   clients: [],
+  partnerTier: null,
+  serviceCount: 0,
+  approvedCaseStudyCount: 0,
+  rotationKey: 'b',
 };
 
-const rich: MarketplacePartner = {
-  ...base,
-  slug: 'rich',
-  name: 'Rich',
-  description: 'x'.repeat(200),
-  profilePictureUrl: 'http://img',
-  partnerScope: ['SOLUTIONING'],
-  hourlyRateUsd: 100,
-  calendarLink: 'http://cal',
-  services: [{ title: 's', description: 'd' }],
-  portfolio: [
-    {
-      client: 'c',
-      title: 't',
-      body: 'b',
-      imageUrl: null,
-      link: null,
-    },
-  ],
-  clients: [{ name: 'n', logoUrl: null }],
-};
-const thin: MarketplacePartner = {
-  ...base,
-  slug: 'thin',
-  name: 'Thin',
-  description: 'a real short blurb about us — thin but visible',
-};
-const ghost: MarketplacePartner = { ...base, slug: 'ghost', name: 'Ghost' };
-
-test('rich scores higher than thin', () => {
-  expect(completenessScore(rich)).toBeGreaterThan(completenessScore(thin));
-});
 test('ghost detected, thin is not', () => {
-  expect(isGhost(ghost)).toBe(true);
-  expect(isGhost(thin)).toBe(false);
+  expect(
+    isGhost({ ...base, slug: 'ghost', name: 'Ghost', description: '' }),
+  ).toBe(true);
+  expect(
+    isGhost({
+      ...base,
+      slug: 'thin',
+      name: 'Thin',
+      description: 'a real short blurb about us — thin but visible',
+    }),
+  ).toBe(false);
 });
-test('rankPartners hides ghosts and orders rich before thin', () => {
-  const out = rankPartners([thin, ghost, rich]);
-  expect(out.map((p) => p.slug)).toEqual(['rich', 'thin']);
+
+test('awards two points per approved case study with a six-point cap', () => {
+  expect(completenessScore({ ...base, approvedCaseStudyCount: 0 })).toBe(0);
+  expect(completenessScore({ ...base, approvedCaseStudyCount: 1 })).toBe(2);
+  expect(completenessScore({ ...base, approvedCaseStudyCount: 3 })).toBe(6);
+  expect(completenessScore({ ...base, approvedCaseStudyCount: 4 })).toBe(6);
+});
+
+test('completeness wins over partner tier', () => {
+  const completeNew = {
+    ...base,
+    slug: 'complete-new',
+    partnerTier: 'NEW' as const,
+    serviceCount: 1,
+  };
+  const thinAdvanced = {
+    ...base,
+    slug: 'thin-advanced',
+    partnerTier: 'ADVANCED' as const,
+  };
+
+  expect(
+    rankPartners([thinAdvanced, completeNew]).map(({ slug }) => slug),
+  ).toEqual(['complete-new', 'thin-advanced']);
+});
+
+test('partner tier wins when completeness is equal', () => {
+  const advanced = {
+    ...base,
+    slug: 'advanced',
+    partnerTier: 'ADVANCED' as const,
+  };
+  const intermediate = {
+    ...base,
+    slug: 'intermediate',
+    partnerTier: 'INTERMEDIATE' as const,
+  };
+  const newPartner = { ...base, slug: 'new', partnerTier: 'NEW' as const };
+  const unranked = { ...base, slug: 'unranked' };
+
+  expect(
+    rankPartners([unranked, newPartner, advanced, intermediate]).map(
+      ({ slug }) => slug,
+    ),
+  ).toEqual(['advanced', 'intermediate', 'new', 'unranked']);
+});
+
+test('weekly rotation wins when completeness and tier are equal', () => {
+  const hashName = {
+    ...base,
+    slug: 'hash-name',
+    name: '#1_novilin',
+    rotationKey: 'z',
+  };
+  const ordinaryName = {
+    ...base,
+    slug: 'ordinary-name',
+    name: 'Zenith',
+    rotationKey: 'a',
+  };
+
+  expect(
+    rankPartners([hashName, ordinaryName]).map(({ slug }) => slug),
+  ).toEqual(['ordinary-name', 'hash-name']);
 });

--- a/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
@@ -169,6 +169,15 @@ test('weekly rotation wins when completeness and tier are equal', () => {
   ).toEqual(['ordinary-name', 'hash-name']);
 });
 
+test('the description threshold sits at one hundred and twenty characters', () => {
+  expect(completenessScore({ ...base, description: 'x'.repeat(119) })).toBe(0);
+  expect(completenessScore({ ...base, description: 'x'.repeat(120) })).toBe(2);
+});
+
+test('whitespace alone never earns the description points', () => {
+  expect(completenessScore({ ...base, description: ' '.repeat(200) })).toBe(0);
+});
+
 test('a full profile scores twenty-three points', () => {
   expect(
     completenessScore({

--- a/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
@@ -47,11 +47,25 @@ test('ghost detected, thin is not', () => {
   ).toBe(false);
 });
 
-test('awards two points per approved case study with a six-point cap', () => {
+test('awards four points per approved case study with a twelve-point cap', () => {
   expect(completenessScore({ ...base, approvedCaseStudyCount: 0 })).toBe(0);
-  expect(completenessScore({ ...base, approvedCaseStudyCount: 1 })).toBe(2);
-  expect(completenessScore({ ...base, approvedCaseStudyCount: 3 })).toBe(6);
-  expect(completenessScore({ ...base, approvedCaseStudyCount: 4 })).toBe(6);
+  expect(completenessScore({ ...base, approvedCaseStudyCount: 1 })).toBe(4);
+  expect(completenessScore({ ...base, approvedCaseStudyCount: 3 })).toBe(12);
+  expect(completenessScore({ ...base, approvedCaseStudyCount: 4 })).toBe(12);
+});
+
+test('one approved case study outweighs picture, calendar and rate together', () => {
+  const evidence = { ...base, approvedCaseStudyCount: 1 };
+  const cheapFields = {
+    ...base,
+    profilePictureUrl: 'https://cdn.example.com/face.png',
+    calendarLink: 'https://cal.example.com/slot',
+    hourlyRateUsd: 200,
+  };
+
+  expect(completenessScore(evidence)).toBeGreaterThan(
+    completenessScore(cheapFields),
+  );
 });
 
 test('awards one extra point per approved case study that has a cover', () => {
@@ -61,21 +75,21 @@ test('awards one extra point per approved case study that has a cover', () => {
       approvedCaseStudyCount: 1,
       approvedCaseStudyWithCoverCount: 1,
     }),
-  ).toBe(3);
+  ).toBe(5);
   expect(
     completenessScore({
       ...base,
       approvedCaseStudyCount: 3,
       approvedCaseStudyWithCoverCount: 3,
     }),
-  ).toBe(9);
+  ).toBe(15);
   expect(
     completenessScore({
       ...base,
       approvedCaseStudyCount: 3,
       approvedCaseStudyWithCoverCount: 1,
     }),
-  ).toBe(7);
+  ).toBe(13);
 });
 
 test('caps the cover bonus at the three counted case studies', () => {
@@ -85,7 +99,7 @@ test('caps the cover bonus at the three counted case studies', () => {
       approvedCaseStudyCount: 5,
       approvedCaseStudyWithCoverCount: 5,
     }),
-  ).toBe(9);
+  ).toBe(15);
 });
 
 test('completeness wins over partner tier', () => {

--- a/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
+++ b/packages/twenty-website/src/partners-marketplace/rank-partners.test.ts
@@ -121,18 +121,27 @@ test('completeness wins over partner tier', () => {
 });
 
 test('partner tier wins when completeness is equal', () => {
+  // Rotation keys run against the tier order, so this fails if the comparator
+  // ever puts rotation before tier.
   const advanced = {
     ...base,
     slug: 'advanced',
     partnerTier: 'ADVANCED' as const,
+    rotationKey: 'z',
   };
   const intermediate = {
     ...base,
     slug: 'intermediate',
     partnerTier: 'INTERMEDIATE' as const,
+    rotationKey: 'y',
   };
-  const newPartner = { ...base, slug: 'new', partnerTier: 'NEW' as const };
-  const unranked = { ...base, slug: 'unranked' };
+  const newPartner = {
+    ...base,
+    slug: 'new',
+    partnerTier: 'NEW' as const,
+    rotationKey: 'x',
+  };
+  const unranked = { ...base, slug: 'unranked', rotationKey: 'a' };
 
   expect(
     rankPartners([unranked, newPartner, advanced, intermediate]).map(
@@ -158,4 +167,54 @@ test('weekly rotation wins when completeness and tier are equal', () => {
   expect(
     rankPartners([hashName, ordinaryName]).map(({ slug }) => slug),
   ).toEqual(['ordinary-name', 'hash-name']);
+});
+
+test('a full profile scores twenty-three points', () => {
+  expect(
+    completenessScore({
+      ...base,
+      description: 'x'.repeat(120),
+      profilePictureUrl: 'https://cdn.example.com/face.png',
+      serviceCount: 4,
+      approvedCaseStudyCount: 3,
+      approvedCaseStudyWithCoverCount: 3,
+      calendarLink: 'https://cal.example.com/slot',
+      hourlyRateUsd: 200,
+      partnerScope: ['SOLUTIONING'],
+    }),
+  ).toBe(23);
+});
+
+test('each signal contributes its documented weight', () => {
+  expect(completenessScore(base)).toBe(0);
+  expect(completenessScore({ ...base, description: 'x'.repeat(120) })).toBe(2);
+  expect(completenessScore({ ...base, serviceCount: 1 })).toBe(2);
+  expect(
+    completenessScore({ ...base, profilePictureUrl: 'https://x.example/p' }),
+  ).toBe(1);
+  expect(
+    completenessScore({ ...base, calendarLink: 'https://cal.example/s' }),
+  ).toBe(1);
+  expect(completenessScore({ ...base, hourlyRateUsd: 200 })).toBe(1);
+  expect(completenessScore({ ...base, projectBudgetMinUsd: 5000 })).toBe(1);
+  expect(completenessScore({ ...base, partnerScope: ['SOLUTIONING'] })).toBe(1);
+});
+
+test('unused portfolio and client arrays no longer score', () => {
+  const withLegacyArrays = {
+    ...base,
+    portfolio: [
+      {
+        client: 'Acme',
+        title: 'A case study',
+        body: '',
+        imageUrl: null,
+        link: null,
+      },
+    ],
+    clients: [{ name: 'Acme', logoUrl: null }],
+    services: [{ title: 'Migration', description: 'We migrate' }],
+  };
+
+  expect(completenessScore(withLegacyArrays)).toBe(completenessScore(base));
 });

--- a/packages/twenty-website/src/partners-marketplace/rank-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/rank-partners.ts
@@ -1,15 +1,25 @@
 import { completenessScore } from './completeness-score';
 import { isGhost } from './is-ghost-partner';
-import { type MarketplacePartner } from './marketplace-partner';
+import { type RankedMarketplacePartner } from './marketplace-partner';
+
+const PARTNER_TIER_WEIGHT = {
+  ADVANCED: 3,
+  INTERMEDIATE: 2,
+  NEW: 1,
+} as const;
+
+const partnerTierWeight = (partner: RankedMarketplacePartner): number =>
+  partner.partnerTier === null ? 0 : PARTNER_TIER_WEIGHT[partner.partnerTier];
 
 export const rankPartners = (
-  partners: readonly MarketplacePartner[],
-): MarketplacePartner[] =>
+  partners: readonly RankedMarketplacePartner[],
+): RankedMarketplacePartner[] =>
   partners
     .filter((p) => !isGhost(p))
     .slice()
     .sort(
-      (a, b) =>
-        completenessScore(b) - completenessScore(a) ||
-        a.name.localeCompare(b.name),
+      (left, right) =>
+        completenessScore(right) - completenessScore(left) ||
+        partnerTierWeight(right) - partnerTierWeight(left) ||
+        left.rotationKey.localeCompare(right.rotationKey),
     );

--- a/packages/twenty-website/src/partners-marketplace/rank-partners.ts
+++ b/packages/twenty-website/src/partners-marketplace/rank-partners.ts
@@ -15,7 +15,7 @@ export const rankPartners = (
   partners: readonly RankedMarketplacePartner[],
 ): RankedMarketplacePartner[] =>
   partners
-    .filter((p) => !isGhost(p))
+    .filter((partner) => !isGhost(partner))
     .slice()
     .sort(
       (left, right) =>


### PR DESCRIPTION
Targets `rashad/partner-ranking-api` (#24459), not `main`. Merge that one first: the website reads fields this PR does not add.

**Requires:** twenty-partners `1.6.4`, shipped in #24459. This PR changes `twenty-website` only and carries no app version of its own.

## Problem

The marketplace list ranked partners by completeness, then alphabetically by name. A partner took the top slot by renaming itself `#1_novilin`.

## Ranking rule

Three criteria, compared in order. A later criterion never compensates an earlier one.

1. **Completeness score**, descending — 23 points max
2. **Partner tier** — `ADVANCED`, `INTERMEDIATE`, `NEW`, then unset
3. **Weekly rotation key**, ascending

The name no longer takes part in the sort. Ties reshuffle every Monday and stay stable within the week, so no partner holds a fixed slot.

### Completeness score

| Signal | Points |
| --- | --- |
| Approved case study | 4 each, 5 with a cover image, up to 3 case studies |
| Introduction of 120 characters or more | 2 |
| At least one service | 2 |
| Profile picture | 1 |
| Calendar link | 1 |
| Hourly rate or minimum project budget | 1 |
| Partner scope | 1 |

A case study scores only once approved, so an unreviewed draft adds nothing.

An approved case study outweighs a picture, a calendar link and a rate combined. Those three fields are worth 3 points together, so evidence of delivered client work has to beat them. At 2 points it did not: a partner who published a case study ranked below partners who filled three quick fields.

`clients` and `portfolio` leave the score. The profile never populated them, and the API now returns real counts instead.

## Deploy order

**Publish twenty-partners `1.6.4` before the website deploy.** `rotationKey` has no fallback value, so a website running against an app older than `1.6.4` returns HTTP 500 on `/partners/list`. Failing loud is deliberate: a partial payload must not silently produce a wrong order.

## Verified against production data

Checked on a local workspace loaded with the 29 published production partners.

- The order matches the tuple. `novlini` moves from rank 1 to rank 11.
- `joseph-chiang`, the one partner whose only strong signal is an approved case study, moves from rank 21 to rank 4. Two thin profiles that also hold one case study move only from 24 to 22 and from 25 to 23, so evidence does not erase completeness.
- Production holds **zero** `partnerService` records, so the service criterion never fires today. The reachable ceiling is 21 points, and the highest observed score is 11.
- 17 of 29 partners tie at 6 points with the same signature, so the weekly rotation decides the order for over half the marketplace. 23 of 29 hold no approved case study at all.
- 6 of 29 profiles are filtered out as ghosts and never reach the sort.
- 2 of 6 approved case studies carry a cover. Both use the pasted `coverImageUrl`; nobody uses the `coverImage` file upload.

## Checks

- 52 tests in `twenty-website`
- `tsc --noEmit`
- `nx lint twenty-website`
- Live landing rendered against a local workspace running the changed app
