### PR TITLE
Validate specialized timeline renderer contracts

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-timeline-activity-type-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-timeline-activity-type-validator.service.spec.ts
@@ -1,3 +1,4 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   FeatureFlagKey,
   MetadataWritability,
@@ -19,6 +20,17 @@ const APPLICATION_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000b1';
 const OTHER_APPLICATION_UNIVERSAL_IDENTIFIER =
   '00000000-0000-4000-8000-0000000000b2';
 const OBJECT_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000c1';
+const SPECIALIZED_RENDERER_CONTRACTS = [
+  {
+    renderer: 'message',
+    objectUniversalIdentifier: STANDARD_OBJECTS.message.universalIdentifier,
+  },
+  {
+    renderer: 'calendarEvent',
+    objectUniversalIdentifier:
+      STANDARD_OBJECTS.calendarEvent.universalIdentifier,
+  },
+] as const;
 
 const featureFlagsMap = {
   [FeatureFlagKey.IS_APP_CLAIMING_ENABLED]: false,
@@ -101,7 +113,11 @@ const mapsFrom = <TEntity extends { universalIdentifier: string }>(
 
 const buildCreationArgs = ({
   flatTimelineActivityType = buildTimelineActivityType(),
-  objectUniversalIdentifiers = [OBJECT_UNIVERSAL_IDENTIFIER],
+  objectUniversalIdentifiers = [
+    OBJECT_UNIVERSAL_IDENTIFIER,
+    STANDARD_OBJECTS.message.universalIdentifier,
+    STANDARD_OBJECTS.calendarEvent.universalIdentifier,
+  ],
 }: {
   flatTimelineActivityType?: UniversalFlatTimelineActivityType;
   objectUniversalIdentifiers?: string[];
@@ -143,6 +159,10 @@ const buildUpdateArgs = ({
       flatTimelineActivityTypeMaps: mapsFrom(existingTimelineActivityTypes),
       flatObjectMetadataMaps: mapsFrom([
         buildObjectMetadata(OBJECT_UNIVERSAL_IDENTIFIER),
+        buildObjectMetadata(STANDARD_OBJECTS.message.universalIdentifier),
+        buildObjectMetadata(
+          STANDARD_OBJECTS.calendarEvent.universalIdentifier,
+        ),
       ]),
     },
     buildOptions: {
@@ -250,12 +270,84 @@ describe('FlatTimelineActivityTypeValidatorService', () => {
             objectUniversalIdentifier: null,
           }),
         ],
-        flatEntityUpdate: { renderer: 'message' },
+        flatEntityUpdate: { renderer: 'message', action: 'linked' },
       }),
     );
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].message).toContain('requires');
+  });
+
+  it.each(SPECIALIZED_RENDERER_CONTRACTS)(
+    'should accept the $renderer renderer with its linked object contract',
+    ({ renderer, objectUniversalIdentifier }) => {
+      const result = service.validateFlatTimelineActivityTypeCreation(
+        buildCreationArgs({
+          flatTimelineActivityType: buildTimelineActivityType({
+            action: 'linked',
+            renderer,
+            objectUniversalIdentifier,
+          }),
+        }),
+      );
+
+      expect(result.errors).toEqual([]);
+    },
+  );
+
+  it.each(SPECIALIZED_RENDERER_CONTRACTS)(
+    'should reject an unsupported action for the $renderer renderer',
+    ({ renderer, objectUniversalIdentifier }) => {
+      const result = service.validateFlatTimelineActivityTypeCreation(
+        buildCreationArgs({
+          flatTimelineActivityType: buildTimelineActivityType({
+            action: 'updated',
+            renderer,
+            objectUniversalIdentifier,
+          }),
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('linked');
+    },
+  );
+
+  it.each(SPECIALIZED_RENDERER_CONTRACTS)(
+    'should reject the wrong object for the $renderer renderer',
+    ({ renderer }) => {
+      const result = service.validateFlatTimelineActivityTypeCreation(
+        buildCreationArgs({
+          flatTimelineActivityType: buildTimelineActivityType({
+            action: 'linked',
+            renderer,
+            objectUniversalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER,
+          }),
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('must reference');
+    },
+  );
+
+  it('should validate a partial action update against the existing specialized renderer', () => {
+    const result = service.validateFlatTimelineActivityTypeUpdate(
+      buildUpdateArgs({
+        existingTimelineActivityTypes: [
+          buildTimelineActivityType({
+            action: 'linked',
+            renderer: 'message',
+            objectUniversalIdentifier:
+              STANDARD_OBJECTS.message.universalIdentifier,
+          }),
+        ],
+        flatEntityUpdate: { action: 'updated' },
+      }),
+    );
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('linked');
   });
 
   it('should reject binding a type to an object that does not exist', () => {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-timeline-activity-type-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-timeline-activity-type-validator.service.ts
@@ -57,6 +57,50 @@ type ValidateTimelineActivityTypePropertiesArgs = {
   updatedProperties?: UniversalFlatEntityUpdate<'timelineActivityType'>;
 };
 
+const validateSpecializedRendererContract = ({
+  flatTimelineActivityType,
+  updatedProperties,
+}: ValidateTimelineActivityTypePropertiesArgs): FlatEntityValidationError[] => {
+  const isUpdate = isDefined(updatedProperties);
+  const shouldValidate =
+    !isUpdate ||
+    'renderer' in updatedProperties ||
+    'action' in updatedProperties ||
+    'objectUniversalIdentifier' in updatedProperties;
+  const renderer = flatTimelineActivityType.renderer;
+  const rendererContract = isDefined(renderer)
+    ? SPECIALIZED_TIMELINE_ACTIVITY_RENDERER_CONTRACTS[renderer]
+    : undefined;
+
+  if (!shouldValidate || !isDefined(renderer) || !isDefined(rendererContract)) {
+    return [];
+  }
+
+  const errors: FlatEntityValidationError[] = [];
+
+  if (flatTimelineActivityType.action !== rendererContract.action) {
+    errors.push({
+      code: TimelineActivityTypeExceptionCode.INVALID_TIMELINE_ACTIVITY_TYPE_INPUT,
+      message: t`Timeline activity renderer ${renderer} only supports the ${rendererContract.action} action`,
+      userFriendlyMessage: msg`This timeline activity renderer does not support the selected action`,
+    });
+  }
+
+  if (
+    isDefined(flatTimelineActivityType.objectUniversalIdentifier) &&
+    flatTimelineActivityType.objectUniversalIdentifier !==
+      rendererContract.objectUniversalIdentifier
+  ) {
+    errors.push({
+      code: TimelineActivityTypeExceptionCode.INVALID_TIMELINE_ACTIVITY_TYPE_INPUT,
+      message: t`Timeline activity renderer ${renderer} must reference its supported object`,
+      userFriendlyMessage: msg`This timeline activity renderer does not support the selected object`,
+    });
+  }
+
+  return errors;
+};
+
 const validateTimelineActivityTypeProperties = ({
   flatTimelineActivityType,
   updatedProperties,
@@ -132,43 +176,12 @@ const validateTimelineActivityTypeProperties = ({
     });
   }
 
-  const shouldValidateSpecializedRendererContract =
-    !isUpdate ||
-    'renderer' in updatedProperties ||
-    'action' in updatedProperties ||
-    'objectUniversalIdentifier' in updatedProperties;
-  const renderer = flatTimelineActivityType.renderer;
-  const specializedRendererContract = isDefined(renderer)
-    ? SPECIALIZED_TIMELINE_ACTIVITY_RENDERER_CONTRACTS[renderer]
-    : undefined;
-
-  if (
-    shouldValidateSpecializedRendererContract &&
-    isDefined(renderer) &&
-    isDefined(specializedRendererContract)
-  ) {
-    if (
-      flatTimelineActivityType.action !== specializedRendererContract.action
-    ) {
-      errors.push({
-        code: TimelineActivityTypeExceptionCode.INVALID_TIMELINE_ACTIVITY_TYPE_INPUT,
-        message: t`Timeline activity renderer ${renderer} only supports the ${specializedRendererContract.action} action`,
-        userFriendlyMessage: msg`This timeline activity renderer does not support the selected action`,
-      });
-    }
-
-    if (
-      isDefined(flatTimelineActivityType.objectUniversalIdentifier) &&
-      flatTimelineActivityType.objectUniversalIdentifier !==
-        specializedRendererContract.objectUniversalIdentifier
-    ) {
-      errors.push({
-        code: TimelineActivityTypeExceptionCode.INVALID_TIMELINE_ACTIVITY_TYPE_INPUT,
-        message: t`Timeline activity renderer ${renderer} must reference its supported object`,
-        userFriendlyMessage: msg`This timeline activity renderer does not support the selected object`,
-      });
-    }
-  }
+  errors.push(
+    ...validateSpecializedRendererContract({
+      flatTimelineActivityType,
+      updatedProperties,
+    }),
+  );
 
   return errors;
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-timeline-activity-type-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-timeline-activity-type-validator.service.ts
@@ -2,10 +2,11 @@ import { Injectable } from '@nestjs/common';
 
 import { msg, t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
-import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+import { ALL_METADATA_NAME, STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   isTimelineActivityAction,
   isTimelineActivityRenderer,
+  type TimelineActivityAction,
   type TimelineActivityRenderer,
 } from 'twenty-shared/timeline';
 import { isDefined } from 'twenty-shared/utils';
@@ -30,6 +31,26 @@ const UNBOUND_TIMELINE_ACTIVITY_RENDERERS: TimelineActivityRenderer[] = [
   'mainObject',
   'genericLinked',
 ];
+
+const SPECIALIZED_TIMELINE_ACTIVITY_RENDERER_CONTRACTS: Partial<
+  Record<
+    TimelineActivityRenderer,
+    {
+      action: TimelineActivityAction;
+      objectUniversalIdentifier: string;
+    }
+  >
+> = {
+  message: {
+    action: 'linked',
+    objectUniversalIdentifier: STANDARD_OBJECTS.message.universalIdentifier,
+  },
+  calendarEvent: {
+    action: 'linked',
+    objectUniversalIdentifier:
+      STANDARD_OBJECTS.calendarEvent.universalIdentifier,
+  },
+};
 
 type ValidateTimelineActivityTypePropertiesArgs = {
   flatTimelineActivityType: UniversalFlatTimelineActivityType;
@@ -109,6 +130,44 @@ const validateTimelineActivityTypeProperties = ({
       message: t`Timeline activity renderer ${flatTimelineActivityType.renderer} requires the type to reference an object`,
       userFriendlyMessage: msg`This timeline activity renderer requires the type to reference an object`,
     });
+  }
+
+  const shouldValidateSpecializedRendererContract =
+    !isUpdate ||
+    'renderer' in updatedProperties ||
+    'action' in updatedProperties ||
+    'objectUniversalIdentifier' in updatedProperties;
+  const renderer = flatTimelineActivityType.renderer;
+  const specializedRendererContract = isDefined(renderer)
+    ? SPECIALIZED_TIMELINE_ACTIVITY_RENDERER_CONTRACTS[renderer]
+    : undefined;
+
+  if (
+    shouldValidateSpecializedRendererContract &&
+    isDefined(renderer) &&
+    isDefined(specializedRendererContract)
+  ) {
+    if (
+      flatTimelineActivityType.action !== specializedRendererContract.action
+    ) {
+      errors.push({
+        code: TimelineActivityTypeExceptionCode.INVALID_TIMELINE_ACTIVITY_TYPE_INPUT,
+        message: t`Timeline activity renderer ${renderer} only supports the ${specializedRendererContract.action} action`,
+        userFriendlyMessage: msg`This timeline activity renderer does not support the selected action`,
+      });
+    }
+
+    if (
+      isDefined(flatTimelineActivityType.objectUniversalIdentifier) &&
+      flatTimelineActivityType.objectUniversalIdentifier !==
+        specializedRendererContract.objectUniversalIdentifier
+    ) {
+      errors.push({
+        code: TimelineActivityTypeExceptionCode.INVALID_TIMELINE_ACTIVITY_TYPE_INPUT,
+        message: t`Timeline activity renderer ${renderer} must reference its supported object`,
+        userFriendlyMessage: msg`This timeline activity renderer does not support the selected object`,
+      });
+    }
   }
 
   return errors;


### PR DESCRIPTION
## Context

The `message` and `calendarEvent` timeline renderers are specialized components, not generic renderer names:

- both frontend components require the `linked` action
- each component interprets `linkedRecordId` as a record of one specific object

The metadata validator previously required only that specialized renderers had some object binding. It therefore accepted definitions that would always throw while rendering or load the wrong object.

## What changed

- define the supported action/object contract for `message` and `calendarEvent`
- validate those contracts during creation
- revalidate the fully merged definition when a partial update changes the renderer, action, or object binding
- cover valid definitions, wrong actions, wrong objects, and partial-update regressions for both renderers
- keep `mainObject`, `genericLinked`, and `activity` flexible; this PR does not turn internal renderer names into a broader app API

## Verification

- validator suite: 23 passing tests
- direct `twenty-server` typecheck
- type-aware oxlint: 0 warnings/errors
- formatting and `git diff --check` clean

## Stack

Depends on #24610.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

