### PR TITLE
Guard attachment activity upgrade on legacy schemas

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787471738599-add-attachment-timeline-activity-types.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/2-34-workspace-command-1787471738599-add-attachment-timeline-activity-types.command.ts
@@ -1,4 +1,5 @@
 import { Command } from 'nest-commander';
+import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 
@@ -19,6 +20,7 @@ const ATTACHMENT_OBJECT_UNIVERSAL_IDENTIFIER =
   '20202020-bd3d-4c60-8dca-571c71d4447a';
 const ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
   '721ddb1f-468d-535a-9809-cb3429a52e06';
+const ATTACHMENT_TARGET_MORPH_ID = '20202020-f634-435d-ab8d-e1168b375c69';
 
 const ATTACHMENT_TIMELINE_ACTIVITY_TYPES = [
   {
@@ -56,8 +58,13 @@ export class AddAttachmentTimelineActivityTypesCommand extends ProvisionedWorksp
     workspaceId,
     options,
   }: RunOnWorkspaceArgs): Promise<void> {
-    const { flatObjectMetadataMaps, flatTimelineActivityTypeMaps } =
+    const {
+      flatFieldMetadataMaps,
+      flatObjectMetadataMaps,
+      flatTimelineActivityTypeMaps,
+    } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatFieldMetadataMaps',
         'flatObjectMetadataMaps',
         'flatTimelineActivityTypeMaps',
       ]);
@@ -80,6 +87,40 @@ export class AddAttachmentTimelineActivityTypesCommand extends ProvisionedWorksp
     );
 
     if (missingDefinitions.length === 0) {
+      return;
+    }
+
+    const attachmentObjectMetadata =
+      flatObjectMetadataMaps.byUniversalIdentifier[
+        ATTACHMENT_OBJECT_UNIVERSAL_IDENTIFIER
+      ];
+    const preferredAttachmentTargetRelationFieldMetadata =
+      flatFieldMetadataMaps.byUniversalIdentifier[
+        ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER
+      ];
+    const isAttachmentTargetMorphRelation = (
+      fieldMetadata: typeof preferredAttachmentTargetRelationFieldMetadata,
+    ) =>
+      isDefined(fieldMetadata) &&
+      isDefined(attachmentObjectMetadata) &&
+      fieldMetadata.objectMetadataId === attachmentObjectMetadata.id &&
+      fieldMetadata.type === FieldMetadataType.MORPH_RELATION &&
+      fieldMetadata.morphId === ATTACHMENT_TARGET_MORPH_ID;
+    const attachmentTargetRelationFieldMetadata =
+      isAttachmentTargetMorphRelation(
+        preferredAttachmentTargetRelationFieldMetadata,
+      )
+        ? preferredAttachmentTargetRelationFieldMetadata
+        : Object.values(flatFieldMetadataMaps.byUniversalIdentifier).find(
+            (fieldMetadata) =>
+              isAttachmentTargetMorphRelation(fieldMetadata),
+          );
+
+    if (!isDefined(attachmentTargetRelationFieldMetadata)) {
+      this.logger.warn(
+        `Attachment target morph relation does not exist for workspace ${workspaceId}, skipping attachment timeline activity types`,
+      );
+
       return;
     }
 
@@ -111,7 +152,7 @@ export class AddAttachmentTimelineActivityTypesCommand extends ProvisionedWorksp
         frontComponentUniversalIdentifier: null,
         objectUniversalIdentifier: ATTACHMENT_OBJECT_UNIVERSAL_IDENTIFIER,
         targetRelationFieldUniversalIdentifier:
-          ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+          attachmentTargetRelationFieldMetadata.universalIdentifier,
         triggerFieldUniversalIdentifiers: null,
         replacesTimelineActivityTypeUniversalIdentifier: null,
         isActive: true,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/__tests__/2-34-workspace-command-1787471738599-add-attachment-timeline-activity-types.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-34/__tests__/2-34-workspace-command-1787471738599-add-attachment-timeline-activity-types.command.spec.ts
@@ -8,16 +8,31 @@ import { type WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/wo
 
 const WORKSPACE_ID = '00000000-0000-4000-8000-000000000001';
 const STANDARD_APPLICATION_ID = '00000000-0000-4000-8000-000000000002';
+const ATTACHMENT_OBJECT_ID = '00000000-0000-4000-8000-000000000003';
+const ATTACHMENT_TARGET_MORPH_ID = '20202020-f634-435d-ab8d-e1168b375c69';
+const ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '721ddb1f-468d-535a-9809-cb3429a52e06';
 const LINKED_TYPE_UNIVERSAL_IDENTIFIER = '20202020-0d1a-4f0e-8a55-1c0a2f0a2c11';
 const UNLINKED_TYPE_UNIVERSAL_IDENTIFIER =
   '20202020-0d1a-4f0e-8a55-1c0a2f0a2c12';
 
 const buildCommand = ({
   flatTimelineActivityTypes = {},
+  attachmentTargetFields = {
+    [ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER]: {
+      id: '00000000-0000-4000-8000-000000000004',
+      objectMetadataId: ATTACHMENT_OBJECT_ID,
+      type: 'MORPH_RELATION',
+      morphId: ATTACHMENT_TARGET_MORPH_ID,
+      universalIdentifier:
+        ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+    },
+  },
   hasTimelineActivity = true,
   migrationResult = { status: 'success' },
 }: {
   flatTimelineActivityTypes?: Record<string, object>;
+  attachmentTargetFields?: Record<string, object>;
   hasTimelineActivity?: boolean;
   migrationResult?: { status: 'success' | 'fail' };
 }) => {
@@ -35,9 +50,17 @@ const buildCommand = ({
     } as unknown as ApplicationService,
     {
       getOrRecompute: jest.fn().mockResolvedValue({
+        flatFieldMetadataMaps: {
+          byUniversalIdentifier: attachmentTargetFields,
+        },
         flatObjectMetadataMaps: {
           byUniversalIdentifier: hasTimelineActivity
-            ? { [STANDARD_OBJECTS.timelineActivity.universalIdentifier]: {} }
+            ? {
+                [STANDARD_OBJECTS.timelineActivity.universalIdentifier]: {},
+                [STANDARD_OBJECTS.attachment.universalIdentifier]: {
+                  id: ATTACHMENT_OBJECT_ID,
+                },
+              }
             : {},
         },
         flatTimelineActivityTypeMaps: {
@@ -111,6 +134,63 @@ describe('AddAttachmentTimelineActivityTypesCommand', () => {
     expect(createdTypes[0].universalIdentifier).toBe(
       UNLINKED_TYPE_UNIVERSAL_IDENTIFIER,
     );
+  });
+
+  it('uses another member when the preferred attachment morph field is missing', async () => {
+    const alternativeFieldUniversalIdentifier =
+      '00000000-0000-4000-8000-000000000005';
+    const { command, validateBuildAndRunWorkspaceMigration } = buildCommand({
+      attachmentTargetFields: {
+        [alternativeFieldUniversalIdentifier]: {
+          id: '00000000-0000-4000-8000-000000000006',
+          objectMetadataId: ATTACHMENT_OBJECT_ID,
+          type: 'MORPH_RELATION',
+          morphId: ATTACHMENT_TARGET_MORPH_ID,
+          universalIdentifier: alternativeFieldUniversalIdentifier,
+        },
+      },
+    });
+
+    await runCommand(command);
+
+    const createdTypes =
+      validateBuildAndRunWorkspaceMigration.mock.calls[0][0]
+        .allFlatEntityOperationByMetadataName.timelineActivityType
+        .flatEntityToCreate;
+
+    expect(createdTypes).toEqual([
+      expect.objectContaining({
+        targetRelationFieldUniversalIdentifier:
+          alternativeFieldUniversalIdentifier,
+      }),
+      expect.objectContaining({
+        targetRelationFieldUniversalIdentifier:
+          alternativeFieldUniversalIdentifier,
+      }),
+    ]);
+  });
+
+  it('skips workspaces that only have legacy attachment relations', async () => {
+    const {
+      command,
+      findStandardApplication,
+      validateBuildAndRunWorkspaceMigration,
+    } = buildCommand({
+      attachmentTargetFields: {
+        '00000000-0000-4000-8000-000000000007': {
+          id: '00000000-0000-4000-8000-000000000007',
+          objectMetadataId: ATTACHMENT_OBJECT_ID,
+          type: 'RELATION',
+          morphId: null,
+          universalIdentifier: '00000000-0000-4000-8000-000000000007',
+        },
+      },
+    });
+
+    await runCommand(command);
+
+    expect(findStandardApplication).not.toHaveBeenCalled();
+    expect(validateBuildAndRunWorkspaceMigration).not.toHaveBeenCalled();
   });
 
   it('does nothing when standard sync already created both definitions', async () => {


### PR DESCRIPTION
## Why

The full v2.34 upgrade was executed against every dev workspace before release. 64 workspaces completed, but one active legacy workspace still models attachment targets as independent `RELATION` fields rather than the normalized attachment `MORPH_RELATION` group. The attachment timeline type validator correctly rejected a route that did not exist, leaving the workspace behind.

## Fix

- Resolve the frozen 2.34 attachment target morph group from actual workspace metadata.
- Prefer the standard `targetPerson` universal identifier, but accept another member of the same frozen morph group so custom-only morph maps remain valid.
- Skip only the additive attachment activity types when a workspace still has the pre-morph legacy attachment schema. The rest of the v2.34 upgrade remains strict and completes.
- Keep the existing command timestamp because this release has not been tagged or run in production; successfully upgraded workspaces already have both types and keep taking the idempotent no-op path, while the failed dev workspace can retry the corrected path.

## Tradeoff

Legacy pre-morph workspaces do not receive automatic attachment timeline events in 2.34. Migrating their physical attachment relations is a separate data-model migration and is not safe to improvise in this release command. Current normalized workspaces and all new workspaces keep the generic attachment behavior.

## Validation

- Focused command suite: 7/7 tests pass, including alternate morph representative and legacy skip.
- Direct twenty-server typecheck passes.
- Dev all-workspace rollout evidence: 64 succeeded, 1 legacy failure before this guard; the failed workspace will be retried after deployment.
