### PR TITLE
fix(front): enable Save when a select option is added programmatically

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -203,7 +203,10 @@ export const SettingsDataModelFieldSelectForm = ({
 
       const optionsWithNew = [...initialOptions, newOption];
 
-      setFormValue('options', optionsWithNew, { shouldDirty: true });
+      setFormValue('options', optionsWithNew, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
       setHasAppliedNewOption(true);
     }
   }, [searchParams, hasAppliedNewOption, initialOptions, setFormValue]);
@@ -301,13 +304,19 @@ export const SettingsDataModelFieldSelectForm = ({
   const handleAddOption = () => {
     const newOptions = getOptionsWithNewOption();
 
-    setFormValue('options', newOptions, { shouldDirty: true });
+    setFormValue('options', newOptions, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
   };
 
   const handleInputEnter = () => {
     const newOptions = getOptionsWithNewOption();
 
-    setFormValue('options', newOptions, { shouldDirty: true });
+    setFormValue('options', newOptions, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
   };
 
   return (


### PR DESCRIPTION
Fixes #23487

## Problem
When a new select option is added from within a record cell's select menu (e.g., "Add ... to options"), the user is directed to the field configuration in the data model editor. The new option is already populated in the options list, but the **Save button remains disabled/stale**. Any subsequent manual edit makes it clickable.

## Root Cause
The `canSave` condition in `SettingsObjectFieldEdit.tsx` requires `isDirty && isValid && !isSubmitting`. The form uses React Hook Form with `mode: 'onTouched'`.

When options are programmatically inserted via `setFormValue('options', ...)`, the call only passed `{ shouldDirty: true }` but **not** `{ shouldValidate: true }`. This meant:
- ✅ `isDirty` was correctly set to `true`
- ❌ `isValid` was **never recalculated** from its initial unresolved state
- Result: Save button stayed disabled

## Fix
Added `shouldValidate: true` alongside `shouldDirty: true` in all three programmatic option insertion paths in `SettingsDataModelFieldSelectForm.tsx`:

1. **URL-driven `newOption` effect** (useEffect) — the primary bug path reported in the issue
2. **`handleAddOption`** — "Add option" button click
3. **`handleInputEnter`** — Enter key handler in option row

This ensures the form validity state is immediately recalculated when options are programmatically added, making the Save button immediately clickable.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

