### PR TITLE
feat(front) - let a widget declare more than one header action

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType.ts
@@ -11,8 +11,6 @@ export type WidgetHeaderActionComponentProps = {
   widget: PageLayoutWidget;
 };
 
-// Actions sharing visibility state stay behind one component, as the field
-// widget does, so the shared hook runs once.
 export const WIDGET_HEADER_ACTION_COMPONENTS_BY_WIDGET_TYPE: Partial<
   Record<WidgetType, ComponentType<WidgetHeaderActionComponentProps>[]>
 > = {

--- a/packages/twenty-front/src/modules/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType.ts
@@ -11,9 +11,8 @@ export type WidgetHeaderActionComponentProps = {
   widget: PageLayoutWidget;
 };
 
-// A widget declares the actions its header offers, in render order. Actions
-// that share visibility state stay behind one component, as the field widget
-// does, so the shared hook runs once.
+// Actions sharing visibility state stay behind one component, as the field
+// widget does, so the shared hook runs once.
 export const WIDGET_HEADER_ACTION_COMPONENTS_BY_WIDGET_TYPE: Partial<
   Record<WidgetType, ComponentType<WidgetHeaderActionComponentProps>[]>
 > = {

--- a/packages/twenty-front/src/modules/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType.ts
@@ -11,12 +11,15 @@ export type WidgetHeaderActionComponentProps = {
   widget: PageLayoutWidget;
 };
 
-export const WIDGET_HEADER_ACTION_COMPONENT_BY_WIDGET_TYPE: Partial<
-  Record<WidgetType, ComponentType<WidgetHeaderActionComponentProps>>
+// A widget declares the actions its header offers, in render order. Actions
+// that share visibility state stay behind one component, as the field widget
+// does, so the shared hook runs once.
+export const WIDGET_HEADER_ACTION_COMPONENTS_BY_WIDGET_TYPE: Partial<
+  Record<WidgetType, ComponentType<WidgetHeaderActionComponentProps>[]>
 > = {
-  [WidgetType.FIELD]: WidgetFieldActions,
-  [WidgetType.EMAILS]: WidgetActionEmailCompose,
-  [WidgetType.TASKS]: WidgetActionTaskCreate,
-  [WidgetType.NOTES]: WidgetActionNoteCreate,
-  [WidgetType.FILES]: WidgetActionFileAttach,
+  [WidgetType.FIELD]: [WidgetFieldActions],
+  [WidgetType.EMAILS]: [WidgetActionEmailCompose],
+  [WidgetType.TASKS]: [WidgetActionTaskCreate],
+  [WidgetType.NOTES]: [WidgetActionNoteCreate],
+  [WidgetType.FILES]: [WidgetActionFileAttach],
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/WidgetCardHeaderActionsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/WidgetCardHeaderActionsRenderer.tsx
@@ -1,9 +1,9 @@
 import { useIsPageLayoutInEditMode } from '@/page-layout/hooks/useIsPageLayoutInEditMode';
-import { WIDGET_HEADER_ACTION_COMPONENT_BY_WIDGET_TYPE } from '@/page-layout/widgets/constants/WidgetHeaderActionComponentByWidgetType';
+import { WIDGET_HEADER_ACTION_COMPONENTS_BY_WIDGET_TYPE } from '@/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType';
 import { useCurrentWidgetOrNull } from '@/page-layout/widgets/hooks/useCurrentWidgetOrNull';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { styled } from '@linaria/react';
-import { isDefined } from 'twenty-shared/utils';
+import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { WidgetType } from '~/generated-metadata/graphql';
 
@@ -29,16 +29,18 @@ export const WidgetCardHeaderActionsRenderer = () => {
     return null;
   }
 
-  const HeaderActionComponent =
-    WIDGET_HEADER_ACTION_COMPONENT_BY_WIDGET_TYPE[widget.type];
+  const headerActionComponents =
+    WIDGET_HEADER_ACTION_COMPONENTS_BY_WIDGET_TYPE[widget.type];
 
-  if (!isDefined(HeaderActionComponent)) {
+  if (!isNonEmptyArray(headerActionComponents)) {
     return null;
   }
 
   return (
     <StyledActionsContainer>
-      <HeaderActionComponent widget={widget} />
+      {headerActionComponents.map((HeaderActionComponent, index) => (
+        <HeaderActionComponent key={index} widget={widget} />
+      ))}
     </StyledActionsContainer>
   );
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/__tests__/WidgetCardHeaderActionsRenderer.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/__tests__/WidgetCardHeaderActionsRenderer.test.tsx
@@ -26,10 +26,7 @@ jest.mock(
   '@/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType',
   () => ({
     WIDGET_HEADER_ACTION_COMPONENTS_BY_WIDGET_TYPE: {
-      NOTES: [
-        () => <button>Create</button>,
-        () => <button>Filter</button>,
-      ],
+      NOTES: [() => <button>Create</button>, () => <button>Filter</button>],
     },
   }),
 );

--- a/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/__tests__/WidgetCardHeaderActionsRenderer.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/__tests__/WidgetCardHeaderActionsRenderer.test.tsx
@@ -1,0 +1,74 @@
+import { WidgetCardHeaderActionsRenderer } from '@/page-layout/widgets/widget-card/components/WidgetCardHeaderActionsRenderer';
+import { render, screen } from '@testing-library/react';
+import { WidgetType } from '~/generated-metadata/graphql';
+
+const mockWidget = { id: 'widget-id', type: WidgetType.NOTES };
+
+let mockIsPageLayoutInEditMode = false;
+let mockWidgetOrNull: typeof mockWidget | null = mockWidget;
+let mockTargetRecordIdentifier: { id: string } | null = { id: 'record-id' };
+
+jest.mock('@/page-layout/widgets/hooks/useCurrentWidgetOrNull', () => ({
+  useCurrentWidgetOrNull: () => mockWidgetOrNull,
+}));
+
+jest.mock('@/ui/layout/contexts/LayoutRenderingContext', () => ({
+  useLayoutRenderingContext: () => ({
+    targetRecordIdentifier: mockTargetRecordIdentifier,
+  }),
+}));
+
+jest.mock('@/page-layout/hooks/useIsPageLayoutInEditMode', () => ({
+  useIsPageLayoutInEditMode: () => mockIsPageLayoutInEditMode,
+}));
+
+jest.mock(
+  '@/page-layout/widgets/constants/WidgetHeaderActionComponentsByWidgetType',
+  () => ({
+    WIDGET_HEADER_ACTION_COMPONENTS_BY_WIDGET_TYPE: {
+      NOTES: [
+        () => <button>Create</button>,
+        () => <button>Filter</button>,
+      ],
+    },
+  }),
+);
+
+describe('WidgetCardHeaderActionsRenderer', () => {
+  beforeEach(() => {
+    mockIsPageLayoutInEditMode = false;
+    mockWidgetOrNull = mockWidget;
+    mockTargetRecordIdentifier = { id: 'record-id' };
+  });
+
+  it('should render every action a widget declares', () => {
+    render(<WidgetCardHeaderActionsRenderer />);
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
+  });
+
+  it('should render nothing when the widget type declares no action', () => {
+    mockWidgetOrNull = { id: 'widget-id', type: WidgetType.TIMELINE };
+
+    render(<WidgetCardHeaderActionsRenderer />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should hide record creating actions while the layout is being arranged', () => {
+    mockIsPageLayoutInEditMode = true;
+
+    render(<WidgetCardHeaderActionsRenderer />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should render nothing without a target record', () => {
+    mockTargetRecordIdentifier = null;
+
+    render(<WidgetCardHeaderActionsRenderer />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Groundwork for putting a filter button next to the create button on a widget header.

`WIDGET_HEADER_ACTION_COMPONENT_BY_WIDGET_TYPE` mapped each widget type to exactly one component, so a widget that wants two actions had no way to say so. Two things already anticipated more than one: `StyledActionsContainer` lays its children out in a row with a gap, and the field widget works around the limit by wrapping `WidgetActionFieldSeeAll` and `WidgetActionFieldEdit` inside a single `WidgetFieldActions` component.

## Change

Each widget type now declares a list of actions, rendered in order. The constant and its file are renamed to the plural to match.

```ts
[WidgetType.FIELD]: [WidgetFieldActions],
[WidgetType.EMAILS]: [WidgetActionEmailCompose],
```

Every existing entry keeps exactly the behaviour it had, so this is a no-op for what ships today.

I deliberately did not split `WidgetFieldActions` into two entries. Its two actions share `useFieldWidgetActionVisibility`, and splitting them would run that hook twice. The rule the comment states: a list is for independent actions, and actions that share visibility state stay behind one component.

## Verification

- New test for `WidgetCardHeaderActionsRenderer` covering the case that motivated the change (a widget declaring two actions renders both) plus the three early returns: no actions declared for the type, layout in edit mode, and no target record.
- The multi-action test fails on the previous single-component renderer, so it is not vacuous.
- Typecheck run with `--skip-nx-cache`, and lint clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CWa5KRySuHDq2JsGPvmW2Z)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

