### PR TITLE
Fix composite field update events

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
@@ -270,7 +270,7 @@ export class WorkspaceUpdateQueryBuilder<
       });
 
       const formattedAfter = formatResult<T[]>(
-        after,
+        this.mergeRecordsWithUpdateValues(after, valuesSet),
         objectMetadata,
         this.internalContext.flatObjectMetadataMaps,
         this.internalContext.flatFieldMetadataMaps,
@@ -468,8 +468,20 @@ export class WorkspaceUpdateQueryBuilder<
         noFormatting: true,
       });
 
+      const updateValuesByRecordId = new Map(
+        this.manyInputs.map(({ criteria, partialEntity }) => [
+          criteria,
+          partialEntity,
+        ]),
+      );
+
       const formattedAfter = formatResult<T[]>(
-        afterRecords,
+        afterRecords.map((record) =>
+          this.mergeRecordWithUpdateValues(
+            record,
+            updateValuesByRecordId.get(record.id),
+          ),
+        ),
         objectMetadata,
         this.internalContext.flatObjectMetadataMaps,
         this.internalContext.flatFieldMetadataMaps,
@@ -681,5 +693,35 @@ export class WorkspaceUpdateQueryBuilder<
       errorMessage:
         'Updated record does not satisfy row-level security constraints of your current role',
     });
+  }
+
+  private mergeRecordsWithUpdateValues(
+    records: T[],
+    values:
+      | QueryDeepPartialEntity<T>
+      | QueryDeepPartialEntity<T>[]
+      | ObjectLiteral,
+  ): T[] {
+    return records.map((record, index) =>
+      this.mergeRecordWithUpdateValues(
+        record,
+        Array.isArray(values) ? (values[index] ?? values[0]) : values,
+      ),
+    );
+  }
+
+  private mergeRecordWithUpdateValues(
+    record: T,
+    values: QueryDeepPartialEntity<T> | ObjectLiteral | undefined,
+  ): T {
+    if (!isDefined(values)) {
+      return record;
+    }
+
+    const concreteValues = Object.fromEntries(
+      Object.entries(values).filter(([, value]) => typeof value !== 'function'),
+    );
+
+    return { ...record, ...concreteValues };
   }
 }

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
@@ -38,6 +38,10 @@ import { formatData } from 'src/engine/twenty-orm/utils/format-data.util';
 import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
 import { formatTwentyOrmEventToDatabaseBatchEvent } from 'src/engine/twenty-orm/utils/format-twenty-orm-event-to-database-batch-event.util';
 import { getObjectMetadataFromEntityTarget } from 'src/engine/twenty-orm/utils/get-object-metadata-from-entity-target.util';
+import {
+  mergeRecordsWithUpdateValues,
+  mergeRecordWithUpdateValues,
+} from 'src/engine/twenty-orm/utils/merge-records-with-update-values.util';
 import { validateRLSPredicatesForRecords } from 'src/engine/twenty-orm/utils/validate-rls-predicates-for-records.util';
 import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
 
@@ -245,15 +249,7 @@ export class WorkspaceUpdateQueryBuilder<
       this.applyRowLevelPermissionPredicates();
 
       const valuesSet = this.expressionMap.valuesSet ?? {};
-      const updatedRecords: T[] = before.map(
-        (record, index) =>
-          ({
-            ...record,
-            ...(Array.isArray(valuesSet)
-              ? (valuesSet[index] ?? valuesSet[0] ?? {})
-              : valuesSet),
-          }) as T,
-      );
+      const updatedRecords = mergeRecordsWithUpdateValues(before, valuesSet);
 
       this.validateRLSPredicatesForUpdate({
         updatedRecords,
@@ -270,7 +266,7 @@ export class WorkspaceUpdateQueryBuilder<
       });
 
       const formattedAfter = formatResult<T[]>(
-        this.mergeRecordsWithUpdateValues(after, valuesSet),
+        mergeRecordsWithUpdateValues(after, valuesSet),
         objectMetadata,
         this.internalContext.flatObjectMetadataMaps,
         this.internalContext.flatFieldMetadataMaps,
@@ -443,12 +439,7 @@ export class WorkspaceUpdateQueryBuilder<
 
         const beforeRecord = beforeRecordById.get(input.criteria);
         const updatedRecords = beforeRecord
-          ? [
-              {
-                ...beforeRecord,
-                ...input.partialEntity,
-              } as T,
-            ]
+          ? [mergeRecordWithUpdateValues(beforeRecord, input.partialEntity)]
           : [];
 
         this.validateRLSPredicatesForUpdate({
@@ -477,7 +468,7 @@ export class WorkspaceUpdateQueryBuilder<
 
       const formattedAfter = formatResult<T[]>(
         afterRecords.map((record) =>
-          this.mergeRecordWithUpdateValues(
+          mergeRecordWithUpdateValues(
             record,
             updateValuesByRecordId.get(record.id),
           ),
@@ -693,35 +684,5 @@ export class WorkspaceUpdateQueryBuilder<
       errorMessage:
         'Updated record does not satisfy row-level security constraints of your current role',
     });
-  }
-
-  private mergeRecordsWithUpdateValues(
-    records: T[],
-    values:
-      | QueryDeepPartialEntity<T>
-      | QueryDeepPartialEntity<T>[]
-      | ObjectLiteral,
-  ): T[] {
-    return records.map((record, index) =>
-      this.mergeRecordWithUpdateValues(
-        record,
-        Array.isArray(values) ? (values[index] ?? values[0]) : values,
-      ),
-    );
-  }
-
-  private mergeRecordWithUpdateValues(
-    record: T,
-    values: QueryDeepPartialEntity<T> | ObjectLiteral | undefined,
-  ): T {
-    if (!isDefined(values)) {
-      return record;
-    }
-
-    const concreteValues = Object.fromEntries(
-      Object.entries(values).filter(([, value]) => typeof value !== 'function'),
-    );
-
-    return { ...record, ...concreteValues };
   }
 }

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/merge-records-with-update-values.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/merge-records-with-update-values.util.spec.ts
@@ -1,0 +1,73 @@
+import {
+  mergeRecordsWithUpdateValues,
+  mergeRecordWithUpdateValues,
+} from 'src/engine/twenty-orm/utils/merge-records-with-update-values.util';
+
+describe('mergeRecordsWithUpdateValues', () => {
+  it('merges shared concrete values into every record', () => {
+    expect(
+      mergeRecordsWithUpdateValues(
+        [
+          { id: 'first', name: 'First' },
+          { id: 'second', name: 'Second' },
+        ],
+        { name: 'Updated', optionalValue: undefined },
+      ),
+    ).toEqual([
+      { id: 'first', name: 'Updated', optionalValue: undefined },
+      { id: 'second', name: 'Updated', optionalValue: undefined },
+    ]);
+  });
+
+  it('ignores raw SQL function values', () => {
+    expect(
+      mergeRecordWithUpdateValues(
+        { id: 'first', name: 'First', computedValue: 'Persisted value' },
+        {
+          name: 'Updated',
+          computedValue: () => 'CURRENT_TIMESTAMP',
+        },
+      ),
+    ).toEqual({
+      id: 'first',
+      name: 'Updated',
+      computedValue: 'Persisted value',
+    });
+  });
+
+  it('uses values at the matching record index', () => {
+    expect(
+      mergeRecordsWithUpdateValues(
+        [
+          { id: 'first', name: 'First' },
+          { id: 'second', name: 'Second' },
+        ],
+        [{ name: 'First updated' }, { name: 'Second updated' }],
+      ),
+    ).toEqual([
+      { id: 'first', name: 'First updated' },
+      { id: 'second', name: 'Second updated' },
+    ]);
+  });
+
+  it('falls back to the first values entry when an index is missing', () => {
+    expect(
+      mergeRecordsWithUpdateValues(
+        [
+          { id: 'first', name: 'First' },
+          { id: 'second', name: 'Second' },
+        ],
+        [{ name: 'Updated' }],
+      ),
+    ).toEqual([
+      { id: 'first', name: 'Updated' },
+      { id: 'second', name: 'Updated' },
+    ]);
+  });
+
+  it('returns the original record when values are missing', () => {
+    const record = { id: 'first', name: 'First' };
+
+    expect(mergeRecordWithUpdateValues(record, undefined)).toBe(record);
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm/utils/merge-records-with-update-values.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/merge-records-with-update-values.util.ts
@@ -1,0 +1,39 @@
+import { type ObjectLiteral } from 'typeorm';
+import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+
+type UpdateValues<TRecord extends ObjectLiteral> =
+  | QueryDeepPartialEntity<TRecord>
+  | ObjectLiteral;
+
+const getConcreteUpdateValues = <TRecord extends ObjectLiteral>(
+  values: UpdateValues<TRecord>,
+): Partial<TRecord> =>
+  Object.fromEntries(
+    Object.entries(values).filter(([, value]) => typeof value !== 'function'),
+  ) as Partial<TRecord>;
+
+export const mergeRecordWithUpdateValues = <TRecord extends ObjectLiteral>(
+  record: TRecord,
+  values: UpdateValues<TRecord> | undefined,
+): TRecord => {
+  if (values === undefined) {
+    return record;
+  }
+
+  return { ...record, ...getConcreteUpdateValues(values) };
+};
+
+export const mergeRecordsWithUpdateValues = <TRecord extends ObjectLiteral>(
+  records: TRecord[],
+  values: UpdateValues<TRecord> | UpdateValues<TRecord>[],
+): TRecord[] => {
+  if (!Array.isArray(values)) {
+    const concreteValues = getConcreteUpdateValues(values);
+
+    return records.map((record) => ({ ...record, ...concreteValues }));
+  }
+
+  return records.map((record, index) =>
+    mergeRecordWithUpdateValues(record, values[index] ?? values[0]),
+  );
+};

--- a/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
@@ -164,6 +164,7 @@ const ATTACHMENT_UNIVERSAL_IDENTIFIER =
 
 const COMPANY_ID = '20202020-7171-4000-8000-000000000001';
 const POSITION_COMPANY_ID = '20202020-7171-4000-8000-000000000002';
+const COMPOSITE_COMPANY_ID = '20202020-7171-4000-8000-000000000003';
 const NOTE_COMPANY_ID = '20202020-7171-4000-8000-000000000004';
 const NOTE_ID = '20202020-7171-4000-8000-000000000005';
 const NOTE_TARGET_ID = '20202020-7171-4000-8000-000000000006';
@@ -210,6 +211,7 @@ const CREATED_RECORD_IDS: { objectMetadataSingularName: string; id: string }[] =
       id,
     })),
     { objectMetadataSingularName: 'company', id: NOTE_COMPANY_ID },
+    { objectMetadataSingularName: 'company', id: COMPOSITE_COMPANY_ID },
     { objectMetadataSingularName: 'company', id: POSITION_COMPANY_ID },
     { objectMetadataSingularName: 'company', id: COMPANY_ID },
   ];
@@ -296,6 +298,56 @@ describe('timeline activity write path (integration)', () => {
           name: {
             before: 'Timeline Write Path',
             after: 'Timeline Write Path Renamed',
+          },
+        },
+      });
+    });
+
+    it('should write an updated entry for a composite field change', async () => {
+      await createRecord({
+        objectMetadataSingularName: 'company',
+        data: {
+          id: COMPOSITE_COMPANY_ID,
+          name: 'Composite Field Timeline',
+        },
+      });
+
+      await updateRecord({
+        objectMetadataSingularName: 'company',
+        recordId: COMPOSITE_COMPANY_ID,
+        data: {
+          address: {
+            addressStreet1: '234 Composite Street',
+            addressStreet2: '',
+            addressCity: 'Paris',
+            addressState: '',
+            addressCountry: '',
+            addressPostcode: '',
+            addressLat: null,
+            addressLng: null,
+          },
+        },
+      });
+
+      const timelineActivities = await findTimelineActivities({
+        targetCompanyId: { eq: COMPOSITE_COMPANY_ID },
+        timelineActivityTypeId: {
+          eq: timelineActivityTypeIdForOrThrow('updated'),
+        },
+      });
+
+      expect(timelineActivities).toHaveLength(1);
+      expect(timelineActivities[0].properties).toMatchObject({
+        diff: {
+          address: {
+            before: {
+              addressStreet1: '',
+              addressCity: '',
+            },
+            after: {
+              addressStreet1: '234 Composite Street',
+              addressCity: 'Paris',
+            },
           },
         },
       });


### PR DESCRIPTION
## Summary

- make update event snapshots include the concrete values accepted by the successful mutation
- apply the same behavior to single-record and batched legacy ORM updates
- keep database expressions out of the overlay so generated SQL values remain sourced from the post-write snapshot
- cover an address update through the timeline integration suite

## Why

Release QA on `twenty-main.com` reproduced a production-only gap through both the real inline editor and a direct authenticated GraphQL mutation: scalar updates emitted `company.updated`, while address and link composite updates persisted successfully but emitted no internal event. The same mutation passes against the local single-node integration database, which isolates the discrepancy to read-after-write event snapshot visibility rather than timeline routing.

An event should not lose values already confirmed by a successful write because the immediate post-write snapshot does not expose them. Overlaying concrete write values on that snapshot preserves database-produced values for every other column while making the event deterministic.

## Verification

- direct `tsgo` typecheck for `twenty-server`
- focused timeline integration suite: 12/13 passed; the sole attachment case is the known stale local metadata fixture and is unrelated (it requires a DB reset)
- targeted composite integration test passed with the UI-shaped full address payload and an `id`-only mutation response
- targeted Oxlint and Oxfmt checks passed

This is a v2.34 release blocker found during production-like QA.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

