### PR TITLE
Preserve rendering for orphaned timeline activity types

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDynamicComponent.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowDynamicComponent.tsx
@@ -1,26 +1,6 @@
 import { TIMELINE_ACTIVITY_ROW_COMPONENT_BY_RENDERER } from '@/activities/timeline-activities/constants/TimelineActivityRowComponentByRenderer';
 import { type EventRowDynamicComponentProps } from '@/activities/timeline-activities/rows/components/EventRowDynamicComponent.types';
-import { CoreObjectNameSingular } from 'twenty-shared/types';
-import { type TimelineActivityRenderer } from 'twenty-shared/timeline';
-import { isDefined } from 'twenty-shared/utils';
-
-const getLegacyTimelineActivityRenderer = (
-  linkedObjectNameSingular: string | undefined,
-): TimelineActivityRenderer => {
-  switch (linkedObjectNameSingular) {
-    case CoreObjectNameSingular.Note:
-    case CoreObjectNameSingular.Task:
-      return 'activity';
-    case CoreObjectNameSingular.Message:
-      return 'message';
-    case CoreObjectNameSingular.CalendarEvent:
-      return 'calendarEvent';
-    default:
-      return isDefined(linkedObjectNameSingular)
-        ? 'genericLinked'
-        : 'mainObject';
-  }
-};
+import { getTimelineActivityRenderer } from '@/activities/timeline-activities/utils/getTimelineActivityRenderer';
 
 export const EventRowDynamicComponent = ({
   labelIdentifierValue,
@@ -32,16 +12,11 @@ export const EventRowDynamicComponent = ({
   authorFullName,
   createdAt,
 }: EventRowDynamicComponentProps) => {
-  const renderer =
-    eventRenderer ??
-    // Old pods can write name-only rows after the 2.33 backfill has run.
-    (isDefined(event.timelineActivityTypeId)
-      ? isDefined(linkedObjectMetadataItem)
-        ? 'genericLinked'
-        : 'mainObject'
-      : getLegacyTimelineActivityRenderer(
-          linkedObjectMetadataItem?.nameSingular,
-        ));
+  const renderer = getTimelineActivityRenderer({
+    eventRenderer,
+    legacyName: event.name,
+    linkedObjectNameSingular: linkedObjectMetadataItem?.nameSingular,
+  });
 
   const EventRowComponent =
     TIMELINE_ACTIVITY_ROW_COMPONENT_BY_RENDERER[renderer];

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/getTimelineActivityRenderer.test.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/getTimelineActivityRenderer.test.ts
@@ -1,0 +1,51 @@
+import { getTimelineActivityRenderer } from '@/activities/timeline-activities/utils/getTimelineActivityRenderer';
+
+describe('getTimelineActivityRenderer', () => {
+  it('uses the renderer resolved from the activity type', () => {
+    expect(
+      getTimelineActivityRenderer({
+        eventRenderer: 'calendarEvent',
+        legacyName: 'linked-note.updated',
+        linkedObjectNameSingular: 'note',
+      }),
+    ).toBe('calendarEvent');
+  });
+
+  it.each([
+    ['note', 'activity'],
+    ['task', 'activity'],
+    ['message', 'message'],
+    ['calendarEvent', 'calendarEvent'],
+  ] as const)(
+    'preserves the legacy %s renderer when the type no longer resolves',
+    (linkedObjectNameSingular, expectedRenderer) => {
+      expect(
+        getTimelineActivityRenderer({
+          eventRenderer: null,
+          legacyName: `linked-${linkedObjectNameSingular}.updated`,
+          linkedObjectNameSingular,
+        }),
+      ).toBe(expectedRenderer);
+    },
+  );
+
+  it('uses the generic renderer for a type-only linked row', () => {
+    expect(
+      getTimelineActivityRenderer({
+        eventRenderer: null,
+        legacyName: null,
+        linkedObjectNameSingular: 'customObject',
+      }),
+    ).toBe('genericLinked');
+  });
+
+  it('uses the main object renderer for a type-only unlinked row', () => {
+    expect(
+      getTimelineActivityRenderer({
+        eventRenderer: null,
+        legacyName: null,
+        linkedObjectNameSingular: undefined,
+      }),
+    ).toBe('mainObject');
+  });
+});

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityRenderer.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityRenderer.ts
@@ -1,0 +1,42 @@
+import { CoreObjectNameSingular } from 'twenty-shared/types';
+import { type TimelineActivityRenderer } from 'twenty-shared/timeline';
+import { isDefined } from 'twenty-shared/utils';
+
+const getLegacyTimelineActivityRenderer = (
+  linkedObjectNameSingular: string | undefined,
+): TimelineActivityRenderer => {
+  switch (linkedObjectNameSingular) {
+    case CoreObjectNameSingular.Note:
+    case CoreObjectNameSingular.Task:
+      return 'activity';
+    case CoreObjectNameSingular.Message:
+      return 'message';
+    case CoreObjectNameSingular.CalendarEvent:
+      return 'calendarEvent';
+    default:
+      return isDefined(linkedObjectNameSingular)
+        ? 'genericLinked'
+        : 'mainObject';
+  }
+};
+
+export const getTimelineActivityRenderer = ({
+  eventRenderer,
+  legacyName,
+  linkedObjectNameSingular,
+}: {
+  eventRenderer: TimelineActivityRenderer | null;
+  legacyName: string | null;
+  linkedObjectNameSingular: string | undefined;
+}): TimelineActivityRenderer => {
+  if (isDefined(eventRenderer)) {
+    return eventRenderer;
+  }
+
+  // The legacy name is the remaining renderer hint when its type is removed.
+  if (isDefined(legacyName)) {
+    return getLegacyTimelineActivityRenderer(linkedObjectNameSingular);
+  }
+
+  return isDefined(linkedObjectNameSingular) ? 'genericLinked' : 'mainObject';
+};


### PR DESCRIPTION
## Summary

- preserve specialized note, task, message, and calendar rendering when a dual-written historical row references a type that no longer resolves
- keep the generic/main-object fallback for new type-only rows whose renderer is intentionally null
- extract renderer selection into a behavior-tested utility

## Why

The existing fallback treated the mere presence of `timelineActivityTypeId` as proof that its type metadata still existed. If an application/type is removed, a 2.33 row still has its legacy discriminator and linked-object metadata, but was incorrectly downgraded to a generic renderer. This uses that durable compatibility data while it exists.

This is independent of #24605 and can merge directly to `main`.

## Validation

- `npx jest src/modules/activities/timeline-activities/utils/__tests__/getTimelineActivityRenderer.test.ts --config=jest.config.mjs --runInBand`
- `npx tsgo -p tsconfig.json --noEmit` in `packages/twenty-front` after rebuilding `twenty-front-component-renderer`
- type-aware oxlint and oxfmt on all three changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

