### PR TITLE
Fix record page widget presentation

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/timeline/components/WidgetActionTimeline.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/timeline/components/WidgetActionTimeline.tsx
@@ -3,7 +3,7 @@ import { WidgetActionTimelineFilter } from '@/page-layout/widgets/timeline/compo
 
 export const WidgetActionTimeline = () => (
   <>
-    <WidgetActionTimelineCreateRelated />
     <WidgetActionTimelineFilter />
+    <WidgetActionTimelineCreateRelated />
   </>
 );

--- a/packages/twenty-front/src/modules/page-layout/widgets/utils/__tests__/getWidgetCardVariant.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/utils/__tests__/getWidgetCardVariant.test.ts
@@ -5,7 +5,6 @@ describe('getWidgetCardVariant', () => {
   describe('page layout variants', () => {
     it.each([
       ['DASHBOARD', PageLayoutType.DASHBOARD],
-      ['RECORD_PAGE', PageLayoutType.RECORD_PAGE],
       ['STANDALONE_PAGE', PageLayoutType.STANDALONE_PAGE],
     ])("returns 'framed' for %s", (_label, pageLayoutType) => {
       expect(
@@ -17,6 +16,7 @@ describe('getWidgetCardVariant', () => {
     });
 
     it.each([
+      ['RECORD_PAGE', PageLayoutType.RECORD_PAGE],
       ['RECORD_INDEX', PageLayoutType.RECORD_INDEX],
       ['no page layout type', null],
     ])("returns 'flush' for %s", (_label, pageLayoutType) => {

--- a/packages/twenty-front/src/modules/page-layout/widgets/utils/getWidgetCardVariant.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/utils/getWidgetCardVariant.ts
@@ -16,9 +16,9 @@ export const getWidgetCardVariant = ({
 
   switch (pageLayoutType) {
     case PageLayoutType.DASHBOARD:
-    case PageLayoutType.RECORD_PAGE:
     case PageLayoutType.STANDALONE_PAGE:
       return 'framed';
+    case PageLayoutType.RECORD_PAGE:
     case PageLayoutType.RECORD_INDEX:
     case null:
       return 'flush';


### PR DESCRIPTION
## Summary

- restore flush widget surfaces on record pages so full-height widgets are not framed
- place the timeline filter before the create-related action

## Before/After



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

