### PR TITLE
fix(front): enable Save when a select option is added from a record cell

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -30,9 +30,7 @@ import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { isAdvancedModeEnabledState } from '@/ui/navigation/navigation-drawer/states/isAdvancedModeEnabledState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { t } from '@lingui/core/macro';
-import { useContext, useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { isDefined } from 'twenty-shared/utils';
+import { useContext, useState } from 'react';
 import {
   IconDotsVertical,
   IconPencil,
@@ -178,8 +176,6 @@ export const SettingsDataModelFieldSelectForm = ({
 
   const isAdvancedModeEnabled = useAtomStateValue(isAdvancedModeEnabledState);
 
-  const [searchParams] = useSearchParams();
-
   const {
     control,
     setValue: setFormValue,
@@ -187,26 +183,12 @@ export const SettingsDataModelFieldSelectForm = ({
     getValues,
   } = useFormContext<SettingsDataModelFieldSelectFormValues>();
 
-  const [hasAppliedNewOption, setHasAppliedNewOption] = useState(false);
   const [isBulkInputMode, setIsBulkInputMode] = useState(false);
   const [bulkInputText, setBulkInputText] = useState('');
 
   const OPTIONS_DROPDOWN_ID =
     'settings-data-model-field-select-options-dropdown';
   const { closeDropdown: closeOptionsDropdown } = useCloseDropdown();
-
-  useEffect(() => {
-    const newOptionValue = searchParams.get('newOption');
-
-    if (isDefined(newOptionValue) && !hasAppliedNewOption) {
-      const newOption = generateNewSelectOption(initialOptions, newOptionValue);
-
-      const optionsWithNew = [...initialOptions, newOption];
-
-      setFormValue('options', optionsWithNew, { shouldDirty: true });
-      setHasAppliedNewOption(true);
-    }
-  }, [searchParams, hasAppliedNewOption, initialOptions, setFormValue]);
 
   const handleDragEnd = (
     values: FieldMetadataItemOption[],

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/__tests__/useApplyNewSelectOptionFromSearchParams.test.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/__tests__/useApplyNewSelectOptionFromSearchParams.test.tsx
@@ -1,0 +1,116 @@
+import { renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { type FieldMetadataItemOption } from '@/object-metadata/types/FieldMetadataItem';
+import { useApplyNewSelectOptionFromSearchParams } from '@/settings/data-model/fields/forms/select/hooks/useApplyNewSelectOptionFromSearchParams';
+
+const PERSISTED_OPTIONS: FieldMetadataItemOption[] = [
+  { id: 'option-1', color: 'green', label: 'New', value: 'NEW', position: 0 },
+];
+
+const FIELD_METADATA_ID = 'field-metadata-id';
+
+const getWrapper =
+  (search: string) =>
+  ({ children }: { children: ReactNode }) => (
+    <MemoryRouter
+      initialEntries={[`/settings/objects/opportunities/stage${search}`]}
+    >
+      {children}
+    </MemoryRouter>
+  );
+
+const renderApplyNewSelectOptionHook = ({
+  search,
+  optionsByRender,
+}: {
+  search: string;
+  optionsByRender: (FieldMetadataItemOption[] | undefined)[];
+}) => {
+  const setValue = jest.fn();
+
+  let currentOptions = optionsByRender[0];
+  const getValues = jest.fn(() => currentOptions);
+
+  const { rerender } = renderHook(
+    ({ fieldMetadataId }: { fieldMetadataId: string | undefined }) =>
+      useApplyNewSelectOptionFromSearchParams({
+        fieldMetadataId,
+        getValues,
+        setValue,
+      }),
+    {
+      wrapper: getWrapper(search),
+      initialProps: {
+        fieldMetadataId:
+          optionsByRender[0] === undefined ? undefined : FIELD_METADATA_ID,
+      },
+    },
+  );
+
+  const renderNext = (options: FieldMetadataItemOption[] | undefined) => {
+    currentOptions = options;
+    rerender({
+      fieldMetadataId: options === undefined ? undefined : FIELD_METADATA_ID,
+    });
+  };
+
+  return { setValue, renderNext };
+};
+
+describe('useApplyNewSelectOptionFromSearchParams', () => {
+  it('appends the option named in the URL to the options already on the field', () => {
+    const { setValue } = renderApplyNewSelectOptionHook({
+      search: '?newOption=Negotiation',
+      optionsByRender: [PERSISTED_OPTIONS],
+    });
+
+    expect(setValue).toHaveBeenCalledTimes(1);
+
+    const [name, nextOptions, config] = setValue.mock.calls[0];
+
+    expect(name).toBe('options');
+    expect(config).toEqual({ shouldDirty: true });
+    expect(nextOptions).toHaveLength(2);
+    expect(nextOptions[0]).toEqual(PERSISTED_OPTIONS[0]);
+    expect(nextOptions[1].label).toBe('Negotiation');
+  });
+
+  it('waits for the field to register instead of giving up on the first miss', () => {
+    const { setValue, renderNext } = renderApplyNewSelectOptionHook({
+      search: '?newOption=Negotiation',
+      optionsByRender: [undefined],
+    });
+
+    expect(setValue).not.toHaveBeenCalled();
+
+    renderNext(PERSISTED_OPTIONS);
+
+    expect(setValue).toHaveBeenCalledTimes(1);
+    expect(setValue.mock.calls[0][1]).toHaveLength(2);
+  });
+
+  it('applies the option only once', () => {
+    const { setValue, renderNext } = renderApplyNewSelectOptionHook({
+      search: '?newOption=Negotiation',
+      optionsByRender: [PERSISTED_OPTIONS],
+    });
+
+    renderNext(PERSISTED_OPTIONS);
+    renderNext(PERSISTED_OPTIONS);
+
+    expect(setValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the form untouched when the URL carries no new option', () => {
+    const { setValue, renderNext } = renderApplyNewSelectOptionHook({
+      search: '',
+      optionsByRender: [PERSISTED_OPTIONS],
+    });
+
+    renderNext(PERSISTED_OPTIONS);
+
+    expect(setValue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useApplyNewSelectOptionFromSearchParams.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useApplyNewSelectOptionFromSearchParams.ts
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react';
-import { type UseFormGetValues, type UseFormSetValue } from 'react-hook-form';
 import { useSearchParams } from 'react-router-dom';
 import { isDefined } from 'twenty-shared/utils';
 
-import { type SettingsDataModelFieldSelectFormValues } from '@/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm';
+import { type FieldMetadataItemOption } from '@/object-metadata/types/FieldMetadataItem';
 import { generateNewSelectOption } from '@/settings/data-model/fields/forms/select/utils/generateNewSelectOption';
 
 type UseApplyNewSelectOptionFromSearchParamsParams = {
-  getValues: UseFormGetValues<SettingsDataModelFieldSelectFormValues>;
-  setValue: UseFormSetValue<SettingsDataModelFieldSelectFormValues>;
+  fieldMetadataId: string | undefined;
+  getValues: (name: 'options') => FieldMetadataItemOption[] | undefined;
+  setValue: (
+    name: 'options',
+    options: FieldMetadataItemOption[],
+    config: { shouldDirty: boolean },
+  ) => void;
 };
 
 // This has to live in the component owning the form: react-hook-form only
@@ -16,6 +20,7 @@ type UseApplyNewSelectOptionFromSearchParamsParams = {
 // option written from the select form below it leaves the form pristine and
 // the Save button disabled.
 export const useApplyNewSelectOptionFromSearchParams = ({
+  fieldMetadataId,
   getValues,
   setValue,
 }: UseApplyNewSelectOptionFromSearchParamsParams) => {
@@ -32,6 +37,8 @@ export const useApplyNewSelectOptionFromSearchParams = ({
 
     const currentOptions = getValues('options');
 
+    // The field only registers once its metadata has resolved, so this waits
+    // for the next field instead of giving up on the first miss.
     if (!isDefined(currentOptions)) {
       return;
     }
@@ -46,5 +53,5 @@ export const useApplyNewSelectOptionFromSearchParams = ({
       ],
       { shouldDirty: true },
     );
-  }, [searchParams, hasAppliedNewOption, getValues, setValue]);
+  }, [searchParams, hasAppliedNewOption, fieldMetadataId, getValues, setValue]);
 };

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useApplyNewSelectOptionFromSearchParams.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useApplyNewSelectOptionFromSearchParams.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { type UseFormGetValues, type UseFormSetValue } from 'react-hook-form';
+import { useSearchParams } from 'react-router-dom';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type SettingsDataModelFieldSelectFormValues } from '@/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm';
+import { generateNewSelectOption } from '@/settings/data-model/fields/forms/select/utils/generateNewSelectOption';
+
+type UseApplyNewSelectOptionFromSearchParamsParams = {
+  getValues: UseFormGetValues<SettingsDataModelFieldSelectFormValues>;
+  setValue: UseFormSetValue<SettingsDataModelFieldSelectFormValues>;
+};
+
+// This has to live in the component owning the form: react-hook-form only
+// starts computing the dirty state once that component has mounted, so an
+// option written from the select form below it leaves the form pristine and
+// the Save button disabled.
+export const useApplyNewSelectOptionFromSearchParams = ({
+  getValues,
+  setValue,
+}: UseApplyNewSelectOptionFromSearchParamsParams) => {
+  const [searchParams] = useSearchParams();
+
+  const [hasAppliedNewOption, setHasAppliedNewOption] = useState(false);
+
+  useEffect(() => {
+    const newOptionLabel = searchParams.get('newOption');
+
+    if (!isDefined(newOptionLabel) || hasAppliedNewOption) {
+      return;
+    }
+
+    const currentOptions = getValues('options');
+
+    if (!isDefined(currentOptions)) {
+      return;
+    }
+
+    setHasAppliedNewOption(true);
+
+    setValue(
+      'options',
+      [
+        ...currentOptions,
+        generateNewSelectOption(currentOptions, newOptionLabel),
+      ],
+      { shouldDirty: true },
+    );
+  }, [searchParams, hasAppliedNewOption, getValues, setValue]);
+};

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -132,6 +132,7 @@ export const SettingsObjectFieldEdit = () => {
   });
 
   useApplyNewSelectOptionFromSearchParams({
+    fieldMetadataId: fieldMetadataItem?.id,
     getValues: formConfig.getValues,
     setValue: formConfig.setValue,
   });

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -22,6 +22,7 @@ import { SettingsDataModelFieldDescriptionForm } from '@/settings/data-model/fie
 import { SettingsTranslationsButton } from '@/settings/translations/components/SettingsTranslationsButton';
 import { SettingsDataModelFieldIconLabelForm } from '@/settings/data-model/fields/forms/components/SettingsDataModelFieldIconLabelForm';
 import { SettingsDataModelFieldSettingsFormCard } from '@/settings/data-model/fields/forms/components/SettingsDataModelFieldSettingsFormCard';
+import { useApplyNewSelectOptionFromSearchParams } from '@/settings/data-model/fields/forms/select/hooks/useApplyNewSelectOptionFromSearchParams';
 import { settingsFieldFormSchema } from '@/settings/data-model/fields/forms/validation-schemas/settingsFieldFormSchema';
 import { type SettingsFieldType } from '@/settings/data-model/types/SettingsFieldType';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
@@ -128,6 +129,11 @@ export const SettingsObjectFieldEdit = () => {
       settings,
       defaultValue,
     },
+  });
+
+  useApplyNewSelectOptionFromSearchParams({
+    getValues: formConfig.getValues,
+    setValue: formConfig.setValue,
   });
 
   useEffect(() => {

--- a/packages/twenty-front/src/pages/settings/data-model/__stories__/SettingsObjectFieldEdit.stories.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/__stories__/SettingsObjectFieldEdit.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
 
 import {
   PageDecorator,
@@ -33,5 +34,24 @@ export const CustomField: Story = {
       ':objectNamePlural': 'companies',
       ':fieldName': 'employees',
     },
+  },
+};
+
+export const SelectFieldWithOptionAddedFromRecord: Story = {
+  args: {
+    routeParams: {
+      ':objectNamePlural': 'opportunities',
+      ':fieldName': 'stage',
+    },
+    searchParams: { newOption: 'Negotiation' },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByDisplayValue('Negotiation');
+
+    const saveButton = await canvas.findByRole('button', { name: /Save/ });
+
+    await expect(saveButton).toBeEnabled();
   },
 };


### PR DESCRIPTION
Fixes #23487

Adding an option from a record cell lands on the field settings with that option already in the list, but Save stays disabled, so it cannot be saved until something else is edited.

`SettingsDataModelFieldSelectForm` applies the option from an effect that runs before `SettingsObjectFieldEdit` has mounted. Until that component mounts, react-hook-form's `getValues()` still returns the default values, so `_getDirty()` compares the defaults against themselves, `isDirty` never flips, and `canSave` stays false. StrictMode re-invokes the effect in dev, which is why this only shows up on a production build — the earlier attempt in #23488 was chasing the same lifecycle detail.

Moving the injection into a hook called by the component that owns `useForm` runs it once react-hook-form is mounted, so the ordinary dirty computation applies. It costs the same single re-render as today, and `canSave` keeps its meaning for every other field form.

Added a story for the flow: it fails on `main` with `expect(element).toBeEnabled()` and passes here.

<img width="672" height="428" alt="Save button before and after" src="https://github.com/user-attachments/assets/0b016c5b-e62b-428f-81a8-29625c4ed2d9" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

