### PR TITLE
Fix custom-only attachment timeline upgrades in v2.35

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-upgrade-version-command.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { RepairAttachmentTimelineActivityTypesCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command';
+import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+
+@Module({
+  imports: [
+    ApplicationModule,
+    WorkspaceCacheModule,
+    WorkspaceIteratorModule,
+    WorkspaceMigrationModule,
+  ],
+  providers: [RepairAttachmentTimelineActivityTypesCommand],
+})
+export class V2_35_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command.ts
@@ -1,0 +1,211 @@
+import { Command } from 'nest-commander';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { v4 } from 'uuid';
+
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { hasTimelineActivityObjectMetadata } from 'src/database/commands/upgrade-version-command/2-34/utils/has-timeline-activity-object-metadata.util';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatTimelineActivityType } from 'src/engine/metadata-modules/flat-timeline-activity-type/types/flat-timeline-activity-type.type';
+import { isFieldMetadataSettingsOfType } from 'src/engine/metadata-modules/field-metadata/utils/is-field-metadata-settings-of-type.util';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER =
+  '20202020-64aa-4b6f-b003-9c74b97cee20';
+const ATTACHMENT_OBJECT_UNIVERSAL_IDENTIFIER =
+  '20202020-bd3d-4c60-8dca-571c71d4447a';
+const ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '721ddb1f-468d-535a-9809-cb3429a52e06';
+const ATTACHMENT_TARGET_MORPH_ID = '20202020-f634-435d-ab8d-e1168b375c69';
+
+const ATTACHMENT_TIMELINE_ACTIVITY_TYPES = [
+  {
+    universalIdentifier: '20202020-0d1a-4f0e-8a55-1c0a2f0a2c11',
+    name: 'attachmentLinked',
+    label: 'attached a file',
+    action: 'linked',
+    icon: 'IconPaperclip',
+  },
+  {
+    universalIdentifier: '20202020-0d1a-4f0e-8a55-1c0a2f0a2c12',
+    name: 'attachmentUnlinked',
+    label: 'removed an attachment',
+    action: 'unlinked',
+    icon: 'IconUnlink',
+  },
+] as const;
+
+@RegisteredWorkspaceCommand('2.35.0', 1787561579075)
+@Command({
+  name: 'upgrade:2-35:repair-attachment-timeline-activity-types',
+  description:
+    'Repair attachment timeline activity types in workspaces whose attachment target morph only contains custom fields',
+})
+export class RepairAttachmentTimelineActivityTypesCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const {
+      flatFieldMetadataMaps,
+      flatObjectMetadataMaps,
+      flatTimelineActivityTypeMaps,
+    } = await this.workspaceCacheService.getOrRecompute(workspaceId, [
+      'flatFieldMetadataMaps',
+      'flatObjectMetadataMaps',
+      'flatTimelineActivityTypeMaps',
+    ]);
+
+    if (!hasTimelineActivityObjectMetadata(flatObjectMetadataMaps)) {
+      return;
+    }
+
+    const missingDefinitions = ATTACHMENT_TIMELINE_ACTIVITY_TYPES.filter(
+      ({ universalIdentifier }) =>
+        !isDefined(
+          flatTimelineActivityTypeMaps.byUniversalIdentifier[
+            universalIdentifier
+          ],
+        ),
+    );
+
+    if (missingDefinitions.length === 0) {
+      return;
+    }
+
+    const attachmentObjectMetadata =
+      flatObjectMetadataMaps.byUniversalIdentifier[
+        ATTACHMENT_OBJECT_UNIVERSAL_IDENTIFIER
+      ];
+    const attachmentTargetRelationFieldMetadata = Object.values(
+      flatFieldMetadataMaps.byUniversalIdentifier,
+    )
+      .filter(isDefined)
+      .filter((fieldMetadata) =>
+        this.isValidAttachmentTargetMorphRelation({
+          attachmentObjectMetadataId: attachmentObjectMetadata?.id,
+          fieldMetadata,
+        }),
+      )
+      .sort((firstFieldMetadata, secondFieldMetadata) => {
+        const firstIsPreferred =
+          firstFieldMetadata.universalIdentifier ===
+          ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER;
+        const secondIsPreferred =
+          secondFieldMetadata.universalIdentifier ===
+          ATTACHMENT_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER;
+
+        if (firstIsPreferred !== secondIsPreferred) {
+          return firstIsPreferred ? -1 : 1;
+        }
+
+        return firstFieldMetadata.universalIdentifier.localeCompare(
+          secondFieldMetadata.universalIdentifier,
+        );
+      })[0];
+
+    if (!isDefined(attachmentTargetRelationFieldMetadata)) {
+      this.logger.warn(
+        `No valid attachment target morph relation for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    if (options.dryRun ?? false) {
+      this.logger.log(
+        `[DRY RUN] Would add ${missingDefinitions.length} attachment timeline activity types for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+    const now = new Date().toISOString();
+    const flatTimelineActivityTypesToCreate: FlatTimelineActivityType[] =
+      missingDefinitions.map((definition) => ({
+        id: v4(),
+        workspaceId,
+        applicationId: twentyStandardFlatApplication.id,
+        applicationUniversalIdentifier:
+          STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+        universalIdentifier: definition.universalIdentifier,
+        name: definition.name,
+        label: definition.label,
+        action: definition.action,
+        icon: definition.icon,
+        frontComponentUniversalIdentifier: null,
+        objectUniversalIdentifier: ATTACHMENT_OBJECT_UNIVERSAL_IDENTIFIER,
+        targetRelationFieldUniversalIdentifier:
+          attachmentTargetRelationFieldMetadata.universalIdentifier,
+        triggerFieldUniversalIdentifiers: null,
+        replacesTimelineActivityTypeUniversalIdentifier: null,
+        isActive: true,
+        overrides: null,
+        createdAt: now,
+        updatedAt: now,
+      }));
+
+    const result =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          workspaceId,
+          applicationUniversalIdentifier:
+            STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+          allFlatEntityOperationByMetadataName: {
+            timelineActivityType: {
+              flatEntityToCreate: flatTimelineActivityTypesToCreate,
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+        },
+      );
+
+    if (result.status === 'fail') {
+      throw new Error(
+        `Failed to repair attachment timeline activity types for workspace ${workspaceId}:\n${JSON.stringify(result, null, 2)}`,
+      );
+    }
+  }
+
+  private isValidAttachmentTargetMorphRelation({
+    attachmentObjectMetadataId,
+    fieldMetadata,
+  }: {
+    attachmentObjectMetadataId: string | undefined;
+    fieldMetadata: FlatFieldMetadata;
+  }): boolean {
+    return (
+      isDefined(attachmentObjectMetadataId) &&
+      fieldMetadata.objectMetadataId === attachmentObjectMetadataId &&
+      fieldMetadata.type === FieldMetadataType.MORPH_RELATION &&
+      fieldMetadata.morphId === ATTACHMENT_TARGET_MORPH_ID &&
+      isFieldMetadataSettingsOfType(
+        fieldMetadata.settings,
+        FieldMetadataType.MORPH_RELATION,
+      ) &&
+      fieldMetadata.settings.relationType === RelationType.MANY_TO_ONE &&
+      isDefined(fieldMetadata.relationTargetObjectMetadataId) &&
+      isDefined(fieldMetadata.relationTargetFieldMetadataId)
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/__tests__/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/__tests__/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command.spec.ts
@@ -1,0 +1,217 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { RepairAttachmentTimelineActivityTypesCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command';
+import { type ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const WORKSPACE_ID = '00000000-0000-4000-8000-000000000001';
+const STANDARD_APPLICATION_ID = '00000000-0000-4000-8000-000000000002';
+const CUSTOM_APPLICATION_ID = '00000000-0000-4000-8000-000000000003';
+const ATTACHMENT_OBJECT_ID = '00000000-0000-4000-8000-000000000004';
+const RELATION_TARGET_OBJECT_ID = '00000000-0000-4000-8000-000000000005';
+const RELATION_TARGET_FIELD_ID = '00000000-0000-4000-8000-000000000006';
+const ATTACHMENT_TARGET_MORPH_ID = '20202020-f634-435d-ab8d-e1168b375c69';
+const PREFERRED_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '721ddb1f-468d-535a-9809-cb3429a52e06';
+const LINKED_TYPE_UNIVERSAL_IDENTIFIER = '20202020-0d1a-4f0e-8a55-1c0a2f0a2c11';
+const UNLINKED_TYPE_UNIVERSAL_IDENTIFIER =
+  '20202020-0d1a-4f0e-8a55-1c0a2f0a2c12';
+
+const buildTargetField = ({
+  universalIdentifier,
+}: {
+  universalIdentifier: string;
+}) => ({
+  id: universalIdentifier,
+  applicationId: CUSTOM_APPLICATION_ID,
+  objectMetadataId: ATTACHMENT_OBJECT_ID,
+  relationTargetObjectMetadataId: RELATION_TARGET_OBJECT_ID,
+  relationTargetFieldMetadataId: RELATION_TARGET_FIELD_ID,
+  type: FieldMetadataType.MORPH_RELATION,
+  morphId: ATTACHMENT_TARGET_MORPH_ID,
+  settings: { relationType: RelationType.MANY_TO_ONE },
+  universalIdentifier,
+});
+
+const buildCommand = ({
+  attachmentTargetFields = {
+    [PREFERRED_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER]: buildTargetField({
+      universalIdentifier: PREFERRED_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+    }),
+  },
+  flatTimelineActivityTypes = {},
+  migrationResult = { status: 'success' },
+}: {
+  attachmentTargetFields?: Record<string, object>;
+  flatTimelineActivityTypes?: Record<string, object>;
+  migrationResult?: { status: 'success' | 'fail' };
+}) => {
+  const validateBuildAndRunWorkspaceMigration = jest
+    .fn()
+    .mockResolvedValue(migrationResult);
+  const command = new RepairAttachmentTimelineActivityTypesCommand(
+    {} as WorkspaceIteratorService,
+    {
+      findWorkspaceTwentyStandardAndCustomApplicationOrThrow: jest
+        .fn()
+        .mockResolvedValue({
+          twentyStandardFlatApplication: { id: STANDARD_APPLICATION_ID },
+        }),
+    } as unknown as ApplicationService,
+    {
+      getOrRecompute: jest.fn().mockResolvedValue({
+        flatFieldMetadataMaps: {
+          byUniversalIdentifier: attachmentTargetFields,
+        },
+        flatObjectMetadataMaps: {
+          byUniversalIdentifier: {
+            [STANDARD_OBJECTS.timelineActivity.universalIdentifier]: {},
+            [STANDARD_OBJECTS.attachment.universalIdentifier]: {
+              id: ATTACHMENT_OBJECT_ID,
+            },
+          },
+        },
+        flatTimelineActivityTypeMaps: {
+          byUniversalIdentifier: flatTimelineActivityTypes,
+        },
+      }),
+    } as unknown as WorkspaceCacheService,
+    {
+      validateBuildAndRunWorkspaceMigration,
+    } as unknown as WorkspaceMigrationValidateBuildAndRunService,
+  );
+
+  return { command, validateBuildAndRunWorkspaceMigration };
+};
+
+const runCommand = (
+  command: RepairAttachmentTimelineActivityTypesCommand,
+  dryRun = false,
+) =>
+  command.runOnWorkspace({
+    workspaceId: WORKSPACE_ID,
+    options: { dryRun },
+    index: 0,
+    total: 1,
+  });
+
+describe('RepairAttachmentTimelineActivityTypesCommand', () => {
+  it('creates both missing definitions through the preferred target field', async () => {
+    const { command, validateBuildAndRunWorkspaceMigration } = buildCommand({});
+
+    await runCommand(command);
+
+    const createdTypes =
+      validateBuildAndRunWorkspaceMigration.mock.calls[0][0]
+        .allFlatEntityOperationByMetadataName.timelineActivityType
+        .flatEntityToCreate;
+
+    expect(createdTypes).toEqual([
+      expect.objectContaining({
+        universalIdentifier: LINKED_TYPE_UNIVERSAL_IDENTIFIER,
+        action: 'linked',
+        targetRelationFieldUniversalIdentifier:
+          PREFERRED_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+      }),
+      expect.objectContaining({
+        universalIdentifier: UNLINKED_TYPE_UNIVERSAL_IDENTIFIER,
+        action: 'unlinked',
+        targetRelationFieldUniversalIdentifier:
+          PREFERRED_TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+      }),
+    ]);
+  });
+
+  it('uses a deterministic custom morph member when no standard member exists', async () => {
+    const firstCustomTarget = '10000000-0000-4000-8000-000000000001';
+    const secondCustomTarget = '20000000-0000-4000-8000-000000000002';
+    const { command, validateBuildAndRunWorkspaceMigration } = buildCommand({
+      attachmentTargetFields: {
+        [secondCustomTarget]: buildTargetField({
+          universalIdentifier: secondCustomTarget,
+        }),
+        [firstCustomTarget]: buildTargetField({
+          universalIdentifier: firstCustomTarget,
+        }),
+      },
+    });
+
+    await runCommand(command);
+
+    const createdTypes =
+      validateBuildAndRunWorkspaceMigration.mock.calls[0][0]
+        .allFlatEntityOperationByMetadataName.timelineActivityType
+        .flatEntityToCreate;
+
+    expect(createdTypes).toEqual([
+      expect.objectContaining({
+        targetRelationFieldUniversalIdentifier: firstCustomTarget,
+      }),
+      expect.objectContaining({
+        targetRelationFieldUniversalIdentifier: firstCustomTarget,
+      }),
+    ]);
+  });
+
+  it('only creates definitions that are still missing', async () => {
+    const { command, validateBuildAndRunWorkspaceMigration } = buildCommand({
+      flatTimelineActivityTypes: {
+        [LINKED_TYPE_UNIVERSAL_IDENTIFIER]: {},
+      },
+    });
+
+    await runCommand(command);
+
+    const createdTypes =
+      validateBuildAndRunWorkspaceMigration.mock.calls[0][0]
+        .allFlatEntityOperationByMetadataName.timelineActivityType
+        .flatEntityToCreate;
+
+    expect(createdTypes).toHaveLength(1);
+    expect(createdTypes[0]).toEqual(
+      expect.objectContaining({
+        universalIdentifier: UNLINKED_TYPE_UNIVERSAL_IDENTIFIER,
+      }),
+    );
+  });
+
+  it('skips invalid attachment morph members', async () => {
+    const invalidFieldUniversalIdentifier =
+      '30000000-0000-4000-8000-000000000003';
+    const { command, validateBuildAndRunWorkspaceMigration } = buildCommand({
+      attachmentTargetFields: {
+        [invalidFieldUniversalIdentifier]: {
+          ...buildTargetField({
+            universalIdentifier: invalidFieldUniversalIdentifier,
+          }),
+          relationTargetFieldMetadataId: null,
+        },
+      },
+    });
+
+    await runCommand(command);
+
+    expect(validateBuildAndRunWorkspaceMigration).not.toHaveBeenCalled();
+  });
+
+  it('does not mutate metadata during a dry run', async () => {
+    const { command, validateBuildAndRunWorkspaceMigration } = buildCommand({});
+
+    await runCommand(command, true);
+
+    expect(validateBuildAndRunWorkspaceMigration).not.toHaveBeenCalled();
+  });
+
+  it('fails when the repair migration is rejected', async () => {
+    const { command } = buildCommand({
+      migrationResult: { status: 'fail' },
+    });
+
+    await expect(runCommand(command)).rejects.toThrow(
+      'Failed to repair attachment timeline activity types',
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/__tests__/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/__tests__/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command.spec.ts
@@ -156,10 +156,10 @@ describe('RepairAttachmentTimelineActivityTypesCommand', () => {
     ]);
   });
 
-  it('only creates definitions that are still missing', async () => {
+  it('only creates missing definitions and preserves muted definitions', async () => {
     const { command, validateBuildAndRunWorkspaceMigration } = buildCommand({
       flatTimelineActivityTypes: {
-        [LINKED_TYPE_UNIVERSAL_IDENTIFIER]: {},
+        [LINKED_TYPE_UNIVERSAL_IDENTIFIER]: { isActive: false },
       },
     });
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -27,6 +27,7 @@ import { V2_31_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
 import { V2_32_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-32/2-32-upgrade-version-command.module';
 import { V2_33_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module';
 import { V2_34_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-34/2-34-upgrade-version-command.module';
+import { V2_35_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-35/2-35-upgrade-version-command.module';
 import { V2_4_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-4/2-4-upgrade-version-command.module';
 import { V2_5_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-5/2-5-upgrade-version-command.module';
 import { V2_7_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-7/2-7-upgrade-version-command.module';
@@ -67,6 +68,7 @@ import { V2_9_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-
     V2_32_UpgradeVersionCommandModule,
     V2_33_UpgradeVersionCommandModule,
     V2_34_UpgradeVersionCommandModule,
+    V2_35_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/__tests__/get-timeline-activity-type-target-relation-application-ids.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/__tests__/get-timeline-activity-type-target-relation-application-ids.util.spec.ts
@@ -1,0 +1,54 @@
+import { getTimelineActivityTypeTargetRelationApplicationIds } from 'src/engine/workspace-manager/workspace-migration/services/utils/get-timeline-activity-type-target-relation-application-ids.util';
+
+const CUSTOM_APPLICATION_ID = '00000000-0000-4000-8000-000000000001';
+const TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-000000000002';
+
+describe('getTimelineActivityTypeTargetRelationApplicationIds', () => {
+  it('includes the application that owns a soft-referenced target relation', () => {
+    const applicationIds = getTimelineActivityTypeTargetRelationApplicationIds({
+      flatFieldMetadataMaps: {
+        byUniversalIdentifier: {
+          [TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER]: {
+            applicationId: CUSTOM_APPLICATION_ID,
+          },
+        },
+      } as never,
+      timelineActivityTypeOperations: {
+        flatEntityToCreate: {
+          timelineActivityType: {
+            targetRelationFieldUniversalIdentifier:
+              TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+          },
+        },
+        flatEntityToUpdate: {},
+        flatEntityToDelete: {},
+      } as never,
+    });
+
+    expect(applicationIds).toEqual([CUSTOM_APPLICATION_ID]);
+  });
+
+  it('ignores absent and unresolved target relations', () => {
+    const applicationIds = getTimelineActivityTypeTargetRelationApplicationIds({
+      flatFieldMetadataMaps: {
+        byUniversalIdentifier: {},
+      } as never,
+      timelineActivityTypeOperations: {
+        flatEntityToCreate: {
+          selfTimelineActivityType: {
+            targetRelationFieldUniversalIdentifier: null,
+          },
+          missingRelationTimelineActivityType: {
+            targetRelationFieldUniversalIdentifier:
+              TARGET_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+          },
+        },
+        flatEntityToUpdate: {},
+        flatEntityToDelete: {},
+      } as never,
+    });
+
+    expect(applicationIds).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/__tests__/get-timeline-activity-type-target-relation-application-ids.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/__tests__/get-timeline-activity-type-target-relation-application-ids.util.spec.ts
@@ -13,7 +13,7 @@ describe('getTimelineActivityTypeTargetRelationApplicationIds', () => {
             applicationId: CUSTOM_APPLICATION_ID,
           },
         },
-      } as never,
+      },
       timelineActivityTypeOperations: {
         flatEntityToCreate: {
           timelineActivityType: {
@@ -23,7 +23,7 @@ describe('getTimelineActivityTypeTargetRelationApplicationIds', () => {
         },
         flatEntityToUpdate: {},
         flatEntityToDelete: {},
-      } as never,
+      },
     });
 
     expect(applicationIds).toEqual([CUSTOM_APPLICATION_ID]);
@@ -33,7 +33,7 @@ describe('getTimelineActivityTypeTargetRelationApplicationIds', () => {
     const applicationIds = getTimelineActivityTypeTargetRelationApplicationIds({
       flatFieldMetadataMaps: {
         byUniversalIdentifier: {},
-      } as never,
+      },
       timelineActivityTypeOperations: {
         flatEntityToCreate: {
           selfTimelineActivityType: {
@@ -46,7 +46,7 @@ describe('getTimelineActivityTypeTargetRelationApplicationIds', () => {
         },
         flatEntityToUpdate: {},
         flatEntityToDelete: {},
-      } as never,
+      },
     });
 
     expect(applicationIds).toEqual([]);

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/get-timeline-activity-type-target-relation-application-ids.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/get-timeline-activity-type-target-relation-application-ids.util.ts
@@ -1,16 +1,38 @@
 import { isDefined } from 'twenty-shared/utils';
 
-import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { type FlatEntityOperationRecord } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-operation-record-by-metadata-name.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatTimelineActivityType } from 'src/engine/metadata-modules/flat-timeline-activity-type/types/flat-timeline-activity-type.type';
+
+type TimelineActivityTypeTargetRelation = Pick<
+  FlatTimelineActivityType,
+  'targetRelationFieldUniversalIdentifier'
+>;
+
+type TimelineActivityTypeTargetRelationOperations = {
+  flatEntityToCreate: Partial<
+    Record<string, TimelineActivityTypeTargetRelation>
+  >;
+  flatEntityToUpdate: Partial<
+    Record<string, TimelineActivityTypeTargetRelation>
+  >;
+  flatEntityToDelete: Partial<
+    Record<string, TimelineActivityTypeTargetRelation>
+  >;
+};
 
 export const getTimelineActivityTypeTargetRelationApplicationIds = ({
   flatFieldMetadataMaps,
   timelineActivityTypeOperations,
 }: {
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata> | undefined;
+  flatFieldMetadataMaps:
+    | {
+        byUniversalIdentifier: Partial<
+          Record<string, Pick<FlatFieldMetadata, 'applicationId'>>
+        >;
+      }
+    | undefined;
   timelineActivityTypeOperations:
-    | FlatEntityOperationRecord<'timelineActivityType'>
+    | TimelineActivityTypeTargetRelationOperations
     | undefined;
 }): string[] => {
   if (

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/get-timeline-activity-type-target-relation-application-ids.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/get-timeline-activity-type-target-relation-application-ids.util.ts
@@ -1,0 +1,52 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatEntityOperationRecord } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-operation-record-by-metadata-name.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+
+export const getTimelineActivityTypeTargetRelationApplicationIds = ({
+  flatFieldMetadataMaps,
+  timelineActivityTypeOperations,
+}: {
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata> | undefined;
+  timelineActivityTypeOperations:
+    | FlatEntityOperationRecord<'timelineActivityType'>
+    | undefined;
+}): string[] => {
+  if (
+    !isDefined(flatFieldMetadataMaps) ||
+    !isDefined(timelineActivityTypeOperations)
+  ) {
+    return [];
+  }
+
+  const applicationIds = new Set<string>();
+
+  for (const timelineActivityType of [
+    ...Object.values(timelineActivityTypeOperations.flatEntityToCreate),
+    ...Object.values(timelineActivityTypeOperations.flatEntityToUpdate),
+    ...Object.values(timelineActivityTypeOperations.flatEntityToDelete),
+  ]) {
+    if (!isDefined(timelineActivityType)) {
+      continue;
+    }
+
+    const targetRelationFieldUniversalIdentifier =
+      timelineActivityType.targetRelationFieldUniversalIdentifier;
+
+    if (!isDefined(targetRelationFieldUniversalIdentifier)) {
+      continue;
+    }
+
+    const targetRelationField =
+      flatFieldMetadataMaps.byUniversalIdentifier[
+        targetRelationFieldUniversalIdentifier
+      ];
+
+    if (isDefined(targetRelationField)) {
+      applicationIds.add(targetRelationField.applicationId);
+    }
+  }
+
+  return [...applicationIds];
+};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-flat-entity-maps.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-flat-entity-maps.service.ts
@@ -20,6 +20,7 @@ import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/works
 import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { WORKSPACE_MIGRATION_ADDITIONAL_CACHE_DATA_MAPS_KEY } from 'src/engine/workspace-manager/workspace-migration/constant/workspace-migration-additional-cache-data-maps-key.constant';
 import { IdByUniversalIdentifierByMetadataName } from 'src/engine/workspace-manager/workspace-migration/services/utils/enrich-create-workspace-migration-action-with-ids.util';
+import { getTimelineActivityTypeTargetRelationApplicationIds } from 'src/engine/workspace-manager/workspace-migration/services/utils/get-timeline-activity-type-target-relation-application-ids.util';
 import { WorkspaceMigrationBuilderAdditionalCacheDataMaps } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-builder-additional-cache-data-maps.type';
 import { FromToAllUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-orchestrator.type';
 import { computeUniversalFlatEntityMapsFromToThroughMutation } from 'src/engine/workspace-manager/workspace-migration/utils/compute-universal-flat-entity-maps-from-to-through-mutation.util';
@@ -264,6 +265,16 @@ export class WorkspaceMigrationFlatEntityMapsService {
 
     if (!isBuildingTwentyStandardApplication) {
       applicationIds.add(twentyStandardApplicationId);
+    }
+
+    for (const targetRelationApplicationId of getTimelineActivityTypeTargetRelationApplicationIds(
+      {
+        timelineActivityTypeOperations:
+          allFlatEntityOperationRecordByMetadataName.timelineActivityType,
+        flatFieldMetadataMaps: allRelatedFlatEntityMaps.flatFieldMetadataMaps,
+      },
+    )) {
+      applicationIds.add(targetRelationApplicationId);
     }
 
     for (const metadataName of Object.keys(


### PR DESCRIPTION
## Context

The production v2.34 upgrade completed for 5,653 workspaces but deterministically failed for two workspaces whose attachment target morph groups contain only custom-object fields. The v2.34 command correctly looked for another morph member when the canonical `attachment.targetPerson` field was absent, but workspace-migration validation scoped its dependency maps to the Twenty standard application. The selected custom-app-owned field was therefore missing from the validator's view.

This is a valid legacy metadata shape, not customer corruption.

## Changes

- add an idempotent v2.35 workspace command that repairs missing `attachmentLinked` and `attachmentUnlinked` timeline activity types
- prefer the canonical standard attachment target relation when present; otherwise select a valid custom morph member deterministically
- require a complete active many-to-one morph relation before using it
- preserve partial progress by creating only missing definitions
- support dry-run and skip workspaces without timeline metadata or a valid attachment morph target
- include the application owning a timeline activity type's soft-referenced target relation in workspace-migration dependency maps
- register the new v2.35 command module without modifying any committed v2.34 command

The dependency-map change is required in addition to the v2.35 command: standard upgrade sequencing encounters the failed v2.34 command before it can execute v2.35. Loading the referenced field's application lets the existing v2.34 command validate and allows both hosted and self-hosted upgrades to progress normally.

## Verification

- focused Jest suites: 8 tests passed
- direct twenty-server typecheck passed with declaration output disabled (the clean worktree's shared dependency symlink otherwise produces unrelated non-portable declaration-path diagnostics)
- oxlint: 0 warnings, 0 errors across all seven changed TypeScript files
- oxfmt and `git diff --check` passed
- no locale catalogs or generated translation files included

## Production rollout

After deployment:

1. dry-run the v2.35 repair for the two affected workspace IDs
2. rerun the normal upgrade for only those two workspaces
3. refresh `upgrade:status` and confirm zero workspaces behind or failed
4. verify attachment linked/unlinked activities on the active custom-only workspace

No global rerun or direct database write is required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

