### PR TITLE
Retry a workflow step in place when it fails on a transient infrastructure error

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -532,20 +532,29 @@ export class LogicFunctionExecutorService {
     let periodStart: Date | undefined;
 
     if (this.billingService.isBillingEnabled()) {
-      const { currentBillingSubscription } =
-        await this.workspaceCacheService.getOrRecompute(workspaceId, [
-          'currentBillingSubscription',
-        ]);
+      // The function has already run by the time we get here, so a failure to
+      // account for it must not be reported as a failure to execute it: the
+      // caller would take it for a transient error and run the function again.
+      try {
+        const { currentBillingSubscription } =
+          await this.workspaceCacheService.getOrRecompute(workspaceId, [
+            'currentBillingSubscription',
+          ]);
 
-      if (currentBillingSubscription !== NO_BILLING_SUBSCRIPTION) {
-        periodStart = currentBillingSubscription.currentPeriodStart;
+        if (currentBillingSubscription !== NO_BILLING_SUBSCRIPTION) {
+          periodStart = currentBillingSubscription.currentPeriodStart;
 
-        if (creditsUsedMicro > 0) {
-          await this.billingUsageService.decrementAvailableCreditsInCache({
-            workspaceId,
-            usedCredits: creditsUsedMicro,
-          });
+          if (creditsUsedMicro > 0) {
+            await this.billingUsageService.decrementAvailableCreditsInCache({
+              workspaceId,
+              usedCredits: creditsUsedMicro,
+            });
+          }
         }
+      } catch (error) {
+        this.logger.error(
+          `Failed to account for the execution of logic function ${flatLogicFunction.id} in workspace ${workspaceId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/constants/workflow-step-retry.constant.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/constants/workflow-step-retry.constant.ts
@@ -1,0 +1,14 @@
+import { WorkflowActionType } from 'twenty-shared/workflow';
+
+export const WORKFLOW_STEP_MAX_ATTEMPTS = 3;
+
+// Replaying these repeats an effect the failed attempt already committed: the
+// iterator and the round robin have advanced a durable cursor, an agent has
+// already made its tool calls, and a delay has already queued the job that
+// resumes the run, which fails the run outright if it is queued twice.
+export const NON_REPLAYABLE_WORKFLOW_ACTION_TYPES: WorkflowActionType[] = [
+  WorkflowActionType.ITERATOR,
+  WorkflowActionType.PICK_RECORD,
+  WorkflowActionType.AI_AGENT,
+  WorkflowActionType.DELAY,
+];

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/execute-with-transient-retry.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/execute-with-transient-retry.util.spec.ts
@@ -1,0 +1,103 @@
+import { QUERY_READ_TIMEOUT_MESSAGE } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-messages.constants';
+import { executeWithTransientRetry } from 'src/modules/workflow/workflow-executor/utils/execute-with-transient-retry.util';
+
+const buildTransientError = () => new Error(QUERY_READ_TIMEOUT_MESSAGE);
+
+describe('executeWithTransientRetry', () => {
+  const onFailedAttempt = jest.fn();
+
+  beforeEach(() => {
+    onFailedAttempt.mockReset();
+    onFailedAttempt.mockResolvedValue(undefined);
+  });
+
+  it('executes once when the step succeeds', async () => {
+    const execute = jest.fn().mockResolvedValue({ result: { ok: true } });
+
+    await expect(
+      executeWithTransientRetry({ execute, maxAttempts: 3, onFailedAttempt }),
+    ).resolves.toEqual({ result: { ok: true } });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(onFailedAttempt).not.toHaveBeenCalled();
+  });
+
+  it('replays the step after a transient failure', async () => {
+    const execute = jest
+      .fn()
+      .mockRejectedValueOnce(buildTransientError())
+      .mockResolvedValue({ result: { ok: true } });
+
+    await expect(
+      executeWithTransientRetry({ execute, maxAttempts: 3, onFailedAttempt }),
+    ).resolves.toEqual({ result: { ok: true } });
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(onFailedAttempt).toHaveBeenCalledTimes(1);
+    expect(onFailedAttempt).toHaveBeenCalledWith({ attempt: 1 });
+  });
+
+  it('returns a failure the action reported rather than replaying it', async () => {
+    const execute = jest.fn().mockResolvedValue({ error: 'Record not found' });
+
+    await expect(
+      executeWithTransientRetry({ execute, maxAttempts: 3, onFailedAttempt }),
+    ).resolves.toEqual({ error: 'Record not found' });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the last failure once the attempts are spent', async () => {
+    const execute = jest
+      .fn()
+      .mockRejectedValueOnce(buildTransientError())
+      .mockRejectedValueOnce(buildTransientError())
+      .mockRejectedValue(new Error('Query read timeout on the last try'));
+
+    await expect(
+      executeWithTransientRetry({ execute, maxAttempts: 3, onFailedAttempt }),
+    ).rejects.toThrow('Query read timeout on the last try');
+
+    expect(execute).toHaveBeenCalledTimes(3);
+    expect(onFailedAttempt).toHaveBeenCalledTimes(2);
+    expect(onFailedAttempt).toHaveBeenNthCalledWith(1, { attempt: 1 });
+    expect(onFailedAttempt).toHaveBeenNthCalledWith(2, { attempt: 2 });
+  });
+
+  it('does not replay an ordinary failure', async () => {
+    const execute = jest.fn().mockRejectedValue(new Error('Invalid input'));
+
+    await expect(
+      executeWithTransientRetry({ execute, maxAttempts: 3, onFailedAttempt }),
+    ).rejects.toThrow('Invalid input');
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(onFailedAttempt).not.toHaveBeenCalled();
+  });
+
+  it('executes once when the step opts out of replays', async () => {
+    const execute = jest.fn().mockRejectedValue(buildTransientError());
+
+    await expect(
+      executeWithTransientRetry({ execute, maxAttempts: 1, onFailedAttempt }),
+    ).rejects.toThrow(QUERY_READ_TIMEOUT_MESSAGE);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(onFailedAttempt).not.toHaveBeenCalled();
+  });
+
+  it('keeps replaying when recording a failed attempt fails', async () => {
+    const execute = jest
+      .fn()
+      .mockRejectedValueOnce(buildTransientError())
+      .mockResolvedValue({ result: { ok: true } });
+
+    onFailedAttempt.mockRejectedValue(buildTransientError());
+
+    await expect(
+      executeWithTransientRetry({ execute, maxAttempts: 3, onFailedAttempt }),
+    ).resolves.toEqual({ result: { ok: true } });
+
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/get-step-max-attempts.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/get-step-max-attempts.util.spec.ts
@@ -1,0 +1,45 @@
+import { WorkflowActionType } from 'twenty-shared/workflow';
+
+import { WORKFLOW_STEP_MAX_ATTEMPTS } from 'src/modules/workflow/workflow-executor/constants/workflow-step-retry.constant';
+import { getStepMaxAttempts } from 'src/modules/workflow/workflow-executor/utils/get-step-max-attempts.util';
+
+// Every action type is spelled out so that adding one forces a decision on
+// whether replaying it would repeat an effect it already committed.
+const EXPECTED_MAX_ATTEMPTS: Record<WorkflowActionType, number> = {
+  [WorkflowActionType.CODE]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.LOGIC_FUNCTION]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.SEND_EMAIL]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.DRAFT_EMAIL]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.CREATE_CALENDAR_EVENT]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.CREATE_RECORD]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.UPDATE_RECORD]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.DELETE_RECORD]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.UPSERT_RECORD]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.FIND_RECORDS]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.FORM]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.FILTER]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.IF_ELSE]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.HTTP_REQUEST]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.EMPTY]: WORKFLOW_STEP_MAX_ATTEMPTS,
+  [WorkflowActionType.ITERATOR]: 1,
+  [WorkflowActionType.PICK_RECORD]: 1,
+  [WorkflowActionType.AI_AGENT]: 1,
+  [WorkflowActionType.DELAY]: 1,
+};
+
+describe('getStepMaxAttempts', () => {
+  it('covers every action type', () => {
+    expect(Object.keys(EXPECTED_MAX_ATTEMPTS).sort()).toEqual(
+      Object.values(WorkflowActionType).sort(),
+    );
+  });
+
+  it.each(Object.entries(EXPECTED_MAX_ATTEMPTS))(
+    'allows %s %i attempts',
+    (stepType, expectedMaxAttempts) => {
+      expect(getStepMaxAttempts(stepType as WorkflowActionType)).toBe(
+        expectedMaxAttempts,
+      );
+    },
+  );
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/is-transient-step-execution-error.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/is-transient-step-execution-error.util.spec.ts
@@ -1,0 +1,144 @@
+import { QueryFailedError } from 'typeorm';
+
+import { POSTGRESQL_ERROR_CODES } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-codes.constants';
+import { QUERY_READ_TIMEOUT_MESSAGE } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-messages.constants';
+import { PostgresException } from 'src/engine/api/graphql/workspace-query-runner/utils/postgres-exception';
+import { computeTwentyORMException } from 'src/engine/twenty-orm/error-handling/compute-twenty-orm-exception';
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+import { isTransientStepExecutionError } from 'src/modules/workflow/workflow-executor/utils/is-transient-step-execution-error.util';
+
+const buildErrorWithCode = (code: string) =>
+  Object.assign(new Error('Something went wrong'), { code });
+
+// Spelled out rather than imported from the util, so dropping a code from it
+// fails here instead of silently narrowing what gets replayed.
+const RETRYABLE_CODES = [
+  TwentyORMExceptionCode.QUERY_READ_TIMEOUT,
+  POSTGRESQL_ERROR_CODES.QUERY_CANCELED,
+  POSTGRESQL_ERROR_CODES.IDLE_SESSION_TIMEOUT,
+  POSTGRESQL_ERROR_CODES.IDLE_IN_TRANSACTION_SESSION_TIMEOUT,
+  POSTGRESQL_ERROR_CODES.TRANSACTION_TIMEOUT,
+  POSTGRESQL_ERROR_CODES.SERIALIZATION_FAILURE,
+  POSTGRESQL_ERROR_CODES.DEADLOCK_DETECTED,
+  POSTGRESQL_ERROR_CODES.LOCK_NOT_AVAILABLE,
+  POSTGRESQL_ERROR_CODES.CONNECTION_EXCEPTION,
+  POSTGRESQL_ERROR_CODES.CONNECTION_DOES_NOT_EXIST,
+  POSTGRESQL_ERROR_CODES.CONNECTION_FAILURE,
+  POSTGRESQL_ERROR_CODES.PROTOCOL_VIOLATION,
+  POSTGRESQL_ERROR_CODES.ADMIN_SHUTDOWN,
+  POSTGRESQL_ERROR_CODES.CRASH_SHUTDOWN,
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'EPIPE',
+];
+
+const TERMINAL_CODES = [
+  POSTGRESQL_ERROR_CODES.TOO_MANY_CONNECTIONS,
+  POSTGRESQL_ERROR_CODES.OUT_OF_MEMORY,
+  POSTGRESQL_ERROR_CODES.INSUFFICIENT_RESOURCES,
+  POSTGRESQL_ERROR_CODES.CANNOT_CONNECT_NOW,
+  POSTGRESQL_ERROR_CODES.SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
+  POSTGRESQL_ERROR_CODES.SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION,
+  POSTGRESQL_ERROR_CODES.NOT_NULL_VIOLATION,
+  POSTGRESQL_ERROR_CODES.UNIQUE_VIOLATION,
+  POSTGRESQL_ERROR_CODES.INVALID_TEXT_REPRESENTATION,
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+];
+
+describe('isTransientStepExecutionError', () => {
+  it.each(RETRYABLE_CODES)('replays %s', (code) => {
+    expect(isTransientStepExecutionError(buildErrorWithCode(code))).toBe(true);
+  });
+
+  it.each(TERMINAL_CODES)('does not replay %s', (code) => {
+    expect(isTransientStepExecutionError(buildErrorWithCode(code))).toBe(false);
+  });
+
+  it('replays the read timeout as the orm reports it, which is the shape a step receives', () => {
+    expect(
+      isTransientStepExecutionError(
+        new TwentyORMException(
+          QUERY_READ_TIMEOUT_MESSAGE,
+          TwentyORMExceptionCode.QUERY_READ_TIMEOUT,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('replays the read timeout the postgres client raises without a code', () => {
+    expect(
+      isTransientStepExecutionError(
+        new QueryFailedError(
+          'select 1',
+          [],
+          new Error(QUERY_READ_TIMEOUT_MESSAGE),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not replay an error that only quotes the read timeout in its message', () => {
+    expect(
+      isTransientStepExecutionError(
+        Object.assign(
+          new Error(
+            `invalid input syntax for type uuid: "${QUERY_READ_TIMEOUT_MESSAGE}"`,
+          ),
+          { code: POSTGRESQL_ERROR_CODES.INVALID_TEXT_REPRESENTATION },
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    'Connection terminated unexpectedly',
+    'Connection terminated',
+    'Client has encountered a connection error and is not queryable',
+    'Client was closed and is not queryable',
+  ])('replays the codeless connection loss "%s"', async (message) => {
+    const error = await computeTwentyORMException(
+      new QueryFailedError('select 1', [], new Error(message)),
+    ).catch((thrownError) => thrownError);
+
+    expect(isTransientStepExecutionError(error)).toBe(true);
+  });
+
+  it('replays what the orm builds from a read timeout', async () => {
+    const error = await computeTwentyORMException(
+      new QueryFailedError(
+        'select 1',
+        [],
+        new Error(QUERY_READ_TIMEOUT_MESSAGE),
+      ),
+    ).catch((thrownError) => thrownError);
+
+    expect(isTransientStepExecutionError(error)).toBe(true);
+  });
+
+  it('does not replay a constraint violation raised by the query runner', () => {
+    expect(
+      isTransientStepExecutionError(
+        new PostgresException(
+          'Data validation error.',
+          POSTGRESQL_ERROR_CODES.NOT_NULL_VIOLATION,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not replay an ordinary error', () => {
+    expect(
+      isTransientStepExecutionError(
+        new Error('Cannot read properties of undefined'),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not replay when there is no error', () => {
+    expect(isTransientStepExecutionError(undefined)).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/execute-with-transient-retry.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/execute-with-transient-retry.util.ts
@@ -1,0 +1,30 @@
+import { type WorkflowActionOutput } from 'src/modules/workflow/workflow-executor/types/workflow-action-output.type';
+import { isTransientStepExecutionError } from 'src/modules/workflow/workflow-executor/utils/is-transient-step-execution-error.util';
+
+export const executeWithTransientRetry = async ({
+  execute,
+  maxAttempts,
+  onFailedAttempt,
+}: {
+  execute: () => Promise<WorkflowActionOutput>;
+  maxAttempts: number;
+  onFailedAttempt: (failedAttempt: { attempt: number }) => Promise<void>;
+}): Promise<WorkflowActionOutput> => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await execute();
+    } catch (error) {
+      if (attempt >= maxAttempts || !isTransientStepExecutionError(error)) {
+        throw error;
+      }
+    }
+
+    try {
+      await onFailedAttempt({ attempt });
+    } catch {
+      // Bookkeeping runs against the database that just failed, so it must
+      // never replace the failure that triggered it nor cost the step a retry.
+      continue;
+    }
+  }
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/get-step-max-attempts.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/get-step-max-attempts.util.ts
@@ -1,0 +1,11 @@
+import { type WorkflowActionType } from 'twenty-shared/workflow';
+
+import {
+  NON_REPLAYABLE_WORKFLOW_ACTION_TYPES,
+  WORKFLOW_STEP_MAX_ATTEMPTS,
+} from 'src/modules/workflow/workflow-executor/constants/workflow-step-retry.constant';
+
+export const getStepMaxAttempts = (stepType: WorkflowActionType): number =>
+  NON_REPLAYABLE_WORKFLOW_ACTION_TYPES.includes(stepType)
+    ? 1
+    : WORKFLOW_STEP_MAX_ATTEMPTS;

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/is-transient-step-execution-error.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/is-transient-step-execution-error.util.ts
@@ -1,0 +1,71 @@
+import { isNonEmptyString } from '@sniptt/guards';
+import { isDefined } from 'twenty-shared/utils';
+
+import { POSTGRESQL_ERROR_CODES } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-codes.constants';
+import { QUERY_READ_TIMEOUT_MESSAGE } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-messages.constants';
+import { TwentyORMExceptionCode } from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+
+// Postgres SQLSTATEs and node errnos both surface as `code`.
+const SELF_SPACED_ERROR_CODES: string[] = [
+  TwentyORMExceptionCode.QUERY_READ_TIMEOUT,
+  POSTGRESQL_ERROR_CODES.QUERY_CANCELED,
+  POSTGRESQL_ERROR_CODES.IDLE_SESSION_TIMEOUT,
+  POSTGRESQL_ERROR_CODES.IDLE_IN_TRANSACTION_SESSION_TIMEOUT,
+  POSTGRESQL_ERROR_CODES.TRANSACTION_TIMEOUT,
+  'ETIMEDOUT',
+];
+
+const RESOLVED_BY_ANOTHER_TRANSACTION_ERROR_CODES: string[] = [
+  POSTGRESQL_ERROR_CODES.SERIALIZATION_FAILURE,
+  POSTGRESQL_ERROR_CODES.DEADLOCK_DETECTED,
+  POSTGRESQL_ERROR_CODES.LOCK_NOT_AVAILABLE,
+];
+
+// Lost mid-flight, which the pool replaces on the next attempt. Refusing to
+// open a connection is not in here: the server is reporting that it has no
+// capacity, so an immediate replay would only add load.
+const LOST_CONNECTION_ERROR_CODES: string[] = [
+  POSTGRESQL_ERROR_CODES.CONNECTION_EXCEPTION,
+  POSTGRESQL_ERROR_CODES.CONNECTION_DOES_NOT_EXIST,
+  POSTGRESQL_ERROR_CODES.CONNECTION_FAILURE,
+  POSTGRESQL_ERROR_CODES.PROTOCOL_VIOLATION,
+  // What a failover or a restart sends to the query it kills.
+  POSTGRESQL_ERROR_CODES.ADMIN_SHUTDOWN,
+  POSTGRESQL_ERROR_CODES.CRASH_SHUTDOWN,
+  'ECONNRESET',
+  'EPIPE',
+];
+
+// node-postgres raises these itself rather than relaying a SQLSTATE, so they
+// arrive with no code at all.
+const RETRYABLE_CODELESS_ERROR_MESSAGES: string[] = [
+  QUERY_READ_TIMEOUT_MESSAGE,
+  'Connection terminated',
+  'Client has encountered a connection error and is not queryable',
+  'Client was closed and is not queryable',
+];
+
+const RETRYABLE_ERROR_CODES = [
+  ...SELF_SPACED_ERROR_CODES,
+  ...RESOLVED_BY_ANOTHER_TRANSACTION_ERROR_CODES,
+  ...LOST_CONNECTION_ERROR_CODES,
+];
+
+export const isTransientStepExecutionError = (error: unknown): boolean => {
+  if (!isDefined(error) || typeof error !== 'object') {
+    return false;
+  }
+
+  const { code, message } = error as { code?: unknown; message?: unknown };
+
+  if (isNonEmptyString(code)) {
+    return RETRYABLE_ERROR_CODES.includes(code);
+  }
+
+  return (
+    isNonEmptyString(message) &&
+    RETRYABLE_CODELESS_ERROR_MESSAGES.some((retryableMessage) =>
+      message.includes(retryableMessage),
+    )
+  );
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/iterator.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/iterator.workflow-action.ts
@@ -196,6 +196,7 @@ export class IteratorWorkflowAction implements WorkflowActionInterface {
           status: StepStatus.NOT_STARTED,
           result: undefined,
           error: undefined,
+          retryCount: undefined,
           history: [
             ...(stepInfos[stepId]?.history ?? []),
             {

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
@@ -36,6 +36,8 @@ import {
   type WorkflowBranchExecutorInput,
   type WorkflowExecutorInput,
 } from 'src/modules/workflow/workflow-executor/types/workflow-executor-input';
+import { executeWithTransientRetry } from 'src/modules/workflow/workflow-executor/utils/execute-with-transient-retry.util';
+import { getStepMaxAttempts } from 'src/modules/workflow/workflow-executor/utils/get-step-max-attempts.util';
 import { shouldExecuteStep } from 'src/modules/workflow/workflow-executor/utils/should-execute-step.util';
 import { shouldFailSafely } from 'src/modules/workflow/workflow-executor/utils/should-fail-safely.util';
 import { shouldSkipStepExecution } from 'src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util';
@@ -326,17 +328,25 @@ export class WorkflowExecutorWorkspaceService {
   ) {
     let periodStart: Date | undefined;
     if (this.billingService.isBillingEnabled()) {
-      const { currentBillingSubscription } =
-        await this.workspaceCacheService.getOrRecompute(workspaceId, [
-          'currentBillingSubscription',
-        ]);
+      // The step has already run, and its SUCCESS is not persisted yet, so a
+      // failure to account for it must not end the run as a system error.
+      try {
+        const { currentBillingSubscription } =
+          await this.workspaceCacheService.getOrRecompute(workspaceId, [
+            'currentBillingSubscription',
+          ]);
 
-      if (currentBillingSubscription !== NO_BILLING_SUBSCRIPTION) {
-        periodStart = currentBillingSubscription.currentPeriodStart;
+        if (currentBillingSubscription !== NO_BILLING_SUBSCRIPTION) {
+          periodStart = currentBillingSubscription.currentPeriodStart;
 
-        await this.billingUsageService.decrementAvailableCreditsInCache({
-          workspaceId,
-          usedCredits: 100,
+          await this.billingUsageService.decrementAvailableCreditsInCache({
+            workspaceId,
+            usedCredits: 100,
+          });
+        }
+      } catch (error) {
+        this.exceptionHandlerService.captureExceptions([error], {
+          workspace: { id: workspaceId },
         });
       }
     }
@@ -447,6 +457,8 @@ export class WorkflowExecutorWorkspaceService {
 
     const workflowAction = this.workflowActionFactory.get(step.type);
 
+    const maxAttempts = getStepMaxAttempts(step.type);
+
     await this.workflowRunWorkspaceService.updateWorkflowRunStepInfo({
       stepId,
       stepInfo: {
@@ -458,14 +470,29 @@ export class WorkflowExecutorWorkspaceService {
     });
 
     try {
-      return await workflowAction.execute({
-        currentStepId: stepId,
-        steps,
-        context: getWorkflowRunContext(stepInfos),
-        runInfo: {
-          workflowRunId,
-          workspaceId,
-        },
+      return await executeWithTransientRetry({
+        maxAttempts,
+        execute: () =>
+          workflowAction.execute({
+            currentStepId: stepId,
+            steps,
+            context: getWorkflowRunContext(stepInfos),
+            runInfo: {
+              workflowRunId,
+              workspaceId,
+            },
+          }),
+        onFailedAttempt: ({ attempt }) =>
+          this.workflowRunWorkspaceService.updateWorkflowRunStepInfos({
+            stepInfos: {
+              [stepId]: {
+                status: StepStatus.RUNNING,
+                retryCount: (stepInfos[stepId]?.retryCount ?? 0) + attempt,
+              },
+            },
+            workflowRunId,
+            workspaceId,
+          }),
       });
     } catch (error) {
       const isUserError =

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/utils/build-retry-iterator-step-infos.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/utils/build-retry-iterator-step-infos.util.ts
@@ -52,10 +52,16 @@ export const buildRetryIteratorStepInfos = ({
   const stepInfosToUpdate: Record<string, WorkflowRunStepInfo> = {};
 
   for (const loopStepId of loopStepIds) {
-    stepInfosToUpdate[loopStepId] = { status: StepStatus.NOT_STARTED };
+    stepInfosToUpdate[loopStepId] = {
+      status: StepStatus.NOT_STARTED,
+      retryCount: undefined,
+    };
   }
 
-  stepInfosToUpdate[iteratorStep.id] = { status: StepStatus.NOT_STARTED };
+  stepInfosToUpdate[iteratorStep.id] = {
+    status: StepStatus.NOT_STARTED,
+    retryCount: undefined,
+  };
 
   return {
     stepInfosToUpdate,

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/utils/build-retry-step-infos.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/utils/build-retry-step-infos.util.ts
@@ -43,7 +43,10 @@ export const buildRetryStepInfos = ({
       continue;
     }
 
-    stepInfosToUpdate[step.id] = { status: StepStatus.NOT_STARTED };
+    stepInfosToUpdate[step.id] = {
+      status: StepStatus.NOT_STARTED,
+      retryCount: undefined,
+    };
     stepIdsToRetry.push(step.id);
   }
 

--- a/packages/twenty-shared/src/workflow/schemas/workflow-run-state-step-info-schema.ts
+++ b/packages/twenty-shared/src/workflow/schemas/workflow-run-state-step-info-schema.ts
@@ -5,6 +5,7 @@ export const workflowRunStateStepInfoSchema = z.object({
   result: z.any().optional(),
   error: z.any().optional(),
   status: workflowRunStepStatusSchema,
+  retryCount: z.number().optional(),
   get history() {
     return z
       .array(


### PR DESCRIPTION
> Draft. The diagnosis below is derived from the two error strings in the issue, not from a stack trace, and I could not verify it against the actual Sentry event.

## What changed

Two unguarded moments in the executor's own bookkeeping, both of which sit between a step finishing and its success being persisted.

- `sendWorkflowNodeRunEvent` reads the billing subscription and decrements credits. It now records its own failure instead of failing the run.
- The write of the step's result is replayed up to three times. The write overwrites the step's state wholesale, so replaying it cannot duplicate anything.

## Why this and not a step retry

Issue #23046 quotes two strings, and together they pin the control flow:

- `Workflow has been ended before this step was completed` is written in exactly one place, `markRunningStepsAsFailed`, and only onto a step that is still `RUNNING` when something else ends the run.
- `Query read timeout` was therefore the run-level error, set from `RunWorkflowJob.handle`'s catch when an exception escapes the executor.

`executeStep` catches everything a step throws and turns it into a step error. Had the timeout happened inside the CODE step, the step would read `FAILED / Query read timeout` and the run would read `WorkflowRun failed`. That is not the reported state, so the step almost certainly ran, and the run died in the bookkeeping around it. The two regions changed here are the only unguarded ones between marking the step `RUNNING` and writing its result.

An earlier version of this PR replayed the step body itself. That is the wrong lever: replaying a step can send a second email or create a second record, which forced a deny list that grew on every review round.

## What this does not fix

- The step body is not retried, so a transient failure inside a step is still terminal, exactly as today.
- `getWorkflowRunOrFail` and `computeWorkflowRunStatus` around the step are still unguarded.
- Record CRUD, HTTP and AI steps swallow their own failures into a returned error, and nothing here changes that.
- Platform-level alerting on `FAILED` runs, the second ask in the issue, is untouched.
- The core datasource sets only the client-side `query_timeout`, which does not cancel the statement or drop the connection, so a timed-out query keeps running and its client goes back into the pool. That is worth fixing on its own and is not attempted here.

## Validation

- 561 workflow unit tests pass, including 3 new ones over the replayed write.
- `tsgo --noEmit` clean on twenty-server, oxlint type-aware and oxfmt clean on the three touched files.
