### PR TITLE
prevent shortcuts in other response input

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/internal/AiChatQuestionOtherOption.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AiChatQuestionOtherOption.tsx
@@ -1,8 +1,12 @@
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
-import { type KeyboardEvent, useContext, useRef } from 'react';
+import { type KeyboardEvent, useContext, useId, useRef } from 'react';
 import { type IconComponent } from 'twenty-ui/icon';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+
+import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
+import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
+import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
 
 const StyledContainer = styled.div<{ isHighlighted: boolean }>`
   background: ${({ isHighlighted }) =>
@@ -79,10 +83,32 @@ export const AiChatQuestionOtherOption = ({
   const { t } = useLingui();
   const { theme } = useContext(ThemeContext);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const textAreaFocusId = useId();
+
+  const { pushFocusItemToFocusStack } = usePushFocusItemToFocusStack();
+  const { removeFocusItemFromFocusStackById } =
+    useRemoveFocusItemFromFocusStackById();
 
   const selectAndFocus = () => {
     onSelect();
     textareaRef.current?.focus();
+  };
+
+  const handleTextareaFocus = () => {
+    pushFocusItemToFocusStack({
+      focusId: textAreaFocusId,
+      component: {
+        type: FocusComponentType.TEXT_AREA,
+        instanceId: textAreaFocusId,
+      },
+      globalHotkeysConfig: {
+        enableGlobalHotkeysConflictingWithKeyboard: false,
+      },
+    });
+  };
+
+  const handleTextareaBlur = () => {
+    removeFocusItemFromFocusStackById({ focusId: textAreaFocusId });
   };
 
   return (
@@ -117,6 +143,8 @@ export const AiChatQuestionOtherOption = ({
         }}
         onChange={(event) => onChange(event.target.value)}
         onKeyDown={onTextareaKeyDown}
+        onFocus={handleTextareaFocus}
+        onBlur={handleTextareaBlur}
       />
     </StyledContainer>
   );


### PR DESCRIPTION
## Description

Fixes #24524.

When typing a custom response in the Agent's "Other" text area, keyboard events
were bubbling to page-level keyboard shortcut handlers.

This change stops the text area's keydown event from propagating to the page
while preserving the existing text area keydown handler.

## Testing

- `git diff --check` passes.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

