### PR TITLE
Identify the workflow run in the Sentry context of a job

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/sentry/utils/__tests__/apply-workspace-sentry-context-from-job-data.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/sentry/utils/__tests__/apply-workspace-sentry-context-from-job-data.util.spec.ts
@@ -1,0 +1,69 @@
+import * as Sentry from '@sentry/node';
+
+import { applyWorkspaceSentryContextFromJobData } from 'src/engine/core-modules/sentry/utils/apply-workspace-sentry-context-from-job-data.util';
+
+jest.mock('@sentry/node', () => ({
+  setTag: jest.fn(),
+  setUser: jest.fn(),
+  setContext: jest.fn(),
+}));
+
+const WORKSPACE_ID = '20202020-0000-0000-0000-000000000001';
+const WORKFLOW_RUN_ID = '3591972b-279c-4559-bbce-748534778852';
+
+describe('applyWorkspaceSentryContextFromJobData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('identifies the workflow run a job belongs to', () => {
+    applyWorkspaceSentryContextFromJobData({
+      workspaceId: WORKSPACE_ID,
+      workflowRunId: WORKFLOW_RUN_ID,
+    });
+
+    expect(Sentry.setTag).toHaveBeenCalledWith(
+      'twenty.workflow_run.id',
+      WORKFLOW_RUN_ID,
+    );
+    expect(Sentry.setContext).toHaveBeenCalledWith('twenty', {
+      workspace_id: WORKSPACE_ID,
+      workflow_run_id: WORKFLOW_RUN_ID,
+    });
+  });
+
+  it('leaves a job that belongs to no workflow run unlabelled', () => {
+    applyWorkspaceSentryContextFromJobData({
+      workspaceId: WORKSPACE_ID,
+      workflowId: 'a-workflow-that-has-not-run-yet',
+    });
+
+    expect(Sentry.setTag).not.toHaveBeenCalledWith(
+      'twenty.workflow_run.id',
+      expect.anything(),
+    );
+    expect(Sentry.setContext).toHaveBeenCalledWith('twenty', {
+      workspace_id: WORKSPACE_ID,
+    });
+  });
+
+  it('still identifies the workspace of a job that has no workflow run', () => {
+    applyWorkspaceSentryContextFromJobData({ workspaceId: WORKSPACE_ID });
+
+    expect(Sentry.setTag).toHaveBeenCalledWith(
+      'twenty.workspace.id',
+      WORKSPACE_ID,
+    );
+  });
+
+  it.each([
+    ['no data at all', undefined],
+    ['data that is not an object', 'workflow-run'],
+    ['no workspace', { workflowRunId: WORKFLOW_RUN_ID }],
+  ])('identifies nothing for a job with %s', (_, jobData) => {
+    applyWorkspaceSentryContextFromJobData(jobData);
+
+    expect(Sentry.setTag).not.toHaveBeenCalled();
+    expect(Sentry.setContext).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/sentry/utils/apply-workspace-sentry-context-from-job-data.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/sentry/utils/apply-workspace-sentry-context-from-job-data.util.ts
@@ -10,6 +10,7 @@ export const applyWorkspaceSentryContextFromJobData = (
   const workspaceId = (jobData as { workspaceId?: unknown }).workspaceId;
   const userWorkspaceId = (jobData as { userWorkspaceId?: unknown })
     .userWorkspaceId;
+  const workflowRunId = (jobData as { workflowRunId?: unknown }).workflowRunId;
 
   if (typeof workspaceId !== 'string' || workspaceId.length === 0) {
     return;
@@ -20,6 +21,10 @@ export const applyWorkspaceSentryContextFromJobData = (
     userWorkspaceId:
       typeof userWorkspaceId === 'string' && userWorkspaceId.length > 0
         ? userWorkspaceId
+        : undefined,
+    workflowRunId:
+      typeof workflowRunId === 'string' && workflowRunId.length > 0
+        ? workflowRunId
         : undefined,
   });
 };

--- a/packages/twenty-server/src/engine/core-modules/sentry/utils/apply-workspace-sentry-fields.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/sentry/utils/apply-workspace-sentry-fields.util.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 type WorkspaceSentryFields = {
   workspaceId: string;
   userWorkspaceId?: string;
+  workflowRunId?: string;
 };
 
 export const applyWorkspaceSentryFields = (
@@ -16,11 +17,17 @@ export const applyWorkspaceSentryFields = (
   if (fields.userWorkspaceId) {
     Sentry.setTag('twenty.user_workspace.id', fields.userWorkspaceId);
   }
+  if (fields.workflowRunId) {
+    Sentry.setTag('twenty.workflow_run.id', fields.workflowRunId);
+  }
 
   Sentry.setContext('twenty', {
     workspace_id: fields.workspaceId,
     ...(fields.userWorkspaceId && {
       user_workspace_id: fields.userWorkspaceId,
+    }),
+    ...(fields.workflowRunId && {
+      workflow_run_id: fields.workflowRunId,
     }),
   });
 };


### PR DESCRIPTION
> Draft. This does not fix #23046 and does not close it. It makes a failed run traceable to the exception behind it, which is what the issue's diagnosis was missing.

## What changed

A job's Sentry context now identifies the workflow run it belongs to: the tag `twenty.workflow_run.id`, and `workflow_run_id` in the `twenty` context.

The worker already applies workspace context from job data before handing off to a processor. It now reads `workflowRunId` from the same place, alongside `workspaceId` and `userWorkspaceId`. Jobs carrying no run id — including the trigger job, which creates the run rather than executing it — are unaffected.

## Why

Errors raised while a run executes do reach Sentry, tagged with the workspace but with nothing identifying the run. So a run that failed in the UI cannot be matched to its exception. In #23046 a run failed with a stored error of `Query read timeout`, and every fix proposed since has been a guess at which query produced it.

## What this does not do

- **It reports nothing new.** Exceptions that reach Sentry today gain a tag; failures that are swallowed today are still invisible. The gap is large: record CRUD, HTTP and AI steps catch their own errors and return them as step output, and a `CODE` step does the same for an error raised inside the logic function. In all of those an `UPDATE_RECORD` or `CODE` step can fail on a read timeout with no Sentry event at all. Those services already separate a user error from an infrastructure one, so capturing the second is the natural next PR — and until it lands, the reported run may have produced nothing for this tag to attach to.
- **It does not identify the step.** Parallel branches share the job's Sentry scope, so a step tag needs a forked scope per step or it attributes one branch's failure to another.
- **It does not retry, and does not alert on failed runs** — the two things #23046 actually asks for. `build-run-workflow-job-options.util.ts` still sets no attempts.

## A judgement call worth confirming

`twenty.workflow_run.id` is an indexed tag with one value per run, so its cardinality is unbounded, higher than the existing `twenty.user_workspace.id`. A context field alone would cost nothing to index, but context values are not searchable, and searching from a run id is the entire point. Tell me if you would rather trade the search away.

## Validation

- 6 unit tests over the context helper, covering a job with a run, a job without one, and every payload shape that must identify nothing.
- `tsgo --noEmit` clean on twenty-server, oxlint type-aware and oxfmt clean on the three touched files.

---

Supersedes #24502, which cannot be reopened: the branch was force-pushed while it was closed.
