### PR TITLE
fix: bump socket.io-parser 4.2.6 -> 4.2.7 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -47360,12 +47360,12 @@ __metadata:
   linkType: hard
 
 "socket.io-parser@npm:~4.2.4":
-  version: 4.2.6
-  resolution: "socket.io-parser@npm:4.2.6"
+  version: 4.2.7
+  resolution: "socket.io-parser@npm:4.2.7"
   dependencies:
     "@socket.io/component-emitter": "npm:~3.1.0"
     debug: "npm:~4.4.1"
-  checksum: 10c0/ba0a0b541b0a8e9d02b45c04c4c93a02331be5ea3478073c65bb9ff87032f12469c9adb309728eb90c0a352618d645ab88999c167a11c783cac861d7fd35c9d1
+  checksum: 10c0/16a5579718b871114ca644d688987dd3cf9292010c949fb083633eefbc1d8fdaf424691d6511d746e5c10f5c88cbd8911cd0b1e807242159f40989be90842b4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **socket.io-parser 4.2.6 -> 4.2.7**, clearing Dependabot alert [1939](https://github.com/twentyhq/twenty/security/dependabot/1939): **GHSA-2m8v-j782-fhvr** (high) - Socket.IO zero-attachment memory exhaustion, vulnerable `>= 4.0.0, < 4.2.7`.

socket.io-parser is transitive via `socket.io` (4.8.0 / 4.8.1), which declares a tilde range (`~4.2.4`) that already permits 4.2.7, so a recursive `yarn up -R socket.io-parser` lifts it with **no resolution and no `package.json` change**.

Root `yarn.lock` only - different section from the other open root PRs (#24489 nanoid, #24491 fast-uri), no overlap with #24487.

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; socket.io-parser resolves to 4.2.7, no 4.2.6 remains.
- 4.2.7 published 2026-07-15, well past the age gate.
