### PR TITLE
Backfill timeline activity types after the 2.33 rollout

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-upgrade-version-command.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { CatchUpTimelineActivityTypeIdsCommand } from 'src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787397332209-catch-up-timeline-activity-type-ids.command';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+
+@Module({
+  imports: [WorkspaceCacheModule, WorkspaceIteratorModule],
+  providers: [CatchUpTimelineActivityTypeIdsCommand],
+})
+export class V2_34_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787397332209-catch-up-timeline-activity-type-ids.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787397332209-catch-up-timeline-activity-type-ids.command.ts
@@ -95,7 +95,7 @@ export class CatchUpTimelineActivityTypeIdsCommand extends ProvisionedWorkspaceC
       validTimelineActivityTypeIds,
     });
 
-    if (options.dryRun === true) {
+    if (options.dryRun) {
       this.logger.log(
         `[DRY RUN] Would backfill ${auditBefore.nullTypeIdCount} timelineActivity row(s); found ${auditBefore.danglingTypeIdCount} dangling type reference(s) for workspace ${workspaceId}`,
       );

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787397332209-catch-up-timeline-activity-type-ids.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787397332209-catch-up-timeline-activity-type-ids.command.ts
@@ -1,0 +1,191 @@
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { buildTimelineActivityTypeBackfillQuery } from 'src/database/commands/upgrade-version-command/2-33/utils/build-timeline-activity-type-backfill-query.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+
+const TIMELINE_ACTIVITY = STANDARD_OBJECTS.timelineActivity;
+const BACKFILL_BATCH_SIZE = 5000;
+
+type TimelineActivityTypeAudit = {
+  nullTypeIdCount: number;
+  danglingTypeIdCount: number;
+};
+
+@RegisteredWorkspaceCommand('2.34.0', 1787397332209)
+@Command({
+  name: 'upgrade:2-34:catch-up-timeline-activity-type-ids',
+  description:
+    'Backfill timeline activity type IDs written during the 2.33 rollout and report unresolved references',
+})
+export class CatchUpTimelineActivityTypeIdsCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    dataSource,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const {
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      flatTimelineActivityTypeMaps,
+    } = await this.workspaceCacheService.getOrRecompute(workspaceId, [
+      'flatObjectMetadataMaps',
+      'flatFieldMetadataMaps',
+      'flatTimelineActivityTypeMaps',
+    ]);
+
+    const timelineActivityObjectMetadata =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier: TIMELINE_ACTIVITY.universalIdentifier,
+      });
+
+    if (!isDefined(timelineActivityObjectMetadata)) {
+      this.logger.log(
+        `timelineActivity object does not exist for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    if (!isDefined(dataSource)) {
+      this.logger.log(`No data source for workspace ${workspaceId}, skipping`);
+
+      return;
+    }
+
+    const timelineActivityTypeIdField =
+      findFlatEntityByUniversalIdentifier<FlatFieldMetadata>({
+        flatEntityMaps: flatFieldMetadataMaps,
+        universalIdentifier:
+          TIMELINE_ACTIVITY.fields.timelineActivityTypeId.universalIdentifier,
+      });
+
+    if (!isDefined(timelineActivityTypeIdField)) {
+      throw new Error(
+        `Workspace ${workspaceId} is missing timelineActivity.timelineActivityTypeId after the 2.33 upgrade`,
+      );
+    }
+
+    const validTimelineActivityTypeIds = Object.values(
+      flatTimelineActivityTypeMaps.byUniversalIdentifier,
+    )
+      .filter(isDefined)
+      .map((flatTimelineActivityType) => flatTimelineActivityType.id);
+
+    const auditBefore = await this.auditTimelineActivityTypeIds({
+      workspaceId,
+      dataSource,
+      validTimelineActivityTypeIds,
+    });
+
+    if (options.dryRun === true) {
+      this.logger.log(
+        `[DRY RUN] Would backfill ${auditBefore.nullTypeIdCount} timelineActivity row(s); found ${auditBefore.danglingTypeIdCount} dangling type reference(s) for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    let backfilledRowCount = 0;
+
+    if (auditBefore.nullTypeIdCount > 0) {
+      const backfillQuery = buildTimelineActivityTypeBackfillQuery({
+        schemaName: getWorkspaceSchemaName(workspaceId),
+        flatTimelineActivityTypeMaps,
+        batchSize: BACKFILL_BATCH_SIZE,
+      });
+
+      if (!isDefined(backfillQuery)) {
+        throw new Error(
+          `Workspace ${workspaceId} is missing the fallback timeline activity type required for backfill`,
+        );
+      }
+
+      let lastBatchRowCount = 0;
+
+      // Each batch commits independently and only selects rows still missing a
+      // type, so retrying after interruption resumes without rewriting rows.
+      do {
+        const result = await dataSource.query(
+          backfillQuery.sql,
+          backfillQuery.parameters,
+          undefined,
+          { shouldBypassPermissionChecks: true },
+        );
+
+        lastBatchRowCount = result?.[1] ?? 0;
+        backfilledRowCount += lastBatchRowCount;
+      } while (lastBatchRowCount === BACKFILL_BATCH_SIZE);
+    }
+
+    const auditAfter = await this.auditTimelineActivityTypeIds({
+      workspaceId,
+      dataSource,
+      validTimelineActivityTypeIds,
+    });
+
+    this.logger.log(
+      `Backfilled ${backfilledRowCount} timelineActivity row(s) for workspace ${workspaceId}`,
+    );
+
+    if (auditAfter.nullTypeIdCount > 0 || auditAfter.danglingTypeIdCount > 0) {
+      this.logger.warn(
+        `Workspace ${workspaceId} still has ${auditAfter.nullTypeIdCount} timelineActivity row(s) without a type and ${auditAfter.danglingTypeIdCount} dangling type reference(s)`,
+      );
+
+      return;
+    }
+
+    this.logger.log(
+      `All timelineActivity rows have valid type references for workspace ${workspaceId}`,
+    );
+  }
+
+  private async auditTimelineActivityTypeIds({
+    workspaceId,
+    dataSource,
+    validTimelineActivityTypeIds,
+  }: {
+    workspaceId: string;
+    dataSource: NonNullable<RunOnWorkspaceArgs['dataSource']>;
+    validTimelineActivityTypeIds: string[];
+  }): Promise<TimelineActivityTypeAudit> {
+    const [audit] = await dataSource.query(
+      `SELECT
+        COUNT(*) FILTER (WHERE "timelineActivityTypeId" IS NULL)::integer AS "nullTypeIdCount",
+        COUNT(*) FILTER (
+          WHERE "timelineActivityTypeId" IS NOT NULL
+            AND NOT ("timelineActivityTypeId" = ANY($1::uuid[]))
+        )::integer AS "danglingTypeIdCount"
+      FROM "${getWorkspaceSchemaName(workspaceId)}"."timelineActivity"`,
+      [validTimelineActivityTypeIds],
+      undefined,
+      { shouldBypassPermissionChecks: true },
+    );
+
+    if (!isDefined(audit)) {
+      throw new Error(
+        `Could not audit timeline activity type references for workspace ${workspaceId}`,
+      );
+    }
+
+    return audit;
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/__tests__/2-34-workspace-command-1787397332209-catch-up-timeline-activity-type-ids.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/__tests__/2-34-workspace-command-1787397332209-catch-up-timeline-activity-type-ids.command.spec.ts
@@ -1,0 +1,172 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+
+import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { CatchUpTimelineActivityTypeIdsCommand } from 'src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787397332209-catch-up-timeline-activity-type-ids.command';
+import { type GlobalWorkspaceDataSource } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+
+const WORKSPACE_ID = '20202020-0000-0000-0000-000000000001';
+const TIMELINE_ACTIVITY_TYPE_ID = '20202020-0000-0000-0000-000000000002';
+
+const buildCache = ({
+  hasTimelineActivityObject = true,
+  hasTimelineActivityTypeIdField = true,
+}: {
+  hasTimelineActivityObject?: boolean;
+  hasTimelineActivityTypeIdField?: boolean;
+} = {}) => ({
+  flatObjectMetadataMaps: {
+    byUniversalIdentifier: hasTimelineActivityObject
+      ? {
+          [STANDARD_OBJECTS.timelineActivity.universalIdentifier]: {
+            id: 'timeline-activity-object-id',
+            universalIdentifier:
+              STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+          },
+        }
+      : {},
+  },
+  flatFieldMetadataMaps: {
+    byUniversalIdentifier: hasTimelineActivityTypeIdField
+      ? {
+          [STANDARD_OBJECTS.timelineActivity.fields.timelineActivityTypeId
+            .universalIdentifier]: {
+            id: 'timeline-activity-type-id-field-id',
+            universalIdentifier:
+              STANDARD_OBJECTS.timelineActivity.fields.timelineActivityTypeId
+                .universalIdentifier,
+          },
+        }
+      : {},
+  },
+  flatTimelineActivityTypeMaps: {
+    byUniversalIdentifier: {
+      '20202020-0000-0000-0000-000000000003': {
+        id: TIMELINE_ACTIVITY_TYPE_ID,
+        action: 'linked',
+        objectUniversalIdentifier: null,
+      },
+    },
+  },
+});
+
+describe('CatchUpTimelineActivityTypeIdsCommand', () => {
+  let command: CatchUpTimelineActivityTypeIdsCommand;
+  let getOrRecomputeMock: jest.Mock;
+  let queryMock: jest.Mock;
+  let dataSource: GlobalWorkspaceDataSource;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    getOrRecomputeMock = jest.fn().mockResolvedValue(buildCache());
+    queryMock = jest.fn();
+    dataSource = {
+      query: queryMock,
+    } as unknown as GlobalWorkspaceDataSource;
+
+    command = new CatchUpTimelineActivityTypeIdsCommand(
+      {} as WorkspaceIteratorService,
+      {
+        getOrRecompute: getOrRecomputeMock,
+      } as unknown as WorkspaceCacheService,
+    );
+  });
+
+  const runOnWorkspace = (dryRun = false) =>
+    command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      dataSource,
+      options: { dryRun },
+      index: 0,
+      total: 1,
+    });
+
+  it('backfills every rollout row in bounded batches and reports dangling references', async () => {
+    queryMock
+      .mockResolvedValueOnce([
+        { nullTypeIdCount: 6000, danglingTypeIdCount: 1 },
+      ])
+      .mockResolvedValueOnce([[], 5000])
+      .mockResolvedValueOnce([[], 1000])
+      .mockResolvedValueOnce([{ nullTypeIdCount: 0, danglingTypeIdCount: 1 }]);
+    const warnSpy = jest
+      .spyOn(command['logger'], 'warn')
+      .mockImplementation(() => undefined);
+
+    await runOnWorkspace();
+
+    expect(queryMock).toHaveBeenCalledTimes(4);
+    expect(queryMock.mock.calls[1][0]).toContain(
+      'UPDATE "workspace_1wgvd1ht596lnc3xc7ykpvqbl"."timelineActivity"',
+    );
+    expect(queryMock.mock.calls[2][0]).toContain(
+      'WHERE "timelineActivityTypeId" IS NULL LIMIT 5000',
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Workspace ${WORKSPACE_ID} still has 0 timelineActivity row(s) without a type and 1 dangling type reference(s)`,
+    );
+  });
+
+  it('audits without changing rows in dry-run mode', async () => {
+    queryMock.mockResolvedValueOnce([
+      { nullTypeIdCount: 3, danglingTypeIdCount: 2 },
+    ]);
+    const logSpy = jest
+      .spyOn(command['logger'], 'log')
+      .mockImplementation(() => undefined);
+
+    await runOnWorkspace(true);
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('COUNT(*) FILTER'),
+      [[TIMELINE_ACTIVITY_TYPE_ID]],
+      undefined,
+      { shouldBypassPermissionChecks: true },
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      `[DRY RUN] Would backfill 3 timelineActivity row(s); found 2 dangling type reference(s) for workspace ${WORKSPACE_ID}`,
+    );
+  });
+
+  it('does not run an update when every row already has a valid type', async () => {
+    queryMock.mockResolvedValue([
+      { nullTypeIdCount: 0, danglingTypeIdCount: 0 },
+    ]);
+    const logSpy = jest
+      .spyOn(command['logger'], 'log')
+      .mockImplementation(() => undefined);
+
+    await runOnWorkspace();
+
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(
+      queryMock.mock.calls.some(([query]) => query.startsWith('UPDATE')),
+    ).toBe(false);
+    expect(logSpy).toHaveBeenCalledWith(
+      `All timelineActivity rows have valid type references for workspace ${WORKSPACE_ID}`,
+    );
+  });
+
+  it('fails before querying when the 2.33 type field is missing', async () => {
+    getOrRecomputeMock.mockResolvedValue(
+      buildCache({ hasTimelineActivityTypeIdField: false }),
+    );
+
+    await expect(runOnWorkspace()).rejects.toThrow(
+      `Workspace ${WORKSPACE_ID} is missing timelineActivity.timelineActivityTypeId after the 2.33 upgrade`,
+    );
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('skips workspaces where timelineActivity was never provisioned', async () => {
+    getOrRecomputeMock.mockResolvedValue(
+      buildCache({ hasTimelineActivityObject: false }),
+    );
+
+    await runOnWorkspace();
+
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -26,6 +26,7 @@ import { V2_3_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-
 import { V2_31_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-31/2-31-upgrade-version-command.module';
 import { V2_32_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-32/2-32-upgrade-version-command.module';
 import { V2_33_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module';
+import { V2_34_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-34/2-34-upgrade-version-command.module';
 import { V2_4_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-4/2-4-upgrade-version-command.module';
 import { V2_5_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-5/2-5-upgrade-version-command.module';
 import { V2_7_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-7/2-7-upgrade-version-command.module';
@@ -65,6 +66,7 @@ import { V2_9_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-
     V2_31_UpgradeVersionCommandModule,
     V2_32_UpgradeVersionCommandModule,
     V2_33_UpgradeVersionCommandModule,
+    V2_34_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}


### PR DESCRIPTION
## Context

2.33 introduced `timelineActivity.timelineActivityTypeId`, backfilled existing rows, and dual-writes the deprecated `name` column during rollout. A workspace can still receive legacy-only writes while old 2.32 processes drain or before its 2.33 workspace upgrade finishes.

This 2.34 command closes that compatibility window before we consider enforcing or removing the deprecated column.

## What changed

- add an idempotent 2.34 workspace command that backfills remaining null type IDs in bounded 5,000-row batches
- reuse the reviewed 2.33 legacy-name resolver so catch-up semantics cannot drift
- audit null type IDs and non-null IDs whose timeline activity type no longer exists
- make dry-run report both categories without mutating data
- warn, rather than guess, for dangling references so orphaned custom types retain their semantics for the renderer
- fail explicitly if the 2.33 field was not provisioned instead of silently marking the 2.34 command complete
- register the new 2.34 upgrade module

## Deliberate boundary

This does not add `NOT NULL`, drop `name`, or rewrite dangling IDs. Those become safe only after rollout data confirms the audit is clean and all supported writers/readers have crossed the compatibility boundary.

## Verification

- focused 2.33 backfill + 2.34 command tests: 12 passing
- `npx tsgo -p tsconfig.json --noEmit` in `packages/twenty-server`
- type-aware oxlint: 0 warnings/errors
- formatting and `git diff --check` clean

## Stack

Base: #24609 (version bump to 2.34.0)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

