### PR TITLE
refactor(rest): move restore to a suffix path and make restore-one reachable

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/core/controllers/rest-api-core.controller.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/controllers/rest-api-core.controller.ts
@@ -107,7 +107,7 @@ export class RestApiCoreController {
     res.status(200).send(result);
   }
 
-  @Patch('restore/*path')
+  @Patch('*path/restore')
   async handleApiRestore(
     @Req() request: AuthenticatedRequest,
     @Res() res: Response,

--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/__tests__/parse-core-path.utils.spec.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/__tests__/parse-core-path.utils.spec.ts
@@ -73,4 +73,38 @@ describe('parseCorePath', () => {
       id: undefined,
     });
   });
+  it('should parse object and id from restore one request', () => {
+    const request: any = { path: `/rest/restore/companies/${testUUID}` };
+
+    expect(parseCorePath(request)).toEqual({
+      object: 'companies',
+      id: testUUID,
+    });
+  });
+
+  it('should parse object from restore many request', () => {
+    const request: any = { path: '/rest/restore/companies' };
+
+    expect(parseCorePath(request)).toEqual({
+      object: 'companies',
+      id: undefined,
+    });
+  });
+
+  it('should throw for malformed uuid in restore one request', () => {
+    const malformedUUID = 'malformed-uuid';
+    const request: any = { path: `/rest/restore/companies/${malformedUUID}` };
+
+    expect(() => parseCorePath(request)).toThrow(
+      `'${malformedUUID}' is not a valid UUID`,
+    );
+  });
+
+  it('should throw for an over-long restore request', () => {
+    const request: any = { path: `/rest/restore/companies/${testUUID}/toto` };
+
+    expect(() => parseCorePath(request)).toThrow(
+      `Query path '/rest/restore/companies/${testUUID}/toto' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
+    );
+  });
 });

--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/__tests__/parse-core-path.utils.spec.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/__tests__/parse-core-path.utils.spec.ts
@@ -74,7 +74,10 @@ describe('parseCorePath', () => {
     });
   });
   it('should parse object and id from restore one request', () => {
-    const request: any = { path: `/rest/restore/companies/${testUUID}` };
+    const request: any = {
+      method: 'PATCH',
+      path: `/rest/restore/companies/${testUUID}`,
+    };
 
     expect(parseCorePath(request)).toEqual({
       object: 'companies',
@@ -83,7 +86,7 @@ describe('parseCorePath', () => {
   });
 
   it('should parse object from restore many request', () => {
-    const request: any = { path: '/rest/restore/companies' };
+    const request: any = { method: 'PATCH', path: '/rest/restore/companies' };
 
     expect(parseCorePath(request)).toEqual({
       object: 'companies',
@@ -93,7 +96,10 @@ describe('parseCorePath', () => {
 
   it('should throw for malformed uuid in restore one request', () => {
     const malformedUUID = 'malformed-uuid';
-    const request: any = { path: `/rest/restore/companies/${malformedUUID}` };
+    const request: any = {
+      method: 'PATCH',
+      path: `/rest/restore/companies/${malformedUUID}`,
+    };
 
     expect(() => parseCorePath(request)).toThrow(
       `'${malformedUUID}' is not a valid UUID`,
@@ -101,10 +107,29 @@ describe('parseCorePath', () => {
   });
 
   it('should throw for an over-long restore request', () => {
-    const request: any = { path: `/rest/restore/companies/${testUUID}/toto` };
+    const request: any = {
+      method: 'PATCH',
+      path: `/rest/restore/companies/${testUUID}/toto`,
+    };
 
     expect(() => parseCorePath(request)).toThrow(
       `Query path '/rest/restore/companies/${testUUID}/toto' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
     );
   });
+  // The wildcard routes for the other methods would otherwise pick up a
+  // restore-shaped path, and DELETE would read the trailing segment as a
+  // destroy target.
+  it.each(['DELETE', 'GET', 'POST', 'PUT'])(
+    'should throw for a restore-shaped path on %s',
+    (method) => {
+      const request: any = {
+        method,
+        path: `/rest/restore/companies/${testUUID}`,
+      };
+
+      expect(() => parseCorePath(request)).toThrow(
+        `Query path '/rest/restore/companies/${testUUID}' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
+      );
+    },
+  );
 });

--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/__tests__/parse-core-path.utils.spec.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/__tests__/parse-core-path.utils.spec.ts
@@ -76,7 +76,7 @@ describe('parseCorePath', () => {
   it('should parse object and id from restore one request', () => {
     const request: any = {
       method: 'PATCH',
-      path: `/rest/restore/companies/${testUUID}`,
+      path: `/rest/companies/${testUUID}/restore`,
     };
 
     expect(parseCorePath(request)).toEqual({
@@ -86,7 +86,7 @@ describe('parseCorePath', () => {
   });
 
   it('should parse object from restore many request', () => {
-    const request: any = { method: 'PATCH', path: '/rest/restore/companies' };
+    const request: any = { method: 'PATCH', path: '/rest/companies/restore' };
 
     expect(parseCorePath(request)).toEqual({
       object: 'companies',
@@ -98,7 +98,7 @@ describe('parseCorePath', () => {
     const malformedUUID = 'malformed-uuid';
     const request: any = {
       method: 'PATCH',
-      path: `/rest/restore/companies/${malformedUUID}`,
+      path: `/rest/companies/${malformedUUID}/restore`,
     };
 
     expect(() => parseCorePath(request)).toThrow(
@@ -109,26 +109,26 @@ describe('parseCorePath', () => {
   it('should throw for an over-long restore request', () => {
     const request: any = {
       method: 'PATCH',
-      path: `/rest/restore/companies/${testUUID}/toto`,
+      path: `/rest/companies/${testUUID}/toto/restore`,
     };
 
     expect(() => parseCorePath(request)).toThrow(
-      `Query path '/rest/restore/companies/${testUUID}/toto' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
+      `Query path '/rest/companies/${testUUID}/toto/restore' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
     );
   });
-  // The wildcard routes for the other methods would otherwise pick up a
-  // restore-shaped path, and DELETE would read the trailing segment as a
-  // destroy target.
+
+  // Every method has a wildcard route on this controller, so without the
+  // method check DELETE would read the id as a destroy target.
   it.each(['DELETE', 'GET', 'POST', 'PUT'])(
     'should throw for a restore-shaped path on %s',
     (method) => {
       const request: any = {
         method,
-        path: `/rest/restore/companies/${testUUID}`,
+        path: `/rest/companies/${testUUID}/restore`,
       };
 
       expect(() => parseCorePath(request)).toThrow(
-        `Query path '/rest/restore/companies/${testUUID}' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
+        `Query path '/rest/companies/${testUUID}/restore' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
       );
     },
   );

--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
@@ -7,18 +7,21 @@ import { isDefined, isValidUuid } from 'twenty-shared/utils';
 export const parseCorePath = (
   request: Request,
 ): { object: string; id?: string } => {
+  // Anchored: an unanchored replace also eats the `/rest` inside a trailing
+  // `/restore`.
   const queryAction = request.path
-    .replace(`/${ApiPath.Rest}/`, '')
-    .replace(`/${ApiPath.Rest}`, '')
+    .replace(new RegExp(`^/${ApiPath.Rest}`), '')
     .split('/')
     .filter(Boolean);
 
-  // Restore is the one route with an extra leading segment
-  // (/restore/{object}/{id}), and it is only mounted on PATCH. Allowing the
-  // segment on other methods would let a restore-shaped path through their
-  // wildcard routes, where DELETE would read it as a destroy target.
+  // Restore is the only action on a single record, so /{object}/{id}/restore
+  // is the one path with a third segment. It is mounted on PATCH alone;
+  // allowing the segment on other methods would let a restore-shaped path
+  // through their wildcard routes, where DELETE would read the id as a
+  // destroy target.
   const isRestoreRequest =
-    request.method === 'PATCH' && queryAction[0] === 'restore';
+    request.method === 'PATCH' &&
+    queryAction[queryAction.length - 1] === 'restore';
 
   const maximumSegmentCount = isRestoreRequest ? 3 : 2;
 
@@ -50,15 +53,15 @@ export const parseCorePath = (
     return { object: queryAction[0] };
   }
 
-  if (queryAction[0] === 'restore') {
-    const recordId = queryAction[2];
+  if (isRestoreRequest) {
+    const recordId = queryAction.length === 3 ? queryAction[1] : undefined;
 
     if (isDefined(recordId) && !isValidUuid(recordId)) {
       throw new BadRequestException(`'${recordId}' is not a valid UUID`);
     }
 
     return {
-      object: queryAction[1],
+      object: queryAction[0],
       id: recordId,
     };
   }

--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
@@ -13,8 +13,14 @@ export const parseCorePath = (
     .split('/')
     .filter(Boolean);
 
-  // A restore path carries an extra leading segment: /restore/{object}/{id}
-  const maximumSegmentCount = queryAction[0] === 'restore' ? 3 : 2;
+  // Restore is the one route with an extra leading segment
+  // (/restore/{object}/{id}), and it is only mounted on PATCH. Allowing the
+  // segment on other methods would let a restore-shaped path through their
+  // wildcard routes, where DELETE would read it as a destroy target.
+  const isRestoreRequest =
+    request.method === 'PATCH' && queryAction[0] === 'restore';
+
+  const maximumSegmentCount = isRestoreRequest ? 3 : 2;
 
   if (queryAction.length > maximumSegmentCount) {
     throw new BadRequestException(

--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
@@ -13,10 +13,10 @@ export const parseCorePath = (
     .split('/')
     .filter(Boolean);
 
-  if (
-    queryAction.length > 2 ||
-    (queryAction.length > 3 && queryAction[0] === 'restore')
-  ) {
+  // A restore path carries an extra leading segment: /restore/{object}/{id}
+  const maximumSegmentCount = queryAction[0] === 'restore' ? 3 : 2;
+
+  if (queryAction.length > maximumSegmentCount) {
     throw new BadRequestException(
       `Query path '${request.path}' invalid. Valid examples: /${ApiPath.Rest}/companies/id or /${ApiPath.Rest}/companies or /${ApiPath.Rest}/batch/companies`,
     );

--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
@@ -7,8 +7,6 @@ import { isDefined, isValidUuid } from 'twenty-shared/utils';
 export const parseCorePath = (
   request: Request,
 ): { object: string; id?: string } => {
-  // Anchored: an unanchored replace also eats the `/rest` inside a trailing
-  // `/restore`.
   const queryAction = request.path
     .replace(new RegExp(`^/${ApiPath.Rest}`), '')
     .split('/')

--- a/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
@@ -124,9 +124,9 @@ export class OpenApiService {
       paths[`/${item.namePlural}/{id}`] = computeSingleResultPath(item);
       paths[`/${item.namePlural}/duplicates`] =
         computeDuplicatesResultPath(item);
-      paths[`/restore/${item.namePlural}/{id}`] =
+      paths[`/${item.namePlural}/{id}/restore`] =
         computeRestoreOneResultPath(item);
-      paths[`/restore/${item.namePlural}`] = computeRestoreManyResultPath(item);
+      paths[`/${item.namePlural}/restore`] = computeRestoreManyResultPath(item);
       paths[`/${item.namePlural}/merge`] = computeMergeManyResultPath(item);
       paths[`/${item.namePlural}/groupBy`] = computeGroupByResultPath(item);
 


### PR DESCRIPTION
From the codebase simplification audit (twentyhq/core-team-issues#2784, finding `BE-48`), reshaped per review.

### The original bug

`parseCorePath` guards against over-long paths. The guard read:

```ts
if (
  queryAction.length > 2 ||
  (queryAction.length > 3 && queryAction[0] === 'restore')
) {
  throw new BadRequestException(...)
}
```

The second clause says the right thing — a restore path carries an extra segment, so allow three — but it never runs. `length > 3` implies `length > 2`, so the left operand always short-circuits first.

So `/restore/companies/{id}` was rejected before reaching the branch written to parse it, and everything downstream was built for a path that could not arrive: the restore branch reads `queryAction[2]` and UUID-validates it (both dead), `RestApiCoreService.restore` dispatches on that id (so **every** restore fell through to restore-many), and `RestApiRestoreOneHandler` was unreachable. Meanwhile the OpenAPI document advertised the route.

### The shape change

Rather than fix the prefix in place, this moves restore to a suffix. It was the only action-on-a-resource wearing a prefix:

| Path | Before | After |
|---|---|---|
| `/{objects}/duplicates` | suffix | unchanged |
| `/{objects}/merge` | suffix | unchanged |
| `/{objects}/groupBy` | suffix | unchanged |
| `/batch/{objects}` | prefix | unchanged — a mode over the collection, not an action |
| `/restore/{objects}/{id}` | prefix | **`/{objects}/{id}/restore`** |
| `/restore/{objects}` | prefix | **`/{objects}/restore`** |

Three files: the route (`@Patch('*path/restore')`), the parser, and the OpenAPI generator. Nothing else referenced the old paths — no client SDK, no docs page. The generated spec is the reference, so there is no prose to update.

### Breaking change

**Restore-one is free.** It has never worked, so `/restore/{objects}/{id}` has no clients to break.

**Restore-many is not.** `/restore/{objects}` works today and this moves it to `/{objects}/restore` with no alias, per review direction. Anything calling the old path gets a 400.

### Two things the migration surfaced

**A latent bug in the path strip.** It was two chained replaces:

```ts
.replace(`/${ApiPath.Rest}/`, '')
.replace(`/${ApiPath.Rest}`, '')
```

The second ran on the already-stripped string, where the only remaining `/rest` was inside a trailing `/restore` — turning `companies` into `companiesore`. Latent under the prefix form because no path ended in `/restore`; the new tests failed on it immediately. Now one anchored replace, since `filter(Boolean)` already drops the empty leading segment.

To be precise about the cause, since an earlier revision of this description got it wrong: a *single* unanchored replace was already correct (non-global, so it takes the first match, which is the prefix). Collapsing two into one is the fix. The `^` is kept because it is free and guards a path not mounted under `/rest`, not because it fixes this.

**The method check is still load-bearing.** I said on the review thread that a suffix would make it redundant — that was wrong, and worth being explicit about. `DELETE /rest/companies/{id}/restore` is still three segments, so without the PATCH gate the parser hands `{ object, id }` straight to `RestApiDestroyOneHandler`. The suffix fixes the *shape*; only the method check stops other verbs' wildcard routes from claiming it.

### Verification

`parse-core-path.utils.spec.ts` had no restore coverage at all, which is how the original bug survived. Eight cases now:

| Case | On `main` | Now |
|---|---|---|
| `PATCH /{objects}/{id}/restore` → `{object, id}` | ❌ 400 (path did not exist) | ✅ |
| `PATCH /{objects}/{malformed}/restore` → not-a-UUID | ❌ | ✅ |
| `PATCH /{objects}/restore` → restore many | ❌ (path did not exist) | ✅ |
| `PATCH /{objects}/{id}/toto/restore` → 400 | ✅ | ✅ |
| `DELETE`/`GET`/`POST`/`PUT` same shape → 400 | ✅ | ✅ |

The four method cases were checked against the code they exist to catch: reverting to a method-agnostic check fails exactly those four and nothing else.

```
Test Suites: 20 passed, 20 total     (rest)
Tests:       101 passed, 101 total

Test Suites: 3 passed, 3 total       (open-api)
Tests:       13 passed, 13 total
```

`tsgo --noEmit` on twenty-server reports 16 errors, all pre-existing and all tracing to unbuilt sibling packages (`twenty-emails`, `twenty-client-sdk`, `twenty-sdk`); none name a file in this diff. It also caught what Jest did not: `Array.prototype.at` is outside this package's `lib` target, so the last-segment read is an index.
