### PR TITLE
fix: stop Element.contains from hanging the front component worker

### DIFF
--- a/packages/twenty-front-component-renderer/src/__stories__/TwentyUiGallery.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/TwentyUiGallery.stories.tsx
@@ -162,18 +162,6 @@ export const SurfacesPreact: Story = createGalleryStory(
   'preact',
 );
 
-// KNOWN ISSUE (TDD) golden test: an open Modal (base-ui Dialog portal) hangs
-// the React-runtime render — the gallery status must never mount. Works under
-// Preact (see ModalOpenPreact). When fixed, flip this story to the strict
-// zero-failure play used by ModalOpenPreact.
-const modalOpenHangTest: Story['play'] = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-
-  await expect(
-    canvas.findByTestId('gallery-status', {}, { timeout: 10000 }),
-  ).rejects.toThrow();
-};
-
 const modalOpenTest: Story['play'] = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
 
@@ -193,7 +181,7 @@ const modalOpenTest: Story['play'] = async ({ canvasElement }) => {
 
 export const ModalOpenReact: Story = {
   ...createGalleryStory('twenty-ui-modal-open-gallery'),
-  play: modalOpenHangTest,
+  play: modalOpenTest,
 };
 export const ModalOpenPreact: Story = {
   ...createGalleryStory('twenty-ui-modal-open-gallery', 'preact'),

--- a/packages/twenty-front-component-renderer/src/polyfills/dom/utils/__tests__/installElementContainsPolyfill.test.ts
+++ b/packages/twenty-front-component-renderer/src/polyfills/dom/utils/__tests__/installElementContainsPolyfill.test.ts
@@ -9,8 +9,10 @@ const createElement = (): FakeNode => ({
   parentNode: null,
 });
 
-const createBrokenRemoteDomContains =
-  (): ((this: FakeNode, other: unknown) => boolean) =>
+const createBrokenRemoteDomContains = (): ((
+  this: FakeNode,
+  other: unknown,
+) => boolean) =>
   // The exact @remote-dom/polyfill implementation this polyfill replaces:
   // it re-reads the ORIGINAL node's parentNode on every iteration, so any
   // indirect descendant loops forever.

--- a/packages/twenty-front-component-renderer/src/polyfills/dom/utils/__tests__/installElementContainsPolyfill.test.ts
+++ b/packages/twenty-front-component-renderer/src/polyfills/dom/utils/__tests__/installElementContainsPolyfill.test.ts
@@ -1,0 +1,113 @@
+import { installElementContainsPolyfill } from '../installElementContainsPolyfill';
+
+type FakeNode = {
+  parentNode: FakeNode | null;
+  contains?: (other: unknown) => boolean;
+};
+
+const createElement = (): FakeNode => ({
+  parentNode: null,
+});
+
+const createBrokenRemoteDomContains =
+  (): ((this: FakeNode, other: unknown) => boolean) =>
+  // The exact @remote-dom/polyfill implementation this polyfill replaces:
+  // it re-reads the ORIGINAL node's parentNode on every iteration, so any
+  // indirect descendant loops forever.
+  function brokenContains(this: FakeNode, other) {
+    const node = other as FakeNode;
+    let currentNode: FakeNode | null = node;
+
+    for (;;) {
+      if (currentNode == null) return false;
+      if (currentNode === this) return true;
+      currentNode = node.parentNode;
+    }
+  };
+
+const createPrototypeWithInstalledContains = (
+  original?: (this: FakeNode, other: unknown) => boolean,
+) => {
+  const prototype: FakeNode = {
+    parentNode: null,
+    ...(original ? { contains: original } : {}),
+  };
+
+  installElementContainsPolyfill(prototype as never);
+
+  return prototype;
+};
+
+describe('installElementContainsPolyfill', () => {
+  it('should return true for a direct child', () => {
+    const prototype = createPrototypeWithInstalledContains();
+    const parent = Object.create(prototype);
+    const child = createElement();
+    child.parentNode = parent;
+
+    expect(parent.contains(child)).toBe(true);
+  });
+
+  it('should return true for an indirect descendant instead of hanging', () => {
+    const prototype = createPrototypeWithInstalledContains();
+    const ancestor = Object.create(prototype);
+    const middle = createElement();
+    middle.parentNode = ancestor;
+    const descendant = createElement();
+    descendant.parentNode = middle;
+
+    // With @remote-dom/polyfill's implementation this call never returns:
+    // middle is re-read forever (#24573).
+    expect(ancestor.contains(descendant)).toBe(true);
+  });
+
+  it('should return true for the element itself', () => {
+    const prototype = createPrototypeWithInstalledContains();
+    const element = Object.create(prototype);
+
+    expect(element.contains(element)).toBe(true);
+  });
+
+  it('should return false for a detached node', () => {
+    const prototype = createPrototypeWithInstalledContains();
+    const element = Object.create(prototype);
+    const detached = createElement();
+
+    expect(element.contains(detached)).toBe(false);
+  });
+
+  it('should return false for sibling subtrees', () => {
+    const prototype = createPrototypeWithInstalledContains();
+    const root = Object.create(prototype);
+    const left = Object.create(prototype);
+    left.parentNode = root;
+    const right = createElement();
+    right.parentNode = root;
+    const rightChild = createElement();
+    rightChild.parentNode = right;
+
+    expect(left.contains(rightChild)).toBe(false);
+  });
+
+  it('should return false for nullish and non-node arguments', () => {
+    const prototype = createPrototypeWithInstalledContains();
+    const element = Object.create(prototype);
+
+    expect(element.contains(null)).toBe(false);
+    expect(element.contains(undefined)).toBe(false);
+    expect(element.contains({})).toBe(false);
+  });
+
+  it('should replace the broken @remote-dom/polyfill implementation', () => {
+    const broken = jest.fn(createBrokenRemoteDomContains());
+    const prototype = createPrototypeWithInstalledContains(broken);
+    const ancestor = Object.create(prototype);
+    const middle = createElement();
+    middle.parentNode = ancestor;
+    const descendant = createElement();
+    descendant.parentNode = middle;
+
+    expect(ancestor.contains(descendant)).toBe(true);
+    expect(broken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front-component-renderer/src/polyfills/dom/utils/__tests__/installElementContainsPolyfill.test.ts
+++ b/packages/twenty-front-component-renderer/src/polyfills/dom/utils/__tests__/installElementContainsPolyfill.test.ts
@@ -33,7 +33,7 @@ const createPrototypeWithInstalledContains = (
     ...(original ? { contains: original } : {}),
   };
 
-  installElementContainsPolyfill(prototype as never);
+  installElementContainsPolyfill(prototype);
 
   return prototype;
 };

--- a/packages/twenty-front-component-renderer/src/polyfills/dom/utils/installElementContainsPolyfill.ts
+++ b/packages/twenty-front-component-renderer/src/polyfills/dom/utils/installElementContainsPolyfill.ts
@@ -1,0 +1,37 @@
+type NodeLike = {
+  parentNode: unknown;
+};
+
+/**
+ * Installs a spec-compliant `contains()` on the remote worker's element
+ * prototype.
+ *
+ * `@remote-dom/polyfill`'s `Node#contains` never advances the walk: it
+ * re-reads the ORIGINAL node's `parentNode` on every iteration
+ * (`currentNode = node.parentNode` instead of `currentNode.parentNode`), so
+ * for any element that is not a DIRECT child the loop never terminates —
+ * and because the worker's DOM is synchronous, that call hangs the worker's
+ * whole event loop with no exception and no way to recover except a reload
+ * (#24573). Direct children returned correctly, which is why the bug looked
+ * like a random freeze that only repro'd on deeper trees.
+ *
+ * The replacement walks `parentNode` from the argument up to the root, the
+ * `Node.prototype.contains` contract: `true` when the receiver is on that
+ * chain, `false` for a detached node, a non-node argument, or `null`.
+ */
+export const installElementContainsPolyfill = (
+  elementPrototype: NodeLike & Record<string, unknown>,
+): void => {
+  elementPrototype.contains = function contains(other: unknown): boolean {
+    let currentNode: unknown = other;
+
+    while (currentNode != null) {
+      if (currentNode === this) {
+        return true;
+      }
+      currentNode = (currentNode as NodeLike).parentNode;
+    }
+
+    return false;
+  };
+};

--- a/packages/twenty-front-component-renderer/src/polyfills/dom/utils/installElementContainsPolyfill.ts
+++ b/packages/twenty-front-component-renderer/src/polyfills/dom/utils/installElementContainsPolyfill.ts
@@ -10,18 +10,22 @@ type NodeLike = {
  * (#24573).
  */
 export const installElementContainsPolyfill = (
-  elementPrototype: NodeLike & Record<string, unknown>,
+  elementPrototype: object,
 ): void => {
-  elementPrototype.contains = function contains(other: unknown): boolean {
-    let currentNode: unknown = other;
+  // Typed loosely on purpose: the caller hands over the runtime's own
+  // Element.prototype, whose class type is not assignable to an index
+  // signature under this package's strict settings.
+  (elementPrototype as { contains?: (other: unknown) => boolean }).contains =
+    function contains(this: NodeLike, other: unknown): boolean {
+      let currentNode: unknown = other;
 
-    while (currentNode != null) {
-      if (currentNode === this) {
-        return true;
+      while (currentNode != null) {
+        if (currentNode === this) {
+          return true;
+        }
+        currentNode = (currentNode as NodeLike).parentNode;
       }
-      currentNode = (currentNode as NodeLike).parentNode;
-    }
 
-    return false;
-  };
+      return false;
+    };
 };

--- a/packages/twenty-front-component-renderer/src/polyfills/dom/utils/installElementContainsPolyfill.ts
+++ b/packages/twenty-front-component-renderer/src/polyfills/dom/utils/installElementContainsPolyfill.ts
@@ -4,20 +4,10 @@ type NodeLike = {
 
 /**
  * Installs a spec-compliant `contains()` on the remote worker's element
- * prototype.
- *
- * `@remote-dom/polyfill`'s `Node#contains` never advances the walk: it
- * re-reads the ORIGINAL node's `parentNode` on every iteration
- * (`currentNode = node.parentNode` instead of `currentNode.parentNode`), so
- * for any element that is not a DIRECT child the loop never terminates —
- * and because the worker's DOM is synchronous, that call hangs the worker's
- * whole event loop with no exception and no way to recover except a reload
- * (#24573). Direct children returned correctly, which is why the bug looked
- * like a random freeze that only repro'd on deeper trees.
- *
- * The replacement walks `parentNode` from the argument up to the root, the
- * `Node.prototype.contains` contract: `true` when the receiver is on that
- * chain, `false` for a detached node, a non-node argument, or `null`.
+ * prototype, replacing the @remote-dom/polyfill implementation whose walk
+ * never advances past the argument's own parentNode: direct children
+ * happen to return, but any indirect descendant hangs the worker forever
+ * (#24573).
  */
 export const installElementContainsPolyfill = (
   elementPrototype: NodeLike & Record<string, unknown>,

--- a/packages/twenty-front-component-renderer/src/remote/worker/remote-worker.ts
+++ b/packages/twenty-front-component-renderer/src/remote/worker/remote-worker.ts
@@ -11,6 +11,7 @@ import { frontComponentHostCommunicationApi } from '@/remote/worker/thread/state
 import { HTML_TAG_TO_CUSTOM_ELEMENT_TAG } from '@/constants/HtmlTagToCustomElementTag';
 import { installClipboardPolyfill } from '@/polyfills/clipboard/utils/installClipboardPolyfill';
 import { installDocumentGetElementById } from '@/polyfills/dom/utils/installDocumentGetElementById';
+import { installElementContainsPolyfill } from '@/polyfills/dom/utils/installElementContainsPolyfill';
 import { installGetComputedStyle } from '@/polyfills/dom/utils/installGetComputedStyle';
 import { installGetElementsByClassName } from '@/polyfills/dom/utils/installGetElementsByClassName';
 import { installLocalStyleOnBaseElements } from '@/polyfills/dom/utils/installLocalStyleOnBaseElements';
@@ -40,7 +41,10 @@ installStylePropertyOnRemoteElements();
 patchRemoteElementAttributes();
 installErrorEventBridge();
 
+// #24573: the upstream Node#contains walks the argument's own parentNode
+// forever, hanging the worker for any indirect descendant.
 installDocumentGetElementById(document);
+installElementContainsPolyfill(Element.prototype);
 installGetElementsByClassName(Element.prototype);
 installGetElementsByClassName(document);
 installLocalStyleOnBaseElements(Element.prototype);


### PR DESCRIPTION
## What?

Calling `Element.contains()` on any non-direct descendant inside a front component hangs the whole Remote DOM worker: no exception, nothing in the console, timers and even direct (non-bridged) `fetch` heartbeats stop — the widget freezes permanently until reload.

Closes #24573

## Root cause — upstream, in `@remote-dom/polyfill`'s `Node#contains`

```js
contains(node) {
  let currentNode = node;
  while (true) {
    if (currentNode == null) return false;
    if (currentNode === this) return true;
    currentNode = node.parentNode;   // ← re-reads the ORIGINAL node's parent, never advances
  }
}
```

The walk is supposed to climb `currentNode.parentNode`; it re-reads `node.parentNode` instead. For a **direct** child the first step happens to hit the receiver and returns `true` — which is exactly why this looked like a random, unreproducible freeze: it only hangs for **indirect** descendants (any nesting deeper than one level, e.g. the hit-testing the reporter's drag-and-drop editor does). For those, the loop re-reads the same middle node forever. The worker's DOM is synchronous, so that one call deadlocks the entire worker event loop.

Reproduced in isolation: the exact upstream implementation run against a three-level chain never terminates (killed at a 5-second wall clock), while the fix below returns immediately.

## Fix

`installElementContainsPolyfill` installs the spec traversal on the worker's `Element.prototype` (where every other worker polyfill in this package installs), wired in `remote-worker.ts`:

```ts
let currentNode = other;
while (currentNode != null) {
  if (currentNode === this) return true;
  currentNode = currentNode.parentNode;
}
return false;
```

`true` for self/direct/indirect descendants, `false` for detached nodes, sibling subtrees, non-node arguments and `null`/`undefined`.

## Testing

Colocated jest suite (`installElementContainsPolyfill.test.ts`), 7 cases:

- direct child → `true`; **indirect descendant → `true` (the case that hung)**; self → `true`
- detached node, sibling subtree, `null`/`undefined`/non-node → `false`
- the installer **replaces** a prototype carrying a copy of the exact upstream loop (asserted not called), which is the differential against today's behavior

All 7 pass. I'll also open the one-line upstream fix against `Shopify/remote-dom` so the bug disappears at the source; this polyfill protects twenty regardless of when that lands and regardless of the pinned `@remote-dom/polyfill` version.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

