### PR TITLE
fix(ci): stop the i18n formatting ping-pong between Crowdin pull and push workflows

### DIFF
--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -93,6 +93,12 @@ jobs:
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      - name: Normalize downloaded catalogs to lingui format
+        run: |
+          npx nx run twenty-server:lingui:extract
+          npx nx run twenty-emails:lingui:extract
+          npx nx run twenty-front:lingui:extract
+
       - name: Compile translations
         id: compile_translations
         run: |

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -9,6 +9,10 @@ on:
   workflow_call:
   push:
     branches: ['main']
+    paths-ignore:
+      - 'packages/twenty-front/src/locales/**'
+      - 'packages/twenty-emails/src/locales/**'
+      - 'packages/twenty-server/src/engine/core-modules/i18n/locales/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -87,6 +87,9 @@ jobs:
       - name: Fix file permissions
         run: sudo chown -R runner:docker .
 
+      - name: Normalize downloaded catalogs to lingui format
+        run: npx nx run twenty-website:lingui:extract
+
       - name: Compile website translations
         id: compile_translations
         run: |

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -11,6 +11,7 @@ on:
     branches: ['main']
     paths:
       - 'packages/twenty-website/**'
+      - '!packages/twenty-website/src/locales/**'
       - '.github/crowdin-website.yml'
       - '.github/workflows/website-i18n-push.yaml'
 


### PR DESCRIPTION
## Symptom

Since Aug 20, the i18n workflows open formatting-only translation PRs in a loop, even with no new translations. On main this shows up as pairs of exactly inverse commits minutes apart, e.g. #24586 (780 insertions / 1534 deletions) then #24587 (1534 / 780), same for #24571/#24572, #24575/#24576, #24579/#24580, and for the app #24577/#24578. App i18n PR volume jumped from 1-6/day to 14 (Aug 20) and 25 (Aug 21).

## The mismatch itself

Crowdin's PO exporter and lingui's PO writer disagree on exactly one thing: multiline strings. Crowdin exports gettext-style `msgid ""` + quoted continuation lines; lingui writes the first line inline (`msgid "first line\n"`). Single-line strings are byte-identical in both. So a download flips every multiline entry, the resulting merge triggers the push workflow, its `lingui extract` flips them back, and the two workflows ping-pong forever.

## Why now: full timeline

The mismatch is old and latent; it needed a Crowdin download to actually run against catalogs containing multiline strings, and scheduled downloads had not been running for about a year:

- **Feb 2025** — the original i18n CI gated the scheduled Crowdin download on `lingui compile --strict` failing: "only download when translations are missing". Sound at the time, since `--strict` genuinely failed on missing translations.
- **2025** — English became the fallback locale in the lingui configs. With a fallback, `--strict` treats missing translations as found and always succeeds, so the gate never opened and scheduled downloads silently stopped.
- **Aug 28, 2025 (#14128)** — the symptom was diagnosed ("--strict does not fail since we've set english as a fallback locale... temporary hotfix"), but the hotfix un-gated only the *compile* step; the *download* step kept the dead condition. Scheduled downloads stayed dead; translations could only land via manual `force_pull` dispatches.
- **May 2026 (#20171)** — the website pull workflow was created following the app one, dead gate included, so its scheduled downloads never worked (why "PRODUCT" stayed English on the zh homepage despite `产品` being approved in Crowdin since July 2).
- **Meanwhile** — multiline strings accumulated in catalogs that had only ever been written by lingui: the website's competitor pricing pages (#23588, Jul 30 2026) and the app's custom-application markdown descriptions.
- **Aug 20, 2026 (#24400)** — the dead gate was removed and downloads became unconditional on schedule. The first scheduled download in a long time brought Crowdin's wrapping of those multiline strings into the repo, and the ping-pong started within hours, in both projects. (Verified: every app i18n PR from Jul 15 to Aug 19 contained no downloaded translations — extract output plus a few encoding-fixer edits — then filled translations and inverse pairs appear from Aug 20.)

## Fix

Two complementary changes:

**1. Normalize downloads (root cause).** In `website-i18n-pull.yaml` and `i18n-pull.yaml`, run the corresponding `lingui:extract` targets on the downloaded catalogs before the change-detection diff. Extract merges the downloaded translations and rewrites the files in lingui's canonical format, so both sides converge on identical bytes: an unchanged download produces no diff and no PR, while real translation updates still flow through. (Validated in production by the loop itself: #24586 is exactly this command running over Crowdin-formatted catalogs, preserving every msgstr.)

**2. Skip push runs for translation-only merges (trigger hygiene).** Exclude the locale catalog directories from the push workflows' `push` triggers (`paths` negation for the website, `paths-ignore` for the app, which previously ran a full install + extract on every merge to main). A translation-only merge can never change extract's input (source code), and its Crowdin upload step is already gated on extract detecting changes, so these runs were pure waste.

An alternative considered: a Crowdin-side export transform (Crowdin Enterprise file processors) could rewrap PO exports into lingui's style instead, with zero CI steps. Trade-off: it lives in Crowdin's UI where repo contributors can't see or verify it. If a processor is set up later, change 1 becomes redundant and can be reverted.

Docs workflows are untouched: docs translations are whole MDX files copied verbatim, no PO reformatting involved.

Notes for after merge: main currently holds the Crowdin-formatted catalogs (from #24587), so the first pull run will produce one final normalization PR per project, then go quiet until there are actual new translations. Worth triggering both pull workflows manually once via workflow_dispatch to confirm.