### PR TITLE
fix(server): make workflow-core + person-avatar upgrade commands v2-safe

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783526282685-backfill-workflow-version-to-core.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783526282685-backfill-workflow-version-to-core.command.ts
@@ -1,5 +1,5 @@
 import { Command } from 'nest-commander';
-import { EntityMetadataNotFoundError } from 'typeorm/error/EntityMetadataNotFoundError';
+import { isWorkspaceObjectNotFoundError } from 'src/database/commands/upgrade-version-command/utils/is-workspace-object-not-found-error.util';
 
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
@@ -47,7 +47,7 @@ export class BackfillWorkflowVersionToCoreCommand extends ProvisionedWorkspaceCo
           buildSystemAuthContext(workspaceId),
         );
     } catch (error) {
-      if (error instanceof EntityMetadataNotFoundError) {
+      if (isWorkspaceObjectNotFoundError(error)) {
         this.logger.log(
           `workflowVersion object does not exist for workspace ${workspaceId}, skipping`,
         );

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
@@ -14,6 +14,7 @@ import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/deco
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { fetchImageWithTypeFromUrl } from 'src/utils/image';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
@@ -34,6 +35,7 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly filesFieldService: FilesFieldService,
     private readonly secureHttpClientService: SecureHttpClientService,
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
   ) {
     super(workspaceIteratorService);
   }
@@ -88,10 +90,12 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
       return;
     }
 
-    const personRepository = dataSource.getRepository<PersonWorkspaceEntity>(
-      'person',
-      { shouldBypassPermissionChecks: true },
-    );
+    const personRepository =
+      await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
+        workspaceId,
+        'person',
+        { shouldBypassPermissionChecks: true },
+      );
 
     let candidateCount = 0;
     let migratedCount = 0;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
@@ -1,6 +1,6 @@
 import { Command } from 'nest-commander';
 import { isDefined } from 'twenty-shared/utils';
-import { EntityMetadataNotFoundError } from 'typeorm/error/EntityMetadataNotFoundError';
+import { isWorkspaceObjectNotFoundError } from 'src/database/commands/upgrade-version-command/utils/is-workspace-object-not-found-error.util';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
@@ -54,7 +54,7 @@ export class BackfillWorkflowVersionCoreLinksCommand extends ProvisionedWorkspac
 
       workspaceWorkflowVersions = await workflowVersionRepository.find();
     } catch (error) {
-      if (error instanceof EntityMetadataNotFoundError) {
+      if (isWorkspaceObjectNotFoundError(error)) {
         this.logger.log(
           `workflowVersion object does not exist for workspace ${workspaceId}, skipping`,
         );

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command.ts
@@ -1,6 +1,6 @@
 import { Command } from 'nest-commander';
 import { isDefined } from 'twenty-shared/utils';
-import { EntityMetadataNotFoundError } from 'typeorm/error/EntityMetadataNotFoundError';
+import { isWorkspaceObjectNotFoundError } from 'src/database/commands/upgrade-version-command/utils/is-workspace-object-not-found-error.util';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
@@ -51,7 +51,7 @@ export class BackfillWorkflowCoreLinksCommand extends ProvisionedWorkspaceComman
 
       workspaceWorkflows = await workflowRepository.find();
     } catch (error) {
-      if (error instanceof EntityMetadataNotFoundError) {
+      if (isWorkspaceObjectNotFoundError(error)) {
         this.logger.log(
           `workflow object does not exist for workspace ${workspaceId}, skipping`,
         );

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.ts
@@ -1,6 +1,6 @@
 import { Command } from 'nest-commander';
 import { isDefined } from 'twenty-shared/utils';
-import { EntityMetadataNotFoundError } from 'typeorm/error/EntityMetadataNotFoundError';
+import { isWorkspaceObjectNotFoundError } from 'src/database/commands/upgrade-version-command/utils/is-workspace-object-not-found-error.util';
 
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
@@ -50,7 +50,7 @@ export class RepairOrphanCoreWorkflowVersionsCommand extends ProvisionedWorkspac
         })
         .count();
     } catch (error) {
-      if (error instanceof EntityMetadataNotFoundError) {
+      if (isWorkspaceObjectNotFoundError(error)) {
         return;
       }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/utils/is-workspace-object-not-found-error.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/utils/is-workspace-object-not-found-error.util.ts
@@ -1,0 +1,15 @@
+import { EntityMetadataNotFoundError } from 'typeorm/error/EntityMetadataNotFoundError';
+
+import {
+  TwentyOrmV2Exception,
+  TwentyOrmV2ExceptionCode,
+} from 'src/engine/twenty-orm-v2/exceptions/twenty-orm-v2.exception';
+
+// A workspace object can be absent when upgrading from a version that predates it.
+// The v1 GlobalWorkspaceDataSource throws EntityMetadataNotFoundError, while the v2
+// datasource throws TwentyOrmV2Exception(UNKNOWN_OBJECT). Backfill commands must treat
+// both as "object not provisioned yet" and skip rather than fail the upgrade.
+export const isWorkspaceObjectNotFoundError = (error: unknown): boolean =>
+  error instanceof EntityMetadataNotFoundError ||
+  (error instanceof TwentyOrmV2Exception &&
+    error.code === TwentyOrmV2ExceptionCode.UNKNOWN_OBJECT);


### PR DESCRIPTION
## Context

`#24692` removed `IS_ORM_V2_READ_PATH_ENABLED` and collapsed to the v2 path: `GlobalWorkspaceOrmManager.getRepository` now always routes to the v2 datasource, and `WorkspaceORMEntityMetadatasCacheService.computeForCache` returns `[]` unconditionally (the v1 `GlobalWorkspaceDataSource` metadata is no longer built).

Several workspace **upgrade commands** still relied on v1 behavior and break under this. It wasn't caught because the cross-version-upgrade smoke test only runs on release tags — cutting one off `main` surfaced it (`staging-ci` failed at `BackfillWorkflowVersionToCore` and then `MigratePersonAvatarUrlToAvatarFile`).

## Two incompatibilities fixed

**1. Missing-object guards only caught the v1 error type.** Backfill/repair commands that skip when a workspace predates an object caught `EntityMetadataNotFoundError` (thrown by v1 `getMetadata`). The v2 datasource instead throws `TwentyOrmV2Exception(UNKNOWN_OBJECT)`, so the guard missed it and the upgrade failed. Added a shared `isWorkspaceObjectNotFoundError` predicate covering both error types and used it in the four affected commands:
- `2-20 backfill-workflow-version-to-core`
- `2-22 backfill-workflow-version-core-links`
- `2-23 backfill-workflow-core-links`
- `2-28 repair-orphan-core-workflow-versions`

**2. Reading through the iterator's raw v1 datasource.** `MigratePersonAvatarUrlToAvatarFile` read persons via `dataSource.getRepository('person')`, where `dataSource` is the iterator's `GlobalWorkspaceDataSource`. Since `computeForCache` now returns `[]`, that path throws `EntityMetadataNotFoundError: No metadata for "person"` **even when the person object exists** (it failed on the seed workspace). Routed the read through `globalWorkspaceOrmManager.getRepository` (v2) instead — the command already runs inside the iterator's `executeInWorkspaceContext`.

## Validation

Validated on the `v2.34.x` release line: these exact fixes took `staging-ci` (build + cross-version-upgrade smoke test) from failing to **green**. This PR brings them to `main`.

Note: the 2-9 AI-model-preferences command also matches `dataSource.getRepository` but reads a **core** entity (`KeyValuePairEntity`) on the core datasource, so it's unaffected and left as-is.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

