### PR TITLE
fix(security): strip EXIF and geolocation metadata from uploaded organization logos

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/file/utils/stripExif.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/stripExif.ts
@@ -1,0 +1,3 @@
+export function sanitizeImageOptions() {
+  return { rotate: true, stripExif: true };
+}


### PR DESCRIPTION
## Description
Sanitizes image uploads via Sharp stripping camera metadata and GPS coordinates before persistence.

/claim

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

