### PR TITLE
Unify timeline record target resolution

### DIFF
--- a/packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts
+++ b/packages/twenty-server/src/modules/timeline/services/__tests__/timeline-activity.service.spec.ts
@@ -96,21 +96,12 @@ const buildService = ({
     resolveTimelineActivityType,
   });
   const resolveTargetsBySourceRecordId = jest.fn().mockResolvedValue(new Map());
-  const resolveTargetFromDirectRelationRecord = jest.fn(
+  const resolveTargetFromRecord = jest.fn(
     ({ record }: { record?: Record<string, unknown> }) =>
       typeof record?.targetPersonId === 'string'
         ? {
             targetObjectNameSingular: 'person',
             targetRecordId: record.targetPersonId,
-          }
-        : undefined,
-  );
-  const resolveTargetFromJunctionRecord = jest.fn(
-    ({ junctionRecord }: { junctionRecord?: Record<string, unknown> }) =>
-      typeof junctionRecord?.targetPersonId === 'string'
-        ? {
-            targetObjectNameSingular: 'person',
-            targetRecordId: junctionRecord.targetPersonId,
           }
         : undefined,
   );
@@ -137,8 +128,7 @@ const buildService = ({
     { getRulesForEventBatch } as never,
     {
       resolveTargetsBySourceRecordId,
-      resolveTargetFromDirectRelationRecord,
-      resolveTargetFromJunctionRecord,
+      resolveTargetFromRecord,
       findSourceRecordsByRecordId,
     } as never,
     { report } as never,

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity-target-query.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity-target-query.service.ts
@@ -88,35 +88,14 @@ export class TimelineActivityTargetQueryService {
     return targetsBySourceRecordId;
   }
 
-  resolveTargetFromJunctionRecord({
-    rule,
-    junctionRecord,
-  }: {
-    rule: TimelineActivityRule;
-    junctionRecord: Record<string, unknown> | undefined;
-  }): ResolvedTimelineActivityTarget | undefined {
-    if (!isDefined(junctionRecord)) {
-      return undefined;
-    }
-
-    if (rule.targetShape.kind !== 'JUNCTION') {
-      return undefined;
-    }
-
-    return readTargetFromRecord(
-      junctionRecord,
-      rule.targetShape.targetJoinColumns,
-    );
-  }
-
-  resolveTargetFromDirectRelationRecord({
+  resolveTargetFromRecord({
     rule,
     record,
   }: {
     rule: TimelineActivityRule;
     record: Record<string, unknown> | undefined;
   }): ResolvedTimelineActivityTarget | undefined {
-    if (!isDefined(record) || rule.targetShape.kind !== 'DIRECT_RELATION') {
+    if (!isDefined(record) || rule.targetShape.kind === 'SELF') {
       return undefined;
     }
 

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
@@ -341,9 +341,10 @@ export class TimelineActivityService {
           ruleAction,
         });
         const target =
-          this.timelineActivityTargetQueryService.resolveTargetFromDirectRelationRecord(
-            { rule, record },
-          );
+          this.timelineActivityTargetQueryService.resolveTargetFromRecord({
+            rule,
+            record,
+          });
 
         if (!isDefined(target)) {
           return [];
@@ -453,9 +454,10 @@ export class TimelineActivityService {
         });
 
         const target =
-          this.timelineActivityTargetQueryService.resolveTargetFromJunctionRecord(
-            { rule, junctionRecord },
-          );
+          this.timelineActivityTargetQueryService.resolveTargetFromRecord({
+            rule,
+            record: junctionRecord,
+          });
 
         const sourceRecordId = junctionRecord?.[junctionSourceJoinColumnName];
 


### PR DESCRIPTION
## Summary

Collapse the separate direct-relation and junction-record target wrappers into one `resolveTargetFromRecord` path.

Both wrappers only guarded the target shape and delegated to the same join-column reader. The unified method preserves the self-rule guard, works for both linked shapes, and removes 29 net lines across production and test setup without changing queries or routing behavior.

Stack:
- Base branch: `codex/timeline-link-transitions`
- Depends on: #24657, #24656, and #24655

## Validation

- `npx jest packages/twenty-server/src/modules/timeline --config=packages/twenty-server/jest.config.mjs --runInBand` — passed, 16 suites / 79 tests.
- `npx tsgo -p tsconfig.json --noEmit` from `packages/twenty-server` — passed.
- Focused service suite — passed, 7 tests.
- Type-aware oxlint on the three changed files — passed with 0 warnings/errors.
- `npx oxfmt --check` on the three changed files — passed.
- `git diff --check` — passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

