### PR TITLE
fix(server): derive view groups for app-synced views grouping by a field

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -112,6 +112,8 @@ export class ApplicationManifestMigrationService {
         ownerFlatApplication,
         now,
         workspaceId,
+        existingFlatFieldMetadataMaps:
+          existingAllFlatEntityMaps.flatFieldMetadataMaps,
       });
 
     const dependencyAllFlatEntityMaps = getApplicationSubAllFlatEntityMaps({
@@ -203,6 +205,8 @@ export class ApplicationManifestMigrationService {
         ownerFlatApplication,
         now,
         workspaceId,
+        existingFlatFieldMetadataMaps:
+          existingAllFlatEntityMaps.flatFieldMetadataMaps,
       });
 
     const allFlatEntityOperationRecordByMetadataName =

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-view-manifest-to-derived-universal-flat-view-groups.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-view-manifest-to-derived-universal-flat-view-groups.util.spec.ts
@@ -1,0 +1,167 @@
+import { getViewGroupUniversalIdentifier } from 'twenty-shared/application';
+import { VIEW_GROUP_VISIBLE_OPTIONS_MAX } from 'twenty-shared/constants';
+import { ViewType } from 'twenty-shared/types';
+
+import { fromViewManifestToDerivedUniversalFlatViewGroups } from 'src/engine/core-modules/application/application-manifest/converters/from-view-manifest-to-derived-universal-flat-view-groups.util';
+
+describe('fromViewManifestToDerivedUniversalFlatViewGroups', () => {
+  const now = '2026-01-01T00:00:00.000Z';
+  const applicationUniversalIdentifier = '3a3946f1-3f2c-4e2f-94a4-3b6c3c9f8ae1';
+  const viewUniversalIdentifier = 'b52a09f5-8a2e-4c47-9efb-4f2f8f6a9c72';
+
+  const viewManifest = {
+    universalIdentifier: viewUniversalIdentifier,
+    name: 'By Stage',
+    objectUniversalIdentifier: 'c9a1f9de-7d09-4a45-a1cb-53f0c65b12d4',
+    type: ViewType.KANBAN,
+    mainGroupByFieldMetadataUniversalIdentifier:
+      'd4e8b0af-6f7a-42be-9d3a-8f1b7f2c3e55',
+  };
+
+  const selectOptions = [
+    { id: 'option-1', label: 'New', value: 'NEW', position: 0 },
+    { id: 'option-2', label: 'Ongoing', value: 'ONGOING', position: 1 },
+    { id: 'option-3', label: 'Done', value: 'DONE', position: 2 },
+  ];
+
+  it('should derive one view group per select option plus a trailing empty group when the field is nullable', () => {
+    const result = fromViewManifestToDerivedUniversalFlatViewGroups({
+      viewManifest,
+      mainGroupByFlatFieldMetadata: {
+        options: selectOptions,
+        isNullable: true,
+      },
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result).toHaveLength(4);
+    expect(result.map(({ fieldValue }) => fieldValue)).toEqual([
+      'NEW',
+      'ONGOING',
+      'DONE',
+      '',
+    ]);
+    expect(result.map(({ position }) => position)).toEqual([0, 1, 2, 3]);
+    expect(result.every(({ isVisible }) => isVisible)).toBe(true);
+    expect(
+      result.every(
+        (viewGroup) =>
+          viewGroup.viewUniversalIdentifier === viewUniversalIdentifier,
+      ),
+    ).toBe(true);
+    expect(
+      result.every(
+        (viewGroup) =>
+          viewGroup.applicationUniversalIdentifier ===
+          applicationUniversalIdentifier,
+      ),
+    ).toBe(true);
+    expect(
+      result.every(
+        (viewGroup) =>
+          viewGroup.createdAt === now &&
+          viewGroup.updatedAt === now &&
+          viewGroup.deletedAt === null,
+      ),
+    ).toBe(true);
+  });
+
+  it('should not derive an empty group when the field is not nullable', () => {
+    const result = fromViewManifestToDerivedUniversalFlatViewGroups({
+      viewManifest,
+      mainGroupByFlatFieldMetadata: {
+        options: selectOptions,
+        isNullable: false,
+      },
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result.map(({ fieldValue }) => fieldValue)).toEqual([
+      'NEW',
+      'ONGOING',
+      'DONE',
+    ]);
+  });
+
+  it('should derive only the empty group for an optionless nullable group-by field', () => {
+    const result = fromViewManifestToDerivedUniversalFlatViewGroups({
+      viewManifest,
+      mainGroupByFlatFieldMetadata: {
+        options: null,
+        isNullable: true,
+      },
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].fieldValue).toBe('');
+    expect(result[0].position).toBe(0);
+  });
+
+  it('should derive deterministic universal identifiers stable across recomputations', () => {
+    const computeTwice = () =>
+      fromViewManifestToDerivedUniversalFlatViewGroups({
+        viewManifest,
+        mainGroupByFlatFieldMetadata: {
+          options: selectOptions,
+          isNullable: true,
+        },
+        applicationUniversalIdentifier,
+        now,
+      });
+
+    const [firstComputation, secondComputation] = [
+      computeTwice(),
+      computeTwice(),
+    ];
+
+    expect(
+      firstComputation.map(({ universalIdentifier }) => universalIdentifier),
+    ).toEqual(
+      secondComputation.map(({ universalIdentifier }) => universalIdentifier),
+    );
+
+    expect(firstComputation[0].universalIdentifier).toBe(
+      getViewGroupUniversalIdentifier({
+        applicationUniversalIdentifier,
+        viewUniversalIdentifier,
+        fieldValue: 'NEW',
+      }),
+    );
+
+    expect(
+      new Set(
+        firstComputation.map(({ universalIdentifier }) => universalIdentifier),
+      ).size,
+    ).toBe(firstComputation.length);
+  });
+
+  it('should hide derived groups beyond the visible options maximum', () => {
+    const manyOptions = Array.from(
+      { length: VIEW_GROUP_VISIBLE_OPTIONS_MAX + 1 },
+      (_, index) => ({
+        id: `option-${index}`,
+        label: `Option ${index}`,
+        value: `OPTION_${index}`,
+        position: index,
+      }),
+    );
+
+    const result = fromViewManifestToDerivedUniversalFlatViewGroups({
+      viewManifest,
+      mainGroupByFlatFieldMetadata: {
+        options: manyOptions,
+        isNullable: false,
+      },
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result).toHaveLength(VIEW_GROUP_VISIBLE_OPTIONS_MAX + 1);
+    expect(result[VIEW_GROUP_VISIBLE_OPTIONS_MAX - 1].isVisible).toBe(true);
+    expect(result[VIEW_GROUP_VISIBLE_OPTIONS_MAX].isVisible).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-view-manifest-to-derived-universal-flat-view-groups.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-view-manifest-to-derived-universal-flat-view-groups.util.ts
@@ -1,0 +1,41 @@
+import {
+  getViewGroupUniversalIdentifier,
+  type ViewManifest,
+} from 'twenty-shared/application';
+
+import { computeUniversalFlatViewGroupsForGroupByField } from 'src/engine/metadata-modules/flat-view-group/utils/compute-universal-flat-view-groups-for-group-by-field.util';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+import { type UniversalFlatViewGroup } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-group.type';
+
+// A manifest view that groups by a field (e.g. a Kanban board) is unusable
+// without view groups, so when the manifest declares none they are derived
+// from the group-by field's options. Universal identifiers are deterministic
+// (application + view + fieldValue) so every sync recomputes the exact same
+// groups: the first sync creates them, later syncs diff them against the
+// workspace instead of deleting entities missing from the manifest.
+export const fromViewManifestToDerivedUniversalFlatViewGroups = ({
+  viewManifest,
+  mainGroupByFlatFieldMetadata,
+  applicationUniversalIdentifier,
+  now,
+}: {
+  viewManifest: ViewManifest;
+  mainGroupByFlatFieldMetadata: Pick<
+    UniversalFlatFieldMetadata,
+    'options' | 'isNullable'
+  >;
+  applicationUniversalIdentifier: string;
+  now: string;
+}): UniversalFlatViewGroup[] =>
+  computeUniversalFlatViewGroupsForGroupByField({
+    viewUniversalIdentifier: viewManifest.universalIdentifier,
+    mainGroupByFlatFieldMetadata,
+    applicationUniversalIdentifier,
+    generateUniversalIdentifier: ({ fieldValue }) =>
+      getViewGroupUniversalIdentifier({
+        applicationUniversalIdentifier,
+        viewUniversalIdentifier: viewManifest.universalIdentifier,
+        fieldValue,
+      }),
+    now,
+  });

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
@@ -6,7 +6,7 @@ import {
 } from 'twenty-shared/application';
 import { MAX_CUSTOM_INDEXES_PER_OBJECT } from 'twenty-shared/constants';
 import { FieldMetadataType } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
+import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 
 import { fromAgentManifestToUniversalFlatRoleTarget } from 'src/engine/core-modules/application/application-manifest/converters/from-agent-manifest-to-universal-flat-role-target.util';
 import { fromApplicationVariableManifestToUniversalFlatApplicationVariable } from 'src/engine/core-modules/application/application-manifest/converters/from-application-variable-manifest-to-universal-flat-application-variable.util';
@@ -34,6 +34,7 @@ import { fromViewFieldManifestToUniversalFlatViewField } from 'src/engine/core-m
 import { fromViewFilterGroupManifestToUniversalFlatViewFilterGroup } from 'src/engine/core-modules/application/application-manifest/converters/from-view-filter-group-manifest-to-universal-flat-view-filter-group.util';
 import { fromViewFilterManifestToUniversalFlatViewFilter } from 'src/engine/core-modules/application/application-manifest/converters/from-view-filter-manifest-to-universal-flat-view-filter.util';
 import { fromViewGroupManifestToUniversalFlatViewGroup } from 'src/engine/core-modules/application/application-manifest/converters/from-view-group-manifest-to-universal-flat-view-group.util';
+import { fromViewManifestToDerivedUniversalFlatViewGroups } from 'src/engine/core-modules/application/application-manifest/converters/from-view-manifest-to-derived-universal-flat-view-groups.util';
 import { fromViewManifestToUniversalFlatView } from 'src/engine/core-modules/application/application-manifest/converters/from-view-manifest-to-universal-flat-view.util';
 import { fromViewSortManifestToUniversalFlatViewSort } from 'src/engine/core-modules/application/application-manifest/converters/from-view-sort-manifest-to-universal-flat-view-sort.util';
 import { type FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
@@ -56,11 +57,15 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
     ownerFlatApplication,
     now,
     workspaceId,
+    existingFlatFieldMetadataMaps,
   }: {
     manifest: Manifest;
     ownerFlatApplication: FlatApplication;
     now: string;
     workspaceId: string;
+    // Workspace-wide field maps, used to resolve a view's group-by field when
+    // it is not declared in the manifest (e.g. a standard object field).
+    existingFlatFieldMetadataMaps: AllFlatEntityMaps['flatFieldMetadataMaps'];
   }): AllFlatEntityMaps {
     const allUniversalFlatEntityMaps = createEmptyAllFlatEntityMaps();
 
@@ -449,6 +454,45 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
           universalFlatEntityMapsToMutate:
             allUniversalFlatEntityMaps.flatViewGroupMaps,
         });
+      }
+
+      const mainGroupByFieldMetadataUniversalIdentifier =
+        viewManifest.mainGroupByFieldMetadataUniversalIdentifier;
+
+      if (
+        !isNonEmptyArray(viewManifest.groups) &&
+        isDefined(mainGroupByFieldMetadataUniversalIdentifier)
+      ) {
+        const mainGroupByFlatFieldMetadata =
+          allUniversalFlatEntityMaps.flatFieldMetadataMaps
+            .byUniversalIdentifier[
+            mainGroupByFieldMetadataUniversalIdentifier
+          ] ??
+          existingFlatFieldMetadataMaps.byUniversalIdentifier[
+            mainGroupByFieldMetadataUniversalIdentifier
+          ];
+
+        // An unresolvable group-by field is reported by the workspace
+        // migration builder's view validation, not here.
+        if (isDefined(mainGroupByFlatFieldMetadata)) {
+          const derivedUniversalFlatViewGroups =
+            fromViewManifestToDerivedUniversalFlatViewGroups({
+              viewManifest,
+              mainGroupByFlatFieldMetadata,
+              applicationUniversalIdentifier,
+              now,
+            });
+
+          for (const universalFlatViewGroup of derivedUniversalFlatViewGroups) {
+            addUniversalFlatEntityToUniversalFlatEntityMapsThroughMutationOrThrow(
+              {
+                universalFlatEntity: universalFlatViewGroup,
+                universalFlatEntityMapsToMutate:
+                  allUniversalFlatEntityMaps.flatViewGroupMaps,
+              },
+            );
+          }
+        }
       }
 
       for (const viewSortManifest of viewManifest.sorts ?? []) {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view-group/utils/compute-flat-view-groups-on-view-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view-group/utils/compute-flat-view-groups-on-view-create.util.ts
@@ -1,4 +1,3 @@
-import { VIEW_GROUP_VISIBLE_OPTIONS_MAX } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 
@@ -8,6 +7,7 @@ import {
 } from 'src/engine/metadata-modules/flat-entity/exceptions/flat-entity-maps.exception';
 import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { computeUniversalFlatViewGroupsForGroupByField } from 'src/engine/metadata-modules/flat-view-group/utils/compute-universal-flat-view-groups-for-group-by-field.util';
 import { type UniversalFlatViewGroup } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-group.type';
 
 type ComputeFlatViewGroupsOnViewCreateArgs = {
@@ -32,44 +32,12 @@ export const computeFlatViewGroupsOnViewCreate = ({
     );
   }
 
-  const createdAt = new Date().toISOString();
-
-  const flatViewGroupsFromOptions: UniversalFlatViewGroup[] = (
-    mainGroupByFieldMetadata.options ?? []
-  ).map((option, index) => ({
+  return computeUniversalFlatViewGroupsForGroupByField({
     viewUniversalIdentifier: flatViewToCreateUniversalIdentifier,
-    createdAt,
-    updatedAt: createdAt,
-    deletedAt: null,
-    universalIdentifier: v4(),
-    isVisible: index < VIEW_GROUP_VISIBLE_OPTIONS_MAX,
-    fieldValue: option.value,
-    position: index,
+    mainGroupByFlatFieldMetadata: mainGroupByFieldMetadata,
     applicationUniversalIdentifier:
       mainGroupByFieldMetadata.applicationUniversalIdentifier,
-  }));
-
-  const flatViewGroups: UniversalFlatViewGroup[] = [
-    ...flatViewGroupsFromOptions,
-  ];
-
-  if (mainGroupByFieldMetadata.isNullable === true) {
-    const emptyGroupId = v4();
-    const emptyGroupPosition = flatViewGroupsFromOptions.length;
-
-    flatViewGroups.push({
-      viewUniversalIdentifier: flatViewToCreateUniversalIdentifier,
-      createdAt,
-      updatedAt: createdAt,
-      deletedAt: null,
-      universalIdentifier: emptyGroupId,
-      isVisible: emptyGroupPosition < VIEW_GROUP_VISIBLE_OPTIONS_MAX,
-      fieldValue: '',
-      position: emptyGroupPosition,
-      applicationUniversalIdentifier:
-        mainGroupByFieldMetadata.applicationUniversalIdentifier,
-    });
-  }
-
-  return flatViewGroups;
+    generateUniversalIdentifier: () => v4(),
+    now: new Date().toISOString(),
+  });
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view-group/utils/compute-universal-flat-view-groups-for-group-by-field.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view-group/utils/compute-universal-flat-view-groups-for-group-by-field.util.ts
@@ -14,9 +14,6 @@ type ComputeUniversalFlatViewGroupsForGroupByFieldArgs = {
   now: string;
 };
 
-// Single source of truth for deriving a grouped view's view groups from its
-// group-by field: one group per select option in option order, plus a trailing
-// empty-value group when the field is nullable.
 export const computeUniversalFlatViewGroupsForGroupByField = ({
   viewUniversalIdentifier,
   mainGroupByFlatFieldMetadata,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view-group/utils/compute-universal-flat-view-groups-for-group-by-field.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view-group/utils/compute-universal-flat-view-groups-for-group-by-field.util.ts
@@ -1,0 +1,64 @@
+import { VIEW_GROUP_VISIBLE_OPTIONS_MAX } from 'twenty-shared/constants';
+
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+import { type UniversalFlatViewGroup } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-group.type';
+
+type ComputeUniversalFlatViewGroupsForGroupByFieldArgs = {
+  viewUniversalIdentifier: string;
+  mainGroupByFlatFieldMetadata: Pick<
+    UniversalFlatFieldMetadata,
+    'options' | 'isNullable'
+  >;
+  applicationUniversalIdentifier: string;
+  generateUniversalIdentifier: (args: { fieldValue: string }) => string;
+  now: string;
+};
+
+// Single source of truth for deriving a grouped view's view groups from its
+// group-by field: one group per select option in option order, plus a trailing
+// empty-value group when the field is nullable.
+export const computeUniversalFlatViewGroupsForGroupByField = ({
+  viewUniversalIdentifier,
+  mainGroupByFlatFieldMetadata,
+  applicationUniversalIdentifier,
+  generateUniversalIdentifier,
+  now,
+}: ComputeUniversalFlatViewGroupsForGroupByFieldArgs): UniversalFlatViewGroup[] => {
+  const buildUniversalFlatViewGroup = ({
+    fieldValue,
+    position,
+  }: {
+    fieldValue: string;
+    position: number;
+  }): UniversalFlatViewGroup => ({
+    universalIdentifier: generateUniversalIdentifier({ fieldValue }),
+    applicationUniversalIdentifier,
+    viewUniversalIdentifier,
+    fieldValue,
+    isVisible: position < VIEW_GROUP_VISIBLE_OPTIONS_MAX,
+    position,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  });
+
+  const universalFlatViewGroups = (
+    mainGroupByFlatFieldMetadata.options ?? []
+  ).map((option, index) =>
+    buildUniversalFlatViewGroup({
+      fieldValue: option.value,
+      position: index,
+    }),
+  );
+
+  if (mainGroupByFlatFieldMetadata.isNullable === true) {
+    universalFlatViewGroups.push(
+      buildUniversalFlatViewGroup({
+        fieldValue: '',
+        position: universalFlatViewGroups.length,
+      }),
+    );
+  }
+
+  return universalFlatViewGroups;
+};

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-derived-kanban-view-groups.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-derived-kanban-view-groups.integration-spec.ts
@@ -1,0 +1,279 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { buildDefaultObjectManifest } from 'test/integration/metadata/suites/application/utils/build-default-object-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
+import { findViews } from 'test/integration/metadata/suites/view/utils/find-views.util';
+import { type Manifest } from 'twenty-shared/application';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, ViewType } from 'twenty-shared/types';
+import { v4 as uuidv4 } from 'uuid';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+const STAGE_FIELD_ID = uuidv4();
+const PROJECT_KANBAN_VIEW_ID = uuidv4();
+const OPPORTUNITY_KANBAN_VIEW_ID = uuidv4();
+const DECLARED_GROUPS_VIEW_ID = uuidv4();
+const DECLARED_VIEW_GROUP_ID = uuidv4();
+
+const PROJECT_KANBAN_VIEW_NAME = 'Projects By Stage';
+const OPPORTUNITY_KANBAN_VIEW_NAME = 'App Opportunities By Stage';
+const DECLARED_GROUPS_VIEW_NAME = 'Projects Curated Board';
+
+const STAGE_OPTION_VALUES = ['TODO', 'DOING', 'DONE'];
+
+const TEST_OBJECT = buildDefaultObjectManifest({
+  applicationUniversalIdentifier: TEST_APP_ID,
+  nameSingular: 'project',
+  namePlural: 'projects',
+  labelSingular: 'Project',
+  labelPlural: 'Projects',
+  description: 'A project',
+  icon: 'IconBriefcase',
+  additionalFields: [
+    {
+      universalIdentifier: STAGE_FIELD_ID,
+      name: 'stage',
+      label: 'Stage',
+      type: FieldMetadataType.SELECT,
+      options: STAGE_OPTION_VALUES.map((value, position) => ({
+        id: uuidv4(),
+        label: value,
+        value,
+        position,
+        color: 'blue',
+      })),
+    },
+  ],
+});
+
+// The report's exact repro: an app-defined Kanban view declaring only a
+// mainGroupByFieldMetadataUniversalIdentifier and no groups.
+const buildManifest = (): Manifest =>
+  buildBaseManifest({
+    appId: TEST_APP_ID,
+    roleId: TEST_ROLE_ID,
+    overrides: {
+      objects: [TEST_OBJECT],
+      views: [
+        {
+          universalIdentifier: PROJECT_KANBAN_VIEW_ID,
+          name: PROJECT_KANBAN_VIEW_NAME,
+          objectUniversalIdentifier: TEST_OBJECT.universalIdentifier,
+          type: ViewType.KANBAN,
+          icon: 'IconLayoutKanban',
+          mainGroupByFieldMetadataUniversalIdentifier: STAGE_FIELD_ID,
+        },
+        {
+          universalIdentifier: OPPORTUNITY_KANBAN_VIEW_ID,
+          name: OPPORTUNITY_KANBAN_VIEW_NAME,
+          objectUniversalIdentifier:
+            STANDARD_OBJECTS.opportunity.universalIdentifier,
+          type: ViewType.KANBAN,
+          icon: 'IconLayoutKanban',
+          mainGroupByFieldMetadataUniversalIdentifier:
+            STANDARD_OBJECTS.opportunity.fields.stage.universalIdentifier,
+        },
+        {
+          universalIdentifier: DECLARED_GROUPS_VIEW_ID,
+          name: DECLARED_GROUPS_VIEW_NAME,
+          objectUniversalIdentifier: TEST_OBJECT.universalIdentifier,
+          type: ViewType.KANBAN,
+          icon: 'IconLayoutKanban',
+          mainGroupByFieldMetadataUniversalIdentifier: STAGE_FIELD_ID,
+          groups: [
+            {
+              universalIdentifier: DECLARED_VIEW_GROUP_ID,
+              fieldValue: 'DONE',
+              position: 0,
+              isVisible: true,
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+type ViewGroupResponse = {
+  id: string;
+  fieldValue: string;
+  position: number;
+  isVisible: boolean;
+};
+
+type ViewWithGroupsResponse = {
+  id: string;
+  name: string;
+  viewGroups: ViewGroupResponse[];
+};
+
+const VIEW_WITH_GROUPS_GQL_FIELDS = `
+  id
+  name
+  viewGroups { id fieldValue position isVisible }
+`;
+
+const findObjectIdByUniversalIdentifier = async (
+  objectUniversalIdentifier: string,
+) => {
+  const { objects } = await findManyObjectMetadata({
+    input: {
+      filter: {},
+      paging: { first: 1000 },
+    },
+    gqlFields: 'id universalIdentifier',
+    expectToFail: false,
+  });
+
+  const objectMetadata = (
+    objects as { id: string; universalIdentifier: string }[]
+  ).find((object) => object.universalIdentifier === objectUniversalIdentifier);
+
+  if (!objectMetadata) {
+    throw new Error(`Object ${objectUniversalIdentifier} not found`);
+  }
+
+  return objectMetadata.id;
+};
+
+const findViewWithGroupsByName = async ({
+  objectMetadataId,
+  viewName,
+}: {
+  objectMetadataId: string;
+  viewName: string;
+}): Promise<ViewWithGroupsResponse> => {
+  const { data } = await findViews({
+    objectMetadataId,
+    gqlFields: VIEW_WITH_GROUPS_GQL_FIELDS,
+    expectToFail: false,
+  });
+
+  const view = (
+    (data?.getViews ?? []) as unknown as ViewWithGroupsResponse[]
+  ).find((candidateView) => candidateView.name === viewName);
+
+  if (!view) {
+    throw new Error(`View ${viewName} not found`);
+  }
+
+  return view;
+};
+
+const sortedGroupsByPosition = (view: ViewWithGroupsResponse) =>
+  [...view.viewGroups].sort(
+    (firstGroup, secondGroup) => firstGroup.position - secondGroup.position,
+  );
+
+describe('Manifest sync - view groups derived from the main group-by field', () => {
+  beforeEach(async () => {
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      name: 'Test Application',
+      description: 'App for testing derived kanban view groups',
+      sourcePath: 'test-derived-kanban-view-groups',
+    });
+  }, 60000);
+
+  afterEach(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+  });
+
+  it('derives view groups for group-by views without declared groups and keeps them stable across re-syncs', async () => {
+    const { errors: firstSyncErrors } = await syncApplication({
+      manifest: buildManifest(),
+      expectToFail: false,
+    });
+
+    expect(firstSyncErrors).toBeUndefined();
+
+    const projectObjectId = await findObjectIdByUniversalIdentifier(
+      TEST_OBJECT.universalIdentifier,
+    );
+    const opportunityObjectId = await findObjectIdByUniversalIdentifier(
+      STANDARD_OBJECTS.opportunity.universalIdentifier,
+    );
+
+    // App object board: one group per manifest-declared select option, in
+    // option order, plus the trailing empty group (the field is nullable).
+    const projectKanbanAfterFirstSync = await findViewWithGroupsByName({
+      objectMetadataId: projectObjectId,
+      viewName: PROJECT_KANBAN_VIEW_NAME,
+    });
+
+    expect(
+      sortedGroupsByPosition(projectKanbanAfterFirstSync).map(
+        ({ fieldValue }) => fieldValue,
+      ),
+    ).toEqual([...STAGE_OPTION_VALUES, '']);
+    expect(
+      projectKanbanAfterFirstSync.viewGroups.every(
+        ({ isVisible }) => isVisible,
+      ),
+    ).toBe(true);
+
+    // Standard object board: groups derived from the workspace's existing
+    // Opportunity stage field, which the manifest does not declare. The stage
+    // field is non-nullable, so there is no empty group.
+    const opportunityKanbanAfterFirstSync = await findViewWithGroupsByName({
+      objectMetadataId: opportunityObjectId,
+      viewName: OPPORTUNITY_KANBAN_VIEW_NAME,
+    });
+
+    expect(
+      sortedGroupsByPosition(opportunityKanbanAfterFirstSync).map(
+        ({ fieldValue }) => fieldValue,
+      ),
+    ).toEqual(['NEW', 'SCREENING', 'MEETING', 'PROPOSAL', 'CUSTOMER']);
+
+    // Declared groups take precedence: nothing is derived next to them.
+    const declaredGroupsViewAfterFirstSync = await findViewWithGroupsByName({
+      objectMetadataId: projectObjectId,
+      viewName: DECLARED_GROUPS_VIEW_NAME,
+    });
+
+    expect(declaredGroupsViewAfterFirstSync.viewGroups).toHaveLength(1);
+    expect(declaredGroupsViewAfterFirstSync.viewGroups[0].fieldValue).toBe(
+      'DONE',
+    );
+
+    const projectGroupIdsAfterFirstSync = sortedGroupsByPosition(
+      projectKanbanAfterFirstSync,
+    ).map(({ id }) => id);
+    const opportunityGroupIdsAfterFirstSync = sortedGroupsByPosition(
+      opportunityKanbanAfterFirstSync,
+    ).map(({ id }) => id);
+
+    // Re-syncing the identical manifest recomputes the same deterministic
+    // universal identifiers: the derived groups are neither deleted (despite
+    // inferDeletionFromMissingEntities) nor recreated under new rows.
+    const { errors: secondSyncErrors } = await syncApplication({
+      manifest: buildManifest(),
+      expectToFail: false,
+    });
+
+    expect(secondSyncErrors).toBeUndefined();
+
+    const projectKanbanAfterSecondSync = await findViewWithGroupsByName({
+      objectMetadataId: projectObjectId,
+      viewName: PROJECT_KANBAN_VIEW_NAME,
+    });
+    const opportunityKanbanAfterSecondSync = await findViewWithGroupsByName({
+      objectMetadataId: opportunityObjectId,
+      viewName: OPPORTUNITY_KANBAN_VIEW_NAME,
+    });
+
+    expect(
+      sortedGroupsByPosition(projectKanbanAfterSecondSync).map(({ id }) => id),
+    ).toEqual(projectGroupIdsAfterFirstSync);
+    expect(
+      sortedGroupsByPosition(opportunityKanbanAfterSecondSync).map(
+        ({ id }) => id,
+      ),
+    ).toEqual(opportunityGroupIdsAfterFirstSync);
+  }, 120000);
+});


### PR DESCRIPTION
## Problem

An app manifest view declaring a `mainGroupByFieldMetadataUniversalIdentifier` (typically `ViewType.KANBAN`) but no explicit `groups` syncs with zero `viewGroup` rows. The board then renders permanently empty: no columns, no cards, no error banner, no console error, while the underlying `groupBy` query returns complete, correctly grouped data.

This came in as an external bug report from an app developer. It blocks any app-defined custom object that wants a board as its primary view, since a brand new object has no engine-provisioned board to fall back on the way a standard object like Opportunity does.

## Root cause

The frontend builds Kanban columns exclusively from `viewGroup` rows. `mapViewGroupsToRecordGroupDefinitions` returns `[]` when a view has none, with no error and no fallback, which is exactly the silent empty board.

Every other view-creation path derives those rows from the group-by field's select options:

- `fromCreateViewInputToFlatViewToCreate` (createCoreView)
- `handleFlatViewUpdateSideEffect` (updateCoreView, when the group-by field changes)
- `useViewsSideEffectsOnViewGroups` (frontend optimistic effect)
- twenty-standard, which hand-authors its groups (`computeStandardOpportunityViewGroups`)

The application manifest sync path was the only one that did not. It creates only the groups explicitly declared under `groups` in the manifest.

## Fix

During manifest compute, when a view declares a main group-by field and no `groups`, the server now derives view groups from that field's options, plus the trailing empty-value group when the field is nullable. The group-by field resolves from the manifest first and falls back to the workspace's existing fields, so grouping by another application's field (for example standard `opportunity.stage`) works too.

Identifiers come from `getViewGroupUniversalIdentifier`, a deterministic v5 helper that already existed in twenty-shared but had no callers anywhere. Being deterministic per (application, view, fieldValue) is what makes this safe under `inferDeletionFromMissingEntities: true`:

- first sync creates the groups
- an identical re-sync recomputes the identical entities, so nothing is deleted or recreated (verified against real DB row ids)
- adding or removing a select option diffs into adding or removing a column on the next sync

Two alternatives were considered and rejected:

- **A create-only side-effect handler**, the engine's usual pattern for this kind of companion entity. App sync runs with `inferDeletionFromMissingEntities: true` and `viewGroup` has no `isSystemSideEffect` column to shield it, so groups created once at view creation would be deleted on the second sync. Adding that column means a migration, and it would also leave columns stale when options change.
- **Random UUIDs at compute time**, which would delete and recreate every group on every sync.

Explicitly declared manifest `groups` keep full author control and skip the derivation entirely.

The options-to-groups loop is extracted out of `computeFlatViewGroupsOnViewCreate` into a shared `computeUniversalFlatViewGroupsForGroupByField` util, so the API create/update paths and the sync path cannot drift apart.

## Known tradeoff

For derived boards the manifest stays the source of truth, so reordering or hiding columns in the UI on an app-owned Kanban is reset by the next sync. This is consistent with how all manifest-declared sub-entities behave today, and authors who want pinned columns can declare `groups` explicitly. Making derived groups both user-editable and sync-stable needs an ownership/override flag on `viewGroup` that does not exist yet, so it is left as a possible follow-up.

## Testing

- New unit spec for the converter: option order, nullable empty group, visibility cap at `VIEW_GROUP_VISIBLE_OPTIONS_MAX`, deterministic and collision-free identifiers.
- New integration spec mirroring the reported repro: Kanban on an app object's select field, Kanban on standard `opportunity.stage` (field not declared in the manifest), a declared-groups view that must stay untouched, and a re-sync stability check on row ids.
- Adjacent suites pass unchanged: `successful-sync-application-workspace-migration`, `successful-manifest-reparent-view-children`, `successful-sync-application-cross-app-view-field`, `successful-resync-application-with-cross-app-owned-view-field`, plus both record-table-view-universal-identifier specs. Snapshots unchanged.
- `nx typecheck twenty-server` and `nx lint:diff-with-main twenty-server` green.

No migration needed. Existing broken installs heal on their next app sync, since the derived groups simply appear in the next computed desired state.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W3vfCsmnVGUcvz9iqKz6Mb)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

