### PR TITLE
fix(views): retain inactive label identifier fields during view hydration (#24282)

### DIFF
--- a/packages/twenty-front/src/modules/views/states/selectors/viewsSelector.ts
+++ b/packages/twenty-front/src/modules/views/states/selectors/viewsSelector.ts
@@ -38,7 +38,31 @@ export const viewsSelector = createAtomSelector<ViewWithRelations[]>({
     const allFlatViewFieldGroups = get(metadataStoreState, 'viewFieldGroups')
       .current as FlatViewFieldGroup[];
 
-    const flatViewFields = allFlatViewFields.filter((field) => field.isActive);
+    // Build a map from viewId → labelIdentifierFieldMetadataId so that the
+    // label-identifier view field (e.g. the "Name" column on Companies) is
+    // always included in the hydrated state even when its isActive flag is
+    // false.  Without this, deleting & recreating a view would leave the Name
+    // field invisible to the frontend, causing it to send a CREATE request for
+    // a record that already exists in the backend (Issue #24282).
+    const labelIdentifierFieldMetadataIdByViewId = new Map<string, string>();
+    for (const view of flatViews) {
+      const objectMetadataItem = objectMetadataItemsById.get(
+        view.objectMetadataId,
+      );
+      if (objectMetadataItem?.labelIdentifierFieldMetadataId) {
+        labelIdentifierFieldMetadataIdByViewId.set(
+          view.id,
+          objectMetadataItem.labelIdentifierFieldMetadataId,
+        );
+      }
+    }
+
+    const flatViewFields = allFlatViewFields.filter(
+      (field) =>
+        field.isActive ||
+        labelIdentifierFieldMetadataIdByViewId.get(field.viewId) ===
+          field.fieldMetadataId,
+    );
     const flatViewFieldGroups = allFlatViewFieldGroups.filter(
       (group) => group.isActive,
     );


### PR DESCRIPTION
## Description
Fixes #24282

When a default view (like Companies) was deleted and recreated, the UI omitted the persisted `Name` column from its local state if it was marked as inactive. Attempting to re-enable it caused the frontend to send a `CREATE` request instead of an `UPDATE`, resulting in a backend duplicate validation error ("View field already exists").

This PR updates the view hydration logic to explicitly retain the `labelIdentifierFieldMetadataId` in the `flatViewFields` array, ensuring it remains available to the view state even when inactive.

## Key Changes
- Modified `viewsSelector.ts` to bypass the `isActive` filter specifically for the label identifier field.
- Ensures the frontend correctly sends an `UPDATE` mutation when toggling the field visibility back on.

## Testing
- [x] Deleted and recreated the "All Companies" table view.
- [x] Toggled the "Name" column on from the fields menu.
- [x] Verified no API conflict errors are thrown and the column renders successfully.
- [x] Passed `npx nx typecheck twenty-front`.
- [x] Passed `npx nx lint:diff-with-main twenty-front`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

