### PR TITLE
Read translatable properties without a cast

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/application-translation-catalog/utils/resolve-translatable-properties.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/application-translation-catalog/utils/resolve-translatable-properties.util.ts
@@ -5,26 +5,22 @@ import { ALL_TRANSLATABLE_PROPERTIES_BY_METADATA_NAME } from 'src/engine/metadat
 import { type EffectiveEntityI18nContext } from 'src/engine/metadata-modules/utils/effective-entity-i18n-context.type';
 import { resolveEffectiveEntityPropertyByName } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
 
-// The registry decides which property to read, so this is the one place a
-// dynamic property name meets a concrete entity. Callers range from TypeORM
-// classes to plain DTOs, some without an overrides column at all, so the read
-// is dynamic rather than typed per shape.
-const readProperty = (entity: object, property: string): unknown =>
-  (entity as Record<string, unknown>)[property];
-
 export const resolveTranslatableProperties = ({
   metadataName,
   entity,
   i18nContext,
 }: {
   metadataName: TranslatableMetadataName;
-  entity: object;
+  // The registry decides which properties to read, so the entity is indexed by
+  // name: callers range from TypeORM classes to plain DTOs, some without an
+  // overrides column at all.
+  entity: Record<string, unknown>;
   i18nContext: EffectiveEntityI18nContext;
 }): Record<string, string> =>
   Object.fromEntries(
     (ALL_TRANSLATABLE_PROPERTIES_BY_METADATA_NAME[metadataName] ?? [])
       .map((property) => {
-        const baseValue = readProperty(entity, property);
+        const baseValue = entity[property];
 
         return isDefined(baseValue)
           ? [
@@ -32,7 +28,7 @@ export const resolveTranslatableProperties = ({
               resolveEffectiveEntityPropertyByName({
                 metadataName,
                 baseValue,
-                overrides: readProperty(entity, 'overrides'),
+                overrides: entity.overrides,
                 property,
                 i18nContext,
               }),


### PR DESCRIPTION
Follow-up to a review nit on #24495, where the finding was correct but the file was outside that PR's diff. Independent of both open PRs — the file landed on `main` with #24410, and neither #24409 nor #24495 touches it, so this can merge in any order.

## Change

`resolveTranslatableProperties` took `entity: object` and reached its dynamic keys through `(entity as Record<string, unknown>)[property]`, wrapped in a `readProperty` helper that existed only to hold that cast in one place.

The registry is what supplies the property name, so the parameter is the thing that should be indexable. Typing it `Record<string, unknown>` removes the cast, and with it the helper and its comment — `entity[property]` and `entity.overrides` read directly.

−10/+6, one file.

## Why this is safe

I had argued against a cast in this same util during #24410's review, so it is worth being explicit that this is a different proposal and my earlier answer did not apply to it. That one suggested adding `[key: string]: unknown` to `PresentableEntity`, which does not compile: TypeORM entity classes have no index signature, so the type would reject every caller. Typing the *parameter* has no such problem — the sole production caller passes a generic constrained to an object type, which is assignable.

Verified rather than assumed: `tsgo` exits 0 across twenty-server including specs, `oxfmt --check src/` and `oxlint --type-aware -c .oxlintrc.json src/` are clean, and the util's suite is 11/11. `grep` finds no remaining `as` in the file.

The one lint warning in the tree — an unused `APP_LOCALES` type import in `application-translation-sync.service.ts` — is pre-existing on `main` from #24408, non-fatal, and left alone as unrelated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFZV45dmajdE3hbASNr9xe)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

