### PR TITLE
fix: bump ip-address to 10.5.0 in app lockfiles (Dependabot)

### DIFF
--- a/packages/twenty-apps/examples/hello-world/yarn.lock
+++ b/packages/twenty-apps/examples/hello-world/yarn.lock
@@ -1769,9 +1769,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: 10c0/c6616bc99c90b552dad2beb850ca697c1ea3e2b89662d652a4439cd72a549b0c9af100a54be0d25be86599e2b089db87ef5303157d142e5b4c21bd2a1301dfa7
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/examples/postcard/yarn.lock
+++ b/packages/twenty-apps/examples/postcard/yarn.lock
@@ -2009,9 +2009,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: 10c0/c6616bc99c90b552dad2beb850ca697c1ea3e2b89662d652a4439cd72a549b0c9af100a54be0d25be86599e2b089db87ef5303157d142e5b4c21bd2a1301dfa7
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/self-hosting/yarn.lock
+++ b/packages/twenty-apps/internal/self-hosting/yarn.lock
@@ -2075,9 +2075,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: 10c0/c6616bc99c90b552dad2beb850ca697c1ea3e2b89662d652a4439cd72a549b0c9af100a54be0d25be86599e2b089db87ef5303157d142e5b4c21bd2a1301dfa7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **ip-address -> 10.5.0** in the three app lockfiles that carry it transitively (hello-world, postcard, self-hosting), clearing **9 Dependabot alerts** - three SSRF / trust-boundary bypass advisories per manifest:

| Severity | Advisory | Issue | Vulnerable |
|---|---|---|---|
| high | GHSA-mwp4-54f8-5fhr | `Address4` decodes leading-zero octets as decimal while resolvers decode them as octal | `<= 10.3.0` |
| medium | GHSA-22jq-vg5j-6vgg | misclassification of IPv4-mapped / NAT64 IPv6 addresses | `10.1.1 - 10.2.0` |
| medium | GHSA-4xrf-jv44-h6hh | a CIDR suffix on the parsed address suppresses special-use classification | `10.1.1 - 10.2.1` |

Each app reaches ip-address through a caret range (`^10.0.1`), so a recursive `yarn up -R ip-address` lifts it with **no resolution and no `package.json` change** - the diff is 3 `yarn.lock` files and nothing else. Yarn resolves to **10.5.0**, the latest in range (above the 10.3.1 floor for the high-severity advisory).

No file overlap with #24482 (undici), which touches a disjoint set of apps.

## Verification

- ip-address resolves to **10.5.0** in all three lockfiles.
- `yarn install --immutable` passes in each.
- 10.5.0 published 2026-08-10, well past the 3-day npm age gate.
