### PR TITLE
fix(front): label indexes that cover morph relation fields

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
@@ -1,4 +1,5 @@
 import { useDeleteOneIndexMetadataItem } from '@/object-metadata/hooks/useDeleteOneIndexMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
@@ -53,6 +54,7 @@ export const SettingsObjectIndexesSection = ({
   const { openModal, closeModal } = useModal();
   const { enqueueSuccessSnackBar } = useSnackBar();
   const { deleteOneIndexMetadataItem } = useDeleteOneIndexMetadataItem();
+  const { objectMetadataItems } = useObjectMetadataItems();
 
   const [searchTerm, setSearchTerm] = useState('');
   const [hideSystemIndexes, setHideSystemIndexes] = useState(false);
@@ -63,6 +65,23 @@ export const SettingsObjectIndexesSection = ({
   const tableItems = useMemo<SettingsObjectIndexesTableItem[]>(() => {
     const fieldsById = new Map(
       objectMetadataItem.fields.map((field) => [field.id, field]),
+    );
+
+    // Indexes reference every concrete morph field, but the server exposes only
+    // one representative per morph group, so the hidden fields' labels have to
+    // be recovered from that representative's morph relations.
+    const objectLabelsById = new Map(
+      objectMetadataItems.map((item) => [item.id, item.labelSingular]),
+    );
+
+    const morphFieldLabelsById = new Map(
+      objectMetadataItem.fields
+        .flatMap((field) => field.morphRelations ?? [])
+        .map(({ sourceFieldMetadata, targetObjectMetadata }) => [
+          sourceFieldMetadata.id,
+          objectLabelsById.get(targetObjectMetadata.id) ??
+            targetObjectMetadata.nameSingular,
+        ]),
     );
 
     return objectMetadataItem.indexMetadatas.map((indexMetadataItem) => ({
@@ -79,7 +98,9 @@ export const SettingsObjectIndexesSection = ({
               indexField.fieldMetadataId,
             );
 
-            if (!isDefined(fieldMetadataItem)) return undefined;
+            if (!isDefined(fieldMetadataItem)) {
+              return morphFieldLabelsById.get(indexField.fieldMetadataId);
+            }
 
             if (isNonEmptyString(indexField.subFieldName)) {
               return `${fieldMetadataItem.label} > ${getCompositeSubFieldLabel(
@@ -93,7 +114,11 @@ export const SettingsObjectIndexesSection = ({
           .filter((label): label is string => Boolean(label))
           .join(', ') ?? '',
     }));
-  }, [objectMetadataItem.indexMetadatas, objectMetadataItem.fields]);
+  }, [
+    objectMetadataItem.indexMetadatas,
+    objectMetadataItem.fields,
+    objectMetadataItems,
+  ]);
 
   const filteredItems = useMemo(() => {
     const searchNormalized = normalizeSearchText(searchTerm);


### PR DESCRIPTION
Fixes #24248

Seven of the nine index rows on Task Targets render with an empty "Fields" cell, and Note Targets does the same. `SettingsObjectIndexesSection` resolves each `indexField.fieldMetadataId` against `objectMetadataItem.fields` and drops what it cannot find — but that list is deduplicated server-side by `filterMorphRelationDuplicateFields`, which keeps one representative per `morphId` while index metadata keeps referencing every concrete morph field.

It is not only cosmetic: the search box filters on that same label, so searching `Company` on Task Targets answers "No indexes match your filters" even though that index exists.

The missing labels are recovered from the representative's `morphRelations`, which already carries every concrete morph field's id and its target object. Lookups that already resolve are untouched, including the `subFieldName` branch. No schema or server change.

Verified on a production build: blank rows 7 → 0 on both Task Targets and Note Targets, `Company` search 0 → 1 row, Companies/People/Tasks/Notes unchanged. Lint, typecheck and fmt clean.

**Task Targets — before**

<img width="1280" height="720" alt="before-fix-task-targets-indexes" src="https://github.com/user-attachments/assets/07f09c26-7545-48e6-974e-1d04364c725c" />

**Task Targets — after**

<img width="1280" height="720" alt="after-fix-task-targets-indexes" src="https://github.com/user-attachments/assets/505095d4-ccb6-45f8-8f49-3d0a518884bd" />
