### PR TITLE
fix: stop Lingui/Crowdin wrapping from opening empty i18n PRs

### DIFF
--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -93,6 +93,16 @@ jobs:
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      # Crowdin rewrites multiline msgid/msgstr wrapping. Re-extract without
+      # --clean so catalogs match Lingui's format without dropping strings
+      # Crowdin just filled. Otherwise the next extract pass opens a wrapping-only PR.
+      - name: Normalize PO wrapping to Lingui format
+        if: inputs.force_pull == true || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          yarn workspace twenty-server exec lingui extract --overwrite
+          yarn workspace twenty-emails exec lingui extract --overwrite
+          yarn workspace twenty-front exec lingui extract --overwrite
+
       - name: Compile translations
         id: compile_translations
         run: |

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -1,5 +1,9 @@
 name: 'Push translations to Crowdin'
 
+# Only extract when app source changes. Ignore locale catalogs so merging an
+# i18n PR does not re-run extract (Lingui and Crowdin wrap the same strings
+# differently). Website-only pushes used to trigger this too.
+
 permissions:
   contents: write
   pull-requests: write
@@ -9,6 +13,15 @@ on:
   workflow_call:
   push:
     branches: ['main']
+    paths:
+      - 'packages/twenty-front/**'
+      - '!packages/twenty-front/src/locales/**'
+      - 'packages/twenty-server/**'
+      - '!packages/twenty-server/src/engine/core-modules/i18n/locales/**'
+      - 'packages/twenty-emails/**'
+      - '!packages/twenty-emails/src/locales/**'
+      - '.github/crowdin-app.yml'
+      - '.github/workflows/i18n-push.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -87,6 +87,13 @@ jobs:
       - name: Fix file permissions
         run: sudo chown -R runner:docker .
 
+      # Crowdin rewrites multiline msgid/msgstr wrapping. Re-extract without
+      # --clean so catalogs match Lingui's format without dropping strings
+      # Crowdin just filled. Otherwise the next extract pass opens a wrapping-only PR.
+      - name: Normalize PO wrapping to Lingui format
+        if: inputs.force_pull == true || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: yarn workspace twenty-website exec lingui extract --overwrite
+
       - name: Compile website translations
         id: compile_translations
         run: |

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -1,5 +1,8 @@
 name: 'Push website translations to Crowdin'
 
+# Ignore locale catalogs so merging an i18n PR does not re-run extract
+# (Lingui and Crowdin wrap the same strings differently).
+
 permissions:
   contents: write
   pull-requests: write
@@ -11,6 +14,7 @@ on:
     branches: ['main']
     paths:
       - 'packages/twenty-website/**'
+      - '!packages/twenty-website/src/locales/**'
       - '.github/crowdin-website.yml'
       - '.github/workflows/website-i18n-push.yaml'
 


### PR DESCRIPTION
## Summary

Lingui extract and Crowdin pull save the same translations with different multiline wrapping. Merging a translation PR retriggered extract, which rewrote wrapping and opened another PR. The scheduled pull then undid it. That is [#24458](https://github.com/twentyhq/twenty/pull/24458) (empty) and the every-two-hours pair of `i18n - translations` PRs.

- Do not run extract when the only changes are locale catalogs (website and app push workflows).
- After Crowdin download, re-extract **without** `--clean` so files stay in Lingui's format and strings Crowdin just filled are not dropped.

## Test plan

- [ ] Merge a website/app i18n PR that only touches `locales/` — extract/push workflows should **not** run
- [ ] Next scheduled Crowdin pull should open a PR only if translations actually changed, not for wrapping
- [ ] New English copy in website/app source still triggers extract and upload

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

