### PR TITLE
fix: bump fast-uri 3.1.4 -> 3.1.5 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -31147,9 +31147,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **fast-uri 3.1.4 -> 3.1.5**, clearing Dependabot alert [1940](https://github.com/twentyhq/twenty/security/dependabot/1940): **GHSA-7p8r-x3mc-p8w7** (high) - host confusion via backslash authority introducer, vulnerable `>= 3.0.0, < 3.1.5`.

fast-uri sits behind a single caret range (`^3.0.1`), so a recursive `yarn up -R fast-uri` lifts it with **no resolution and no `package.json` change**.

Root `yarn.lock` only - no overlap with the open app-lockfile PR #24487 or #24489 (nanoid, different lockfile section).

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; fast-uri resolves to 3.1.5, no 3.1.4 remains.
- 3.1.5 published 2026-07-31, well past the age gate.
