### PR TITLE
Swap timeline widget header actions

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/timeline/components/WidgetActionTimeline.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/timeline/components/WidgetActionTimeline.tsx
@@ -3,7 +3,7 @@ import { WidgetActionTimelineFilter } from '@/page-layout/widgets/timeline/compo
 
 export const WidgetActionTimeline = () => (
   <>
-    <WidgetActionTimelineCreateRelated />
     <WidgetActionTimelineFilter />
+    <WidgetActionTimelineCreateRelated />
   </>
 );


### PR DESCRIPTION
## Summary

- place the timeline filter action before the create-related action
- keep the existing actions, behavior, and styling unchanged

This makes the `+` button the rightmost primary action in the timeline widget header.

## Validation

- `npx prettier --check packages/twenty-front/src/modules/page-layout/widgets/timeline/components/WidgetActionTimeline.tsx` — passed
- `npx oxlint --type-aware --type-check packages/twenty-front/src/modules/page-layout/widgets/timeline/components/WidgetActionTimeline.tsx` — 0 warnings / 0 errors
- `git diff --check` — passed

Direct frontend `tsgo` was also attempted. It reached unrelated existing `SidePanelPages` errors because the reused local dependency tree contained an older `twenty-shared` build; this one-line reorder produced no local type or lint finding.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

