### PR TITLE
Repair activity junction targets for custom-only morphs

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-upgrade-version-command.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { RepairActivityTargetsJunctionTargetCommand } from 'src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787461587487-repair-activity-targets-junction-target.command';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([FieldMetadataEntity]),
+    WorkspaceIteratorModule,
+    WorkspaceMigrationRunnerModule,
+  ],
+  providers: [RepairActivityTargetsJunctionTargetCommand],
+})
+export class V2_34_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787461587487-repair-activity-targets-junction-target.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787461587487-repair-activity-targets-junction-target.command.ts
@@ -1,0 +1,276 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { invalidateFieldMetadataCache } from 'src/database/commands/upgrade-version-command/utils/invalidate-field-metadata-cache.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { isFieldMetadataSettingsOfType } from 'src/engine/metadata-modules/field-metadata/utils/is-field-metadata-settings-of-type.util';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+const LEGACY_NOTE_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-38ca-4aab-92f5-8a605ca2e4c5';
+const LEGACY_TASK_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-c8a0-4e85-a016-87e2349cfbec';
+
+const ACTIVITY_JUNCTIONS = [
+  {
+    label: 'note.noteTargets',
+    junctionRelationFieldUniversalIdentifier:
+      STANDARD_OBJECTS.note.fields.noteTargets.universalIdentifier,
+    targetMorphId: STANDARD_OBJECTS.noteTarget.morphIds.targetMorphId.morphId,
+    preferredTargetFieldUniversalIdentifiers: [
+      STANDARD_OBJECTS.noteTarget.fields.targetPerson.universalIdentifier,
+      LEGACY_NOTE_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER,
+    ],
+  },
+  {
+    label: 'task.taskTargets',
+    junctionRelationFieldUniversalIdentifier:
+      STANDARD_OBJECTS.task.fields.taskTargets.universalIdentifier,
+    targetMorphId: STANDARD_OBJECTS.taskTarget.morphIds.targetMorphId.morphId,
+    preferredTargetFieldUniversalIdentifiers: [
+      STANDARD_OBJECTS.taskTarget.fields.targetPerson.universalIdentifier,
+      LEGACY_TASK_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER,
+    ],
+  },
+] as const;
+
+type ActivityJunction = (typeof ACTIVITY_JUNCTIONS)[number];
+
+@RegisteredWorkspaceCommand('2.34.0', 1787461587487)
+@Command({
+  name: 'upgrade:2-34:repair-activity-targets-junction-target',
+  description:
+    'Repair note and task activity junction target settings when the target morph only contains custom object fields.',
+})
+export class RepairActivityTargetsJunctionTargetCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
+    @InjectRepository(FieldMetadataEntity)
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+    const repairedLabels =
+      await this.fieldMetadataRepository.manager.transaction(
+        async (entityManager) => {
+          const fieldMetadataRepository =
+            entityManager.getRepository(FieldMetadataEntity);
+          const activeFieldMetadatas = await fieldMetadataRepository.find({
+            where: { workspaceId, isActive: true },
+            order: { universalIdentifier: 'ASC' },
+          });
+          const repairedLabels: string[] = [];
+
+          for (const activityJunction of ACTIVITY_JUNCTIONS) {
+            const repaired = await this.repairActivityJunction({
+              activityJunction,
+              activeFieldMetadatas,
+              fieldMetadataRepository,
+              isDryRun,
+              workspaceId,
+            });
+
+            if (repaired) {
+              repairedLabels.push(activityJunction.label);
+            }
+          }
+
+          return repairedLabels;
+        },
+      );
+
+    if (repairedLabels.length === 0) {
+      return;
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] Would repair' : 'Repaired'} ${repairedLabels.join(', ')} junction target for workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    await invalidateFieldMetadataCache({
+      workspaceId,
+      workspaceMigrationRunnerService: this.workspaceMigrationRunnerService,
+    });
+  }
+
+  private async repairActivityJunction({
+    activityJunction,
+    activeFieldMetadatas,
+    fieldMetadataRepository,
+    isDryRun,
+    workspaceId,
+  }: {
+    activityJunction: ActivityJunction;
+    activeFieldMetadatas: FieldMetadataEntity[];
+    fieldMetadataRepository: Repository<FieldMetadataEntity>;
+    isDryRun: boolean;
+    workspaceId: string;
+  }): Promise<boolean> {
+    const junctionRelationFieldMetadata = activeFieldMetadatas.find(
+      ({ universalIdentifier }) =>
+        universalIdentifier ===
+        activityJunction.junctionRelationFieldUniversalIdentifier,
+    );
+
+    if (!isDefined(junctionRelationFieldMetadata)) {
+      return false;
+    }
+
+    const junctionTargetFieldMetadatas = activeFieldMetadatas
+      .filter((fieldMetadata) =>
+        this.isValidJunctionTargetFieldMetadata({
+          activityJunction,
+          fieldMetadata,
+          junctionRelationFieldMetadata,
+        }),
+      )
+      .sort(
+        (firstFieldMetadata, secondFieldMetadata) =>
+          this.getTargetFieldPriority({
+            activityJunction,
+            fieldMetadata: firstFieldMetadata,
+          }) -
+          this.getTargetFieldPriority({
+            activityJunction,
+            fieldMetadata: secondFieldMetadata,
+          }),
+      );
+    const junctionTargetFieldMetadata = junctionTargetFieldMetadatas[0];
+
+    if (!isDefined(junctionTargetFieldMetadata)) {
+      this.logger.warn(
+        `No valid junction target field for ${activityJunction.label} in workspace ${workspaceId}, skipping`,
+      );
+
+      return false;
+    }
+
+    const lockedJunctionRelationFieldMetadata =
+      await fieldMetadataRepository.findOne({
+        where: { id: junctionRelationFieldMetadata.id, workspaceId },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+    if (
+      !isDefined(lockedJunctionRelationFieldMetadata) ||
+      !isFieldMetadataSettingsOfType(
+        lockedJunctionRelationFieldMetadata.settings,
+        FieldMetadataType.RELATION,
+      ) ||
+      lockedJunctionRelationFieldMetadata.settings.relationType !==
+        RelationType.ONE_TO_MANY
+    ) {
+      this.logger.warn(
+        `${activityJunction.label} is no longer a one to many relation for workspace ${workspaceId}, skipping`,
+      );
+
+      return false;
+    }
+
+    const lockedJunctionRelationSettings =
+      lockedJunctionRelationFieldMetadata.settings;
+
+    if (
+      junctionTargetFieldMetadatas.some(
+        ({ id }) =>
+          id === lockedJunctionRelationSettings.junctionTargetFieldId,
+      )
+    ) {
+      return false;
+    }
+
+    if (isDryRun) {
+      return true;
+    }
+
+    await fieldMetadataRepository.update(
+      { id: lockedJunctionRelationFieldMetadata.id, workspaceId },
+      {
+        settings: {
+          ...lockedJunctionRelationSettings,
+          junctionTargetFieldId: junctionTargetFieldMetadata.id,
+        },
+      },
+    );
+
+    return true;
+  }
+
+  private isValidJunctionTargetFieldMetadata({
+    activityJunction,
+    fieldMetadata,
+    junctionRelationFieldMetadata,
+  }: {
+    activityJunction: ActivityJunction;
+    fieldMetadata: FieldMetadataEntity;
+    junctionRelationFieldMetadata: FieldMetadataEntity;
+  }): boolean {
+    if (
+      !isDefined(
+        junctionRelationFieldMetadata.relationTargetObjectMetadataId,
+      ) ||
+      fieldMetadata.objectMetadataId !==
+        junctionRelationFieldMetadata.relationTargetObjectMetadataId
+    ) {
+      return false;
+    }
+
+    if (fieldMetadata.type === FieldMetadataType.MORPH_RELATION) {
+      return (
+        fieldMetadata.morphId === activityJunction.targetMorphId &&
+        isFieldMetadataSettingsOfType(
+          fieldMetadata.settings,
+          FieldMetadataType.MORPH_RELATION,
+        ) &&
+        fieldMetadata.settings.relationType === RelationType.MANY_TO_ONE
+      );
+    }
+
+    return (
+      fieldMetadata.type === FieldMetadataType.RELATION &&
+      activityJunction.preferredTargetFieldUniversalIdentifiers.includes(
+        fieldMetadata.universalIdentifier,
+      ) &&
+      isFieldMetadataSettingsOfType(
+        fieldMetadata.settings,
+        FieldMetadataType.RELATION,
+      ) &&
+      fieldMetadata.settings.relationType === RelationType.MANY_TO_ONE
+    );
+  }
+
+  private getTargetFieldPriority({
+    activityJunction,
+    fieldMetadata,
+  }: {
+    activityJunction: ActivityJunction;
+    fieldMetadata: FieldMetadataEntity;
+  }): number {
+    const preferredIndex =
+      activityJunction.preferredTargetFieldUniversalIdentifiers.indexOf(
+        fieldMetadata.universalIdentifier,
+      );
+
+    return preferredIndex === -1 ? Number.MAX_SAFE_INTEGER : preferredIndex;
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/__tests__/2-34-workspace-command-1787461587487-repair-activity-targets-junction-target.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/__tests__/2-34-workspace-command-1787461587487-repair-activity-targets-junction-target.command.spec.ts
@@ -1,0 +1,271 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import { type Repository } from 'typeorm';
+
+import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { RepairActivityTargetsJunctionTargetCommand } from 'src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787461587487-repair-activity-targets-junction-target.command';
+import { invalidateFieldMetadataCache } from 'src/database/commands/upgrade-version-command/utils/invalidate-field-metadata-cache.util';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { type WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+jest.mock(
+  'src/database/commands/upgrade-version-command/utils/invalidate-field-metadata-cache.util',
+);
+
+const invalidateFieldMetadataCacheMock = jest.mocked(
+  invalidateFieldMetadataCache,
+);
+
+const WORKSPACE_ID = '20202020-0000-0000-0000-000000000001';
+const NOTE_TARGET_OBJECT_METADATA_ID = '20202020-0000-0000-0000-000000000002';
+const TASK_TARGET_OBJECT_METADATA_ID = '20202020-0000-0000-0000-000000000003';
+const NOTE_TARGETS_FIELD_METADATA_ID = '20202020-0000-0000-0000-000000000004';
+const TASK_TARGETS_FIELD_METADATA_ID = '20202020-0000-0000-0000-000000000005';
+const CUSTOM_NOTE_TARGET_FIELD_METADATA_ID =
+  '20202020-0000-0000-0000-000000000006';
+const CUSTOM_TASK_TARGET_FIELD_METADATA_ID =
+  '20202020-0000-0000-0000-000000000007';
+const LEGACY_NOTE_TARGET_PERSON_FIELD_METADATA_ID =
+  '20202020-0000-0000-0000-000000000008';
+const LEGACY_NOTE_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-38ca-4aab-92f5-8a605ca2e4c5';
+
+const buildFieldMetadata = (
+  overrides: Partial<FieldMetadataEntity>,
+): FieldMetadataEntity =>
+  ({
+    id: '20202020-0000-0000-0000-000000000099',
+    workspaceId: WORKSPACE_ID,
+    universalIdentifier: '20202020-0000-0000-0000-000000000098',
+    type: FieldMetadataType.TEXT,
+    settings: null,
+    isActive: true,
+    ...overrides,
+  }) as FieldMetadataEntity;
+
+const NOTE_TARGETS_FIELD_METADATA = buildFieldMetadata({
+  id: NOTE_TARGETS_FIELD_METADATA_ID,
+  universalIdentifier:
+    STANDARD_OBJECTS.note.fields.noteTargets.universalIdentifier,
+  type: FieldMetadataType.RELATION,
+  relationTargetObjectMetadataId: NOTE_TARGET_OBJECT_METADATA_ID,
+  settings: { relationType: RelationType.ONE_TO_MANY },
+});
+
+const TASK_TARGETS_FIELD_METADATA = buildFieldMetadata({
+  id: TASK_TARGETS_FIELD_METADATA_ID,
+  universalIdentifier:
+    STANDARD_OBJECTS.task.fields.taskTargets.universalIdentifier,
+  type: FieldMetadataType.RELATION,
+  relationTargetObjectMetadataId: TASK_TARGET_OBJECT_METADATA_ID,
+  settings: { relationType: RelationType.ONE_TO_MANY },
+});
+
+const CUSTOM_NOTE_TARGET_FIELD_METADATA = buildFieldMetadata({
+  id: CUSTOM_NOTE_TARGET_FIELD_METADATA_ID,
+  universalIdentifier: '20202020-0000-0000-0000-000000000010',
+  objectMetadataId: NOTE_TARGET_OBJECT_METADATA_ID,
+  type: FieldMetadataType.MORPH_RELATION,
+  morphId: STANDARD_OBJECTS.noteTarget.morphIds.targetMorphId.morphId,
+  settings: { relationType: RelationType.MANY_TO_ONE },
+});
+
+const CUSTOM_TASK_TARGET_FIELD_METADATA = buildFieldMetadata({
+  id: CUSTOM_TASK_TARGET_FIELD_METADATA_ID,
+  universalIdentifier: '20202020-0000-0000-0000-000000000011',
+  objectMetadataId: TASK_TARGET_OBJECT_METADATA_ID,
+  type: FieldMetadataType.MORPH_RELATION,
+  morphId: STANDARD_OBJECTS.taskTarget.morphIds.targetMorphId.morphId,
+  settings: { relationType: RelationType.MANY_TO_ONE },
+});
+
+const LEGACY_NOTE_TARGET_PERSON_FIELD_METADATA = buildFieldMetadata({
+  id: LEGACY_NOTE_TARGET_PERSON_FIELD_METADATA_ID,
+  universalIdentifier: LEGACY_NOTE_TARGET_PERSON_FIELD_UNIVERSAL_IDENTIFIER,
+  objectMetadataId: NOTE_TARGET_OBJECT_METADATA_ID,
+  type: FieldMetadataType.RELATION,
+  settings: { relationType: RelationType.MANY_TO_ONE },
+});
+
+describe('RepairActivityTargetsJunctionTargetCommand', () => {
+  const workspaceMigrationRunnerService = {} as WorkspaceMigrationRunnerService;
+  let command: RepairActivityTargetsJunctionTargetCommand;
+  let findMock: jest.Mock;
+  let findOneMock: jest.Mock;
+  let updateMock: jest.Mock;
+
+  const initializeCommand = ({
+    activeFieldMetadatas,
+    lockedJunctionRelationFieldMetadatas,
+  }: {
+    activeFieldMetadatas: FieldMetadataEntity[];
+    lockedJunctionRelationFieldMetadatas: FieldMetadataEntity[];
+  }) => {
+    findMock = jest.fn().mockResolvedValue(activeFieldMetadatas);
+    findOneMock = jest
+      .fn()
+      .mockImplementation(({ where: { id } }: { where: { id: string } }) =>
+        Promise.resolve(
+          lockedJunctionRelationFieldMetadatas.find(
+            (fieldMetadata) => fieldMetadata.id === id,
+          ) ?? null,
+        ),
+      );
+    updateMock = jest.fn();
+
+    const transactionalRepository = {
+      find: findMock,
+      findOne: findOneMock,
+      update: updateMock,
+    };
+    const fieldMetadataRepository = {
+      manager: {
+        transaction: jest.fn(
+          async (
+            callback: (entityManager: {
+              getRepository: () => typeof transactionalRepository;
+            }) => Promise<string[]>,
+          ) =>
+            callback({
+              getRepository: () => transactionalRepository,
+            }),
+        ),
+      },
+    } as unknown as Repository<FieldMetadataEntity>;
+
+    command = new RepairActivityTargetsJunctionTargetCommand(
+      {} as WorkspaceIteratorService,
+      workspaceMigrationRunnerService,
+      fieldMetadataRepository,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('repairs note and task junctions that only have custom morph targets', async () => {
+    initializeCommand({
+      activeFieldMetadatas: [
+        NOTE_TARGETS_FIELD_METADATA,
+        TASK_TARGETS_FIELD_METADATA,
+        CUSTOM_NOTE_TARGET_FIELD_METADATA,
+        CUSTOM_TASK_TARGET_FIELD_METADATA,
+      ],
+      lockedJunctionRelationFieldMetadatas: [
+        NOTE_TARGETS_FIELD_METADATA,
+        TASK_TARGETS_FIELD_METADATA,
+      ],
+    });
+
+    await command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(findMock).toHaveBeenCalledWith({
+      where: { workspaceId: WORKSPACE_ID, isActive: true },
+      order: { universalIdentifier: 'ASC' },
+    });
+    expect(updateMock).toHaveBeenNthCalledWith(
+      1,
+      { id: NOTE_TARGETS_FIELD_METADATA_ID, workspaceId: WORKSPACE_ID },
+      {
+        settings: {
+          relationType: RelationType.ONE_TO_MANY,
+          junctionTargetFieldId: CUSTOM_NOTE_TARGET_FIELD_METADATA_ID,
+        },
+      },
+    );
+    expect(updateMock).toHaveBeenNthCalledWith(
+      2,
+      { id: TASK_TARGETS_FIELD_METADATA_ID, workspaceId: WORKSPACE_ID },
+      {
+        settings: {
+          relationType: RelationType.ONE_TO_MANY,
+          junctionTargetFieldId: CUSTOM_TASK_TARGET_FIELD_METADATA_ID,
+        },
+      },
+    );
+    expect(invalidateFieldMetadataCacheMock).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      workspaceMigrationRunnerService,
+    });
+  });
+
+  it('preserves a valid legacy junction target', async () => {
+    const noteTargetsFieldMetadata = buildFieldMetadata({
+      ...NOTE_TARGETS_FIELD_METADATA,
+      settings: {
+        relationType: RelationType.ONE_TO_MANY,
+        junctionTargetFieldId: LEGACY_NOTE_TARGET_PERSON_FIELD_METADATA_ID,
+      },
+    });
+
+    initializeCommand({
+      activeFieldMetadatas: [
+        noteTargetsFieldMetadata,
+        LEGACY_NOTE_TARGET_PERSON_FIELD_METADATA,
+      ],
+      lockedJunctionRelationFieldMetadatas: [noteTargetsFieldMetadata],
+    });
+
+    await command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(invalidateFieldMetadataCacheMock).not.toHaveBeenCalled();
+  });
+
+  it('reports repairs without writing during a dry run', async () => {
+    initializeCommand({
+      activeFieldMetadatas: [
+        NOTE_TARGETS_FIELD_METADATA,
+        CUSTOM_NOTE_TARGET_FIELD_METADATA,
+      ],
+      lockedJunctionRelationFieldMetadatas: [NOTE_TARGETS_FIELD_METADATA],
+    });
+
+    await command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      options: { dryRun: true },
+      index: 0,
+      total: 1,
+    });
+
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(invalidateFieldMetadataCacheMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores targets from another morph group', async () => {
+    const unrelatedMorphFieldMetadata = buildFieldMetadata({
+      ...CUSTOM_NOTE_TARGET_FIELD_METADATA,
+      morphId: '20202020-0000-0000-0000-000000000012',
+    });
+
+    initializeCommand({
+      activeFieldMetadatas: [
+        NOTE_TARGETS_FIELD_METADATA,
+        unrelatedMorphFieldMetadata,
+      ],
+      lockedJunctionRelationFieldMetadatas: [NOTE_TARGETS_FIELD_METADATA],
+    });
+
+    await command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(findOneMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(invalidateFieldMetadataCacheMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -26,6 +26,7 @@ import { V2_3_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-
 import { V2_31_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-31/2-31-upgrade-version-command.module';
 import { V2_32_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-32/2-32-upgrade-version-command.module';
 import { V2_33_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module';
+import { V2_34_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-34/2-34-upgrade-version-command.module';
 import { V2_4_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-4/2-4-upgrade-version-command.module';
 import { V2_5_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-5/2-5-upgrade-version-command.module';
 import { V2_7_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-7/2-7-upgrade-version-command.module';
@@ -65,6 +66,7 @@ import { V2_9_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-
     V2_31_UpgradeVersionCommandModule,
     V2_32_UpgradeVersionCommandModule,
     V2_33_UpgradeVersionCommandModule,
+    V2_34_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}


### PR DESCRIPTION
## Context

The v2.33 activity-junction backfill resolves the note/task target through the current or legacy `targetPerson` universal identifier. A production audit after the v2.33 upgrade found one active and one suspended workspace whose morph groups contain only custom-object target fields, so those workspaces were skipped while the command was still recorded as complete.

This leaves four junction settings unset across 1,384 existing note/task links. The timeline rule builder then omits the corresponding note/task rules.

## Fix

- Add a new v2.34 workspace repair command because the v2.33 command has already executed in production.
- Resolve a target from the correct note/task morph group even when no `targetPerson` field exists.
- Prefer the current `targetPerson` identifier, then the legacy identifier, while selecting custom morph members deterministically.
- Preserve any already-valid junction target, lock before updating, support dry-run, and invalidate metadata caches only after a write.

## Tests

- Custom-only note and task morph groups are repaired.
- Valid legacy targets remain unchanged.
- Dry-run performs no writes or cache invalidation.
- Fields from unrelated morph groups are ignored.

`npx jest packages/twenty-server/src/database/commands/upgrade-version-command/2-34/__tests__/2-34-workspace-command-1787461587487-repair-activity-targets-junction-target.command.spec.ts --config=packages/twenty-server/jest.config.mjs --runInBand`

`npx oxlint --type-aware ...` on all four changed files: 0 warnings, 0 errors.

The direct package typecheck still reports pre-existing timeline-contract errors on `main`; the new command produces no remaining typecheck errors.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

