### PR TITLE
Fix website marketplace queries after logo -> logoUrl schema rename

### DIFF
--- a/packages/twenty-website/src/apps-marketplace/fetch-marketplace-app-detail.ts
+++ b/packages/twenty-website/src/apps-marketplace/fetch-marketplace-app-detail.ts
@@ -14,10 +14,10 @@ const FIND_MARKETPLACE_APP_DETAIL_QUERY = `
       description
       author
       category
-      logo
+      logoUrl
       websiteUrl
       aboutDescription
-      screenshots
+      galleryImages
     }
   }
 `;
@@ -31,10 +31,10 @@ type ApiMarketplaceAppDetail = {
   description?: string | null;
   author?: string | null;
   category?: string | null;
-  logo?: string | null;
+  logoUrl?: string | null;
   websiteUrl?: string | null;
   aboutDescription?: string | null;
-  screenshots?: string[] | null;
+  galleryImages?: string[] | null;
 };
 
 type FindMarketplaceAppDetailData = {
@@ -69,11 +69,11 @@ export async function fetchMarketplaceAppDetailBySlug(
       tagline: app.tagline,
       author: detail.author ?? app.author,
       category: detail.category ?? app.category,
-      logoUrl: detail.logo ?? app.logoUrl,
+      logoUrl: detail.logoUrl ?? app.logoUrl,
       sourcePackage: detail.sourcePackage ?? undefined,
       isVetted: detail.isVetted,
       description: detail.aboutDescription ?? detail.description ?? app.tagline,
-      screenshots: detail.screenshots ?? [],
+      screenshots: detail.galleryImages ?? [],
       websiteUrl: detail.websiteUrl ?? undefined,
       latestAvailableVersion: detail.latestAvailableVersion ?? undefined,
     };

--- a/packages/twenty-website/src/apps-marketplace/fetch-marketplace-apps.ts
+++ b/packages/twenty-website/src/apps-marketplace/fetch-marketplace-apps.ts
@@ -10,7 +10,7 @@ const FIND_MANY_MARKETPLACE_APPS_QUERY = `
       description
       author
       category
-      logo
+      logoUrl
       sourcePackage
       isVetted
     }
@@ -23,7 +23,7 @@ type ApiMarketplaceApp = {
   description: string;
   author: string;
   category: string;
-  logo?: string | null;
+  logoUrl?: string | null;
   sourcePackage?: string | null;
   isVetted: boolean;
 };
@@ -39,7 +39,7 @@ const normalizeApp = (apiApp: ApiMarketplaceApp): MarketplaceApp => ({
   tagline: apiApp.description,
   author: apiApp.author,
   category: apiApp.category,
-  logoUrl: apiApp.logo ?? undefined,
+  logoUrl: apiApp.logoUrl ?? undefined,
   sourcePackage: apiApp.sourcePackage ?? undefined,
   isVetted: apiApp.isVetted,
 });


### PR DESCRIPTION
## Context

https://twenty.com/apps was broken: the apps grid rendered empty and every `/apps/[slug]` detail page returned a 404, even though `packages/twenty-website/src/app/[locale]/(site)/apps/[slug]/page.tsx` hadn't changed.

The root cause is a server-side schema change: the public marketplace API renamed `logo` to `logoUrl` on both `MarketplaceApp` and `MarketplaceAppDetail`, and replaced `screenshots` with `galleryImages` on the detail type. The website's GraphQL queries still requested the old field names, so the live API rejects them with `Cannot query field "logo" on type "MarketplaceApp"`. `fetchMarketplaceApps` swallows the error and returns `[]`, which empties the grid and makes `fetchMarketplaceAppDetailBySlug` return `null` for every slug, so the page calls `notFound()`.

## What this PR does

- `fetch-marketplace-apps.ts`: query `logoUrl` instead of `logo` and map it accordingly.
- `fetch-marketplace-app-detail.ts`: query `logoUrl` instead of `logo` and `galleryImages` instead of the deprecated `screenshots`.

Both corrected queries were verified against the live `https://api.twenty.com/metadata` endpoint and return full data. Typecheck and lint pass for `twenty-website`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XS6BeS4qUfpU3DuKi12v5)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

