### PR TITLE
fix(open-api): make request-body examples deterministic

### DIFF
--- a/.github/workflows/ci-breaking-changes.yaml
+++ b/.github/workflows/ci-breaking-changes.yaml
@@ -544,7 +544,7 @@ jobs:
                   "## 🚨 Removed Endpoints (" + (.missingEndpoints | length | tostring) + ")\n" +
                   (.missingEndpoints | map("- **" + .method + " " + .pathUrl + "**: " + (.summary // "")) | join("\n"))
                 else "" end,
-                ([.changedOperations[] | select(.incompatible)] | if length > 0 then
+                ([(.changedOperations // [])[] | select(.incompatible)] | if length > 0 then
                   "\n## ⚠️ Incompatible Operations (" + (length | tostring) + ")\n" +
                   (map("- **" + .httpMethod + " " + .pathUrl + "**: " + (.summary // "Modified operation")) | join("\n"))
                 else "" end),
@@ -615,7 +615,7 @@ jobs:
                   "## 🚨 Removed Endpoints (" + (.missingEndpoints | length | tostring) + ")\n" +
                   (.missingEndpoints | map("- **" + .method + " " + .pathUrl + "**: " + (.summary // "")) | join("\n"))
                 else "" end,
-                ([.changedOperations[] | select(.incompatible)] | if length > 0 then
+                ([(.changedOperations // [])[] | select(.incompatible)] | if length > 0 then
                   "\n## ⚠️ Incompatible Operations (" + (length | tostring) + ")\n" +
                   (map("- **" + .httpMethod + " " + .pathUrl + "**: " + (.summary // "Modified operation")) | join("\n"))
                 else "" end),
@@ -682,7 +682,7 @@ jobs:
                   "  Removed endpoints:\n" +
                   (.missingEndpoints | map("    - " + (.method // "?") + " " + (.pathUrl // "?")) | join("\n"))
                 else "" end),
-                ([.changedOperations[] | select(.incompatible)] | if length > 0 then
+                ([(.changedOperations // [])[] | select(.incompatible)] | if length > 0 then
                   "  Incompatible operations:\n" +
                   (map("    - " + (.httpMethod // "?") + " " + (.pathUrl // "?")) | join("\n"))
                 else "" end)
@@ -701,7 +701,7 @@ jobs:
                   "  Removed endpoints:\n" +
                   (.missingEndpoints | map("    - " + (.method // "?") + " " + (.pathUrl // "?")) | join("\n"))
                 else "" end),
-                ([.changedOperations[] | select(.incompatible)] | if length > 0 then
+                ([(.changedOperations // [])[] | select(.incompatible)] | if length > 0 then
                   "  Incompatible operations:\n" +
                   (map("    - " + (.httpMethod // "?") + " " + (.pathUrl // "?")) | join("\n"))
                 else "" end)

--- a/.github/workflows/ci-breaking-changes.yaml
+++ b/.github/workflows/ci-breaking-changes.yaml
@@ -544,10 +544,10 @@ jobs:
                   "## 🚨 Removed Endpoints (" + (.missingEndpoints | length | tostring) + ")\n" +
                   (.missingEndpoints | map("- **" + .method + " " + .pathUrl + "**: " + (.summary // "")) | join("\n"))
                 else "" end,
-                if (.changedOperations | length) > 0 then
-                  "\n## ⚠️ Changed Operations (" + (.changedOperations | length | tostring) + ")\n" +
-                  (.changedOperations | map("- **" + .method + " " + .pathUrl + "**: " + (.summary // "Modified operation")) | join("\n"))
-                else "" end,
+                ([.changedOperations[] | select(.incompatible)] | if length > 0 then
+                  "\n## ⚠️ Incompatible Operations (" + (length | tostring) + ")\n" +
+                  (map("- **" + .httpMethod + " " + .pathUrl + "**: " + (.summary // "Modified operation")) | join("\n"))
+                else "" end),
                 if (.newEndpoints | length) > 0 then
                   "\n## ✅ New Endpoints (" + (.newEndpoints | length | tostring) + ")\n" +
                   (.newEndpoints | map("- " + .method + " " + .pathUrl + ": " + (.summary // "")) | join("\n"))
@@ -615,10 +615,10 @@ jobs:
                   "## 🚨 Removed Endpoints (" + (.missingEndpoints | length | tostring) + ")\n" +
                   (.missingEndpoints | map("- **" + .method + " " + .pathUrl + "**: " + (.summary // "")) | join("\n"))
                 else "" end,
-                if (.changedOperations | length) > 0 then
-                  "\n## ⚠️ Changed Operations (" + (.changedOperations | length | tostring) + ")\n" +
-                  (.changedOperations | map("- **" + .method + " " + .pathUrl + "**: " + (.summary // "Modified operation")) | join("\n"))
-                else "" end,
+                ([.changedOperations[] | select(.incompatible)] | if length > 0 then
+                  "\n## ⚠️ Incompatible Operations (" + (length | tostring) + ")\n" +
+                  (map("- **" + .httpMethod + " " + .pathUrl + "**: " + (.summary // "Modified operation")) | join("\n"))
+                else "" end),
                 if (.newEndpoints | length) > 0 then
                   "\n## ✅ New Endpoints (" + (.newEndpoints | length | tostring) + ")\n" +
                   (.newEndpoints | map("- " + .method + " " + .pathUrl + ": " + (.summary // "")) | join("\n"))
@@ -682,9 +682,9 @@ jobs:
                   "  Removed endpoints:\n" +
                   (.missingEndpoints | map("    - " + (.method // "?") + " " + (.pathUrl // "?")) | join("\n"))
                 else "" end),
-                (if (.changedOperations | length) > 0 then
-                  "  Changed operations:\n" +
-                  (.changedOperations | map("    - " + (.method // "?") + " " + (.pathUrl // "?")) | join("\n"))
+                ([.changedOperations[] | select(.incompatible)] | if length > 0 then
+                  "  Incompatible operations:\n" +
+                  (map("    - " + (.httpMethod // "?") + " " + (.pathUrl // "?")) | join("\n"))
                 else "" end)
               ' rest-api-diff.json | sed '/^$/d'
               echo ""
@@ -701,9 +701,9 @@ jobs:
                   "  Removed endpoints:\n" +
                   (.missingEndpoints | map("    - " + (.method // "?") + " " + (.pathUrl // "?")) | join("\n"))
                 else "" end),
-                (if (.changedOperations | length) > 0 then
-                  "  Changed operations:\n" +
-                  (.changedOperations | map("    - " + (.method // "?") + " " + (.pathUrl // "?")) | join("\n"))
+                ([.changedOperations[] | select(.incompatible)] | if length > 0 then
+                  "  Incompatible operations:\n" +
+                  (map("    - " + (.httpMethod // "?") + " " + (.pathUrl // "?")) | join("\n"))
                 else "" end)
               ' rest-metadata-api-diff.json | sed '/^$/d'
               echo ""

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/__snapshots__/components.utils.spec.ts.snap
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/__snapshots__/components.utils.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`computeSchemaComponents Float without decimals 1`] = `
   "ObjectName": {
     "description": undefined,
     "example": {
-      "number2": 692.1852368365229,
+      "number2": 312.53387874865376,
     },
     "properties": {
       "number2": {
@@ -29,7 +29,7 @@ exports[`computeSchemaComponents Float without decimals 1`] = `
   "ObjectNameForUpdate": {
     "description": undefined,
     "example": {
-      "number2": 316.2001153750569,
+      "number2": 312.53387874865376,
     },
     "properties": {
       "number2": {
@@ -46,7 +46,7 @@ exports[`computeSchemaComponents Integer dataType with decimals 1`] = `
   "ObjectName": {
     "description": undefined,
     "example": {
-      "number1": 957.9316406203515,
+      "number1": 420.981408197018,
     },
     "properties": {
       "number1": {
@@ -70,7 +70,7 @@ exports[`computeSchemaComponents Integer dataType with decimals 1`] = `
   "ObjectNameForUpdate": {
     "description": undefined,
     "example": {
-      "number1": 533.6321196880441,
+      "number1": 420.981408197018,
     },
     "properties": {
       "number1": {
@@ -87,7 +87,7 @@ exports[`computeSchemaComponents Integer with a 0 decimals 1`] = `
   "ObjectName": {
     "description": undefined,
     "example": {
-      "number3": 686.8144267539021,
+      "number3": 240.28247834791884,
     },
     "properties": {
       "number3": {
@@ -111,7 +111,7 @@ exports[`computeSchemaComponents Integer with a 0 decimals 1`] = `
   "ObjectNameForUpdate": {
     "description": undefined,
     "example": {
-      "number3": 834.7910462254755,
+      "number3": 240.28247834791884,
     },
     "properties": {
       "number3": {

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
@@ -67,26 +67,26 @@ describe('computeSchemaComponents', () => {
     "description": "Object description",
     "example": {
       "fieldCurrency": {
-        "amountMicros": "284000000",
+        "amountMicros": "773000000",
         "currencyCode": "EUR",
       },
       "fieldEmails": {
         "additionalEmails": null,
-        "primaryEmail": "mina.gutmann9@hotmail.com",
+        "primaryEmail": "clair.runte69@yahoo.com",
       },
       "fieldFullName": {
-        "firstName": "Shad",
-        "lastName": "Osinski",
+        "firstName": "Maxie",
+        "lastName": "Davis",
       },
       "fieldLinks": {
         "primaryLinkLabel": "",
-        "primaryLinkUrl": "https://narrow-help.net/",
+        "primaryLinkUrl": "https://frivolous-lox.info/",
         "secondaryLinks": [],
       },
       "fieldMultiSelect": [
         "OPTION_1",
       ],
-      "fieldNumber": 346.2151663160047,
+      "fieldNumber": 352.6893054576472,
       "fieldPhones": {
         "additionalPhones": [],
         "primaryPhoneCallingCode": "+33",
@@ -582,26 +582,26 @@ describe('computeSchemaComponents', () => {
     "description": "Object description",
     "example": {
       "fieldCurrency": {
-        "amountMicros": "253000000",
+        "amountMicros": "773000000",
         "currencyCode": "EUR",
       },
       "fieldEmails": {
         "additionalEmails": null,
-        "primaryEmail": "keegan_donnelly96@hotmail.com",
+        "primaryEmail": "clair.runte69@yahoo.com",
       },
       "fieldFullName": {
-        "firstName": "Shad",
-        "lastName": "Jones",
+        "firstName": "Maxie",
+        "lastName": "Davis",
       },
       "fieldLinks": {
         "primaryLinkLabel": "",
-        "primaryLinkUrl": "https://unlawful-blowgun.biz",
+        "primaryLinkUrl": "https://frivolous-lox.info/",
         "secondaryLinks": [],
       },
       "fieldMultiSelect": [
         "OPTION_1",
       ],
-      "fieldNumber": 692.6302930536448,
+      "fieldNumber": 352.6893054576472,
       "fieldPhones": {
         "additionalPhones": [],
         "primaryPhoneCallingCode": "+33",

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/generate-random-field-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/generate-random-field-value.util.spec.ts
@@ -2,8 +2,11 @@ import { FieldMetadataType } from 'twenty-shared/types';
 
 import { generateRandomFieldValue } from 'src/engine/core-modules/open-api/utils/generate-random-field-value.util';
 
-const buildField = (name: string, type: FieldMetadataType) =>
-  ({ name, type }) as any;
+const buildField = (name: string, type: FieldMetadataType) => ({
+  name,
+  type,
+  options: null,
+});
 
 describe('generateRandomFieldValue', () => {
   // The document is diffed against main's in CI, so two generations of the same

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/generate-random-field-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/generate-random-field-value.util.spec.ts
@@ -1,0 +1,53 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { generateRandomFieldValue } from 'src/engine/core-modules/open-api/utils/generate-random-field-value.util';
+
+const buildField = (name: string, type: FieldMetadataType) =>
+  ({ name, type }) as any;
+
+describe('generateRandomFieldValue', () => {
+  // The document is diffed against main's in CI, so two generations of the same
+  // field have to agree or every operation reads as changed.
+  it.each([
+    FieldMetadataType.UUID,
+    FieldMetadataType.TEXT,
+    FieldMetadataType.EMAILS,
+    FieldMetadataType.LINKS,
+    FieldMetadataType.CURRENCY,
+    FieldMetadataType.FULL_NAME,
+    FieldMetadataType.ADDRESS,
+    FieldMetadataType.ACTOR,
+    FieldMetadataType.NUMBER,
+    FieldMetadataType.NUMERIC,
+    FieldMetadataType.DATE_TIME,
+  ])('returns a stable value for %s', (type) => {
+    const field = buildField('someField', type);
+
+    expect(generateRandomFieldValue({ field })).toEqual(
+      generateRandomFieldValue({ field }),
+    );
+  });
+
+  it('does not depend on the order fields are generated in', () => {
+    const first = buildField('firstField', FieldMetadataType.EMAILS);
+    const second = buildField('secondField', FieldMetadataType.EMAILS);
+
+    const inOrder = generateRandomFieldValue({ field: second });
+
+    generateRandomFieldValue({ field: first });
+
+    expect(generateRandomFieldValue({ field: second })).toEqual(inOrder);
+  });
+
+  it('gives different fields different values', () => {
+    expect(
+      generateRandomFieldValue({
+        field: buildField('alpha', FieldMetadataType.FULL_NAME),
+      }),
+    ).not.toEqual(
+      generateRandomFieldValue({
+        field: buildField('beta', FieldMetadataType.FULL_NAME),
+      }),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/generate-random-field-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/generate-random-field-value.util.ts
@@ -8,12 +8,17 @@ import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 import { type FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 
+type ExampleField = Pick<
+  FieldMetadataEntity | FlatFieldMetadata,
+  'name' | 'type' | 'options'
+>;
+
 // Its own instance so seeding cannot disturb the shared faker other callers use.
 const faker = new Faker({ locale: en });
 
 // CI diffs this document against the one main generates, so an example may only
 // depend on the field it describes. Field ids are per-workspace, hence the name.
-const seedForField = (field: FieldMetadataEntity | FlatFieldMetadata) => {
+const seedForField = (field: ExampleField) => {
   let seed = 0;
 
   for (const character of `${field.name}:${field.type}`) {
@@ -29,7 +34,7 @@ const EXAMPLE_REFERENCE_DATE = new Date('2024-01-01T00:00:00.000Z');
 export const generateRandomFieldValue = ({
   field,
 }: {
-  field: FieldMetadataEntity | FlatFieldMetadata;
+  field: ExampleField;
 }): FieldMetadataDefaultValue => {
   seedForField(field);
 

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/generate-random-field-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/generate-random-field-value.util.ts
@@ -1,22 +1,41 @@
-import { faker } from '@faker-js/faker';
+import { en, Faker } from '@faker-js/faker';
 import {
   type FieldMetadataDefaultValue,
   FieldMetadataType,
 } from 'twenty-shared/types';
 import { assertUnreachable, isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 import { type FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+
+// Its own instance so seeding cannot disturb the shared faker other callers use.
+const faker = new Faker({ locale: en });
+
+// CI diffs this document against the one main generates, so an example may only
+// depend on the field it describes. Field ids are per-workspace, hence the name.
+const seedForField = (field: FieldMetadataEntity | FlatFieldMetadata) => {
+  let seed = 0;
+
+  for (const character of `${field.name}:${field.type}`) {
+    seed = (seed * 31 + character.charCodeAt(0)) | 0;
+  }
+
+  faker.seed(Math.abs(seed));
+};
+
+// Anchors faker.date, which is otherwise relative to the moment of generation.
+const EXAMPLE_REFERENCE_DATE = new Date('2024-01-01T00:00:00.000Z');
 
 export const generateRandomFieldValue = ({
   field,
 }: {
   field: FieldMetadataEntity | FlatFieldMetadata;
 }): FieldMetadataDefaultValue => {
+  seedForField(field);
+
   switch (field.type) {
     case FieldMetadataType.UUID: {
-      return v4();
+      return faker.string.uuid();
     }
 
     case FieldMetadataType.TEXT: {
@@ -41,7 +60,7 @@ export const generateRandomFieldValue = ({
 
     case FieldMetadataType.DATE:
     case FieldMetadataType.DATE_TIME: {
-      return faker.date.soon();
+      return faker.date.soon({ refDate: EXAMPLE_REFERENCE_DATE });
     }
 
     case FieldMetadataType.BOOLEAN: {


### PR DESCRIPTION
## Context

Follow-up to #24544. While reading that job's failure output we noticed it listed 93 "changed operations" covering `/duplicates`, `/merge` and every base collection path, which read as a huge unintended breaking change. It was not: none of the 93 were breaking, and the same 93 are reported on **every** run of the breaking-changes job, including runs where nothing changed.

Two independent problems, both fixed here.

## 1. The examples were random

`generateRandomFieldValue` drew from the shared faker with no seed and used `v4()` for UUID fields, so the OpenAPI document differed on every generation.

The breaking-changes job boots a server on the PR branch and one on main, generates a document from each, and diffs them. Since the examples are random, every operation with a request body differs between the two documents. From the #24544 artifact:

```
changedOperations: 93
of which incompatible: 0
changed ops whose ONLY difference is the request-body example: 93 / 93
```

So the noise never failed anything on its own (`incompatible: false`), which is why it went unnoticed. It only got printed when the job failed for another reason, and there it buried the real signal.

Examples now come from a private `Faker` instance seeded per field, so a field's example depends on the field and nothing else: not on generation order, not on when it ran. `faker.date.soon` is anchored to a fixed reference date for the same reason. The instance is private so seeding cannot disturb the shared faker other callers use.

The seed derives from the field **name**, not its id, because ids differ between two freshly created workspaces and the two documents have to agree.

The snapshot delta shows the second half of this. The same field used to get a different example in `ObjectName` and in `ObjectNameForUpdate` and now gets one value:

```diff
   "ObjectNameForUpdate": {
       "fieldCurrency": {
-        "amountMicros": "253000000",
+        "amountMicros": "773000000",   // same as ObjectName now
-      "fieldNumber": 692.6302930536448,
+      "fieldNumber": 352.6893054576472,
```

## 2. The job's own failure output was unreadable

The printer dumped **every** changed operation whether or not it was incompatible, and read `.method` where openapi-diff puts `httpMethod` on changed operations (it is `.method` on `newEndpoints`/`missingEndpoints` only). So all 93 rendered as `?`:

```
  Changed operations:
    - ? /companies
    - ? /companies/duplicates
    - ? /companies/merge
    ... 90 more
```

Narrowed to `select(.incompatible)` and reading `httpMethod`. Replayed against the real artifact from #24544, the failure summary goes from 93 unattributed lines to the 66 removed endpoints that actually broke the job:

```
  Removed endpoints:
    - PATCH /restore/attachments/{id}
    - PATCH /restore/attachments
    ... 64 more
```

The non-breaking-changes log line still counts all changed operations, since "N operations differ, none breaking" is the useful number there.

## Test plan

- New `generate-random-field-value.util.spec.ts`: 13 tests covering stability across 11 field types, independence from generation order, and that distinct fields still get distinct values.
- `npx jest src/engine/core-modules/open-api --config=jest.config.mjs` — 4 suites, 26 tests, 4 snapshots passing.
- Both rewritten jq programs run against the real `rest-api-diff.json` from #24544: 67 output lines, zero `?` placeholders.
- oxfmt and oxlint clean; typecheck introduces no new errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_016pz8KcZkNpYoqngfKk5Yzm)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

