### PR TITLE
Give the i18n context helper one home

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
@@ -10,7 +10,6 @@ import {
 import { compileMessage } from '@lingui/message-utils/compileMessage';
 import { type APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 
-
 import { messages as afMessages } from 'src/engine/core-modules/i18n/locales/generated/af-ZA';
 import { messages as arMessages } from 'src/engine/core-modules/i18n/locales/generated/ar-SA';
 import { messages as caMessages } from 'src/engine/core-modules/i18n/locales/generated/ca-ES';

--- a/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
@@ -9,10 +9,7 @@ import {
 } from '@lingui/core';
 import { compileMessage } from '@lingui/message-utils/compileMessage';
 import { type APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
-import { isDefined } from 'twenty-shared/utils';
 
-import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
-import { type EffectiveEntityI18nContext } from 'src/engine/metadata-modules/utils/effective-entity-i18n-context.type';
 
 import { messages as afMessages } from 'src/engine/core-modules/i18n/locales/generated/af-ZA';
 import { messages as arMessages } from 'src/engine/core-modules/i18n/locales/generated/ar-SA';
@@ -125,38 +122,6 @@ export class I18nService implements OnModuleInit {
     const i18n = this.getI18nInstance(locale);
 
     return i18n._(messageId, values, options);
-  }
-
-  async buildEffectiveEntityI18nContext({
-    applicationId,
-    loaders,
-    locale,
-    workspaceId,
-  }: {
-    applicationId: string | undefined;
-    loaders: IDataloaders;
-    locale: keyof typeof APP_LOCALES | undefined;
-    workspaceId: string;
-  }): Promise<EffectiveEntityI18nContext> {
-    const safeLocale = locale ?? SOURCE_LOCALE;
-
-    const standardApplicationId =
-      await loaders.standardApplicationIdLoader.load({ workspaceId });
-
-    const applicationCatalog = isDefined(applicationId)
-      ? await loaders.applicationTranslationCatalogLoader.load({
-          applicationId,
-          workspaceId,
-          locale: safeLocale,
-        })
-      : undefined;
-
-    return {
-      locale,
-      i18nInstance: this.getI18nInstance(safeLocale),
-      isStandardApp: applicationId === standardApplicationId,
-      applicationCatalog,
-    };
   }
 
   async onModuleInit() {

--- a/packages/twenty-server/src/engine/core-modules/search/search.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/search.module.ts
@@ -3,10 +3,15 @@ import { Module } from '@nestjs/common';
 import { FileModule } from 'src/engine/core-modules/file/file.module';
 import { SearchResolver } from 'src/engine/core-modules/search/search.resolver';
 import { SearchService } from 'src/engine/core-modules/search/services/search.service';
+import { ApplicationTranslationCatalogModule } from 'src/engine/metadata-modules/application-translation-catalog/application-translation-catalog.module';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
 
 @Module({
-  imports: [FileModule, WorkspaceManyOrAllFlatEntityMapsCacheModule],
+  imports: [
+    FileModule,
+    WorkspaceManyOrAllFlatEntityMapsCacheModule,
+    ApplicationTranslationCatalogModule,
+  ],
   providers: [SearchResolver, SearchService],
 })
 export class SearchModule {}

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -28,7 +28,6 @@ import {
 import { isQueryCanceledError } from 'src/engine/api/graphql/workspace-query-runner/utils/is-query-canceled-error.util';
 import { FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
 import { extractFileIdFromUrl } from 'src/engine/core-modules/file/files-field/utils/extract-file-id-from-url.util';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { STANDARD_OBJECTS_BY_PRIORITY_RANK } from 'src/engine/core-modules/search/constants/standard-objects-by-priority-rank';
 import { type ObjectRecordFilterInput } from 'src/engine/core-modules/search/dtos/object-record-filter-input';
 import { type SearchArgs } from 'src/engine/core-modules/search/dtos/search-args';
@@ -57,6 +56,7 @@ import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/works
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 type LastRanks = { tsRankCD: number; tsRank: number };
 
@@ -75,7 +75,7 @@ export class SearchService {
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
     private readonly fileUrlService: FileUrlService,
     private readonly twentyConfigService: TwentyConfigService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
   ) {}
 
   async getAllRecordsWithObjectMetadataItems({
@@ -807,13 +807,15 @@ export class SearchService {
                 overrides: objectMetadataItem.overrides,
                 property: 'labelSingular',
                 i18nContext:
-                  await this.i18nService.buildEffectiveEntityI18nContext({
-                    applicationId:
-                      objectMetadataItem.applicationId ?? undefined,
-                    loaders,
-                    locale,
-                    workspaceId,
-                  }),
+                  await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+                    {
+                      applicationId:
+                        objectMetadataItem.applicationId ?? undefined,
+                      loaders,
+                      locale,
+                      workspaceId,
+                    },
+                  ),
               }),
             ] as const,
         ),

--- a/packages/twenty-server/src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service.ts
@@ -121,23 +121,30 @@ export class ApplicationTranslationCatalogService {
       return getI18nContext(applicationId);
     }
 
-    return {
+    const getI18nContext = this.toI18nContextResolver({
+      standardApplicationId: await loaders.standardApplicationIdLoader.load({
+        workspaceId,
+      }),
+      catalogByApplicationId: new Map(
+        isDefined(applicationId)
+          ? [
+              [
+                applicationId,
+                await loaders.applicationTranslationCatalogLoader.load({
+                  applicationId,
+                  workspaceId,
+                  locale: safeLocale,
+                }),
+              ],
+            ]
+          : [],
+      ),
       locale,
-      i18nInstance: this.i18nService.getI18nInstance(safeLocale),
-      isStandardApp:
-        applicationId ===
-        (await loaders.standardApplicationIdLoader.load({ workspaceId })),
-      applicationCatalog: isDefined(applicationId)
-        ? await loaders.applicationTranslationCatalogLoader.load({
-            applicationId,
-            workspaceId,
-            locale: safeLocale,
-          })
-        : undefined,
-    };
+    });
+
+    return getI18nContext(applicationId);
   }
 
-  // The batched counterpart: one context per application for a whole page.
   async getI18nContextByApplicationId({
     applicationIds,
     locale,
@@ -149,15 +156,34 @@ export class ApplicationTranslationCatalogService {
   }): Promise<
     (applicationId: string | undefined) => EffectiveEntityI18nContext
   > {
-    const safeLocale = locale ?? SOURCE_LOCALE;
-
     const { standardApplicationId, catalogByApplicationId } =
       await this.getCatalogs({
         applicationIds,
-        locale: safeLocale,
+        locale: locale ?? SOURCE_LOCALE,
         workspaceId,
       });
-    const i18nInstance = this.i18nService.getI18nInstance(safeLocale);
+
+    return this.toI18nContextResolver({
+      standardApplicationId,
+      catalogByApplicationId,
+      locale,
+    });
+  }
+
+  // The one place the context shape is built, so the loader-backed and
+  // batched sources cannot drift apart.
+  private toI18nContextResolver({
+    standardApplicationId,
+    catalogByApplicationId,
+    locale,
+  }: {
+    standardApplicationId: string;
+    catalogByApplicationId: Map<string, Record<string, string> | undefined>;
+    locale: keyof typeof APP_LOCALES | undefined;
+  }): (applicationId: string | undefined) => EffectiveEntityI18nContext {
+    const i18nInstance = this.i18nService.getI18nInstance(
+      locale ?? SOURCE_LOCALE,
+    );
 
     return (applicationId) => ({
       locale,

--- a/packages/twenty-server/src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service.ts
@@ -10,6 +10,7 @@ import { type FlatApplicationCacheMaps } from 'src/engine/core-modules/applicati
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { resolveRegistrationIdByApplicationId } from 'src/engine/metadata-modules/application-translation-catalog/utils/resolve-registration-id-by-application-id.util';
 import { resolveTranslatableProperties } from 'src/engine/metadata-modules/application-translation-catalog/utils/resolve-translatable-properties.util';
+import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { type EffectiveEntityI18nContext } from 'src/engine/metadata-modules/utils/effective-entity-i18n-context.type';
 import { getTwentyStandardApplicationIdOrThrow } from 'src/engine/metadata-modules/utils/get-twenty-standard-application-id-or-throw.util';
 
@@ -93,9 +94,50 @@ export class ApplicationTranslationCatalogService {
     return { standardApplicationId, catalogByApplicationId };
   }
 
-  // Every REST controller needs the same thing the GraphQL resolvers get from
-  // buildEffectiveEntityI18nContext, minus the per-request dataloaders that
-  // only exist in a GraphQL context: one context per application, batched.
+  // The single-entity context. GraphQL resolves labels in per-entity
+  // ResolveFields, so it passes its request dataloaders to coalesce the N
+  // calls one page produces; REST resolves a whole page in one call and has
+  // nothing to coalesce, so it passes none. Same resolution either way.
+  async buildEffectiveEntityI18nContext({
+    applicationId,
+    loaders,
+    locale,
+    workspaceId,
+  }: {
+    applicationId: string | undefined;
+    loaders?: IDataloaders;
+    locale: keyof typeof APP_LOCALES | undefined;
+    workspaceId: string;
+  }): Promise<EffectiveEntityI18nContext> {
+    const safeLocale = locale ?? SOURCE_LOCALE;
+
+    if (!isDefined(loaders)) {
+      const getI18nContext = await this.getI18nContextByApplicationId({
+        applicationIds: [applicationId],
+        locale,
+        workspaceId,
+      });
+
+      return getI18nContext(applicationId);
+    }
+
+    return {
+      locale,
+      i18nInstance: this.i18nService.getI18nInstance(safeLocale),
+      isStandardApp:
+        applicationId ===
+        (await loaders.standardApplicationIdLoader.load({ workspaceId })),
+      applicationCatalog: isDefined(applicationId)
+        ? await loaders.applicationTranslationCatalogLoader.load({
+            applicationId,
+            workspaceId,
+            locale: safeLocale,
+          })
+        : undefined,
+    };
+  }
+
+  // The batched counterpart: one context per application for a whole page.
   async getI18nContextByApplicationId({
     applicationIds,
     locale,

--- a/packages/twenty-server/src/engine/metadata-modules/command-menu-item/command-menu-item.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/command-menu-item/command-menu-item.module.ts
@@ -11,9 +11,11 @@ import { FlatCommandMenuItemModule } from 'src/engine/metadata-modules/flat-comm
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
 import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-graphql-api-exception.interceptor';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+import { ApplicationTranslationCatalogModule } from 'src/engine/metadata-modules/application-translation-catalog/application-translation-catalog.module';
 
 @Module({
   imports: [
+    ApplicationTranslationCatalogModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
     WorkspaceMigrationModule,
     ApplicationModule,

--- a/packages/twenty-server/src/engine/metadata-modules/command-menu-item/command-menu-item.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/command-menu-item/command-menu-item.service.ts
@@ -6,7 +6,6 @@ import { type APP_LOCALES } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
 
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type ObjectMetadataLoaderPayload } from 'src/engine/dataloaders/dataloader.service';
 import {
   CommandMenuItemException,
@@ -32,6 +31,7 @@ import { type ObjectMetadataDTO } from 'src/engine/metadata-modules/object-metad
 import { isCallerOverridingEntity } from 'src/engine/metadata-modules/utils/is-caller-overriding-entity.util';
 import { WorkspaceMigrationBuilderException } from 'src/engine/workspace-manager/workspace-migration/exceptions/workspace-migration-builder-exception';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 @Injectable()
 export class CommandMenuItemService {
@@ -39,7 +39,7 @@ export class CommandMenuItemService {
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
     private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
     private readonly applicationService: ApplicationService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
   ) {}
 
   async findAll(workspaceId: string): Promise<CommandMenuItemDTO[]> {
@@ -462,12 +462,15 @@ export class CommandMenuItemService {
     workspaceId: string;
     locale: keyof typeof APP_LOCALES | undefined;
   }): Promise<string | undefined> {
-    const i18nContext = await this.i18nService.buildEffectiveEntityI18nContext({
-      applicationId: commandMenuItem.applicationId,
-      loaders,
-      locale,
-      workspaceId,
-    });
+    const i18nContext =
+      await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+        {
+          applicationId: commandMenuItem.applicationId,
+          loaders,
+          locale,
+          workspaceId,
+        },
+      );
 
     const effectiveValue = resolveEffectiveEntityProperty({
       metadataName: 'commandMenuItem',
@@ -506,12 +509,14 @@ export class CommandMenuItemService {
       // The navigated-to object may belong to a different application than the
       // command menu item pointing at it.
       objectMetadataI18nContext:
-        await this.i18nService.buildEffectiveEntityI18nContext({
-          applicationId: objectMetadata.applicationId,
-          loaders,
-          locale,
-          workspaceId,
-        }),
+        await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+          {
+            applicationId: objectMetadata.applicationId,
+            loaders,
+            locale,
+            workspaceId,
+          },
+        ),
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
@@ -21,7 +21,6 @@ import {
   ForbiddenError,
   NotFoundError,
 } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
@@ -52,6 +51,7 @@ import { fromFlatFieldMetadataToFieldMetadataDto } from 'src/engine/metadata-mod
 import { UniqueFieldMetadataIdsService } from 'src/engine/metadata-modules/index-metadata/services/unique-field-metadata-ids.service';
 import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 // Keep @Parent() structurally typed so ResolverValidationPipe does not validate
 // FieldMetadataDTO date decorators on already-loaded parent records.
@@ -70,7 +70,7 @@ type FieldMetadataStandardOverrideParent = Pick<
 export class FieldMetadataResolver {
   constructor(
     private readonly fieldMetadataService: FieldMetadataService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
     @InjectRepository(FieldMetadataEntity)
     private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
     private readonly uniqueFieldMetadataIdsService: UniqueFieldMetadataIdsService,
@@ -187,12 +187,15 @@ export class FieldMetadataResolver {
       baseValue: fieldMetadata[labelKey],
       overrides: fieldMetadata.overrides,
       property: labelKey,
-      i18nContext: await this.i18nService.buildEffectiveEntityI18nContext({
-        applicationId: fieldMetadata.applicationId ?? undefined,
-        loaders: context.loaders,
-        locale: context.req.locale,
-        workspaceId,
-      }),
+      i18nContext:
+        await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+          {
+            applicationId: fieldMetadata.applicationId ?? undefined,
+            loaders: context.loaders,
+            locale: context.req.locale,
+            workspaceId,
+          },
+        ),
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.module.ts
@@ -16,9 +16,11 @@ import { NavigationMenuItemToolWorkspaceService } from 'src/engine/metadata-modu
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-graphql-api-exception.interceptor';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+import { ApplicationTranslationCatalogModule } from 'src/engine/metadata-modules/application-translation-catalog/application-translation-catalog.module';
 
 @Module({
   imports: [
+    ApplicationTranslationCatalogModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
     WorkspaceMigrationModule,
     ApplicationModule,

--- a/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.resolver.ts
@@ -16,7 +16,6 @@ import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { getWorkspaceAuthContext } from 'src/engine/core-modules/auth/storage/workspace-auth-context.storage';
 import { type I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { AuthApiKey } from 'src/engine/decorators/auth/auth-api-key.decorator';
@@ -33,6 +32,7 @@ import { NavigationMenuItemGraphqlApiExceptionInterceptor } from 'src/engine/met
 import { NavigationMenuItemService } from 'src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.service';
 import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
 import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-graphql-api-exception.interceptor';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 @UseGuards(WorkspaceAuthGuard)
 @UseInterceptors(
@@ -43,7 +43,7 @@ import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/wor
 export class NavigationMenuItemResolver {
   constructor(
     private readonly navigationMenuItemService: NavigationMenuItemService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
   ) {}
 
   @ResolveField(() => String, { nullable: true })
@@ -64,12 +64,15 @@ export class NavigationMenuItemResolver {
       // translate and no override to arbitrate against.
       overrides: undefined,
       property: 'name',
-      i18nContext: await this.i18nService.buildEffectiveEntityI18nContext({
-        applicationId: navigationMenuItem.applicationId,
-        loaders: context.loaders,
-        locale: context.req.locale,
-        workspaceId: workspace.id,
-      }),
+      i18nContext:
+        await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+          {
+            applicationId: navigationMenuItem.applicationId,
+            loaders: context.loaders,
+            locale: context.req.locale,
+            workspaceId: workspace.id,
+          },
+        ),
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
@@ -18,7 +18,6 @@ import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/
 import { NotFoundError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules/graphql/filters/prevent-nest-to-auto-log-graphql-errors.filter';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
@@ -58,6 +57,7 @@ import { objectMetadataGraphqlApiExceptionHandler } from 'src/engine/metadata-mo
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
 import { SearchFieldMetadataDTO } from 'src/engine/metadata-modules/search-field-metadata/dtos/search-field-metadata.dto';
 import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 @UseGuards(WorkspaceAuthGuard)
 @MetadataResolver(() => ObjectMetadataDTO)
@@ -71,7 +71,7 @@ export class ObjectMetadataResolver {
     private readonly objectMetadataService: ObjectMetadataService,
     private readonly objectRecordCountService: ObjectRecordCountService,
     private readonly mostlyEmptyFieldsService: MostlyEmptyFieldsService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
     @InjectRepository(ObjectMetadataEntity)
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
   ) {}
@@ -241,12 +241,15 @@ export class ObjectMetadataResolver {
       baseValue: objectMetadata[labelKey],
       overrides: objectMetadata.overrides,
       property: labelKey,
-      i18nContext: await this.i18nService.buildEffectiveEntityI18nContext({
-        applicationId: objectMetadata.applicationId ?? undefined,
-        loaders: context.loaders,
-        locale: context.req.locale,
-        workspaceId,
-      }),
+      i18nContext:
+        await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+          {
+            applicationId: objectMetadata.applicationId ?? undefined,
+            loaders: context.loaders,
+            locale: context.req.locale,
+            workspaceId,
+          },
+        ),
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout-tab/resolvers/page-layout-tab.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout-tab/resolvers/page-layout-tab.resolver.ts
@@ -17,7 +17,6 @@ import { PermissionFlagType } from 'twenty-shared/constants';
 
 import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
@@ -32,6 +31,7 @@ import { PageLayoutTabService } from 'src/engine/metadata-modules/page-layout-ta
 import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
 import { PageLayoutGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/page-layout/utils/page-layout-graphql-api-exception.filter';
 import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-graphql-api-exception.interceptor';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 @MetadataResolver(() => PageLayoutTabDTO)
 @UseInterceptors(WorkspaceMigrationGraphqlApiExceptionInterceptor)
@@ -41,7 +41,7 @@ import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/wor
 export class PageLayoutTabResolver {
   constructor(
     private readonly pageLayoutTabService: PageLayoutTabService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
   ) {}
 
   @ResolveField(() => String)
@@ -50,12 +50,15 @@ export class PageLayoutTabResolver {
     @Context() context: { loaders: IDataloaders } & I18nContext,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<string> {
-    const i18nContext = await this.i18nService.buildEffectiveEntityI18nContext({
-      applicationId: tab.applicationId,
-      loaders: context.loaders,
-      locale: context.req.locale,
-      workspaceId: workspace.id,
-    });
+    const i18nContext =
+      await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+        {
+          applicationId: tab.applicationId,
+          loaders: context.loaders,
+          locale: context.req.locale,
+          workspaceId: workspace.id,
+        },
+      );
 
     return resolveEffectiveEntityProperty({
       metadataName: 'pageLayoutTab',

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/resolvers/page-layout-widget.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/resolvers/page-layout-widget.resolver.ts
@@ -16,7 +16,6 @@ import {
 import { PermissionFlagType } from 'twenty-shared/constants';
 
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
@@ -33,6 +32,7 @@ import { PageLayoutWidgetService } from 'src/engine/metadata-modules/page-layout
 import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
 import { PageLayoutGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/page-layout/utils/page-layout-graphql-api-exception.filter';
 import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-graphql-api-exception.interceptor';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 @MetadataResolver(() => PageLayoutWidgetDTO)
 @UseInterceptors(WorkspaceMigrationGraphqlApiExceptionInterceptor)
@@ -42,7 +42,7 @@ import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/wor
 export class PageLayoutWidgetResolver {
   constructor(
     private readonly pageLayoutWidgetService: PageLayoutWidgetService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
   ) {}
 
   @ResolveField(() => String)
@@ -51,12 +51,15 @@ export class PageLayoutWidgetResolver {
     @Context() context: { loaders: IDataloaders } & I18nContext,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<string> {
-    const i18nContext = await this.i18nService.buildEffectiveEntityI18nContext({
-      applicationId: widget.applicationId,
-      loaders: context.loaders,
-      locale: context.req.locale,
-      workspaceId: workspace.id,
-    });
+    const i18nContext =
+      await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+        {
+          applicationId: widget.applicationId,
+          loaders: context.loaders,
+          locale: context.req.locale,
+          workspaceId: workspace.id,
+        },
+      );
 
     return resolveEffectiveEntityProperty({
       metadataName: 'pageLayoutWidget',

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout/resolvers/page-layout.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout/resolvers/page-layout.resolver.ts
@@ -16,7 +16,6 @@ import {
 import { PermissionFlagType } from 'twenty-shared/constants';
 
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
@@ -38,6 +37,7 @@ import { PageLayoutService } from 'src/engine/metadata-modules/page-layout/servi
 import { PageLayoutGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/page-layout/utils/page-layout-graphql-api-exception.filter';
 import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
 import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-graphql-api-exception.interceptor';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 @MetadataResolver(() => PageLayoutDTO)
 @UseInterceptors(WorkspaceMigrationGraphqlApiExceptionInterceptor)
@@ -49,7 +49,7 @@ export class PageLayoutResolver {
     private readonly pageLayoutService: PageLayoutService,
     private readonly pageLayoutUpdateService: PageLayoutUpdateService,
     private readonly pageLayoutResetService: PageLayoutResetService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
   ) {}
 
   @ResolveField(() => String)
@@ -58,12 +58,15 @@ export class PageLayoutResolver {
     @Context() context: { loaders: IDataloaders } & I18nContext,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<string> {
-    const i18nContext = await this.i18nService.buildEffectiveEntityI18nContext({
-      applicationId: pageLayout.applicationId,
-      loaders: context.loaders,
-      locale: context.req.locale,
-      workspaceId: workspace.id,
-    });
+    const i18nContext =
+      await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+        {
+          applicationId: pageLayout.applicationId,
+          loaders: context.loaders,
+          locale: context.req.locale,
+          workspaceId: workspace.id,
+        },
+      );
 
     return resolveEffectiveEntityProperty({
       metadataName: 'pageLayout',

--- a/packages/twenty-server/src/engine/metadata-modules/view-field-group/resolvers/view-field-group.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-field-group/resolvers/view-field-group.resolver.ts
@@ -12,7 +12,6 @@ import { isArray } from '@sniptt/guards';
 
 import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
@@ -32,6 +31,7 @@ import { ViewFieldDTO } from 'src/engine/metadata-modules/view-field/dtos/view-f
 import { ViewDTO } from 'src/engine/metadata-modules/view/dtos/view.dto';
 import { type ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 import { ViewGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/view/utils/view-graphql-api-exception.filter';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 @MetadataResolver(() => ViewFieldGroupDTO)
 @UseFilters(ViewGraphqlApiExceptionFilter)
@@ -40,7 +40,7 @@ export class ViewFieldGroupResolver {
   constructor(
     private readonly viewFieldGroupService: ViewFieldGroupService,
     private readonly fieldsWidgetUpsertService: FieldsWidgetUpsertService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
   ) {}
 
   @ResolveField(() => String)
@@ -49,12 +49,15 @@ export class ViewFieldGroupResolver {
     @Context() context: { loaders: IDataloaders } & I18nContext,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<string> {
-    const i18nContext = await this.i18nService.buildEffectiveEntityI18nContext({
-      applicationId: viewFieldGroup.applicationId,
-      loaders: context.loaders,
-      locale: context.req.locale,
-      workspaceId: workspace.id,
-    });
+    const i18nContext =
+      await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+        {
+          applicationId: viewFieldGroup.applicationId,
+          loaders: context.loaders,
+          locale: context.req.locale,
+          workspaceId: workspace.id,
+        },
+      );
 
     return resolveEffectiveEntityProperty({
       metadataName: 'viewFieldGroup',

--- a/packages/twenty-server/src/engine/metadata-modules/view-field-group/view-field-group.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-field-group/view-field-group.module.ts
@@ -12,9 +12,11 @@ import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entit
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+import { ApplicationTranslationCatalogModule } from 'src/engine/metadata-modules/application-translation-catalog/application-translation-catalog.module';
 
 @Module({
   imports: [
+    ApplicationTranslationCatalogModule,
     TypeOrmModule.forFeature([ViewFieldGroupEntity, ViewEntity]),
     WorkspaceCacheStorageModule,
     ApplicationModule,

--- a/packages/twenty-server/src/engine/metadata-modules/view/resolvers/view.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/resolvers/view.resolver.ts
@@ -18,7 +18,6 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
-import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
@@ -46,6 +45,7 @@ import { ViewService } from 'src/engine/metadata-modules/view/services/view.serv
 import { ViewGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/view/utils/view-graphql-api-exception.filter';
 import { ViewPermissionGuard } from 'src/engine/metadata-modules/view-permissions/guards/view-permission.guard';
 import { CreateViewPermissionGuard } from 'src/engine/metadata-modules/view-permissions/guards/create-view-permission.guard';
+import { ApplicationTranslationCatalogService } from 'src/engine/metadata-modules/application-translation-catalog/services/application-translation-catalog.service';
 
 @MetadataResolver(() => ViewDTO)
 @UseFilters(ViewGraphqlApiExceptionFilter)
@@ -54,7 +54,7 @@ export class ViewResolver {
   constructor(
     private readonly viewService: ViewService,
     private readonly viewWidgetUpsertService: ViewWidgetUpsertService,
-    private readonly i18nService: I18nService,
+    private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
   ) {}
 
   @ResolveField(() => String)
@@ -63,12 +63,15 @@ export class ViewResolver {
     @Context() context: { loaders: IDataloaders } & I18nContext,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<string> {
-    const i18nContext = await this.i18nService.buildEffectiveEntityI18nContext({
-      applicationId: view.applicationId,
-      loaders: context.loaders,
-      locale: context.req.locale,
-      workspaceId: workspace.id,
-    });
+    const i18nContext =
+      await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+        {
+          applicationId: view.applicationId,
+          loaders: context.loaders,
+          locale: context.req.locale,
+          workspaceId: workspace.id,
+        },
+      );
 
     return resolveViewName({
       view,
@@ -108,12 +111,14 @@ export class ViewResolver {
     }
 
     const objectI18nContext =
-      await this.i18nService.buildEffectiveEntityI18nContext({
-        applicationId: objectMetadata.applicationId,
-        loaders: context.loaders,
-        locale: context.req.locale,
-        workspaceId: workspace.id,
-      });
+      await this.applicationTranslationCatalogService.buildEffectiveEntityI18nContext(
+        {
+          applicationId: objectMetadata.applicationId,
+          loaders: context.loaders,
+          locale: context.req.locale,
+          workspaceId: workspace.id,
+        },
+      );
 
     return buildViewNameObjectLabels({
       viewName: view.name,


### PR DESCRIPTION
## Why

#24410 left two methods doing the same job in two places:

- `I18nService.buildEffectiveEntityI18nContext` — one entity, takes `loaders: IDataloaders`, used by the GraphQL resolvers.
- `ApplicationTranslationCatalogService.getI18nContextByApplicationId` — a page of entities, no loaders, used by the REST controllers.

The dataloader argument was what forced the split, and it turns out not to be a real boundary. Both loaders are three-line wrappers around the very methods the REST path calls:

- `standardApplicationIdLoader` → `applicationTranslationCatalogService.getStandardApplicationId`
- `applicationTranslationCatalogLoader` → `applicationTranslationCatalogService.getCatalogs`

So both paths already shared the data source and the cache (`ApplicationTranslationCacheService` memoizes per `applicationRegistrationId` for 30s and loads every locale in one query). The loaders add no data, no caching and no logic — only **coalescing**, which GraphQL genuinely needs and REST genuinely doesn't.

## Change

`buildEffectiveEntityI18nContext` moves onto `ApplicationTranslationCatalogService`, beside the batched builder it duplicated, with `loaders` optional:

- **GraphQL** passes its request loaders. Labels resolve in per-entity `@ResolveField`s, so a page of N views/widgets/tabs produces N calls in one tick, and DataLoader collapses them into one batched call. Unchanged behaviour, unchanged call count.
- **REST** passes none. Its controllers already hand `getCatalogs` every `applicationId` at once, so there is nothing left to coalesce.

The context shape itself is built in exactly one place — a private `toI18nContextResolver` both entry points feed — so the loader-backed and batched sources cannot drift, and neither entry point decides on its own how a missing locale falls back.

The direction is forced: `ApplicationTranslationCatalogService` already injects `I18nService`, so the helper could move down but not up. `IDataloaders` arrives as a type-only import, so no runtime cycle with `dataloader.service` either.

All 12 call sites across 10 files now call the one method. `I18nService` keeps `getI18nInstance` and loses the helper along with its now-unused imports; five call sites stop injecting `I18nService` entirely.

## The part typecheck could not catch

Four modules used the helper through `I18nService` and so had never imported `ApplicationTranslationCatalogModule` — `view-field-group`, `command-menu-item`, `navigation-menu-item` and `search`. They type-check fine and fail at runtime with an unresolved dependency. They now import it; the rest already did. Worth a look in review, since this is the only part of the change a green typecheck says nothing about.

## Validation

- `tsgo` clean on twenty-server; `oxfmt --check src/` and `oxlint --type-aware -c .oxlintrc.json src/` (CI's exact commands) clean — the one remaining warning, an unused `APP_LOCALES` type import in `application-translation-sync.service.ts`, is pre-existing on `main` from #24408, outside this diff, and non-fatal.
- Touched suites 60/60.
- `ApplicationTranslationCatalogModule` imports none of the four newly-wired modules, so no module cycle is introduced.