### PR TITLE
feat(server): add a gauge tracking feature flag rollout across workspaces

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/feature-flag/feature-flag.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/feature-flag.module.ts
@@ -3,7 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
-import { FeatureFlagMetricsService } from 'src/engine/core-modules/feature-flag/services/feature-flag-metrics.service';
+import { FeatureFlagGaugeService } from 'src/engine/core-modules/feature-flag/services/feature-flag-gauge.service';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { WorkspaceFeatureFlagsMapCacheModule } from 'src/engine/metadata-modules/workspace-feature-flags-map-cache/workspace-feature-flags-map-cache.module';
@@ -21,7 +21,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
   exports: [FeatureFlagService],
   providers: [
     FeatureFlagService,
-    FeatureFlagMetricsService,
+    FeatureFlagGaugeService,
     provideWorkspaceScopedRepository(FeatureFlagEntity),
   ],
 })

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/feature-flag.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/feature-flag.module.ts
@@ -3,7 +3,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
+import { FeatureFlagMetricsService } from 'src/engine/core-modules/feature-flag/services/feature-flag-metrics.service';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
+import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { WorkspaceFeatureFlagsMapCacheModule } from 'src/engine/metadata-modules/workspace-feature-flags-map-cache/workspace-feature-flags-map-cache.module';
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -12,12 +14,14 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
   imports: [
     TypeORMModule,
     TypeOrmModule.forFeature([FeatureFlagEntity]),
+    MetricsModule,
     WorkspaceFeatureFlagsMapCacheModule,
     WorkspaceCacheModule,
   ],
   exports: [FeatureFlagService],
   providers: [
     FeatureFlagService,
+    FeatureFlagMetricsService,
     provideWorkspaceScopedRepository(FeatureFlagEntity),
   ],
 })

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag-gauge.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag-gauge.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 
+import { FeatureFlagKey } from 'twenty-shared/types';
 import { DataSource } from 'typeorm';
 
 import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
@@ -8,8 +9,11 @@ import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service'
 
 const ENABLED_WORKSPACES_METRIC_NAME = 'twenty_feature_flag_enabled_workspaces';
 
+// The rollout gauge counts enabled workspaces across every tenant, so it needs
+// the global repository rather than the workspace-scoped one (there is no
+// workspace context during a metrics scrape).
 @Injectable()
-export class FeatureFlagMetricsService implements OnModuleInit {
+export class FeatureFlagGaugeService implements OnModuleInit {
   constructor(
     @InjectDataSource()
     private readonly dataSource: DataSource,
@@ -24,10 +28,13 @@ export class FeatureFlagMetricsService implements OnModuleInit {
           'Number of workspaces with a given feature flag enabled, labelled by flag_key. Tracks the progress of a feature flag rollout.',
       },
       callback: async () => {
-        const rows = await this.getEnabledWorkspaceCountsByFlag();
+        const enabledWorkspacesByFlag =
+          await this.getEnabledWorkspaceCountsByFlag();
 
-        return rows.map(({ flagKey, enabledWorkspaces }) => ({
-          value: enabledWorkspaces,
+        // Emit a series for every known flag, defaulting to 0, so a flag with
+        // no enabled workspaces reads as zero rollout rather than missing data.
+        return Object.values(FeatureFlagKey).map((flagKey) => ({
+          value: enabledWorkspacesByFlag.get(flagKey) ?? 0,
           attributes: { flag_key: flagKey },
         }));
       },
@@ -36,7 +43,7 @@ export class FeatureFlagMetricsService implements OnModuleInit {
   }
 
   private async getEnabledWorkspaceCountsByFlag(): Promise<
-    Array<{ flagKey: string; enabledWorkspaces: number }>
+    Map<string, number>
   > {
     const rows = await this.dataSource
       .getRepository(FeatureFlagEntity)
@@ -47,9 +54,8 @@ export class FeatureFlagMetricsService implements OnModuleInit {
       .groupBy('featureFlag.key')
       .getRawMany<{ flagKey: string; enabledWorkspaces: string }>();
 
-    return rows.map((row) => ({
-      flagKey: row.flagKey,
-      enabledWorkspaces: Number(row.enabledWorkspaces),
-    }));
+    return new Map(
+      rows.map((row) => [row.flagKey, Number(row.enabledWorkspaces)]),
+    );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag-gauge.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag-gauge.service.ts
@@ -45,12 +45,17 @@ export class FeatureFlagGaugeService implements OnModuleInit {
   private async getEnabledWorkspaceCountsByFlag(): Promise<
     Map<string, number>
   > {
+    // Join workspace and filter deletedAt: the workspace relation cascades on
+    // hard delete only, and featureFlag has no deletedAt, so a soft-deleted
+    // workspace would otherwise keep counting toward the rollout forever.
     const rows = await this.dataSource
       .getRepository(FeatureFlagEntity)
       .createQueryBuilder('featureFlag')
       .select('featureFlag.key', 'flagKey')
       .addSelect('COUNT(*)', 'enabledWorkspaces')
+      .innerJoin('featureFlag.workspace', 'workspace')
       .where('featureFlag.value = :value', { value: true })
+      .andWhere('workspace.deletedAt IS NULL')
       .groupBy('featureFlag.key')
       .getRawMany<{ flagKey: string; enabledWorkspaces: string }>();
 

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag-metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag-metrics.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+import { DataSource } from 'typeorm';
+
+import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+
+const ENABLED_WORKSPACES_METRIC_NAME = 'twenty_feature_flag_enabled_workspaces';
+
+@Injectable()
+export class FeatureFlagMetricsService implements OnModuleInit {
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly metricsService: MetricsService,
+  ) {}
+
+  onModuleInit() {
+    this.metricsService.createMultiObservableGauge({
+      metricName: ENABLED_WORKSPACES_METRIC_NAME,
+      options: {
+        description:
+          'Number of workspaces with a given feature flag enabled, labelled by flag_key. Tracks the progress of a feature flag rollout.',
+      },
+      callback: async () => {
+        const rows = await this.getEnabledWorkspaceCountsByFlag();
+
+        return rows.map(({ flagKey, enabledWorkspaces }) => ({
+          value: enabledWorkspaces,
+          attributes: { flag_key: flagKey },
+        }));
+      },
+      cacheValue: true,
+    });
+  }
+
+  private async getEnabledWorkspaceCountsByFlag(): Promise<
+    Array<{ flagKey: string; enabledWorkspaces: number }>
+  > {
+    const rows = await this.dataSource
+      .getRepository(FeatureFlagEntity)
+      .createQueryBuilder('featureFlag')
+      .select('featureFlag.key', 'flagKey')
+      .addSelect('COUNT(*)', 'enabledWorkspaces')
+      .where('featureFlag.value = :value', { value: true })
+      .groupBy('featureFlag.key')
+      .getRawMany<{ flagKey: string; enabledWorkspaces: string }>();
+
+    return rows.map((row) => ({
+      flagKey: row.flagKey,
+      enabledWorkspaces: Number(row.enabledWorkspaces),
+    }));
+  }
+}


### PR DESCRIPTION
## What

Adds `twenty_feature_flag_enabled_workspaces`, an OpenTelemetry observable gauge (exported to Prometheus) labelled by `flag_key`, reporting how many workspaces have each feature flag enabled.

This gives a metric-based view of a per-workspace feature flag rollout (e.g. the ORM v2 read path) so progress can be tracked on a dashboard instead of ad-hoc DB queries against `core."featureFlag"`.

## How

- New `FeatureFlagMetricsService` (`OnModuleInit`) follows the existing `DatabaseGaugeService` pattern: it registers a `createMultiObservableGauge` whose callback runs `SELECT key, COUNT(*) ... WHERE value = true GROUP BY key` against the core datasource and emits one observation per flag with `{ flag_key }` as the attribute.
- Wired into `FeatureFlagModule` (imports `MetricsModule`, provides the new service).
- The query result is cached (`cacheValue: true`, 60s TTL in `MetricsService`), so each pod runs at most one small count query per minute. Cardinality is one series per feature flag (low).

## Notes

- Every server pod reports the same DB-derived count, so dashboards should aggregate across replicas with `max by (flag_key)`.
- The companion Grafana dashboard lives in twenty-infra (`Twenty / Feature Flag Release`).
- No spec added, matching the existing gauge/metric services (`DatabaseGaugeService`, `EventLoopMetricsService`), which have none.

## Test plan

- [ ] Typecheck / lint pass (CI).
- [ ] After deploy, confirm `twenty_feature_flag_enabled_workspaces{flag_key="IS_ORM_V2_READ_PATH_ENABLED"}` appears in Prometheus and matches the row count in `core."featureFlag"`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

