### PR TITLE
fix(workflow): read a filter variable that resolved to null as an emptiness check

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/resolve-filter-value-and-operand.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/resolve-filter-value-and-operand.util.spec.ts
@@ -1,0 +1,64 @@
+import { ViewFilterOperand } from 'twenty-shared/types';
+
+import { resolveFilterValueAndOperand } from 'src/modules/workflow/workflow-executor/utils/resolve-filter-value-and-operand.util';
+
+const context = {
+  trigger: { companyId: null, name: 'Acme', missing: undefined },
+};
+
+const resolve = (value: unknown, operand = ViewFilterOperand.IS) =>
+  resolveFilterValueAndOperand({ value, operand, context });
+
+describe('resolveFilterValueAndOperand', () => {
+  it('resolves a variable and keeps the operand when it has a value', () => {
+    expect(resolve('{{trigger.name}}')).toEqual({
+      value: 'Acme',
+      operand: ViewFilterOperand.IS,
+    });
+  });
+
+  it.each([
+    [ViewFilterOperand.IS, ViewFilterOperand.IS_EMPTY],
+    [ViewFilterOperand.IS_NOT, ViewFilterOperand.IS_NOT_EMPTY],
+    [ViewFilterOperand.CONTAINS, ViewFilterOperand.IS_EMPTY],
+    [ViewFilterOperand.DOES_NOT_CONTAIN, ViewFilterOperand.IS_NOT_EMPTY],
+  ])(
+    'turns %s into %s when the variable resolves to null',
+    (operand, emptinessOperand) => {
+      expect(resolve('{{trigger.companyId}}', operand)).toEqual({
+        value: null,
+        operand: emptinessOperand,
+      });
+    },
+  );
+
+  it('leaves a filter the user never filled alone', () => {
+    expect(resolve('')).toEqual({ value: '', operand: ViewFilterOperand.IS });
+  });
+
+  it('leaves a literal value alone even when it reads as empty', () => {
+    expect(resolve('[]')).toEqual({
+      value: '[]',
+      operand: ViewFilterOperand.IS,
+    });
+  });
+
+  it('keeps the operand when a variable cannot be resolved at all', () => {
+    expect(resolve('{{trigger.missing}}')).toEqual({
+      value: undefined,
+      operand: ViewFilterOperand.IS,
+    });
+  });
+
+  it.each([
+    [ViewFilterOperand.GREATER_THAN_OR_EQUAL],
+    [ViewFilterOperand.LESS_THAN_OR_EQUAL],
+    [ViewFilterOperand.IS_BEFORE],
+    [ViewFilterOperand.IS_AFTER],
+  ])('keeps %s, which has no emptiness reading', (operand) => {
+    expect(resolve('{{trigger.companyId}}', operand)).toEqual({
+      value: null,
+      operand,
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/resolve-filter-value-and-operand.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/resolve-filter-value-and-operand.util.ts
@@ -1,0 +1,32 @@
+import { ViewFilterOperand } from 'twenty-shared/types';
+import { isVariableReference, resolveInput } from 'twenty-shared/utils';
+
+const EMPTINESS_OPERAND_BY_OPERAND: Partial<
+  Record<ViewFilterOperand, ViewFilterOperand>
+> = {
+  [ViewFilterOperand.IS]: ViewFilterOperand.IS_EMPTY,
+  [ViewFilterOperand.IS_NOT]: ViewFilterOperand.IS_NOT_EMPTY,
+  [ViewFilterOperand.CONTAINS]: ViewFilterOperand.IS_EMPTY,
+  [ViewFilterOperand.DOES_NOT_CONTAIN]: ViewFilterOperand.IS_NOT_EMPTY,
+};
+
+export const resolveFilterValueAndOperand = ({
+  value,
+  operand,
+  context,
+}: {
+  value: unknown;
+  operand: ViewFilterOperand;
+  context: Record<string, unknown>;
+}): { value: unknown; operand: ViewFilterOperand } => {
+  const resolvedValue = resolveInput(value, context);
+
+  if (!isVariableReference(value) || resolvedValue !== null) {
+    return { value: resolvedValue, operand };
+  }
+
+  return {
+    value: resolvedValue,
+    operand: EMPTINESS_OPERAND_BY_OPERAND[operand] ?? operand,
+  };
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/resolve-step-filters.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/resolve-step-filters.util.ts
@@ -1,0 +1,26 @@
+import { type StepFilter } from 'twenty-shared/types';
+import { resolveInput } from 'twenty-shared/utils';
+
+import { resolveFilterValueAndOperand } from 'src/modules/workflow/workflow-executor/utils/resolve-filter-value-and-operand.util';
+
+export const resolveStepFilters = ({
+  stepFilters,
+  context,
+}: {
+  stepFilters: StepFilter[];
+  context: Record<string, unknown>;
+}) =>
+  stepFilters.map((stepFilter) => {
+    const { value: rightOperand, operand } = resolveFilterValueAndOperand({
+      value: stepFilter.value,
+      operand: stepFilter.operand,
+      context,
+    });
+
+    return {
+      ...stepFilter,
+      operand,
+      rightOperand,
+      leftOperand: resolveInput(stepFilter.stepOutputKey, context),
+    };
+  });

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-step-filters.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-step-filters.util.spec.ts
@@ -14,6 +14,8 @@ describe('evaluateStepFilters', () => {
         after: {
           createdBy: { source: 'EMAIL' },
           name: 'Acme',
+          companyId: null,
+          jobTitle: '',
         },
       },
     },
@@ -136,6 +138,80 @@ describe('evaluateStepFilters', () => {
       evaluateStepFilters({
         stepFilterGroups: [],
         stepFilters: [nameContains, sourceIsCalendar],
+        context,
+      }),
+    ).toBe(false);
+  });
+  const companyFilter = (
+    operand: ViewFilterOperand,
+    stepOutputKey: string,
+  ): StepFilter => ({
+    id: 'filter-company',
+    type: 'TEXT',
+    operand,
+    value: '{{trigger.properties.after.companyId}}',
+    stepOutputKey,
+    stepFilterGroupId: group.id,
+  });
+
+  it('matches an empty field when the filter variable resolves to null', () => {
+    expect(
+      evaluateStepFilters({
+        stepFilterGroups: [group],
+        stepFilters: [
+          companyFilter(
+            ViewFilterOperand.IS,
+            '{{trigger.properties.after.jobTitle}}',
+          ),
+        ],
+        context,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not match a field that has a value when the filter variable resolves to null', () => {
+    expect(
+      evaluateStepFilters({
+        stepFilterGroups: [group],
+        stepFilters: [
+          companyFilter(
+            ViewFilterOperand.IS,
+            '{{trigger.properties.after.name}}',
+          ),
+        ],
+        context,
+      }),
+    ).toBe(false);
+  });
+
+  it('inverts that for IS_NOT when the filter variable resolves to null', () => {
+    expect(
+      evaluateStepFilters({
+        stepFilterGroups: [group],
+        stepFilters: [
+          companyFilter(
+            ViewFilterOperand.IS_NOT,
+            '{{trigger.properties.after.name}}',
+          ),
+        ],
+        context,
+      }),
+    ).toBe(true);
+  });
+
+  it('leaves a filter the user never filled in alone, so an empty field is not treated as a match', () => {
+    expect(
+      evaluateStepFilters({
+        stepFilterGroups: [group],
+        stepFilters: [
+          {
+            ...companyFilter(
+              ViewFilterOperand.IS,
+              '{{trigger.properties.after.companyId}}',
+            ),
+            value: '',
+          },
+        ],
         context,
       }),
     ).toBe(false);

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-step-filters.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-step-filters.util.ts
@@ -1,5 +1,6 @@
 import { type StepFilter, type StepFilterGroup } from 'twenty-shared/types';
-import { resolveInput } from 'twenty-shared/utils';
+
+import { resolveStepFilters } from 'src/modules/workflow/workflow-executor/utils/resolve-step-filters.util';
 
 import { evaluateFilterConditions } from 'src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util';
 
@@ -12,11 +13,7 @@ export const evaluateStepFilters = ({
   stepFilterGroups: StepFilterGroup[];
   context: Record<string, unknown>;
 }): boolean => {
-  const resolvedFilters = stepFilters.map((filter) => ({
-    ...filter,
-    rightOperand: resolveInput(filter.value, context),
-    leftOperand: resolveInput(filter.stepOutputKey, context),
-  }));
+  const resolvedFilters = resolveStepFilters({ stepFilters, context });
 
   return evaluateFilterConditions({
     filterGroups: stepFilterGroups,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/if-else.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/if-else.workflow-action.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@nestjs/common';
 
-import { resolveInput } from 'twenty-shared/utils';
-
 import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/interfaces/workflow-action.interface';
 
 import {
@@ -12,6 +10,7 @@ import { type WorkflowActionInput } from 'src/modules/workflow/workflow-executor
 import { type WorkflowActionOutput } from 'src/modules/workflow/workflow-executor/types/workflow-action-output.type';
 import { findStepOrThrow } from 'src/modules/workflow/workflow-executor/utils/find-step-or-throw.util';
 import { isWorkflowIfElseAction } from 'src/modules/workflow/workflow-executor/workflow-actions/if-else/guards/is-workflow-if-else-action.guard';
+import { resolveStepFilters } from 'src/modules/workflow/workflow-executor/utils/resolve-step-filters.util';
 import { findMatchingBranch } from 'src/modules/workflow/workflow-executor/workflow-actions/if-else/utils/find-matching-branch.util';
 
 @Injectable()
@@ -47,11 +46,7 @@ export class IfElseWorkflowAction implements WorkflowAction {
       );
     }
 
-    const resolvedFilters = stepFilters.map((filter) => ({
-      ...filter,
-      rightOperand: resolveInput(filter.value, context),
-      leftOperand: resolveInput(filter.stepOutputKey, context),
-    }));
+    const resolvedFilters = resolveStepFilters({ stepFilters, context });
 
     const matchingBranch = findMatchingBranch({
       branches,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
@@ -26,6 +26,7 @@ import { isWorkflowFindRecordsAction } from 'src/modules/workflow/workflow-execu
 import { type WorkflowFindRecordsActionInput } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type';
 import { resolveLimitInput } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/utils/resolve-limit-input.util';
 import { resolveOffsetInput } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/utils/resolve-offset-input.util';
+import { resolveRecordFilters } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/utils/resolve-record-filters.util';
 
 @Injectable()
 export class FindRecordsWorkflowAction implements WorkflowAction {
@@ -53,6 +54,11 @@ export class FindRecordsWorkflowAction implements WorkflowAction {
       );
     }
 
+    const recordFilters = resolveRecordFilters({
+      unresolvedRecordFilters: step.settings.input.filter?.recordFilters,
+      context,
+    });
+
     const workflowActionInput = resolveInput(
       step.settings.input,
       context,
@@ -69,8 +75,8 @@ export class FindRecordsWorkflowAction implements WorkflowAction {
         workspaceId,
       );
 
-    if (workflowActionInput.filter?.recordFilters) {
-      for (const filter of workflowActionInput.filter.recordFilters) {
+    if (recordFilters) {
+      for (const filter of recordFilters) {
         if (!isRecordFilterValueValid(filter)) {
           throw new WorkflowStepExecutorException(
             `Filter condition has an empty value after variable resolution. This likely means a workflow variable could not be resolved. Filter field: ${filter.fieldMetadataId}, operand: ${filter.operand}`,
@@ -79,8 +85,6 @@ export class FindRecordsWorkflowAction implements WorkflowAction {
         }
       }
     }
-
-    const recordFilters = workflowActionInput.filter?.recordFilters;
 
     let gqlOperationFilter: RecordGqlOperationFilter;
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/utils/resolve-record-filters.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/utils/resolve-record-filters.util.ts
@@ -1,0 +1,20 @@
+import { type RecordFilter } from 'twenty-shared/utils';
+
+import { resolveFilterValueAndOperand } from 'src/modules/workflow/workflow-executor/utils/resolve-filter-value-and-operand.util';
+
+export const resolveRecordFilters = ({
+  unresolvedRecordFilters,
+  context,
+}: {
+  unresolvedRecordFilters: RecordFilter[] | undefined;
+  context: Record<string, unknown>;
+}): RecordFilter[] | undefined =>
+  unresolvedRecordFilters?.map((recordFilter) => {
+    const { value, operand } = resolveFilterValueAndOperand({
+      value: recordFilter.value,
+      operand: recordFilter.operand,
+      context,
+    });
+
+    return { ...recordFilter, value: value as string, operand };
+  });

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/find-records-relation-traversal-workflow.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/find-records-relation-traversal-workflow.integration-spec.ts
@@ -30,7 +30,7 @@ describe('FindRecords workflow action with relation-traversal filter (e2e)', () 
   let createdWorkflowId: string | null = null;
   let createdWorkflowVersionId: string | null = null;
   let findRecordsStepId: string | null = null;
-  let createdWorkflowRunId: string | null = null;
+  const createdWorkflowRunIds: string[] = [];
   let personCompanyFieldMetadataId: string | null = null;
   let companyNameFieldMetadataId: string | null = null;
 
@@ -235,9 +235,9 @@ describe('FindRecords workflow action with relation-traversal filter (e2e)', () 
                         id: filterId,
                         type: 'TEXT',
                         label: 'Company → Name',
-                        value: 'AirbnbWorkflowTest',
+                        value: '{{trigger.companyName}}',
                         operand: 'CONTAINS',
-                        displayValue: 'AirbnbWorkflowTest',
+                        displayValue: '{{trigger.companyName}}',
                         fieldMetadataId: personCompanyFieldMetadataId,
                         relationTargetFieldMetadataId:
                           companyNameFieldMetadataId,
@@ -272,6 +272,17 @@ describe('FindRecords workflow action with relation-traversal filter (e2e)', () 
     expect(activateResponse.body.errors).toBeUndefined();
   };
 
+  const runWithCompanyName = async (companyName: string | null) => {
+    const workflowRunId = await runWorkflowVersion({
+      workflowVersionId: createdWorkflowVersionId!,
+      payload: { companyName },
+    });
+
+    createdWorkflowRunIds.push(workflowRunId);
+
+    return waitForWorkflowCompletion(workflowRunId);
+  };
+
   beforeAll(async () => {
     await lookupFieldMetadataIds();
     await seedTestRecords();
@@ -279,8 +290,8 @@ describe('FindRecords workflow action with relation-traversal filter (e2e)', () 
   });
 
   afterAll(async () => {
-    if (createdWorkflowRunId) {
-      await destroyWorkflowRun(createdWorkflowRunId);
+    for (const workflowRunId of createdWorkflowRunIds) {
+      await destroyWorkflowRun(workflowRunId);
     }
     if (createdWorkflowId) {
       await client
@@ -310,13 +321,7 @@ describe('FindRecords workflow action with relation-traversal filter (e2e)', () 
   });
 
   it('should apply a one-hop relation-traversal filter and return only matching records', async () => {
-    const workflowRunId = await runWorkflowVersion({
-      workflowVersionId: createdWorkflowVersionId!,
-    });
-
-    createdWorkflowRunId = workflowRunId;
-
-    const workflowRun = await waitForWorkflowCompletion(workflowRunId);
+    const workflowRun = await runWithCompanyName('AirbnbWorkflowTest');
 
     expect(workflowRun?.status).toBe('COMPLETED');
     expect(workflowRun?.state?.stepInfos?.[findRecordsStepId!]?.status).toBe(
@@ -333,5 +338,22 @@ describe('FindRecords workflow action with relation-traversal filter (e2e)', () 
     expect(returnedIds).toContain(TEST_PERSON_AIRBNB_1_ID);
     expect(returnedIds).toContain(TEST_PERSON_AIRBNB_2_ID);
     expect(returnedIds).not.toContain(TEST_PERSON_STRIPE_1_ID);
+  });
+
+  it('should complete the run when the filter value resolves to empty', async () => {
+    const workflowRun = await runWithCompanyName(null);
+
+    expect(workflowRun?.status).toBe('COMPLETED');
+    expect(workflowRun?.state?.stepInfos?.[findRecordsStepId!]?.status).toBe(
+      'SUCCESS',
+    );
+
+    const result = workflowRun?.state?.stepInfos?.[findRecordsStepId!]
+      ?.result as
+      | { all?: Array<{ id: string }>; totalCount?: number | string }
+      | undefined;
+
+    expect(result?.all).toEqual([]);
+    expect(Number(result?.totalCount)).toBe(0);
   });
 });

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -309,6 +309,6 @@ export { isValidVariable } from './validation/isValidVariable';
 export { normalizeLocale } from './validation/normalizeLocale';
 export { getCountryCodesForCallingCode } from './validation/phones-value/getCountryCodesForCallingCode';
 export { isValidCountryCode } from './validation/phones-value/isValidCountryCode';
-export { resolveInput } from './variable-resolver';
+export { isVariableReference, resolveInput } from './variable-resolver';
 export { getViewLayoutFromViewType } from './views/getViewLayoutFromViewType';
 export { isWidgetViewType } from './views/isWidgetViewType';

--- a/packages/twenty-shared/src/utils/variable-resolver.ts
+++ b/packages/twenty-shared/src/utils/variable-resolver.ts
@@ -7,6 +7,9 @@ const isString = (value: unknown): value is string => {
 
 const VARIABLE_PATTERN = RegExp('\\{\\{([^{}]+)\\}\\}', 'g');
 
+export const isVariableReference = (input: unknown): boolean =>
+  isString(input) && isDefined(input.match(VARIABLE_PATTERN));
+
 export const resolveInput = (
   unresolvedInput: unknown,
   context: Record<string, unknown>,


### PR DESCRIPTION
## Problem

`FIND_RECORDS`, `FILTER` and `IF/ELSE` all let a filter value come from a variable. When that variable resolves to nothing, `FIND_RECORDS` aborts the whole run: `Id IS {{trigger.properties.after.companyId}}`, triggered for a person with no company, throws `INVALID_STEP_INPUT`.

The throw was added in #18814, which treated a resolved `null` the same as a filter nobody filled in. They are not the same thing. A filter driven by a variable is a question asked of the data, and "the field is empty" is a valid answer to it.

## Change

The three steps that accept variables now decide the operand at the moment they resolve the value:

| stored value | resolves to | operand |
| --- | --- | --- |
| `{{trigger.companyId}}` | a uuid | `IS`, unchanged |
| `{{trigger.companyId}}` | `null` | `IS_EMPTY` |
| `{{trigger.companyId}}` | `undefined` — the path does not resolve | `IS`, unchanged, still invalid |
| `''` — the filter was never filled in | `''` | `IS`, unchanged, still invalid |

Only a value that *was* a variable can be rewritten, so a filter the user left blank behaves exactly as it did before. Operands with no emptiness reading — `>=`, `<=`, `IS_BEFORE`, `IS_AFTER` — are left alone and still fail as invalid step input.

Where the code lands: the decision util and its callers are in the workflow executor, one for each of the three steps. The only edit in `twenty-shared` exports `isVariableReference` from the variable resolver, reusing the `VARIABLE_PATTERN` already there rather than writing a second regex. No filter code in `twenty-shared` changes.

Nothing downstream needed changing. `computeRecordGqlOperationFilter` already compiles `IS_EMPTY` per field type, and `evaluateFilterConditions` already evaluates it in memory, so both the SQL path and the in-memory path get the same answer from the same decision.

`Id IS {{empty}}` becomes `id IS EMPTY` and the step returns 0 records — no company has an empty id. `Company IS {{empty}}` over people returns the people who have no company.

## Rejected alternatives

- **Return 0 records whenever a value resolves empty.** Five lines, closes the reported repro, but makes `Company IS {{empty}}` find nothing when it should find the people with no company.
- **Change `isRecordFilterValueValid` to accept `null`.** Puts the decision in `twenty-shared`, where it is inert: every other caller stringifies before it gets there, so only workflows can produce a `null`. It also cannot see whether the value came from a variable, which is the distinction that matters.
- **Handle `null` inside the filter compiler.** Same objection, plus each field type improvises — text searches for the literal `%null%`, boolean silently becomes `eq: false`.

## Test plan

- util spec: each mapped operand on a resolved `null`, a variable that resolves to a value, a variable that fails to resolve, an unfilled filter, and the comparison operands
- `find-records-relation-traversal-workflow.integration-spec.ts` drives its filter value from a trigger variable and adds a case running it with `null`, asserting the run completes with 0 records

Closes #24042
