### PR TITLE
fix(sdk): rerun dev sync when changes arrive during sync

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/__tests__/dev-mode-orchestrator.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/__tests__/dev-mode-orchestrator.spec.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/cli/utilities/api/api-service', () => ({
+  ApiService: class ApiService {},
+}));
+vi.mock('@/cli/utilities/auth/build-app-token-pair-fetcher', () => ({
+  buildAppTokenPairFetcher: vi.fn(),
+}));
+vi.mock('@/cli/utilities/client/client-service', () => ({
+  ClientService: class ClientService {},
+}));
+vi.mock('@/cli/utilities/config/config-service', () => ({
+  ConfigService: class ConfigService {
+    static getActiveRemote() {
+      return 'test';
+    }
+  },
+}));
+vi.mock(
+  '@/cli/utilities/dev/orchestrator/steps/build-manifest-orchestrator-step',
+  () => ({ BuildManifestOrchestratorStep: class {} }),
+);
+vi.mock(
+  '@/cli/utilities/dev/orchestrator/steps/check-server-orchestrator-step',
+  () => ({ CheckServerOrchestratorStep: class {} }),
+);
+vi.mock(
+  '@/cli/utilities/dev/orchestrator/steps/generate-api-client-orchestrator-step',
+  () => ({ GenerateApiClientOrchestratorStep: class {} }),
+);
+vi.mock(
+  '@/cli/utilities/dev/orchestrator/steps/register-app-orchestrator-step',
+  () => ({ RegisterAppOrchestratorStep: class {} }),
+);
+vi.mock(
+  '@/cli/utilities/dev/orchestrator/steps/start-watchers-orchestrator-step',
+  () => ({
+    StartWatchersOrchestratorStep: class {
+      async close() {}
+    },
+  }),
+);
+vi.mock(
+  '@/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step',
+  () => ({ SyncApplicationOrchestratorStep: class {} }),
+);
+vi.mock(
+  '@/cli/utilities/dev/orchestrator/steps/upload-files-orchestrator-step',
+  () => ({ UploadFilesOrchestratorStep: class {} }),
+);
+vi.mock('@/cli/utilities/error/serialize-error', () => ({
+  serializeError: vi.fn(),
+}));
+vi.mock('@/cli/utilities/file/fs-utils', () => ({
+  emptyDir: vi.fn(),
+  ensureDir: vi.fn(),
+}));
+vi.mock('twenty-shared/application', () => ({
+  OUTPUT_DIR: '.twenty',
+  SyncableEntity: {
+    Object: 'object',
+    Field: 'field',
+    LogicFunction: 'logicFunction',
+    FrontComponent: 'frontComponent',
+    Role: 'role',
+    Skill: 'skill',
+    ConnectionProvider: 'connectionProvider',
+    View: 'view',
+    ViewField: 'viewField',
+    NavigationMenuItem: 'navigationMenuItem',
+    PageLayout: 'pageLayout',
+    PageLayoutTab: 'pageLayoutTab',
+    CommandMenuItem: 'commandMenuItem',
+  },
+}));
+
+import { DevModeOrchestrator } from '@/cli/utilities/dev/orchestrator/dev-mode-orchestrator';
+import { OrchestratorState } from '@/cli/utilities/dev/orchestrator/dev-mode-orchestrator-state';
+
+type DevModeOrchestratorTestHarness = {
+  runSyncPipeline: () => Promise<void>;
+  scheduleSync: () => void;
+};
+
+describe('DevModeOrchestrator', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs another sync when changes arrive during an active sync', async () => {
+    vi.useFakeTimers();
+
+    const state = new OrchestratorState({ appPath: '/tmp/app' });
+    const orchestrator = new DevModeOrchestrator({
+      state,
+      debounceMs: 10,
+    });
+    const testHarness =
+      orchestrator as unknown as DevModeOrchestratorTestHarness;
+    let resolveFirstSync: (() => void) | undefined;
+    const firstSync = new Promise<void>((resolve) => {
+      resolveFirstSync = resolve;
+    });
+    const runSyncPipeline = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => firstSync)
+      .mockResolvedValueOnce();
+
+    testHarness.runSyncPipeline = runSyncPipeline;
+
+    testHarness.scheduleSync();
+    await vi.advanceTimersByTimeAsync(10);
+
+    testHarness.scheduleSync();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(runSyncPipeline).toHaveBeenCalledTimes(1);
+
+    resolveFirstSync?.();
+    await firstSync;
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(runSyncPipeline).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels a scheduled sync when closed', async () => {
+    vi.useFakeTimers();
+
+    const state = new OrchestratorState({ appPath: '/tmp/app' });
+    const orchestrator = new DevModeOrchestrator({
+      state,
+      debounceMs: 10,
+    });
+    const testHarness =
+      orchestrator as unknown as DevModeOrchestratorTestHarness;
+    const runSyncPipeline = vi.fn<() => Promise<void>>().mockResolvedValue();
+
+    testHarness.runSyncPipeline = runSyncPipeline;
+    testHarness.scheduleSync();
+
+    await orchestrator.close();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(runSyncPipeline).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator.ts
@@ -33,6 +33,8 @@ export class DevModeOrchestrator {
   private debounceMs: number;
   private syncTimer: NodeJS.Timeout | null = null;
   private serverCheckInterval: NodeJS.Timeout | null = null;
+  private syncRequestedWhileRunning = false;
+  private isClosed = false;
 
   private apiService: ApiService;
   private clientService: ClientService;
@@ -94,6 +96,8 @@ export class DevModeOrchestrator {
   }
 
   async start(): Promise<void> {
+    this.isClosed = false;
+
     const outputDir = path.join(this.state.appPath, OUTPUT_DIR);
 
     await ensureDir(outputDir);
@@ -121,8 +125,16 @@ export class DevModeOrchestrator {
   }
 
   async close(): Promise<void> {
+    this.isClosed = true;
+
+    if (this.syncTimer) {
+      clearTimeout(this.syncTimer);
+      this.syncTimer = null;
+    }
+
     if (this.serverCheckInterval) {
       clearInterval(this.serverCheckInterval);
+      this.serverCheckInterval = null;
     }
 
     await this.startWatchersStep.close();
@@ -152,6 +164,10 @@ export class DevModeOrchestrator {
   }
 
   private scheduleSync(): void {
+    if (this.isClosed) {
+      return;
+    }
+
     if (this.syncTimer) {
       clearTimeout(this.syncTimer);
     }
@@ -164,6 +180,7 @@ export class DevModeOrchestrator {
 
   private async performSync(): Promise<void> {
     if (this.state.pipeline.isSyncing) {
+      this.syncRequestedWhileRunning = true;
       return;
     }
 
@@ -180,6 +197,11 @@ export class DevModeOrchestrator {
       this.state.updateAllEntitiesStatus('error');
     } finally {
       this.state.updatePipeline({ isSyncing: false });
+
+      if (this.syncRequestedWhileRunning && !this.isClosed) {
+        this.syncRequestedWhileRunning = false;
+        this.scheduleSync();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- remember when a debounced sync fires while another sync is active
- schedule exactly one follow-up sync when the active pipeline finishes
- stop pending timers from restarting work after the orchestrator closes
- add focused coverage for reruns and close behavior

## Validation

- `npx vitest run --config vitest.config.ts src/cli/utilities/dev/orchestrator/__tests__/dev-mode-orchestrator.spec.ts` — 2 passed
- type-aware Oxlint and Oxfmt on both changed files
- full SDK typecheck was unavailable because generated `twenty-shared` declarations were not present in the isolated worktree

Audit source: https://github.com/twentyhq/core-team-issues/issues/2784

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

