### PR TITLE
fix(call-recorder): require Twenty 2.32

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -6,7 +6,7 @@
     "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2",
-    "twenty": ">=2.31.0"
+    "twenty": ">=2.32.0"
   },
   "keywords": [
     "twenty-app"


### PR DESCRIPTION
## Context

Call recorder `1.8.0` adds the uninstall hook from #24361. Server support for resolving `uninstallLogicFunctionId` lands with the Twenty 2.32 migration, but the app still declared `engines.twenty: ">=2.31.0"`. A 2.31 workspace could therefore install this release without ever running its Recall bot cleanup on uninstall.

This addresses [Raph's final review note on #24361](https://github.com/twentyhq/twenty/pull/24361#pullrequestreview-4994650916).

## Change

- Raise the call recorder's required Twenty version from `>=2.31.0` to `>=2.32.0`.
- Keep the app version at `1.8.0`: npm `latest` is currently `1.7.2`, so `1.8.0` remains the correct next unpublished release.

## Verification

- Parsed `package.json` and verified `version: 1.8.0` with `engines.twenty: ">=2.32.0"`.
- `git diff --check` passes.

No runtime code changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

