### PR TITLE
fix: bump nanoid to 5.1.16 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -39888,38 +39888,20 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
-"nanoid@npm:^5.0.7":
-  version: 5.1.3
-  resolution: "nanoid@npm:5.1.3"
+"nanoid@npm:^5.0.7, nanoid@npm:^5.1.3, nanoid@npm:^5.1.6, nanoid@npm:^5.1.7":
+  version: 5.1.16
+  resolution: "nanoid@npm:5.1.16"
   bin:
     nanoid: bin/nanoid.js
-  checksum: 10c0/632ab0e758f8cdd3d14835b2c094e7320cdb92c2404e4bc6cd864765d8fab76647e73ee664a7d11b1a5b5c7e04b8c030d6719d2b61f8b1295a5fb64a9d779a8b
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^5.1.3":
-  version: 5.1.6
-  resolution: "nanoid@npm:5.1.6"
-  bin:
-    nanoid: bin/nanoid.js
-  checksum: 10c0/27b5b055ad8332cf4f0f9f6e2a494aa7e5ded89df4cab8c8490d4eabefe72c4423971d2745d22002868b1d50576a5e42b7b05214733b19f576382323282dd26e
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^5.1.6, nanoid@npm:^5.1.7":
-  version: 5.1.11
-  resolution: "nanoid@npm:5.1.11"
-  bin:
-    nanoid: bin/nanoid.js
-  checksum: 10c0/91580d18c29263ac0e871734f0d86e7f906f523f974d3c30fc65354ccf387ccffd606c2a6c28acc2977a3950146347e790ce9e3f514133a48995af5ccdb308ce
+  checksum: 10c0/04b4f96237f5639716da0e98f453361b313bebaf458bb67dea2d384724fc8b3340a28f032a4373052150bcf3b801d122e291d81ae4fc522969f55c134f4401a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **nanoid -> 5.1.16**, clearing **2 high Dependabot alerts**:

| Advisory | Issue | Vulnerable | Alert |
|---|---|---|---|
| GHSA-2v37-7h3g-55p8 | custom generators can loop indefinitely when size is zero | `>= 4.0.0, < 5.1.6` | [1953](https://github.com/twentyhq/twenty/security/dependabot/1953) |
| GHSA-28wg-ghj8-5hjv | non-secure generators can loop indefinitely with negative size | `>= 4.0.0, < 5.1.16` | [1954](https://github.com/twentyhq/twenty/security/dependabot/1954) |

The root lockfile had three 5.x copies (5.1.3, 5.1.6, 5.1.11), all behind carets (`^5.0.7`, `^5.1.3`, `^5.1.6`/`^5.1.7`), so a recursive `yarn up -R nanoid` **collapses them into a single 5.1.16 entry** with no resolution and no `package.json` change.

The separate 3.x copy (`^3.3.16`) is outside both advisories' `>= 4.0.0` range; the recursive up moved it 3.3.16 -> 3.3.18 within its caret as a side effect (published 2026-08-07, gate-clear).

Root `yarn.lock` only - no overlap with the open app-lockfile PRs (#24482, #24487).

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; nanoid 5.x resolves to a single 5.1.16 entry, no 5.1.3 / 5.1.6 / 5.1.11 remains.
- 5.1.16 published 2026-06-24.
