### PR TITLE
fix(server): honor the statusCode option CustomException declares

### DIFF
--- a/packages/twenty-server/src/utils/__test__/custom-exception.spec.ts
+++ b/packages/twenty-server/src/utils/__test__/custom-exception.spec.ts
@@ -31,6 +31,23 @@ describe('appendCommonExceptionCode', () => {
 });
 
 describe('CustomException', () => {
+  it('should assign the statusCode option when provided', () => {
+    const exception = new UnknownException('Not found', 'NOT_FOUND', {
+      userFriendlyMessage: msg`Not found`,
+      statusCode: 404,
+    });
+
+    expect(exception.statusCode).toBe(404);
+  });
+
+  it('should leave statusCode undefined when the option is omitted', () => {
+    const exception = new UnknownException('Boom', 'INTERNAL_SERVER_ERROR', {
+      userFriendlyMessage: msg`Boom`,
+    });
+
+    expect(exception.statusCode).toBeUndefined();
+  });
+
   class TestException extends CustomException<string> {
     constructor(
       message: string,

--- a/packages/twenty-server/src/utils/custom-exception.ts
+++ b/packages/twenty-server/src/utils/custom-exception.ts
@@ -29,11 +29,13 @@ export abstract class CustomException<
     code: ExceptionCode,
     {
       userFriendlyMessage,
+      statusCode,
     }: { userFriendlyMessage: MessageDescriptor; statusCode?: number },
   ) {
     super(message);
     this.code = code;
     this.userFriendlyMessage = userFriendlyMessage;
+    this.statusCode = statusCode;
   }
 }
 


### PR DESCRIPTION
From the codebase simplification audit (twentyhq/core-team-issues#2784, finding `BE-40-2`).

### Problem

`CustomException` declared a `statusCode?: number` field **and** accepted `statusCode` in its constructor options bag — but never read the option:

```ts
  statusCode?: number;

  constructor(
    message: ExceptionMessage,
    code: ExceptionCode,
    {
      userFriendlyMessage,                                          // statusCode not destructured
    }: { userFriendlyMessage: MessageDescriptor; statusCode?: number },
  ) {
    super(message);
    this.code = code;
    this.userFriendlyMessage = userFriendlyMessage;                 // and never assigned
  }
```

So `new SomeException(msg, code, { userFriendlyMessage, statusCode: 404 })` type-checked and silently left `statusCode` undefined.

That matters because `shouldCaptureException` skips Sentry capture only for a `CustomException` whose `statusCode` is defined and below 500 — an author-declared 4xx was reported as a server error instead.

The class advertised two contradictory contracts: "pass it at construction" (the option) and "assign it yourself after `super()`" (what the two subclasses that use it actually do). Only the second worked.

### Change

Destructure and assign the option, making the declared contract true.

**No current caller passes the option**, so this is behavior-preserving today; it closes the trap before someone falls into it. The two subclasses that set `statusCode` do so after `super()` and are unaffected.

### Verification

- `custom-exception.spec.ts`: **10 passed** (8 existing + 2 new).
- The new `statusCode: 404` assertion **fails on `main`** (1 failed / 9 passed with the source change reverted), so it is a real regression lock.
- `tsc --noEmit` on twenty-server: same 18 pre-existing errors as `main`, zero in `custom-exception`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016pz8KcZkNpYoqngfKk5Yzm)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

