### PR TITLE
fix(docker): patch prod image OS CVEs (postgresql18-client, python3, sqlite)

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -94,7 +94,7 @@ RUN apk add --no-cache \
     'nghttp2-libs>=1.69.0-r0' \
     'libcrypto3>=3.5.7-r0' \
     'libssl3>=3.5.7-r0' \
-    'postgresql18-client>=18.4-r0' \
+    'postgresql18-client>=18.5-r0' \
     jq
 
 COPY ./packages/twenty-docker/twenty/entrypoint.sh /app/entrypoint.sh


### PR DESCRIPTION
## What

Clears the AWS ECR / Inspector **HIGH-severity SLA breach** on the `prod-twenty` image (built from the `twenty-server-aws` target). The findings are all **OS-layer Alpine packages**, unrelated to the recent Node dependency fixes (#24698, #24717):

| Package | Installed | Fixed in | Source |
|---|---|---|---|
| `postgresql18-client` | 18.4 | **18.5-r0** | explicit `apk add` pin in the `twenty-server` stage |
| `python3` | 3.12.13 | **3.12.14-r0** | transitive via `apk add aws-cli` |
| `sqlite` (`sqlite-libs`) | 3.51.2 | **3.53.4-r0** | transitive via aws-cli |

(postgresql18 alone accounts for ~84 active findings: CVE-2026-6464, -14669, -15741, -16238, -14671, and more.)

## Change

One line, matching the existing "Force the patched Alpine libs … clears the scanner" block:

```
- 'postgresql18-client>=18.4-r0' \
+ 'postgresql18-client>=18.5-r0' \
```

**No pins added for python3 / sqlite** — they're transitive to `aws-cli` and refresh to the patched versions automatically on rebuild (`apk add --no-cache` resolves to the current Alpine repo), so forcing them would be an unnecessary resolution.

## Verification (Docker)

Rebuilt the OS layer (base `node:24.18.0-alpine3.23` + the apk block with the new pin + `apk add aws-cli`) and inspected + scanned it:

- Installed versions: `postgresql18-client 18.6-r0`, `python3 3.12.14-r0`, `sqlite-libs 3.53.4-r0` — all ≥ the fixed versions.
- **`trivy image` → 0 HIGH/CRITICAL OS vulnerabilities** (alpine 3.23.5).

## Rollout

Clears the ECR monitor on the **next `prod-twenty` image build + deploy** (Inspector rescans the new digest; the old vulnerable digest ages out via the 14-day pull filter or can be archived). No runtime/behavior change — OS package patch bumps only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

