### PR TITLE
fix(query-runner): apply the ordering's LOWER() to the record scan and its cursors

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/__tests__/graphql-query.parser.order-by.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/__tests__/graphql-query.parser.order-by.spec.ts
@@ -75,6 +75,13 @@ describe('GraphqlQueryParser order by rendering', () => {
     objectMetadataId: 'company-object-id',
   });
 
+  const companyContactNameField = createMockField({
+    id: 'company-contactname-id',
+    type: FieldMetadataType.FULL_NAME,
+    name: 'contactName',
+    objectMetadataId: 'company-object-id',
+  });
+
   const rootFields = [
     nameField,
     stageField,
@@ -83,7 +90,7 @@ describe('GraphqlQueryParser order by rendering', () => {
     contactNameField,
     companyField,
   ];
-  const fields = [...rootFields, companyNameField];
+  const fields = [...rootFields, companyNameField, companyContactNameField];
 
   const flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata> = {
     byUniversalIdentifier: Object.fromEntries(
@@ -107,7 +114,7 @@ describe('GraphqlQueryParser order by rendering', () => {
     universalIdentifier: 'company-object-id',
     workspaceId,
     nameSingular: 'company',
-    fieldIds: ['company-name-id'],
+    fieldIds: ['company-name-id', 'company-contactname-id'],
   } as unknown as FlatObjectMetadata;
 
   const flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata> = {
@@ -188,6 +195,21 @@ describe('GraphqlQueryParser order by rendering', () => {
         nulls: 'NULLS LAST',
       },
       'LOWER("company"."name")': { order: 'ASC', nulls: 'NULLS LAST' },
+    });
+  });
+
+  it('should wrap a composite text sub-column of a relation target', () => {
+    expect(
+      applyOrderBy([
+        {
+          company: { contactName: { lastName: OrderByDirection.AscNullsLast } },
+        },
+      ]),
+    ).toEqual({
+      'LOWER("company"."contactNameLastName")': {
+        order: 'ASC',
+        nulls: 'NULLS LAST',
+      },
     });
   });
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/__tests__/graphql-query.parser.order-by.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/__tests__/graphql-query.parser.order-by.spec.ts
@@ -1,0 +1,204 @@
+import { FieldMetadataType, OrderByDirection } from 'twenty-shared/types';
+
+import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+
+describe('GraphqlQueryParser order by rendering', () => {
+  const workspaceId = 'workspace-id';
+  const objectMetadataId = 'object-id';
+
+  const createMockField = (
+    overrides: Partial<FlatFieldMetadata> & {
+      id: string;
+      name: string;
+      type: FieldMetadataType;
+    },
+  ): FlatFieldMetadata =>
+    ({
+      workspaceId,
+      objectMetadataId,
+      isNullable: true,
+      universalIdentifier: overrides.id,
+      label: overrides.name,
+      ...overrides,
+    }) as FlatFieldMetadata;
+
+  const nameField = createMockField({
+    id: 'name-id',
+    type: FieldMetadataType.TEXT,
+    name: 'name',
+  });
+
+  const stageField = createMockField({
+    id: 'stage-id',
+    type: FieldMetadataType.SELECT,
+    name: 'stage',
+  });
+
+  const tagsField = createMockField({
+    id: 'tags-id',
+    type: FieldMetadataType.MULTI_SELECT,
+    name: 'tags',
+  });
+
+  const closeDateField = createMockField({
+    id: 'closedate-id',
+    type: FieldMetadataType.DATE_TIME,
+    name: 'closeDate',
+  });
+
+  const contactNameField = createMockField({
+    id: 'contactname-id',
+    type: FieldMetadataType.FULL_NAME,
+    name: 'contactName',
+  });
+
+  const companyField = createMockField({
+    id: 'company-id',
+    type: FieldMetadataType.RELATION,
+    name: 'company',
+    relationTargetObjectMetadataId: 'company-object-id',
+    settings: {
+      relationType: 'MANY_TO_ONE',
+      joinColumnName: 'companyId',
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any,
+  });
+
+  const companyNameField = createMockField({
+    id: 'company-name-id',
+    type: FieldMetadataType.TEXT,
+    name: 'name',
+    objectMetadataId: 'company-object-id',
+  });
+
+  const rootFields = [
+    nameField,
+    stageField,
+    tagsField,
+    closeDateField,
+    contactNameField,
+    companyField,
+  ];
+  const fields = [...rootFields, companyNameField];
+
+  const flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata> = {
+    byUniversalIdentifier: Object.fromEntries(
+      fields.map((field) => [field.universalIdentifier, field]),
+    ),
+    universalIdentifierById: Object.fromEntries(
+      fields.map((field) => [field.id, field.universalIdentifier]),
+    ),
+    universalIdentifiersByApplicationId: {},
+  };
+
+  const flatObjectMetadata = {
+    id: objectMetadataId,
+    workspaceId,
+    nameSingular: 'opportunity',
+    fieldIds: rootFields.map((field) => field.id),
+  } as unknown as FlatObjectMetadata;
+
+  const companyObjectMetadata = {
+    id: 'company-object-id',
+    universalIdentifier: 'company-object-id',
+    workspaceId,
+    nameSingular: 'company',
+    fieldIds: ['company-name-id'],
+  } as unknown as FlatObjectMetadata;
+
+  const flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata> = {
+    byUniversalIdentifier: {
+      [objectMetadataId]: flatObjectMetadata,
+      'company-object-id': companyObjectMetadata,
+    },
+    universalIdentifierById: {
+      [objectMetadataId]: objectMetadataId,
+      'company-object-id': 'company-object-id',
+    },
+    universalIdentifiersByApplicationId: {},
+  };
+
+  const buildQueryBuilderSpy = () => {
+    const orderBy = jest.fn();
+
+    return {
+      orderBy,
+      queryBuilder: {
+        objectRecordsPermissions: {},
+        getJoinAliases: () => [],
+        orderBy,
+        leftJoin: jest.fn(),
+      } as unknown as WorkspaceSelectQueryBuilder,
+    };
+  };
+
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const applyOrderBy = (orderBy: any) => {
+    const { orderBy: orderBySpy, queryBuilder } = buildQueryBuilderSpy();
+
+    new GraphqlQueryParser(
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    ).applyOrderToBuilder(queryBuilder, orderBy, 'opportunity');
+
+    return orderBySpy.mock.calls[0][0];
+  };
+
+  it('should hand a case-insensitively ordered column to the builder already wrapped in LOWER()', () => {
+    expect(applyOrderBy([{ name: OrderByDirection.AscNullsLast }])).toEqual({
+      'LOWER("opportunity"."name")': { order: 'ASC', nulls: 'NULLS LAST' },
+    });
+  });
+
+  it('should cast a SELECT column to text before lowercasing it', () => {
+    expect(applyOrderBy([{ stage: OrderByDirection.DescNullsFirst }])).toEqual({
+      'LOWER("opportunity"."stage"::text)': {
+        order: 'DESC',
+        nulls: 'NULLS FIRST',
+      },
+    });
+  });
+
+  it('should leave a column the ordering compares raw in its unrendered form', () => {
+    expect(
+      applyOrderBy([
+        { closeDate: OrderByDirection.AscNullsLast },
+        { tags: OrderByDirection.AscNullsLast },
+      ]),
+    ).toEqual({
+      'opportunity.closeDate': { order: 'ASC', nulls: 'NULLS LAST' },
+      'opportunity.tags': { order: 'ASC', nulls: 'NULLS LAST' },
+    });
+  });
+
+  it('should wrap a composite text sub-column and a relation target column', () => {
+    expect(
+      applyOrderBy([
+        { contactName: { firstName: OrderByDirection.AscNullsLast } },
+        { company: { name: OrderByDirection.AscNullsLast } },
+      ]),
+    ).toEqual({
+      'LOWER("opportunity"."contactNameFirstName")': {
+        order: 'ASC',
+        nulls: 'NULLS LAST',
+      },
+      'LOWER("company"."name")': { order: 'ASC', nulls: 'NULLS LAST' },
+    });
+  });
+
+  it('should keep the requested order of the clauses', () => {
+    expect(
+      Object.keys(
+        applyOrderBy([
+          { closeDate: OrderByDirection.AscNullsLast },
+          { name: OrderByDirection.AscNullsLast },
+        ]),
+      ),
+    ).toEqual(['opportunity.closeDate', 'LOWER("opportunity"."name")']);
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/__tests__/build-order-by-key.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/__tests__/build-order-by-key.spec.ts
@@ -2,6 +2,7 @@ import { FieldMetadataType } from 'twenty-shared/types';
 
 import {
   buildOrderByColumnExpression,
+  renderOrderByColumnSql,
   shouldCastToText,
   shouldUseCaseInsensitiveOrder,
 } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/build-order-by-column-expression.util';
@@ -37,9 +38,9 @@ describe('shouldUseCaseInsensitiveOrder', () => {
     expect(shouldUseCaseInsensitiveOrder(FieldMetadataType.SELECT)).toBe(true);
   });
 
-  it('should return true for MULTI_SELECT fields', () => {
+  it('should return false for MULTI_SELECT fields', () => {
     expect(shouldUseCaseInsensitiveOrder(FieldMetadataType.MULTI_SELECT)).toBe(
-      true,
+      false,
     );
   });
 
@@ -69,8 +70,8 @@ describe('shouldCastToText', () => {
     expect(shouldCastToText(FieldMetadataType.SELECT)).toBe(true);
   });
 
-  it('should return true for MULTI_SELECT fields', () => {
-    expect(shouldCastToText(FieldMetadataType.MULTI_SELECT)).toBe(true);
+  it('should return false for MULTI_SELECT fields', () => {
+    expect(shouldCastToText(FieldMetadataType.MULTI_SELECT)).toBe(false);
   });
 
   it('should return false for TEXT fields', () => {
@@ -83,5 +84,39 @@ describe('shouldCastToText', () => {
 
   it('should return false for DATE_TIME fields', () => {
     expect(shouldCastToText(FieldMetadataType.DATE_TIME)).toBe(false);
+  });
+});
+
+describe('renderOrderByColumnSql', () => {
+  it('should quote a bare alias.column expression', () => {
+    expect(renderOrderByColumnSql('company.name', {})).toBe('"company"."name"');
+  });
+
+  it('should quote a column expression without an alias', () => {
+    expect(renderOrderByColumnSql('name', {})).toBe('"name"');
+  });
+
+  it('should wrap a case-insensitively ordered column in LOWER()', () => {
+    expect(renderOrderByColumnSql('company.name', { useLower: true })).toBe(
+      'LOWER("company"."name")',
+    );
+  });
+
+  it('should cast to text before lowercasing an enum column', () => {
+    expect(
+      renderOrderByColumnSql('opportunity.stage', {
+        useLower: true,
+        castToText: true,
+      }),
+    ).toBe('LOWER("opportunity"."stage"::text)');
+  });
+
+  it('should leave an already rendered expression alone', () => {
+    expect(renderOrderByColumnSql('COUNT("opportunity"."id")', {})).toBe(
+      'COUNT("opportunity"."id")',
+    );
+    expect(renderOrderByColumnSql('"opportunity"."stage"', {})).toBe(
+      '"opportunity"."stage"',
+    );
   });
 });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/build-order-by-column-expression.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/build-order-by-column-expression.util.ts
@@ -1,27 +1,58 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
+import { type OrderByClause } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/types/order-by-condition.type';
+
+// MULTI_SELECT is left out even though its values are text: the column is an
+// array, so the only case-insensitive expression available for it is
+// LOWER(column::text) over the array literal, which no scalar cursor value can
+// mirror. Ordering it raw keeps the scan and the keyset continuation on the
+// same relation (issue #24359).
 export const shouldUseCaseInsensitiveOrder = (
   fieldType: FieldMetadataType,
 ): boolean => {
   return (
     fieldType === FieldMetadataType.TEXT ||
-    fieldType === FieldMetadataType.SELECT ||
-    fieldType === FieldMetadataType.MULTI_SELECT
+    fieldType === FieldMetadataType.SELECT
   );
 };
 
 export const shouldCastToText = (fieldType: FieldMetadataType): boolean => {
-  return (
-    fieldType === FieldMetadataType.SELECT ||
-    fieldType === FieldMetadataType.MULTI_SELECT
-  );
+  return fieldType === FieldMetadataType.SELECT;
 };
 
-// Returns unquoted column expression for TypeORM's orderBy (e.g., "company.name")
-// Quoting and LOWER() wrapping is handled in getOrderByRawSQL
+// Returns unquoted column expression for the order parser's clause keys (e.g.,
+// "company.name"). Quoting and LOWER() wrapping happen in
+// renderOrderByColumnSql, which every ORDER BY rendering goes through.
 export const buildOrderByColumnExpression = (
   prefix: string,
   columnName: string,
 ): string => {
   return `${prefix}.${columnName}`;
+};
+
+// An expression already carrying quotes or a call is rendered SQL (a group-by
+// bucket, an aggregate): only a bare "alias.column" is ours to quote
+const quoteOrderByColumnExpression = (columnExpression: string): string => {
+  if (columnExpression.includes('"') || columnExpression.includes('(')) {
+    return columnExpression;
+  }
+
+  const parts = columnExpression.split('.');
+
+  return parts.length === 2
+    ? `"${parts[0]}"."${parts[1]}"`
+    : `"${columnExpression}"`;
+};
+
+// The one SQL rendering of an ordered column. Every ORDER BY compiles it, and
+// the keyset cursor conditions compare on the same expression, so the scan
+// order and the continuation cannot disagree about the ordering relation.
+export const renderOrderByColumnSql = (
+  columnExpression: string,
+  { useLower, castToText }: Pick<OrderByClause, 'useLower' | 'castToText'>,
+): string => {
+  const quotedColumn = quoteOrderByColumnExpression(columnExpression);
+  const castColumn = castToText ? `${quotedColumn}::text` : quotedColumn;
+
+  return useLower ? `LOWER(${castColumn})` : castColumn;
 };

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
@@ -11,6 +11,7 @@ import {
 import { type GroupByField } from 'src/engine/api/common/common-query-runners/types/group-by-field.types';
 import { GraphqlQueryFilterConditionParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-condition.parser';
 import { GraphqlQueryOrderGroupByParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/graphql-query-order-group-by.parser';
+import { renderOrderByColumnSql } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/build-order-by-column-expression.util';
 import {
   GraphqlQueryOrderFieldParser,
   type OrderByClause,
@@ -25,6 +26,18 @@ import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/typ
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+
+// A column the ordering compares through LOWER() has to reach the query
+// builders with that expression already rendered: both drop the keys of an
+// order value they do not know. Every other column stays in the "alias.column"
+// form the builders resolve themselves.
+const buildOrderByExpressionForBuilder = (
+  columnExpression: string,
+  orderByCondition: OrderByClause,
+): string =>
+  orderByCondition.useLower === true || orderByCondition.castToText === true
+    ? renderOrderByColumnSql(columnExpression, orderByCondition)
+    : columnExpression;
 
 export class GraphqlQueryParser {
   private flatObjectMetadata: FlatObjectMetadata;
@@ -140,7 +153,22 @@ export class GraphqlQueryParser {
       });
     }
 
-    queryBuilder.orderBy(parseResult.orderBy);
+    // Both query builders drop the keys of an order value they do not know, so
+    // the LOWER()/::text of a case-insensitively ordered column has to reach
+    // them rendered into the ORDER BY expression itself
+    queryBuilder.orderBy(
+      Object.fromEntries(
+        Object.entries(parseResult.orderBy).map(
+          ([columnExpression, orderByCondition]) => [
+            buildOrderByExpressionForBuilder(
+              columnExpression,
+              orderByCondition,
+            ),
+            { order: orderByCondition.order, nulls: orderByCondition.nulls },
+          ],
+        ),
+      ),
+    );
 
     // Return parsed orderBy so caller can add relation columns after setFindOptions
     return parseResult.orderBy;
@@ -194,21 +222,10 @@ export class GraphqlQueryParser {
           ? ` ${orderByCondition.nulls}`
           : '';
 
-        // Convert "alias.column" to quoted SQL identifier "alias"."column"
-        const parts = orderByField.split('.');
-        const quotedColumn =
-          parts.length === 2
-            ? `"${parts[0]}"."${parts[1]}"`
-            : `"${orderByField}"`;
-
-        let columnExpr = quotedColumn;
-
-        if (orderByCondition.castToText) {
-          columnExpr = `${columnExpr}::text`;
-        }
-        if (orderByCondition.useLower) {
-          columnExpr = `LOWER(${columnExpr})`;
-        }
+        const columnExpr = renderOrderByColumnSql(
+          orderByField,
+          orderByCondition,
+        );
 
         return `${columnExpr} ${orderByCondition.order}${nullsCondition}`;
       },
@@ -237,10 +254,15 @@ export class GraphqlQueryParser {
 
     parsedOrderBys.forEach((orderByField, index) => {
       Object.entries(orderByField).forEach(([expression, direction]) => {
+        const columnExpr = buildOrderByExpressionForBuilder(
+          expression,
+          direction,
+        );
+
         if (index === 0) {
-          queryBuilder.orderBy(expression, direction.order, direction.nulls);
+          queryBuilder.orderBy(columnExpr, direction.order, direction.nulls);
         } else {
-          queryBuilder.addOrderBy(expression, direction.order, direction.nulls);
+          queryBuilder.addOrderBy(columnExpr, direction.order, direction.nulls);
         }
       });
     });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-where-condition-parts.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-where-condition-parts.spec.ts
@@ -1,0 +1,117 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { computeWhereConditionParts } from 'src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts';
+
+describe('computeWhereConditionParts', () => {
+  // Param names carry a random suffix per call, so assertions resolve the
+  // generated placeholder instead of hardcoding it
+  const computeSqlWithResolvedParam = ({
+    operator,
+    value = 'Acme',
+    fieldMetadataType = FieldMetadataType.TEXT,
+    key = 'name',
+    subFieldKey,
+  }: {
+    operator: string;
+    value?: unknown;
+    fieldMetadataType?: FieldMetadataType;
+    key?: string;
+    subFieldKey?: string;
+  }): { sql: string; paramValues: unknown[] } => {
+    const { sql, params } = computeWhereConditionParts({
+      operator,
+      objectNameSingular: 'company',
+      key,
+      subFieldKey,
+      value,
+      fieldMetadataType,
+    });
+
+    const resolvedSql = Object.keys(params).reduce(
+      (acc, paramName) => acc.split(`:${paramName}`).join(':param'),
+      sql,
+    );
+
+    return { sql: resolvedSql, paramValues: Object.values(params) };
+  };
+
+  describe('case-insensitive keyset operators', () => {
+    it('should compare the lowercased column against the lowercased cursor value', () => {
+      expect(
+        computeSqlWithResolvedParam({ operator: 'gtCaseInsensitive' }),
+      ).toEqual({
+        sql: 'LOWER("company"."name"::text) > LOWER(:param)',
+        paramValues: ['Acme'],
+      });
+
+      expect(
+        computeSqlWithResolvedParam({ operator: 'ltCaseInsensitive' }),
+      ).toEqual({
+        sql: 'LOWER("company"."name"::text) < LOWER(:param)',
+        paramValues: ['Acme'],
+      });
+
+      expect(
+        computeSqlWithResolvedParam({ operator: 'eqStrictCaseInsensitive' }),
+      ).toEqual({
+        sql: 'LOWER("company"."name"::text) = LOWER(:param)',
+        paramValues: ['Acme'],
+      });
+    });
+
+    it('should compare on the same expression the SQL ordering sorts a SELECT field by', () => {
+      // LOWER() cannot take an enum column directly, which is why the ordering
+      // casts it; the keyset predicate has to reach the very same expression
+      const { sql } = computeSqlWithResolvedParam({
+        operator: 'gtCaseInsensitive',
+        value: 'MEDIUM',
+        fieldMetadataType: FieldMetadataType.SELECT,
+        key: 'priority',
+      });
+
+      expect(sql).toBe('LOWER("company"."priority"::text) > LOWER(:param)');
+    });
+
+    it('should cast a composite sub-column whose own type the caller cannot see', () => {
+      // The filter parser reports the composite type (ACTOR), never the SELECT
+      // of createdBy.source, so deriving the cast here would emit LOWER() on an
+      // enum column and fail at the database instead of paginating
+      const { sql } = computeSqlWithResolvedParam({
+        operator: 'eqStrictCaseInsensitive',
+        value: 'MANUAL',
+        fieldMetadataType: FieldMetadataType.ACTOR,
+        key: 'createdBySource',
+        subFieldKey: 'source',
+      });
+
+      expect(sql).toBe(
+        'LOWER("company"."createdBySource"::text) = LOWER(:param)',
+      );
+    });
+
+    it('should not widen the comparison to empty values the ordering keeps out of the NULL block', () => {
+      const { sql } = computeSqlWithResolvedParam({
+        operator: 'eqStrictCaseInsensitive',
+        value: '',
+      });
+
+      expect(sql).not.toContain('IS NULL');
+    });
+  });
+
+  describe('range operators outside keyset pagination', () => {
+    it('should keep comparing raw values', () => {
+      expect(computeSqlWithResolvedParam({ operator: 'gt' }).sql).toBe(
+        '"company"."name" > :param',
+      );
+
+      expect(computeSqlWithResolvedParam({ operator: 'lt' }).sql).toBe(
+        '"company"."name" < :param',
+      );
+
+      expect(computeSqlWithResolvedParam({ operator: 'eqStrict' }).sql).toBe(
+        '"company"."name" = :param',
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
@@ -151,6 +151,27 @@ export const computeWhereConditionParts = ({
         sql: `${fieldReference} = :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
+    // Case-insensitive keyset variants, for the columns the SQL ordering sorts
+    // through LOWER(): comparing raw values there would resolve case ties
+    // against the scan order and skip or duplicate rows across page
+    // boundaries. The ::text cast is unconditional because it is a no-op on
+    // text columns and required for the enum column of a SELECT field, which
+    // LOWER() cannot take directly.
+    case 'gtCaseInsensitive':
+      return {
+        sql: `LOWER(${fieldReference}::text) > LOWER(:${key}${paramSuffix})`,
+        params: { [`${key}${paramSuffix}`]: value },
+      };
+    case 'ltCaseInsensitive':
+      return {
+        sql: `LOWER(${fieldReference}::text) < LOWER(:${key}${paramSuffix})`,
+        params: { [`${key}${paramSuffix}`]: value },
+      };
+    case 'eqStrictCaseInsensitive':
+      return {
+        sql: `LOWER(${fieldReference}::text) = LOWER(:${key}${paramSuffix})`,
+        params: { [`${key}${paramSuffix}`]: value },
+      };
     case 'like':
       return {
         sql: `${fieldReference}::text LIKE :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,

--- a/packages/twenty-server/src/engine/api/utils/__tests__/compute-cursor-arg-filter.utils.spec.ts
+++ b/packages/twenty-server/src/engine/api/utils/__tests__/compute-cursor-arg-filter.utils.spec.ts
@@ -80,6 +80,20 @@ describe('computeCursorArgFilter', () => {
     isNullable: true,
   });
 
+  const priorityField = createMockField({
+    id: 'priority-id',
+    type: FieldMetadataType.SELECT,
+    name: 'priority',
+    label: 'Priority',
+  });
+
+  const tagsField = createMockField({
+    id: 'tags-id',
+    type: FieldMetadataType.MULTI_SELECT,
+    name: 'tags',
+    label: 'Tags',
+  });
+
   const companyField = {
     ...createMockField({
       id: 'company-id',
@@ -139,6 +153,8 @@ describe('computeCursorArgFilter', () => {
     fullNameField,
     idField,
     closeDateField,
+    priorityField,
+    tagsField,
     companyField,
     companyNameField,
     companyContactNameField,
@@ -167,6 +183,8 @@ describe('computeCursorArgFilter', () => {
       'fullname-id',
       'id-id',
       'closedate-id',
+      'priority-id',
+      'tags-id',
       'company-id',
     ],
     indexMetadataIds: [],
@@ -225,7 +243,12 @@ describe('computeCursorArgFilter', () => {
       // TEXT columns hold SQL NULL for rows written empty or without the
       // field, so the trailing NULL block is part of the continuation
       expect(result).toEqual([
-        { or: [{ name: { gt: 'John' } }, { name: { isStrictly: 'NULL' } }] },
+        {
+          or: [
+            { name: { gtCaseInsensitive: 'John' } },
+            { name: { isStrictly: 'NULL' } },
+          ],
+        },
       ]);
     });
 
@@ -242,7 +265,7 @@ describe('computeCursorArgFilter', () => {
         isForwardPagination: false,
       });
 
-      expect(result).toEqual([{ name: { lt: 'John' } }]);
+      expect(result).toEqual([{ name: { ltCaseInsensitive: 'John' } }]);
     });
   });
 
@@ -264,10 +287,15 @@ describe('computeCursorArgFilter', () => {
       });
 
       expect(result).toEqual([
-        { or: [{ name: { gt: 'John' } }, { name: { isStrictly: 'NULL' } }] },
+        {
+          or: [
+            { name: { gtCaseInsensitive: 'John' } },
+            { name: { isStrictly: 'NULL' } },
+          ],
+        },
         {
           and: [
-            { name: { eqStrict: 'John' } },
+            { name: { eqStrictCaseInsensitive: 'John' } },
             { or: [{ age: { lt: 30 } }, { age: { isStrictly: 'NULL' } }] },
           ],
         },
@@ -301,7 +329,7 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { fullName: { firstName: { gt: 'John' } } },
+            { fullName: { firstName: { gtCaseInsensitive: 'John' } } },
             { fullName: { firstName: { isStrictly: 'NULL' } } },
           ],
         },
@@ -309,12 +337,12 @@ describe('computeCursorArgFilter', () => {
           and: [
             {
               fullName: {
-                firstName: { eqStrict: 'John' },
+                firstName: { eqStrictCaseInsensitive: 'John' },
               },
             },
             {
               or: [
-                { fullName: { lastName: { gt: 'Doe' } } },
+                { fullName: { lastName: { gtCaseInsensitive: 'Doe' } } },
                 { fullName: { lastName: { isStrictly: 'NULL' } } },
               ],
             },
@@ -347,7 +375,7 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { fullName: { firstName: { gt: 'John' } } },
+            { fullName: { firstName: { gtCaseInsensitive: 'John' } } },
             { fullName: { firstName: { isStrictly: 'NULL' } } },
           ],
         },
@@ -380,7 +408,7 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { fullName: { firstName: { gt: 'John' } } },
+            { fullName: { firstName: { gtCaseInsensitive: 'John' } } },
             { fullName: { firstName: { isStrictly: 'NULL' } } },
           ],
         },
@@ -388,12 +416,12 @@ describe('computeCursorArgFilter', () => {
           and: [
             {
               fullName: {
-                firstName: { eqStrict: 'John' },
+                firstName: { eqStrictCaseInsensitive: 'John' },
               },
             },
             {
               or: [
-                { fullName: { lastName: { gt: 'Doe' } } },
+                { fullName: { lastName: { gtCaseInsensitive: 'Doe' } } },
                 { fullName: { lastName: { isStrictly: 'NULL' } } },
               ],
             },
@@ -427,24 +455,106 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           fullName: {
-            firstName: { lt: 'John' },
+            firstName: { ltCaseInsensitive: 'John' },
           },
         },
         {
           and: [
             {
               fullName: {
-                firstName: { eqStrict: 'John' },
+                firstName: { eqStrictCaseInsensitive: 'John' },
               },
             },
             {
               fullName: {
-                lastName: { lt: 'Doe' },
+                lastName: { ltCaseInsensitive: 'Doe' },
               },
             },
           ],
         },
       ]);
+    });
+  });
+
+  describe('ordering relation of the continuation', () => {
+    // The SQL ordering sorts TEXT and SELECT columns through LOWER(), so a raw
+    // comparison here resolves case ties against the scan order and skips or
+    // duplicates rows across page boundaries (issue #24359)
+    it('should continue a SELECT ordering on the lowercased column', () => {
+      const result = computeCursorArgFilter({
+        cursor: { priority: 'Medium' },
+        orderBy: [{ priority: OrderByDirection.AscNullsLast }],
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        isForwardPagination: true,
+      });
+
+      expect(result).toEqual([
+        {
+          or: [
+            { priority: { gtCaseInsensitive: 'Medium' } },
+            { priority: { isStrictly: 'NULL' } },
+          ],
+        },
+      ]);
+    });
+
+    it('should tie a SELECT ordering on the lowercased column too', () => {
+      // Values differing only by case are one tie for the ordering: comparing
+      // them exactly would strand the rows the id tie-breaker should reach
+      const result = computeCursorArgFilter({
+        cursor: { priority: 'Medium', id: 'uuid-1' },
+        orderBy: [
+          { priority: OrderByDirection.AscNullsFirst },
+          { id: OrderByDirection.AscNullsFirst },
+        ],
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        isForwardPagination: true,
+      });
+
+      expect(result).toEqual([
+        { priority: { gtCaseInsensitive: 'Medium' } },
+        {
+          and: [
+            { priority: { eqStrictCaseInsensitive: 'Medium' } },
+            { id: { gt: 'uuid-1' } },
+          ],
+        },
+      ]);
+    });
+
+    it.each([
+      ['a NUMBER field', 'age', 30],
+      ['a DATE_TIME field', 'closeDate', '2026-01-01T00:00:00.000Z'],
+    ])('should keep comparing %s raw', (_label, fieldName, cursorValue) => {
+      const result = computeCursorArgFilter({
+        cursor: { [fieldName]: cursorValue },
+        orderBy: [{ [fieldName]: OrderByDirection.AscNullsFirst }],
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        isForwardPagination: true,
+      });
+
+      expect(result).toEqual([{ [fieldName]: { gt: cursorValue } }]);
+    });
+
+    it('should keep comparing a MULTI_SELECT field raw', () => {
+      // Its cursor value is an array, so the ordering leaves it raw too: a
+      // scalar LOWER() comparison could not mirror the array rendering
+      const result = computeCursorArgFilter({
+        cursor: { tags: ['URGENT'] } as unknown as ObjectRecordCursor,
+        orderBy: [{ tags: OrderByDirection.AscNullsFirst }],
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        isForwardPagination: true,
+      });
+
+      expect(result).toEqual([{ tags: { gt: ['URGENT'] } }]);
     });
   });
 
@@ -697,13 +807,13 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { company: { name: { gt: 'Acme' } } },
+            { company: { name: { gtCaseInsensitive: 'Acme' } } },
             { company: { name: { isStrictly: 'NULL' } } },
           ],
         },
         {
           and: [
-            { company: { name: { eqStrict: 'Acme' } } },
+            { company: { name: { eqStrictCaseInsensitive: 'Acme' } } },
             { id: { gt: 'uuid-1' } },
           ],
         },
@@ -780,16 +890,30 @@ describe('computeCursorArgFilter', () => {
       expect(result).toEqual([
         {
           or: [
-            { company: { contactName: { firstName: { gt: 'Ada' } } } },
+            {
+              company: {
+                contactName: { firstName: { gtCaseInsensitive: 'Ada' } },
+              },
+            },
             { company: { contactName: { firstName: { isStrictly: 'NULL' } } } },
           ],
         },
         {
           and: [
-            { company: { contactName: { firstName: { eqStrict: 'Ada' } } } },
+            {
+              company: {
+                contactName: { firstName: { eqStrictCaseInsensitive: 'Ada' } },
+              },
+            },
             {
               or: [
-                { company: { contactName: { lastName: { gt: 'Lovelace' } } } },
+                {
+                  company: {
+                    contactName: {
+                      lastName: { gtCaseInsensitive: 'Lovelace' },
+                    },
+                  },
+                },
                 {
                   company: {
                     contactName: { lastName: { isStrictly: 'NULL' } },
@@ -801,9 +925,17 @@ describe('computeCursorArgFilter', () => {
         },
         {
           and: [
-            { company: { contactName: { firstName: { eqStrict: 'Ada' } } } },
             {
-              company: { contactName: { lastName: { eqStrict: 'Lovelace' } } },
+              company: {
+                contactName: { firstName: { eqStrictCaseInsensitive: 'Ada' } },
+              },
+            },
+            {
+              company: {
+                contactName: {
+                  lastName: { eqStrictCaseInsensitive: 'Lovelace' },
+                },
+              },
             },
             { id: { gt: 'uuid-1' } },
           ],

--- a/packages/twenty-server/src/engine/api/utils/build-cursor-keyset-condition.utils.ts
+++ b/packages/twenty-server/src/engine/api/utils/build-cursor-keyset-condition.utils.ts
@@ -8,6 +8,9 @@ type BuildCursorKeysetConditionParams = {
   isForwardPagination: boolean;
   isEqualityCondition: boolean;
   canFieldHoldNullValue: boolean;
+  // Mirrors the LOWER() the SQL ordering applies to this column: the
+  // continuation has to compare on the same expression that produced the page
+  isCaseInsensitiveOrder: boolean;
   // Wraps a leaf filter (e.g. { gt: value }) into the field's filter path
   buildLeafCondition: (
     leafFilter: Record<string, unknown>,
@@ -34,6 +37,7 @@ export function buildCursorKeysetCondition({
   isForwardPagination,
   isEqualityCondition,
   canFieldHoldNullValue,
+  isCaseInsensitiveOrder,
   buildLeafCondition,
   // The strict operators compare exactly: the empty-value widening of 'is'
   // and 'eq' does not mirror the SQL scan order the cursor continues
@@ -41,9 +45,17 @@ export function buildCursorKeysetCondition({
     buildLeafCondition({ isStrictly: isNull ? 'NULL' : 'NOT_NULL' }),
 }: BuildCursorKeysetConditionParams): Record<string, unknown> | null {
   if (isEqualityCondition) {
-    return cursorValue === null
-      ? buildNullCheckCondition(true)
-      : buildLeafCondition({ eqStrict: cursorValue });
+    if (cursorValue === null) {
+      return buildNullCheckCondition(true);
+    }
+
+    // Rows tying under LOWER() are one tie for the ordering, so the branch
+    // handing over to the next key has to treat them as one tie too
+    return buildLeafCondition(
+      isCaseInsensitiveOrder
+        ? { eqStrictCaseInsensitive: cursorValue }
+        : { eqStrict: cursorValue },
+    );
   }
 
   const { isAscending, areNullsScannedLast } = getEffectiveScanOrder(
@@ -57,8 +69,16 @@ export function buildCursorKeysetCondition({
     return areNullsScannedLast ? null : buildNullCheckCondition(false);
   }
 
+  const strictComparisonOperator = isCaseInsensitiveOrder
+    ? isAscending
+      ? 'gtCaseInsensitive'
+      : 'ltCaseInsensitive'
+    : isAscending
+      ? 'gt'
+      : 'lt';
+
   const mainCondition = buildLeafCondition({
-    [isAscending ? 'gt' : 'lt']: cursorValue,
+    [strictComparisonOperator]: cursorValue,
   });
 
   if (areNullsScannedLast && canFieldHoldNullValue) {

--- a/packages/twenty-server/src/engine/api/utils/build-cursor-leaf-where-condition.utils.ts
+++ b/packages/twenty-server/src/engine/api/utils/build-cursor-leaf-where-condition.utils.ts
@@ -1,4 +1,8 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { shouldUseCaseInsensitiveOrder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/utils/build-order-by-column-expression.util';
 import { buildCursorKeysetCondition } from 'src/engine/api/utils/build-cursor-keyset-condition.utils';
+import { computeOrderByLeafColumnType } from 'src/engine/api/utils/compute-order-by-leaf-column.util';
 import { type OrderByLeaf } from 'src/engine/api/utils/resolve-order-by-leaves.utils';
 
 // SQL NULL can sit in any nullable column whatever its type: write-side
@@ -8,6 +12,15 @@ import { type OrderByLeaf } from 'src/engine/api/utils/resolve-order-by-leaves.u
 // and are treated as nullable; a needless IS NULL branch matches nothing.
 const checkIfLeafCanHoldNullValue = (leaf: OrderByLeaf): boolean =>
   leaf.kind === 'scalar' ? leaf.fieldMetadata.isNullable !== false : true;
+
+// Read from the leaf's own column type, the way the SQL order parser decides
+// whether to wrap the column in LOWER(), so the keyset predicate and the scan
+// order cannot disagree about the ordering relation.
+const checkIfLeafIsOrderedCaseInsensitively = (leaf: OrderByLeaf): boolean => {
+  const columnType = computeOrderByLeafColumnType(leaf);
+
+  return isDefined(columnType) && shouldUseCaseInsensitiveOrder(columnType);
+};
 
 type BuildCursorLeafWhereConditionParams = {
   leaf: OrderByLeaf;
@@ -37,6 +50,7 @@ export function buildCursorLeafWhereCondition({
     isForwardPagination,
     isEqualityCondition,
     canFieldHoldNullValue: checkIfLeafCanHoldNullValue(leaf),
+    isCaseInsensitiveOrder: checkIfLeafIsOrderedCaseInsensitively(leaf),
     buildLeafCondition: (leafFilter) =>
       leaf.path.reduceRight<Record<string, unknown>>(
         (nested, key) => ({ [key]: nested }),

--- a/packages/twenty-server/src/engine/api/utils/compute-order-by-leaf-column.util.ts
+++ b/packages/twenty-server/src/engine/api/utils/compute-order-by-leaf-column.util.ts
@@ -12,6 +12,26 @@ export type OrderByLeafColumn = {
   columnType: FieldMetadataType;
 };
 
+// The type of the column an orderBy leaf sorts on, which for composite and
+// relation leaves is the resolved sub/target column rather than the field the
+// leaf hangs off. Callers that only need the comparison semantics of the
+// ordering (e.g. the cursor keyset conditions) read it without resolving an
+// alias they have no use for.
+export const computeOrderByLeafColumnType = (
+  leaf: OrderByLeaf,
+): FieldMetadataType | null => {
+  switch (leaf.kind) {
+    case 'relation':
+      return isDefined(leaf.targetFieldMetadata)
+        ? (leaf.targetCompositeProperty ?? leaf.targetFieldMetadata).type
+        : null;
+    case 'composite':
+      return leaf.compositeProperty.type;
+    case 'scalar':
+      return leaf.fieldMetadata.type;
+  }
+};
+
 // The one mapping from an orderBy leaf to the column its values live in. The
 // SQL ORDER BY expression, the hidden column selection and the raw-row alias
 // the cursor side channel reads back (`"<tableAlias>_<columnName>"`) all
@@ -20,13 +40,15 @@ export const computeOrderByLeafColumn = (
   leaf: OrderByLeaf,
   objectNameSingular: string,
 ): OrderByLeafColumn | null => {
-  switch (leaf.kind) {
-    case 'relation': {
-      if (!isDefined(leaf.targetFieldMetadata)) {
-        // A relation without a resolvable target contributes no ordering
-        return null;
-      }
+  const columnType = computeOrderByLeafColumnType(leaf);
 
+  if (!isDefined(columnType)) {
+    // A relation without a resolvable target contributes no ordering
+    return null;
+  }
+
+  switch (leaf.kind) {
+    case 'relation':
       return {
         tableAlias: leaf.path[0],
         columnName: isDefined(leaf.targetCompositeProperty)
@@ -35,10 +57,8 @@ export const computeOrderByLeafColumn = (
               leaf.targetCompositeProperty,
             )
           : leaf.path[1],
-        columnType: (leaf.targetCompositeProperty ?? leaf.targetFieldMetadata)
-          .type,
+        columnType,
       };
-    }
     case 'composite':
       return {
         tableAlias: objectNameSingular,
@@ -46,13 +66,13 @@ export const computeOrderByLeafColumn = (
           leaf.path[0],
           leaf.compositeProperty,
         ),
-        columnType: leaf.compositeProperty.type,
+        columnType,
       };
     case 'scalar':
       return {
         tableAlias: objectNameSingular,
         columnName: leaf.path[0],
-        columnType: leaf.fieldMetadata.type,
+        columnType,
       };
   }
 };

--- a/packages/twenty-server/test/integration/graphql/suites/cursor-pagination-order-by.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/cursor-pagination-order-by.integration-spec.ts
@@ -590,3 +590,130 @@ describe('Cursor pagination ordered by a TEXT field with empty values', () => {
     ]);
   });
 });
+
+// TEXT and SELECT columns are ordered through LOWER(), so the continuation has
+// to compare on that same expression: a raw comparison resolves case ties
+// against the scan order and skips or duplicates rows at page boundaries
+// (issue #24359)
+describe('Cursor pagination ordered by a case-insensitively sorted TEXT field', () => {
+  const caseTiedCompanyIds = [
+    '20202020-ffff-4000-8000-000000000001',
+    '20202020-ffff-4000-8000-000000000002',
+    '20202020-ffff-4000-8000-000000000003',
+  ];
+  const lastCompanyId = '20202020-ffff-4000-8000-000000000004';
+  const allCompanyIds = [...caseTiedCompanyIds, lastCompanyId];
+
+  beforeAll(async () => {
+    await makeGraphqlAPIRequest(
+      createManyOperationFactory({
+        objectMetadataSingularName: 'company',
+        objectMetadataPluralName: 'companies',
+        gqlFields: 'id',
+        data: [
+          // Three spellings of one lowercased value: every page boundary below
+          // lands inside the tie they form
+          { id: caseTiedCompanyIds[0], name: 'acme' },
+          { id: caseTiedCompanyIds[1], name: 'ACME' },
+          { id: caseTiedCompanyIds[2], name: 'Acme' },
+          { id: lastCompanyId, name: 'Zebra' },
+        ],
+        upsert: true,
+      }),
+    ).expect(200);
+  });
+
+  it.each(['AscNullsLast', 'DescNullsLast'])(
+    'should neither skip nor repeat records across a case tie with %s',
+    async (direction) => {
+      const { ids } = await paginateForward({
+        objectMetadataSingularName: 'company',
+        objectMetadataPluralName: 'companies',
+        filter: { id: { in: allCompanyIds } },
+        orderBy: { name: direction },
+        // One record per page puts a cursor between every pair of tied rows
+        first: 1,
+      });
+
+      expect(ids).toHaveLength(allCompanyIds.length);
+      expect(new Set(ids)).toEqual(new Set(allCompanyIds));
+    },
+  );
+
+  it('should keep the tied rows together on one side of the later name', async () => {
+    const { ids } = await paginateForward({
+      objectMetadataSingularName: 'company',
+      objectMetadataPluralName: 'companies',
+      filter: { id: { in: allCompanyIds } },
+      orderBy: { name: 'AscNullsLast' },
+      first: 1,
+    });
+
+    expect(new Set(ids.slice(0, caseTiedCompanyIds.length))).toEqual(
+      new Set(caseTiedCompanyIds),
+    );
+    expect(ids[ids.length - 1]).toBe(lastCompanyId);
+  });
+});
+
+// A SELECT column is an enum: a raw comparison follows the enum's declaration
+// order (NEW, SCREENING, MEETING, PROPOSAL, CUSTOMER) while the ordering sorts
+// by LOWER(stage::text), so the two disagree wholesale rather than only at ties
+describe('Cursor pagination ordered by a SELECT field', () => {
+  const stagesInDeclarationOrder = [
+    'NEW',
+    'SCREENING',
+    'MEETING',
+    'PROPOSAL',
+    'CUSTOMER',
+  ];
+  const opportunityIdByStage: Record<string, string> = {
+    NEW: '20202020-ffff-4100-8000-000000000001',
+    SCREENING: '20202020-ffff-4100-8000-000000000002',
+    MEETING: '20202020-ffff-4100-8000-000000000003',
+    PROPOSAL: '20202020-ffff-4100-8000-000000000004',
+    CUSTOMER: '20202020-ffff-4100-8000-000000000005',
+  };
+  const allOpportunityIds = Object.values(opportunityIdByStage);
+
+  beforeAll(async () => {
+    await makeGraphqlAPIRequest(
+      createManyOperationFactory({
+        objectMetadataSingularName: 'opportunity',
+        objectMetadataPluralName: 'opportunities',
+        gqlFields: 'id',
+        data: stagesInDeclarationOrder.map((stage) => ({
+          id: opportunityIdByStage[stage],
+          name: `Stage ${stage} opportunity`,
+          stage,
+        })),
+        upsert: true,
+      }),
+    ).expect(200);
+  });
+
+  it('should follow the lowercased text order the scan uses, not the enum order', async () => {
+    const { ids } = await paginateForward({
+      filter: { id: { in: allOpportunityIds } },
+      orderBy: { stage: 'AscNullsLast' },
+      first: 2,
+    });
+
+    expect(ids).toEqual(
+      ['CUSTOMER', 'MEETING', 'NEW', 'PROPOSAL', 'SCREENING'].map(
+        (stage) => opportunityIdByStage[stage],
+      ),
+    );
+  });
+
+  it('should neither skip nor repeat records when paged one at a time', async () => {
+    const { ids } = await paginateForward({
+      filter: { id: { in: allOpportunityIds } },
+      orderBy: { stage: 'DescNullsLast' },
+      first: 1,
+    });
+
+    expect(ids).toHaveLength(allOpportunityIds.length);
+    expect(new Set(ids)).toEqual(new Set(allOpportunityIds));
+  });
+});


### PR DESCRIPTION
Closes #24359

## Problem

`GraphqlQueryOrderFieldParser` marks TEXT and SELECT columns for case-insensitive ordering (`useLower`, plus `castToText` for the enum column of a SELECT) — but nothing on the record-list path reads those flags. `applyOrderToBuilder` hands the order value straight to the query builder, and both builders drop the keys they do not know: TypeORM ignores extra properties on an `OrderByCondition`, and ORM v2 documents the same parity. Only `getOrderByRawSQL` rendered them, and its sole callers are the group-by `ROW_NUMBER()` window.

So the record scan compared raw values:

```
ORDER BY "person"."nameFirstName" ASC NULLS LAST     -- what ships today
ORDER BY LOWER("person"."nameFirstName") ASC NULLS LAST  -- what the parser asks for
```

Two consequences:

- **Text lists disagree with the client.** #17023 shipped the case-insensitive `sortAsc` that `sortCachedObjectEdges` applies to the Apollo cache, so an optimistically inserted record is placed by a rule the server never used.
- **A SELECT field sorts by enum declaration order.** For `opportunity.stage` the raw comparison follows `NEW, SCREENING, MEETING, PROPOSAL, CUSTOMER` while the client sorts `customer, meeting, new, proposal, screening`.

Fixing the ORDER BY alone would then break keyset pagination, which is the mismatch #24359 describes: the cursor conditions travel as ordinary filter objects (`{ name: { gt: v } }`) and compare the raw column, so rows tying under `LOWER()` sit at a tie the raw `>` resolves differently and get skipped or repeated at a page boundary. Both halves have to move together, so they are one change.

## Fix

One renderer, `renderOrderByColumnSql`, is now the only place an ordered column becomes SQL. Every ORDER BY compiles through it, and the keyset conditions compare on the same expression.

- `build-order-by-column-expression.util.ts` — `renderOrderByColumnSql` quotes the column and applies `::text` / `LOWER()` from the clause's own flags. An expression that already carries quotes or a call (a group-by bucket, an aggregate) is passed through untouched.
- `graphql-query.parser.ts` — `applyOrderToBuilder` and `applyGroupByOrderToBuilder` render a case-insensitively ordered column before handing it to the builder; `getOrderByRawSQL` loses its inline copy of the same logic. Columns the ordering compares raw keep the plain `alias.column` form the builders resolve themselves, so nothing changes for them.
- `build-cursor-leaf-where-condition.utils.ts` — decides the comparison from the leaf's own column type with `shouldUseCaseInsensitiveOrder`, the same predicate the order parser uses, so the scan and the continuation read one flag rather than two that can drift.
- `compute-order-by-leaf-column.util.ts` — `computeOrderByLeafColumnType` split out of `computeOrderByLeafColumn`, keeping the leaf→column mapping in one place while letting the cursor side read the type without resolving a table alias it has no use for.
- `build-cursor-keyset-condition.utils.ts` / `compute-where-condition-parts.ts` — `gtCaseInsensitive` / `ltCaseInsensitive` / `eqStrictCaseInsensitive`, comparing `LOWER(col::text)` against `LOWER(:value)`.

`applyOrderToBuilder` still returns the unrendered clauses, so `addRelationOrderColumnsToBuilder` keeps resolving the hidden order columns the cursor side-channel reads back.

Three details worth flagging for review:

**Why new operators rather than a parameter.** The cursor conditions go through the shared filter parser, which reads one `[operator, value]` pair per leaf. Threading a "compare case-insensitively" flag through it would put a keyset concern into every filter call site; a distinct operator keeps it where the keyset already lives, next to `eqStrict` and `isStrictly`.

**MULTI_SELECT drops out of case-insensitive ordering.** Its column is an array, so the only case-insensitive expression available is `LOWER(col::text)` over the array literal, and no scalar cursor value can mirror that. Ordering it raw keeps both sides on the same relation. This is the one place the group-by window ordering changes; no test orders by a MULTI_SELECT field.

**Index usage.** `ORDER BY LOWER(col)` cannot use a plain btree index on `col`, so a large list sorted by a text field sorts instead of scanning an index. That is inherent to the behaviour #17023 asked for; if it matters, the follow-up is an expression index on `LOWER(col)` for the columns views actually sort by. Happy to add that here if you would rather have both at once.

## Tests

**Integration** (`cursor-pagination-order-by.integration-spec.ts`): four tests over a case tie (`acme` / `ACME` / `Acme` / `Zebra`) and over the five `opportunity.stage` values, paging one and two records at a time so a boundary lands inside the tie. They assert exhaustiveness in both directions, that the tied rows stay together, and that the SELECT order follows the option values rather than the enum's.

**Unit**: `applyOrderToBuilder` hands the builder `LOWER("opportunity"."name")` and `LOWER("opportunity"."stage"::text)` while leaving a DATE_TIME and a MULTI_SELECT column unrendered, in the requested clause order; `renderOrderByColumnSql` quotes, casts and passes rendered expressions through; the keyset conditions emit the case-insensitive operators for TEXT and SELECT leaves and the raw ones elsewhere; the operators emit the expected SQL.

I also replayed the algebra directly against Postgres 16 on `en_US.utf8` (the CI image's locale) with those exact fixtures: `LOWER()` scan plus `LOWER()` keyset paginates the case tie and the NULL block exhaustively in both directions, and a control that pairs a raw scan with a `LOWER()` keyset drops rows — the failure a half-fix produces.

```
Test Suites: 160 passed, 160 total
Tests:       1241 passed, 1241 total
```

`oxlint --type-aware` and `oxfmt --check` clean on the changed files; `tsgo --noEmit` clean on twenty-server.

## Notes

I audited every integration test that asserts an order under a TEXT, SELECT or composite-text sort. None changes verdict: their fixtures are either distinct-initial (`Alpha`/`Beta`/`Gamma`, `Anvers`/`Barcelona`/`Cuzco`, `Airbnb`/`Notion`/`Stripe`), uniformly cased, or numerically suffixed, so `LOWER()` reorders nothing. The two deliberate case-tie tests in `order-by-relation-field.integration-spec.ts` assert only that both `acme` spellings precede `Zebra`, never their order relative to each other, so they hold either way.

This supersedes #24483, which fixed only the cursor half and — as its CI run showed — pointed the keyset at an expression the scan was not using.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

