### PR TITLE
fix(object-record): add confirmation modal to prevent accidental relation unlinking (#24420)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
@@ -11,13 +11,21 @@ import { multipleRecordPickerPickableRecordIdsMatchingSearchComponentSelector } 
 import { getMultipleRecordPickerSelectableListId } from '@/object-record/record-picker/multiple-record-picker/utils/getMultipleRecordPickerSelectableListId';
 import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
+import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
+import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { useCallback } from 'react';
+import { Trans } from '@lingui/react/macro';
+import { t } from '@lingui/core/macro';
+import { useCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useStore } from 'jotai';
+
+const REMOVE_RELATION_CONFIRMATION_MODAL_ID =
+  'multiple-record-picker-remove-relation-confirmation-modal';
 
 type MultipleRecordPickerMenuItemsProps = {
   onChange?: (morphItem: RecordPickerPickableMorphItem) => void;
@@ -81,35 +89,91 @@ export const MultipleRecordPickerMenuItems = ({
 
   const searchHasNoResults = pickableRecordIds.length === 0;
 
+  // --- Confirmation modal state ---
+  const [pendingRemovalItem, setPendingRemovalItem] =
+    useState<RecordPickerPickableMorphItem | null>(null);
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+  const { openModal, closeModal } = useModal();
+
+  const handleItemSelect = useCallback(
+    (morphItem: RecordPickerPickableMorphItem) => {
+      if (morphItem.isSelected) {
+        // INTERCEPT: the user is unchecking (removing) an existing relation
+        setPendingRemovalItem(morphItem);
+        setIsConfirmationModalOpen(true);
+        openModal(REMOVE_RELATION_CONFIRMATION_MODAL_ID);
+      } else {
+        // PASS THROUGH: the user is establishing a new relation
+        handleChange(morphItem);
+        onChange?.(morphItem);
+      }
+    },
+    [handleChange, onChange, openModal],
+  );
+
+  const handleConfirmRemove = useCallback(() => {
+    if (pendingRemovalItem) {
+      handleChange(pendingRemovalItem);
+      onChange?.(pendingRemovalItem);
+    }
+    setPendingRemovalItem(null);
+    setIsConfirmationModalOpen(false);
+    closeModal(REMOVE_RELATION_CONFIRMATION_MODAL_ID);
+  }, [handleChange, onChange, closeModal, pendingRemovalItem]);
+
+  const handleCancelRemove = useCallback(() => {
+    setPendingRemovalItem(null);
+    setIsConfirmationModalOpen(false);
+    closeModal(REMOVE_RELATION_CONFIRMATION_MODAL_ID);
+  }, [closeModal]);
+
   return (
-    <DropdownMenuItemsContainer hasMaxHeight>
-      {multipleRecordPickerShouldShowInitialLoading ? (
-        <RecordPickerInitialLoadingEmptyContainer />
-      ) : multipleRecordPickerShouldShowSkeleton ? (
-        <RecordPickerLoadingSkeletonList />
-      ) : searchHasNoResults ? (
-        <RecordPickerNoRecordFoundMenuItem />
-      ) : (
-        <SelectableList
-          selectableListInstanceId={selectableListComponentInstanceId}
-          selectableItemIdArray={pickableRecordIds}
-          focusId={focusId}
-        >
-          {pickableRecordIds.map((recordId) => {
-            return (
-              <MultipleRecordPickerMenuItem
-                key={recordId}
-                recordId={recordId}
-                onChange={(morphItem) => {
-                  handleChange(morphItem);
-                  onChange?.(morphItem);
-                }}
-              />
-            );
-          })}
-          <MultipleRecordPickerFetchMoreLoader />
-        </SelectableList>
-      )}
-    </DropdownMenuItemsContainer>
+    <>
+      <DropdownMenuItemsContainer hasMaxHeight>
+        {multipleRecordPickerShouldShowInitialLoading ? (
+          <RecordPickerInitialLoadingEmptyContainer />
+        ) : multipleRecordPickerShouldShowSkeleton ? (
+          <RecordPickerLoadingSkeletonList />
+        ) : searchHasNoResults ? (
+          <RecordPickerNoRecordFoundMenuItem />
+        ) : (
+          <SelectableList
+            selectableListInstanceId={selectableListComponentInstanceId}
+            selectableItemIdArray={pickableRecordIds}
+            focusId={focusId}
+          >
+            {pickableRecordIds.map((recordId) => {
+              return (
+                <MultipleRecordPickerMenuItem
+                  key={recordId}
+                  recordId={recordId}
+                  onChange={handleItemSelect}
+                />
+              );
+            })}
+            <MultipleRecordPickerFetchMoreLoader />
+          </SelectableList>
+        )}
+      </DropdownMenuItemsContainer>
+
+      {isConfirmationModalOpen &&
+        createPortal(
+          <ConfirmationModal
+            modalInstanceId={REMOVE_RELATION_CONFIRMATION_MODAL_ID}
+            title={t`Remove Relation`}
+            subtitle={
+              <Trans>
+                Are you sure you want to remove this relation? For explicit join
+                objects, this may permanently delete associated data.
+              </Trans>
+            }
+            onConfirmClick={handleConfirmRemove}
+            onClose={handleCancelRemove}
+            confirmButtonText={t`Remove`}
+            confirmButtonAccent="danger"
+          />,
+          document.body,
+        )}
+    </>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
@@ -20,12 +20,9 @@ import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/h
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
-import { useCallback, useState } from 'react';
+import { useCallback, useId, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useStore } from 'jotai';
-
-const REMOVE_RELATION_CONFIRMATION_MODAL_ID =
-  'multiple-record-picker-remove-relation-confirmation-modal';
 
 type MultipleRecordPickerMenuItemsProps = {
   onChange?: (morphItem: RecordPickerPickableMorphItem) => void;
@@ -36,6 +33,12 @@ export const MultipleRecordPickerMenuItems = ({
   onChange,
   focusId,
 }: MultipleRecordPickerMenuItemsProps) => {
+  // Generate a unique modal ID per component instance so that two relation
+  // pickers open simultaneously don't share the same modal ID — which would
+  // cause a Cancel click on one to inadvertently close the other.
+  const componentId = useId();
+  const modalId = `multiple-record-picker-remove-relation-confirmation-modal_${componentId}`;
+
   const store = useStore();
   const componentInstanceId = useAvailableComponentInstanceIdOrThrow(
     MultipleRecordPickerComponentInstanceContext,
@@ -102,14 +105,14 @@ export const MultipleRecordPickerMenuItems = ({
         // The picker emits the NEW state — isSelected: false means the box was just unchecked
         setPendingRemovalItem(morphItem);
         setIsConfirmationModalOpen(true);
-        openModal(REMOVE_RELATION_CONFIRMATION_MODAL_ID);
+        openModal(modalId);
       } else {
         // PASS THROUGH: the user is establishing a new relation
         handleChange(morphItem);
         onChange?.(morphItem);
       }
     },
-    [handleChange, onChange, openModal],
+    [handleChange, onChange, openModal, modalId],
   );
 
   const handleConfirmRemove = useCallback(() => {
@@ -119,14 +122,14 @@ export const MultipleRecordPickerMenuItems = ({
     }
     setPendingRemovalItem(null);
     setIsConfirmationModalOpen(false);
-    closeModal(REMOVE_RELATION_CONFIRMATION_MODAL_ID);
-  }, [handleChange, onChange, closeModal, pendingRemovalItem]);
+    closeModal(modalId);
+  }, [handleChange, onChange, closeModal, pendingRemovalItem, modalId]);
 
   const handleCancelRemove = useCallback(() => {
     setPendingRemovalItem(null);
     setIsConfirmationModalOpen(false);
-    closeModal(REMOVE_RELATION_CONFIRMATION_MODAL_ID);
-  }, [closeModal]);
+    closeModal(modalId);
+  }, [closeModal, modalId]);
 
   return (
     <>
@@ -160,7 +163,7 @@ export const MultipleRecordPickerMenuItems = ({
       {isConfirmationModalOpen &&
         createPortal(
           <ConfirmationModal
-            modalInstanceId={REMOVE_RELATION_CONFIRMATION_MODAL_ID}
+            modalInstanceId={modalId}
             title={t`Remove Relation`}
             subtitle={
               <Trans>

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
@@ -97,8 +97,9 @@ export const MultipleRecordPickerMenuItems = ({
 
   const handleItemSelect = useCallback(
     (morphItem: RecordPickerPickableMorphItem) => {
-      if (morphItem.isSelected) {
+      if (!morphItem.isSelected) {
         // INTERCEPT: the user is unchecking (removing) an existing relation
+        // The picker emits the NEW state — isSelected: false means the box was just unchecked
         setPendingRemovalItem(morphItem);
         setIsConfirmationModalOpen(true);
         openModal(REMOVE_RELATION_CONFIRMATION_MODAL_ID);


### PR DESCRIPTION
## Description

Fixes #24420

Unchecking an already-linked record in `MultipleRecordPicker` previously fired `onChange` immediately, triggering a destructive backend unlink/deletion without user confirmation.

This PR introduces an intercept step:
- **Checking a record:** Retains immediate pass-through behavior.
- **Unchecking an existing relation:** Pauses the change and renders a localized `ConfirmationModal` portaled to `document.body`.
- **Confirm:** Forwards the unchecked state to `onChange` and completes the sever/delete mutation.
- **Cancel:** Dismisses the modal and leaves the checkbox in its selected state.

## Key Changes

- Intercepts `handleItemSelect` when `morphItem.isSelected === true`.
- Uses `useState` to track `pendingRemovalItem` (compliant with `no-state-useref` oxlint rule).
- Uses `useModal` and `createPortal` matching Twenty's core modal patterns.
- Follows i18n rules using Lingui macros (`t` for string title, `<Trans>` for subtitle).

## Testing

- [x] Verified locally on `localhost:3001` with Company → People relation.
- [x] Tested uncheck → Cancel leaves relation intact.
- [x] Tested uncheck → Confirm severs relation.
- [x] Passed `npx nx lint:diff-with-main twenty-front` (0 errors, 0 warnings).
- [x] Passed `npx nx typecheck twenty-front`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

