### PR TITLE
fix(twenty-front): blank index field labels on settings page

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
@@ -1,5 +1,9 @@
 import { useDeleteOneIndexMetadataItem } from '@/object-metadata/hooks/useDeleteOneIndexMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { getCompositeSubFieldLabel } from '@/object-record/object-filter-dropdown/utils/getCompositeSubFieldLabel';
+import { type CompositeFieldSubFieldName } from '@/settings/data-model/types/CompositeFieldSubFieldName';
+import { type CompositeFieldType } from '@/settings/data-model/types/CompositeFieldType';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
@@ -8,21 +12,18 @@ import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModa
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
+import { isNonEmptyString } from '@sniptt/guards';
 import { type ReactNode, useMemo, useState } from 'react';
+import { MAX_CUSTOM_INDEXES_PER_OBJECT } from 'twenty-shared/constants';
+import { SettingsPath } from 'twenty-shared/types';
+import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { IconEyeOff, IconPlus } from 'twenty-ui/icon';
 import { Button, SearchInput } from 'twenty-ui/input';
 import { MenuItemToggle, UndecoratedLink } from 'twenty-ui/navigation';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { SettingsPath } from 'twenty-shared/types';
-import { isNonEmptyString } from '@sniptt/guards';
-import { getSettingsPath, isDefined } from 'twenty-shared/utils';
-import { normalizeSearchText } from '~/utils/normalizeSearchText';
-import { MAX_CUSTOM_INDEXES_PER_OBJECT } from 'twenty-shared/constants';
 import { SettingsObjectIndexTable } from '~/pages/settings/data-model/SettingsObjectIndexTable';
 import { type SettingsObjectIndexesTableItem } from '~/pages/settings/data-model/types/SettingsObjectIndexesTableItem';
-import { getCompositeSubFieldLabel } from '@/object-record/object-filter-dropdown/utils/getCompositeSubFieldLabel';
-import { type CompositeFieldSubFieldName } from '@/settings/data-model/types/CompositeFieldSubFieldName';
-import { type CompositeFieldType } from '@/settings/data-model/types/CompositeFieldType';
+import { normalizeSearchText } from '~/utils/normalizeSearchText';
 
 type SettingsObjectIndexesSectionProps = {
   objectMetadataItem: EnrichedObjectMetadataItem;
@@ -53,6 +54,7 @@ export const SettingsObjectIndexesSection = ({
   const { openModal, closeModal } = useModal();
   const { enqueueSuccessSnackBar } = useSnackBar();
   const { deleteOneIndexMetadataItem } = useDeleteOneIndexMetadataItem();
+  const { objectMetadataItems } = useObjectMetadataItems();
 
   const [searchTerm, setSearchTerm] = useState('');
   const [hideSystemIndexes, setHideSystemIndexes] = useState(false);
@@ -64,6 +66,27 @@ export const SettingsObjectIndexesSection = ({
     const fieldsById = new Map(
       objectMetadataItem.fields.map((field) => [field.id, field]),
     );
+
+    const morphFieldLabelsById = new Map<string, string>();
+
+    for (const field of objectMetadataItem.fields) {
+      for (const morphRelation of field.morphRelations ?? []) {
+        const morphFieldId = morphRelation.sourceFieldMetadata.id;
+
+        if (!fieldsById.has(morphFieldId)) {
+          const targetObjectMetadataItem = objectMetadataItems.find(
+            ({ id }) => id === morphRelation.targetObjectMetadata.id,
+          );
+
+          if (isDefined(targetObjectMetadataItem)) {
+            morphFieldLabelsById.set(
+              morphFieldId,
+              targetObjectMetadataItem.labelSingular,
+            );
+          }
+        }
+      }
+    }
 
     return objectMetadataItem.indexMetadatas.map((indexMetadataItem) => ({
       id: indexMetadataItem.id,
@@ -79,7 +102,9 @@ export const SettingsObjectIndexesSection = ({
               indexField.fieldMetadataId,
             );
 
-            if (!isDefined(fieldMetadataItem)) return undefined;
+            if (!isDefined(fieldMetadataItem)) {
+              return morphFieldLabelsById.get(indexField.fieldMetadataId);
+            }
 
             if (isNonEmptyString(indexField.subFieldName)) {
               return `${fieldMetadataItem.label} > ${getCompositeSubFieldLabel(
@@ -93,7 +118,11 @@ export const SettingsObjectIndexesSection = ({
           .filter((label): label is string => Boolean(label))
           .join(', ') ?? '',
     }));
-  }, [objectMetadataItem.indexMetadatas, objectMetadataItem.fields]);
+  }, [
+    objectMetadataItem.indexMetadatas,
+    objectMetadataItem.fields,
+    objectMetadataItems,
+  ]);
 
   const filteredItems = useMemo(() => {
     const searchNormalized = normalizeSearchText(searchTerm);

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
@@ -67,26 +67,21 @@ export const SettingsObjectIndexesSection = ({
       objectMetadataItem.fields.map((field) => [field.id, field]),
     );
 
-    const morphFieldLabelsById = new Map<string, string>();
+    const objectLabelsById = new Map(
+      objectMetadataItems.map(({ id, labelSingular }) => [id, labelSingular]),
+    );
 
-    for (const field of objectMetadataItem.fields) {
-      for (const morphRelation of field.morphRelations ?? []) {
-        const morphFieldId = morphRelation.sourceFieldMetadata.id;
-
-        if (!fieldsById.has(morphFieldId)) {
-          const targetObjectMetadataItem = objectMetadataItems.find(
-            ({ id }) => id === morphRelation.targetObjectMetadata.id,
-          );
-
-          if (isDefined(targetObjectMetadataItem)) {
-            morphFieldLabelsById.set(
-              morphFieldId,
-              targetObjectMetadataItem.labelSingular,
-            );
-          }
-        }
-      }
-    }
+    const morphFieldLabelsById = new Map(
+      objectMetadataItem.fields
+        .flatMap((field) => field.morphRelations ?? [])
+        .filter(
+          ({ sourceFieldMetadata }) => !fieldsById.has(sourceFieldMetadata.id),
+        )
+        .map(({ sourceFieldMetadata, targetObjectMetadata }) => [
+          sourceFieldMetadata.id,
+          objectLabelsById.get(targetObjectMetadata.id),
+        ]),
+    );
 
     return objectMetadataItem.indexMetadatas.map((indexMetadataItem) => ({
       id: indexMetadataItem.id,


### PR DESCRIPTION
### Before
<img width="1512" height="870" alt="image" src="https://github.com/user-attachments/assets/70b23ec0-97d3-489b-9719-f40152c0778b" />



### After
<img width="1512" height="872" alt="image" src="https://github.com/user-attachments/assets/0285a244-514e-486f-a267-bcf4faa2aa8d" />

Fixes #24248 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

