### PR TITLE
Keep legacy timeline rows in type filters

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/EventList.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/EventList.tsx
@@ -60,6 +60,8 @@ export const EventList = ({ events, targetableObject }: EventListProps) => {
     keepTimelineActivitiesOfSelectedTypes(
       events,
       timelineActivityTypeIdsFilter,
+      timelineActivityTypeById,
+      objectMetadataItems,
     ),
     targetableObject.targetObjectNameSingular,
     objectMetadataItems,

--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/EventList.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/EventList.tsx
@@ -57,12 +57,12 @@ export const EventList = ({ events, targetableObject }: EventListProps) => {
   );
 
   const filteredEvents = filterOutInvalidTimelineActivities(
-    keepTimelineActivitiesOfSelectedTypes(
-      events,
-      timelineActivityTypeIdsFilter,
+    keepTimelineActivitiesOfSelectedTypes({
+      timelineActivities: events,
+      selectedTimelineActivityTypeIds: timelineActivityTypeIdsFilter,
       timelineActivityTypeById,
       objectMetadataItems,
-    ),
+    }),
     targetableObject.targetObjectNameSingular,
     objectMetadataItems,
     timelineActivityTypeById,

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/keepTimelineActivitiesOfSelectedTypes.test.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/keepTimelineActivitiesOfSelectedTypes.test.ts
@@ -1,8 +1,13 @@
 import { type FilterableTimelineActivity } from '@/activities/timeline-activities/types/FilterableTimelineActivity';
+import { type TimelineActivityType } from '@/activities/timeline-activities/types/TimelineActivityType';
 import { keepTimelineActivitiesOfSelectedTypes } from '@/activities/timeline-activities/utils/keepTimelineActivitiesOfSelectedTypes';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 
 const UPDATED_TYPE_ID = '20202020-0000-4000-8000-0000000update';
 const LINKED_TYPE_ID = '20202020-0000-4000-8000-0000000linked';
+const CREATED_TYPE_ID = '20202020-0000-4000-8000-0000000create';
+const NOTE_UPDATED_TYPE_ID = '20202020-0000-4000-8000-00000noteupd';
 
 const updatedActivity = {
   timelineActivityTypeId: UPDATED_TYPE_ID,
@@ -16,18 +21,77 @@ const linkedActivity = {
 
 const untypedActivity = { properties: {} } satisfies FilterableTimelineActivity;
 
+const buildTimelineActivityType = (
+  overrides: Partial<TimelineActivityType>,
+): TimelineActivityType => ({
+  id: UPDATED_TYPE_ID,
+  name: 'recordUpdated',
+  label: 'updated',
+  action: 'updated',
+  icon: null,
+  renderer: null,
+  objectUniversalIdentifier: null,
+  ...overrides,
+});
+
+const timelineActivityTypeById = new Map<string, TimelineActivityType>([
+  [UPDATED_TYPE_ID, buildTimelineActivityType({})],
+  [
+    LINKED_TYPE_ID,
+    buildTimelineActivityType({
+      id: LINKED_TYPE_ID,
+      name: 'recordLinked',
+      action: 'linked',
+    }),
+  ],
+  [
+    CREATED_TYPE_ID,
+    buildTimelineActivityType({
+      id: CREATED_TYPE_ID,
+      name: 'recordCreated',
+      action: 'created',
+    }),
+  ],
+  [
+    NOTE_UPDATED_TYPE_ID,
+    buildTimelineActivityType({
+      id: NOTE_UPDATED_TYPE_ID,
+      name: 'noteUpdated',
+      objectUniversalIdentifier: STANDARD_OBJECTS.note.universalIdentifier,
+    }),
+  ],
+]);
+
+const objectMetadataItems = [
+  {
+    id: 'note-object-metadata-id',
+    nameSingular: 'note',
+    universalIdentifier: STANDARD_OBJECTS.note.universalIdentifier,
+  } as EnrichedObjectMetadataItem,
+];
+
+const filterTimelineActivities = (
+  timelineActivities: FilterableTimelineActivity[],
+  selectedTimelineActivityTypeIds: string[],
+  typeById = timelineActivityTypeById,
+) =>
+  keepTimelineActivitiesOfSelectedTypes(
+    timelineActivities,
+    selectedTimelineActivityTypeIds,
+    typeById,
+    objectMetadataItems,
+  );
+
 describe('keepTimelineActivitiesOfSelectedTypes', () => {
   it('keeps everything when nothing is selected', () => {
     const activities = [updatedActivity, linkedActivity, untypedActivity];
 
-    expect(keepTimelineActivitiesOfSelectedTypes(activities, [])).toEqual(
-      activities,
-    );
+    expect(filterTimelineActivities(activities, [])).toEqual(activities);
   });
 
   it('keeps only the activities carrying a selected type', () => {
     expect(
-      keepTimelineActivitiesOfSelectedTypes(
+      filterTimelineActivities(
         [updatedActivity, linkedActivity, untypedActivity],
         [LINKED_TYPE_ID],
       ),
@@ -36,7 +100,7 @@ describe('keepTimelineActivitiesOfSelectedTypes', () => {
 
   it('keeps activities across several selected types', () => {
     expect(
-      keepTimelineActivitiesOfSelectedTypes(
+      filterTimelineActivities(
         [updatedActivity, linkedActivity, untypedActivity],
         [LINKED_TYPE_ID, UPDATED_TYPE_ID],
       ),
@@ -45,9 +109,66 @@ describe('keepTimelineActivitiesOfSelectedTypes', () => {
 
   it('drops activities with no type when a selection is active', () => {
     expect(
-      keepTimelineActivitiesOfSelectedTypes(
-        [untypedActivity],
+      filterTimelineActivities([untypedActivity], [UPDATED_TYPE_ID]),
+    ).toEqual([]);
+  });
+
+  it('matches a legacy main-object row to its shared action type', () => {
+    const legacyActivity = {
+      timelineActivityTypeId: null,
+      name: 'company.updated',
+      properties: {},
+    } satisfies FilterableTimelineActivity;
+
+    expect(
+      filterTimelineActivities([legacyActivity], [UPDATED_TYPE_ID]),
+    ).toEqual([legacyActivity]);
+  });
+
+  it('prefers an object-bound type for a legacy linked-object row', () => {
+    const legacyActivity = {
+      timelineActivityTypeId: null,
+      name: 'linked-note.updated',
+      properties: {},
+    } satisfies FilterableTimelineActivity;
+
+    expect(
+      filterTimelineActivities([legacyActivity], [NOTE_UPDATED_TYPE_ID]),
+    ).toEqual([legacyActivity]);
+    expect(
+      filterTimelineActivities([legacyActivity], [UPDATED_TYPE_ID]),
+    ).toEqual([]);
+  });
+
+  it('falls back to a shared type when no object-bound type exists', () => {
+    const legacyActivity = {
+      timelineActivityTypeId: null,
+      name: 'linked-note.created',
+      properties: {},
+    } satisfies FilterableTimelineActivity;
+
+    expect(
+      filterTimelineActivities([legacyActivity], [CREATED_TYPE_ID]),
+    ).toEqual([legacyActivity]);
+  });
+
+  it('does not guess when the legacy row resolves ambiguously', () => {
+    const duplicateUpdatedTypeId = '20202020-0000-4000-8000-0000000duplic';
+    const ambiguousTypeById = new Map(timelineActivityTypeById).set(
+      duplicateUpdatedTypeId,
+      buildTimelineActivityType({ id: duplicateUpdatedTypeId }),
+    );
+    const legacyActivity = {
+      timelineActivityTypeId: null,
+      name: 'company.updated',
+      properties: {},
+    } satisfies FilterableTimelineActivity;
+
+    expect(
+      filterTimelineActivities(
+        [legacyActivity],
         [UPDATED_TYPE_ID],
+        ambiguousTypeById,
       ),
     ).toEqual([]);
   });

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/keepTimelineActivitiesOfSelectedTypes.test.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/__tests__/keepTimelineActivitiesOfSelectedTypes.test.ts
@@ -1,7 +1,6 @@
 import { type FilterableTimelineActivity } from '@/activities/timeline-activities/types/FilterableTimelineActivity';
 import { type TimelineActivityType } from '@/activities/timeline-activities/types/TimelineActivityType';
 import { keepTimelineActivitiesOfSelectedTypes } from '@/activities/timeline-activities/utils/keepTimelineActivitiesOfSelectedTypes';
-import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 
 const UPDATED_TYPE_ID = '20202020-0000-4000-8000-0000000update';
@@ -67,7 +66,7 @@ const objectMetadataItems = [
     id: 'note-object-metadata-id',
     nameSingular: 'note',
     universalIdentifier: STANDARD_OBJECTS.note.universalIdentifier,
-  } as EnrichedObjectMetadataItem,
+  },
 ];
 
 const filterTimelineActivities = (
@@ -75,12 +74,12 @@ const filterTimelineActivities = (
   selectedTimelineActivityTypeIds: string[],
   typeById = timelineActivityTypeById,
 ) =>
-  keepTimelineActivitiesOfSelectedTypes(
+  keepTimelineActivitiesOfSelectedTypes({
     timelineActivities,
     selectedTimelineActivityTypeIds,
-    typeById,
+    timelineActivityTypeById: typeById,
     objectMetadataItems,
-  );
+  });
 
 describe('keepTimelineActivitiesOfSelectedTypes', () => {
   it('keeps everything when nothing is selected', () => {

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityLinkedObjectMetadataItem.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityLinkedObjectMetadataItem.ts
@@ -4,15 +4,22 @@ import { getTimelineActivityType } from '@/activities/timeline-activities/utils/
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 
-export const getTimelineActivityLinkedObjectMetadataItem = ({
+export type TimelineActivityObjectMetadataItem = Pick<
+  EnrichedObjectMetadataItem,
+  'id' | 'nameSingular' | 'universalIdentifier'
+>;
+
+export const getTimelineActivityLinkedObjectMetadataItem = <
+  TObjectMetadataItem extends TimelineActivityObjectMetadataItem,
+>({
   timelineActivity,
   timelineActivityTypeById,
   objectMetadataItems,
 }: {
   timelineActivity: FilterableTimelineActivity;
   timelineActivityTypeById: Map<string, TimelineActivityType>;
-  objectMetadataItems: EnrichedObjectMetadataItem[];
-}): EnrichedObjectMetadataItem | undefined => {
+  objectMetadataItems: TObjectMetadataItem[];
+}): TObjectMetadataItem | undefined => {
   if (isDefined(timelineActivity.linkedObjectMetadataId)) {
     return objectMetadataItems.find(
       (objectMetadataItem) =>

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/keepTimelineActivitiesOfSelectedTypes.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/keepTimelineActivitiesOfSelectedTypes.ts
@@ -1,4 +1,7 @@
 import { type FilterableTimelineActivity } from '@/activities/timeline-activities/types/FilterableTimelineActivity';
+import { type TimelineActivityType } from '@/activities/timeline-activities/types/TimelineActivityType';
+import { resolveTimelineActivityTypeId } from '@/activities/timeline-activities/utils/resolveTimelineActivityTypeId';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 
 // No selection means no filter, so an untouched timeline shows everything
@@ -8,13 +11,20 @@ export const keepTimelineActivitiesOfSelectedTypes = <
 >(
   timelineActivities: TTimelineActivity[],
   selectedTimelineActivityTypeIds: string[],
+  timelineActivityTypeById: Map<string, TimelineActivityType>,
+  objectMetadataItems: EnrichedObjectMetadataItem[],
 ): TTimelineActivity[] =>
   selectedTimelineActivityTypeIds.length === 0
     ? timelineActivities
-    : timelineActivities.filter(
-        (timelineActivity) =>
-          isDefined(timelineActivity.timelineActivityTypeId) &&
-          selectedTimelineActivityTypeIds.includes(
-            timelineActivity.timelineActivityTypeId,
-          ),
-      );
+    : timelineActivities.filter((timelineActivity) => {
+        const timelineActivityTypeId = resolveTimelineActivityTypeId({
+          timelineActivity,
+          timelineActivityTypeById,
+          objectMetadataItems,
+        });
+
+        return (
+          isDefined(timelineActivityTypeId) &&
+          selectedTimelineActivityTypeIds.includes(timelineActivityTypeId)
+        );
+      });

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/keepTimelineActivitiesOfSelectedTypes.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/keepTimelineActivitiesOfSelectedTypes.ts
@@ -1,30 +1,48 @@
 import { type FilterableTimelineActivity } from '@/activities/timeline-activities/types/FilterableTimelineActivity';
 import { type TimelineActivityType } from '@/activities/timeline-activities/types/TimelineActivityType';
+import { type TimelineActivityObjectMetadataItem } from '@/activities/timeline-activities/utils/getTimelineActivityLinkedObjectMetadataItem';
 import { resolveTimelineActivityTypeId } from '@/activities/timeline-activities/utils/resolveTimelineActivityTypeId';
-import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
+
+type KeepTimelineActivitiesOfSelectedTypesArgs<
+  TTimelineActivity extends FilterableTimelineActivity,
+> = {
+  timelineActivities: TTimelineActivity[];
+  selectedTimelineActivityTypeIds: string[];
+  timelineActivityTypeById: Map<string, TimelineActivityType>;
+  objectMetadataItems: TimelineActivityObjectMetadataItem[];
+};
 
 // No selection means no filter, so an untouched timeline shows everything
 // rather than nothing.
 export const keepTimelineActivitiesOfSelectedTypes = <
   TTimelineActivity extends FilterableTimelineActivity,
->(
-  timelineActivities: TTimelineActivity[],
-  selectedTimelineActivityTypeIds: string[],
-  timelineActivityTypeById: Map<string, TimelineActivityType>,
-  objectMetadataItems: EnrichedObjectMetadataItem[],
-): TTimelineActivity[] =>
-  selectedTimelineActivityTypeIds.length === 0
-    ? timelineActivities
-    : timelineActivities.filter((timelineActivity) => {
-        const timelineActivityTypeId = resolveTimelineActivityTypeId({
-          timelineActivity,
-          timelineActivityTypeById,
-          objectMetadataItems,
-        });
+>({
+  timelineActivities,
+  selectedTimelineActivityTypeIds,
+  timelineActivityTypeById,
+  objectMetadataItems,
+}: KeepTimelineActivitiesOfSelectedTypesArgs<TTimelineActivity>): TTimelineActivity[] => {
+  if (selectedTimelineActivityTypeIds.length === 0) {
+    return timelineActivities;
+  }
 
-        return (
-          isDefined(timelineActivityTypeId) &&
-          selectedTimelineActivityTypeIds.includes(timelineActivityTypeId)
-        );
-      });
+  const selectedTimelineActivityTypeIdSet = new Set(
+    selectedTimelineActivityTypeIds,
+  );
+  const timelineActivityTypes = [...timelineActivityTypeById.values()];
+
+  return timelineActivities.filter((timelineActivity) => {
+    const timelineActivityTypeId = resolveTimelineActivityTypeId({
+      timelineActivity,
+      timelineActivityTypeById,
+      timelineActivityTypes,
+      objectMetadataItems,
+    });
+
+    return (
+      isDefined(timelineActivityTypeId) &&
+      selectedTimelineActivityTypeIdSet.has(timelineActivityTypeId)
+    );
+  });
+};

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/resolveTimelineActivityTypeId.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/resolveTimelineActivityTypeId.ts
@@ -1,8 +1,10 @@
 import { type FilterableTimelineActivity } from '@/activities/timeline-activities/types/FilterableTimelineActivity';
 import { type TimelineActivityType } from '@/activities/timeline-activities/types/TimelineActivityType';
 import { getTimelineActivityAction } from '@/activities/timeline-activities/utils/getTimelineActivityAction';
-import { getTimelineActivityLinkedObjectMetadataItem } from '@/activities/timeline-activities/utils/getTimelineActivityLinkedObjectMetadataItem';
-import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import {
+  getTimelineActivityLinkedObjectMetadataItem,
+  type TimelineActivityObjectMetadataItem,
+} from '@/activities/timeline-activities/utils/getTimelineActivityLinkedObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 
 const getUniqueTimelineActivityTypeId = (
@@ -13,11 +15,13 @@ const getUniqueTimelineActivityTypeId = (
 export const resolveTimelineActivityTypeId = ({
   timelineActivity,
   timelineActivityTypeById,
+  timelineActivityTypes,
   objectMetadataItems,
 }: {
   timelineActivity: FilterableTimelineActivity;
   timelineActivityTypeById: Map<string, TimelineActivityType>;
-  objectMetadataItems: EnrichedObjectMetadataItem[];
+  timelineActivityTypes: TimelineActivityType[];
+  objectMetadataItems: TimelineActivityObjectMetadataItem[];
 }): string | undefined => {
   if (isDefined(timelineActivity.timelineActivityTypeId)) {
     return timelineActivity.timelineActivityTypeId;
@@ -37,8 +41,6 @@ export const resolveTimelineActivityTypeId = ({
     timelineActivityTypeById,
     objectMetadataItems,
   });
-  const timelineActivityTypes = [...timelineActivityTypeById.values()];
-
   if (isDefined(linkedObjectMetadataItem)) {
     const objectBoundTimelineActivityTypes = timelineActivityTypes.filter(
       (timelineActivityType) =>

--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/resolveTimelineActivityTypeId.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/resolveTimelineActivityTypeId.ts
@@ -1,0 +1,62 @@
+import { type FilterableTimelineActivity } from '@/activities/timeline-activities/types/FilterableTimelineActivity';
+import { type TimelineActivityType } from '@/activities/timeline-activities/types/TimelineActivityType';
+import { getTimelineActivityAction } from '@/activities/timeline-activities/utils/getTimelineActivityAction';
+import { getTimelineActivityLinkedObjectMetadataItem } from '@/activities/timeline-activities/utils/getTimelineActivityLinkedObjectMetadataItem';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { isDefined } from 'twenty-shared/utils';
+
+const getUniqueTimelineActivityTypeId = (
+  timelineActivityTypes: TimelineActivityType[],
+): string | undefined =>
+  timelineActivityTypes.length === 1 ? timelineActivityTypes[0].id : undefined;
+
+export const resolveTimelineActivityTypeId = ({
+  timelineActivity,
+  timelineActivityTypeById,
+  objectMetadataItems,
+}: {
+  timelineActivity: FilterableTimelineActivity;
+  timelineActivityTypeById: Map<string, TimelineActivityType>;
+  objectMetadataItems: EnrichedObjectMetadataItem[];
+}): string | undefined => {
+  if (isDefined(timelineActivity.timelineActivityTypeId)) {
+    return timelineActivity.timelineActivityTypeId;
+  }
+
+  const action = getTimelineActivityAction(
+    timelineActivity,
+    timelineActivityTypeById,
+  );
+
+  if (!isDefined(action)) {
+    return undefined;
+  }
+
+  const linkedObjectMetadataItem = getTimelineActivityLinkedObjectMetadataItem({
+    timelineActivity,
+    timelineActivityTypeById,
+    objectMetadataItems,
+  });
+  const timelineActivityTypes = [...timelineActivityTypeById.values()];
+
+  if (isDefined(linkedObjectMetadataItem)) {
+    const objectBoundTimelineActivityTypes = timelineActivityTypes.filter(
+      (timelineActivityType) =>
+        timelineActivityType.action === action &&
+        timelineActivityType.objectUniversalIdentifier ===
+          linkedObjectMetadataItem.universalIdentifier,
+    );
+
+    if (objectBoundTimelineActivityTypes.length > 0) {
+      return getUniqueTimelineActivityTypeId(objectBoundTimelineActivityTypes);
+    }
+  }
+
+  return getUniqueTimelineActivityTypeId(
+    timelineActivityTypes.filter(
+      (timelineActivityType) =>
+        timelineActivityType.action === action &&
+        !isDefined(timelineActivityType.objectUniversalIdentifier),
+    ),
+  );
+};


### PR DESCRIPTION
## Context

During a 2.33 rolling deployment, an older pod can still write a name-only timeline row. Compatibility rendering understands those rows, but selecting any timeline activity type currently drops them because filtering only accepts a stored `timelineActivityTypeId`.

## Changes

- resolve a missing type ID from the legacy action and linked object metadata
- mirror server dispatch precedence: prefer a unique object-bound type, then a unique shared action type
- refuse to guess when either candidate set is ambiguous
- use the resolved ID in the timeline type filter
- cover shared events, object-specific events, shared fallback, and ambiguous metadata

## Verification

- 8 focused Jest tests
- direct twenty-front TypeScript check
- type-aware oxlint and oxfmt checks

Stacked on #24608 because both PRs harden legacy/orphan compatibility. Related to twentyhq/core-team-issues#2785.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

