### PR TITLE
Handle timeline snapshot rolling upgrades

### DIFF
--- a/packages/twenty-server/src/modules/timeline/query-hooks/timeline-activity-mutation-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/timeline/query-hooks/timeline-activity-mutation-query-hook.service.ts
@@ -28,8 +28,11 @@ export class TimelineActivityMutationQueryHookService {
   }): Promise<TimelineActivityMutationInput[]> {
     assertTimelineActivityCreationInputIsValid({ records, upsert });
 
-    const resolvedTimelineActivityTypeById = new Map(
-      await Promise.all(
+    const [
+      resolvedTimelineActivityTypes,
+      hasTimelineActivityTypeSnapshotField,
+    ] = await Promise.all([
+      Promise.all(
         [
           ...new Set(
             records
@@ -46,12 +49,20 @@ export class TimelineActivityMutationQueryHookService {
             ] as const,
         ),
       ),
+      this.timelineActivityTypeCacheService.hasTimelineActivityTypeSnapshotField(
+        workspaceId,
+      ),
+    ]);
+
+    const resolvedTimelineActivityTypeById = new Map(
+      resolvedTimelineActivityTypes,
     );
 
     return stampTimelineActivityTypeSnapshots({
       applicationId,
       records,
       resolvedTimelineActivityTypeById,
+      shouldStampSnapshot: hasTimelineActivityTypeSnapshotField,
     });
   }
 }

--- a/packages/twenty-server/src/modules/timeline/query-hooks/utils/__tests__/timeline-activity-mutation-input.util.spec.ts
+++ b/packages/twenty-server/src/modules/timeline/query-hooks/utils/__tests__/timeline-activity-mutation-input.util.spec.ts
@@ -51,6 +51,27 @@ describe('timeline activity mutation input', () => {
     ]);
   });
 
+  it('removes snapshots while the workspace metadata field is unavailable', () => {
+    expect(
+      stampTimelineActivityTypeSnapshots({
+        records: [
+          {
+            timelineActivityTypeId: TYPE_ID,
+            timelineActivityTypeSnapshot: { label: 'forged' },
+            targetPersonId: '00000000-0000-4000-8000-000000000010',
+          },
+        ],
+        resolvedTimelineActivityTypeById,
+        shouldStampSnapshot: false,
+      }),
+    ).toEqual([
+      {
+        timelineActivityTypeId: TYPE_ID,
+        targetPersonId: '00000000-0000-4000-8000-000000000010',
+      },
+    ]);
+  });
+
   it('rejects missing targets and partial linked records', () => {
     expect(() =>
       assertTimelineActivityCreationInputIsValid({

--- a/packages/twenty-server/src/modules/timeline/query-hooks/utils/timeline-activity-mutation-input.util.ts
+++ b/packages/twenty-server/src/modules/timeline/query-hooks/utils/timeline-activity-mutation-input.util.ts
@@ -1,4 +1,4 @@
-import { isDefined } from 'twenty-shared/utils';
+import { isDefined, removePropertiesFromRecord } from 'twenty-shared/utils';
 
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
 import {
@@ -80,6 +80,7 @@ export const stampTimelineActivityTypeSnapshots = ({
   now = new Date(),
   records,
   resolvedTimelineActivityTypeById,
+  shouldStampSnapshot = true,
 }: {
   applicationId?: string;
   now?: Date;
@@ -88,6 +89,7 @@ export const stampTimelineActivityTypeSnapshots = ({
     string,
     ResolvedTimelineActivityType
   >;
+  shouldStampSnapshot?: boolean;
 }): TimelineActivityMutationInput[] => {
   if (
     isDefined(applicationId) &&
@@ -118,10 +120,12 @@ export const stampTimelineActivityTypeSnapshots = ({
       );
     }
 
-    const stampedRecord = {
-      ...record,
-      timelineActivityTypeSnapshot: resolvedTimelineActivityType.snapshot,
-    };
+    const stampedRecord = shouldStampSnapshot
+      ? {
+          ...record,
+          timelineActivityTypeSnapshot: resolvedTimelineActivityType.snapshot,
+        }
+      : removePropertiesFromRecord(record, ['timelineActivityTypeSnapshot']);
 
     return isDefined(applicationId)
       ? sanitizeApplicationTimelineActivityInput({

--- a/packages/twenty-server/src/modules/timeline/repositories/__tests__/timeline-activity.repository.spec.ts
+++ b/packages/twenty-server/src/modules/timeline/repositories/__tests__/timeline-activity.repository.spec.ts
@@ -23,6 +23,13 @@ describe('TimelineActivityRepository', () => {
     const update = jest.fn().mockResolvedValue(undefined);
     const insert = jest.fn().mockResolvedValue(undefined);
     const workspaceRepository = {
+      internalContext: {
+        flatFieldMetadataMaps: {
+          byUniversalIdentifier: {
+            '20202020-e006-493a-9b07-f2a768a204ca': {},
+          },
+        },
+      },
       find: jest.fn().mockResolvedValue([
         {
           id: '20202020-0000-4000-8000-000000000006',
@@ -77,5 +84,46 @@ describe('TimelineActivityRepository', () => {
         timelineActivityTypeSnapshot: TIMELINE_ACTIVITY_TYPE_SNAPSHOT,
       },
     );
+  });
+
+  it('omits the snapshot until the workspace metadata field exists', async () => {
+    const insert = jest.fn().mockResolvedValue(undefined);
+    const globalWorkspaceOrmManager = {
+      executeInWorkspaceContext: jest.fn(
+        async (callback: () => Promise<void>) => callback(),
+      ),
+      getRepository: jest.fn().mockResolvedValue({
+        internalContext: {
+          flatFieldMetadataMaps: { byUniversalIdentifier: {} },
+        },
+        find: jest.fn().mockResolvedValue([]),
+        insert,
+        update: jest.fn().mockResolvedValue(undefined),
+      }),
+    } as unknown as GlobalWorkspaceOrmManager;
+    const repository = new TimelineActivityRepository(
+      globalWorkspaceOrmManager,
+    );
+
+    await repository.upsertTimelineActivities({
+      objectSingularName: 'person',
+      workspaceId: WORKSPACE_ID,
+      payloads: [
+        {
+          happensAt: new Date('2026-08-23T09:00:00.000Z'),
+          properties: {},
+          recordId: RECORD_ID,
+          workspaceMemberId: WORKSPACE_MEMBER_ID,
+          timelineActivityTypeId: TIMELINE_ACTIVITY_TYPE_ID,
+          timelineActivityTypeSnapshot: TIMELINE_ACTIVITY_TYPE_SNAPSHOT,
+        },
+      ],
+    });
+
+    expect(insert).toHaveBeenCalledWith([
+      expect.not.objectContaining({
+        timelineActivityTypeSnapshot: expect.anything(),
+      }),
+    ]);
   });
 });

--- a/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
+++ b/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import { type ObjectRecord } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { In, MoreThan } from 'typeorm';
@@ -22,6 +23,11 @@ type TimelineActivityPayloadWorkspaceIdAndObjectSingularName = {
   objectSingularName: string;
 };
 
+type InsertTimelineActivitiesArgs =
+  TimelineActivityPayloadWorkspaceIdAndObjectSingularName & {
+    shouldWriteTimelineActivityTypeSnapshot: boolean;
+  };
+
 @Injectable()
 export class TimelineActivityRepository {
   constructor(
@@ -34,6 +40,8 @@ export class TimelineActivityRepository {
     payloads,
   }: TimelineActivityPayloadWorkspaceIdAndObjectSingularName) {
     const authContext = buildSystemAuthContext(workspaceId);
+    const shouldWriteTimelineActivityTypeSnapshot =
+      await this.hasTimelineActivityTypeSnapshotField(workspaceId);
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const recentTimelineActivities = await this.findRecentTimelineActivities({
@@ -104,12 +112,13 @@ export class TimelineActivityRepository {
               payload.properties,
             ),
             workspaceMemberId: payload.workspaceMemberId,
-            ...(!isDefined(
-              recentTimelineActivity.timelineActivityTypeSnapshot,
-            ) && {
-              timelineActivityTypeSnapshot:
-                payload.timelineActivityTypeSnapshot,
-            }),
+            ...(shouldWriteTimelineActivityTypeSnapshot &&
+              !isDefined(
+                recentTimelineActivity.timelineActivityTypeSnapshot,
+              ) && {
+                timelineActivityTypeSnapshot:
+                  payload.timelineActivityTypeSnapshot,
+              }),
           });
         } else {
           payloadsToInsert.push(payload);
@@ -121,6 +130,7 @@ export class TimelineActivityRepository {
         this.insertTimelineActivities({
           objectSingularName,
           payloads: payloadsToInsert,
+          shouldWriteTimelineActivityTypeSnapshot,
           workspaceId,
         }),
       ]);
@@ -174,7 +184,8 @@ export class TimelineActivityRepository {
     objectSingularName,
     workspaceId,
     payloads,
-  }: TimelineActivityPayloadWorkspaceIdAndObjectSingularName) {
+    shouldWriteTimelineActivityTypeSnapshot,
+  }: InsertTimelineActivitiesArgs) {
     if (payloads.length === 0) {
       return;
     }
@@ -195,7 +206,9 @@ export class TimelineActivityRepository {
       payloads.map((payload) => ({
         happensAt: payload.happensAt,
         timelineActivityTypeId: payload.timelineActivityTypeId,
-        timelineActivityTypeSnapshot: payload.timelineActivityTypeSnapshot,
+        ...(shouldWriteTimelineActivityTypeSnapshot && {
+          timelineActivityTypeSnapshot: payload.timelineActivityTypeSnapshot,
+        }),
         properties: payload.properties,
         workspaceMemberId: payload.workspaceMemberId,
         [timelineActivityPropertyName]: payload.recordId,
@@ -247,5 +260,24 @@ export class TimelineActivityRepository {
 
   private async getTimelineActivityPropertyName(objectSingularName: string) {
     return `${buildTimelineActivityRelatedMorphFieldMetadataName(objectSingularName)}Id`;
+  }
+
+  private async hasTimelineActivityTypeSnapshotField(
+    workspaceId: string,
+  ): Promise<boolean> {
+    const timelineActivityRepository =
+      await this.globalWorkspaceOrmManager.getRepository(
+        workspaceId,
+        'timelineActivity',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    return isDefined(
+      timelineActivityRepository.internalContext.flatFieldMetadataMaps
+        .byUniversalIdentifier[
+        STANDARD_OBJECTS.timelineActivity.fields.timelineActivityTypeSnapshot
+          .universalIdentifier
+      ],
+    );
   }
 }

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity-type-cache.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity-type-cache.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import { isDefined } from 'twenty-shared/utils';
 
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
@@ -53,6 +54,22 @@ export class TimelineActivityTypeCacheService {
     });
 
     return resolveTimelineActivityType;
+  }
+
+  async hasTimelineActivityTypeSnapshotField(
+    workspaceId: string,
+  ): Promise<boolean> {
+    const { flatFieldMetadataMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        { workspaceId, flatMapsKeys: ['flatFieldMetadataMaps'] },
+      );
+
+    return isDefined(
+      flatFieldMetadataMaps.byUniversalIdentifier[
+        STANDARD_OBJECTS.timelineActivity.fields.timelineActivityTypeSnapshot
+          .universalIdentifier
+      ],
+    );
   }
 
   async getTimelineActivityTypeByIdOrThrow({


### PR DESCRIPTION
## Summary

- detect whether each workspace has the new timeline activity snapshot metadata field
- omit timelineActivityTypeSnapshot from automatic and explicit timeline writes until that field exists
- continue validating type ownership and stripping client-provided snapshots during the compatibility window
- preserve normal snapshot stamping for upgraded workspaces

## Why

v2.34 application code can start processing events before every workspace has run the v2.34 workspace commands. Writing timelineActivityTypeSnapshot during that interval fails in Twenty ORM because the field is absent from the workspace metadata.

This makes the write path compatible across the rolling-upgrade boundary. It does not replace the workspace command or backfill.

## Verification

- focused repository and mutation-input tests: 12 passed
- server typecheck with declaration emission disabled: passed
- diff lint and formatting: passed