### PR TITLE
Match participants on the transaction that inserted them

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -322,7 +322,7 @@ jobs:
       # the 16-way split the unflagged shards use.
       ORM_V2_SHARD_COUNTER: 5
       TEST_FORCED_FEATURE_FLAGS: ${{ matrix.orm-v2 && 'IS_ORM_V2_READ_PATH_ENABLED' || '' }}
-      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls|object-records-permissions|merge-many|mutate-by-relation-field|mutation-relation-filter-rls|upsert|unique-field|object-generated|files-field|timeline-from-object-record)'
+      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls|object-records-permissions|merge-many|mutate-by-relation-field|mutation-relation-filter-rls|upsert|unique-field|object-generated|files-field|timeline-from-object-record|participant-matching)'
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
@@ -178,6 +178,7 @@ export class CalendarEventParticipantService {
           objectMetadataName: 'calendarEventParticipant',
           matchWith: 'workspaceMemberAndPerson',
           workspaceId,
+          transactionScope,
         });
       },
       authContext,

--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -69,25 +69,27 @@ export class MatchParticipantService<
     transactionScope?: WorkspaceTransactionScope,
   ) {
     if (objectMetadataName === 'messageParticipant') {
-      return (
-        transactionScope?.getRepository<MessageParticipantWorkspaceEntity>(
+      if (isDefined(transactionScope)) {
+        return transactionScope.getRepository<MessageParticipantWorkspaceEntity>(
           objectMetadataName,
-        ) ??
-        (await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
-          workspaceId,
-          objectMetadataName,
-        ))
+        );
+      }
+
+      return await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+        workspaceId,
+        objectMetadataName,
       );
     }
 
-    return (
-      transactionScope?.getRepository<CalendarEventParticipantWorkspaceEntity>(
+    if (isDefined(transactionScope)) {
+      return transactionScope.getRepository<CalendarEventParticipantWorkspaceEntity>(
         objectMetadataName,
-      ) ??
-      (await this.globalWorkspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
-        workspaceId,
-        objectMetadataName,
-      ))
+      );
+    }
+
+    return await this.globalWorkspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
+      workspaceId,
+      objectMetadataName,
     );
   }
 

--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -5,6 +5,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { Any, In } from 'typeorm';
 
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/global-workspace-datasource/types/workspace-transaction-scope.type';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
 import { type CalendarEventParticipantWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event-participant.workspace-entity';
@@ -48,6 +49,7 @@ type MatchParticipantsArgs<
   objectMetadataName: ObjectMetadataName;
   matchWith: 'workspaceMemberOnly' | 'personOnly' | 'workspaceMemberAndPerson';
   workspaceId: string;
+  transactionScope?: WorkspaceTransactionScope;
 };
 
 @Injectable()
@@ -64,17 +66,28 @@ export class MatchParticipantService<
   private async getParticipantRepository(
     workspaceId: string,
     objectMetadataName: 'messageParticipant' | 'calendarEventParticipant',
+    transactionScope?: WorkspaceTransactionScope,
   ) {
     if (objectMetadataName === 'messageParticipant') {
-      return await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
-        workspaceId,
-        objectMetadataName,
+      return (
+        transactionScope?.getRepository<MessageParticipantWorkspaceEntity>(
+          objectMetadataName,
+        ) ??
+        (await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+          workspaceId,
+          objectMetadataName,
+        ))
       );
     }
 
-    return await this.globalWorkspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
-      workspaceId,
-      objectMetadataName,
+    return (
+      transactionScope?.getRepository<CalendarEventParticipantWorkspaceEntity>(
+        objectMetadataName,
+      ) ??
+      (await this.globalWorkspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
+        workspaceId,
+        objectMetadataName,
+      ))
     );
   }
 
@@ -83,6 +96,7 @@ export class MatchParticipantService<
     objectMetadataName,
     matchWith = 'workspaceMemberAndPerson',
     workspaceId,
+    transactionScope,
   }: MatchParticipantsArgs<ParticipantWorkspaceEntity>) {
     if (participants.length === 0) {
       return;
@@ -98,6 +112,7 @@ export class MatchParticipantService<
     const participantRepository = await this.getParticipantRepository(
       workspaceId,
       objectMetadataName,
+      transactionScope,
     );
 
     const workspaceMemberRepository =

--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -17,6 +17,12 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 
 type ObjectMetadataName = 'messageParticipant' | 'calendarEventParticipant';
 
+type GetParticipantRepositoryArgs = {
+  workspaceId: string;
+  objectMetadataName: ObjectMetadataName;
+  transactionScope?: WorkspaceTransactionScope;
+};
+
 type MatchParticipantsForWorkspaceMembersArgs = {
   participantMatching: {
     workspaceMemberIds: string[];
@@ -63,11 +69,11 @@ export class MatchParticipantService<
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
   ) {}
 
-  private async getParticipantRepository(
-    workspaceId: string,
-    objectMetadataName: 'messageParticipant' | 'calendarEventParticipant',
-    transactionScope?: WorkspaceTransactionScope,
-  ) {
+  private async getParticipantRepository({
+    workspaceId,
+    objectMetadataName,
+    transactionScope,
+  }: GetParticipantRepositoryArgs) {
     if (objectMetadataName === 'messageParticipant') {
       if (isDefined(transactionScope)) {
         return transactionScope.getRepository<MessageParticipantWorkspaceEntity>(
@@ -111,11 +117,11 @@ export class MatchParticipantService<
         { shouldBypassPermissionChecks: true },
       );
 
-    const participantRepository = await this.getParticipantRepository(
+    const participantRepository = await this.getParticipantRepository({
       workspaceId,
       objectMetadataName,
       transactionScope,
-    );
+    });
 
     const workspaceMemberRepository =
       await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -225,10 +231,10 @@ export class MatchParticipantService<
     const authContext = buildSystemAuthContext(workspaceId);
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      const participantRepository = await this.getParticipantRepository(
+      const participantRepository = await this.getParticipantRepository({
         workspaceId,
         objectMetadataName,
-      );
+      });
 
       const participants = await participantRepository.find({
         where: {
@@ -260,10 +266,10 @@ export class MatchParticipantService<
     const authContext = buildSystemAuthContext(workspaceId);
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      const participantRepository = await this.getParticipantRepository(
+      const participantRepository = await this.getParticipantRepository({
         workspaceId,
         objectMetadataName,
-      );
+      });
 
       let participantsMatchingPersonEmails: ParticipantWorkspaceEntity[] = [];
       let participantsMatchingPersonId: ParticipantWorkspaceEntity[] = [];

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
@@ -74,6 +74,7 @@ export class MessagingMessageParticipantService {
           objectMetadataName: 'messageParticipant',
           matchWith: 'workspaceMemberAndPerson',
           workspaceId,
+          transactionScope,
         });
       },
       authContext,

--- a/packages/twenty-server/test/integration/google/messaging/participant-matching-existing-person.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/participant-matching-existing-person.integration-spec.ts
@@ -1,0 +1,131 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  ConnectedAccountProvider,
+  MessageChannelContactAutoCreationPolicy,
+} from 'twenty-shared/types';
+
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { googleCalendarEvent } from 'test/integration/google/mocks/google-calendar-event.util';
+import { gmailMessage } from 'test/integration/google/mocks/gmail-message.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { findRecordNodesByFilter } from 'test/integration/utils/find-records-by-filter.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import { runCalendarChannelEventsImport } from 'test/integration/utils/run-calendar-channel-events-import.util';
+import { runCalendarChannelListFetch } from 'test/integration/utils/run-calendar-channel-list-fetch.util';
+import { runMessageChannelSync } from 'test/integration/utils/run-message-channel-sync.util';
+import { waitForAllJobsToFinish } from 'test/integration/utils/wait-for-all-jobs-to-finish.util';
+
+const HANDLE = 'gmail-existing-person-matching@apple.dev';
+
+const KNOWN_SENDER = `known-sender-${randomUUID()}@acme.com`;
+const KNOWN_ATTENDEE = `known-attendee-${randomUUID()}@acme.com`;
+
+const findParticipantPersonIds = async (
+  objectMetadataSingularName: string,
+  objectMetadataPluralName: string,
+  handle: string,
+) => {
+  const participants = await findRecordNodesByFilter<{
+    personId: string | null;
+  }>(objectMetadataSingularName, objectMetadataPluralName, 'personId', {
+    handle: { eq: handle },
+  });
+
+  return participants.map((participant) => participant.personId);
+};
+
+const createPerson = async (primaryEmail: string) => {
+  const response = await makeGraphqlAPIRequest(
+    createOneOperationFactory({
+      objectMetadataSingularName: 'person',
+      gqlFields: 'id',
+      data: { emails: { primaryEmail } },
+    }),
+  );
+
+  expect(response.body.errors).toBeUndefined();
+
+  return response.body.data.createPerson.id as string;
+};
+
+describe('Participant matching when the person already exists (integration)', () => {
+  const gmail = setupGoogleMock({
+    handle: HANDLE,
+    inbox: [gmailMessage({ from: KNOWN_SENDER, to: HANDLE })],
+  });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let senderPersonId: string;
+  let attendeePersonId: string;
+
+  beforeAll(async () => {
+    senderPersonId = await createPerson(KNOWN_SENDER);
+    attendeePersonId = await createPerson(KNOWN_ATTENDEE);
+
+    await waitForAllJobsToFinish();
+
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    await getCoreRepository<MessageChannelEntity>(MessageChannelEntity).update(
+      { id: channel.channelId },
+      {
+        isContactAutoCreationEnabled: false,
+        contactAutoCreationPolicy: MessageChannelContactAutoCreationPolicy.NONE,
+      },
+    );
+
+    await getCoreRepository<CalendarChannelEntity>(
+      CalendarChannelEntity,
+    ).update(
+      { id: channel.calendarChannelId },
+      { isContactAutoCreationEnabled: false },
+    );
+
+    await runMessageChannelSync(channel.channelId);
+
+    gmail.serveCalendarEvents([
+      googleCalendarEvent({
+        summary: `Calendar event ${randomUUID()}`,
+        attendees: [{ email: KNOWN_ATTENDEE }],
+      }),
+    ]);
+
+    await runCalendarChannelListFetch(channel.calendarChannelId);
+    await runCalendarChannelEventsImport(channel.calendarChannelId);
+
+    await waitForAllJobsToFinish();
+  }, 180000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('links the imported message participant to the person that already owned the handle', async () => {
+    expect(
+      await findParticipantPersonIds(
+        'messageParticipant',
+        'messageParticipants',
+        KNOWN_SENDER,
+      ),
+    ).toEqual([senderPersonId]);
+  }, 60000);
+
+  it('links the imported calendar event participant to the person that already owned the handle', async () => {
+    expect(
+      await findParticipantPersonIds(
+        'calendarEventParticipant',
+        'calendarEventParticipants',
+        KNOWN_ATTENDEE,
+      ),
+    ).toEqual([attendeePersonId]);
+  }, 60000);
+});


### PR DESCRIPTION
Sync inserts participants through the transaction scope, but `matchParticipants` took its repository from the global ORM manager. With `IS_ORM_V2_READ_PATH_ENABLED` on, that update runs on a pooled connection that cannot see the just-inserted rows, so it updates nothing and leaves `personId` null. The matched event still fires off the in-memory participants, so the record page Timeline shows the event while the Calendar and Emails tabs show nothing.

#24182 dropped the `transactionManager` argument `matchParticipants` used to take and nothing replaced it. This threads the scope back in, optional because the rematch jobs call it outside a transaction.

Test run with `TEST_FORCED_FEATURE_FLAGS=IS_ORM_V2_READ_PATH_ENABLED`, on the new spec alone.

<details>
<summary>Before the fix — 2 failed</summary>

```

FAIL test/integration/google/messaging/participant-matching-existing-person.integration-spec.ts (7.359 s)
  Participant matching when the person already exists (integration)
    ✕ links the imported message participant to the person that already owned the handle (41 ms)
    ✕ links the imported calendar event participant to the person that already owned the handle (49 ms)

  ● Participant matching when the person already exists (integration) › links the imported message participant to the person that already owned the handle

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Array [
    -   "66442b51-7c80-49b2-88f9-a4af2385179f",
    +   null,
      ]

      117 |         KNOWN_SENDER,
      118 |       ),
    > 119 |     ).toEqual([senderPersonId]);
          |       ^
      120 |   }, 60000);
      121 |
      122 |   it('links the imported calendar event participant to the person that already owned the handle', async () => {

      at Object.<anonymous> (test/integration/google/messaging/participant-matching-existing-person.integration-spec.ts:119:7)

  ● Participant matching when the person already exists (integration) › links the imported calendar event participant to the person that already owned the handle

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Array [
    -   "c08f8d45-1c3c-4ad5-af65-dd3198d645c8",
    +   null,
      ]

      127 |         KNOWN_ATTENDEE,
      128 |       ),
    > 129 |     ).toEqual([attendeePersonId]);
          |       ^
      130 |   }, 60000);
      131 | });
      132 |

      at Object.<anonymous> (test/integration/google/messaging/participant-matching-existing-person.integration-spec.ts:129:7)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 2 total
Snapshots:   0 total
Time:        7.418 s
Ran all test suites matching /test\/integration\/google\/messaging\/participant-matching-existing-person.integration-spec.ts/i.
```

</details>

<details>
<summary>After the fix — 2 passed</summary>

```

PASS test/integration/google/messaging/participant-matching-existing-person.integration-spec.ts (5.883 s)
  Participant matching when the person already exists (integration)
    ✓ links the imported message participant to the person that already owned the handle (50 ms)
    ✓ links the imported calendar event participant to the person that already owned the handle (36 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        6.111 s, estimated 8 s
Ran all test suites matching /test\/integration\/google\/messaging\/participant-matching-existing-person.integration-spec.ts/i.
```

</details>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

