### PR TITLE
feat(workflow): enable core read and dispatch flags on new workspaces

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-feature-flags.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-feature-flags.util.ts
@@ -10,6 +10,8 @@ const DEFAULT_SEEDED_FEATURE_FLAGS: Partial<Record<FeatureFlagKey, boolean>> = {
   [FeatureFlagKey.IS_CALENDAR_WEEK_VIEW_ENABLED]: true,
   [FeatureFlagKey.IS_EMAIL_GROUP_ENABLED]: true,
   [FeatureFlagKey.IS_JUNCTION_RELATIONS_ENABLED]: true,
+  [FeatureFlagKey.IS_WORKFLOW_VERSION_IN_CORE_ENABLED]: true,
+  [FeatureFlagKey.IS_WORKFLOW_DISPATCH_FROM_CORE_ENABLED]: true,
 };
 
 // Temporary: lets CI run the suite against the ORM v2 read path while it is behind a

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/constant/default-feature-flags.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/constant/default-feature-flags.ts
@@ -3,4 +3,6 @@ import { FeatureFlagKey } from 'twenty-shared/types';
 export const DEFAULT_FEATURE_FLAGS = [
   FeatureFlagKey.IS_REST_METADATA_API_NEW_FORMAT_DIRECT,
   FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED,
+  FeatureFlagKey.IS_WORKFLOW_VERSION_IN_CORE_ENABLED,
+  FeatureFlagKey.IS_WORKFLOW_DISPATCH_FROM_CORE_ENABLED,
 ] as const satisfies FeatureFlagKey[];


### PR DESCRIPTION
## What

New workspaces start on the workflow core read path directly, instead of being created on the workspace path and migrated later.

- `DEFAULT_FEATURE_FLAGS` (workspace activation) gains `IS_WORKFLOW_VERSION_IN_CORE_ENABLED` and `IS_WORKFLOW_DISPATCH_FROM_CORE_ENABLED`, so every workspace created from now on reads version content from core and dispatches from the cached core trigger maps.
- The dev seeder seeds both flags as true, so local workspaces match.

Deliberately NOT included: `IS_WORKFLOW_CORE_INDEX_PAGE_ENABLED` — the front index page rollout stays manual.

## Why now

The per-workspace rollout is flipping existing workspaces to these flags; without this, every new signup adds one more workspace to migrate later. New workspaces have no workflow data, so they are trivially consistent — there is nothing to verify before enabling.

## Test

Two constant changes; both flag keys exist in `FeatureFlagKey`. No behavior change for any existing workspace.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

