### PR TITLE
fix(ui): keep Checkbox state controlled

### DIFF
--- a/packages/twenty-ui/src/input/Checkbox/Checkbox.tsx
+++ b/packages/twenty-ui/src/input/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
 import { clsx } from 'clsx';
-import * as React from 'react';
+import { type ChangeEvent } from 'react';
 
 import { IconCheck, IconMinus } from '@ui/icon/components/TablerIcons';
 
@@ -31,7 +31,7 @@ type CheckboxProps = {
   checked: boolean;
   indeterminate?: boolean;
   hoverable?: boolean;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   onCheckedChange?: (value: boolean) => void;
   variant?: CheckboxVariant;
   size?: CheckboxSize;
@@ -60,16 +60,9 @@ export const Checkbox = ({
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
 }: CheckboxProps) => {
-  const [isInternalChecked, setIsInternalChecked] =
-    React.useState<boolean>(false);
-
-  React.useEffect(() => {
-    setIsInternalChecked(checked ?? false);
-  }, [checked]);
-
   return (
     <CheckboxPrimitive.Root
-      checked={isInternalChecked}
+      checked={checked}
       indeterminate={indeterminate}
       disabled={disabled}
       id={id}
@@ -79,10 +72,9 @@ export const Checkbox = ({
       data-testid="input-checkbox"
       onCheckedChange={(value, eventDetails) => {
         onChange?.(
-          eventDetails.event as unknown as React.ChangeEvent<HTMLInputElement>,
+          eventDetails.event as unknown as ChangeEvent<HTMLInputElement>,
         );
         onCheckedChange?.(value);
-        setIsInternalChecked(value);
       }}
       className={clsx(
         styles.root,

--- a/packages/twenty-ui/src/input/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/twenty-ui/src/input/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Checkbox } from '../Checkbox';
+
+describe('Checkbox', () => {
+  const originalPointerEvent = window.PointerEvent;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'PointerEvent', {
+      configurable: true,
+      value: MouseEvent,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'PointerEvent', {
+      configurable: true,
+      value: originalPointerEvent,
+    });
+  });
+
+  it('keeps the rendered state controlled by the checked prop', async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = jest.fn();
+    const { rerender } = render(
+      <Checkbox
+        checked={false}
+        onCheckedChange={onCheckedChange}
+        aria-label="Controlled checkbox"
+      />,
+    );
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Controlled checkbox',
+    });
+
+    await user.click(checkbox);
+
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+    expect(checkbox).not.toBeChecked();
+
+    rerender(
+      <Checkbox
+        checked
+        onCheckedChange={onCheckedChange}
+        aria-label="Controlled checkbox"
+      />,
+    );
+
+    expect(checkbox).toBeChecked();
+  });
+});


### PR DESCRIPTION
## Summary

- remove the Checkbox component's mirrored internal checked state
- pass the controlled `checked` prop directly to Base UI
- cover that clicks emit a proposed value without visually committing until the parent rerenders

This removes a second source of truth while preserving the existing component API.

## Validation

- focused Jest test — 1 passed
- type-aware Oxlint and Oxfmt on both changed files
- `npx tsgo -p packages/twenty-ui/tsconfig.lib.json --noEmit`

Audit source: https://github.com/twentyhq/core-team-issues/issues/2784

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

