### PR TITLE
Deprecate enqueueJob in favor of enqueueJobs batch mutation

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -3086,7 +3086,9 @@ type EnqueueJobResult {
 }
 
 type EnqueueJobsResult {
-  jobs: [EnqueueJobResult!]!
+  enqueued: Boolean!
+  logicFunctionUniversalIdentifier: String!
+  enqueuedJobsCount: Int!
 }
 
 type AppKeyValue {
@@ -4906,7 +4908,10 @@ input EnqueueJobInput {
 }
 
 input EnqueueJobsInput {
-  jobs: [EnqueueJobInput!]!
+  logicFunctionUniversalIdentifier: String!
+  payloads: [JSON!]!
+  retryLimit: Int
+  delayMs: Int
 }
 
 input FileAttachmentInput {

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -3085,6 +3085,10 @@ type EnqueueJobResult {
   logicFunctionUniversalIdentifier: String!
 }
 
+type EnqueueJobsResult {
+  jobs: [EnqueueJobResult!]!
+}
+
 type AppKeyValue {
   key: String!
   value: JSON
@@ -3705,7 +3709,8 @@ type Mutation {
   updateCalendarChannel(input: UpdateCalendarChannelInput!): CalendarChannel!
   setAppKeyValue(input: SetAppKeyValueInput!): AppKeyValue!
   deleteAppKeyValue(key: String!, scope: AppKeyValueScope = WORKSPACE): Boolean!
-  enqueueJob(input: EnqueueJobInput!): EnqueueJobResult!
+  enqueueJob(input: EnqueueJobInput!): EnqueueJobResult! @deprecated(reason: "Use enqueueJobs instead.")
+  enqueueJobs(input: EnqueueJobsInput!): EnqueueJobsResult!
   createChatThread: AgentChatThread!
   sendChatMessage(threadId: UUID!, text: String!, messageId: UUID!, browsingContext: JSON, modelId: String, fileAttachments: [FileAttachmentInput!]): SendChatMessageResult!
   retryChatMessage(threadId: UUID!, modelId: String): SendChatMessageResult!
@@ -4898,6 +4903,10 @@ input EnqueueJobInput {
   payload: JSON
   retryLimit: Int
   delayMs: Int
+}
+
+input EnqueueJobsInput {
+  jobs: [EnqueueJobInput!]!
 }
 
 input FileAttachmentInput {

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -2762,7 +2762,9 @@ export interface EnqueueJobResult {
 }
 
 export interface EnqueueJobsResult {
-    jobs: EnqueueJobResult[]
+    enqueued: Scalars['Boolean']
+    logicFunctionUniversalIdentifier: Scalars['String']
+    enqueuedJobsCount: Scalars['Int']
     __typename: 'EnqueueJobsResult'
 }
 
@@ -6200,7 +6202,9 @@ export interface EnqueueJobResultGenqlSelection{
 }
 
 export interface EnqueueJobsResultGenqlSelection{
-    jobs?: EnqueueJobResultGenqlSelection
+    enqueued?: boolean | number
+    logicFunctionUniversalIdentifier?: boolean | number
+    enqueuedJobsCount?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -7128,7 +7132,7 @@ export interface SetAppKeyValueInput {key: Scalars['String'],value?: (Scalars['J
 
 export interface EnqueueJobInput {logicFunctionUniversalIdentifier: Scalars['String'],payload?: (Scalars['JSON'] | null),retryLimit?: (Scalars['Int'] | null),delayMs?: (Scalars['Int'] | null)}
 
-export interface EnqueueJobsInput {jobs: EnqueueJobInput[]}
+export interface EnqueueJobsInput {logicFunctionUniversalIdentifier: Scalars['String'],payloads: Scalars['JSON'][],retryLimit?: (Scalars['Int'] | null),delayMs?: (Scalars['Int'] | null)}
 
 export interface FileAttachmentInput {id: Scalars['UUID'],filename: Scalars['String']}
 

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -2761,6 +2761,11 @@ export interface EnqueueJobResult {
     __typename: 'EnqueueJobResult'
 }
 
+export interface EnqueueJobsResult {
+    jobs: EnqueueJobResult[]
+    __typename: 'EnqueueJobsResult'
+}
+
 export interface AppKeyValue {
     key: Scalars['String']
     value?: Scalars['JSON']
@@ -3201,7 +3206,9 @@ export interface Mutation {
     updateCalendarChannel: CalendarChannel
     setAppKeyValue: AppKeyValue
     deleteAppKeyValue: Scalars['Boolean']
+    /** @deprecated Use enqueueJobs instead. */
     enqueueJob: EnqueueJobResult
+    enqueueJobs: EnqueueJobsResult
     createChatThread: AgentChatThread
     sendChatMessage: SendChatMessageResult
     retryChatMessage: SendChatMessageResult
@@ -6192,6 +6199,12 @@ export interface EnqueueJobResultGenqlSelection{
     __scalar?: boolean | number
 }
 
+export interface EnqueueJobsResultGenqlSelection{
+    jobs?: EnqueueJobResultGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
 export interface AppKeyValueGenqlSelection{
     key?: boolean | number
     value?: boolean | number
@@ -6666,7 +6679,9 @@ export interface MutationGenqlSelection{
     updateCalendarChannel?: (CalendarChannelGenqlSelection & { __args: {input: UpdateCalendarChannelInput} })
     setAppKeyValue?: (AppKeyValueGenqlSelection & { __args: {input: SetAppKeyValueInput} })
     deleteAppKeyValue?: { __args: {key: Scalars['String'], scope?: (AppKeyValueScope | null)} }
+    /** @deprecated Use enqueueJobs instead. */
     enqueueJob?: (EnqueueJobResultGenqlSelection & { __args: {input: EnqueueJobInput} })
+    enqueueJobs?: (EnqueueJobsResultGenqlSelection & { __args: {input: EnqueueJobsInput} })
     createChatThread?: AgentChatThreadGenqlSelection
     sendChatMessage?: (SendChatMessageResultGenqlSelection & { __args: {threadId: Scalars['UUID'], text: Scalars['String'], messageId: Scalars['UUID'], browsingContext?: (Scalars['JSON'] | null), modelId?: (Scalars['String'] | null), fileAttachments?: (FileAttachmentInput[] | null)} })
     retryChatMessage?: (SendChatMessageResultGenqlSelection & { __args: {threadId: Scalars['UUID'], modelId?: (Scalars['String'] | null)} })
@@ -7112,6 +7127,8 @@ export interface UpdateCalendarChannelInputUpdates {visibility?: (CalendarChanne
 export interface SetAppKeyValueInput {key: Scalars['String'],value?: (Scalars['JSON'] | null),scope?: (AppKeyValueScope | null)}
 
 export interface EnqueueJobInput {logicFunctionUniversalIdentifier: Scalars['String'],payload?: (Scalars['JSON'] | null),retryLimit?: (Scalars['Int'] | null),delayMs?: (Scalars['Int'] | null)}
+
+export interface EnqueueJobsInput {jobs: EnqueueJobInput[]}
 
 export interface FileAttachmentInput {id: Scalars['UUID'],filename: Scalars['String']}
 
@@ -9245,6 +9262,14 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     export const isEnqueueJobResult = (obj?: { __typename?: any } | null): obj is EnqueueJobResult => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isEnqueueJobResult"')
       return EnqueueJobResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const EnqueueJobsResult_possibleTypes: string[] = ['EnqueueJobsResult']
+    export const isEnqueueJobsResult = (obj?: { __typename?: any } | null): obj is EnqueueJobsResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isEnqueueJobsResult"')
+      return EnqueueJobsResult_possibleTypes.includes(obj.__typename)
     }
     
 

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -6190,8 +6190,14 @@ export default {
             ]
         },
         "EnqueueJobsResult": {
-            "jobs": [
-                344
+            "enqueued": [
+                8
+            ],
+            "logicFunctionUniversalIdentifier": [
+                1
+            ],
+            "enqueuedJobsCount": [
+                26
             ],
             "__typename": [
                 1
@@ -12502,8 +12508,17 @@ export default {
             ]
         },
         "EnqueueJobsInput": {
-            "jobs": [
-                513
+            "logicFunctionUniversalIdentifier": [
+                1
+            ],
+            "payloads": [
+                9
+            ],
+            "retryLimit": [
+                26
+            ],
+            "delayMs": [
+                26
             ],
             "__typename": [
                 1

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -79,20 +79,20 @@ export default {
         300,
         303,
         340,
-        346,
-        348,
+        347,
         349,
         350,
         351,
-        353,
-        355,
-        360,
-        374,
-        381,
-        388,
+        352,
+        354,
+        356,
+        361,
+        375,
+        382,
         389,
-        502,
-        525
+        390,
+        503,
+        527
     ],
     "types": {
         "BillingProductDTO": {
@@ -6189,6 +6189,14 @@ export default {
                 1
             ]
         },
+        "EnqueueJobsResult": {
+            "jobs": [
+                344
+            ],
+            "__typename": [
+                1
+            ]
+        },
         "AppKeyValue": {
             "key": [
                 1
@@ -6197,7 +6205,7 @@ export default {
                 9
             ],
             "scope": [
-                346
+                347
             ],
             "__typename": [
                 1
@@ -6212,19 +6220,19 @@ export default {
                 1
             ],
             "syncStatus": [
-                348
-            ],
-            "syncStage": [
                 349
             ],
-            "visibility": [
+            "syncStage": [
                 350
+            ],
+            "visibility": [
+                351
             ],
             "isContactAutoCreationEnabled": [
                 8
             ],
             "contactAutoCreationPolicy": [
-                351
+                352
             ],
             "isSyncEnabled": [
                 8
@@ -6275,7 +6283,7 @@ export default {
                 1
             ],
             "pendingSyncAction": [
-                353
+                354
             ],
             "messageChannelId": [
                 3
@@ -6317,7 +6325,7 @@ export default {
                 1
             ],
             "provenance": [
-                355
+                356
             ],
             "__typename": [
                 1
@@ -6343,7 +6351,7 @@ export default {
                 3
             ],
             "through": [
-                356
+                357
             ],
             "__typename": [
                 1
@@ -6363,7 +6371,7 @@ export default {
                 1
             ],
             "emit": [
-                357
+                358
             ],
             "action": [
                 1
@@ -6401,7 +6409,7 @@ export default {
         },
         "CollectionHash": {
             "collectionName": [
-                360
+                361
             ],
             "hash": [
                 1
@@ -6465,13 +6473,13 @@ export default {
         },
         "MinimalMetadata": {
             "objectMetadataItems": [
-                361
-            ],
-            "views": [
                 362
             ],
+            "views": [
+                363
+            ],
             "collectionHashes": [
-                359
+                360
             ],
             "__typename": [
                 1
@@ -6645,7 +6653,7 @@ export default {
                 2,
                 {
                     "input": [
-                        365,
+                        366,
                         "GetApiKeyInput!"
                     ]
                 }
@@ -6751,7 +6759,7 @@ export default {
                 10,
                 {
                     "input": [
-                        366,
+                        367,
                         "AgentIdInput!"
                     ]
                 }
@@ -6764,7 +6772,7 @@ export default {
                         "CursorPaging!"
                     ],
                     "filter": [
-                        367,
+                        368,
                         "ObjectFilter!"
                     ]
                 }
@@ -6794,7 +6802,7 @@ export default {
                 21,
                 {
                     "input": [
-                        368,
+                        369,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6806,7 +6814,7 @@ export default {
                 9,
                 {
                     "input": [
-                        368,
+                        369,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6815,7 +6823,7 @@ export default {
                 1,
                 {
                     "input": [
-                        368,
+                        369,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -7037,7 +7045,7 @@ export default {
                 294,
                 {
                     "input": [
-                        369,
+                        370,
                         "PreviewMessageCampaignAudienceInput!"
                     ]
                 }
@@ -7046,7 +7054,7 @@ export default {
                 301,
                 {
                     "input": [
-                        370,
+                        371,
                         "FindMessageSuppressionsInput!"
                     ]
                 }
@@ -7093,7 +7101,7 @@ export default {
                 }
             ],
             "myMessageFolders": [
-                352,
+                353,
                 {
                     "messageChannelId": [
                         3
@@ -7101,7 +7109,7 @@ export default {
                 }
             ],
             "myCalendarChannels": [
-                347,
+                348,
                 {
                     "connectedAccountId": [
                         3
@@ -7109,17 +7117,17 @@ export default {
                 }
             ],
             "minimalMetadata": [
-                363
+                364
             ],
             "appKeyValue": [
-                345,
+                346,
                 {
                     "key": [
                         1,
                         "String!"
                     ],
                     "scope": [
-                        346
+                        347
                     ]
                 }
             ],
@@ -7127,7 +7135,7 @@ export default {
                 204,
                 {
                     "filter": [
-                        371
+                        372
                     ]
                 }
             ],
@@ -7198,13 +7206,13 @@ export default {
                 }
             ],
             "timelineActivityTypes": [
-                358
+                359
             ],
             "metadataTranslations": [
-                354,
+                355,
                 {
                     "input": [
-                        372,
+                        373,
                         "MetadataTranslationsInput!"
                     ]
                 }
@@ -7270,7 +7278,7 @@ export default {
                 329,
                 {
                     "input": [
-                        373,
+                        374,
                         "EventLogQueryInput!"
                     ]
                 }
@@ -7279,7 +7287,7 @@ export default {
                 323,
                 {
                     "input": [
-                        377,
+                        378,
                         "PieChartDataInput!"
                     ]
                 }
@@ -7288,7 +7296,7 @@ export default {
                 321,
                 {
                     "input": [
-                        378,
+                        379,
                         "LineChartDataInput!"
                     ]
                 }
@@ -7297,7 +7305,7 @@ export default {
                 318,
                 {
                     "input": [
-                        379,
+                        380,
                         "BarChartDataInput!"
                     ]
                 }
@@ -7347,7 +7355,7 @@ export default {
                 276,
                 {
                     "input": [
-                        380
+                        381
                     ]
                 }
             ],
@@ -7379,10 +7387,10 @@ export default {
         },
         "ObjectFilter": {
             "and": [
-                367
+                368
             ],
             "or": [
-                367
+                368
             ],
             "id": [
                 29
@@ -7484,10 +7492,10 @@ export default {
         },
         "EventLogQueryInput": {
             "table": [
-                374
+                375
             ],
             "filters": [
-                375
+                376
             ],
             "first": [
                 26
@@ -7508,7 +7516,7 @@ export default {
                 1
             ],
             "dateRange": [
-                376
+                377
             ],
             "recordId": [
                 1
@@ -7575,7 +7583,7 @@ export default {
                 1
             ],
             "operationTypes": [
-                381
+                382
             ],
             "__typename": [
                 1
@@ -7587,7 +7595,7 @@ export default {
                 8,
                 {
                     "input": [
-                        383,
+                        384,
                         "AddQuerySubscriptionInput!"
                     ]
                 }
@@ -7596,7 +7604,7 @@ export default {
                 8,
                 {
                     "input": [
-                        384,
+                        385,
                         "RemoveQueryFromEventStreamInput!"
                     ]
                 }
@@ -7605,7 +7613,7 @@ export default {
                 150,
                 {
                     "inputs": [
-                        385,
+                        386,
                         "[CreateNavigationMenuItemInput!]!"
                     ]
                 }
@@ -7614,7 +7622,7 @@ export default {
                 150,
                 {
                     "input": [
-                        385,
+                        386,
                         "CreateNavigationMenuItemInput!"
                     ]
                 }
@@ -7623,7 +7631,7 @@ export default {
                 150,
                 {
                     "inputs": [
-                        386,
+                        387,
                         "[UpdateOneNavigationMenuItemInput!]!"
                     ]
                 }
@@ -7632,7 +7640,7 @@ export default {
                 150,
                 {
                     "input": [
-                        386,
+                        387,
                         "UpdateOneNavigationMenuItemInput!"
                     ]
                 }
@@ -7667,7 +7675,7 @@ export default {
                         "Float!"
                     ],
                     "fileFolder": [
-                        388,
+                        389,
                         "FileFolder!"
                     ],
                     "fieldMetadataId": [
@@ -7706,7 +7714,7 @@ export default {
                 147,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ]
                 }
@@ -7715,7 +7723,7 @@ export default {
                 147,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ]
                 }
@@ -7724,7 +7732,7 @@ export default {
                 147,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ]
                 }
@@ -7733,7 +7741,7 @@ export default {
                 147,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ]
                 }
@@ -7742,7 +7750,7 @@ export default {
                 147,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ]
                 }
@@ -7751,7 +7759,7 @@ export default {
                 147,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ],
                     "fieldMetadataId": [
@@ -7764,7 +7772,7 @@ export default {
                 147,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ],
                     "fieldMetadataUniversalIdentifier": [
@@ -7777,7 +7785,7 @@ export default {
                 53,
                 {
                     "input": [
-                        390,
+                        391,
                         "CreateViewFilterGroupInput!"
                     ]
                 }
@@ -7790,7 +7798,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        391,
+                        392,
                         "UpdateViewFilterGroupInput!"
                     ]
                 }
@@ -7817,7 +7825,7 @@ export default {
                 55,
                 {
                     "input": [
-                        392,
+                        393,
                         "CreateViewFilterInput!"
                     ]
                 }
@@ -7826,7 +7834,7 @@ export default {
                 55,
                 {
                     "input": [
-                        393,
+                        394,
                         "UpdateViewFilterInput!"
                     ]
                 }
@@ -7835,7 +7843,7 @@ export default {
                 55,
                 {
                     "input": [
-                        395,
+                        396,
                         "DeleteViewFilterInput!"
                     ]
                 }
@@ -7844,7 +7852,7 @@ export default {
                 55,
                 {
                     "input": [
-                        396,
+                        397,
                         "DestroyViewFilterInput!"
                     ]
                 }
@@ -7853,7 +7861,7 @@ export default {
                 61,
                 {
                     "input": [
-                        397,
+                        398,
                         "CreateViewInput!"
                     ]
                 }
@@ -7866,7 +7874,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        398,
+                        399,
                         "UpdateViewInput!"
                     ]
                 }
@@ -7893,7 +7901,7 @@ export default {
                 61,
                 {
                     "input": [
-                        399,
+                        400,
                         "UpsertViewWidgetInput!"
                     ]
                 }
@@ -7902,7 +7910,7 @@ export default {
                 58,
                 {
                     "input": [
-                        405,
+                        406,
                         "CreateViewSortInput!"
                     ]
                 }
@@ -7911,7 +7919,7 @@ export default {
                 58,
                 {
                     "input": [
-                        406,
+                        407,
                         "UpdateViewSortInput!"
                     ]
                 }
@@ -7920,7 +7928,7 @@ export default {
                 8,
                 {
                     "input": [
-                        408,
+                        409,
                         "DeleteViewSortInput!"
                     ]
                 }
@@ -7929,7 +7937,7 @@ export default {
                 8,
                 {
                     "input": [
-                        409,
+                        410,
                         "DestroyViewSortInput!"
                     ]
                 }
@@ -7938,7 +7946,7 @@ export default {
                 51,
                 {
                     "input": [
-                        410,
+                        411,
                         "UpdateViewFieldInput!"
                     ]
                 }
@@ -7947,7 +7955,7 @@ export default {
                 51,
                 {
                     "input": [
-                        412,
+                        413,
                         "CreateViewFieldInput!"
                     ]
                 }
@@ -7956,7 +7964,7 @@ export default {
                 51,
                 {
                     "inputs": [
-                        412,
+                        413,
                         "[CreateViewFieldInput!]!"
                     ]
                 }
@@ -7965,7 +7973,7 @@ export default {
                 51,
                 {
                     "input": [
-                        413,
+                        414,
                         "DeleteViewFieldInput!"
                     ]
                 }
@@ -7974,7 +7982,7 @@ export default {
                 51,
                 {
                     "input": [
-                        414,
+                        415,
                         "DestroyViewFieldInput!"
                     ]
                 }
@@ -7983,7 +7991,7 @@ export default {
                 60,
                 {
                     "input": [
-                        415,
+                        416,
                         "UpdateViewFieldGroupInput!"
                     ]
                 }
@@ -7992,7 +8000,7 @@ export default {
                 60,
                 {
                     "input": [
-                        417,
+                        418,
                         "CreateViewFieldGroupInput!"
                     ]
                 }
@@ -8001,7 +8009,7 @@ export default {
                 60,
                 {
                     "inputs": [
-                        417,
+                        418,
                         "[CreateViewFieldGroupInput!]!"
                     ]
                 }
@@ -8010,7 +8018,7 @@ export default {
                 60,
                 {
                     "input": [
-                        418,
+                        419,
                         "DeleteViewFieldGroupInput!"
                     ]
                 }
@@ -8019,7 +8027,7 @@ export default {
                 60,
                 {
                     "input": [
-                        419,
+                        420,
                         "DestroyViewFieldGroupInput!"
                     ]
                 }
@@ -8028,7 +8036,7 @@ export default {
                 61,
                 {
                     "input": [
-                        420,
+                        421,
                         "UpsertFieldsWidgetInput!"
                     ]
                 }
@@ -8037,7 +8045,7 @@ export default {
                 2,
                 {
                     "input": [
-                        423,
+                        424,
                         "CreateApiKeyInput!"
                     ]
                 }
@@ -8046,7 +8054,7 @@ export default {
                 2,
                 {
                     "input": [
-                        424,
+                        425,
                         "UpdateApiKeyInput!"
                     ]
                 }
@@ -8055,7 +8063,7 @@ export default {
                 2,
                 {
                     "input": [
-                        425,
+                        426,
                         "RevokeApiKeyInput!"
                     ]
                 }
@@ -8248,7 +8256,7 @@ export default {
                 146,
                 {
                     "input": [
-                        426,
+                        427,
                         "CreateApprovedAccessDomainInput!"
                     ]
                 }
@@ -8257,7 +8265,7 @@ export default {
                 8,
                 {
                     "input": [
-                        427,
+                        428,
                         "DeleteApprovedAccessDomainInput!"
                     ]
                 }
@@ -8266,7 +8274,7 @@ export default {
                 146,
                 {
                     "input": [
-                        428,
+                        429,
                         "ValidateApprovedAccessDomainInput!"
                     ]
                 }
@@ -8275,7 +8283,7 @@ export default {
                 120,
                 {
                     "input": [
-                        429,
+                        430,
                         "CreatePageLayoutTabInput!"
                     ]
                 }
@@ -8288,7 +8296,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        430,
+                        431,
                         "UpdatePageLayoutTabInput!"
                     ]
                 }
@@ -8306,7 +8314,7 @@ export default {
                 121,
                 {
                     "input": [
-                        431,
+                        432,
                         "CreatePageLayoutInput!"
                     ]
                 }
@@ -8319,7 +8327,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        432,
+                        433,
                         "UpdatePageLayoutInput!"
                     ]
                 }
@@ -8341,7 +8349,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        433,
+                        434,
                         "UpdatePageLayoutWithTabsInput!"
                     ]
                 }
@@ -8377,7 +8385,7 @@ export default {
                 78,
                 {
                     "input": [
-                        437,
+                        438,
                         "CreatePageLayoutWidgetInput!"
                     ]
                 }
@@ -8390,7 +8398,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        438,
+                        439,
                         "UpdatePageLayoutWidgetInput!"
                     ]
                 }
@@ -8408,7 +8416,7 @@ export default {
                 10,
                 {
                     "input": [
-                        439,
+                        440,
                         "CreateAgentInput!"
                     ]
                 }
@@ -8417,7 +8425,7 @@ export default {
                 10,
                 {
                     "input": [
-                        440,
+                        441,
                         "UpdateAgentInput!"
                     ]
                 }
@@ -8426,7 +8434,7 @@ export default {
                 10,
                 {
                     "input": [
-                        366,
+                        367,
                         "AgentIdInput!"
                     ]
                 }
@@ -8435,7 +8443,7 @@ export default {
                 23,
                 {
                     "input": [
-                        441,
+                        442,
                         "CreateOneObjectInput!"
                     ]
                 }
@@ -8444,7 +8452,7 @@ export default {
                 23,
                 {
                     "input": [
-                        443,
+                        444,
                         "DeleteOneObjectInput!"
                     ]
                 }
@@ -8453,7 +8461,7 @@ export default {
                 23,
                 {
                     "input": [
-                        444,
+                        445,
                         "UpdateOneObjectInput!"
                     ]
                 }
@@ -8462,7 +8470,7 @@ export default {
                 232,
                 {
                     "input": [
-                        447,
+                        448,
                         "CreateOneIndexInput!"
                     ]
                 }
@@ -8471,7 +8479,7 @@ export default {
                 232,
                 {
                     "input": [
-                        450,
+                        451,
                         "DeleteOneIndexInput!"
                     ]
                 }
@@ -8480,7 +8488,7 @@ export default {
                 21,
                 {
                     "input": [
-                        368,
+                        369,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -8489,7 +8497,7 @@ export default {
                 21,
                 {
                     "input": [
-                        451,
+                        452,
                         "CreateLogicFunctionFromSourceInput!"
                     ]
                 }
@@ -8498,7 +8506,7 @@ export default {
                 142,
                 {
                     "input": [
-                        452,
+                        453,
                         "ExecuteOneLogicFunctionInput!"
                     ]
                 }
@@ -8507,7 +8515,7 @@ export default {
                 8,
                 {
                     "input": [
-                        453,
+                        454,
                         "UpdateLogicFunctionFromSourceInput!"
                     ]
                 }
@@ -8516,7 +8524,7 @@ export default {
                 14,
                 {
                     "input": [
-                        455,
+                        456,
                         "CreateCommandMenuItemInput!"
                     ]
                 }
@@ -8525,7 +8533,7 @@ export default {
                 14,
                 {
                     "input": [
-                        456,
+                        457,
                         "UpdateCommandMenuItemInput!"
                     ]
                 }
@@ -8552,7 +8560,7 @@ export default {
                 13,
                 {
                     "input": [
-                        457,
+                        458,
                         "CreateFrontComponentInput!"
                     ]
                 }
@@ -8561,7 +8569,7 @@ export default {
                 13,
                 {
                     "input": [
-                        458,
+                        459,
                         "UpdateFrontComponentInput!"
                     ]
                 }
@@ -8579,7 +8587,7 @@ export default {
                 67,
                 {
                     "data": [
-                        460,
+                        461,
                         "ActivateWorkspaceInput!"
                     ]
                 }
@@ -8588,7 +8596,7 @@ export default {
                 67,
                 {
                     "data": [
-                        461,
+                        462,
                         "UpdateWorkspaceInput!"
                     ]
                 }
@@ -8619,7 +8627,7 @@ export default {
                 201,
                 {
                     "input": [
-                        462,
+                        463,
                         "CreateApplicationRegistrationInput!"
                     ]
                 }
@@ -8628,7 +8636,7 @@ export default {
                 73,
                 {
                     "input": [
-                        463,
+                        464,
                         "UpdateApplicationRegistrationInput!"
                     ]
                 }
@@ -8655,7 +8663,7 @@ export default {
                 174,
                 {
                     "input": [
-                        465,
+                        466,
                         "CreateApplicationRegistrationVariableInput!"
                     ]
                 }
@@ -8664,7 +8672,7 @@ export default {
                 174,
                 {
                     "input": [
-                        466,
+                        467,
                         "UpdateApplicationRegistrationVariableInput!"
                     ]
                 }
@@ -8682,7 +8690,7 @@ export default {
                 73,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ],
                     "universalIdentifier": [
@@ -8744,7 +8752,7 @@ export default {
                         "UUID!"
                     ],
                     "input": [
-                        468,
+                        469,
                         "UpdateApplicationInput!"
                     ]
                 }
@@ -8765,7 +8773,7 @@ export default {
                 224,
                 {
                     "input": [
-                        469,
+                        470,
                         "CreateOneFieldMetadataInput!"
                     ]
                 }
@@ -8774,7 +8782,7 @@ export default {
                 224,
                 {
                     "input": [
-                        471,
+                        472,
                         "UpdateOneFieldMetadataInput!"
                     ]
                 }
@@ -8783,7 +8791,7 @@ export default {
                 224,
                 {
                     "input": [
-                        473,
+                        474,
                         "DeleteOneFieldInput!"
                     ]
                 }
@@ -8792,7 +8800,7 @@ export default {
                 57,
                 {
                     "input": [
-                        474,
+                        475,
                         "CreateViewGroupInput!"
                     ]
                 }
@@ -8801,7 +8809,7 @@ export default {
                 57,
                 {
                     "inputs": [
-                        474,
+                        475,
                         "[CreateViewGroupInput!]!"
                     ]
                 }
@@ -8810,7 +8818,7 @@ export default {
                 57,
                 {
                     "input": [
-                        475,
+                        476,
                         "UpdateViewGroupInput!"
                     ]
                 }
@@ -8819,7 +8827,7 @@ export default {
                 57,
                 {
                     "inputs": [
-                        475,
+                        476,
                         "[UpdateViewGroupInput!]!"
                     ]
                 }
@@ -8828,7 +8836,7 @@ export default {
                 57,
                 {
                     "input": [
-                        477,
+                        478,
                         "DeleteViewGroupInput!"
                     ]
                 }
@@ -8837,7 +8845,7 @@ export default {
                 57,
                 {
                     "input": [
-                        478,
+                        479,
                         "DestroyViewGroupInput!"
                     ]
                 }
@@ -8859,7 +8867,7 @@ export default {
                 46,
                 {
                     "createRoleInput": [
-                        479,
+                        480,
                         "CreateRoleInput!"
                     ]
                 }
@@ -8868,7 +8876,7 @@ export default {
                 46,
                 {
                     "updateRoleInput": [
-                        480,
+                        481,
                         "UpdateRoleInput!"
                     ]
                 }
@@ -8886,7 +8894,7 @@ export default {
                 43,
                 {
                     "upsertObjectPermissionsInput": [
-                        482,
+                        483,
                         "UpsertObjectPermissionsInput!"
                     ]
                 }
@@ -8895,7 +8903,7 @@ export default {
                 44,
                 {
                     "upsertPermissionFlagsInput": [
-                        484,
+                        485,
                         "UpsertPermissionFlagsInput!"
                     ]
                 }
@@ -8904,7 +8912,7 @@ export default {
                 38,
                 {
                     "upsertFieldPermissionsInput": [
-                        485,
+                        486,
                         "UpsertFieldPermissionsInput!"
                     ]
                 }
@@ -8913,7 +8921,7 @@ export default {
                 245,
                 {
                     "input": [
-                        487,
+                        488,
                         "UpsertRowLevelPermissionPredicatesInput!"
                     ]
                 }
@@ -8944,7 +8952,7 @@ export default {
                 295,
                 {
                     "input": [
-                        490,
+                        491,
                         "SendEmailViaDomainInput!"
                     ]
                 }
@@ -8953,7 +8961,7 @@ export default {
                 297,
                 {
                     "input": [
-                        491,
+                        492,
                         "SendMessageCampaignInput!"
                     ]
                 }
@@ -8962,7 +8970,7 @@ export default {
                 295,
                 {
                     "input": [
-                        492,
+                        493,
                         "SendMessageCampaignTestInput!"
                     ]
                 }
@@ -8971,7 +8979,7 @@ export default {
                 302,
                 {
                     "input": [
-                        493,
+                        494,
                         "CreateUnsubscribeTopicInput!"
                     ]
                 }
@@ -8980,7 +8988,7 @@ export default {
                 302,
                 {
                     "input": [
-                        494,
+                        495,
                         "UpdateUnsubscribeTopicInput!"
                     ]
                 }
@@ -8998,7 +9006,7 @@ export default {
                 285,
                 {
                     "input": [
-                        495,
+                        496,
                         "UpdateMessageChannelInput!"
                     ]
                 }
@@ -9007,7 +9015,7 @@ export default {
                 293,
                 {
                     "input": [
-                        497,
+                        498,
                         "CreateEmailGroupChannelInput!"
                     ]
                 }
@@ -9016,7 +9024,7 @@ export default {
                 285,
                 {
                     "input": [
-                        498,
+                        499,
                         "UpdateEmailGroupChannelInput!"
                     ]
                 }
@@ -9034,7 +9042,7 @@ export default {
                 283,
                 {
                     "input": [
-                        499,
+                        500,
                         "CreateEmailingDomainInput!"
                     ]
                 }
@@ -9070,7 +9078,7 @@ export default {
                 314,
                 {
                     "input": [
-                        500,
+                        501,
                         "RunAgentInput!"
                     ]
                 }
@@ -9079,7 +9087,7 @@ export default {
                 311,
                 {
                     "input": [
-                        503,
+                        504,
                         "CreateWebhookInput!"
                     ]
                 }
@@ -9088,7 +9096,7 @@ export default {
                 311,
                 {
                     "input": [
-                        504,
+                        505,
                         "UpdateWebhookInput!"
                     ]
                 }
@@ -9103,37 +9111,37 @@ export default {
                 }
             ],
             "updateMessageFolder": [
-                352,
+                353,
                 {
                     "input": [
-                        506,
+                        507,
                         "UpdateMessageFolderInput!"
                     ]
                 }
             ],
             "updateMessageFolders": [
-                352,
+                353,
                 {
                     "input": [
-                        508,
+                        509,
                         "UpdateMessageFoldersInput!"
                     ]
                 }
             ],
             "updateCalendarChannel": [
-                347,
+                348,
                 {
                     "input": [
-                        509,
+                        510,
                         "UpdateCalendarChannelInput!"
                     ]
                 }
             ],
             "setAppKeyValue": [
-                345,
+                346,
                 {
                     "input": [
-                        511,
+                        512,
                         "SetAppKeyValueInput!"
                     ]
                 }
@@ -9146,7 +9154,7 @@ export default {
                         "String!"
                     ],
                     "scope": [
-                        346
+                        347
                     ]
                 }
             ],
@@ -9154,8 +9162,17 @@ export default {
                 344,
                 {
                     "input": [
-                        512,
+                        513,
                         "EnqueueJobInput!"
+                    ]
+                }
+            ],
+            "enqueueJobs": [
+                345,
+                {
+                    "input": [
+                        514,
+                        "EnqueueJobsInput!"
                     ]
                 }
             ],
@@ -9184,7 +9201,7 @@ export default {
                         1
                     ],
                     "fileAttachments": [
-                        513,
+                        515,
                         "[FileAttachmentInput!]"
                     ]
                 }
@@ -9213,14 +9230,14 @@ export default {
                         "UUID!"
                     ],
                     "answers": [
-                        514,
+                        516,
                         "[AgentChatQuestionAnswerInput!]!"
                     ],
                     "modelId": [
                         1
                     ],
                     "fileAttachments": [
-                        513,
+                        515,
                         "[FileAttachmentInput!]"
                     ]
                 }
@@ -9298,7 +9315,7 @@ export default {
                 330,
                 {
                     "input": [
-                        515,
+                        517,
                         "CreateSkillInput!"
                     ]
                 }
@@ -9307,7 +9324,7 @@ export default {
                 330,
                 {
                     "input": [
-                        516,
+                        518,
                         "UpdateSkillInput!"
                     ]
                 }
@@ -9362,16 +9379,16 @@ export default {
                 }
             ],
             "updateTimelineActivityType": [
-                358,
+                359,
                 {
                     "input": [
-                        517,
+                        519,
                         "UpdateTimelineActivityTypeInput!"
                     ]
                 }
             ],
             "resetTimelineActivityType": [
-                358,
+                359,
                 {
                     "id": [
                         3,
@@ -9383,7 +9400,7 @@ export default {
                 258,
                 {
                     "input": [
-                        518,
+                        520,
                         "GetAuthorizationUrlForSSOInput!"
                     ]
                 }
@@ -9549,7 +9566,7 @@ export default {
                 261,
                 {
                     "input": [
-                        519
+                        521
                     ]
                 }
             ],
@@ -9561,7 +9578,7 @@ export default {
                         "String!"
                     ],
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ]
                 }
@@ -9724,7 +9741,7 @@ export default {
                 8,
                 {
                     "input": [
-                        520,
+                        522,
                         "UpdateWorkspaceMemberSettingsInput!"
                     ]
                 }
@@ -9758,7 +9775,7 @@ export default {
                 211,
                 {
                     "input": [
-                        521,
+                        523,
                         "SetupOIDCSsoInput!"
                     ]
                 }
@@ -9767,7 +9784,7 @@ export default {
                 211,
                 {
                     "input": [
-                        522,
+                        524,
                         "SetupSAMLSsoInput!"
                     ]
                 }
@@ -9776,7 +9793,7 @@ export default {
                 207,
                 {
                     "input": [
-                        523,
+                        525,
                         "DeleteSsoInput!"
                     ]
                 }
@@ -9785,7 +9802,7 @@ export default {
                 208,
                 {
                     "input": [
-                        524,
+                        526,
                         "EditSsoInput!"
                     ]
                 }
@@ -9814,7 +9831,7 @@ export default {
                 326,
                 {
                     "type": [
-                        525,
+                        527,
                         "AnalyticsType!"
                     ],
                     "name": [
@@ -9857,7 +9874,7 @@ export default {
                 316,
                 {
                     "input": [
-                        526,
+                        528,
                         "CreateCalendarEventInput!"
                     ]
                 }
@@ -9866,7 +9883,7 @@ export default {
                 325,
                 {
                     "input": [
-                        527,
+                        529,
                         "SendEmailInput!"
                     ]
                 }
@@ -9888,7 +9905,7 @@ export default {
                         "String!"
                     ],
                     "connectionParameters": [
-                        529,
+                        531,
                         "EmailAccountConnectionParameters!"
                     ],
                     "id": [
@@ -9900,7 +9917,7 @@ export default {
                 171,
                 {
                     "input": [
-                        531,
+                        533,
                         "UpdateLabPublicFeatureFlagInput!"
                     ]
                 }
@@ -9965,7 +9982,7 @@ export default {
                 280,
                 {
                     "file": [
-                        389,
+                        390,
                         "Upload!"
                     ],
                     "applicationUniversalIdentifier": [
@@ -9973,7 +9990,7 @@ export default {
                         "String!"
                     ],
                     "fileFolder": [
-                        388,
+                        389,
                         "FileFolder!"
                     ],
                     "filePath": [
@@ -10087,7 +10104,7 @@ export default {
                 3
             ],
             "update": [
-                387
+                388
             ],
             "__typename": [
                 1
@@ -10198,7 +10215,7 @@ export default {
                 3
             ],
             "update": [
-                394
+                395
             ],
             "__typename": [
                 1
@@ -10369,19 +10386,19 @@ export default {
                 3
             ],
             "view": [
-                400
-            ],
-            "viewFields": [
                 401
             ],
-            "viewFilters": [
+            "viewFields": [
                 402
             ],
-            "viewFilterGroups": [
+            "viewFilters": [
                 403
             ],
-            "viewSorts": [
+            "viewFilterGroups": [
                 404
+            ],
+            "viewSorts": [
+                405
             ],
             "__typename": [
                 1
@@ -10530,7 +10547,7 @@ export default {
                 3
             ],
             "update": [
-                407
+                408
             ],
             "__typename": [
                 1
@@ -10568,7 +10585,7 @@ export default {
                 3
             ],
             "update": [
-                411
+                412
             ],
             "__typename": [
                 1
@@ -10644,7 +10661,7 @@ export default {
                 3
             ],
             "update": [
-                416
+                417
             ],
             "__typename": [
                 1
@@ -10708,10 +10725,10 @@ export default {
                 3
             ],
             "groups": [
-                421
+                422
             ],
             "fields": [
-                422
+                423
             ],
             "__typename": [
                 1
@@ -10731,7 +10748,7 @@ export default {
                 8
             ],
             "fields": [
-                422
+                423
             ],
             "__typename": [
                 1
@@ -10899,7 +10916,7 @@ export default {
                 3
             ],
             "tabs": [
-                434
+                435
             ],
             "__typename": [
                 1
@@ -10922,7 +10939,7 @@ export default {
                 82
             ],
             "widgets": [
-                435
+                436
             ],
             "__typename": [
                 1
@@ -10945,7 +10962,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                436
+                437
             ],
             "position": [
                 9
@@ -10994,7 +11011,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                436
+                437
             ],
             "position": [
                 9
@@ -11020,7 +11037,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                436
+                437
             ],
             "position": [
                 9
@@ -11113,7 +11130,7 @@ export default {
         },
         "CreateOneObjectInput": {
             "object": [
-                442
+                443
             ],
             "__typename": [
                 1
@@ -11173,7 +11190,7 @@ export default {
         },
         "UpdateOneObjectInput": {
             "update": [
-                445
+                446
             ],
             "id": [
                 3
@@ -11226,7 +11243,7 @@ export default {
                 24
             ],
             "translations": [
-                446
+                447
             ],
             "__typename": [
                 1
@@ -11248,7 +11265,7 @@ export default {
         },
         "CreateOneIndexInput": {
             "index": [
-                448
+                449
             ],
             "__typename": [
                 1
@@ -11259,7 +11276,7 @@ export default {
                 3
             ],
             "fields": [
-                449
+                450
             ],
             "indexType": [
                 233
@@ -11344,7 +11361,7 @@ export default {
                 3
             ],
             "update": [
-                454
+                455
             ],
             "__typename": [
                 1
@@ -11504,7 +11521,7 @@ export default {
                 3
             ],
             "update": [
-                459
+                460
             ],
             "__typename": [
                 1
@@ -11631,7 +11648,7 @@ export default {
                 1
             ],
             "update": [
-                464
+                465
             ],
             "__typename": [
                 1
@@ -11685,7 +11702,7 @@ export default {
                 1
             ],
             "update": [
-                467
+                468
             ],
             "__typename": [
                 1
@@ -11715,7 +11732,7 @@ export default {
         },
         "CreateOneFieldMetadataInput": {
             "field": [
-                470
+                471
             ],
             "__typename": [
                 1
@@ -11788,7 +11805,7 @@ export default {
                 3
             ],
             "update": [
-                472
+                473
             ],
             "__typename": [
                 1
@@ -11847,7 +11864,7 @@ export default {
                 9
             ],
             "translations": [
-                446
+                447
             ],
             "__typename": [
                 1
@@ -11886,7 +11903,7 @@ export default {
                 3
             ],
             "update": [
-                476
+                477
             ],
             "__typename": [
                 1
@@ -11971,7 +11988,7 @@ export default {
         },
         "UpdateRoleInput": {
             "update": [
-                481
+                482
             ],
             "id": [
                 3
@@ -12026,7 +12043,7 @@ export default {
                 3
             ],
             "objectPermissions": [
-                483
+                484
             ],
             "__typename": [
                 1
@@ -12068,7 +12085,7 @@ export default {
                 3
             ],
             "fieldPermissions": [
-                486
+                487
             ],
             "__typename": [
                 1
@@ -12099,10 +12116,10 @@ export default {
                 3
             ],
             "predicates": [
-                488
+                489
             ],
             "predicateGroups": [
-                489
+                490
             ],
             "__typename": [
                 1
@@ -12256,7 +12273,7 @@ export default {
                 3
             ],
             "update": [
-                496
+                497
             ],
             "__typename": [
                 1
@@ -12329,7 +12346,7 @@ export default {
                 3
             ],
             "messages": [
-                501
+                502
             ],
             "__typename": [
                 1
@@ -12337,7 +12354,7 @@ export default {
         },
         "RunAgentMessageInput": {
             "role": [
-                502
+                503
             ],
             "content": [
                 1
@@ -12372,7 +12389,7 @@ export default {
                 3
             ],
             "update": [
-                505
+                506
             ],
             "__typename": [
                 1
@@ -12400,7 +12417,7 @@ export default {
                 3
             ],
             "update": [
-                507
+                508
             ],
             "__typename": [
                 1
@@ -12419,7 +12436,7 @@ export default {
                 3
             ],
             "update": [
-                507
+                508
             ],
             "__typename": [
                 1
@@ -12430,7 +12447,7 @@ export default {
                 3
             ],
             "update": [
-                510
+                511
             ],
             "__typename": [
                 1
@@ -12438,13 +12455,13 @@ export default {
         },
         "UpdateCalendarChannelInputUpdates": {
             "visibility": [
-                350
+                351
             ],
             "isContactAutoCreationEnabled": [
                 8
             ],
             "contactAutoCreationPolicy": [
-                351
+                352
             ],
             "isSyncEnabled": [
                 8
@@ -12461,7 +12478,7 @@ export default {
                 9
             ],
             "scope": [
-                346
+                347
             ],
             "__typename": [
                 1
@@ -12479,6 +12496,14 @@ export default {
             ],
             "delayMs": [
                 26
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "EnqueueJobsInput": {
+            "jobs": [
+                513
             ],
             "__typename": [
                 1
@@ -12572,7 +12597,7 @@ export default {
                 8
             ],
             "translations": [
-                446
+                447
             ],
             "__typename": [
                 1
@@ -12735,7 +12760,7 @@ export default {
                 1
             ],
             "files": [
-                528
+                530
             ],
             "__typename": [
                 1
@@ -12757,13 +12782,13 @@ export default {
                 1
             ],
             "IMAP": [
-                530
+                532
             ],
             "SMTP": [
-                530
+                532
             ],
             "CALDAV": [
-                530
+                532
             ],
             "__typename": [
                 1
@@ -12814,7 +12839,7 @@ export default {
                 246,
                 {
                     "input": [
-                        533,
+                        535,
                         "LogicFunctionLogsInput!"
                     ]
                 }
@@ -12832,7 +12857,7 @@ export default {
                 327,
                 {
                     "table": [
-                        374,
+                        375,
                         "EventLogTable!"
                     ]
                 }

--- a/packages/twenty-docs/developers/extend/apps/logic/background-jobs.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/background-jobs.mdx
@@ -30,7 +30,7 @@ await enqueueJobs([
 ]);
 ```
 
-Each target function receives its `payload` as its handler argument, exactly like any other trigger. Every target must belong to the **same application** as the caller — enqueuing another app's function rejects the whole batch with `Logic function not found`, and no job from the batch is enqueued. A single call accepts up to `10000` jobs.
+Each target function receives its `payload` as its handler argument, exactly like any other trigger. Every target must belong to the **same application** as the caller — enqueuing another app's function rejects the whole batch with `Logic function not found`, and no job from the batch is enqueued. A single call accepts up to `200` jobs.
 
 <Note>
 `enqueueJobs` returns as soon as the jobs are accepted, not when they have run. It does not return the targets' results — have each target write what it produces to the [key-value store](/developers/extend/apps/logic/key-value-store) or to a workspace record if you need to read it back.

--- a/packages/twenty-docs/developers/extend/apps/logic/background-jobs.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/background-jobs.mdx
@@ -22,24 +22,22 @@ Import `enqueueJobs` from `twenty-sdk/logic-function` and pass it the list of jo
 ```ts src/logic-functions/sync-all-contacts.ts
 import { enqueueJobs } from 'twenty-sdk/logic-function';
 
-await enqueueJobs({
-  jobs: [
-    {
-      logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
-      payload: { page: 1 },
-    },
-  ],
-});
+await enqueueJobs([
+  {
+    logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
+    payload: { page: 1 },
+  },
+]);
 ```
 
-Each target function receives its `payload` as its handler argument, exactly like any other trigger. Every target must belong to the **same application** as the caller — enqueuing another app's function rejects the whole batch with `Logic function not found`, and no job from the batch is enqueued. A single call accepts up to `100` jobs.
+Each target function receives its `payload` as its handler argument, exactly like any other trigger. Every target must belong to the **same application** as the caller — enqueuing another app's function rejects the whole batch with `Logic function not found`, and no job from the batch is enqueued. A single call accepts up to `10000` jobs.
 
 <Note>
 `enqueueJobs` returns as soon as the jobs are accepted, not when they have run. It does not return the targets' results — have each target write what it produces to the [key-value store](/developers/extend/apps/logic/key-value-store) or to a workspace record if you need to read it back.
 </Note>
 
 <Note>
-The older `enqueueJob` helper, which enqueues a single job per call, is deprecated. Use `enqueueJobs` with a one-element `jobs` list instead.
+The older `enqueueJob` helper, which enqueues a single job per call, is deprecated. Use `enqueueJobs` with a one-element list instead.
 </Note>
 
 ## Job options
@@ -52,16 +50,14 @@ Each job in the batch carries its own options.
 | `delayMs` | `0` | `0`–`604800000` (7 days) | Wait this long before the run becomes eligible. |
 
 ```ts
-await enqueueJobs({
-  jobs: [
-    {
-      logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
-      payload: { page: 1 },
-      retryLimit: 3,
-      delayMs: 60_000,
-    },
-  ],
-});
+await enqueueJobs([
+  {
+    logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
+    payload: { page: 1 },
+    retryLimit: 3,
+    delayMs: 60_000,
+  },
+]);
 ```
 
 <Note>
@@ -120,15 +116,13 @@ const handler = async (params: { cursor?: string }) => {
   await importContacts(contacts);
 
   if (nextCursor) {
-    await enqueueJobs({
-      jobs: [
-        {
-          logicFunctionUniversalIdentifier: SYNC_CONTACTS_PAGE,
-          payload: { cursor: nextCursor },
-          delayMs: 2_000,
-        },
-      ],
-    });
+    await enqueueJobs([
+      {
+        logicFunctionUniversalIdentifier: SYNC_CONTACTS_PAGE,
+        payload: { cursor: nextCursor },
+        delayMs: 2_000,
+      },
+    ]);
   }
 
   return { imported: contacts.length, done: !nextCursor };
@@ -149,13 +143,13 @@ When the work is naturally per-item, enqueue one job per item in a single call a
 ```ts
 const companies = await listCompaniesToEnrich();
 
-await enqueueJobs({
-  jobs: companies.map((company) => ({
+await enqueueJobs(
+  companies.map((company) => ({
     logicFunctionUniversalIdentifier: ENRICH_COMPANY,
     payload: { companyId: company.id },
     retryLimit: 2,
   })),
-});
+);
 ```
 
 ## Good practice for long-running work
@@ -185,14 +179,12 @@ const handler = async (params: { offset?: number }) => {
   await kv.set('enrich:progress', { offset: offset + companies.length });
 
   if (companies.length === CHUNK_SIZE) {
-    await enqueueJobs({
-      jobs: [
-        {
-          logicFunctionUniversalIdentifier: ENRICH_COMPANIES_BATCH,
-          payload: { offset: offset + CHUNK_SIZE },
-        },
-      ],
-    });
+    await enqueueJobs([
+      {
+        logicFunctionUniversalIdentifier: ENRICH_COMPANIES_BATCH,
+        payload: { offset: offset + CHUNK_SIZE },
+      },
+    ]);
   }
 
   return { processed: companies.length, done: companies.length < CHUNK_SIZE };

--- a/packages/twenty-docs/developers/extend/apps/logic/background-jobs.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/background-jobs.mdx
@@ -6,7 +6,7 @@ icon: "layer-group"
 
 A logic function run is capped by its `timeoutSeconds` (900 seconds maximum). Anything that can't finish in that window — a full re-sync, a per-record fan-out, a third-party API that rate-limits you — has to be split into smaller runs.
 
-`enqueueJobs` does exactly that: it asks the Twenty workers to run one or more of your app's logic functions later, each in its own process, with its own timeout budget. The caller returns immediately.
+`enqueueJobs` does exactly that: it asks the Twenty workers to run one of your app's logic functions later, once per payload, each run in its own process with its own timeout budget. The caller returns immediately.
 
 ```text
   ┌─────────────────┐  enqueueJobs(...)  ┌──────────────┐   ┌────────────────────┐
@@ -17,47 +17,43 @@ A logic function run is capped by its `timeoutSeconds` (900 seconds maximum). An
 
 ## Enqueue runs
 
-Import `enqueueJobs` from `twenty-sdk/logic-function` and pass it the list of jobs to enqueue. Each job points at the `universalIdentifier` of the logic function to run.
+Import `enqueueJobs` from `twenty-sdk/logic-function`, point it at the `universalIdentifier` of the logic function to run, and pass one payload per run to enqueue.
 
 ```ts src/logic-functions/sync-all-contacts.ts
 import { enqueueJobs } from 'twenty-sdk/logic-function';
 
-await enqueueJobs([
-  {
-    logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
-    payload: { page: 1 },
-  },
-]);
+await enqueueJobs({
+  logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
+  payloads: [{ page: 1 }],
+});
 ```
 
-Each target function receives its `payload` as its handler argument, exactly like any other trigger. Every target must belong to the **same application** as the caller — enqueuing another app's function rejects the whole batch with `Logic function not found`, and no job from the batch is enqueued. A single call accepts up to `200` jobs.
+Each run receives its payload as the handler argument, exactly like any other trigger. The target must belong to the **same application** as the caller — enqueuing another app's function is rejected with `Logic function not found` and nothing is enqueued. A single call accepts up to `200` payloads.
 
 <Note>
 `enqueueJobs` returns as soon as the jobs are accepted, not when they have run. It does not return the targets' results — have each target write what it produces to the [key-value store](/developers/extend/apps/logic/key-value-store) or to a workspace record if you need to read it back.
 </Note>
 
 <Note>
-The older `enqueueJob` helper, which enqueues a single job per call, is deprecated. Use `enqueueJobs` with a one-element list instead.
+The older `enqueueJob` helper, which enqueues a single job per call, is deprecated. Use `enqueueJobs` with a one-element `payloads` list instead.
 </Note>
 
 ## Job options
 
-Each job in the batch carries its own options.
+Options apply to every run in the batch.
 
 | Option | Default | Range | What it does |
 |--------|---------|-------|--------------|
 | `retryLimit` | `0` | `0`–`10` | Overall extra queue attempts. Application-requested retries are capped at `3`. Only raise this for handlers that are safe to run twice. |
-| `delayMs` | `0` | `0`–`604800000` (7 days) | Wait this long before the run becomes eligible. |
+| `delayMs` | `0` | `0`–`604800000` (7 days) | Wait this long before the runs become eligible. |
 
 ```ts
-await enqueueJobs([
-  {
-    logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
-    payload: { page: 1 },
-    retryLimit: 3,
-    delayMs: 60_000,
-  },
-]);
+await enqueueJobs({
+  logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
+  payloads: [{ page: 1 }],
+  retryLimit: 3,
+  delayMs: 60_000,
+});
 ```
 
 <Note>
@@ -116,13 +112,11 @@ const handler = async (params: { cursor?: string }) => {
   await importContacts(contacts);
 
   if (nextCursor) {
-    await enqueueJobs([
-      {
-        logicFunctionUniversalIdentifier: SYNC_CONTACTS_PAGE,
-        payload: { cursor: nextCursor },
-        delayMs: 2_000,
-      },
-    ]);
+    await enqueueJobs({
+      logicFunctionUniversalIdentifier: SYNC_CONTACTS_PAGE,
+      payloads: [{ cursor: nextCursor }],
+      delayMs: 2_000,
+    });
   }
 
   return { imported: contacts.length, done: !nextCursor };
@@ -143,13 +137,11 @@ When the work is naturally per-item, enqueue one job per item in a single call a
 ```ts
 const companies = await listCompaniesToEnrich();
 
-await enqueueJobs(
-  companies.map((company) => ({
-    logicFunctionUniversalIdentifier: ENRICH_COMPANY,
-    payload: { companyId: company.id },
-    retryLimit: 2,
-  })),
-);
+await enqueueJobs({
+  logicFunctionUniversalIdentifier: ENRICH_COMPANY,
+  payloads: companies.map((company) => ({ companyId: company.id })),
+  retryLimit: 2,
+});
 ```
 
 ## Good practice for long-running work
@@ -179,12 +171,10 @@ const handler = async (params: { offset?: number }) => {
   await kv.set('enrich:progress', { offset: offset + companies.length });
 
   if (companies.length === CHUNK_SIZE) {
-    await enqueueJobs([
-      {
-        logicFunctionUniversalIdentifier: ENRICH_COMPANIES_BATCH,
-        payload: { offset: offset + CHUNK_SIZE },
-      },
-    ]);
+    await enqueueJobs({
+      logicFunctionUniversalIdentifier: ENRICH_COMPANIES_BATCH,
+      payloads: [{ offset: offset + CHUNK_SIZE }],
+    });
   }
 
   return { processed: companies.length, done: companies.length < CHUNK_SIZE };

--- a/packages/twenty-docs/developers/extend/apps/logic/background-jobs.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/background-jobs.mdx
@@ -6,35 +6,45 @@ icon: "layer-group"
 
 A logic function run is capped by its `timeoutSeconds` (900 seconds maximum). Anything that can't finish in that window — a full re-sync, a per-record fan-out, a third-party API that rate-limits you — has to be split into smaller runs.
 
-`enqueueJob` does exactly that: it asks the Twenty workers to run one of your app's logic functions later, in its own process, with its own timeout budget. The caller returns immediately.
+`enqueueJobs` does exactly that: it asks the Twenty workers to run one or more of your app's logic functions later, each in its own process, with its own timeout budget. The caller returns immediately.
 
 ```text
-  ┌─────────────────┐  enqueueJob(...)   ┌──────────────┐   ┌────────────────────┐
+  ┌─────────────────┐  enqueueJobs(...)  ┌──────────────┐   ┌────────────────────┐
   │ Logic function  │ ─────────────────▶ │ Job queue    │──▶│ Logic function     │
   │ (returns now)   │                    │ (workers)    │   │ (fresh run/timeout)│
   └─────────────────┘                    └──────────────┘   └────────────────────┘
 ```
 
-## Enqueue a run
+## Enqueue runs
 
-Import `enqueueJob` from `twenty-sdk/logic-function` and point it at the `universalIdentifier` of the logic function you want to run.
+Import `enqueueJobs` from `twenty-sdk/logic-function` and pass it the list of jobs to enqueue. Each job points at the `universalIdentifier` of the logic function to run.
 
 ```ts src/logic-functions/sync-all-contacts.ts
-import { enqueueJob } from 'twenty-sdk/logic-function';
+import { enqueueJobs } from 'twenty-sdk/logic-function';
 
-await enqueueJob({
-  logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
-  payload: { page: 1 },
+await enqueueJobs({
+  jobs: [
+    {
+      logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
+      payload: { page: 1 },
+    },
+  ],
 });
 ```
 
-The target function receives `payload` as its handler argument, exactly like any other trigger. It must belong to the **same application** as the caller — enqueuing another app's function is rejected with `Logic function not found`.
+Each target function receives its `payload` as its handler argument, exactly like any other trigger. Every target must belong to the **same application** as the caller — enqueuing another app's function rejects the whole batch with `Logic function not found`, and no job from the batch is enqueued. A single call accepts up to `100` jobs.
 
 <Note>
-`enqueueJob` returns as soon as the job is accepted, not when it has run. It does not return the target's result — have the target write what it produces to the [key-value store](/developers/extend/apps/logic/key-value-store) or to a workspace record if you need to read it back.
+`enqueueJobs` returns as soon as the jobs are accepted, not when they have run. It does not return the targets' results — have each target write what it produces to the [key-value store](/developers/extend/apps/logic/key-value-store) or to a workspace record if you need to read it back.
+</Note>
+
+<Note>
+The older `enqueueJob` helper, which enqueues a single job per call, is deprecated. Use `enqueueJobs` with a one-element `jobs` list instead.
 </Note>
 
 ## Job options
+
+Each job in the batch carries its own options.
 
 | Option | Default | Range | What it does |
 |--------|---------|-------|--------------|
@@ -42,11 +52,15 @@ The target function receives `payload` as its handler argument, exactly like any
 | `delayMs` | `0` | `0`–`604800000` (7 days) | Wait this long before the run becomes eligible. |
 
 ```ts
-await enqueueJob({
-  logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
-  payload: { page: 1 },
-  retryLimit: 3,
-  delayMs: 60_000,
+await enqueueJobs({
+  jobs: [
+    {
+      logicFunctionUniversalIdentifier: '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33',
+      payload: { page: 1 },
+      retryLimit: 3,
+      delayMs: 60_000,
+    },
+  ],
 });
 ```
 
@@ -96,7 +110,7 @@ The classic shape is a function that enqueues *itself* with the next cursor. Eac
 
 ```ts src/logic-functions/sync-contacts-page.ts
 import { defineLogicFunction } from 'twenty-sdk/define';
-import { enqueueJob } from 'twenty-sdk/logic-function';
+import { enqueueJobs } from 'twenty-sdk/logic-function';
 
 const SYNC_CONTACTS_PAGE = '9f1c3d7e-51b8-4a29-8f0d-7c4e2a6b1d33';
 
@@ -106,10 +120,14 @@ const handler = async (params: { cursor?: string }) => {
   await importContacts(contacts);
 
   if (nextCursor) {
-    await enqueueJob({
-      logicFunctionUniversalIdentifier: SYNC_CONTACTS_PAGE,
-      payload: { cursor: nextCursor },
-      delayMs: 2_000,
+    await enqueueJobs({
+      jobs: [
+        {
+          logicFunctionUniversalIdentifier: SYNC_CONTACTS_PAGE,
+          payload: { cursor: nextCursor },
+          delayMs: 2_000,
+        },
+      ],
     });
   }
 
@@ -126,20 +144,18 @@ export default defineLogicFunction({
 
 ## Fan out per record
 
-When the work is naturally per-item, enqueue one job per item and let the workers process them in parallel instead of looping inline.
+When the work is naturally per-item, enqueue one job per item in a single call and let the workers process them in parallel instead of looping inline.
 
 ```ts
 const companies = await listCompaniesToEnrich();
 
-await Promise.all(
-  companies.map((company) =>
-    enqueueJob({
-      logicFunctionUniversalIdentifier: ENRICH_COMPANY,
-      payload: { companyId: company.id },
-      retryLimit: 2,
-    }),
-  ),
-);
+await enqueueJobs({
+  jobs: companies.map((company) => ({
+    logicFunctionUniversalIdentifier: ENRICH_COMPANY,
+    payload: { companyId: company.id },
+    retryLimit: 2,
+  })),
+});
 ```
 
 ## Good practice for long-running work
@@ -150,7 +166,7 @@ A run that tries to do everything is the failure mode — it hits the timeout, a
 
 ```ts src/logic-functions/enrich-companies-batch.ts
 import { defineLogicFunction } from 'twenty-sdk/define';
-import { enqueueJob, kv } from 'twenty-sdk/logic-function';
+import { enqueueJobs, kv } from 'twenty-sdk/logic-function';
 
 const ENRICH_COMPANIES_BATCH = '3f9d1c02-8a44-4f0e-b1d7-9c2e5a7b4f10';
 const CHUNK_SIZE = 50;
@@ -169,9 +185,13 @@ const handler = async (params: { offset?: number }) => {
   await kv.set('enrich:progress', { offset: offset + companies.length });
 
   if (companies.length === CHUNK_SIZE) {
-    await enqueueJob({
-      logicFunctionUniversalIdentifier: ENRICH_COMPANIES_BATCH,
-      payload: { offset: offset + CHUNK_SIZE },
+    await enqueueJobs({
+      jobs: [
+        {
+          logicFunctionUniversalIdentifier: ENRICH_COMPANIES_BATCH,
+          payload: { offset: offset + CHUNK_SIZE },
+        },
+      ],
     });
   }
 

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1710,6 +1710,15 @@ export type EnqueueJobResult = {
   logicFunctionUniversalIdentifier: Scalars['String']['output'];
 };
 
+export type EnqueueJobsInput = {
+  jobs: Array<EnqueueJobInput>;
+};
+
+export type EnqueueJobsResult = {
+  __typename?: 'EnqueueJobsResult';
+  jobs: Array<EnqueueJobResult>;
+};
+
 export type EnterpriseLicenseInfoDto = {
   __typename?: 'EnterpriseLicenseInfoDTO';
   expiresAt?: Maybe<Scalars['DateTime']['output']>;
@@ -2743,7 +2752,9 @@ export type Mutation = {
   editSSOIdentityProvider: EditSso;
   emailPasswordResetLink: EmailPasswordResetLink;
   endSubscriptionTrialPeriod: BillingEndTrialPeriod;
+  /** @deprecated Use enqueueJobs instead. */
   enqueueJob: EnqueueJobResult;
+  enqueueJobs: EnqueueJobsResult;
   enrichWorkspaceCompany: WorkspaceCompanyEnrichmentResult;
   evaluateAgentTurn: AgentTurnEvaluation;
   executeOneLogicFunction: LogicFunctionExecutionResult;
@@ -3417,6 +3428,11 @@ export type MutationEmailPasswordResetLinkArgs = {
 
 export type MutationEnqueueJobArgs = {
   input: EnqueueJobInput;
+};
+
+
+export type MutationEnqueueJobsArgs = {
+  input: EnqueueJobsInput;
 };
 
 

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1711,12 +1711,17 @@ export type EnqueueJobResult = {
 };
 
 export type EnqueueJobsInput = {
-  jobs: Array<EnqueueJobInput>;
+  delayMs?: InputMaybe<Scalars['Int']['input']>;
+  logicFunctionUniversalIdentifier: Scalars['String']['input'];
+  payloads: Array<Scalars['JSON']['input']>;
+  retryLimit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type EnqueueJobsResult = {
   __typename?: 'EnqueueJobsResult';
-  jobs: Array<EnqueueJobResult>;
+  enqueued: Scalars['Boolean']['output'];
+  enqueuedJobsCount: Scalars['Int']['output'];
+  logicFunctionUniversalIdentifier: Scalars['String']['output'];
 };
 
 export type EnterpriseLicenseInfoDto = {

--- a/packages/twenty-sdk/CHANGELOG.md
+++ b/packages/twenty-sdk/CHANGELOG.md
@@ -8,7 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- **`enqueueJobs` in `twenty-sdk/logic-function`.** Enqueues a list of jobs in a single call (up to 10,000 per batch). Each entry takes the same shape as the former `enqueueJob` input (`logicFunctionUniversalIdentifier`, `payload`, `retryLimit`, `delayMs`). The whole batch is validated before anything is enqueued, so an invalid entry rejects the call without enqueuing any job.
+- **`enqueueJobs` in `twenty-sdk/logic-function`.** Enqueues a list of jobs in a single call (up to 200 per batch). Each entry takes the same shape as the former `enqueueJob` input (`logicFunctionUniversalIdentifier`, `payload`, `retryLimit`, `delayMs`). The whole batch is validated before anything is enqueued, so an invalid entry rejects the call without enqueuing any job.
 
   ```ts
   import { enqueueJobs } from 'twenty-sdk/logic-function';

--- a/packages/twenty-sdk/CHANGELOG.md
+++ b/packages/twenty-sdk/CHANGELOG.md
@@ -6,6 +6,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **`enqueueJobs` in `twenty-sdk/logic-function`.** Enqueues a list of jobs in a single call (up to 100 per batch). Each entry takes the same shape as the former `enqueueJob` input (`logicFunctionUniversalIdentifier`, `payload`, `retryLimit`, `delayMs`). The whole batch is validated before anything is enqueued, so an invalid entry rejects the call without enqueuing any job.
+
+  ```ts
+  import { enqueueJobs } from 'twenty-sdk/logic-function';
+
+  await enqueueJobs({
+    jobs: batches.map((batch, batchIndex) => ({
+      logicFunctionUniversalIdentifier: PROCESS_BATCH,
+      payload: { batchIndex },
+    })),
+  });
+  ```
+
+### Deprecated
+
+- **`enqueueJob` in `twenty-sdk/logic-function`.** Use `enqueueJobs` with a one-element `jobs` list instead. `enqueueJob` keeps working for now and will be removed in a future major version.
+
 ### Changed
 
 - **`twenty-client-sdk` should now be a dev dependency too.** Although app code imports it (`CoreApiClient`, `MetadataApiClient`, `RestApiClient`), Twenty provides it at runtime — logic functions get it from a generated SDK layer and front components resolve it from server-served modules — so the installed copy is only needed for typechecking and the deploy-time build. Newly scaffolded apps now place it under `devDependencies`. Moving it is recommended (not required: the server already strips it from the deployed runtime), and keeps the installed app leaner:

--- a/packages/twenty-sdk/CHANGELOG.md
+++ b/packages/twenty-sdk/CHANGELOG.md
@@ -8,22 +8,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- **`enqueueJobs` in `twenty-sdk/logic-function`.** Enqueues a list of jobs in a single call (up to 200 per batch). Each entry takes the same shape as the former `enqueueJob` input (`logicFunctionUniversalIdentifier`, `payload`, `retryLimit`, `delayMs`). The whole batch is validated before anything is enqueued, so an invalid entry rejects the call without enqueuing any job.
+- **`enqueueJobs` in `twenty-sdk/logic-function`.** Enqueues one run per payload of a single logic function in one call (up to 200 payloads per batch). `retryLimit` and `delayMs` apply to every run in the batch.
 
   ```ts
   import { enqueueJobs } from 'twenty-sdk/logic-function';
 
-  await enqueueJobs(
-    batches.map((batch, batchIndex) => ({
-      logicFunctionUniversalIdentifier: PROCESS_BATCH,
-      payload: { batchIndex },
-    })),
-  );
+  await enqueueJobs({
+    logicFunctionUniversalIdentifier: PROCESS_BATCH,
+    payloads: batches.map((batch, batchIndex) => ({ batchIndex })),
+  });
   ```
 
 ### Deprecated
 
-- **`enqueueJob` in `twenty-sdk/logic-function`.** Use `enqueueJobs` with a one-element list instead. `enqueueJob` keeps working for now and will be removed in a future major version.
+- **`enqueueJob` in `twenty-sdk/logic-function`.** Use `enqueueJobs` with a one-element `payloads` list instead. `enqueueJob` keeps working for now and will be removed in a future major version.
 
 ### Changed
 

--- a/packages/twenty-sdk/CHANGELOG.md
+++ b/packages/twenty-sdk/CHANGELOG.md
@@ -8,22 +8,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- **`enqueueJobs` in `twenty-sdk/logic-function`.** Enqueues a list of jobs in a single call (up to 100 per batch). Each entry takes the same shape as the former `enqueueJob` input (`logicFunctionUniversalIdentifier`, `payload`, `retryLimit`, `delayMs`). The whole batch is validated before anything is enqueued, so an invalid entry rejects the call without enqueuing any job.
+- **`enqueueJobs` in `twenty-sdk/logic-function`.** Enqueues a list of jobs in a single call (up to 10,000 per batch). Each entry takes the same shape as the former `enqueueJob` input (`logicFunctionUniversalIdentifier`, `payload`, `retryLimit`, `delayMs`). The whole batch is validated before anything is enqueued, so an invalid entry rejects the call without enqueuing any job.
 
   ```ts
   import { enqueueJobs } from 'twenty-sdk/logic-function';
 
-  await enqueueJobs({
-    jobs: batches.map((batch, batchIndex) => ({
+  await enqueueJobs(
+    batches.map((batch, batchIndex) => ({
       logicFunctionUniversalIdentifier: PROCESS_BATCH,
       payload: { batchIndex },
     })),
-  });
+  );
   ```
 
 ### Deprecated
 
-- **`enqueueJob` in `twenty-sdk/logic-function`.** Use `enqueueJobs` with a one-element `jobs` list instead. `enqueueJob` keeps working for now and will be removed in a future major version.
+- **`enqueueJob` in `twenty-sdk/logic-function`.** Use `enqueueJobs` with a one-element list instead. `enqueueJob` keeps working for now and will be removed in a future major version.
 
 ### Changed
 

--- a/packages/twenty-sdk/src/sdk/logic-function/index.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/index.ts
@@ -61,10 +61,13 @@ export { runAgent } from '@/sdk/logic-function/agents/run-agent';
 export type { RunAgentInput, RunAgentResult } from 'twenty-shared/application';
 
 export { enqueueJob } from '@/sdk/logic-function/jobs/enqueue-job';
+export { enqueueJobs } from '@/sdk/logic-function/jobs/enqueue-jobs';
 export type {
   EnqueueJobInput,
   EnqueueJobOptions,
   EnqueueJobResult,
+  EnqueueJobsInput,
+  EnqueueJobsResult,
 } from 'twenty-shared/application';
 
 export { createTimelineActivity } from '@/sdk/logic-function/timeline/create-timeline-activity';

--- a/packages/twenty-sdk/src/sdk/logic-function/index.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/index.ts
@@ -66,8 +66,6 @@ export type {
   EnqueueJobInput,
   EnqueueJobOptions,
   EnqueueJobResult,
-  EnqueueJobsInput,
-  EnqueueJobsResult,
 } from 'twenty-shared/application';
 
 export { createTimelineActivity } from '@/sdk/logic-function/timeline/create-timeline-activity';

--- a/packages/twenty-sdk/src/sdk/logic-function/index.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/index.ts
@@ -66,6 +66,8 @@ export type {
   EnqueueJobInput,
   EnqueueJobOptions,
   EnqueueJobResult,
+  EnqueueJobsInput,
+  EnqueueJobsResult,
 } from 'twenty-shared/application';
 
 export { createTimelineActivity } from '@/sdk/logic-function/timeline/create-timeline-activity';

--- a/packages/twenty-sdk/src/sdk/logic-function/jobs/__tests__/enqueue-jobs.spec.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/jobs/__tests__/enqueue-jobs.spec.ts
@@ -8,8 +8,7 @@ import {
   type MockInstance,
 } from 'vitest';
 
-const FIRST_UNIVERSAL_IDENTIFIER = '5a2f4d2a-1a1e-4c66-8a54-1f0a2b3c4d5e';
-const SECOND_UNIVERSAL_IDENTIFIER = '7c1b9e3d-2b2f-4d77-9b65-2a1b3c4d5e6f';
+const TARGET_UNIVERSAL_IDENTIFIER = '5a2f4d2a-1a1e-4c66-8a54-1f0a2b3c4d5e';
 
 const importEnqueueJobs = async () => {
   const module = await import('@/sdk/logic-function/jobs/enqueue-jobs');
@@ -23,19 +22,12 @@ const graphqlResponse = (data: unknown) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
-const successResponse = () =>
+const successResponse = (enqueuedJobsCount: number) =>
   graphqlResponse({
     enqueueJobs: {
-      jobs: [
-        {
-          enqueued: true,
-          logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
-        },
-        {
-          enqueued: true,
-          logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
-        },
-      ],
+      enqueued: true,
+      logicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+      enqueuedJobsCount,
     },
   });
 
@@ -56,33 +48,22 @@ describe('enqueueJobs', () => {
   });
 
   it('calls the enqueueJobs mutation on the metadata API and returns its result', async () => {
-    fetchSpy.mockResolvedValue(successResponse());
+    fetchSpy.mockResolvedValue(successResponse(2));
 
     const enqueueJobs = await importEnqueueJobs();
 
-    const result = await enqueueJobs([
-      {
-        logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
-        payload: { batchIndex: 0 },
-        retryLimit: 3,
-        delayMs: 1000,
-      },
-      {
-        logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
-        payload: { batchIndex: 1 },
-      },
-    ]);
+    const result = await enqueueJobs({
+      logicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+      payloads: [{ batchIndex: 0 }, { batchIndex: 1 }],
+      retryLimit: 3,
+      delayMs: 1000,
+    });
 
-    expect(result).toEqual([
-      {
-        enqueued: true,
-        logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
-      },
-      {
-        enqueued: true,
-        logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
-      },
-    ]);
+    expect(result).toEqual({
+      enqueued: true,
+      logicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+      enqueuedJobsCount: 2,
+    });
 
     const [url, requestInit] = fetchSpy.mock.calls[0];
 
@@ -91,34 +72,27 @@ describe('enqueueJobs', () => {
     const sentBody = JSON.parse(requestInit?.body as string);
 
     expect(sentBody.query).toContain(
-      'enqueueJobs(input:$v1){jobs{enqueued,logicFunctionUniversalIdentifier}}',
+      'enqueueJobs(input:$v1){enqueued,logicFunctionUniversalIdentifier,enqueuedJobsCount}',
     );
     expect(Object.values(sentBody.variables)).toEqual([
       {
-        jobs: [
-          {
-            logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
-            payload: { batchIndex: 0 },
-            retryLimit: 3,
-            delayMs: 1000,
-          },
-          {
-            logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
-            payload: { batchIndex: 1 },
-          },
-        ],
+        logicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+        payloads: [{ batchIndex: 0 }, { batchIndex: 1 }],
+        retryLimit: 3,
+        delayMs: 1000,
       },
     ]);
   });
 
   it('sends the app access token as a bearer credential', async () => {
-    fetchSpy.mockResolvedValue(successResponse());
+    fetchSpy.mockResolvedValue(successResponse(1));
 
     const enqueueJobs = await importEnqueueJobs();
 
-    await enqueueJobs([
-      { logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER },
-    ]);
+    await enqueueJobs({
+      logicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+      payloads: [{}],
+    });
 
     const [, requestInit] = fetchSpy.mock.calls[0];
     const headers = new Headers(requestInit?.headers);
@@ -137,9 +111,10 @@ describe('enqueueJobs', () => {
     const enqueueJobs = await importEnqueueJobs();
 
     await expect(
-      enqueueJobs([
-        { logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER },
-      ]),
+      enqueueJobs({
+        logicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+        payloads: [{}],
+      }),
     ).rejects.toThrow(/Logic function not found/);
   });
 });

--- a/packages/twenty-sdk/src/sdk/logic-function/jobs/__tests__/enqueue-jobs.spec.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/jobs/__tests__/enqueue-jobs.spec.ts
@@ -60,33 +60,29 @@ describe('enqueueJobs', () => {
 
     const enqueueJobs = await importEnqueueJobs();
 
-    const result = await enqueueJobs({
-      jobs: [
-        {
-          logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
-          payload: { batchIndex: 0 },
-          retryLimit: 3,
-          delayMs: 1000,
-        },
-        {
-          logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
-          payload: { batchIndex: 1 },
-        },
-      ],
-    });
+    const result = await enqueueJobs([
+      {
+        logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
+        payload: { batchIndex: 0 },
+        retryLimit: 3,
+        delayMs: 1000,
+      },
+      {
+        logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
+        payload: { batchIndex: 1 },
+      },
+    ]);
 
-    expect(result).toEqual({
-      jobs: [
-        {
-          enqueued: true,
-          logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
-        },
-        {
-          enqueued: true,
-          logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
-        },
-      ],
-    });
+    expect(result).toEqual([
+      {
+        enqueued: true,
+        logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
+      },
+      {
+        enqueued: true,
+        logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
+      },
+    ]);
 
     const [url, requestInit] = fetchSpy.mock.calls[0];
 
@@ -120,9 +116,9 @@ describe('enqueueJobs', () => {
 
     const enqueueJobs = await importEnqueueJobs();
 
-    await enqueueJobs({
-      jobs: [{ logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER }],
-    });
+    await enqueueJobs([
+      { logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER },
+    ]);
 
     const [, requestInit] = fetchSpy.mock.calls[0];
     const headers = new Headers(requestInit?.headers);
@@ -141,11 +137,9 @@ describe('enqueueJobs', () => {
     const enqueueJobs = await importEnqueueJobs();
 
     await expect(
-      enqueueJobs({
-        jobs: [
-          { logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER },
-        ],
-      }),
+      enqueueJobs([
+        { logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER },
+      ]),
     ).rejects.toThrow(/Logic function not found/);
   });
 });

--- a/packages/twenty-sdk/src/sdk/logic-function/jobs/__tests__/enqueue-jobs.spec.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/jobs/__tests__/enqueue-jobs.spec.ts
@@ -1,0 +1,151 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vitest';
+
+const FIRST_UNIVERSAL_IDENTIFIER = '5a2f4d2a-1a1e-4c66-8a54-1f0a2b3c4d5e';
+const SECOND_UNIVERSAL_IDENTIFIER = '7c1b9e3d-2b2f-4d77-9b65-2a1b3c4d5e6f';
+
+const importEnqueueJobs = async () => {
+  const module = await import('@/sdk/logic-function/jobs/enqueue-jobs');
+
+  return module.enqueueJobs;
+};
+
+const graphqlResponse = (data: unknown) =>
+  new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const successResponse = () =>
+  graphqlResponse({
+    enqueueJobs: {
+      jobs: [
+        {
+          enqueued: true,
+          logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
+        },
+        {
+          enqueued: true,
+          logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
+        },
+      ],
+    },
+  });
+
+describe('enqueueJobs', () => {
+  let fetchSpy: MockInstance<typeof fetch>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.TWENTY_API_URL = 'https://api.test';
+    process.env.TWENTY_APP_ACCESS_TOKEN = 'app-token';
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    delete process.env.TWENTY_API_URL;
+    delete process.env.TWENTY_APP_ACCESS_TOKEN;
+    fetchSpy.mockRestore();
+  });
+
+  it('calls the enqueueJobs mutation on the metadata API and returns its result', async () => {
+    fetchSpy.mockResolvedValue(successResponse());
+
+    const enqueueJobs = await importEnqueueJobs();
+
+    const result = await enqueueJobs({
+      jobs: [
+        {
+          logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
+          payload: { batchIndex: 0 },
+          retryLimit: 3,
+          delayMs: 1000,
+        },
+        {
+          logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
+          payload: { batchIndex: 1 },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      jobs: [
+        {
+          enqueued: true,
+          logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
+        },
+        {
+          enqueued: true,
+          logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
+        },
+      ],
+    });
+
+    const [url, requestInit] = fetchSpy.mock.calls[0];
+
+    expect(url).toBe('https://api.test/metadata');
+
+    const sentBody = JSON.parse(requestInit?.body as string);
+
+    expect(sentBody.query).toContain(
+      'enqueueJobs(input:$v1){jobs{enqueued,logicFunctionUniversalIdentifier}}',
+    );
+    expect(Object.values(sentBody.variables)).toEqual([
+      {
+        jobs: [
+          {
+            logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER,
+            payload: { batchIndex: 0 },
+            retryLimit: 3,
+            delayMs: 1000,
+          },
+          {
+            logicFunctionUniversalIdentifier: SECOND_UNIVERSAL_IDENTIFIER,
+            payload: { batchIndex: 1 },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('sends the app access token as a bearer credential', async () => {
+    fetchSpy.mockResolvedValue(successResponse());
+
+    const enqueueJobs = await importEnqueueJobs();
+
+    await enqueueJobs({
+      jobs: [{ logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER }],
+    });
+
+    const [, requestInit] = fetchSpy.mock.calls[0];
+    const headers = new Headers(requestInit?.headers);
+
+    expect(headers.get('authorization')).toBe('Bearer app-token');
+  });
+
+  it('surfaces GraphQL errors as a rejection', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({ errors: [{ message: 'Logic function not found' }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const enqueueJobs = await importEnqueueJobs();
+
+    await expect(
+      enqueueJobs({
+        jobs: [
+          { logicFunctionUniversalIdentifier: FIRST_UNIVERSAL_IDENTIFIER },
+        ],
+      }),
+    ).rejects.toThrow(/Logic function not found/);
+  });
+});

--- a/packages/twenty-sdk/src/sdk/logic-function/jobs/enqueue-job.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/jobs/enqueue-job.ts
@@ -4,6 +4,9 @@ import {
   type EnqueueJobResult,
 } from 'twenty-shared/application';
 
+/**
+ * @deprecated Use `enqueueJobs` instead.
+ */
 export const enqueueJob = async (
   input: EnqueueJobInput,
 ): Promise<EnqueueJobResult> => {

--- a/packages/twenty-sdk/src/sdk/logic-function/jobs/enqueue-jobs.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/jobs/enqueue-jobs.ts
@@ -1,17 +1,17 @@
 import { MetadataApiClient } from 'twenty-client-sdk/metadata';
 import {
-  type EnqueueJobsInput,
-  type EnqueueJobsResult,
+  type EnqueueJobInput,
+  type EnqueueJobResult,
 } from 'twenty-shared/application';
 
 export const enqueueJobs = async (
-  input: EnqueueJobsInput,
-): Promise<EnqueueJobsResult> => {
+  jobs: EnqueueJobInput[],
+): Promise<EnqueueJobResult[]> => {
   const client = new MetadataApiClient();
 
   const { enqueueJobs: result } = await client.mutation({
     enqueueJobs: {
-      __args: { input },
+      __args: { input: { jobs } },
       jobs: {
         enqueued: true,
         logicFunctionUniversalIdentifier: true,
@@ -19,5 +19,5 @@ export const enqueueJobs = async (
     },
   });
 
-  return result;
+  return result.jobs;
 };

--- a/packages/twenty-sdk/src/sdk/logic-function/jobs/enqueue-jobs.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/jobs/enqueue-jobs.ts
@@ -1,0 +1,23 @@
+import { MetadataApiClient } from 'twenty-client-sdk/metadata';
+import {
+  type EnqueueJobsInput,
+  type EnqueueJobsResult,
+} from 'twenty-shared/application';
+
+export const enqueueJobs = async (
+  input: EnqueueJobsInput,
+): Promise<EnqueueJobsResult> => {
+  const client = new MetadataApiClient();
+
+  const { enqueueJobs: result } = await client.mutation({
+    enqueueJobs: {
+      __args: { input },
+      jobs: {
+        enqueued: true,
+        logicFunctionUniversalIdentifier: true,
+      },
+    },
+  });
+
+  return result;
+};

--- a/packages/twenty-sdk/src/sdk/logic-function/jobs/enqueue-jobs.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/jobs/enqueue-jobs.ts
@@ -1,23 +1,22 @@
 import { MetadataApiClient } from 'twenty-client-sdk/metadata';
 import {
-  type EnqueueJobInput,
-  type EnqueueJobResult,
+  type EnqueueJobsInput,
+  type EnqueueJobsResult,
 } from 'twenty-shared/application';
 
 export const enqueueJobs = async (
-  jobs: EnqueueJobInput[],
-): Promise<EnqueueJobResult[]> => {
+  input: EnqueueJobsInput,
+): Promise<EnqueueJobsResult> => {
   const client = new MetadataApiClient();
 
   const { enqueueJobs: result } = await client.mutation({
     enqueueJobs: {
-      __args: { input: { jobs } },
-      jobs: {
-        enqueued: true,
-        logicFunctionUniversalIdentifier: true,
-      },
+      __args: { input },
+      enqueued: true,
+      logicFunctionUniversalIdentifier: true,
+      enqueuedJobsCount: true,
     },
   });
 
-  return result.jobs;
+  return result;
 };

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/application-job.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/application-job.resolver.ts
@@ -1,12 +1,17 @@
 import { UseFilters, UseGuards, UsePipes } from '@nestjs/common';
 import { Args, Mutation } from '@nestjs/graphql';
 
-import { type EnqueueJobResult } from 'twenty-shared/application';
+import {
+  type EnqueueJobResult,
+  type EnqueueJobsResult,
+} from 'twenty-shared/application';
 
 import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
 import { ApplicationExceptionFilter } from 'src/engine/core-modules/application/application-exception-filter';
 import { EnqueueJobResultDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job-result.dto';
 import { EnqueueJobInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job.input';
+import { EnqueueJobsResultDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-jobs-result.dto';
+import { EnqueueJobsInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input';
 import { ApplicationJobService } from 'src/engine/core-modules/application/application-job/services/application-job.service';
 import { type FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
 import { type AuthContextUser } from 'src/engine/core-modules/auth/types/auth-context.type';
@@ -26,7 +31,9 @@ import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 export class ApplicationJobResolver {
   constructor(private readonly applicationJobService: ApplicationJobService) {}
 
-  @Mutation(() => EnqueueJobResultDTO)
+  @Mutation(() => EnqueueJobResultDTO, {
+    deprecationReason: 'Use enqueueJobs instead.',
+  })
   async enqueueJob(
     @AuthApplication() application: FlatApplication,
     @AuthWorkspace() workspace: FlatWorkspace,
@@ -36,6 +43,24 @@ export class ApplicationJobResolver {
     @Args('input') input: EnqueueJobInputDTO,
   ): Promise<EnqueueJobResult> {
     return this.applicationJobService.enqueueJob({
+      applicationId: application.id,
+      workspaceId: workspace.id,
+      userId: user?.id ?? null,
+      userWorkspaceId: userWorkspaceId ?? null,
+      input,
+    });
+  }
+
+  @Mutation(() => EnqueueJobsResultDTO)
+  async enqueueJobs(
+    @AuthApplication() application: FlatApplication,
+    @AuthWorkspace() workspace: FlatWorkspace,
+    @AuthUser({ allowUndefined: true }) user: AuthContextUser | undefined,
+    @AuthUserWorkspaceId({ allowUndefined: true })
+    userWorkspaceId: string | undefined,
+    @Args('input') input: EnqueueJobsInputDTO,
+  ): Promise<EnqueueJobsResult> {
+    return this.applicationJobService.enqueueJobs({
       applicationId: application.id,
       workspaceId: workspace.id,
       userId: user?.id ?? null,

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/constants/enqueue-job.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/constants/enqueue-job.constant.ts
@@ -7,4 +7,4 @@ export const ENQUEUE_JOB_PRIORITY = 10;
 export const ENQUEUE_JOB_MIN_DELAY_MS = 0;
 export const ENQUEUE_JOB_MAX_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
 
-export const ENQUEUE_JOBS_MAX_BATCH_SIZE = 100;
+export const MAX_JOBS_PER_ENQUEUE = 10_000;

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/constants/enqueue-job.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/constants/enqueue-job.constant.ts
@@ -7,4 +7,4 @@ export const ENQUEUE_JOB_PRIORITY = 10;
 export const ENQUEUE_JOB_MIN_DELAY_MS = 0;
 export const ENQUEUE_JOB_MAX_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
 
-export const MAX_JOBS_PER_ENQUEUE = 10_000;
+export const MAX_JOBS_PER_ENQUEUE = 200;

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/constants/enqueue-job.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/constants/enqueue-job.constant.ts
@@ -6,3 +6,5 @@ export const ENQUEUE_JOB_PRIORITY = 10;
 
 export const ENQUEUE_JOB_MIN_DELAY_MS = 0;
 export const ENQUEUE_JOB_MAX_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const ENQUEUE_JOBS_MAX_BATCH_SIZE = 100;

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs-result.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs-result.dto.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+import { type EnqueueJobsResult } from 'twenty-shared/application';
+
+import { EnqueueJobResultDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job-result.dto';
+
+@ObjectType('EnqueueJobsResult')
+export class EnqueueJobsResultDTO implements EnqueueJobsResult {
+  @Field(() => [EnqueueJobResultDTO])
+  jobs: EnqueueJobResultDTO[];
+}

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs-result.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs-result.dto.ts
@@ -1,11 +1,15 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 
 import { type EnqueueJobsResult } from 'twenty-shared/application';
 
-import { EnqueueJobResultDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job-result.dto';
-
 @ObjectType('EnqueueJobsResult')
 export class EnqueueJobsResultDTO implements EnqueueJobsResult {
-  @Field(() => [EnqueueJobResultDTO])
-  jobs: EnqueueJobResultDTO[];
+  @Field()
+  enqueued: boolean;
+
+  @Field()
+  logicFunctionUniversalIdentifier: string;
+
+  @Field(() => Int)
+  enqueuedJobsCount: number;
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input.ts
@@ -1,0 +1,18 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+import { Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayMinSize, ValidateNested } from 'class-validator';
+import { type EnqueueJobsInput } from 'twenty-shared/application';
+
+import { ENQUEUE_JOBS_MAX_BATCH_SIZE } from 'src/engine/core-modules/application/application-job/constants/enqueue-job.constant';
+import { EnqueueJobInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job.input';
+
+@InputType('EnqueueJobsInput')
+export class EnqueueJobsInputDTO implements EnqueueJobsInput {
+  @ValidateNested({ each: true })
+  @Type(() => EnqueueJobInputDTO)
+  @ArrayMinSize(1)
+  @ArrayMaxSize(ENQUEUE_JOBS_MAX_BATCH_SIZE)
+  @Field(() => [EnqueueJobInputDTO])
+  jobs: EnqueueJobInputDTO[];
+}

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input.ts
@@ -1,18 +1,51 @@
-import { Field, InputType } from '@nestjs/graphql';
+import { Field, InputType, Int } from '@nestjs/graphql';
 
-import { Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayMinSize, ValidateNested } from 'class-validator';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+import GraphQLJSON from 'graphql-type-json';
 import { type EnqueueJobsInput } from 'twenty-shared/application';
 
-import { MAX_JOBS_PER_ENQUEUE } from 'src/engine/core-modules/application/application-job/constants/enqueue-job.constant';
-import { EnqueueJobInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job.input';
+import {
+  ENQUEUE_JOB_MAX_DELAY_MS,
+  ENQUEUE_JOB_MAX_RETRY_LIMIT,
+  ENQUEUE_JOB_MIN_DELAY_MS,
+  ENQUEUE_JOB_MIN_RETRY_LIMIT,
+  MAX_JOBS_PER_ENQUEUE,
+} from 'src/engine/core-modules/application/application-job/constants/enqueue-job.constant';
 
 @InputType('EnqueueJobsInput')
 export class EnqueueJobsInputDTO implements EnqueueJobsInput {
-  @ValidateNested({ each: true })
-  @Type(() => EnqueueJobInputDTO)
+  @IsUUID()
+  @IsNotEmpty()
+  @Field()
+  logicFunctionUniversalIdentifier: string;
+
+  @IsObject({ each: true })
   @ArrayMinSize(1)
   @ArrayMaxSize(MAX_JOBS_PER_ENQUEUE)
-  @Field(() => [EnqueueJobInputDTO])
-  jobs: EnqueueJobInputDTO[];
+  @Field(() => [GraphQLJSON])
+  payloads: Record<string, unknown>[];
+
+  @IsInt()
+  @Min(ENQUEUE_JOB_MIN_RETRY_LIMIT)
+  @Max(ENQUEUE_JOB_MAX_RETRY_LIMIT)
+  @IsOptional()
+  @Field(() => Int, { nullable: true })
+  retryLimit?: number;
+
+  @IsInt()
+  @Min(ENQUEUE_JOB_MIN_DELAY_MS)
+  @Max(ENQUEUE_JOB_MAX_DELAY_MS)
+  @IsOptional()
+  @Field(() => Int, { nullable: true })
+  delayMs?: number;
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input.ts
@@ -1,10 +1,9 @@
 import { Field, InputType } from '@nestjs/graphql';
 
 import { Type } from 'class-transformer';
-import { ArrayMaxSize, ArrayMinSize, ValidateNested } from 'class-validator';
+import { ArrayMinSize, ValidateNested } from 'class-validator';
 import { type EnqueueJobsInput } from 'twenty-shared/application';
 
-import { ENQUEUE_JOBS_MAX_BATCH_SIZE } from 'src/engine/core-modules/application/application-job/constants/enqueue-job.constant';
 import { EnqueueJobInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job.input';
 
 @InputType('EnqueueJobsInput')
@@ -12,7 +11,6 @@ export class EnqueueJobsInputDTO implements EnqueueJobsInput {
   @ValidateNested({ each: true })
   @Type(() => EnqueueJobInputDTO)
   @ArrayMinSize(1)
-  @ArrayMaxSize(ENQUEUE_JOBS_MAX_BATCH_SIZE)
   @Field(() => [EnqueueJobInputDTO])
   jobs: EnqueueJobInputDTO[];
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input.ts
@@ -1,9 +1,10 @@
 import { Field, InputType } from '@nestjs/graphql';
 
 import { Type } from 'class-transformer';
-import { ArrayMinSize, ValidateNested } from 'class-validator';
+import { ArrayMaxSize, ArrayMinSize, ValidateNested } from 'class-validator';
 import { type EnqueueJobsInput } from 'twenty-shared/application';
 
+import { MAX_JOBS_PER_ENQUEUE } from 'src/engine/core-modules/application/application-job/constants/enqueue-job.constant';
 import { EnqueueJobInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job.input';
 
 @InputType('EnqueueJobsInput')
@@ -11,6 +12,7 @@ export class EnqueueJobsInputDTO implements EnqueueJobsInput {
   @ValidateNested({ each: true })
   @Type(() => EnqueueJobInputDTO)
   @ArrayMinSize(1)
+  @ArrayMaxSize(MAX_JOBS_PER_ENQUEUE)
   @Field(() => [EnqueueJobInputDTO])
   jobs: EnqueueJobInputDTO[];
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@nestjs/common';
 
-import { type EnqueueJobResult } from 'twenty-shared/application';
+import {
+  type EnqueueJobResult,
+  type EnqueueJobsResult,
+} from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
 
 import {
@@ -8,6 +11,7 @@ import {
   ENQUEUE_JOB_PRIORITY,
 } from 'src/engine/core-modules/application/application-job/constants/enqueue-job.constant';
 import { type EnqueueJobInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job.input';
+import { type EnqueueJobsInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input';
 import {
   ApplicationException,
   ApplicationExceptionCode,
@@ -44,46 +48,83 @@ export class ApplicationJobService {
     userWorkspaceId: string | null;
     input: EnqueueJobInputDTO;
   }): Promise<EnqueueJobResult> {
-    const { logicFunctionUniversalIdentifier } = input;
+    const { jobs } = await this.enqueueJobs({
+      applicationId,
+      workspaceId,
+      userId,
+      userWorkspaceId,
+      input: { jobs: [input] },
+    });
 
+    return jobs[0];
+  }
+
+  async enqueueJobs({
+    applicationId,
+    workspaceId,
+    userId,
+    userWorkspaceId,
+    input,
+  }: {
+    applicationId: string;
+    workspaceId: string;
+    userId: string | null;
+    userWorkspaceId: string | null;
+    input: EnqueueJobsInputDTO;
+  }): Promise<EnqueueJobsResult> {
     const { flatLogicFunctionMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
         'flatLogicFunctionMaps',
       ]);
 
-    const flatLogicFunction = findFlatEntityByUniversalIdentifier({
-      flatEntityMaps: flatLogicFunctionMaps,
-      universalIdentifier: logicFunctionUniversalIdentifier,
+    // Resolve every job before enqueuing any, so an invalid job in the batch
+    // does not leave a partially enqueued batch behind.
+    const jobsToEnqueue = input.jobs.map((job) => {
+      const { logicFunctionUniversalIdentifier } = job;
+
+      const flatLogicFunction = findFlatEntityByUniversalIdentifier({
+        flatEntityMaps: flatLogicFunctionMaps,
+        universalIdentifier: logicFunctionUniversalIdentifier,
+      });
+
+      if (
+        !isDefined(flatLogicFunction) ||
+        isDefined(flatLogicFunction.deletedAt) ||
+        flatLogicFunction.applicationId !== applicationId
+      ) {
+        throw new ApplicationException(
+          `Logic function ${logicFunctionUniversalIdentifier} not found in this application`,
+          ApplicationExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
+        );
+      }
+
+      return { job, logicFunctionId: flatLogicFunction.id };
     });
 
-    if (
-      !isDefined(flatLogicFunction) ||
-      isDefined(flatLogicFunction.deletedAt) ||
-      flatLogicFunction.applicationId !== applicationId
-    ) {
-      throw new ApplicationException(
-        `Logic function ${logicFunctionUniversalIdentifier} not found in this application`,
-        ApplicationExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
+    for (const { job, logicFunctionId } of jobsToEnqueue) {
+      await this.messageQueueService.add<LogicFunctionTriggerJobData>(
+        LogicFunctionTriggerJob.name,
+        {
+          logicFunctionId,
+          workspaceId,
+          payload: job.payload ?? {},
+          ...(isDefined(userId) ? { userId } : {}),
+          ...(isDefined(userWorkspaceId) ? { userWorkspaceId } : {}),
+        },
+        {
+          retryLimit: job.retryLimit ?? ENQUEUE_JOB_DEFAULT_RETRY_LIMIT,
+          backoff: LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF,
+          priority: ENQUEUE_JOB_PRIORITY,
+          ...(isDefined(job.delayMs) ? { delay: job.delayMs } : {}),
+        },
       );
     }
 
-    await this.messageQueueService.add<LogicFunctionTriggerJobData>(
-      LogicFunctionTriggerJob.name,
-      {
-        logicFunctionId: flatLogicFunction.id,
-        workspaceId,
-        payload: input.payload ?? {},
-        ...(isDefined(userId) ? { userId } : {}),
-        ...(isDefined(userWorkspaceId) ? { userWorkspaceId } : {}),
-      },
-      {
-        retryLimit: input.retryLimit ?? ENQUEUE_JOB_DEFAULT_RETRY_LIMIT,
-        backoff: LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF,
-        priority: ENQUEUE_JOB_PRIORITY,
-        ...(isDefined(input.delayMs) ? { delay: input.delayMs } : {}),
-      },
-    );
-
-    return { enqueued: true, logicFunctionUniversalIdentifier };
+    return {
+      jobs: jobsToEnqueue.map(({ job }) => ({
+        enqueued: true,
+        logicFunctionUniversalIdentifier: job.logicFunctionUniversalIdentifier,
+      })),
+    };
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
@@ -21,7 +21,6 @@ import {
   type LogicFunctionTriggerJobData,
 } from 'src/engine/core-modules/logic-function/logic-function-trigger/jobs/logic-function-trigger.job';
 import { LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF } from 'src/engine/core-modules/logic-function/logic-function-trigger/constants/logic-function-queue-retry-backoff.constant';
-import { type QueueJobOptions } from 'src/engine/core-modules/message-queue/drivers/interfaces/job-options.interface';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
@@ -49,21 +48,22 @@ export class ApplicationJobService {
     userWorkspaceId: string | null;
     input: EnqueueJobInputDTO;
   }): Promise<EnqueueJobResult> {
-    const { jobs } = await this.enqueueJobs({
-      applicationId,
-      workspaceId,
-      userId,
-      userWorkspaceId,
-      input: { jobs: [input] },
-    });
+    const { enqueued, logicFunctionUniversalIdentifier } =
+      await this.enqueueJobs({
+        applicationId,
+        workspaceId,
+        userId,
+        userWorkspaceId,
+        input: {
+          logicFunctionUniversalIdentifier:
+            input.logicFunctionUniversalIdentifier,
+          payloads: [input.payload ?? {}],
+          retryLimit: input.retryLimit,
+          delayMs: input.delayMs,
+        },
+      });
 
-    if (jobs.length !== 1) {
-      throw new Error(
-        `Expected exactly one enqueued job result, got ${jobs.length}`,
-      );
-    }
-
-    return jobs[0];
+    return { enqueued, logicFunctionUniversalIdentifier };
   }
 
   async enqueueJobs({
@@ -79,79 +79,50 @@ export class ApplicationJobService {
     userWorkspaceId: string | null;
     input: EnqueueJobsInputDTO;
   }): Promise<EnqueueJobsResult> {
+    const { logicFunctionUniversalIdentifier } = input;
+
     const { flatLogicFunctionMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
         'flatLogicFunctionMaps',
       ]);
 
-    // Resolve every job before enqueuing any, so an invalid job in the batch
-    // does not leave a partially enqueued batch behind.
-    const jobsToEnqueue = input.jobs.map((job) => {
-      const { logicFunctionUniversalIdentifier } = job;
-
-      const flatLogicFunction = findFlatEntityByUniversalIdentifier({
-        flatEntityMaps: flatLogicFunctionMaps,
-        universalIdentifier: logicFunctionUniversalIdentifier,
-      });
-
-      if (
-        !isDefined(flatLogicFunction) ||
-        isDefined(flatLogicFunction.deletedAt) ||
-        flatLogicFunction.applicationId !== applicationId
-      ) {
-        throw new ApplicationException(
-          `Logic function ${logicFunctionUniversalIdentifier} not found in this application`,
-          ApplicationExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
-        );
-      }
-
-      return { job, logicFunctionId: flatLogicFunction.id };
+    const flatLogicFunction = findFlatEntityByUniversalIdentifier({
+      flatEntityMaps: flatLogicFunctionMaps,
+      universalIdentifier: logicFunctionUniversalIdentifier,
     });
 
-    // bulkAdd applies one options object to every job, so jobs sharing the
-    // same queue options are batched together and enqueued per group.
-    const jobGroupsByOptions = new Map<
-      string,
-      { options: QueueJobOptions; dataItems: LogicFunctionTriggerJobData[] }
-    >();
-
-    for (const { job, logicFunctionId } of jobsToEnqueue) {
-      const options: QueueJobOptions = {
-        retryLimit: job.retryLimit ?? ENQUEUE_JOB_DEFAULT_RETRY_LIMIT,
-        backoff: LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF,
-        priority: ENQUEUE_JOB_PRIORITY,
-        ...(isDefined(job.delayMs) ? { delay: job.delayMs } : {}),
-      };
-      const optionsKey = `${options.retryLimit}:${options.delay ?? 0}`;
-
-      const jobGroup = jobGroupsByOptions.get(optionsKey) ?? {
-        options,
-        dataItems: [],
-      };
-
-      jobGroup.dataItems.push({
-        logicFunctionId,
-        workspaceId,
-        payload: job.payload ?? {},
-        ...(isDefined(userId) ? { userId } : {}),
-        ...(isDefined(userWorkspaceId) ? { userWorkspaceId } : {}),
-      });
-      jobGroupsByOptions.set(optionsKey, jobGroup);
-    }
-
-    for (const { options, dataItems } of jobGroupsByOptions.values()) {
-      await this.messageQueueService.bulkAdd<LogicFunctionTriggerJobData>(
-        LogicFunctionTriggerJob.name,
-        dataItems,
-        options,
+    if (
+      !isDefined(flatLogicFunction) ||
+      isDefined(flatLogicFunction.deletedAt) ||
+      flatLogicFunction.applicationId !== applicationId
+    ) {
+      throw new ApplicationException(
+        `Logic function ${logicFunctionUniversalIdentifier} not found in this application`,
+        ApplicationExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
       );
     }
 
-    return {
-      jobs: jobsToEnqueue.map(({ job }) => ({
-        enqueued: true,
-        logicFunctionUniversalIdentifier: job.logicFunctionUniversalIdentifier,
+    await this.messageQueueService.bulkAdd<LogicFunctionTriggerJobData>(
+      LogicFunctionTriggerJob.name,
+      input.payloads.map((payload) => ({
+        logicFunctionId: flatLogicFunction.id,
+        workspaceId,
+        payload,
+        ...(isDefined(userId) ? { userId } : {}),
+        ...(isDefined(userWorkspaceId) ? { userWorkspaceId } : {}),
       })),
+      {
+        retryLimit: input.retryLimit ?? ENQUEUE_JOB_DEFAULT_RETRY_LIMIT,
+        backoff: LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF,
+        priority: ENQUEUE_JOB_PRIORITY,
+        ...(isDefined(input.delayMs) ? { delay: input.delayMs } : {}),
+      },
+    );
+
+    return {
+      enqueued: true,
+      logicFunctionUniversalIdentifier,
+      enqueuedJobsCount: input.payloads.length,
     };
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
@@ -9,7 +9,6 @@ import { isDefined } from 'twenty-shared/utils';
 import {
   ENQUEUE_JOB_DEFAULT_RETRY_LIMIT,
   ENQUEUE_JOB_PRIORITY,
-  MAX_JOBS_PER_ENQUEUE,
 } from 'src/engine/core-modules/application/application-job/constants/enqueue-job.constant';
 import { type EnqueueJobInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job.input';
 import { type EnqueueJobsInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input';
@@ -74,13 +73,6 @@ export class ApplicationJobService {
     userWorkspaceId: string | null;
     input: EnqueueJobsInputDTO;
   }): Promise<EnqueueJobsResult> {
-    if (input.jobs.length > MAX_JOBS_PER_ENQUEUE) {
-      throw new ApplicationException(
-        `Cannot enqueue more than ${MAX_JOBS_PER_ENQUEUE} jobs at once`,
-        ApplicationExceptionCode.INVALID_INPUT,
-      );
-    }
-
     const { flatLogicFunctionMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
         'flatLogicFunctionMaps',

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
@@ -57,6 +57,12 @@ export class ApplicationJobService {
       input: { jobs: [input] },
     });
 
+    if (jobs.length !== 1) {
+      throw new Error(
+        `Expected exactly one enqueued job result, got ${jobs.length}`,
+      );
+    }
+
     return jobs[0];
   }
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-job/services/application-job.service.ts
@@ -9,6 +9,7 @@ import { isDefined } from 'twenty-shared/utils';
 import {
   ENQUEUE_JOB_DEFAULT_RETRY_LIMIT,
   ENQUEUE_JOB_PRIORITY,
+  MAX_JOBS_PER_ENQUEUE,
 } from 'src/engine/core-modules/application/application-job/constants/enqueue-job.constant';
 import { type EnqueueJobInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-job.input';
 import { type EnqueueJobsInputDTO } from 'src/engine/core-modules/application/application-job/dtos/enqueue-jobs.input';
@@ -21,6 +22,7 @@ import {
   type LogicFunctionTriggerJobData,
 } from 'src/engine/core-modules/logic-function/logic-function-trigger/jobs/logic-function-trigger.job';
 import { LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF } from 'src/engine/core-modules/logic-function/logic-function-trigger/constants/logic-function-queue-retry-backoff.constant';
+import { type QueueJobOptions } from 'src/engine/core-modules/message-queue/drivers/interfaces/job-options.interface';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
@@ -72,6 +74,13 @@ export class ApplicationJobService {
     userWorkspaceId: string | null;
     input: EnqueueJobsInputDTO;
   }): Promise<EnqueueJobsResult> {
+    if (input.jobs.length > MAX_JOBS_PER_ENQUEUE) {
+      throw new ApplicationException(
+        `Cannot enqueue more than ${MAX_JOBS_PER_ENQUEUE} jobs at once`,
+        ApplicationExceptionCode.INVALID_INPUT,
+      );
+    }
+
     const { flatLogicFunctionMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
         'flatLogicFunctionMaps',
@@ -101,22 +110,42 @@ export class ApplicationJobService {
       return { job, logicFunctionId: flatLogicFunction.id };
     });
 
+    // bulkAdd applies one options object to every job, so jobs sharing the
+    // same queue options are batched together and enqueued per group.
+    const jobGroupsByOptions = new Map<
+      string,
+      { options: QueueJobOptions; dataItems: LogicFunctionTriggerJobData[] }
+    >();
+
     for (const { job, logicFunctionId } of jobsToEnqueue) {
-      await this.messageQueueService.add<LogicFunctionTriggerJobData>(
+      const options: QueueJobOptions = {
+        retryLimit: job.retryLimit ?? ENQUEUE_JOB_DEFAULT_RETRY_LIMIT,
+        backoff: LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF,
+        priority: ENQUEUE_JOB_PRIORITY,
+        ...(isDefined(job.delayMs) ? { delay: job.delayMs } : {}),
+      };
+      const optionsKey = `${options.retryLimit}:${options.delay ?? 0}`;
+
+      const jobGroup = jobGroupsByOptions.get(optionsKey) ?? {
+        options,
+        dataItems: [],
+      };
+
+      jobGroup.dataItems.push({
+        logicFunctionId,
+        workspaceId,
+        payload: job.payload ?? {},
+        ...(isDefined(userId) ? { userId } : {}),
+        ...(isDefined(userWorkspaceId) ? { userWorkspaceId } : {}),
+      });
+      jobGroupsByOptions.set(optionsKey, jobGroup);
+    }
+
+    for (const { options, dataItems } of jobGroupsByOptions.values()) {
+      await this.messageQueueService.bulkAdd<LogicFunctionTriggerJobData>(
         LogicFunctionTriggerJob.name,
-        {
-          logicFunctionId,
-          workspaceId,
-          payload: job.payload ?? {},
-          ...(isDefined(userId) ? { userId } : {}),
-          ...(isDefined(userWorkspaceId) ? { userWorkspaceId } : {}),
-        },
-        {
-          retryLimit: job.retryLimit ?? ENQUEUE_JOB_DEFAULT_RETRY_LIMIT,
-          backoff: LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF,
-          priority: ENQUEUE_JOB_PRIORITY,
-          ...(isDefined(job.delayMs) ? { delay: job.delayMs } : {}),
-        },
+        dataItems,
+        options,
       );
     }
 

--- a/packages/twenty-server/test/integration/metadata/suites/application/enqueue-job.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/enqueue-job.integration-spec.ts
@@ -69,6 +69,17 @@ const ENQUEUE_JOB = gql`
   }
 `;
 
+const ENQUEUE_JOBS = gql`
+  mutation EnqueueJobs($input: EnqueueJobsInput!) {
+    enqueueJobs(input: $input) {
+      jobs {
+        enqueued
+        logicFunctionUniversalIdentifier
+      }
+    }
+  }
+`;
+
 describe('enqueueJob (e2e)', () => {
   let customApplicationToken: string;
   let standardApplicationToken: string;
@@ -316,6 +327,77 @@ describe('enqueueJob (e2e)', () => {
 
     expect(response.body.errors).toBeDefined();
     expect(response.body.errors[0].message).toContain('not found');
+  });
+
+  it('enqueues a batch of jobs in a single call and the worker runs them all', async () => {
+    const markerPaths = [
+      join(MARKER_DIRECTORY, 'batch-0.txt'),
+      join(MARKER_DIRECTORY, 'batch-1.txt'),
+    ];
+
+    const response = await makeMetadataAPIRequest(
+      {
+        query: ENQUEUE_JOBS,
+        variables: {
+          input: {
+            jobs: markerPaths.map((markerPath) => ({
+              logicFunctionUniversalIdentifier,
+              payload: { markerPath },
+            })),
+          },
+        },
+      },
+      customApplicationToken,
+    );
+
+    expect(response.body.errors).toBeUndefined();
+    expect(response.body.data.enqueueJobs).toEqual({
+      jobs: markerPaths.map(() => ({
+        enqueued: true,
+        logicFunctionUniversalIdentifier,
+      })),
+    });
+
+    await waitForAllJobsToFinish();
+
+    await expectEventually(() => {
+      for (const markerPath of markerPaths) {
+        expect(existsSync(markerPath)).toBe(true);
+      }
+    });
+  });
+
+  it('rejects the whole batch when one job targets an unknown logic function', async () => {
+    const response = await makeMetadataAPIRequest(
+      {
+        query: ENQUEUE_JOBS,
+        variables: {
+          input: {
+            jobs: [
+              { logicFunctionUniversalIdentifier },
+              { logicFunctionUniversalIdentifier: uuidv4() },
+            ],
+          },
+        },
+      },
+      customApplicationToken,
+    );
+
+    expect(response.body.errors).toBeDefined();
+    expect(response.body.errors[0].message).toContain('not found');
+  });
+
+  it('rejects an empty batch', async () => {
+    const response = await makeMetadataAPIRequest(
+      {
+        query: ENQUEUE_JOBS,
+        variables: { input: { jobs: [] } },
+      },
+      customApplicationToken,
+    );
+
+    expect(response.body.errors).toBeDefined();
+    expect(response.body.errors[0].message).toContain('jobs');
   });
 
   it('rejects job options outside of their allowed range', async () => {

--- a/packages/twenty-server/test/integration/metadata/suites/application/enqueue-job.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/enqueue-job.integration-spec.ts
@@ -72,10 +72,9 @@ const ENQUEUE_JOB = gql`
 const ENQUEUE_JOBS = gql`
   mutation EnqueueJobs($input: EnqueueJobsInput!) {
     enqueueJobs(input: $input) {
-      jobs {
-        enqueued
-        logicFunctionUniversalIdentifier
-      }
+      enqueued
+      logicFunctionUniversalIdentifier
+      enqueuedJobsCount
     }
   }
 `;
@@ -329,7 +328,7 @@ describe('enqueueJob (e2e)', () => {
     expect(response.body.errors[0].message).toContain('not found');
   });
 
-  it('enqueues a batch of jobs in a single call and the worker runs them all', async () => {
+  it('enqueues a batch of payloads in a single call and the worker runs them all', async () => {
     const markerPaths = [
       join(MARKER_DIRECTORY, 'batch-0.txt'),
       join(MARKER_DIRECTORY, 'batch-1.txt'),
@@ -340,10 +339,8 @@ describe('enqueueJob (e2e)', () => {
         query: ENQUEUE_JOBS,
         variables: {
           input: {
-            jobs: markerPaths.map((markerPath) => ({
-              logicFunctionUniversalIdentifier,
-              payload: { markerPath },
-            })),
+            logicFunctionUniversalIdentifier,
+            payloads: markerPaths.map((markerPath) => ({ markerPath })),
           },
         },
       },
@@ -352,10 +349,9 @@ describe('enqueueJob (e2e)', () => {
 
     expect(response.body.errors).toBeUndefined();
     expect(response.body.data.enqueueJobs).toEqual({
-      jobs: markerPaths.map(() => ({
-        enqueued: true,
-        logicFunctionUniversalIdentifier,
-      })),
+      enqueued: true,
+      logicFunctionUniversalIdentifier,
+      enqueuedJobsCount: markerPaths.length,
     });
 
     await waitForAllJobsToFinish();
@@ -367,16 +363,14 @@ describe('enqueueJob (e2e)', () => {
     });
   });
 
-  it('rejects the whole batch when one job targets an unknown logic function', async () => {
+  it('rejects a batch targeting an unknown logic function', async () => {
     const response = await makeMetadataAPIRequest(
       {
         query: ENQUEUE_JOBS,
         variables: {
           input: {
-            jobs: [
-              { logicFunctionUniversalIdentifier },
-              { logicFunctionUniversalIdentifier: uuidv4() },
-            ],
+            logicFunctionUniversalIdentifier: uuidv4(),
+            payloads: [{}],
           },
         },
       },
@@ -391,13 +385,15 @@ describe('enqueueJob (e2e)', () => {
     const response = await makeMetadataAPIRequest(
       {
         query: ENQUEUE_JOBS,
-        variables: { input: { jobs: [] } },
+        variables: {
+          input: { logicFunctionUniversalIdentifier, payloads: [] },
+        },
       },
       customApplicationToken,
     );
 
     expect(response.body.errors).toBeDefined();
-    expect(response.body.errors[0].message).toContain('jobs');
+    expect(response.body.errors[0].message).toContain('payloads');
   });
 
   it('rejects job options outside of their allowed range', async () => {

--- a/packages/twenty-shared/src/application/enqueueJobType.ts
+++ b/packages/twenty-shared/src/application/enqueueJobType.ts
@@ -13,10 +13,13 @@ export type EnqueueJobResult = {
   logicFunctionUniversalIdentifier: string;
 };
 
-export type EnqueueJobsInput = {
-  jobs: EnqueueJobInput[];
+export type EnqueueJobsInput = EnqueueJobOptions & {
+  logicFunctionUniversalIdentifier: string;
+  payloads: Record<string, unknown>[];
 };
 
 export type EnqueueJobsResult = {
-  jobs: EnqueueJobResult[];
+  enqueued: boolean;
+  logicFunctionUniversalIdentifier: string;
+  enqueuedJobsCount: number;
 };

--- a/packages/twenty-shared/src/application/enqueueJobType.ts
+++ b/packages/twenty-shared/src/application/enqueueJobType.ts
@@ -12,3 +12,11 @@ export type EnqueueJobResult = {
   enqueued: boolean;
   logicFunctionUniversalIdentifier: string;
 };
+
+export type EnqueueJobsInput = {
+  jobs: EnqueueJobInput[];
+};
+
+export type EnqueueJobsResult = {
+  jobs: EnqueueJobResult[];
+};

--- a/packages/twenty-shared/src/application/index.ts
+++ b/packages/twenty-shared/src/application/index.ts
@@ -96,6 +96,8 @@ export type {
   EnqueueJobOptions,
   EnqueueJobInput,
   EnqueueJobResult,
+  EnqueueJobsInput,
+  EnqueueJobsResult,
 } from './enqueueJobType';
 export { SyncableEntity } from './enums/syncable-entities.enum';
 export type {


### PR DESCRIPTION
## What

Deprecates `enqueueJob` and replaces it with `enqueueJobs`, which enqueues one run per payload of a single logic function in a single call.

## Changes

**twenty-server**
- New `enqueueJobs` mutation taking `EnqueueJobsInput { logicFunctionUniversalIdentifier, payloads: [JSON!]!, retryLimit, delayMs }` (1 to 200 payloads per batch, options apply to the whole batch) and returning `EnqueueJobsResult { enqueued, logicFunctionUniversalIdentifier, enqueuedJobsCount }`.
- The target function is resolved and validated before anything is enqueued; the whole batch goes through a single `messageQueueService.bulkAdd` call.
- `enqueueJob` is marked `@deprecated` in the schema and now delegates to `enqueueJobs` internally with a one-element `payloads` list.

**twenty-sdk**
- New `enqueueJobs` helper exported from `twenty-sdk/logic-function`; `enqueueJob` is marked `@deprecated`.
- Changelog entry under Unreleased.

**twenty-shared**
- New `EnqueueJobsInput` / `EnqueueJobsResult` types.

**Generated**
- `twenty-client-sdk` metadata client and `twenty-front` generated-metadata types regenerated against a running server.

**Docs**
- `background-jobs.mdx` rewritten around `enqueueJobs`, with a note pointing `enqueueJob` users at the replacement.

## Tests

- Unit specs for the new SDK helper (mutation shape, auth header, GraphQL error surfacing).
- Integration specs: a batch of payloads runs through the worker, unknown-function rejection, empty batch rejection.

## Notes

- Public apps (`last-contact`, `fireflies`) still call the deprecated `enqueueJob`; migrating them to batched calls is left as a follow-up since it touches app versioning/changelogs. Note their per-job `delayMs` staggering maps to one `enqueueJobs` call per delay step under the batch-level options.

<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24691?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>