### PR TITLE
Enforce timeline activity type resolution

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/services/timeline-activity-seeder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/services/timeline-activity-seeder.service.ts
@@ -7,7 +7,10 @@ import { capitalize } from 'twenty-shared/utils';
 
 import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metadata/object-metadata.service';
 import { TimelineActivityTypeCacheService } from 'src/modules/timeline/services/timeline-activity-type-cache.service';
-import { type TimelineActivityTypeResolver } from 'src/modules/timeline/utils/resolve-timeline-activity-type-id.util';
+import {
+  type ResolveTimelineActivityTypeIdArgs,
+  resolveTimelineActivityTypeIdOrThrow,
+} from 'src/modules/timeline/utils/resolve-timeline-activity-type-id.util';
 import { type WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
 import { CALENDAR_EVENT_DATA_SEEDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/calendar-event-data-seeds.constant';
 import {
@@ -34,6 +37,10 @@ import { type TimelineActivityWorkspaceEntity } from 'src/modules/timeline/stand
 import { buildTimelineActivityRelatedMorphFieldMetadataName } from 'src/modules/timeline/utils/timeline-activity-related-morph-field-metadata-name-builder.util';
 
 type RecordSeedWithId = Pick<ObjectRecord, 'id'> & Record<string, unknown>;
+
+type RequiredTimelineActivityTypeResolver = (
+  args: ResolveTimelineActivityTypeIdArgs,
+) => string;
 
 type TimelineActivitySeedData = Pick<
   TimelineActivityWorkspaceEntity,
@@ -64,7 +71,7 @@ type CreateTimelineActivityParams = {
   entityType: string;
   recordSeed: RecordSeedWithId;
   index: number;
-  resolveTimelineActivityTypeId: TimelineActivityTypeResolver;
+  resolveTimelineActivityTypeId: RequiredTimelineActivityTypeResolver;
 };
 
 type CreateLinkedActivityParams = {
@@ -74,7 +81,7 @@ type CreateLinkedActivityParams = {
   activityIndex: number;
   linkedObjectMetadataId: string;
   targetInfo: ActivityTargetInfo;
-  resolveTimelineActivityTypeId: TimelineActivityTypeResolver;
+  resolveTimelineActivityTypeId: RequiredTimelineActivityTypeResolver;
 };
 
 type EntityConfig = {
@@ -137,6 +144,14 @@ export class TimelineActivitySeederService {
       await this.timelineActivityTypeCacheService.getTimelineActivityTypeResolver(
         workspaceId,
       );
+    const resolveRequiredTimelineActivityTypeId = (
+      args: ResolveTimelineActivityTypeIdArgs,
+    ) =>
+      resolveTimelineActivityTypeIdOrThrow({
+        ...args,
+        resolveTimelineActivityTypeId,
+        workspaceId,
+      });
     let activityIndex = 0;
 
     const entityConfigs: EntityConfig[] = [
@@ -158,7 +173,7 @@ export class TimelineActivitySeederService {
           entityType: type,
           recordSeed: seed,
           index,
-          resolveTimelineActivityTypeId,
+          resolveTimelineActivityTypeId: resolveRequiredTimelineActivityTypeId,
         });
 
         timelineActivities.push(activity);
@@ -180,7 +195,7 @@ export class TimelineActivitySeederService {
           linkedObjectMetadataId,
           calendarEventParticipants,
           messageParticipants,
-          resolveTimelineActivityTypeId,
+          resolveTimelineActivityTypeId: resolveRequiredTimelineActivityTypeId,
         });
 
         timelineActivities.push(...linkedActivities);
@@ -202,7 +217,7 @@ export class TimelineActivitySeederService {
           linkedObjectMetadataId,
           calendarEventParticipants,
           messageParticipants,
-          resolveTimelineActivityTypeId,
+          resolveTimelineActivityTypeId: resolveRequiredTimelineActivityTypeId,
         });
 
         timelineActivities.push(...linkedActivities);
@@ -287,8 +302,9 @@ export class TimelineActivitySeederService {
 
     const timelineActivity: TimelineActivitySeedData = {
       id: timelineActivityId,
-      timelineActivityTypeId:
-        resolveTimelineActivityTypeId({ action: 'created' }) ?? null,
+      timelineActivityTypeId: resolveTimelineActivityTypeId({
+        action: 'created',
+      }),
       properties: JSON.stringify({
         after: this.getEventAfterRecordProperties(entityType, recordSeed),
       }),
@@ -412,7 +428,7 @@ export class TimelineActivitySeederService {
     linkedObjectMetadataId: string;
     calendarEventParticipants: CalendarEventParticipantDataSeed[];
     messageParticipants: MessageParticipantDataSeed[];
-    resolveTimelineActivityTypeId: TimelineActivityTypeResolver;
+    resolveTimelineActivityTypeId: RequiredTimelineActivityTypeResolver;
   }): TimelineActivitySeedData[] {
     const targetInfos = this.getActivityTargetInfos(
       activityType,
@@ -588,12 +604,11 @@ export class TimelineActivitySeederService {
 
     const linkedActivity: TimelineActivitySeedData = {
       id: linkedActivityId,
-      timelineActivityTypeId:
-        resolveTimelineActivityTypeId({
-          action: 'linked',
-          objectUniversalIdentifier:
-            STANDARD_OBJECTS[activityType].universalIdentifier,
-        }) ?? null,
+      timelineActivityTypeId: resolveTimelineActivityTypeId({
+        action: 'linked',
+        objectUniversalIdentifier:
+          STANDARD_OBJECTS[activityType].universalIdentifier,
+      }),
       properties: JSON.stringify({ after: linkedProperties }),
       linkedRecordCachedName,
       linkedRecordId: recordSeed.id,

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/calendar-event-participant-manager.module.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/calendar-event-participant-manager.module.ts
@@ -1,17 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.module';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
-import { WorkspaceFeatureFlagsMapCacheService } from 'src/engine/metadata-modules/workspace-feature-flags-map-cache/workspace-feature-flags-map-cache.service';
-import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
-import { GetDataFromCacheWithRecomputeService } from 'src/engine/workspace-cache-storage/services/get-data-from-cache-with-recompute.service';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
-import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { CalendarEventParticipantMatchParticipantJob } from 'src/modules/calendar/calendar-event-participant-manager/jobs/calendar-event-participant-match-participant.job';
 import { CalendarEventParticipantPersonListener } from 'src/modules/calendar/calendar-event-participant-manager/listeners/calendar-event-participant-person.listener';
@@ -26,15 +18,9 @@ import { TimelineActivityModule } from 'src/modules/timeline/timeline-activity.m
   imports: [
     WorkspaceDataSourceModule,
     WorkspaceModule,
-    TypeOrmModule.forFeature([
-      ObjectMetadataEntity,
-      FieldMetadataEntity,
-      FeatureFlagEntity,
-      WorkspaceEntity,
-    ]),
+    TypeOrmModule.forFeature([ObjectMetadataEntity, WorkspaceEntity]),
     ContactCreationManagerModule,
     MatchParticipantModule,
-    WorkspaceCacheModule,
     TimelineActivityModule,
   ],
   providers: [
@@ -43,11 +29,6 @@ import { TimelineActivityModule } from 'src/modules/timeline/timeline-activity.m
     CalendarEventParticipantListener,
     CalendarEventParticipantPersonListener,
     CalendarEventParticipantWorkspaceMemberListener,
-    FeatureFlagService,
-    WorkspaceFeatureFlagsMapCacheService,
-    WorkspaceCacheStorageService,
-    GetDataFromCacheWithRecomputeService,
-    provideWorkspaceScopedRepository(FeatureFlagEntity),
   ],
   exports: [CalendarEventParticipantService],
 })

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/listeners/calendar-event-participant.listener.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/listeners/calendar-event-participant.listener.ts
@@ -6,7 +6,6 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
 import { OnCustomBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-custom-batch-event.decorator';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
 import { CustomWorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/custom-workspace-batch-event.type';
@@ -14,6 +13,7 @@ import { type CalendarEventParticipantWorkspaceEntity } from 'src/modules/calend
 import { TimelineActivityRepository } from 'src/modules/timeline/repositories/timeline-activity.repository';
 import { TimelineActivityTypeCacheService } from 'src/modules/timeline/services/timeline-activity-type-cache.service';
 import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
+import { resolveTimelineActivityTypeIdOrThrow } from 'src/modules/timeline/utils/resolve-timeline-activity-type-id.util';
 
 @Injectable()
 export class CalendarEventParticipantListener {
@@ -22,7 +22,6 @@ export class CalendarEventParticipantListener {
     private readonly timelineActivityRepository: TimelineActivityRepository,
     @InjectRepository(ObjectMetadataEntity)
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly timelineActivityTypeCacheService: TimelineActivityTypeCacheService,
   ) {}
 
@@ -50,15 +49,13 @@ export class CalendarEventParticipantListener {
         batchEvent.workspaceId,
       );
 
-    const timelineActivityTypeId = resolveTimelineActivityTypeId({
+    const timelineActivityTypeId = resolveTimelineActivityTypeIdOrThrow({
+      resolveTimelineActivityTypeId,
+      workspaceId: batchEvent.workspaceId,
       action: 'linked',
       objectUniversalIdentifier:
         STANDARD_OBJECTS.calendarEvent.universalIdentifier,
     });
-
-    if (!isDefined(timelineActivityTypeId)) {
-      return;
-    }
 
     const timelineActivityPayloads = batchEvent.events.flatMap((event) => {
       const calendarEventParticipants = event.participants ?? [];

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant.listener.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant.listener.ts
@@ -6,7 +6,6 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
 import { OnCustomBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-custom-batch-event.decorator';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
 import { CustomWorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/custom-workspace-batch-event.type';
@@ -14,6 +13,7 @@ import { type MessageParticipantWorkspaceEntity } from 'src/modules/messaging/co
 import { TimelineActivityRepository } from 'src/modules/timeline/repositories/timeline-activity.repository';
 import { TimelineActivityTypeCacheService } from 'src/modules/timeline/services/timeline-activity-type-cache.service';
 import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
+import { resolveTimelineActivityTypeIdOrThrow } from 'src/modules/timeline/utils/resolve-timeline-activity-type-id.util';
 
 @Injectable()
 export class MessageParticipantListener {
@@ -22,7 +22,6 @@ export class MessageParticipantListener {
     private readonly timelineActivityRepository: TimelineActivityRepository,
     @InjectRepository(ObjectMetadataEntity)
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly timelineActivityTypeCacheService: TimelineActivityTypeCacheService,
   ) {}
 
@@ -50,14 +49,12 @@ export class MessageParticipantListener {
         batchEvent.workspaceId,
       );
 
-    const timelineActivityTypeId = resolveTimelineActivityTypeId({
+    const timelineActivityTypeId = resolveTimelineActivityTypeIdOrThrow({
+      resolveTimelineActivityTypeId,
+      workspaceId: batchEvent.workspaceId,
       action: 'linked',
       objectUniversalIdentifier: STANDARD_OBJECTS.message.universalIdentifier,
     });
-
-    if (!isDefined(timelineActivityTypeId)) {
-      return;
-    }
 
     const timelineActivityPayloads = batchEvent.events.flatMap((event) => {
       const messageParticipants = event.participants ?? [];

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/message-participant-manager.module.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/message-participant-manager.module.ts
@@ -1,18 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
-import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
-import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
-import { WorkspaceFeatureFlagsMapCacheService } from 'src/engine/metadata-modules/workspace-feature-flags-map-cache/workspace-feature-flags-map-cache.service';
 import { ObjectMetadataRepositoryModule } from 'src/engine/object-metadata-repository/object-metadata-repository.module';
-import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
-import { GetDataFromCacheWithRecomputeService } from 'src/engine/workspace-cache-storage/services/get-data-from-cache-with-recompute.service';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
-import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { ContactCreationManagerModule } from 'src/modules/contact-creation-manager/contact-creation-manager.module';
 import { MatchParticipantModule } from 'src/modules/match-participant/match-participant.module';
@@ -27,13 +18,7 @@ import { TimelineActivityModule } from 'src/modules/timeline/timeline-activity.m
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([
-      FeatureFlagEntity,
-      WorkspaceEntity,
-      ObjectMetadataEntity,
-      RoleEntity,
-      RoleTargetEntity,
-    ]),
+    TypeOrmModule.forFeature([WorkspaceEntity, ObjectMetadataEntity]),
     ContactCreationManagerModule,
     WorkspaceDataSourceModule,
     ObjectMetadataRepositoryModule.forFeature([
@@ -41,7 +26,6 @@ import { TimelineActivityModule } from 'src/modules/timeline/timeline-activity.m
     ]),
     MessagingCommonModule,
     MatchParticipantModule,
-    WorkspaceCacheModule,
     TimelineActivityModule,
   ],
   providers: [
@@ -50,11 +34,6 @@ import { TimelineActivityModule } from 'src/modules/timeline/timeline-activity.m
     MessageParticipantListener,
     MessageParticipantPersonListener,
     MessageParticipantWorkspaceMemberListener,
-    FeatureFlagService,
-    WorkspaceFeatureFlagsMapCacheService,
-    WorkspaceCacheStorageService,
-    GetDataFromCacheWithRecomputeService,
-    provideWorkspaceScopedRepository(FeatureFlagEntity),
   ],
   exports: [MessagingMessageParticipantService],
 })

--- a/packages/twenty-server/src/modules/timeline/exceptions/timeline.exception.ts
+++ b/packages/twenty-server/src/modules/timeline/exceptions/timeline.exception.ts
@@ -1,0 +1,16 @@
+import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
+import { CustomException } from 'src/utils/custom-exception';
+
+export enum TimelineExceptionCode {
+  TIMELINE_ACTIVITY_TYPE_RESOLUTION_FAILED = 'TIMELINE_ACTIVITY_TYPE_RESOLUTION_FAILED',
+}
+
+export class TimelineException extends CustomException<TimelineExceptionCode> {
+  constructor(message: string) {
+    super(
+      message,
+      TimelineExceptionCode.TIMELINE_ACTIVITY_TYPE_RESOLUTION_FAILED,
+      { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 
 import { type ObjectRecordBaseEvent } from 'twenty-shared/database-events';
 import { FieldMetadataType, type ObjectRecord } from 'twenty-shared/types';
@@ -18,7 +18,10 @@ import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/wo
 import { parseEventNameOrThrow } from 'src/engine/workspace-event-emitter/utils/parse-event-name';
 import { TimelineActivityRepository } from 'src/modules/timeline/repositories/timeline-activity.repository';
 import { TimelineActivityRuleBuilderService } from 'src/modules/timeline/services/timeline-activity-rule-builder.service';
-import { type TimelineActivityTypeResolver } from 'src/modules/timeline/utils/resolve-timeline-activity-type-id.util';
+import {
+  resolveTimelineActivityTypeIdOrThrow,
+  type TimelineActivityTypeResolver,
+} from 'src/modules/timeline/utils/resolve-timeline-activity-type-id.util';
 import { TimelineActivityTargetQueryService } from 'src/modules/timeline/services/timeline-activity-target-query.service';
 import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
 import { type ResolvedTimelineActivityTarget } from 'src/modules/timeline/types/resolved-timeline-activity-target.type';
@@ -92,8 +95,6 @@ const buildLinkedPayload = ({
 
 @Injectable()
 export class TimelineActivityService {
-  private readonly logger = new Logger(TimelineActivityService.name);
-
   constructor(
     @InjectObjectMetadataRepository(TimelineActivityWorkspaceEntity)
     private readonly timelineActivityRepository: TimelineActivityRepository,
@@ -241,21 +242,15 @@ export class TimelineActivityService {
     // A self rule writes the record's own row, which carries no linked record,
     // so it must not take the object-bound type: that one renders as a linked
     // entry and has no linked object to draw.
-    const timelineActivityTypeId = resolveTimelineActivityTypeId({
+    const timelineActivityTypeId = resolveTimelineActivityTypeIdOrThrow({
+      resolveTimelineActivityTypeId,
+      workspaceId,
       action: ruleAction,
       objectUniversalIdentifier:
         rule.targetShape.kind === 'SELF'
           ? undefined
           : rule.sourceFlatObjectMetadata.universalIdentifier,
     });
-
-    if (!isDefined(timelineActivityTypeId)) {
-      this.logger.warn(
-        `No timeline activity type resolves ${ruleAction} on ${rule.sourceFlatObjectMetadata.nameSingular} in workspace ${workspaceId}, dropping ${events.length} events`,
-      );
-
-      return [];
-    }
 
     const matchingEvents = events.filter((event) =>
       this.ruleMatchesEvent({ rule, ruleAction, event }),
@@ -340,19 +335,13 @@ export class TimelineActivityService {
       return [];
     }
 
-    const timelineActivityTypeId = resolveTimelineActivityTypeId({
+    const timelineActivityTypeId = resolveTimelineActivityTypeIdOrThrow({
+      resolveTimelineActivityTypeId,
+      workspaceId,
       action: ruleAction,
       objectUniversalIdentifier:
         rule.sourceFlatObjectMetadata.universalIdentifier,
     });
-
-    if (!isDefined(timelineActivityTypeId)) {
-      this.logger.warn(
-        `No timeline activity type resolves ${ruleAction} on ${rule.sourceFlatObjectMetadata.nameSingular} in workspace ${workspaceId}, dropping ${events.length} events`,
-      );
-
-      return [];
-    }
 
     const { junctionSourceJoinColumnName } = rule.targetShape;
 

--- a/packages/twenty-server/src/modules/timeline/utils/__tests__/resolve-timeline-activity-type-id.util.spec.ts
+++ b/packages/twenty-server/src/modules/timeline/utils/__tests__/resolve-timeline-activity-type-id.util.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildTimelineActivityTypeResolver,
+  resolveTimelineActivityTypeIdOrThrow,
   type TimelineActivityTypeResolutionMaps,
 } from 'src/modules/timeline/utils/resolve-timeline-activity-type-id.util';
 
@@ -72,5 +73,75 @@ describe('buildTimelineActivityTypeResolver', () => {
         objectUniversalIdentifier: NOTE_UNIVERSAL_IDENTIFIER,
       }),
     ).toBe(NOTE_UPDATED_ID);
+  });
+
+  it('rejects ambiguous shared types', () => {
+    expect(() =>
+      buildTimelineActivityTypeResolver({
+        byUniversalIdentifier: {
+          first: {
+            id: SHARED_LINKED_ID,
+            action: 'linked',
+            objectUniversalIdentifier: null,
+          },
+          second: {
+            id: NOTE_LINKED_ID,
+            action: 'linked',
+            objectUniversalIdentifier: null,
+          },
+        },
+      }),
+    ).toThrow('Multiple timeline activity types resolve shared action linked');
+  });
+
+  it('rejects ambiguous object-bound types', () => {
+    expect(() =>
+      buildTimelineActivityTypeResolver({
+        byUniversalIdentifier: {
+          first: {
+            id: SHARED_LINKED_ID,
+            action: 'linked',
+            objectUniversalIdentifier: NOTE_UNIVERSAL_IDENTIFIER,
+          },
+          second: {
+            id: NOTE_LINKED_ID,
+            action: 'linked',
+            objectUniversalIdentifier: NOTE_UNIVERSAL_IDENTIFIER,
+          },
+        },
+      }),
+    ).toThrow(
+      `Multiple timeline activity types resolve action linked for object ${NOTE_UNIVERSAL_IDENTIFIER}`,
+    );
+  });
+});
+
+describe('resolveTimelineActivityTypeIdOrThrow', () => {
+  const resolveTimelineActivityTypeId = buildTimelineActivityTypeResolver(
+    flatTimelineActivityTypeMaps,
+  );
+
+  it('returns the resolved type id', () => {
+    expect(
+      resolveTimelineActivityTypeIdOrThrow({
+        resolveTimelineActivityTypeId,
+        workspaceId: 'workspace-id',
+        action: 'linked',
+        objectUniversalIdentifier: NOTE_UNIVERSAL_IDENTIFIER,
+      }),
+    ).toBe(NOTE_LINKED_ID);
+  });
+
+  it('throws when the workspace has no type for the event', () => {
+    expect(() =>
+      resolveTimelineActivityTypeIdOrThrow({
+        resolveTimelineActivityTypeId,
+        workspaceId: 'workspace-id',
+        action: 'deleted',
+        objectUniversalIdentifier: NOTE_UNIVERSAL_IDENTIFIER,
+      }),
+    ).toThrow(
+      `No timeline activity type resolves action deleted for object ${NOTE_UNIVERSAL_IDENTIFIER} in workspace workspace-id`,
+    );
   });
 });

--- a/packages/twenty-server/src/modules/timeline/utils/resolve-timeline-activity-type-id.util.ts
+++ b/packages/twenty-server/src/modules/timeline/utils/resolve-timeline-activity-type-id.util.ts
@@ -2,6 +2,7 @@ import { type TimelineActivityAction } from 'twenty-shared/timeline';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatTimelineActivityType } from 'src/engine/metadata-modules/flat-timeline-activity-type/types/flat-timeline-activity-type.type';
+import { TimelineException } from 'src/modules/timeline/exceptions/timeline.exception';
 
 export type TimelineActivityTypeResolutionMaps = {
   byUniversalIdentifier: Partial<
@@ -15,33 +16,53 @@ export type TimelineActivityTypeResolutionMaps = {
   >;
 };
 
-export type TimelineActivityTypeResolver = (args: {
+export type ResolveTimelineActivityTypeIdArgs = {
   action: TimelineActivityAction;
   objectUniversalIdentifier?: string | null;
-}) => string | undefined;
+};
+
+export type TimelineActivityTypeResolver = (
+  args: ResolveTimelineActivityTypeIdArgs,
+) => string | undefined;
+
+export const resolveTimelineActivityTypeIdOrThrow = ({
+  resolveTimelineActivityTypeId,
+  workspaceId,
+  ...args
+}: ResolveTimelineActivityTypeIdArgs & {
+  resolveTimelineActivityTypeId: TimelineActivityTypeResolver;
+  workspaceId: string;
+}): string => {
+  const timelineActivityTypeId = resolveTimelineActivityTypeId(args);
+
+  if (!isDefined(timelineActivityTypeId)) {
+    const objectContext = isDefined(args.objectUniversalIdentifier)
+      ? ` for object ${args.objectUniversalIdentifier}`
+      : '';
+
+    throw new TimelineException(
+      `No timeline activity type resolves action ${args.action}${objectContext} in workspace ${workspaceId}`,
+    );
+  }
+
+  return timelineActivityTypeId;
+};
 
 // A type bound to the event's object wins, so a linked note is stamped with the
 // note type and renders through its own component; the unbound type for the same
 // action is the fallback every other object shares.
 //
-// Candidates are ordered by universal identifier before the first one wins, so a
-// workspace whose types collide on a dispatch key still resolves the same way on
-// every run rather than following map iteration order.
+// Ambiguous definitions fail while building the cache: silently choosing one
+// would make an application's audit semantics depend on metadata ordering.
 export const buildTimelineActivityTypeResolver = (
   flatTimelineActivityTypeMaps: TimelineActivityTypeResolutionMaps,
 ): TimelineActivityTypeResolver => {
   const idByObjectAndAction = new Map<string, string>();
   const idByAction = new Map<TimelineActivityAction, string>();
 
-  const orderedFlatTimelineActivityTypes = Object.entries(
+  for (const flatTimelineActivityType of Object.values(
     flatTimelineActivityTypeMaps.byUniversalIdentifier,
-  )
-    .sort(([leftUniversalIdentifier], [rightUniversalIdentifier]) =>
-      leftUniversalIdentifier.localeCompare(rightUniversalIdentifier),
-    )
-    .map(([, flatTimelineActivityType]) => flatTimelineActivityType);
-
-  for (const flatTimelineActivityType of orderedFlatTimelineActivityTypes) {
+  )) {
     if (
       !isDefined(flatTimelineActivityType) ||
       !isDefined(flatTimelineActivityType.action)
@@ -52,18 +73,26 @@ export const buildTimelineActivityTypeResolver = (
     const { action, objectUniversalIdentifier, id } = flatTimelineActivityType;
 
     if (!isDefined(objectUniversalIdentifier)) {
-      if (!idByAction.has(action)) {
-        idByAction.set(action, id);
+      if (idByAction.has(action)) {
+        throw new TimelineException(
+          `Multiple timeline activity types resolve shared action ${action}`,
+        );
       }
+
+      idByAction.set(action, id);
 
       continue;
     }
 
     const key = `${objectUniversalIdentifier}|${action}`;
 
-    if (!idByObjectAndAction.has(key)) {
-      idByObjectAndAction.set(key, id);
+    if (idByObjectAndAction.has(key)) {
+      throw new TimelineException(
+        `Multiple timeline activity types resolve action ${action} for object ${objectUniversalIdentifier}`,
+      );
     }
+
+    idByObjectAndAction.set(key, id);
   }
 
   return ({ action, objectUniversalIdentifier }) =>


### PR DESCRIPTION
## Summary

- fail timeline activity jobs when no type metadata resolves instead of silently discarding audit history
- reject ambiguous shared or object/action dispatch keys instead of selecting a type from metadata ordering
- apply the same required-type invariant to record, message, calendar, and development-seed writers
- remove the obsolete feature-flag service, cache providers, scoped repository, and entity registrations left in both participant-manager modules
- remove unrelated dead TypeORM registrations from those modules
- cover successful, missing, and ambiguous resolution

## Why stacked

This is a 2.34 cleanup stacked on #24605 because it touches the same three production writers. Once #24605 merges, this PR can be rebased or retargeted to `main`.

This deliberately does not add workspace-wide uniqueness to type definitions: the future app surface needs explicit binding metadata and may legitimately contain multiple definitions. It only prevents the current implicit resolver from silently choosing among them.

## Validation

- `npx jest src/modules/timeline/utils/__tests__/resolve-timeline-activity-type-id.util.spec.ts --config=jest.config.mjs --runInBand`
- `npx tsgo -p tsconfig.json --noEmit` in `packages/twenty-server`
- type-aware oxlint and oxfmt on all eight changed files