### PR TITLE
fix(server): prevent cleared PromiseMemoizer work from overwriting newer values

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/storage/__tests__/promise-memoizer.storage.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/storage/__tests__/promise-memoizer.storage.spec.ts
@@ -137,6 +137,52 @@ describe('PromiseMemoizer', () => {
       expect(result2).toBe('test-value');
       expect(mockFactory).toHaveBeenCalledTimes(1);
     });
+
+    it('should not cache a stale promise after its key is cleared', async () => {
+      let markFirstFactoryStarted: (() => void) | undefined;
+      const firstFactoryStarted = new Promise<void>((resolve) => {
+        markFirstFactoryStarted = resolve;
+      });
+      let resolveFirstFactory: (value: string) => void;
+      let resolveSecondFactory: (value: string) => void;
+      const firstFactoryPromise = new Promise<string>((resolve) => {
+        resolveFirstFactory = resolve;
+      });
+      const secondFactoryPromise = new Promise<string>((resolve) => {
+        resolveSecondFactory = resolve;
+      });
+
+      mockFactory
+        .mockImplementationOnce(() => {
+          markFirstFactoryStarted?.();
+
+          return firstFactoryPromise;
+        })
+        .mockImplementationOnce(() => secondFactoryPromise);
+
+      const firstResultPromise = memoizer.memoizePromiseAndExecute(
+        'test-key-1',
+        mockFactory,
+      );
+
+      await firstFactoryStarted;
+      await memoizer.clearKey('test-key-1');
+
+      const secondResultPromise = memoizer.memoizePromiseAndExecute(
+        'test-key-1',
+        mockFactory,
+      );
+
+      resolveFirstFactory!('stale-value');
+      resolveSecondFactory!('fresh-value');
+
+      await expect(firstResultPromise).resolves.toBe('stale-value');
+      await expect(secondResultPromise).resolves.toBe('fresh-value');
+      await expect(
+        memoizer.memoizePromiseAndExecute('test-key-1', mockFactory),
+      ).resolves.toBe('fresh-value');
+      expect(mockFactory).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('clearKey', () => {

--- a/packages/twenty-server/src/engine/twenty-orm/storage/promise-memoizer.storage.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/storage/promise-memoizer.storage.ts
@@ -1,15 +1,24 @@
 import { type Milliseconds } from 'cache-manager';
-import { isDefined } from 'twenty-shared/utils';
 
 import { type CacheKey } from 'src/engine/twenty-orm/storage/types/cache-key.type';
 
 type AsyncFactoryCallback<T> = () => Promise<T | null>;
 
+type PromiseMemoizerEntry<T> =
+  | {
+      state: 'pending';
+      promise: Promise<T | null>;
+    }
+  | {
+      state: 'resolved';
+      value: T;
+      expiresAt: number;
+    };
+
 const ONE_HOUR_IN_MS = 3600_000;
 
 export class PromiseMemoizer<T> {
-  private cache = new Map<CacheKey, { value: T; expiresAt: number }>();
-  private pending = new Map<CacheKey, Promise<T | null>>();
+  private cache = new Map<CacheKey, PromiseMemoizerEntry<T>>();
   private ttlMs: number;
 
   constructor(ttlMs: Milliseconds = ONE_HOUR_IN_MS) {
@@ -23,24 +32,29 @@ export class PromiseMemoizer<T> {
   ): Promise<T | null> {
     await this.clearExpiredKeys(onDelete);
 
-    const cachedEntry = this.cache.get(cacheKey);
+    const existingEntry = this.cache.get(cacheKey);
 
-    if (cachedEntry) {
-      return cachedEntry.value;
+    if (existingEntry) {
+      return existingEntry.state === 'resolved'
+        ? existingEntry.value
+        : existingEntry.promise;
     }
 
-    const existingPromise = this.pending.get(cacheKey);
+    let newPromise: Promise<T | null>;
 
-    if (existingPromise) {
-      return existingPromise;
-    }
-
-    const newPromise = (async () => {
+    newPromise = (async () => {
       try {
         const value = await factory();
 
-        if (value) {
+        const currentEntry = this.cache.get(cacheKey);
+
+        if (
+          value &&
+          currentEntry?.state === 'pending' &&
+          currentEntry.promise === newPromise
+        ) {
           this.cache.set(cacheKey, {
+            state: 'resolved',
             value,
             expiresAt: Date.now() + this.ttlMs,
           });
@@ -48,11 +62,21 @@ export class PromiseMemoizer<T> {
 
         return value;
       } finally {
-        this.pending.delete(cacheKey);
+        const currentEntry = this.cache.get(cacheKey);
+
+        if (
+          currentEntry?.state === 'pending' &&
+          currentEntry.promise === newPromise
+        ) {
+          this.cache.delete(cacheKey);
+        }
       }
     })();
 
-    this.pending.set(cacheKey, newPromise);
+    this.cache.set(cacheKey, {
+      state: 'pending',
+      promise: newPromise,
+    });
 
     return newPromise;
   }
@@ -61,7 +85,7 @@ export class PromiseMemoizer<T> {
     const now = Date.now();
 
     for (const [cacheKey, cachedEntry] of this.cache.entries()) {
-      if (cachedEntry.expiresAt <= now) {
+      if (cachedEntry.state === 'resolved' && cachedEntry.expiresAt <= now) {
         await this.clearKey(cacheKey, onDelete);
       }
     }
@@ -73,7 +97,7 @@ export class PromiseMemoizer<T> {
   ): Promise<void> {
     const cachedValue = this.cache.get(cacheKey);
 
-    if (isDefined(cachedValue)) {
+    if (cachedValue?.state === 'resolved') {
       await onDelete?.(cachedValue.value);
     }
     this.cache.delete(cacheKey);
@@ -88,17 +112,13 @@ export class PromiseMemoizer<T> {
         await this.clearKey(cacheKey, onDelete);
       }
     }
-
-    for (const cacheKey of [...this.pending.keys()]) {
-      if (cacheKey.startsWith(cacheKeyPrefix)) {
-        this.pending.delete(cacheKey);
-      }
-    }
   }
 
   async clearAll(onDelete?: (value: T) => Promise<void> | void): Promise<void> {
     for (const [, entry] of this.cache.entries()) {
-      await onDelete?.(entry.value);
+      if (entry.state === 'resolved') {
+        await onDelete?.(entry.value);
+      }
     }
 
     this.cache.clear();

--- a/packages/twenty-server/src/engine/twenty-orm/storage/promise-memoizer.storage.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/storage/promise-memoizer.storage.ts
@@ -7,6 +7,7 @@ type AsyncFactoryCallback<T> = () => Promise<T | null>;
 type PromiseMemoizerEntry<T> =
   | {
       state: 'pending';
+      generation: symbol;
       promise: Promise<T | null>;
     }
   | {
@@ -40,9 +41,9 @@ export class PromiseMemoizer<T> {
         : existingEntry.promise;
     }
 
-    let newPromise: Promise<T | null>;
+    const generation = Symbol();
 
-    newPromise = (async () => {
+    const newPromise = (async () => {
       try {
         const value = await factory();
 
@@ -51,7 +52,7 @@ export class PromiseMemoizer<T> {
         if (
           value &&
           currentEntry?.state === 'pending' &&
-          currentEntry.promise === newPromise
+          currentEntry.generation === generation
         ) {
           this.cache.set(cacheKey, {
             state: 'resolved',
@@ -66,7 +67,7 @@ export class PromiseMemoizer<T> {
 
         if (
           currentEntry?.state === 'pending' &&
-          currentEntry.promise === newPromise
+          currentEntry.generation === generation
         ) {
           this.cache.delete(cacheKey);
         }
@@ -75,6 +76,7 @@ export class PromiseMemoizer<T> {
 
     this.cache.set(cacheKey, {
       state: 'pending',
+      generation,
       promise: newPromise,
     });
 


### PR DESCRIPTION
## Summary

- represent pending and resolved memoizer entries in one discriminated map
- make promise completion conditional on still owning the current cache entry
- preserve clear/delete callbacks for resolved values only
- cover the clear-then-replace race

A cleared in-flight promise can no longer populate or delete a newer entry for the same key.

## Validation

- `npx nx jest twenty-server --runTestsByPath src/engine/twenty-orm/storage/__tests__/promise-memoizer.storage.spec.ts --runInBand` — 11 passed
- type-aware Oxlint and Oxfmt on both changed files
- full workspace typecheck was unavailable because generated `twenty-shared` declarations were not present in the isolated worktree

Audit source: https://github.com/twentyhq/core-team-issues/issues/2784

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

