### PR TITLE
fix(server): deep-merge custom AI providers into the built-in catalog

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/provider-config.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/provider-config.service.ts
@@ -7,6 +7,7 @@ import { DefaultAiCatalogService } from 'src/engine/metadata-modules/ai/ai-model
 import { type AiProviderConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-provider-config.type';
 import { type AiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-providers-config.type';
 import { extractConfigVariableName } from 'src/engine/metadata-modules/ai/ai-models/utils/extract-config-variable-name.util';
+import { mergeAiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/utils/merge-ai-providers-config.util';
 
 @Injectable()
 export class ProviderConfigService {
@@ -28,7 +29,7 @@ export class ProviderConfigService {
     const catalog = this.resolveTemplates(rawCatalog);
     const custom = this.twentyConfigService.get('AI_PROVIDERS');
 
-    return { ...catalog, ...custom };
+    return mergeAiProvidersConfig(catalog, custom);
   }
 
   private resolveTemplates(providers: AiProvidersConfig): AiProvidersConfig {

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/__tests__/merge-ai-providers-config.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/__tests__/merge-ai-providers-config.util.spec.ts
@@ -1,0 +1,106 @@
+import { type AiProviderConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-provider-config.type';
+import { type AiProviderModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.type';
+import { type AiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-providers-config.type';
+import { mergeAiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/utils/merge-ai-providers-config.util';
+
+const buildModel = (name: string, label = name): AiProviderModelConfig =>
+  ({ name, label, modelFamily: 'MISTRAL' }) as AiProviderModelConfig;
+
+const buildMistralProvider = (
+  overrides: Partial<AiProviderConfig>,
+): AiProviderConfig =>
+  ({
+    npm: '@ai-sdk/mistral',
+    label: 'Mistral',
+    ...overrides,
+  }) as AiProviderConfig;
+
+const CATALOG: AiProvidersConfig = {
+  mistral: buildMistralProvider({
+    apiKey: 'catalog-key',
+    models: [buildModel('mistral-medium'), buildModel('mistral-small')],
+  }),
+  openai: {
+    npm: '@ai-sdk/openai',
+    label: 'OpenAI',
+    models: [buildModel('gpt-5')],
+  } as AiProviderConfig,
+};
+
+const modelNamesOf = (providers: AiProvidersConfig, providerName: string) =>
+  providers[providerName].models?.map((model) => model.name);
+
+describe('mergeAiProvidersConfig', () => {
+  it('should keep the catalog models when a custom entry only overrides credentials', () => {
+    const merged = mergeAiProvidersConfig(CATALOG, {
+      mistral: buildMistralProvider({ apiKey: 'custom-key' }),
+    });
+
+    expect(merged.mistral.apiKey).toBe('custom-key');
+    expect(modelNamesOf(merged, 'mistral')).toEqual([
+      'mistral-medium',
+      'mistral-small',
+    ]);
+  });
+
+  it('should add custom models on top of the catalog ones', () => {
+    const merged = mergeAiProvidersConfig(CATALOG, {
+      mistral: buildMistralProvider({
+        models: [buildModel('mistral-private')],
+      }),
+    });
+
+    expect(modelNamesOf(merged, 'mistral')).toEqual([
+      'mistral-medium',
+      'mistral-small',
+      'mistral-private',
+    ]);
+  });
+
+  it('should let a custom model replace the catalog model of the same name', () => {
+    const merged = mergeAiProvidersConfig(CATALOG, {
+      mistral: buildMistralProvider({
+        models: [buildModel('mistral-small', 'Renamed')],
+      }),
+    });
+
+    expect(modelNamesOf(merged, 'mistral')).toEqual([
+      'mistral-medium',
+      'mistral-small',
+    ]);
+    expect(
+      merged.mistral.models?.find((model) => model.name === 'mistral-small')
+        ?.label,
+    ).toBe('Renamed');
+  });
+
+  it('should keep providers that the custom config does not mention', () => {
+    const merged = mergeAiProvidersConfig(CATALOG, {
+      mistral: buildMistralProvider({ apiKey: 'custom-key' }),
+    });
+
+    expect(modelNamesOf(merged, 'openai')).toEqual(['gpt-5']);
+  });
+
+  it('should add a provider that only exists in the custom config', () => {
+    const merged = mergeAiProvidersConfig(CATALOG, {
+      selfHosted: {
+        npm: '@ai-sdk/openai-compatible',
+        label: 'Self hosted',
+        baseUrl: 'https://llm.internal',
+        models: [buildModel('local-model')],
+      } as AiProviderConfig,
+    });
+
+    expect(merged.selfHosted.baseUrl).toBe('https://llm.internal');
+    expect(Object.keys(merged).sort()).toEqual([
+      'mistral',
+      'openai',
+      'selfHosted',
+    ]);
+  });
+
+  it('should leave the catalog untouched when there is no custom config', () => {
+    expect(mergeAiProvidersConfig(CATALOG, {})).toEqual(CATALOG);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/merge-ai-providers-config.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/merge-ai-providers-config.util.ts
@@ -1,0 +1,55 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type AiProviderModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.type';
+import { type AiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-providers-config.type';
+
+const mergeProviderModels = (
+  catalogModels: AiProviderModelConfig[] | undefined,
+  customModels: AiProviderModelConfig[] | undefined,
+): AiProviderModelConfig[] | undefined => {
+  if (!isDefined(customModels)) {
+    return catalogModels;
+  }
+
+  if (!isDefined(catalogModels)) {
+    return customModels;
+  }
+
+  const customModelNames = new Set(customModels.map((model) => model.name));
+
+  return [
+    ...catalogModels.filter((model) => !customModelNames.has(model.name)),
+    ...customModels,
+  ];
+};
+
+export const mergeAiProvidersConfig = (
+  catalog: AiProvidersConfig,
+  custom: AiProvidersConfig,
+): AiProvidersConfig => {
+  const merged: AiProvidersConfig = { ...catalog };
+
+  for (const [providerName, customProvider] of Object.entries(custom)) {
+    const catalogProvider = merged[providerName];
+
+    if (!isDefined(catalogProvider)) {
+      merged[providerName] = customProvider;
+      continue;
+    }
+
+    // A custom entry usually only carries credentials or an endpoint, so the
+    // catalog models have to survive it instead of being replaced wholesale.
+    const models = mergeProviderModels(
+      catalogProvider.models,
+      customProvider.models,
+    );
+
+    merged[providerName] = {
+      ...catalogProvider,
+      ...customProvider,
+      ...(isDefined(models) ? { models } : {}),
+    };
+  }
+
+  return merged;
+};


### PR DESCRIPTION
Fixes #24286

`AI_PROVIDERS` documents itself as "deep-merged on top of the built-in catalog", but `ProviderConfigService` merges it with `{ ...catalog, ...custom }` — a one-level spread that replaces the whole provider entry. A custom entry for a built-in provider carrying only credentials therefore drops that provider's models, and the admin panel lists none.

This is not only a self-hosting config edge case: the admin panel writes `AI_PROVIDERS` itself, and `addAiProvider` assigns `customProviders[providerName] = providerConfig` without merging anything.

Merging is now two-tiered. Provider fields still let the custom entry win, so credentials and endpoints override exactly as before. Models are merged by name, so catalog models survive unless a custom model shadows them — which also covers `addModelToProvider`, since it appends to `AI_PROVIDERS[provider].models` and would otherwise drop the catalog list all the same.

Verified on a production build with a custom `mistral` entry: the provider page goes from 0 to 30 models while the custom API key still wins. Six unit tests cover credentials-only overrides, added and shadowing models, untouched providers and custom-only providers; the ai module's 241 tests, lint and typecheck are green.

**Mistral provider page with a custom `AI_PROVIDERS` entry — before**

<img width="1280" height="720" alt="before-fix-mistral-models" src="https://github.com/user-attachments/assets/86926497-a95c-4d1c-9061-0e3a58d96a34" />

**After**

<img width="1280" height="720" alt="after-fix-mistral-models" src="https://github.com/user-attachments/assets/ad5a37ec-85ce-4efe-ae1b-7a665248191d" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

