### PR TITLE
fix(query-runner): compare keyset cursors on the ordering's LOWER() expression

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-where-condition-parts.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-where-condition-parts.spec.ts
@@ -1,0 +1,117 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { computeWhereConditionParts } from 'src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts';
+
+describe('computeWhereConditionParts', () => {
+  // Param names carry a random suffix per call, so assertions resolve the
+  // generated placeholder instead of hardcoding it
+  const computeSqlWithResolvedParam = ({
+    operator,
+    value = 'Acme',
+    fieldMetadataType = FieldMetadataType.TEXT,
+    key = 'name',
+    subFieldKey,
+  }: {
+    operator: string;
+    value?: unknown;
+    fieldMetadataType?: FieldMetadataType;
+    key?: string;
+    subFieldKey?: string;
+  }): { sql: string; paramValues: unknown[] } => {
+    const { sql, params } = computeWhereConditionParts({
+      operator,
+      objectNameSingular: 'company',
+      key,
+      subFieldKey,
+      value,
+      fieldMetadataType,
+    });
+
+    const resolvedSql = Object.keys(params).reduce(
+      (acc, paramName) => acc.split(`:${paramName}`).join(':param'),
+      sql,
+    );
+
+    return { sql: resolvedSql, paramValues: Object.values(params) };
+  };
+
+  describe('case-insensitive keyset operators', () => {
+    it('should compare the lowercased column against the lowercased cursor value', () => {
+      expect(
+        computeSqlWithResolvedParam({ operator: 'gtCaseInsensitive' }),
+      ).toEqual({
+        sql: 'LOWER("company"."name"::text) > LOWER(:param)',
+        paramValues: ['Acme'],
+      });
+
+      expect(
+        computeSqlWithResolvedParam({ operator: 'ltCaseInsensitive' }),
+      ).toEqual({
+        sql: 'LOWER("company"."name"::text) < LOWER(:param)',
+        paramValues: ['Acme'],
+      });
+
+      expect(
+        computeSqlWithResolvedParam({ operator: 'eqStrictCaseInsensitive' }),
+      ).toEqual({
+        sql: 'LOWER("company"."name"::text) = LOWER(:param)',
+        paramValues: ['Acme'],
+      });
+    });
+
+    it('should compare on the same expression the SQL ordering sorts a SELECT field by', () => {
+      // LOWER() cannot take an enum column directly, which is why the ordering
+      // casts it; the keyset predicate has to reach the very same expression
+      const { sql } = computeSqlWithResolvedParam({
+        operator: 'gtCaseInsensitive',
+        value: 'MEDIUM',
+        fieldMetadataType: FieldMetadataType.SELECT,
+        key: 'priority',
+      });
+
+      expect(sql).toBe('LOWER("company"."priority"::text) > LOWER(:param)');
+    });
+
+    it('should cast a composite sub-column whose own type the caller cannot see', () => {
+      // The filter parser reports the composite type (ACTOR), never the SELECT
+      // of createdBy.source, so deriving the cast here would emit LOWER() on an
+      // enum column and fail at the database instead of paginating
+      const { sql } = computeSqlWithResolvedParam({
+        operator: 'eqStrictCaseInsensitive',
+        value: 'MANUAL',
+        fieldMetadataType: FieldMetadataType.ACTOR,
+        key: 'createdBySource',
+        subFieldKey: 'source',
+      });
+
+      expect(sql).toBe(
+        'LOWER("company"."createdBySource"::text) = LOWER(:param)',
+      );
+    });
+
+    it('should not widen the comparison to empty values the ordering keeps out of the NULL block', () => {
+      const { sql } = computeSqlWithResolvedParam({
+        operator: 'eqStrictCaseInsensitive',
+        value: '',
+      });
+
+      expect(sql).not.toContain('IS NULL');
+    });
+  });
+
+  describe('range operators outside keyset pagination', () => {
+    it('should keep comparing raw values', () => {
+      expect(computeSqlWithResolvedParam({ operator: 'gt' }).sql).toBe(
+        '"company"."name" > :param',
+      );
+
+      expect(computeSqlWithResolvedParam({ operator: 'lt' }).sql).toBe(
+        '"company"."name" < :param',
+      );
+
+      expect(computeSqlWithResolvedParam({ operator: 'eqStrict' }).sql).toBe(
+        '"company"."name" = :param',
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
@@ -151,6 +151,27 @@ export const computeWhereConditionParts = ({
         sql: `${fieldReference} = :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
+    // Case-insensitive keyset variants, for the columns the SQL ordering sorts
+    // through LOWER(): comparing raw values there would resolve case ties
+    // against the scan order and skip or duplicate rows across page
+    // boundaries. The ::text cast is unconditional because it is a no-op on
+    // text columns and required for the enum column of a SELECT field, which
+    // LOWER() cannot take directly.
+    case 'gtCaseInsensitive':
+      return {
+        sql: `LOWER(${fieldReference}::text) > LOWER(:${key}${paramSuffix})`,
+        params: { [`${key}${paramSuffix}`]: value },
+      };
+    case 'ltCaseInsensitive':
+      return {
+        sql: `LOWER(${fieldReference}::text) < LOWER(:${key}${paramSuffix})`,
+        params: { [`${key}${paramSuffix}`]: value },
+      };
+    case 'eqStrictCaseInsensitive':
+      return {
+        sql: `LOWER(${fieldReference}::text) = LOWER(:${key}${paramSuffix})`,
+        params: { [`${key}${paramSuffix}`]: value },
+      };
     case 'like':
       return {
         sql: `${fieldReference}::text LIKE :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,

--- a/packages/twenty-server/src/engine/api/utils/__tests__/compute-cursor-arg-filter.utils.spec.ts
+++ b/packages/twenty-server/src/engine/api/utils/__tests__/compute-cursor-arg-filter.utils.spec.ts
@@ -80,6 +80,20 @@ describe('computeCursorArgFilter', () => {
     isNullable: true,
   });
 
+  const priorityField = createMockField({
+    id: 'priority-id',
+    type: FieldMetadataType.SELECT,
+    name: 'priority',
+    label: 'Priority',
+  });
+
+  const tagsField = createMockField({
+    id: 'tags-id',
+    type: FieldMetadataType.MULTI_SELECT,
+    name: 'tags',
+    label: 'Tags',
+  });
+
   const companyField = {
     ...createMockField({
       id: 'company-id',
@@ -139,6 +153,8 @@ describe('computeCursorArgFilter', () => {
     fullNameField,
     idField,
     closeDateField,
+    priorityField,
+    tagsField,
     companyField,
     companyNameField,
     companyContactNameField,
@@ -167,6 +183,8 @@ describe('computeCursorArgFilter', () => {
       'fullname-id',
       'id-id',
       'closedate-id',
+      'priority-id',
+      'tags-id',
       'company-id',
     ],
     indexMetadataIds: [],
@@ -225,7 +243,12 @@ describe('computeCursorArgFilter', () => {
       // TEXT columns hold SQL NULL for rows written empty or without the
       // field, so the trailing NULL block is part of the continuation
       expect(result).toEqual([
-        { or: [{ name: { gt: 'John' } }, { name: { isStrictly: 'NULL' } }] },
+        {
+          or: [
+            { name: { gtCaseInsensitive: 'John' } },
+            { name: { isStrictly: 'NULL' } },
+          ],
+        },
       ]);
     });
 
@@ -242,7 +265,7 @@ describe('computeCursorArgFilter', () => {
         isForwardPagination: false,
       });
 
-      expect(result).toEqual([{ name: { lt: 'John' } }]);
+      expect(result).toEqual([{ name: { ltCaseInsensitive: 'John' } }]);
     });
   });
 
@@ -264,10 +287,15 @@ describe('computeCursorArgFilter', () => {
       });
 
       expect(result).toEqual([
-        { or: [{ name: { gt: 'John' } }, { name: { isStrictly: 'NULL' } }] },
+        {
+          or: [
+            { name: { gtCaseInsensitive: 'John' } },
+            { name: { isStrictly: 'NULL' } },
+          ],
+        },
         {
           and: [
-            { name: { eqStrict: 'John' } },
+            { name: { eqStrictCaseInsensitive: 'John' } },
             { or: [{ age: { lt: 30 } }, { age: { isStrictly: 'NULL' } }] },
           ],
         },
@@ -301,7 +329,7 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { fullName: { firstName: { gt: 'John' } } },
+            { fullName: { firstName: { gtCaseInsensitive: 'John' } } },
             { fullName: { firstName: { isStrictly: 'NULL' } } },
           ],
         },
@@ -309,12 +337,12 @@ describe('computeCursorArgFilter', () => {
           and: [
             {
               fullName: {
-                firstName: { eqStrict: 'John' },
+                firstName: { eqStrictCaseInsensitive: 'John' },
               },
             },
             {
               or: [
-                { fullName: { lastName: { gt: 'Doe' } } },
+                { fullName: { lastName: { gtCaseInsensitive: 'Doe' } } },
                 { fullName: { lastName: { isStrictly: 'NULL' } } },
               ],
             },
@@ -347,7 +375,7 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { fullName: { firstName: { gt: 'John' } } },
+            { fullName: { firstName: { gtCaseInsensitive: 'John' } } },
             { fullName: { firstName: { isStrictly: 'NULL' } } },
           ],
         },
@@ -380,7 +408,7 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { fullName: { firstName: { gt: 'John' } } },
+            { fullName: { firstName: { gtCaseInsensitive: 'John' } } },
             { fullName: { firstName: { isStrictly: 'NULL' } } },
           ],
         },
@@ -388,12 +416,12 @@ describe('computeCursorArgFilter', () => {
           and: [
             {
               fullName: {
-                firstName: { eqStrict: 'John' },
+                firstName: { eqStrictCaseInsensitive: 'John' },
               },
             },
             {
               or: [
-                { fullName: { lastName: { gt: 'Doe' } } },
+                { fullName: { lastName: { gtCaseInsensitive: 'Doe' } } },
                 { fullName: { lastName: { isStrictly: 'NULL' } } },
               ],
             },
@@ -427,24 +455,107 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           fullName: {
-            firstName: { lt: 'John' },
+            firstName: { ltCaseInsensitive: 'John' },
           },
         },
         {
           and: [
             {
               fullName: {
-                firstName: { eqStrict: 'John' },
+                firstName: { eqStrictCaseInsensitive: 'John' },
               },
             },
             {
               fullName: {
-                lastName: { lt: 'Doe' },
+                lastName: { ltCaseInsensitive: 'Doe' },
               },
             },
           ],
         },
       ]);
+    });
+  });
+
+  describe('ordering relation of the continuation', () => {
+    // The SQL ordering sorts TEXT and SELECT columns through LOWER(), so a raw
+    // comparison here resolves case ties against the scan order and skips or
+    // duplicates rows across page boundaries (issue #24359)
+    it('should continue a SELECT ordering on the lowercased column', () => {
+      const result = computeCursorArgFilter({
+        cursor: { priority: 'Medium' },
+        orderBy: [{ priority: OrderByDirection.AscNullsLast }],
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        isForwardPagination: true,
+      });
+
+      expect(result).toEqual([
+        {
+          or: [
+            { priority: { gtCaseInsensitive: 'Medium' } },
+            { priority: { isStrictly: 'NULL' } },
+          ],
+        },
+      ]);
+    });
+
+    it('should tie a SELECT ordering on the lowercased column too', () => {
+      // Values differing only by case are one tie for the ordering: comparing
+      // them exactly would strand the rows the id tie-breaker should reach
+      const result = computeCursorArgFilter({
+        cursor: { priority: 'Medium', id: 'uuid-1' },
+        orderBy: [
+          { priority: OrderByDirection.AscNullsFirst },
+          { id: OrderByDirection.AscNullsFirst },
+        ],
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        isForwardPagination: true,
+      });
+
+      expect(result).toEqual([
+        { priority: { gtCaseInsensitive: 'Medium' } },
+        {
+          and: [
+            { priority: { eqStrictCaseInsensitive: 'Medium' } },
+            { id: { gt: 'uuid-1' } },
+          ],
+        },
+      ]);
+    });
+
+    it.each([
+      ['a NUMBER field', 'age', 30],
+      ['a DATE_TIME field', 'closeDate', '2026-01-01T00:00:00.000Z'],
+    ])('should keep comparing %s raw', (_label, fieldName, cursorValue) => {
+      const result = computeCursorArgFilter({
+        cursor: { [fieldName]: cursorValue },
+        orderBy: [{ [fieldName]: OrderByDirection.AscNullsFirst }],
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        isForwardPagination: true,
+      });
+
+      expect(result).toEqual([{ [fieldName]: { gt: cursorValue } }]);
+    });
+
+    it('should keep comparing a MULTI_SELECT field raw', () => {
+      // Its cursor value is an array, which no scalar LOWER() comparison can
+      // carry, so it stays on the raw predicate until the ordering's array
+      // rendering is mirrored as well
+      const result = computeCursorArgFilter({
+        cursor: { tags: ['URGENT'] } as unknown as ObjectRecordCursor,
+        orderBy: [{ tags: OrderByDirection.AscNullsFirst }],
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        isForwardPagination: true,
+      });
+
+      expect(result).toEqual([{ tags: { gt: ['URGENT'] } }]);
     });
   });
 
@@ -697,13 +808,13 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { company: { name: { gt: 'Acme' } } },
+            { company: { name: { gtCaseInsensitive: 'Acme' } } },
             { company: { name: { isStrictly: 'NULL' } } },
           ],
         },
         {
           and: [
-            { company: { name: { eqStrict: 'Acme' } } },
+            { company: { name: { eqStrictCaseInsensitive: 'Acme' } } },
             { id: { gt: 'uuid-1' } },
           ],
         },
@@ -780,16 +891,30 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { company: { contactName: { firstName: { gt: 'Ada' } } } },
+            {
+              company: {
+                contactName: { firstName: { gtCaseInsensitive: 'Ada' } },
+              },
+            },
             { company: { contactName: { firstName: { isStrictly: 'NULL' } } } },
           ],
         },
         {
           and: [
-            { company: { contactName: { firstName: { eqStrict: 'Ada' } } } },
+            {
+              company: {
+                contactName: { firstName: { eqStrictCaseInsensitive: 'Ada' } },
+              },
+            },
             {
               or: [
-                { company: { contactName: { lastName: { gt: 'Lovelace' } } } },
+                {
+                  company: {
+                    contactName: {
+                      lastName: { gtCaseInsensitive: 'Lovelace' },
+                    },
+                  },
+                },
                 {
                   company: {
                     contactName: { lastName: { isStrictly: 'NULL' } },
@@ -801,9 +926,17 @@ describe('computeCursorArgFilter', () => {
         },
         {
           and: [
-            { company: { contactName: { firstName: { eqStrict: 'Ada' } } } },
             {
-              company: { contactName: { lastName: { eqStrict: 'Lovelace' } } },
+              company: {
+                contactName: { firstName: { eqStrictCaseInsensitive: 'Ada' } },
+              },
+            },
+            {
+              company: {
+                contactName: {
+                  lastName: { eqStrictCaseInsensitive: 'Lovelace' },
+                },
+              },
             },
             { id: { gt: 'uuid-1' } },
           ],

--- a/packages/twenty-server/src/engine/api/utils/build-cursor-keyset-condition.utils.ts
+++ b/packages/twenty-server/src/engine/api/utils/build-cursor-keyset-condition.utils.ts
@@ -8,6 +8,9 @@ type BuildCursorKeysetConditionParams = {
   isForwardPagination: boolean;
   isEqualityCondition: boolean;
   canFieldHoldNullValue: boolean;
+  // Mirrors the LOWER() the SQL ordering applies to this column: the
+  // continuation has to compare on the same expression that produced the page
+  isCaseInsensitiveOrder: boolean;
   // Wraps a leaf filter (e.g. { gt: value }) into the field's filter path
   buildLeafCondition: (
     leafFilter: Record<string, unknown>,
@@ -34,6 +37,7 @@ export function buildCursorKeysetCondition({
   isForwardPagination,
   isEqualityCondition,
   canFieldHoldNullValue,
+  isCaseInsensitiveOrder,
   buildLeafCondition,
   // The strict operators compare exactly: the empty-value widening of 'is'
   // and 'eq' does not mirror the SQL scan order the cursor continues
@@ -41,9 +45,17 @@ export function buildCursorKeysetCondition({
     buildLeafCondition({ isStrictly: isNull ? 'NULL' : 'NOT_NULL' }),
 }: BuildCursorKeysetConditionParams): Record<string, unknown> | null {
   if (isEqualityCondition) {
-    return cursorValue === null
-      ? buildNullCheckCondition(true)
-      : buildLeafCondition({ eqStrict: cursorValue });
+    if (cursorValue === null) {
+      return buildNullCheckCondition(true);
+    }
+
+    // Rows tying under LOWER() are one tie for the ordering, so the branch
+    // handing over to the next key has to treat them as one tie too
+    return buildLeafCondition(
+      isCaseInsensitiveOrder
+        ? { eqStrictCaseInsensitive: cursorValue }
+        : { eqStrict: cursorValue },
+    );
   }
 
   const { isAscending, areNullsScannedLast } = getEffectiveScanOrder(
@@ -57,8 +69,16 @@ export function buildCursorKeysetCondition({
     return areNullsScannedLast ? null : buildNullCheckCondition(false);
   }
 
+  const strictComparisonOperator = isCaseInsensitiveOrder
+    ? isAscending
+      ? 'gtCaseInsensitive'
+      : 'ltCaseInsensitive'
+    : isAscending
+      ? 'gt'
+      : 'lt';
+
   const mainCondition = buildLeafCondition({
-    [isAscending ? 'gt' : 'lt']: cursorValue,
+    [strictComparisonOperator]: cursorValue,
   });
 
   if (areNullsScannedLast && canFieldHoldNullValue) {

--- a/packages/twenty-server/src/engine/api/utils/build-cursor-leaf-where-condition.utils.ts
+++ b/packages/twenty-server/src/engine/api/utils/build-cursor-leaf-where-condition.utils.ts
@@ -1,4 +1,9 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { shouldUseCaseInsensitiveOrder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/build-order-by-column-expression.util';
 import { buildCursorKeysetCondition } from 'src/engine/api/utils/build-cursor-keyset-condition.utils';
+import { computeOrderByLeafColumnType } from 'src/engine/api/utils/compute-order-by-leaf-column.util';
 import { type OrderByLeaf } from 'src/engine/api/utils/resolve-order-by-leaves.utils';
 
 // SQL NULL can sit in any nullable column whatever its type: write-side
@@ -8,6 +13,22 @@ import { type OrderByLeaf } from 'src/engine/api/utils/resolve-order-by-leaves.u
 // and are treated as nullable; a needless IS NULL branch matches nothing.
 const checkIfLeafCanHoldNullValue = (leaf: OrderByLeaf): boolean =>
   leaf.kind === 'scalar' ? leaf.fieldMetadata.isNullable !== false : true;
+
+// Read from the leaf's own column type, the way the SQL order parser decides
+// whether to wrap the column in LOWER(), so the keyset predicate and the scan
+// order cannot disagree about the ordering relation. MULTI_SELECT is left out
+// even though it is ordered case-insensitively: its cursor value is an array,
+// which no scalar LOWER() comparison can carry, so aligning it needs the array
+// rendering of the ordering (issue #24359 covers TEXT and SELECT).
+const checkIfLeafIsOrderedCaseInsensitively = (leaf: OrderByLeaf): boolean => {
+  const columnType = computeOrderByLeafColumnType(leaf);
+
+  return (
+    isDefined(columnType) &&
+    columnType !== FieldMetadataType.MULTI_SELECT &&
+    shouldUseCaseInsensitiveOrder(columnType)
+  );
+};
 
 type BuildCursorLeafWhereConditionParams = {
   leaf: OrderByLeaf;
@@ -37,6 +58,7 @@ export function buildCursorLeafWhereCondition({
     isForwardPagination,
     isEqualityCondition,
     canFieldHoldNullValue: checkIfLeafCanHoldNullValue(leaf),
+    isCaseInsensitiveOrder: checkIfLeafIsOrderedCaseInsensitively(leaf),
     buildLeafCondition: (leafFilter) =>
       leaf.path.reduceRight<Record<string, unknown>>(
         (nested, key) => ({ [key]: nested }),

--- a/packages/twenty-server/src/engine/api/utils/compute-order-by-leaf-column.util.ts
+++ b/packages/twenty-server/src/engine/api/utils/compute-order-by-leaf-column.util.ts
@@ -12,6 +12,26 @@ export type OrderByLeafColumn = {
   columnType: FieldMetadataType;
 };
 
+// The type of the column an orderBy leaf sorts on, which for composite and
+// relation leaves is the resolved sub/target column rather than the field the
+// leaf hangs off. Callers that only need the comparison semantics of the
+// ordering (e.g. the cursor keyset conditions) read it without resolving an
+// alias they have no use for.
+export const computeOrderByLeafColumnType = (
+  leaf: OrderByLeaf,
+): FieldMetadataType | null => {
+  switch (leaf.kind) {
+    case 'relation':
+      return isDefined(leaf.targetFieldMetadata)
+        ? (leaf.targetCompositeProperty ?? leaf.targetFieldMetadata).type
+        : null;
+    case 'composite':
+      return leaf.compositeProperty.type;
+    case 'scalar':
+      return leaf.fieldMetadata.type;
+  }
+};
+
 // The one mapping from an orderBy leaf to the column its values live in. The
 // SQL ORDER BY expression, the hidden column selection and the raw-row alias
 // the cursor side channel reads back (`"<tableAlias>_<columnName>"`) all
@@ -20,13 +40,15 @@ export const computeOrderByLeafColumn = (
   leaf: OrderByLeaf,
   objectNameSingular: string,
 ): OrderByLeafColumn | null => {
-  switch (leaf.kind) {
-    case 'relation': {
-      if (!isDefined(leaf.targetFieldMetadata)) {
-        // A relation without a resolvable target contributes no ordering
-        return null;
-      }
+  const columnType = computeOrderByLeafColumnType(leaf);
 
+  if (!isDefined(columnType)) {
+    // A relation without a resolvable target contributes no ordering
+    return null;
+  }
+
+  switch (leaf.kind) {
+    case 'relation':
       return {
         tableAlias: leaf.path[0],
         columnName: isDefined(leaf.targetCompositeProperty)
@@ -35,10 +57,8 @@ export const computeOrderByLeafColumn = (
               leaf.targetCompositeProperty,
             )
           : leaf.path[1],
-        columnType: (leaf.targetCompositeProperty ?? leaf.targetFieldMetadata)
-          .type,
+        columnType,
       };
-    }
     case 'composite':
       return {
         tableAlias: objectNameSingular,
@@ -46,13 +66,13 @@ export const computeOrderByLeafColumn = (
           leaf.path[0],
           leaf.compositeProperty,
         ),
-        columnType: leaf.compositeProperty.type,
+        columnType,
       };
     case 'scalar':
       return {
         tableAlias: objectNameSingular,
         columnName: leaf.path[0],
-        columnType: leaf.fieldMetadata.type,
+        columnType,
       };
   }
 };

--- a/packages/twenty-server/test/integration/graphql/suites/cursor-pagination-order-by.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/cursor-pagination-order-by.integration-spec.ts
@@ -590,3 +590,130 @@ describe('Cursor pagination ordered by a TEXT field with empty values', () => {
     ]);
   });
 });
+
+// TEXT and SELECT columns are ordered through LOWER(), so the continuation has
+// to compare on that same expression: a raw comparison resolves case ties
+// against the scan order and skips or duplicates rows at page boundaries
+// (issue #24359)
+describe('Cursor pagination ordered by a case-insensitively sorted TEXT field', () => {
+  const caseTiedCompanyIds = [
+    '20202020-ffff-4000-8000-000000000001',
+    '20202020-ffff-4000-8000-000000000002',
+    '20202020-ffff-4000-8000-000000000003',
+  ];
+  const lastCompanyId = '20202020-ffff-4000-8000-000000000004';
+  const allCompanyIds = [...caseTiedCompanyIds, lastCompanyId];
+
+  beforeAll(async () => {
+    await makeGraphqlAPIRequest(
+      createManyOperationFactory({
+        objectMetadataSingularName: 'company',
+        objectMetadataPluralName: 'companies',
+        gqlFields: 'id',
+        data: [
+          // Three spellings of one lowercased value: every page boundary below
+          // lands inside the tie they form
+          { id: caseTiedCompanyIds[0], name: 'acme' },
+          { id: caseTiedCompanyIds[1], name: 'ACME' },
+          { id: caseTiedCompanyIds[2], name: 'Acme' },
+          { id: lastCompanyId, name: 'Zebra' },
+        ],
+        upsert: true,
+      }),
+    ).expect(200);
+  });
+
+  it.each(['AscNullsLast', 'DescNullsLast'])(
+    'should neither skip nor repeat records across a case tie with %s',
+    async (direction) => {
+      const { ids } = await paginateForward({
+        objectMetadataSingularName: 'company',
+        objectMetadataPluralName: 'companies',
+        filter: { id: { in: allCompanyIds } },
+        orderBy: { name: direction },
+        // One record per page puts a cursor between every pair of tied rows
+        first: 1,
+      });
+
+      expect(ids).toHaveLength(allCompanyIds.length);
+      expect(new Set(ids)).toEqual(new Set(allCompanyIds));
+    },
+  );
+
+  it('should keep the tied rows together on one side of the later name', async () => {
+    const { ids } = await paginateForward({
+      objectMetadataSingularName: 'company',
+      objectMetadataPluralName: 'companies',
+      filter: { id: { in: allCompanyIds } },
+      orderBy: { name: 'AscNullsLast' },
+      first: 1,
+    });
+
+    expect(new Set(ids.slice(0, caseTiedCompanyIds.length))).toEqual(
+      new Set(caseTiedCompanyIds),
+    );
+    expect(ids[ids.length - 1]).toBe(lastCompanyId);
+  });
+});
+
+// A SELECT column is an enum: a raw comparison follows the enum's declaration
+// order (NEW, SCREENING, MEETING, PROPOSAL, CUSTOMER) while the ordering sorts
+// by LOWER(stage::text), so the two disagree wholesale rather than only at ties
+describe('Cursor pagination ordered by a SELECT field', () => {
+  const stagesInDeclarationOrder = [
+    'NEW',
+    'SCREENING',
+    'MEETING',
+    'PROPOSAL',
+    'CUSTOMER',
+  ];
+  const opportunityIdByStage: Record<string, string> = {
+    NEW: '20202020-ffff-4100-8000-000000000001',
+    SCREENING: '20202020-ffff-4100-8000-000000000002',
+    MEETING: '20202020-ffff-4100-8000-000000000003',
+    PROPOSAL: '20202020-ffff-4100-8000-000000000004',
+    CUSTOMER: '20202020-ffff-4100-8000-000000000005',
+  };
+  const allOpportunityIds = Object.values(opportunityIdByStage);
+
+  beforeAll(async () => {
+    await makeGraphqlAPIRequest(
+      createManyOperationFactory({
+        objectMetadataSingularName: 'opportunity',
+        objectMetadataPluralName: 'opportunities',
+        gqlFields: 'id',
+        data: stagesInDeclarationOrder.map((stage) => ({
+          id: opportunityIdByStage[stage],
+          name: `Stage ${stage} opportunity`,
+          stage,
+        })),
+        upsert: true,
+      }),
+    ).expect(200);
+  });
+
+  it('should follow the lowercased text order the scan uses, not the enum order', async () => {
+    const { ids } = await paginateForward({
+      filter: { id: { in: allOpportunityIds } },
+      orderBy: { stage: 'AscNullsLast' },
+      first: 2,
+    });
+
+    expect(ids).toEqual(
+      ['CUSTOMER', 'MEETING', 'NEW', 'PROPOSAL', 'SCREENING'].map(
+        (stage) => opportunityIdByStage[stage],
+      ),
+    );
+  });
+
+  it('should neither skip nor repeat records when paged one at a time', async () => {
+    const { ids } = await paginateForward({
+      filter: { id: { in: allOpportunityIds } },
+      orderBy: { stage: 'DescNullsLast' },
+      first: 1,
+    });
+
+    expect(ids).toHaveLength(allOpportunityIds.length);
+    expect(new Set(ids)).toEqual(new Set(allOpportunityIds));
+  });
+});


### PR DESCRIPTION
Closes #24359

## Problem

Ordering by a TEXT column emits `LOWER(col)` and a SELECT/MULTI_SELECT column `LOWER(col::text)`, but the cursor continuation compared the raw column value (`col > :cursorValue`). The keyset predicate and the ORDER BY therefore disagreed about the ordering relation:

- **TEXT**: rows differing from the cursor only by case sit at a `LOWER()` tie that the raw `>` resolves differently, so records near case boundaries are duplicated or skipped, collation-dependent.
- **SELECT**: the raw comparison `enum_col > 'VALUE'` follows the enum's declaration order while the ORDER BY sorts by lowercased text. For `opportunity.stage` that is `NEW, SCREENING, MEETING, PROPOSAL, CUSTOMER` against `customer, meeting, new, proposal, screening` — the two orders diverge wholesale, not just at ties.

## Fix

The keyset conditions now emit case-insensitive comparison variants for the leaves whose column the order parser wraps in `LOWER()`.

- `build-cursor-leaf-where-condition.utils.ts` — decides it from the leaf's own column type with `shouldUseCaseInsensitiveOrder`, the same predicate `GraphqlQueryOrderFieldParser` uses, so the scan order and the continuation read one flag rather than two that can drift.
- `compute-order-by-leaf-column.util.ts` — `computeOrderByLeafColumnType` split out of `computeOrderByLeafColumn`, which keeps the leaf→column mapping in one place while letting the cursor side read the type without resolving a table alias it has no use for.
- `build-cursor-keyset-condition.utils.ts` — picks the operator per leaf.
- `compute-where-condition-parts.ts` — `gtCaseInsensitive` / `ltCaseInsensitive` / `eqStrictCaseInsensitive`, comparing `LOWER(col::text)` against `LOWER(:value)`.

Three details worth flagging for review:

**Why new operators rather than a parameter.** The cursor conditions travel as ordinary filter objects (`{ company: { name: { gt: v } } }`) through the shared filter parser, which reads one `[operator, value]` pair per leaf, so the operator name is the only channel available. This is the same reason `eqStrict` and `isStrictly` already exist as keyset-only variants; the new cases sit in that block. Generic `gt`/`lt`/`eqStrict` are untouched, so ordinary user filters keep comparing raw values.

**The equality branch changed too.** With `ORDER BY LOWER(name), id`, a cursor at `ACME` must treat a later `acme` row as tied, otherwise neither `LOWER(name) > 'acme'` nor `name = 'ACME'` matches it and the id tie-breaker can never reach it. So the branch handing over to the next key uses the lowercased equality as well.

**The `::text` cast is unconditional**, where the ORDER BY only casts for SELECT. It is a no-op on text columns and required on an enum, and it has to be decided here because the filter parser reports a composite field's own type, never its sub-column's: `createdBy.source` is a SELECT inside the ACTOR composite, so a cast derived from `fieldMetadataType` would emit `LOWER(enum)` and fail at the database. If you would rather mirror the two flags exactly, that is a small follow-up.

## Not covered

MULTI_SELECT keeps the raw comparison even though it is ordered case-insensitively: its cursor value is an array, which no scalar `LOWER()` comparison can carry, so aligning it needs the ordering's array rendering too. Left deliberately unchanged rather than guessed at, and pinned by a test so it is visible. Happy to fold it in if you want it here.

The two collation-sensitive `order-by-relation-field.integration-spec.ts` tests mentioned in the issue are untouched: they assert ORDER BY only, with no cursor, so this change does not affect them.

## Tests

Unit coverage for the SQL (`compute-where-condition-parts.spec.ts`, new) and for the operator each leaf kind resolves to (`compute-cursor-arg-filter.utils.spec.ts`), including that NUMBER, DATE_TIME and MULTI_SELECT stay raw. The 9 existing assertions that flipped are TEXT leaves — scalar, composite and relation-composite — which is the regression surface.

Integration coverage in `cursor-pagination-order-by.integration-spec.ts`: paging the `acme`/`ACME`/`Acme`/`Zebra` fixture one record per page, so every boundary lands inside the case tie, and paging opportunities by `stage` to assert the lowercased text order rather than the enum order. The exhaustiveness assertions are set-based, so they hold regardless of the test database's collation.

Neutralizing the fix (`isCaseInsensitiveOrder: false`) fails exactly the 2 new SELECT cases and the 9 updated TEXT ones, while the raw-comparison cases still pass.

```
Test Suites: 111 passed, 111 total
Tests:       762 passed, 762 total
```

`oxlint --type-aware` and `oxfmt --check` clean on all 7 changed files; `tsgo --noEmit` clean on twenty-server. The full server unit suite is green apart from 3 suites that fail identically on a clean `main` here (`file.controller`, the two local logic-function layer-path utils — Windows path separators). I could not run the integration suite locally, so that part is on CI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

