### PR TITLE
Cover timeline activity routing branches

### DIFF
--- a/packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts
+++ b/packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts
@@ -1,4 +1,4 @@
-import { type ObjectRecordBaseEvent } from 'twenty-shared/database-events';
+import { ObjectRecordBaseEvent } from 'twenty-shared/database-events';
 import { type TimelineActivityTypeSnapshot } from 'twenty-shared/timeline';
 
 import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
@@ -55,14 +55,17 @@ const buildEvent = ({
 }: {
   before?: Record<string, unknown>;
   after?: Record<string, unknown>;
-  diff?: Record<string, unknown>;
+  diff?: ObjectRecordBaseEvent<Record<string, unknown>>['properties']['diff'];
   updatedFields?: string[];
-}): ObjectRecordBaseEvent =>
-  ({
-    recordId: SOURCE_RECORD_ID,
-    workspaceMemberId: WORKSPACE_MEMBER_ID,
-    properties: { before, after, diff, updatedFields },
-  }) as ObjectRecordBaseEvent;
+}): ObjectRecordBaseEvent<Record<string, unknown>> => {
+  const event = new ObjectRecordBaseEvent<Record<string, unknown>>();
+
+  event.recordId = SOURCE_RECORD_ID;
+  event.workspaceMemberId = WORKSPACE_MEMBER_ID;
+  event.properties = { before, after, diff, updatedFields };
+
+  return event;
+};
 
 const buildRule = ({
   action,
@@ -190,6 +193,7 @@ describe('TimelineActivityService', () => {
       }),
     });
 
+    expect(upsertTimelineActivities).toHaveBeenCalledTimes(1);
     expect(upsertTimelineActivities).toHaveBeenCalledWith({
       objectSingularName: 'attachment',
       workspaceId: WORKSPACE_ID,
@@ -262,11 +266,12 @@ describe('TimelineActivityService', () => {
       }),
     });
 
+    expect(upsertTimelineActivities).toHaveBeenCalledTimes(1);
     expect(upsertTimelineActivities).toHaveBeenCalledWith(
       expect.objectContaining({
         objectSingularName: 'person',
         workspaceId: WORKSPACE_ID,
-        payloads: [
+        payloads: expect.arrayContaining([
           expect.objectContaining({
             recordId: OLD_TARGET_RECORD_ID,
             linkedRecordId: SOURCE_RECORD_ID,
@@ -275,7 +280,7 @@ describe('TimelineActivityService', () => {
             recordId: NEW_TARGET_RECORD_ID,
             linkedRecordId: SOURCE_RECORD_ID,
           }),
-        ],
+        ]),
       }),
     );
   });
@@ -320,6 +325,7 @@ describe('TimelineActivityService', () => {
       }),
     });
 
+    expect(upsertTimelineActivities).toHaveBeenCalledTimes(1);
     expect(upsertTimelineActivities).toHaveBeenCalledWith(
       expect.objectContaining({
         objectSingularName: 'person',
@@ -381,6 +387,8 @@ describe('TimelineActivityService', () => {
         recordIds: [SOURCE_RECORD_ID],
         workspaceId: WORKSPACE_ID,
       });
+      expect(findSourceRecordsByRecordId).toHaveBeenCalledTimes(1);
+      expect(upsertTimelineActivities).toHaveBeenCalledTimes(1);
       expect(upsertTimelineActivities).toHaveBeenCalledWith(
         expect.objectContaining({
           objectSingularName: 'person',

--- a/packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts
+++ b/packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts
@@ -1,0 +1,436 @@
+import { type ObjectRecordBaseEvent } from 'twenty-shared/database-events';
+import { type TimelineActivityTypeSnapshot } from 'twenty-shared/timeline';
+
+import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
+import { type TimelineActivityPayload } from 'src/modules/timeline/types/timeline-activity-payload';
+import { type TimelineActivityRule } from 'src/modules/timeline/types/timeline-activity-rule.type';
+import { type ResolvedTimelineActivityType } from 'src/modules/timeline/utils/resolve-timeline-activity-type.util';
+import { TimelineActivityService } from 'src/modules/timeline/services/timeline-activity.service';
+
+const WORKSPACE_ID = '20202020-0000-4000-8000-000000000001';
+const SOURCE_RECORD_ID = '20202020-0000-4000-8000-000000000002';
+const OLD_TARGET_RECORD_ID = '20202020-0000-4000-8000-000000000003';
+const NEW_TARGET_RECORD_ID = '20202020-0000-4000-8000-000000000004';
+const WORKSPACE_MEMBER_ID = '20202020-0000-4000-8000-000000000005';
+const EVENT_DATE = '2026-08-23T09:00:00.000Z';
+
+const SOURCE_OBJECT = getFlatObjectMetadataMock({
+  id: 'source-object-id',
+  universalIdentifier: 'source-object-universal-identifier',
+  nameSingular: 'attachment',
+});
+
+const EMPTY_FLAT_FIELD_METADATA_MAPS = {
+  byUniversalIdentifier: {},
+  universalIdentifierById: {},
+  universalIdentifiersByApplicationId: {},
+};
+
+const buildTimelineActivityType = (
+  action: TimelineActivityTypeSnapshot['action'],
+): ResolvedTimelineActivityType => {
+  const id = `timeline-activity-type-${action}`;
+
+  return {
+    id,
+    applicationId: 'application-id',
+    snapshot: {
+      id,
+      universalIdentifier: `${id}-universal-identifier`,
+      name: `${action}Attachment`,
+      label: `${action} an attachment`,
+      action,
+      icon: 'IconPaperclip',
+      objectUniversalIdentifier: SOURCE_OBJECT.universalIdentifier,
+      frontComponentUniversalIdentifier: null,
+    },
+  };
+};
+
+const buildEvent = ({
+  before,
+  after,
+  diff,
+  updatedFields,
+}: {
+  before?: Record<string, unknown>;
+  after?: Record<string, unknown>;
+  diff?: Record<string, unknown>;
+  updatedFields?: string[];
+}): ObjectRecordBaseEvent =>
+  ({
+    recordId: SOURCE_RECORD_ID,
+    workspaceMemberId: WORKSPACE_MEMBER_ID,
+    properties: { before, after, diff, updatedFields },
+  }) as ObjectRecordBaseEvent;
+
+const buildRule = ({
+  action,
+  targetShape,
+}: Pick<TimelineActivityRule, 'targetShape'> & {
+  action: TimelineActivityTypeSnapshot['action'];
+}): TimelineActivityRule => ({
+  sourceFlatObjectMetadata: SOURCE_OBJECT,
+  actions: action === null ? [] : [action],
+  timelineActivityType: buildTimelineActivityType(action),
+  triggerFieldNames: null,
+  targetShape,
+});
+
+const buildService = ({
+  sourceRules = [],
+  junctionRules = [],
+}: {
+  sourceRules?: TimelineActivityRule[];
+  junctionRules?: TimelineActivityRule[];
+}) => {
+  const upsertTimelineActivities = jest.fn().mockResolvedValue(undefined);
+  const resolveTimelineActivityType = jest.fn();
+  const getRulesForEventBatch = jest.fn().mockResolvedValue({
+    sourceRules,
+    junctionRules,
+    flatFieldMetadataMaps: EMPTY_FLAT_FIELD_METADATA_MAPS,
+    resolveTimelineActivityType,
+  });
+  const resolveTargetsBySourceRecordId = jest.fn().mockResolvedValue(new Map());
+  const resolveTargetFromDirectRelationRecord = jest.fn(
+    ({ record }: { record?: Record<string, unknown> }) =>
+      typeof record?.targetPersonId === 'string'
+        ? {
+            targetObjectNameSingular: 'person',
+            targetRecordId: record.targetPersonId,
+          }
+        : undefined,
+  );
+  const resolveTargetFromJunctionRecord = jest.fn(
+    ({ junctionRecord }: { junctionRecord?: Record<string, unknown> }) =>
+      typeof junctionRecord?.targetPersonId === 'string'
+        ? {
+            targetObjectNameSingular: 'person',
+            targetRecordId: junctionRecord.targetPersonId,
+          }
+        : undefined,
+  );
+  const findSourceRecordsByRecordId = jest
+    .fn()
+    .mockResolvedValue(
+      new Map([
+        [
+          SOURCE_RECORD_ID,
+          { id: SOURCE_RECORD_ID, name: 'Quarterly report.pdf' },
+        ],
+      ]),
+    );
+  const report = jest.fn();
+
+  const service = new TimelineActivityService(
+    { upsertTimelineActivities } as never,
+    {
+      executeInWorkspaceContext: jest.fn(
+        async (callback: () => Promise<TimelineActivityPayload[][]>) =>
+          callback(),
+      ),
+    } as never,
+    { getRulesForEventBatch } as never,
+    {
+      resolveTargetsBySourceRecordId,
+      resolveTargetFromDirectRelationRecord,
+      resolveTargetFromJunctionRecord,
+      findSourceRecordsByRecordId,
+    } as never,
+    { report } as never,
+  );
+
+  return {
+    service,
+    upsertTimelineActivities,
+    resolveTimelineActivityType,
+    resolveTargetsBySourceRecordId,
+    findSourceRecordsByRecordId,
+    report,
+  };
+};
+
+const upsertEvent = async ({
+  service,
+  action,
+  event,
+}: {
+  service: TimelineActivityService;
+  action: 'created' | 'updated' | 'deleted';
+  event: ObjectRecordBaseEvent;
+}) =>
+  service.upsertEvents({
+    name: `attachment.${action}`,
+    workspaceId: WORKSPACE_ID,
+    objectMetadata: SOURCE_OBJECT,
+    events: [event],
+  });
+
+describe('TimelineActivityService', () => {
+  it('writes a self activity with only the displayable update diff', async () => {
+    const timelineActivityType = buildTimelineActivityType('updated');
+    const rule: TimelineActivityRule = {
+      sourceFlatObjectMetadata: SOURCE_OBJECT,
+      actions: ['updated'],
+      triggerFieldNames: null,
+      targetShape: { kind: 'SELF' },
+    };
+    const { service, upsertTimelineActivities, resolveTimelineActivityType } =
+      buildService({ sourceRules: [rule] });
+
+    resolveTimelineActivityType.mockReturnValue(timelineActivityType);
+
+    await upsertEvent({
+      service,
+      action: 'updated',
+      event: buildEvent({
+        after: { id: SOURCE_RECORD_ID, updatedAt: EVENT_DATE },
+        diff: { name: { before: 'Before', after: 'After' } },
+      }),
+    });
+
+    expect(upsertTimelineActivities).toHaveBeenCalledWith({
+      objectSingularName: 'attachment',
+      workspaceId: WORKSPACE_ID,
+      payloads: [
+        {
+          timelineActivityTypeId: timelineActivityType.id,
+          timelineActivityTypeSnapshot: timelineActivityType.snapshot,
+          happensAt: new Date(EVENT_DATE),
+          objectSingularName: 'attachment',
+          recordId: SOURCE_RECORD_ID,
+          workspaceMemberId: WORKSPACE_MEMBER_ID,
+          properties: {
+            diff: { name: { before: 'Before', after: 'After' } },
+          },
+        },
+      ],
+    });
+  });
+
+  it('fans a source update out through every junction target', async () => {
+    const rule = buildRule({
+      action: 'updated',
+      targetShape: {
+        kind: 'JUNCTION',
+        junctionObjectMetadataId: 'junction-object-id',
+        junctionObjectNameSingular: 'attachmentTarget',
+        junctionSourceJoinColumnName: 'attachmentId',
+        targetJoinColumns: [
+          {
+            joinColumnName: 'targetPersonId',
+            targetObjectNameSingular: 'person',
+          },
+        ],
+      },
+    });
+    const {
+      service,
+      upsertTimelineActivities,
+      resolveTargetsBySourceRecordId,
+    } = buildService({ sourceRules: [rule] });
+
+    resolveTargetsBySourceRecordId.mockResolvedValue(
+      new Map([
+        [
+          SOURCE_RECORD_ID,
+          [
+            {
+              targetObjectNameSingular: 'person',
+              targetRecordId: OLD_TARGET_RECORD_ID,
+            },
+            {
+              targetObjectNameSingular: 'person',
+              targetRecordId: NEW_TARGET_RECORD_ID,
+            },
+          ],
+        ],
+      ]),
+    );
+
+    await upsertEvent({
+      service,
+      action: 'updated',
+      event: buildEvent({
+        after: {
+          id: SOURCE_RECORD_ID,
+          name: 'Quarterly report.pdf',
+          updatedAt: EVENT_DATE,
+        },
+        diff: { name: { before: 'Old.pdf', after: 'Quarterly report.pdf' } },
+      }),
+    });
+
+    expect(upsertTimelineActivities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectSingularName: 'person',
+        workspaceId: WORKSPACE_ID,
+        payloads: [
+          expect.objectContaining({
+            recordId: OLD_TARGET_RECORD_ID,
+            linkedRecordId: SOURCE_RECORD_ID,
+          }),
+          expect.objectContaining({
+            recordId: NEW_TARGET_RECORD_ID,
+            linkedRecordId: SOURCE_RECORD_ID,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('emits unlinked and linked activities when a direct relation is repointed', async () => {
+    const targetShape = {
+      kind: 'DIRECT_RELATION' as const,
+      targetJoinColumns: [
+        {
+          joinColumnName: 'targetPersonId',
+          targetObjectNameSingular: 'person',
+        },
+      ],
+    };
+    const unlinkedRule = buildRule({ action: 'unlinked', targetShape });
+    const linkedRule = buildRule({ action: 'linked', targetShape });
+    const { service, upsertTimelineActivities } = buildService({
+      sourceRules: [unlinkedRule, linkedRule],
+    });
+
+    await upsertEvent({
+      service,
+      action: 'updated',
+      event: buildEvent({
+        before: {
+          id: SOURCE_RECORD_ID,
+          targetPersonId: OLD_TARGET_RECORD_ID,
+          updatedAt: EVENT_DATE,
+        },
+        after: {
+          id: SOURCE_RECORD_ID,
+          targetPersonId: NEW_TARGET_RECORD_ID,
+          updatedAt: EVENT_DATE,
+        },
+        diff: {
+          targetPersonId: {
+            before: OLD_TARGET_RECORD_ID,
+            after: NEW_TARGET_RECORD_ID,
+          },
+        },
+        updatedFields: ['targetPersonId'],
+      }),
+    });
+
+    expect(upsertTimelineActivities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectSingularName: 'person',
+        payloads: [
+          expect.objectContaining({
+            timelineActivityTypeId: unlinkedRule.timelineActivityType?.id,
+            recordId: OLD_TARGET_RECORD_ID,
+          }),
+          expect.objectContaining({
+            timelineActivityTypeId: linkedRule.timelineActivityType?.id,
+            recordId: NEW_TARGET_RECORD_ID,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it.each([
+    { eventAction: 'created' as const, ruleAction: 'linked' as const },
+    { eventAction: 'deleted' as const, ruleAction: 'unlinked' as const },
+  ])(
+    'turns a $eventAction junction row into a $ruleAction activity',
+    async ({ eventAction, ruleAction }) => {
+      const rule = buildRule({
+        action: ruleAction,
+        targetShape: {
+          kind: 'JUNCTION',
+          junctionObjectMetadataId: 'junction-object-id',
+          junctionObjectNameSingular: 'attachmentTarget',
+          junctionSourceJoinColumnName: 'attachmentId',
+          targetJoinColumns: [
+            {
+              joinColumnName: 'targetPersonId',
+              targetObjectNameSingular: 'person',
+            },
+          ],
+        },
+      });
+      const { service, upsertTimelineActivities, findSourceRecordsByRecordId } =
+        buildService({ junctionRules: [rule] });
+      const junctionRecord = {
+        id: 'junction-record-id',
+        attachmentId: SOURCE_RECORD_ID,
+        targetPersonId: NEW_TARGET_RECORD_ID,
+        updatedAt: EVENT_DATE,
+      };
+
+      await upsertEvent({
+        service,
+        action: eventAction,
+        event: buildEvent({
+          before: junctionRecord,
+          after: junctionRecord,
+        }),
+      });
+
+      expect(findSourceRecordsByRecordId).toHaveBeenCalledWith({
+        rule,
+        recordIds: [SOURCE_RECORD_ID],
+        workspaceId: WORKSPACE_ID,
+      });
+      expect(upsertTimelineActivities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          objectSingularName: 'person',
+          payloads: [
+            expect.objectContaining({
+              timelineActivityTypeId: rule.timelineActivityType?.id,
+              recordId: NEW_TARGET_RECORD_ID,
+              linkedRecordId: SOURCE_RECORD_ID,
+              properties: {},
+            }),
+          ],
+        }),
+      );
+    },
+  );
+
+  it('does not treat an unrelated junction update as a new link', async () => {
+    const rule = buildRule({
+      action: 'linked',
+      targetShape: {
+        kind: 'JUNCTION',
+        junctionObjectMetadataId: 'junction-object-id',
+        junctionObjectNameSingular: 'attachmentTarget',
+        junctionSourceJoinColumnName: 'attachmentId',
+        targetJoinColumns: [
+          {
+            joinColumnName: 'targetPersonId',
+            targetObjectNameSingular: 'person',
+          },
+        ],
+      },
+    });
+    const { service, upsertTimelineActivities } = buildService({
+      junctionRules: [rule],
+    });
+
+    await upsertEvent({
+      service,
+      action: 'updated',
+      event: buildEvent({
+        after: {
+          attachmentId: SOURCE_RECORD_ID,
+          targetPersonId: NEW_TARGET_RECORD_ID,
+          updatedAt: EVENT_DATE,
+        },
+        diff: { position: { before: 1, after: 2 } },
+        updatedFields: ['position'],
+      }),
+    });
+
+    expect(upsertTimelineActivities).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Add service-level regression coverage around the automatic timeline activity routing paths introduced by #24620 before simplifying their implementation.

The suite exercises:
- self activity creation with diff-only properties;
- source-record fan-out through junction targets;
- direct-relation repointing as an unlinked old target plus linked new target;
- junction create/delete as linked/unlinked activities;
- suppression of unrelated junction updates.

Existing query-hook coverage continues to cover explicit typed writes and immutable snapshots; existing repository coverage covers coalescing/stamping. This PR deliberately changes no production behavior.

Base branch: `main`.

## Validation

- `npx nx build twenty-shared --skip-nx-cache --excludeTaskDependencies` — passed (the barrel generator completed its writes but its `tsx` helper remained alive in this fresh Node 24 worktree, so the already-generated barrel step was excluded from the actual build invocation).
- `npx jest packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts --config=packages/twenty-server/jest.config.mjs --runInBand` — passed, 1 suite / 6 tests.
- `npx tsgo -p tsconfig.json --noEmit` from `packages/twenty-server` — passed after building required workspace package artifacts.
- `npx oxlint --type-aware -c packages/twenty-server/.oxlintrc.json packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts` — passed.
- `npx oxfmt --check packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts` — passed.
- `git diff --check` — passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

