### PR TITLE
fix(front): show loading and error states for video attachment previews (#24453)

### DIFF
--- a/packages/twenty-front/.storybook/preview.tsx
+++ b/packages/twenty-front/.storybook/preview.tsx
@@ -44,7 +44,7 @@ import { mockedUserJWT } from '~/testing/mock-data/jwt';
 import { ClickOutsideListenerContext } from '../src/modules/ui/utilities/pointer-event/contexts/ClickOutsideListenerContext';
 
 const MOCK_IMAGE_SVG =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192"><rect width="192" height="192" fill="#d9d9d9"/></svg>';
+  '<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192"><rect width="192" height="192" fill="currentColor"/></svg>';
 
 const respondWithMockImage = () =>
   new HttpResponse(MOCK_IMAGE_SVG, {

--- a/packages/twenty-front/src/modules/activities/files/components/AttachmentList.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/AttachmentList.tsx
@@ -1,5 +1,4 @@
 import { styled } from '@linaria/react';
-import { t } from '@lingui/core/macro';
 import { lazy, Suspense, useState } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -23,6 +22,7 @@ import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFla
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { isDefined } from 'twenty-shared/utils';
+import { Loader } from 'twenty-ui/feedback';
 import { IconDownload, IconX } from 'twenty-ui/icon';
 import { IconButton } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
@@ -65,12 +65,6 @@ const StyledLoadingContainer = styled.div`
   height: calc(80vh / var(--t-zoom, 1));
   justify-content: center;
   width: 100%;
-`;
-
-const StyledLoadingText = styled.div`
-  color: ${themeCssVariables.font.color.secondary};
-  font-size: ${themeCssVariables.font.size.lg};
-  font-weight: ${themeCssVariables.font.weight.medium};
 `;
 
 const StyledHeader = styled.div`
@@ -211,9 +205,7 @@ export const AttachmentList = ({
                 <Suspense
                   fallback={
                     <StyledLoadingContainer>
-                      <StyledLoadingText>
-                        {t`Loading document viewer...`}
-                      </StyledLoadingText>
+                      <Loader />
                     </StyledLoadingContainer>
                   }
                 >

--- a/packages/twenty-front/src/modules/activities/files/components/DocumentViewer.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/DocumentViewer.tsx
@@ -11,6 +11,7 @@ import { styled } from '@linaria/react';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { useContext, useEffect, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
+import { Loader } from 'twenty-ui/feedback';
 import { IconDownload } from 'twenty-ui/icon';
 import { Button } from 'twenty-ui/input';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
@@ -55,6 +56,30 @@ const StyledDocumentViewerContainer = styled.div`
     overflow: auto;
     width: 100%;
   }
+`;
+
+const StyledVideoContainer = styled.div`
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+`;
+
+const StyledVideoLoadingContainer = styled.div`
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+`;
+
+const StyledVideo = styled.video`
+  max-height: 100%;
+  max-width: 100%;
+  outline: none;
 `;
 
 const StyledUnavailablePreviewContainer = styled.div`
@@ -207,6 +232,8 @@ export const DocumentViewer = ({
   const [csvPreview, setCsvPreview] = useState<CsvPreviewData | undefined>(
     undefined,
   );
+  const [isVideoLoading, setIsVideoLoading] = useState(true);
+  const [hasVideoError, setHasVideoError] = useState(false);
 
   const { extension } = getFileNameAndExtension(documentName);
   const fileExtension = isDefined(documentExtension)
@@ -224,7 +251,14 @@ export const DocumentViewer = ({
     }
   }, [documentUrl, fileExtension]);
 
-  if (!isPreviewable) {
+  useEffect(() => {
+    if (fileExtension === 'mp4') {
+      setIsVideoLoading(true);
+      setHasVideoError(false);
+    }
+  }, [documentUrl, fileExtension]);
+
+  if (!isPreviewable || hasVideoError) {
     return (
       <StyledDocumentViewerContainer>
         <StyledUnavailablePreviewContainer>
@@ -283,6 +317,31 @@ export const DocumentViewer = ({
             ))}
           </tbody>
         </StyledCsvTable>
+      </StyledDocumentViewerContainer>
+    );
+  }
+
+  if (fileExtension === 'mp4') {
+    return (
+      <StyledDocumentViewerContainer>
+        <StyledVideoContainer>
+          {isVideoLoading && (
+            <StyledVideoLoadingContainer>
+              <Loader />
+            </StyledVideoLoadingContainer>
+          )}
+          <StyledVideo
+            controls
+            src={documentUrl}
+            onCanPlay={() => setIsVideoLoading(false)}
+            onLoadedData={() => setIsVideoLoading(false)}
+            onError={() => {
+              setIsVideoLoading(false);
+              setHasVideoError(true);
+            }}
+            style={{ visibility: isVideoLoading ? 'hidden' : 'visible' }}
+          />
+        </StyledVideoContainer>
       </StyledDocumentViewerContainer>
     );
   }

--- a/packages/twenty-front/src/modules/activities/files/components/__tests__/DocumentViewer.test.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/__tests__/DocumentViewer.test.tsx
@@ -1,0 +1,111 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { DocumentViewer } from '@/activities/files/components/DocumentViewer';
+
+jest.mock('@cyntler/react-doc-viewer', () => () => (
+  <div data-testid="doc-viewer" />
+));
+
+jest.mock('@/activities/files/utils/downloadFile', () => ({
+  downloadFile: jest.fn(),
+}));
+
+const renderWithI18n = (node: ReactNode) =>
+  render(<I18nProvider i18n={i18n}>{node}</I18nProvider>);
+
+describe('DocumentViewer', () => {
+  beforeAll(() => {
+    i18n.load('en', {});
+    i18n.activate('en');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('video preview', () => {
+    it('renders loader initially while video is downloading/loading', () => {
+      const { container } = renderWithI18n(
+        <DocumentViewer
+          documentName="test-video.mp4"
+          documentUrl="https://example.com/test-video.mp4"
+        />,
+      );
+
+      const videoElement = container.querySelector('video');
+      expect(videoElement).toBeInTheDocument();
+      expect(videoElement).toHaveAttribute(
+        'src',
+        'https://example.com/test-video.mp4',
+      );
+      expect(videoElement).toHaveStyle({ visibility: 'hidden' });
+    });
+
+    it('hides loader and shows video when video can play', () => {
+      const { container } = renderWithI18n(
+        <DocumentViewer
+          documentName="test-video.mp4"
+          documentUrl="https://example.com/test-video.mp4"
+        />,
+      );
+
+      const videoElement = container.querySelector('video');
+      expect(videoElement).toBeInTheDocument();
+
+      fireEvent.canPlay(videoElement!);
+
+      expect(videoElement).toHaveStyle({ visibility: 'visible' });
+    });
+
+    it('hides loader and shows video when loadeddata event fires', () => {
+      const { container } = renderWithI18n(
+        <DocumentViewer
+          documentName="test-video.mp4"
+          documentUrl="https://example.com/test-video.mp4"
+        />,
+      );
+
+      const videoElement = container.querySelector('video');
+      expect(videoElement).toBeInTheDocument();
+
+      fireEvent.loadedData(videoElement!);
+
+      expect(videoElement).toHaveStyle({ visibility: 'visible' });
+    });
+
+    it('transitions to "Preview Not Available" fallback when video errors', () => {
+      const { container } = renderWithI18n(
+        <DocumentViewer
+          documentName="test-video.mp4"
+          documentUrl="https://example.com/test-video.mp4"
+        />,
+      );
+
+      const videoElement = container.querySelector('video');
+      expect(videoElement).toBeInTheDocument();
+
+      fireEvent.error(videoElement!);
+
+      expect(container.querySelector('video')).not.toBeInTheDocument();
+      expect(screen.getByText('Preview Not Available')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Download/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('non-previewable files', () => {
+    it('renders "Preview Not Available" for unsupported formats', () => {
+      renderWithI18n(
+        <DocumentViewer
+          documentName="archive.zip"
+          documentUrl="https://example.com/archive.zip"
+        />,
+      );
+
+      expect(screen.getByText('Preview Not Available')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Download/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/activities/files/components/__tests__/DocumentViewer.test.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/__tests__/DocumentViewer.test.tsx
@@ -91,7 +91,9 @@ describe('DocumentViewer', () => {
 
       expect(container.querySelector('video')).not.toBeInTheDocument();
       expect(screen.getByText('Preview Not Available')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /Download/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Download/i }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -105,7 +107,9 @@ describe('DocumentViewer', () => {
       );
 
       expect(screen.getByText('Preview Not Available')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /Download/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Download/i }),
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Resolves #24453 /claim #24453

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

