### PR TITLE
fix(front): allow confirmation modal button label to wrap

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -33,6 +33,16 @@ export type ConfirmationModalProps = {
 const StyledCenteredButtonContainer = styled.div`
   box-sizing: border-box;
   margin-top: ${themeCssVariables.spacing[2]};
+
+  > button {
+    height: auto;
+    min-height: 32px;
+    white-space: normal;
+
+    * {
+      white-space: normal;
+    }
+  }
 `;
 
 export const StyledCenteredButton = (
@@ -51,30 +61,6 @@ const StyledCenteredTitle = styled.div`
 const StyledSectionContainer = styled.div`
   margin-bottom: ${themeCssVariables.spacing[6]};
 `;
-
-const StyledConfirmationButtonContainer = styled.div`
-  box-sizing: border-box;
-  margin-top: ${themeCssVariables.spacing[2]};
-  > button {
-    border-color: ${themeCssVariables.border.color.danger};
-    box-shadow: none;
-    color: ${themeCssVariables.color.red};
-    font-size: ${themeCssVariables.font.size.md};
-    line-height: ${themeCssVariables.text.lineHeight.lg};
-    &:hover {
-      background-color: ${themeCssVariables.color.red3};
-    }
-  }
-`;
-
-export const StyledConfirmationButton = (
-  props: React.ComponentProps<typeof Button>,
-) => (
-  <StyledConfirmationButtonContainer>
-    {/* oxlint-disable-next-line react/jsx-props-no-spreading */}
-    <Button {...props} />
-  </StyledConfirmationButtonContainer>
-);
 
 const defaultConfirmButtonText = msg`Confirm`;
 


### PR DESCRIPTION
Fixes #23501

## Problem
In some locales (e.g., Dutch), the permanent delete confirmation action ("Permanently delete [Object]") overflows the confirmation button boundary inside the fixed-width `ConfirmationModal`. 

## Root Cause
The confirmation modal relies on the shared `Button` and `ButtonText` components, which both apply `white-space: nowrap;` by default. Since the modal width is narrow/fixed, any localized text longer than the container width gets forced out instead of wrapping gracefully.

## Fix
Updated the wrapper `StyledCenteredButtonContainer` inside `ConfirmationModal.tsx` to override the default `nowrap` behavior, allowing text to wrap naturally (`white-space: normal`). The button now grows vertically to accommodate longer strings and removed the unused `StyledConfirmationButton` declaration.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

