### PR TITLE
refactor(server): drop unused flat-metadata params from OpenAPI path builders

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
@@ -122,8 +122,10 @@ export class OpenApiService {
       paths[`/${item.namePlural}`] = computeManyResultPath(item);
       paths[`/batch/${item.namePlural}`] = computeBatchPath(item);
       paths[`/${item.namePlural}/{id}`] = computeSingleResultPath(item);
-      paths[`/${item.namePlural}/duplicates`] = computeDuplicatesResultPath(item);
-      paths[`/restore/${item.namePlural}/{id}`] = computeRestoreOneResultPath(item);
+      paths[`/${item.namePlural}/duplicates`] =
+        computeDuplicatesResultPath(item);
+      paths[`/restore/${item.namePlural}/{id}`] =
+        computeRestoreOneResultPath(item);
       paths[`/restore/${item.namePlural}`] = computeRestoreManyResultPath(item);
       paths[`/${item.namePlural}/merge`] = computeMergeManyResultPath(item);
       paths[`/${item.namePlural}/groupBy`] = computeGroupByResultPath(item);

--- a/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
@@ -119,46 +119,14 @@ export class OpenApiService {
     }
 
     schema.paths = flatObjectMetadataArray.reduce((paths, item) => {
-      paths[`/${item.namePlural}`] = computeManyResultPath(
-        item,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
-      paths[`/batch/${item.namePlural}`] = computeBatchPath(
-        item,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
-      paths[`/${item.namePlural}/{id}`] = computeSingleResultPath(
-        item,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
-      paths[`/${item.namePlural}/duplicates`] = computeDuplicatesResultPath(
-        item,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
-      paths[`/restore/${item.namePlural}/{id}`] = computeRestoreOneResultPath(
-        item,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
-      paths[`/restore/${item.namePlural}`] = computeRestoreManyResultPath(
-        item,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
-      paths[`/${item.namePlural}/merge`] = computeMergeManyResultPath(
-        item,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
-      paths[`/${item.namePlural}/groupBy`] = computeGroupByResultPath(
-        item,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
+      paths[`/${item.namePlural}`] = computeManyResultPath(item);
+      paths[`/batch/${item.namePlural}`] = computeBatchPath(item);
+      paths[`/${item.namePlural}/{id}`] = computeSingleResultPath(item);
+      paths[`/${item.namePlural}/duplicates`] = computeDuplicatesResultPath(item);
+      paths[`/restore/${item.namePlural}/{id}`] = computeRestoreOneResultPath(item);
+      paths[`/restore/${item.namePlural}`] = computeRestoreManyResultPath(item);
+      paths[`/${item.namePlural}/merge`] = computeMergeManyResultPath(item);
+      paths[`/${item.namePlural}/groupBy`] = computeGroupByResultPath(item);
 
       return paths;
     }, schema.paths as OpenAPIV3_1.PathsObject);
@@ -194,34 +162,19 @@ export class OpenApiService {
             DatabaseEventAction.CREATED,
             item.nameSingular,
           )
-        ] = computeWebhooks(
-          DatabaseEventAction.CREATED,
-          item,
-          flatObjectMetadataMaps,
-          flatFieldMetadataMaps,
-        );
+        ] = computeWebhooks(DatabaseEventAction.CREATED, item);
         paths[
           this.createWebhookEventName(
             DatabaseEventAction.UPDATED,
             item.nameSingular,
           )
-        ] = computeWebhooks(
-          DatabaseEventAction.UPDATED,
-          item,
-          flatObjectMetadataMaps,
-          flatFieldMetadataMaps,
-        );
+        ] = computeWebhooks(DatabaseEventAction.UPDATED, item);
         paths[
           this.createWebhookEventName(
             DatabaseEventAction.DELETED,
             item.nameSingular,
           )
-        ] = computeWebhooks(
-          DatabaseEventAction.DELETED,
-          item,
-          flatObjectMetadataMaps,
-          flatFieldMetadataMaps,
-        );
+        ] = computeWebhooks(DatabaseEventAction.DELETED, item);
 
         return paths;
       },

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/computeWebhooks.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/computeWebhooks.utils.ts
@@ -2,20 +2,11 @@ import { type OpenAPIV3_1 } from 'openapi-types';
 import { capitalize } from 'twenty-shared/utils';
 
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
-import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 export const computeWebhooks = (
   type: DatabaseEventAction,
   item: Pick<FlatObjectMetadata, 'nameSingular'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   const updatedFields = {
     type: 'array',

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/path.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/path.utils.ts
@@ -24,19 +24,10 @@ import {
   getUpdateManyResponse200,
   getUpdateOneResponse200,
 } from 'src/engine/core-modules/open-api/utils/responses.utils';
-import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 export const computeBatchPath = (
   item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   return {
     post: {
@@ -59,14 +50,6 @@ export const computeBatchPath = (
 
 export const computeManyResultPath = (
   item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   return {
     get: {
@@ -137,14 +120,6 @@ export const computeManyResultPath = (
 
 export const computeSingleResultPath = (
   item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   return {
     get: {
@@ -216,14 +191,6 @@ export const computeOpenApiPath = (
 
 export const computeDuplicatesResultPath = (
   item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   return {
     post: {
@@ -244,14 +211,6 @@ export const computeDuplicatesResultPath = (
 
 export const computeRestoreOneResultPath = (
   item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   return {
     patch: {
@@ -273,14 +232,6 @@ export const computeRestoreOneResultPath = (
 
 export const computeRestoreManyResultPath = (
   item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   return {
     patch: {
@@ -302,14 +253,6 @@ export const computeRestoreManyResultPath = (
 
 export const computeMergeManyResultPath = (
   item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   return {
     patch: {
@@ -329,14 +272,6 @@ export const computeMergeManyResultPath = (
 
 export const computeGroupByResultPath = (
   item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
-  _flatObjectMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatObjectMetadataMaps'
-  >['flatObjectMetadataMaps'],
-  _flatFieldMetadataMaps: Pick<
-    AllFlatEntityMaps,
-    'flatFieldMetadataMaps'
-  >['flatFieldMetadataMaps'],
 ): OpenAPIV3_1.PathItemObject => {
   return {
     get: {


### PR DESCRIPTION
From the codebase simplification audit (twentyhq/core-team-issues#2784, finding `BE-48-2`).

### Problem

All eight path builders in `open-api/utils/path.utils.ts` and `computeWebhooks` declared two parameters they never referenced:

```ts
export const computeBatchPath = (
  item: Pick<FlatObjectMetadata, 'nameSingular' | 'namePlural'>,
  _flatObjectMetadataMaps: Pick<AllFlatEntityMaps, 'flatObjectMetadataMaps'>['flatObjectMetadataMaps'],
  _flatFieldMetadataMaps: Pick<AllFlatEntityMaps, 'flatFieldMetadataMaps'>['flatFieldMetadataMaps'],
): OpenAPIV3_1.PathItemObject => {
```

The builders emit only `$ref` strings and `capitalize(item.name*)`. The eleven call sites threaded both maps through anyway, so the one block that lists **which URLs the core REST API publishes** was 44 lines of argument passing rather than an eight-line path table.

The signatures also claim that path generation depends on workspace field metadata, which it does not.

### Change

Remove the two parameters and collapse the call sites. `getFlatObjectMetadataArray` still returns both maps for `computeSchemaComponents`, which genuinely uses them.

### Verification

- The generated document is unchanged — no builder read either parameter.
- `tsc --noEmit` on twenty-server reports the **same 18 pre-existing errors** as on `main` (all `Cannot find module 'twenty-emails' / 'twenty-sdk'` from unbuilt sibling packages), with **zero** in `open-api/`.
- Every builder's call count was checked before and after; all call sites live in `open-api.service.ts` and are updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_016pz8KcZkNpYoqngfKk5Yzm)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

