### PR TITLE
fix(ui): let AnimatedPlaceholder asset maps infer their key union

### DIFF
--- a/packages/twenty-ui/src/feedback/AnimatedPlaceholder/constants/Background.ts
+++ b/packages/twenty-ui/src/feedback/AnimatedPlaceholder/constants/Background.ts
@@ -1,4 +1,4 @@
-export const BACKGROUND: Record<string, string> = {
+export const BACKGROUND = {
   noFile: '/images/placeholders/background/no_file_bg.png',
   noNote: '/images/placeholders/background/no_note_bg.png',
   noRecord: '/images/placeholders/background/no_record_bg.png',

--- a/packages/twenty-ui/src/feedback/AnimatedPlaceholder/constants/DarkBackground.ts
+++ b/packages/twenty-ui/src/feedback/AnimatedPlaceholder/constants/DarkBackground.ts
@@ -1,4 +1,4 @@
-export const DARK_BACKGROUND: Record<string, string> = {
+export const DARK_BACKGROUND = {
   noFile: '/images/placeholders/dark-background/no_file_bg.png',
   noNote: '/images/placeholders/dark-background/no_note_bg.png',
   noRecord: '/images/placeholders/dark-background/no_record_bg.png',

--- a/packages/twenty-ui/src/feedback/AnimatedPlaceholder/constants/DarkMovingImage.ts
+++ b/packages/twenty-ui/src/feedback/AnimatedPlaceholder/constants/DarkMovingImage.ts
@@ -1,4 +1,4 @@
-export const DARK_MOVING_IMAGE: Record<string, string> = {
+export const DARK_MOVING_IMAGE = {
   noFile: '/images/placeholders/dark-moving-image/no_file.png',
   noNote: '/images/placeholders/dark-moving-image/no_note.png',
   noRecord: '/images/placeholders/dark-moving-image/no_record.png',

--- a/packages/twenty-ui/src/feedback/AnimatedPlaceholder/constants/MovingImage.ts
+++ b/packages/twenty-ui/src/feedback/AnimatedPlaceholder/constants/MovingImage.ts
@@ -1,4 +1,4 @@
-export const MOVING_IMAGE: Record<string, string> = {
+export const MOVING_IMAGE = {
   noFile: '/images/placeholders/moving-image/no_file.png',
   noNote: '/images/placeholders/moving-image/no_note.png',
   noRecord: '/images/placeholders/moving-image/no_record.png',


### PR DESCRIPTION
From the codebase simplification audit (twentyhq/core-team-issues#2784, finding `UI-02-2`).

### Problem

The four `AnimatedPlaceholder` asset maps were annotated `Record<string, string>`:

```ts
export const BACKGROUND: Record<string, string> = { ... };
```

That annotation widens `keyof typeof BACKGROUND`, so the exported type

```ts
export type AnimatedPlaceholderType =
  | keyof typeof BACKGROUND
  | keyof typeof MOVING_IMAGE;
```

degenerated to `string`. Every `<AnimatedPlaceholder type="..." />` call site was unchecked, and a typo'd key would render nothing rather than fail to compile.

### Change

Delete the annotation from the four constant files. TypeScript then infers the object literals and `AnimatedPlaceholderType` becomes the 16-member union the maps actually define.

**No call site changes.** All four maps declare identical key sets, and the maps are only ever indexed by `AnimatedPlaceholderType` itself.

### Verification

- `nx build twenty-ui` passes.
- `tsc --noEmit` on twenty-front against the rebuilt twenty-ui reports the **same 23 pre-existing errors** as on `main` (all cascading from the unbuilt `twenty-front-component-renderer`), and **zero** AnimatedPlaceholder-related errors — so all ~30 call sites, including the two that pass the type through as a prop, were already using valid keys and now type-check.

---
_Generated by [Claude Code](https://claude.ai/code/session_016pz8KcZkNpYoqngfKk5Yzm)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

