### PR TITLE
Stop writing deprecated timeline activity names

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/listeners/calendar-event-participant.listener.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/listeners/calendar-event-participant.listener.ts
@@ -79,7 +79,7 @@ export class CalendarEventParticipantListener {
           }
 
           return {
-            name: 'calendarEvent.linked',
+            legacyName: 'calendarEvent.linked',
             timelineActivityTypeId,
             properties: {},
             objectSingularName: 'person',

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant.listener.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant.listener.ts
@@ -77,7 +77,7 @@ export class MessageParticipantListener {
           }
 
           return {
-            name: 'message.linked',
+            legacyName: 'message.linked',
             timelineActivityTypeId,
             properties: {},
             objectSingularName: 'person',

--- a/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
+++ b/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
@@ -107,7 +107,7 @@ export class TimelineActivityRepository {
         const nameMergeKey = buildMergeKey({
           recordId: payload.recordId,
           workspaceMemberId: payload.workspaceMemberId,
-          discriminator: `name:${payload.name}`,
+          discriminator: `name:${payload.legacyName}`,
         });
 
         const recentTimelineActivity = [
@@ -187,7 +187,7 @@ export class TimelineActivityRepository {
         },
         {
           ...whereConditions,
-          name: In(payloads.map((payload) => payload.name)),
+          name: In(payloads.map((payload) => payload.legacyName)),
         },
       ],
       order: { createdAt: 'DESC' },
@@ -217,7 +217,8 @@ export class TimelineActivityRepository {
 
     return timelineActivityTypeORMRepository.insert(
       payloads.map((payload) => ({
-        name: payload.name,
+        // Omitting a standard text field applies its empty-string default.
+        name: null,
         timelineActivityTypeId: payload.timelineActivityTypeId,
         properties: payload.properties,
         workspaceMemberId: payload.workspaceMemberId,

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
@@ -62,7 +62,7 @@ const keepDiffOnly = (
 // cached name and the persisted properties differ.
 const buildLinkedPayload = ({
   rule,
-  name,
+  legacyName,
   timelineActivityTypeId,
   target,
   workspaceMemberId,
@@ -71,7 +71,7 @@ const buildLinkedPayload = ({
   properties,
 }: {
   rule: TimelineActivityRule;
-  name: string;
+  legacyName: string;
   timelineActivityTypeId: string;
   target: ResolvedTimelineActivityTarget;
   workspaceMemberId: string | undefined;
@@ -79,7 +79,7 @@ const buildLinkedPayload = ({
   linkedRecordCachedName: string | undefined;
   properties: ObjectRecordBaseEvent['properties'];
 }): TimelineActivityPayload => ({
-  name,
+  legacyName,
   timelineActivityTypeId,
   objectSingularName: target.targetObjectNameSingular,
   recordId: target.targetRecordId,
@@ -279,7 +279,7 @@ export class TimelineActivityService {
 
         return [
           {
-            name: `${nameSingular}.${action}`,
+            legacyName: `${nameSingular}.${action}`,
             timelineActivityTypeId,
             objectSingularName: nameSingular,
             recordId: event.recordId,
@@ -303,7 +303,7 @@ export class TimelineActivityService {
       (targetsBySourceRecordId.get(event.recordId) ?? []).map((target) =>
         buildLinkedPayload({
           rule,
-          name: `linked-${rule.sourceFlatObjectMetadata.nameSingular}.${action}`,
+          legacyName: `linked-${rule.sourceFlatObjectMetadata.nameSingular}.${action}`,
           timelineActivityTypeId,
           target,
           workspaceMemberId: event.workspaceMemberId,
@@ -400,7 +400,7 @@ export class TimelineActivityService {
       .map(({ event, target, sourceRecordId }) =>
         buildLinkedPayload({
           rule,
-          name: `linked-${rule.sourceFlatObjectMetadata.nameSingular}.${action}`,
+          legacyName: `linked-${rule.sourceFlatObjectMetadata.nameSingular}.${action}`,
           timelineActivityTypeId,
           target,
           workspaceMemberId: event.workspaceMemberId,

--- a/packages/twenty-server/src/modules/timeline/types/timeline-activity-payload.ts
+++ b/packages/twenty-server/src/modules/timeline/types/timeline-activity-payload.ts
@@ -6,7 +6,8 @@ export type TimelineActivityPayload = {
   linkedRecordId?: string;
   linkedRecordCachedName?: string;
   workspaceMemberId?: string;
-  name: string;
+  // Kept only to merge with name-only rows written during a rolling upgrade.
+  legacyName: string;
   timelineActivityTypeId: string;
   recordId: string;
   objectSingularName?: string;

--- a/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
@@ -104,6 +104,18 @@ const findTimelineActivities = async (
 
 const TEST_SCHEMA_NAME = 'workspace_1wgvd1injqtife6y4rvfbu3h5';
 
+const expectDeprecatedNameNotToBeStored = async (
+  timelineActivityId: string,
+): Promise<void> => {
+  const [timelineActivity]: { name: string | null }[] =
+    await global.testDataSource.query(
+      `SELECT "name" FROM "${TEST_SCHEMA_NAME}"."timelineActivity" WHERE "id" = $1`,
+      [timelineActivityId],
+    );
+
+  expect(timelineActivity.name).toBeNull();
+};
+
 const findTimelineActivityRowsByLinkedRecordId = async ({
   timelineActivityTypeId,
   linkedRecordId,
@@ -235,7 +247,9 @@ describe('timeline activity write path (integration)', () => {
       expect(timelineActivities[0].timelineActivityTypeId).toBe(
         timelineActivityTypeIdForOrThrow('created'),
       );
-      expect(timelineActivities[0].name).toBe('company.created');
+      // Nullable text is exposed as its empty-string equivalent by TwentyORM.
+      expect(timelineActivities[0].name).toBe('');
+      await expectDeprecatedNameNotToBeStored(timelineActivities[0].id);
       expect(timelineActivities[0].targetCompanyId).toBe(COMPANY_ID);
       expect(timelineActivities[0].linkedRecordId).toBeNull();
     });
@@ -267,7 +281,7 @@ describe('timeline activity write path (integration)', () => {
       });
     });
 
-    it('should merge two updates from the same author into a single entry', async () => {
+    it('should merge into a recent name-only entry written by an older server', async () => {
       await createRecord({
         objectMetadataSingularName: 'company',
         data: {
@@ -285,6 +299,24 @@ describe('timeline activity write path (integration)', () => {
       });
       await waitForAllJobsToFinish();
 
+      const [timelineActivityWrittenByCurrentServer] =
+        await findTimelineActivities({
+          targetCompanyId: { eq: MERGE_COMPANY_ID },
+          timelineActivityTypeId: {
+            eq: timelineActivityTypeIdForOrThrow('updated'),
+          },
+        });
+
+      expect(timelineActivityWrittenByCurrentServer.name).toBe('');
+      await expectDeprecatedNameNotToBeStored(
+        timelineActivityWrittenByCurrentServer.id,
+      );
+
+      await global.testDataSource.query(
+        `UPDATE "${TEST_SCHEMA_NAME}"."timelineActivity" SET "name" = $1, "timelineActivityTypeId" = NULL WHERE "id" = $2`,
+        ['company.updated', timelineActivityWrittenByCurrentServer.id],
+      );
+
       await updateRecord({
         objectMetadataSingularName: 'company',
         recordId: MERGE_COMPANY_ID,
@@ -301,6 +333,10 @@ describe('timeline activity write path (integration)', () => {
       });
 
       expect(timelineActivities).toHaveLength(1);
+      expect(timelineActivities[0].id).toBe(
+        timelineActivityWrittenByCurrentServer.id,
+      );
+      expect(timelineActivities[0].name).toBe('company.updated');
       expect(timelineActivities[0].properties).toEqual({
         diff: {
           name: { before: 'Merge Window', after: 'Merge Window Twice' },
@@ -411,6 +447,8 @@ describe('timeline activity write path (integration)', () => {
       });
 
       expect(timelineActivities).toHaveLength(1);
+      expect(timelineActivities[0].name).toBe('');
+      await expectDeprecatedNameNotToBeStored(timelineActivities[0].id);
       expect(timelineActivities[0].linkedRecordId).toBe(NOTE_ID);
       expect(timelineActivities[0].linkedRecordCachedName).toBe('Linked note');
       expect(timelineActivities[0].linkedObjectMetadataId).not.toBeNull();


### PR DESCRIPTION
## Summary

- stop persisting the deprecated `timelineActivity.name` discriminator from record, message, and calendar activity writers
- retain the derived legacy name only inside the repository so 2.34 servers can still merge with recent name-only rows written during a rolling upgrade
- heal a matched legacy row by setting its `timelineActivityTypeId`
- cover both type-only inserts and mixed-version merging in the database integration suite

## Release sequencing

This is the first 2.34 cleanup step after #24568. It is safe to merge after the 2.33 release branch/tag is cut. It intentionally keeps the workspace field, GraphQL surface, read fallback, and legacy merge query for the entire 2.34 window.

The next PR will run the 2.34 catch-up backfill and audit. The read fallback and physical column removal remain later cleanup steps after the compatibility window.

Part of https://github.com/twentyhq/core-team-issues/issues/2785

## Validation

- `npx tsgo -p tsconfig.json --noEmit` in `packages/twenty-server`
- type-aware oxlint and oxfmt on all six changed TypeScript files
- full database integration scenario added; local execution was blocked before test startup because Docker Desktop did not expose its engine, so CI is the database-backed gate