### PR TITLE
Fix legacy activity junction target backfill

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.ts
@@ -18,6 +18,13 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
 
+// These identifiers predate deterministic system relation identifiers and
+// remain in standard workspaces provisioned before that migration.
+const LEGACY_NOTE_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-38ca-4aab-92f5-8a605ca2e4c5';
+const LEGACY_TASK_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-c8a0-4e85-a016-87e2349cfbec';
+
 // The junction target points at one member of the target morph. Consumers expand
 // the whole morph group from it, so any member identifies the polymorphic edge.
 const ACTIVITY_JUNCTIONS = [
@@ -25,15 +32,19 @@ const ACTIVITY_JUNCTIONS = [
     label: 'note.noteTargets',
     junctionRelationFieldUniversalIdentifier:
       STANDARD_OBJECTS.note.fields.noteTargets.universalIdentifier,
-    junctionTargetFieldUniversalIdentifier:
+    junctionTargetFieldUniversalIdentifiers: [
       STANDARD_OBJECTS.noteTarget.fields.targetPerson.universalIdentifier,
+      LEGACY_NOTE_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER,
+    ],
   },
   {
     label: 'task.taskTargets',
     junctionRelationFieldUniversalIdentifier:
       STANDARD_OBJECTS.task.fields.taskTargets.universalIdentifier,
-    junctionTargetFieldUniversalIdentifier:
+    junctionTargetFieldUniversalIdentifiers: [
       STANDARD_OBJECTS.taskTarget.fields.targetPerson.universalIdentifier,
+      LEGACY_TASK_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER,
+    ],
   },
 ] as const;
 
@@ -188,7 +199,7 @@ export class BackfillActivityTargetsJunctionTargetCommand extends ProvisionedWor
     const {
       label,
       junctionRelationFieldUniversalIdentifier,
-      junctionTargetFieldUniversalIdentifier,
+      junctionTargetFieldUniversalIdentifiers,
     } = activityJunction;
 
     const junctionRelationFlatFieldMetadata =
@@ -221,9 +232,12 @@ export class BackfillActivityTargetsJunctionTargetCommand extends ProvisionedWor
     }
 
     const junctionTargetFlatFieldMetadata =
-      flatFieldMetadataMaps.byUniversalIdentifier[
-        junctionTargetFieldUniversalIdentifier
-      ];
+      junctionTargetFieldUniversalIdentifiers
+        .map(
+          (universalIdentifier) =>
+            flatFieldMetadataMaps.byUniversalIdentifier[universalIdentifier],
+        )
+        .find(isDefined);
 
     if (!isDefined(junctionTargetFlatFieldMetadata)) {
       this.logger.warn(

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/__tests__/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/__tests__/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.spec.ts
@@ -1,0 +1,190 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import { type Repository } from 'typeorm';
+
+import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { BackfillActivityTargetsJunctionTargetCommand } from 'src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command';
+import { invalidateFieldMetadataCache } from 'src/database/commands/upgrade-version-command/utils/invalidate-field-metadata-cache.util';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+jest.mock(
+  'src/database/commands/upgrade-version-command/utils/invalidate-field-metadata-cache.util',
+);
+
+const invalidateFieldMetadataCacheMock = jest.mocked(
+  invalidateFieldMetadataCache,
+);
+
+const WORKSPACE_ID = '20202020-0000-0000-0000-000000000001';
+const NOTE_TARGET_OBJECT_METADATA_ID =
+  '20202020-0000-0000-0000-000000000002';
+const TASK_TARGET_OBJECT_METADATA_ID =
+  '20202020-0000-0000-0000-000000000003';
+const NOTE_TARGETS_FIELD_METADATA_ID =
+  '20202020-0000-0000-0000-000000000004';
+const TASK_TARGETS_FIELD_METADATA_ID =
+  '20202020-0000-0000-0000-000000000005';
+const LEGACY_NOTE_TARGET_PERSON_FIELD_METADATA_ID =
+  '20202020-0000-0000-0000-000000000006';
+const LEGACY_TASK_TARGET_PERSON_FIELD_METADATA_ID =
+  '20202020-0000-0000-0000-000000000007';
+const LEGACY_NOTE_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-38ca-4aab-92f5-8a605ca2e4c5';
+const LEGACY_TASK_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-c8a0-4e85-a016-87e2349cfbec';
+
+const buildFlatFieldMetadata = (
+  overrides: Partial<FlatFieldMetadata>,
+): FlatFieldMetadata =>
+  ({
+    id: '20202020-0000-0000-0000-000000000099',
+    universalIdentifier: '20202020-0000-0000-0000-000000000098',
+    type: FieldMetadataType.TEXT,
+    settings: null,
+    ...overrides,
+  }) as FlatFieldMetadata;
+
+const buildFlatFieldMetadataMaps = (
+  flatFieldMetadatas: FlatFieldMetadata[],
+): FlatEntityMaps<FlatFieldMetadata> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    flatFieldMetadatas.map((flatFieldMetadata) => [
+      flatFieldMetadata.universalIdentifier,
+      flatFieldMetadata,
+    ]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    flatFieldMetadatas.map((flatFieldMetadata) => [
+      flatFieldMetadata.id,
+      flatFieldMetadata.universalIdentifier,
+    ]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+const NOTE_TARGETS_FLAT_FIELD_METADATA = buildFlatFieldMetadata({
+  id: NOTE_TARGETS_FIELD_METADATA_ID,
+  universalIdentifier:
+    STANDARD_OBJECTS.note.fields.noteTargets.universalIdentifier,
+  type: FieldMetadataType.RELATION,
+  relationTargetObjectMetadataId: NOTE_TARGET_OBJECT_METADATA_ID,
+  settings: { relationType: RelationType.ONE_TO_MANY },
+});
+
+const TASK_TARGETS_FLAT_FIELD_METADATA = buildFlatFieldMetadata({
+  id: TASK_TARGETS_FIELD_METADATA_ID,
+  universalIdentifier:
+    STANDARD_OBJECTS.task.fields.taskTargets.universalIdentifier,
+  type: FieldMetadataType.RELATION,
+  relationTargetObjectMetadataId: TASK_TARGET_OBJECT_METADATA_ID,
+  settings: { relationType: RelationType.ONE_TO_MANY },
+});
+
+const LEGACY_NOTE_TARGET_PERSON_FLAT_FIELD_METADATA = buildFlatFieldMetadata({
+  id: LEGACY_NOTE_TARGET_PERSON_FIELD_METADATA_ID,
+  universalIdentifier: LEGACY_NOTE_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER,
+  objectMetadataId: NOTE_TARGET_OBJECT_METADATA_ID,
+  type: FieldMetadataType.RELATION,
+  settings: { relationType: RelationType.MANY_TO_ONE },
+});
+
+const LEGACY_TASK_TARGET_PERSON_FLAT_FIELD_METADATA = buildFlatFieldMetadata({
+  id: LEGACY_TASK_TARGET_PERSON_FIELD_METADATA_ID,
+  universalIdentifier: LEGACY_TASK_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER,
+  objectMetadataId: TASK_TARGET_OBJECT_METADATA_ID,
+  type: FieldMetadataType.RELATION,
+  settings: { relationType: RelationType.MANY_TO_ONE },
+});
+
+describe('BackfillActivityTargetsJunctionTargetCommand', () => {
+  let command: BackfillActivityTargetsJunctionTargetCommand;
+  let findOneMock: jest.Mock;
+  let updateMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    findOneMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        settings: { relationType: RelationType.ONE_TO_MANY },
+      })
+      .mockResolvedValueOnce({
+        settings: { relationType: RelationType.ONE_TO_MANY },
+      });
+    updateMock = jest.fn();
+
+    const transactionalRepository = {
+      findOne: findOneMock,
+      update: updateMock,
+    };
+    const fieldMetadataRepository = {
+      manager: {
+        transaction: jest.fn(
+          async (
+            callback: (entityManager: {
+              getRepository: () => typeof transactionalRepository;
+            }) => Promise<string[]>,
+          ) =>
+            callback({
+              getRepository: () => transactionalRepository,
+            }),
+        ),
+      },
+    } as unknown as Repository<FieldMetadataEntity>;
+
+    command = new BackfillActivityTargetsJunctionTargetCommand(
+      {} as WorkspaceIteratorService,
+      {
+        getOrRecompute: jest.fn().mockResolvedValue({
+          flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+            NOTE_TARGETS_FLAT_FIELD_METADATA,
+            TASK_TARGETS_FLAT_FIELD_METADATA,
+            LEGACY_NOTE_TARGET_PERSON_FLAT_FIELD_METADATA,
+            LEGACY_TASK_TARGET_PERSON_FLAT_FIELD_METADATA,
+          ]),
+        }),
+      } as unknown as WorkspaceCacheService,
+      {} as WorkspaceMigrationRunnerService,
+      fieldMetadataRepository,
+    );
+  });
+
+  it('backfills legacy note and task target person relation identifiers', async () => {
+    await command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(updateMock).toHaveBeenNthCalledWith(
+      1,
+      { id: NOTE_TARGETS_FIELD_METADATA_ID, workspaceId: WORKSPACE_ID },
+      {
+        settings: {
+          relationType: RelationType.ONE_TO_MANY,
+          junctionTargetFieldId: LEGACY_NOTE_TARGET_PERSON_FIELD_METADATA_ID,
+        },
+      },
+    );
+    expect(updateMock).toHaveBeenNthCalledWith(
+      2,
+      { id: TASK_TARGETS_FIELD_METADATA_ID, workspaceId: WORKSPACE_ID },
+      {
+        settings: {
+          relationType: RelationType.ONE_TO_MANY,
+          junctionTargetFieldId: LEGACY_TASK_TARGET_PERSON_FIELD_METADATA_ID,
+        },
+      },
+    );
+    expect(invalidateFieldMetadataCacheMock).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      workspaceMigrationRunnerService: expect.anything(),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- prefer the current deterministic note/task target-person field identifiers
- fall back to the legacy standard person relation identifiers still present in older workspaces
- retain the existing junction object, relation type, and dangling-setting validation
- add regression coverage for both legacy note and task target relations

## Why

The v2.33 command completed on dev/main but skipped 7 active and 2 suspended non-deleted workspaces. Their standard noteTarget.person and taskTarget.person fields predate deterministic system relation identifiers, so looking up only the current targetPerson identifiers returns no field.

The normal upgrade cursor already records this command as completed on dev/main. After this patch is deployed there, rerun the named workspace command directly:

    yarn command:prod upgrade:2-33:backfill-activity-targets-junction-target --dry-run
    yarn command:prod upgrade:2-33:backfill-activity-targets-junction-target

The direct command is idempotent and does not rewrite upgradeMigration history.

## Test plan

- focused Jest regression spec passes
- twenty-server diff lint and formatting pass
- after deployment, dry-run should report the 9 affected workspaces
- after the direct run, every non-deleted note.noteTargets and task.taskTargets relation should have a valid junctionTargetFieldId

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

