### PR TITLE
feat(twenty-front): show secondary links in workflow action

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/components/FormFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/components/FormFieldInput.tsx
@@ -28,7 +28,6 @@ import {
   type FieldArrayValue,
   type FieldEmailsValue,
   type FieldFullNameValue,
-  type FieldLinksValue,
   type FieldMetadata,
   type FieldMultiSelectValue,
   type FieldPhonesValue,
@@ -36,6 +35,7 @@ import {
   type FieldRelationValue,
   type FieldRichTextValue,
   type FormFieldCurrencyValue,
+  type FormFieldLinksValue,
 } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { isFieldAddress } from '@/object-record/record-field/ui/types/guards/isFieldAddress';
 import { isFieldArray } from '@/object-record/record-field/ui/types/guards/isFieldArray';
@@ -142,10 +142,11 @@ export const FormFieldInput = ({
   ) : isFieldLinks(field) ? (
     <FormLinksFieldInput
       label={field.label}
-      defaultValue={defaultValue as FieldLinksValue | undefined}
+      defaultValue={defaultValue as FormFieldLinksValue | undefined}
       onChange={onChange}
       VariablePicker={VariablePicker}
       readonly={readonly}
+      maxNumberOfValues={field.metadata.settings?.maxNumberOfValues}
     />
   ) : isFieldEmails(field) ? (
     <FormEmailsFieldInput

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -40,6 +40,7 @@ type FormArrayFieldInputProps = {
   readonly?: boolean;
   placeholder?: string;
   testId?: string;
+  maxItemCount?: number;
 };
 
 const StyledDisplayModeReadonlyContainer = styled.div`
@@ -90,6 +91,7 @@ export const FormArrayFieldInput = ({
   readonly,
   placeholder,
   testId,
+  maxItemCount,
 }: FormArrayFieldInputProps) => {
   const { t } = useLingui();
   const { theme } = useContext(ThemeContext);
@@ -142,6 +144,11 @@ export const FormArrayFieldInput = ({
   const preventContainerFocusStackUpdate =
     draftValue.type === 'static' && draftValue.value.length >= 1;
 
+  const isLimitReached =
+    typeof maxItemCount === 'number' &&
+    draftValue.type === 'static' &&
+    draftValue.value.length >= maxItemCount;
+
   const formFieldInputInstanceId = `form-array-field-container-${instanceId}`;
   const newItemInputInstanceId = `array-field-input-new-item-${instanceId}`;
 
@@ -150,6 +157,10 @@ export const FormArrayFieldInput = ({
   };
 
   const handleFirstItemInputEnter = () => {
+    if (isLimitReached) {
+      return;
+    }
+
     setDraftValue({
       type: 'static',
       value: [...draftValue.value, newItemDraftValue],
@@ -270,6 +281,10 @@ export const FormArrayFieldInput = ({
   };
 
   const handleAddItemButtonClick = () => {
+    if (isLimitReached) {
+      return;
+    }
+
     setItemToEditIndex(-1);
     setIsInputDisplayed(true);
   };
@@ -374,7 +389,7 @@ export const FormArrayFieldInput = ({
                         onEnter={handleNewItemInputSubmit}
                         hasItem
                       />
-                    ) : (
+                    ) : !isLimitReached ? (
                       <DropdownMenuItemsContainer>
                         <MenuItem
                           onClick={handleAddItemButtonClick}
@@ -382,7 +397,7 @@ export const FormArrayFieldInput = ({
                           text={t`Add item`}
                         />
                       </DropdownMenuItemsContainer>
-                    )}
+                    ) : null}
                   </DropdownContent>
                 }
               />

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormLinksFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormLinksFieldInput.tsx
@@ -1,19 +1,25 @@
-import { t } from '@lingui/core/macro';
-import { FormFieldInputContainer } from '@/ui/input/components/FormFieldInputContainer';
+import { FormArrayFieldInput } from '@/object-record/record-field/ui/form-types/components/FormArrayFieldInput';
 import { FormNestedFieldInputContainer } from '@/object-record/record-field/ui/form-types/components/FormNestedFieldInputContainer';
 import { FormTextFieldInput } from '@/object-record/record-field/ui/form-types/components/FormTextFieldInput';
 import { type VariablePickerComponent } from '@/object-record/record-field/ui/form-types/types/VariablePickerComponent';
 import { type FieldLinksDraftValue } from '@/object-record/record-field/ui/types/FieldInputDraftValue';
-import { type FieldLinksValue } from '@/object-record/record-field/ui/types/FieldMetadata';
+import {
+  type FieldArrayValue,
+  type FormFieldLinksValue,
+} from '@/object-record/record-field/ui/types/FieldMetadata';
+import { FormFieldInputContainer } from '@/ui/input/components/FormFieldInputContainer';
+import { t } from '@lingui/core/macro';
+import { isStandaloneVariableString } from 'twenty-shared/workflow';
 import { Field } from 'twenty-ui/input';
 
 type FormLinksFieldInputProps = {
   label?: string;
-  defaultValue?: FieldLinksValue;
-  onChange: (value: FieldLinksValue) => void;
+  defaultValue?: FormFieldLinksValue;
+  onChange: (value: FormFieldLinksValue) => void;
   VariablePicker?: VariablePickerComponent;
   readonly?: boolean;
   placeholder?: string;
+  maxNumberOfValues?: number | null;
 };
 
 export const FormLinksFieldInput = ({
@@ -23,16 +29,37 @@ export const FormLinksFieldInput = ({
   readonly,
   VariablePicker,
   placeholder,
+  maxNumberOfValues,
 }: FormLinksFieldInputProps) => {
+  const allowsSecondaryLinks = maxNumberOfValues !== 1;
+  const secondaryLinks = defaultValue?.secondaryLinks;
+
   const handleChange =
     (field: keyof FieldLinksDraftValue) => (updatedLinksPart: string) => {
       const updatedLinks = {
         primaryLinkLabel: defaultValue?.primaryLinkLabel ?? '',
         primaryLinkUrl: defaultValue?.primaryLinkUrl ?? '',
+        secondaryLinks: secondaryLinks ?? null,
         [field]: updatedLinksPart,
       };
       onChange(updatedLinks);
     };
+
+  const secondaryLinkUrls = isStandaloneVariableString(secondaryLinks)
+    ? secondaryLinks
+    : (secondaryLinks ?? []).map((link) => link.url ?? '');
+
+  const handleSecondaryLinksChange = (
+    updatedUrls: FieldArrayValue | string,
+  ) => {
+    onChange({
+      primaryLinkLabel: defaultValue?.primaryLinkLabel ?? '',
+      primaryLinkUrl: defaultValue?.primaryLinkUrl ?? '',
+      secondaryLinks: isStandaloneVariableString(updatedUrls)
+        ? updatedUrls
+        : updatedUrls.map((url) => ({ url, label: null })),
+    });
+  };
 
   return (
     <FormFieldInputContainer>
@@ -54,6 +81,15 @@ export const FormLinksFieldInput = ({
           readonly={readonly}
           VariablePicker={VariablePicker}
         />
+        {allowsSecondaryLinks && (
+          <FormArrayFieldInput
+            label={t`Secondary Links`}
+            defaultValue={secondaryLinkUrls}
+            onChange={handleSecondaryLinksChange}
+            readonly={readonly}
+            VariablePicker={VariablePicker}
+          />
+        )}
       </FormNestedFieldInputContainer>
     </FormFieldInputContainer>
   );

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormLinksFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormLinksFieldInput.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { FormFieldInputContainer } from '@/ui/input/components/FormFieldInputContainer';
 import { t } from '@lingui/core/macro';
+import { isDefined } from 'twenty-shared/utils';
 import { isStandaloneVariableString } from 'twenty-shared/workflow';
 import { Field } from 'twenty-ui/input';
 
@@ -33,6 +34,11 @@ export const FormLinksFieldInput = ({
 }: FormLinksFieldInputProps) => {
   const allowsSecondaryLinks = maxNumberOfValues !== 1;
   const secondaryLinks = defaultValue?.secondaryLinks;
+
+  // the primary link takes one of the field's allowed values
+  const maxSecondaryLinkCount = isDefined(maxNumberOfValues)
+    ? maxNumberOfValues - 1
+    : undefined;
 
   const handleChange =
     (field: keyof FieldLinksDraftValue) => (updatedLinksPart: string) => {
@@ -88,6 +94,7 @@ export const FormLinksFieldInput = ({
             onChange={handleSecondaryLinksChange}
             readonly={readonly}
             VariablePicker={VariablePicker}
+            maxItemCount={maxSecondaryLinkCount}
           />
         )}
       </FormNestedFieldInputContainer>

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormLinksFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormLinksFieldInput.tsx
@@ -35,7 +35,6 @@ export const FormLinksFieldInput = ({
   const allowsSecondaryLinks = maxNumberOfValues !== 1;
   const secondaryLinks = defaultValue?.secondaryLinks;
 
-  // the primary link takes one of the field's allowed values
   const maxSecondaryLinkCount = isDefined(maxNumberOfValues)
     ? maxNumberOfValues - 1
     : undefined;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormLinksFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormLinksFieldInput.stories.tsx
@@ -142,6 +142,29 @@ export const BindsSecondaryLinksToAVariable: Story = {
   },
 };
 
+export const StopsAddingSecondaryLinksAtTheFieldLimit: Story = {
+  args: {
+    label: 'Intro Video',
+    onChange: fn(),
+    // two allowed values: the primary link plus one secondary
+    maxNumberOfValues: 2,
+    defaultValue: {
+      primaryLinkLabel: 'Google',
+      primaryLinkUrl: 'https://www.google.com',
+      secondaryLinks: [{ label: null, url: 'https://docs.twenty.com' }],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(await canvas.findByText('https://docs.twenty.com'));
+
+    await waitFor(() => {
+      expect(canvas.queryByText('Add item')).not.toBeInTheDocument();
+    });
+  },
+};
+
 export const HidesSecondaryLinksWhenSingleValueField: Story = {
   args: {
     label: 'Domain Name',

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormLinksFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormLinksFieldInput.stories.tsx
@@ -1,7 +1,8 @@
 import { FormLinksFieldInput } from '@/object-record/record-field/ui/form-types/components/FormLinksFieldInput';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { WorkflowStepDecorator } from '~/testing/decorators/WorkflowStepDecorator';
+import { MOCKED_STEP_ID } from '~/testing/mock-data/workflow';
 
 const meta: Meta<typeof FormLinksFieldInput> = {
   title: 'UI/Data/Field/Form/Input/FormLinksFieldInput',
@@ -50,12 +51,112 @@ export const WithVariables: Story = {
     const primaryLinkUrlVariable = await canvas.findByText('Stage');
     expect(primaryLinkUrlVariable).toBeVisible();
 
+    // primary label, primary url, and the secondary links list
     const variablePickers = await canvas.findAllByText('VariablePicker');
-    expect(variablePickers).toHaveLength(2);
+    expect(variablePickers).toHaveLength(3);
 
     for (const variablePicker of variablePickers) {
       expect(variablePicker).toBeVisible();
     }
+  },
+};
+
+export const PreservesSecondaryLinksWhenEditingPrimary: Story = {
+  args: {
+    label: 'Intro Video',
+    onChange: fn(),
+    defaultValue: {
+      primaryLinkLabel: 'Google',
+      primaryLinkUrl: 'https://www.google.com',
+      secondaryLinks: [
+        { label: 'Documentation', url: 'https://docs.twenty.com' },
+      ],
+    },
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    const labelInput = await canvas.findByText('Google');
+
+    await userEvent.type(labelInput, 'X');
+
+    await waitFor(() => {
+      expect(args.onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          secondaryLinks: [
+            { label: 'Documentation', url: 'https://docs.twenty.com' },
+          ],
+        }),
+      );
+    });
+  },
+};
+
+export const AddsASecondaryLink: Story = {
+  args: {
+    label: 'Intro Video',
+    onChange: fn(),
+    defaultValue: {
+      primaryLinkLabel: 'Google',
+      primaryLinkUrl: 'https://www.google.com',
+      secondaryLinks: [],
+    },
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    const secondaryLinkInput =
+      await canvas.findByPlaceholderText('Enter an item');
+
+    await userEvent.type(secondaryLinkInput, 'https://docs.twenty.com{enter}');
+
+    await waitFor(() => {
+      expect(args.onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          secondaryLinks: [{ label: null, url: 'https://docs.twenty.com' }],
+        }),
+      );
+    });
+  },
+};
+
+export const BindsSecondaryLinksToAVariable: Story = {
+  args: {
+    label: 'Intro Video',
+    onChange: fn(),
+    defaultValue: {
+      primaryLinkLabel: 'Google',
+      primaryLinkUrl: 'https://www.google.com',
+      secondaryLinks: `{{${MOCKED_STEP_ID}.name}}`,
+    },
+    VariablePicker: () => <div>VariablePicker</div>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // the bound variable renders as a chip instead of the list input
+    expect(await canvas.findByText('Name')).toBeVisible();
+    expect(
+      canvas.queryByPlaceholderText('Enter an item'),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const HidesSecondaryLinksWhenSingleValueField: Story = {
+  args: {
+    label: 'Domain Name',
+    maxNumberOfValues: 1,
+    defaultValue: {
+      primaryLinkLabel: 'Google',
+      primaryLinkUrl: 'https://www.google.com',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText('Primary Link Label');
+
+    expect(canvas.queryByText('Secondary Links')).not.toBeInTheDocument();
   },
 };
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
@@ -243,6 +243,14 @@ export type FieldLinksValue = {
   primaryLinkUrl: string | null;
   secondaryLinks?: { label: string | null; url: string | null }[] | null;
 };
+export type FormFieldLinksValue = {
+  primaryLinkLabel: string | null;
+  primaryLinkUrl: string | null;
+  secondaryLinks?:
+    | { label: string | null; url: string | null }[]
+    | string
+    | null;
+};
 
 export const fieldMetadataCurrencyFormat = ['short', 'full'] as const;
 export type FieldCurrencyFormat = (typeof fieldMetadataCurrencyFormat)[number];


### PR DESCRIPTION
Fixes #24329 


https://github.com/user-attachments/assets/9c1a017c-10be-4315-88f0-27803b839aa0



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

