### PR TITLE
fix(i18n): repair backslash-escaped tags in Crowdin inline code

### DIFF
--- a/packages/twenty-utils/crowdin-normalizer/rules/__tests__/escaped-inline-code-tags.rule.spec.ts
+++ b/packages/twenty-utils/crowdin-normalizer/rules/__tests__/escaped-inline-code-tags.rule.spec.ts
@@ -29,6 +29,34 @@ describe('ESCAPED_INLINE_CODE_TAGS_RULE', () => {
     expect(sourceFilter?.('Escape a literal &lt; in prose')).toBe(false);
   });
 
+  it('repairs a backslash-escaped tag inside an inline-code span', () => {
+    const translationText =
+      'Ouvrez `https://\\<your-workspace-subdomain>.withtwenty.com`';
+
+    expect(detect(translationText)).toBe(true);
+    expect(fix(translationText)).toBe(
+      'Ouvrez `https://<your-workspace-subdomain>.withtwenty.com`',
+    );
+  });
+
+  it('repairs several backslash-escaped tags in one span', () => {
+    expect(fix('Utilisez `\\<server-url>/s/\\<path>` ici')).toBe(
+      'Utilisez `<server-url>/s/<path>` ici',
+    );
+  });
+
+  it('leaves backslash-escaped angle brackets outside inline code untouched', () => {
+    expect(fix('Gardez `\\<path>` mais laissez \\<literal> en prose')).toBe(
+      'Gardez `<path>` mais laissez \\<literal> en prose',
+    );
+  });
+
+  it('is idempotent for backslash escapes', () => {
+    const once = fix('Utilisez `\\<path>` et `\\<name>`');
+
+    expect(fix(once)).toBe(once);
+  });
+
   it('is idempotent', () => {
     const once = fix('Remplacez `&lt;path&gt;` par `&lt;autre&gt;`');
 

--- a/packages/twenty-utils/crowdin-normalizer/rules/escaped-inline-code-tags.rule.ts
+++ b/packages/twenty-utils/crowdin-normalizer/rules/escaped-inline-code-tags.rule.ts
@@ -1,7 +1,9 @@
 import { type NormalizationRule } from '../types/normalization-rule.type';
 
 const INLINE_CODE_SPAN_REGEX = /`[^`\n]+`/g;
-const ESCAPED_TAG_REGEX = /&lt;|&gt;|&#0*60;|&#0*62;|&#x0*3c;|&#x0*3e;/i;
+
+const ESCAPED_TAG_REGEX =
+  /&lt;|&gt;|&#0*60;|&#0*62;|&#x0*3c;|&#x0*3e;|\\<|\\>/i;
 
 function inlineCodeSpans(text: string): string[] {
   return text.match(INLINE_CODE_SPAN_REGEX) ?? [];
@@ -23,7 +25,9 @@ function unescapeTagsInInlineCode(text: string): string {
       .replace(/&lt;/gi, '<')
       .replace(/&gt;/gi, '>')
       .replace(/&#0*60;|&#x0*3c;/gi, '<')
-      .replace(/&#0*62;|&#x0*3e;/gi, '>'),
+      .replace(/&#0*62;|&#x0*3e;/gi, '>')
+      .replace(/\\</g, '<')
+      .replace(/\\>/g, '>'),
   );
 }
 


### PR DESCRIPTION
Follow-up to #24540. That PR gates the English source; this repairs the corruption already in the translated output, which a source-side gate cannot see.

### Problem

Crowdin escapes tags inside inline code two ways depending on the engine that produced the translation. `escaped-inline-code-tags` already repairs the `mdx_v2` HTML-entity form (`` `&lt;path&gt;` ``). It does not cover the backslash form that MT/AI output emits:

```
EN:  https://<your-workspace-subdomain>.withtwenty.com<path>
FR:  https://\<your-workspace-subdomain>.withtwenty.com\<path>
```

A backslash escape does not apply inside a code span, so the `\` renders verbatim on the page. 546 occurrences across 156 translated docs pages, none in the English source. Top offenders: `\<name>`, `\<path>`, `\<your-workspace-subdomain>`.

### Change

Extends the existing `escaped-inline-code-tags` rule rather than adding a new one: same corruption class (a tag escaped inside inline code), same `sourceFilter`, and no workflow change since `docs-i18n-pull.yaml` already runs `--rules=escaped-inline-code-tags`. The detect regex gains `\<` / `\>`, and the fix strips the backslash inside code spans only. 10 lines.

### Verification

```
$ npx nx test twenty-utils
Test Suites  5 passed (5)
Tests        26 passed (26)
```

Four new cases, all of which fail against the unpatched rule.

Applied to the live corpus (dry, off-CI): 546 backslashes cleared across the same 156 files, 0 residual, and every change was exactly a backslash removal (undoing the fix reproduces the original byte for byte).

Note the normalizer repairs translations in Crowdin, so the 546 clear on the next scheduled pull rather than in this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDpcgmYtZxPVvWpCS4hGdD)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

