### PR TITLE
fix(auth): sign up in the resolved workspace in single-workspace mode

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useSignInUp.test.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useSignInUp.test.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook } from '@testing-library/react';
+import { type UseFormReturn } from 'react-hook-form';
+import { MemoryRouter } from 'react-router-dom';
+
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { Provider as JotaiProvider } from 'jotai';
+
+import { useAuth } from '@/auth/hooks/useAuth';
+import { type Form } from '@/auth/sign-in-up/hooks/useSignInUpForm';
+import { useSignInUp } from '@/auth/sign-in-up/hooks/useSignInUp';
+import { signInUpModeState } from '@/auth/states/signInUpModeState';
+import { workspacePublicDataState } from '@/auth/states/workspacePublicDataState';
+import { SignInUpMode } from '@/auth/types/signInUpMode';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { type PublicWorkspaceData } from '~/generated-metadata/graphql';
+
+jest.mock('@/auth/hooks/useAuth', () => ({ useAuth: jest.fn() }));
+
+jest.mock('@/domain-manager/hooks/useIsCurrentLocationOnAWorkspace', () => ({
+  useIsCurrentLocationOnAWorkspace: () => ({ isOnAWorkspace: true }),
+}));
+
+jest.mock('@/ui/feedback/snack-bar-manager/hooks/useSnackBar', () => ({
+  useSnackBar: () => ({ enqueueErrorSnackBar: jest.fn() }),
+}));
+
+jest.mock('@/client-config/hooks/useCaptcha', () => ({
+  useCaptcha: () => ({ isCaptchaReady: true }),
+}));
+
+jest.mock('@/captcha/hooks/useReadCaptchaToken', () => ({
+  useReadCaptchaToken: () => ({ readCaptchaToken: () => 'captcha-token' }),
+}));
+
+jest.mock(
+  '@/domain-manager/hooks/useBuildSearchParamsFromUrlSyncedStates',
+  () => ({
+    useBuildSearchParamsFromUrlSyncedStates: () => ({
+      buildSearchParamsFromUrlSyncedStates: async () => ({}),
+    }),
+  }),
+);
+
+const signUpWithCredentialsMock = jest.fn();
+const signUpWithCredentialsInWorkspaceMock = jest.fn();
+
+(useAuth as jest.Mock).mockReturnValue({
+  signUpWithCredentialsInWorkspace: signUpWithCredentialsInWorkspaceMock,
+  signUpWithCredentials: signUpWithCredentialsMock,
+  checkUserExists: { checkUserExistsQuery: jest.fn() },
+});
+
+const credentials: Form = {
+  email: 'someone@example.com',
+  password: 'Passw0rd!',
+  exist: false,
+  captchaToken: '',
+};
+
+const renderUseSignInUp = (workspacePublicData: PublicWorkspaceData | null) => {
+  jotaiStore.set(workspacePublicDataState.atom, workspacePublicData);
+  jotaiStore.set(signInUpModeState.atom, SignInUpMode.SignUp);
+
+  return renderHook(() => useSignInUp({} as UseFormReturn<Form>), {
+    wrapper: ({ children }) => (
+      <JotaiProvider store={jotaiStore}>
+        <I18nProvider i18n={i18n}>
+          <MemoryRouter>{children}</MemoryRouter>
+        </I18nProvider>
+      </JotaiProvider>
+    ),
+  });
+};
+
+describe('useSignInUp > submitCredentials > sign-up routing', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('signs up in the workspace when the location resolves one, so its approved access domains are checked', async () => {
+    const { result } = renderUseSignInUp({
+      id: 'workspace-id',
+    } as PublicWorkspaceData);
+
+    await act(() => result.current.submitCredentials(credentials));
+
+    expect(signUpWithCredentialsInWorkspaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'someone@example.com',
+        password: 'Passw0rd!',
+        captchaToken: 'captcha-token',
+      }),
+    );
+    expect(signUpWithCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  it('signs up without a workspace when the location has none yet', async () => {
+    const { result } = renderUseSignInUp(null);
+
+    await act(() => result.current.submitCredentials(credentials));
+
+    expect(signUpWithCredentialsMock).toHaveBeenCalledWith(
+      'someone@example.com',
+      'Passw0rd!',
+      'captcha-token',
+    );
+    expect(signUpWithCredentialsInWorkspaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useSignInUp.test.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useSignInUp.test.tsx
@@ -12,7 +12,10 @@ import { useSignInUp } from '@/auth/sign-in-up/hooks/useSignInUp';
 import { signInUpModeState } from '@/auth/states/signInUpModeState';
 import { workspacePublicDataState } from '@/auth/states/workspacePublicDataState';
 import { SignInUpMode } from '@/auth/types/signInUpMode';
-import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import {
+  jotaiStore,
+  resetJotaiStore,
+} from '@/ui/utilities/state/jotai/jotaiStore';
 import { type PublicWorkspaceData } from '~/generated-metadata/graphql';
 
 jest.mock('@/auth/hooks/useAuth', () => ({ useAuth: jest.fn() }));
@@ -74,7 +77,10 @@ const renderUseSignInUp = (workspacePublicData: PublicWorkspaceData | null) => {
 };
 
 describe('useSignInUp > submitCredentials > sign-up routing', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    resetJotaiStore();
+    jest.clearAllMocks();
+  });
 
   it('signs up in the workspace when the location resolves one, so its approved access domains are checked', async () => {
     const { result } = renderUseSignInUp({
@@ -90,6 +96,7 @@ describe('useSignInUp > submitCredentials > sign-up routing', () => {
         captchaToken: 'captcha-token',
       }),
     );
+    expect(signUpWithCredentialsInWorkspaceMock).toHaveBeenCalledTimes(1);
     expect(signUpWithCredentialsMock).not.toHaveBeenCalled();
   });
 
@@ -103,6 +110,7 @@ describe('useSignInUp > submitCredentials > sign-up routing', () => {
       'Passw0rd!',
       'captcha-token',
     );
+    expect(signUpWithCredentialsMock).toHaveBeenCalledTimes(1);
     expect(signUpWithCredentialsInWorkspaceMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
@@ -5,6 +5,7 @@ import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { type Form } from '@/auth/sign-in-up/hooks/useSignInUpForm';
 import { lastAuthenticatedMethodState } from '@/auth/states/lastAuthenticatedMethodState';
 import { signInUpModeState } from '@/auth/states/signInUpModeState';
+import { workspacePublicDataState } from '@/auth/states/workspacePublicDataState';
 import {
   SignInUpStep,
   signInUpStepState,
@@ -13,7 +14,6 @@ import { AuthenticatedMethod } from '@/auth/types/AuthenticatedMethod.enum';
 import { SignInUpMode } from '@/auth/types/signInUpMode';
 import { useReadCaptchaToken } from '@/captcha/hooks/useReadCaptchaToken';
 import { useCaptcha } from '@/client-config/hooks/useCaptcha';
-import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
 import { useBuildSearchParamsFromUrlSyncedStates } from '@/domain-manager/hooks/useBuildSearchParamsFromUrlSyncedStates';
 import { useIsCurrentLocationOnAWorkspace } from '@/domain-manager/hooks/useIsCurrentLocationOnAWorkspace';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
@@ -35,9 +35,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
   const [signInUpStep, setSignInUpStep] = useAtomState(signInUpStepState);
   const [signInUpMode, setSignInUpMode] = useAtomState(signInUpModeState);
   const { isOnAWorkspace } = useIsCurrentLocationOnAWorkspace();
-  const isMultiWorkspaceEnabled = useAtomStateValue(
-    isMultiWorkspaceEnabledState,
-  );
+  const workspacePublicData = useAtomStateValue(workspacePublicDataState);
   const { isCaptchaReady } = useCaptcha();
   const setLastAuthenticatedMethod = useSetAtomState(
     lastAuthenticatedMethodState,
@@ -161,7 +159,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
         if (
           !isInviteMode &&
           signInUpMode === SignInUpMode.SignUp &&
-          (!isOnAWorkspace || !isMultiWorkspaceEnabled)
+          (!isOnAWorkspace || !isDefined(workspacePublicData))
         ) {
           return await signUpWithCredentials(
             data.email.toLowerCase().trim(),
@@ -203,7 +201,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
       enqueueErrorSnackBar,
       buildSearchParamsFromUrlSyncedStates,
       isOnAWorkspace,
-      isMultiWorkspaceEnabled,
+      workspacePublicData,
       setLastAuthenticatedMethod,
       t,
     ],


### PR DESCRIPTION

Fixes #24521.

In single-workspace mode `useIsCurrentLocationOnAWorkspace` hardcodes `isOnAWorkspace` to `true`, so `(!isOnAWorkspace || !isMultiWorkspaceEnabled)` in `useSignInUp` is always true and every signup goes to the workspace-agnostic `SignUp` mutation. That path resolves no workspace, so `checkAccessForSignIn` never sees `approvedAccessDomains`, and `signUpWithoutWorkspace` rejects with `SIGNUP_DISABLED` as soon as one workspace exists. Nothing in the configuration gets around it, and self-serve signup through a validated approved access domain has been dead on these instances since 2.15.0.

The `|| !isMultiWorkspaceEnabled` clause came in with #21723 (6a1b28bc), which wanted instances with 0 workspaces to reach the shared creation form. Workspace count is what that should test, and the client already knows it, so:

```diff
 if (
   !isInviteMode &&
   signInUpMode === SignInUpMode.SignUp &&
-  (!isOnAWorkspace || !isMultiWorkspaceEnabled)
+  (!isOnAWorkspace || !isDefined(workspacePublicData))
 ) {
   return await signUpWithCredentials(...);
 }
```

That is the same condition `SignInUp` already uses to decide whether to render the workspace-scoped form (`SignInUp.tsx:180`, `isDefined(workspacePublicData) && isOnAWorkspace`). Rendering the workspace-scoped form and then submitting the workspace-agnostic mutation was the actual bug; after this the two cannot disagree.

`workspacePublicData` is a reliable signal for "this location has a workspace": `getPublicWorkspaceDataByDomain` resolves the default workspace in single-workspace mode, and `getDefaultWorkspace` throws `WorkspaceNotFound` when there is none, so the state stays `null` on a fresh instance. No new client-config field needed.

What changes and what does not:

- single-workspace, no workspace yet: still `SignUp`, so the #21723 flow is untouched
- single-workspace with a workspace: now `signUpInWorkspace`, which sends `workspaceId: workspacePublicData.id`, loads the workspace with `approvedAccessDomains` and runs the domain check
- multi-workspace: unchanged in both positions, on the default domain via `!isOnAWorkspace` and on a workspace subdomain because `workspacePublicData` is set

Someone signing up from a domain that is not approved now gets `User does not have access to this workspace` instead of `New workspace setup is disabled`, which at least describes what happened.

No server change. `assertSignUpEnabled` stays as it is: if a workspace already exists, joining it is not new workspace setup, and the frontend should not be asking for one.

## Testing

Added `useSignInUp.test.tsx` with two cases: a location that resolves a workspace goes to `signUpInWorkspace`, a location with no workspace yet goes to `SignUp`. The first fails on `main` and passes with this change, the second passes either way and is there so a later change cannot quietly break first-run signup again.

`jest src/modules/auth src/pages/auth` is green, 21 suites and 91 tests, including `SignInUpWorkspaceCreationForm` (multi and single-workspace), `SignInUpGlobalScopeForm` and `useAuth`. `oxlint --type-aware` and `oxfmt` are clean on both changed files, and `tsgo -p tsconfig.json --noEmit` reports nothing outside the unrelated `src/modules/front-components` tree.

Beyond the reproduction described in the issue I have not run this against a live instance yet.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

