### PR TITLE
fix: re-land brace-expansion 5.0.9 in app lockfiles (Dependabot)

### DIFF
--- a/packages/twenty-apps/examples/hello-world/yarn.lock
+++ b/packages/twenty-apps/examples/hello-world/yarn.lock
@@ -1019,11 +1019,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.2":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/examples/postcard/yarn.lock
+++ b/packages/twenty-apps/examples/postcard/yarn.lock
@@ -1263,11 +1263,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/self-hosting/yarn.lock
+++ b/packages/twenty-apps/internal/self-hosting/yarn.lock
@@ -1341,11 +1341,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Re-lands **#24615** (brace-expansion **5.0.8 -> 5.0.9** in `examples/hello-world`, `examples/postcard`, `internal/self-hosting`), clearing **GHSA-rgw5-rvv9-x895** (high) - DoS via unbounded expansion length causing an out-of-memory process crash, vulnerable `>= 4.0.0, < 5.0.9`. Alerts [1874](https://github.com/twentyhq/twenty/security/dependabot/1874), [1876](https://github.com/twentyhq/twenty/security/dependabot/1876), [1878](https://github.com/twentyhq/twenty/security/dependabot/1878).

## Why again

#24615 merged on 2026-08-22, but #24620 was built on a branch cut before it: its copies of the same three app lockfiles still carried 5.0.8 and overwrote the bump when it merged a day later. Nothing intentional - just the stale-branch lockfile pattern; any branch that reinstalls an app and merges after a security bump can silently undo it, since app lockfiles have no conflict to surface (the whole file is regenerated).

Same fix as before: recursive `yarn up -R brace-expansion` per app (caret ranges `^5.0.2` / `^5.0.5`), **no resolution, no `package.json` change**.

## Verification

- brace-expansion 5.x resolves to **5.0.9** in all three lockfiles.
- `yarn install --immutable` passes in each.
