### PR TITLE
Enable ORM v2 read path by default on new workspaces

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/constant/default-feature-flags.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/constant/default-feature-flags.ts
@@ -2,4 +2,5 @@ import { FeatureFlagKey } from 'twenty-shared/types';
 
 export const DEFAULT_FEATURE_FLAGS = [
   FeatureFlagKey.IS_REST_METADATA_API_NEW_FORMAT_DIRECT,
+  FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED,
 ] as const satisfies FeatureFlagKey[];


### PR DESCRIPTION
## What

Adds `IS_ORM_V2_READ_PATH_ENABLED` to `DEFAULT_FEATURE_FLAGS`, so every newly created workspace gets the new ORM read path enabled on activation.

## Why

Rolls out the new ORM to fresh workspaces without touching existing ones. New workspaces start on the new read path from day one, while existing workspaces are unaffected and continue to be migrated separately.

## Scope

- Only the default flag set for new workspace activation changes.
- Existing workspaces are not modified.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

