### PR TITLE
fix(server): always build ORM v2 entity metadata so background jobs resolve repositories

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
-import { FeatureFlagKey } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { type EntityMetadata, EntitySchema, Repository } from 'typeorm';
 import { EntitySchemaTransformer } from 'typeorm/entity-schema/EntitySchemaTransformer';
@@ -11,14 +10,11 @@ import { EntityMetadataBuilder } from 'typeorm/metadata-builder/EntityMetadataBu
 import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
 
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
-import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { EntitySchemaFactory } from 'src/engine/twenty-orm/factories/entity-schema.factory';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildEntitySchemaMetadataMaps } from 'src/engine/twenty-orm/global-workspace-datasource/types/entity-schema-metadata.type';
-import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
-import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
 
 @Injectable()
@@ -36,8 +32,6 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
     private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
     @InjectRepository(ApplicationEntity)
     private readonly applicationRepository: Repository<ApplicationEntity>,
-    @InjectWorkspaceScopedRepository(FeatureFlagEntity)
-    private readonly featureFlagRepository: WorkspaceScopedRepository<FeatureFlagEntity>,
     private readonly entitySchemaFactory: EntitySchemaFactory,
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
   ) {
@@ -45,15 +39,6 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
   }
 
   async computeForCache(workspaceId: string): Promise<EntityMetadata[]> {
-    const ormV2FeatureFlag = await this.featureFlagRepository.findOne(
-      workspaceId,
-      { where: { key: FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED } },
-    );
-
-    if (ormV2FeatureFlag?.value) {
-      return [];
-    }
-
     const [objectMetadatas, fieldMetadatas, twentyStandardApplication] =
       await Promise.all([
         this.objectMetadataRepository.find({


### PR DESCRIPTION
## Context

Hotfix for the `v2.34.x` release line (deployed to prod-eu as `v2.34.1`). `main` is already unaffected because #24692 removed `IS_ORM_V2_READ_PATH_ENABLED` entirely and always builds the metadata; this PR restores that behavior on the flag-gated release line without pulling in the full flag removal.

## Symptom

`EntityMetadataNotFoundError: No metadata for "<entity>" was found.` thrown from `GlobalWorkspaceDataSource.getMetadata`, on prod, for workspaces with `IS_ORM_V2_READ_PATH_ENABLED` on. Observed entities: `messageChannelMessageAssociation`, `calendarEvent`, `calendarEventParticipant`, `workflow`. All on the background worker pods, breaking message and calendar sync.

Stack trace:

```
global-workspace-datasource.ts   getMetadata -> throw EntityMetadataNotFoundError
workspace-entity-manager.ts      .find
workspace.repository.ts          .find
messaging-message-list-fetch.service.ts   messageChannelMessageAssociationRepository.find({...})
messaging-message-list-fetch.job.ts       MessagingMessageListFetchJob.handle
```

## Root cause

`WorkspaceORMEntityMetadatasCacheService.computeForCache` short-circuited to an empty `EntityMetadata[]` whenever the ORM v2 flag was on:

```ts
if (ormV2FeatureFlag?.value) {
  return [];
}
```

This was an intentional optimization (#24219 / #24299): the v2 **request** path builds its queries without these `EntityMetadata` objects, so building them for v2 workspaces was skipped to save per-pod memory.

The gap: repository `.find()` / `.findOne()` / `.findBy()` call `DataSource.getMetadata()`, and the messaging, calendar and workflow **background jobs** were migrated to the v2 global manager and use exactly those repository methods. With an empty metadata array, every such call throws. The request path masked it, and flag-on CI does not exercise these jobs, so it shipped silently. It affects every flag-on workspace's sync (internal workspaces included), and #24685/`v2.34.1` (ORM v2 default-on for new workspaces) widened the blast radius.

## Fix

Always build the entity metadata, regardless of the flag. This is what `main` already does post flag-removal, and it additionally removes the empty-cache rollback hazard that #24299 was working around (a flag flip could leave `[]` cached and 500 the v1 path).

Trade-off: the per-pod `ORMEntityMetadatas` graph is rebuilt for flag-on workspaces, reversing the memory optimization from #24219. This is the same trade-off `main` accepted at GA; correctness of email/calendar/workflow sync takes priority. Worth watching pod memory after deploy.

## Test plan

- [x] `tsc` clean on the changed file
- [ ] Deploy to staging, enable the flag on a workspace with a connected mailbox, confirm `MessagingMessageListFetchJob` runs without `EntityMetadataNotFoundError`
- [ ] Confirm the request path (Companies / People views + aggregates) still renders under the flag


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

