### PR TITLE
Harden the timeline activity target field repair command

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-upgrade-version-command.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { RepairAttachmentTimelineActivityTypesCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787561579075-repair-attachment-timeline-activity-types.command';
+import { RepairTimelineActivityTargetFieldNamesCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
@@ -13,6 +14,9 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     WorkspaceIteratorModule,
     WorkspaceMigrationModule,
   ],
-  providers: [RepairAttachmentTimelineActivityTypesCommand],
+  providers: [
+    RepairAttachmentTimelineActivityTypesCommand,
+    RepairTimelineActivityTargetFieldNamesCommand,
+  ],
 })
 export class V2_35_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command.ts
@@ -1,97 +1,13 @@
 import { Command } from 'nest-commander';
-import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
-import { FieldMetadataType, RelationType } from 'twenty-shared/types';
-import {
-  capitalize,
-  fromArrayToValuesByKeyRecord,
-  isDefined,
-} from 'twenty-shared/utils';
+import { fromArrayToValuesByKeyRecord } from 'twenty-shared/utils';
 
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
-import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util';
+import { buildTimelineActivityTargetFieldRepairs } from 'src/database/commands/upgrade-version-command/2-35/utils/build-timeline-activity-target-field-repairs.util';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
-import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
-import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
-import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
-import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
-
-const buildTimelineActivityTargetFieldRepairs = ({
-  flatObjectMetadataMaps,
-  flatFieldMetadataMaps,
-}: {
-  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
-}): UniversalFlatFieldMetadata<FieldMetadataType.MORPH_RELATION>[] => {
-  const timelineActivityObjectMetadata = findFlatEntityByUniversalIdentifier({
-    flatEntityMaps: flatObjectMetadataMaps,
-    universalIdentifier: STANDARD_OBJECTS.timelineActivity.universalIdentifier,
-  });
-
-  if (!isDefined(timelineActivityObjectMetadata)) {
-    return [];
-  }
-
-  return getFlatFieldsFromFlatObjectMetadata(
-    timelineActivityObjectMetadata,
-    flatFieldMetadataMaps,
-  ).flatMap((fieldMetadata) => {
-    if (
-      !isFlatFieldMetadataOfType(
-        fieldMetadata,
-        FieldMetadataType.MORPH_RELATION,
-      ) ||
-      fieldMetadata.morphId !==
-        STANDARD_OBJECTS.timelineActivity.morphIds.targetMorphId.morphId ||
-      fieldMetadata.universalSettings.relationType !==
-        RelationType.MANY_TO_ONE ||
-      !isDefined(fieldMetadata.relationTargetObjectMetadataId)
-    ) {
-      return [];
-    }
-
-    const targetObjectMetadata = findFlatEntityByIdInFlatEntityMaps({
-      flatEntityMaps: flatObjectMetadataMaps,
-      flatEntityId: fieldMetadata.relationTargetObjectMetadataId,
-    });
-
-    if (!isDefined(targetObjectMetadata)) {
-      return [];
-    }
-
-    const expectedName = `target${capitalize(
-      targetObjectMetadata.nameSingular,
-    )}`;
-    const expectedJoinColumnName = computeMorphOrRelationFieldJoinColumnName({
-      name: expectedName,
-    });
-
-    if (
-      fieldMetadata.name === expectedName &&
-      fieldMetadata.universalSettings.joinColumnName === expectedJoinColumnName
-    ) {
-      return [];
-    }
-
-    return [
-      {
-        ...fieldMetadata,
-        name: expectedName,
-        universalSettings: {
-          ...fieldMetadata.universalSettings,
-          joinColumnName: expectedJoinColumnName,
-        },
-      },
-    ];
-  });
-};
 
 @RegisteredWorkspaceCommand('2.35.0', 1787641226000)
 @Command({
@@ -112,39 +28,52 @@ export class RepairTimelineActivityTargetFieldNamesCommand extends ProvisionedWo
     workspaceId,
     options,
   }: RunOnWorkspaceArgs): Promise<void> {
-    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps, flatIndexMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
         'flatObjectMetadataMaps',
         'flatFieldMetadataMaps',
+        'flatIndexMaps',
       ]);
-    const fieldsToRepair = buildTimelineActivityTargetFieldRepairs({
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-    });
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      {
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        flatIndexMaps,
+      },
+    );
 
-    if (fieldsToRepair.length === 0) {
+    if (skippedRepairs.length > 0) {
+      this.logger.warn(
+        `Skipped ${skippedRepairs.length} unrepairable timeline activity target field(s) for workspace ${workspaceId}: ${skippedRepairs.join(', ')}`,
+      );
+    }
+
+    if (repairs.length === 0) {
       return;
     }
 
     if (options.dryRun ?? false) {
       this.logger.log(
-        `[DRY RUN] Would repair ${fieldsToRepair.length} timeline activity target field(s) for workspace ${workspaceId}`,
+        `[DRY RUN] Would repair ${repairs.length} timeline activity target field(s) for workspace ${workspaceId}`,
       );
 
       return;
     }
 
-    const fieldsByApplicationUniversalIdentifier = fromArrayToValuesByKeyRecord(
-      {
-        array: fieldsToRepair,
+    const repairsByApplicationUniversalIdentifier =
+      fromArrayToValuesByKeyRecord({
+        array: repairs.map((repair) => ({
+          ...repair,
+          applicationUniversalIdentifier:
+            repair.flatFieldMetadataToUpdate.applicationUniversalIdentifier,
+        })),
         key: 'applicationUniversalIdentifier',
-      },
-    );
+      });
 
     for (const [
       applicationUniversalIdentifier,
-      applicationFieldsToRepair,
-    ] of Object.entries(fieldsByApplicationUniversalIdentifier)) {
+      applicationRepairs,
+    ] of Object.entries(repairsByApplicationUniversalIdentifier)) {
       const result =
         await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
           {
@@ -155,7 +84,17 @@ export class RepairTimelineActivityTargetFieldNamesCommand extends ProvisionedWo
               fieldMetadata: {
                 flatEntityToCreate: [],
                 flatEntityToDelete: [],
-                flatEntityToUpdate: applicationFieldsToRepair,
+                flatEntityToUpdate: applicationRepairs.map(
+                  ({ flatFieldMetadataToUpdate }) => flatFieldMetadataToUpdate,
+                ),
+              },
+              index: {
+                flatEntityToCreate: [],
+                flatEntityToDelete: [],
+                flatEntityToUpdate: applicationRepairs.flatMap(
+                  ({ flatIndexMetadatasToUpdate }) =>
+                    flatIndexMetadatasToUpdate,
+                ),
               },
             },
           },

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command.ts
@@ -1,0 +1,171 @@
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import {
+  capitalize,
+  fromArrayToValuesByKeyRecord,
+  isDefined,
+} from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+
+const buildTimelineActivityTargetFieldRepairs = ({
+  flatObjectMetadataMaps,
+  flatFieldMetadataMaps,
+}: {
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+}): UniversalFlatFieldMetadata<FieldMetadataType.MORPH_RELATION>[] => {
+  const timelineActivityObjectMetadata = findFlatEntityByUniversalIdentifier({
+    flatEntityMaps: flatObjectMetadataMaps,
+    universalIdentifier: STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+  });
+
+  if (!isDefined(timelineActivityObjectMetadata)) {
+    return [];
+  }
+
+  return getFlatFieldsFromFlatObjectMetadata(
+    timelineActivityObjectMetadata,
+    flatFieldMetadataMaps,
+  ).flatMap((fieldMetadata) => {
+    if (
+      !isFlatFieldMetadataOfType(
+        fieldMetadata,
+        FieldMetadataType.MORPH_RELATION,
+      ) ||
+      fieldMetadata.morphId !==
+        STANDARD_OBJECTS.timelineActivity.morphIds.targetMorphId.morphId ||
+      fieldMetadata.universalSettings.relationType !==
+        RelationType.MANY_TO_ONE ||
+      !isDefined(fieldMetadata.relationTargetObjectMetadataId)
+    ) {
+      return [];
+    }
+
+    const targetObjectMetadata = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityMaps: flatObjectMetadataMaps,
+      flatEntityId: fieldMetadata.relationTargetObjectMetadataId,
+    });
+
+    if (!isDefined(targetObjectMetadata)) {
+      return [];
+    }
+
+    const expectedName = `target${capitalize(
+      targetObjectMetadata.nameSingular,
+    )}`;
+    const expectedJoinColumnName = computeMorphOrRelationFieldJoinColumnName({
+      name: expectedName,
+    });
+
+    if (
+      fieldMetadata.name === expectedName &&
+      fieldMetadata.universalSettings.joinColumnName === expectedJoinColumnName
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        ...fieldMetadata,
+        name: expectedName,
+        universalSettings: {
+          ...fieldMetadata.universalSettings,
+          joinColumnName: expectedJoinColumnName,
+        },
+      },
+    ];
+  });
+};
+
+@RegisteredWorkspaceCommand('2.35.0', 1787641226000)
+@Command({
+  name: 'upgrade:2-35:repair-timeline-activity-target-field-names',
+  description:
+    'Repair timeline activity target morph field names left stale by object renames',
+})
+export class RepairTimelineActivityTargetFieldNamesCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+        'flatFieldMetadataMaps',
+      ]);
+    const fieldsToRepair = buildTimelineActivityTargetFieldRepairs({
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    });
+
+    if (fieldsToRepair.length === 0) {
+      return;
+    }
+
+    if (options.dryRun ?? false) {
+      this.logger.log(
+        `[DRY RUN] Would repair ${fieldsToRepair.length} timeline activity target field(s) for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const fieldsByApplicationUniversalIdentifier = fromArrayToValuesByKeyRecord(
+      {
+        array: fieldsToRepair,
+        key: 'applicationUniversalIdentifier',
+      },
+    );
+
+    for (const [
+      applicationUniversalIdentifier,
+      applicationFieldsToRepair,
+    ] of Object.entries(fieldsByApplicationUniversalIdentifier)) {
+      const result =
+        await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
+          {
+            isSystemBuild: true,
+            workspaceId,
+            applicationUniversalIdentifier,
+            allFlatEntityOperationByMetadataName: {
+              fieldMetadata: {
+                flatEntityToCreate: [],
+                flatEntityToDelete: [],
+                flatEntityToUpdate: applicationFieldsToRepair,
+              },
+            },
+          },
+        );
+
+      if (result.status === 'fail') {
+        throw new Error(
+          `Failed to repair timeline activity target fields for workspace ${workspaceId}:\n${JSON.stringify(result, null, 2)}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/__tests__/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/__tests__/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command.spec.ts
@@ -15,35 +15,21 @@ const TARGET_FIELD_ID = '00000000-0000-4000-8000-000000000005';
 const TARGET_FIELD_UNIVERSAL_IDENTIFIER =
   '00000000-0000-4000-8000-000000000006';
 const APPLICATION_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-000000000007';
+const TARGET_INDEX_ID = '00000000-0000-4000-8000-000000000008';
+const TARGET_INDEX_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-000000000009';
 
 const buildCommand = ({
   targetObjectNameSingular = 'phoneNumber2',
   targetFieldName = 'targetPhoneNumber',
   targetJoinColumnName = 'targetPhoneNumberId',
-  targetMorphId = STANDARD_OBJECTS.timelineActivity.morphIds.targetMorphId
-    .morphId,
   migrationResult = { status: 'success' },
 }: {
   targetObjectNameSingular?: string;
   targetFieldName?: string;
   targetJoinColumnName?: string;
-  targetMorphId?: string;
   migrationResult?: { status: 'success' | 'fail' };
 } = {}) => {
-  const targetFieldMetadata = {
-    id: TARGET_FIELD_ID,
-    universalIdentifier: TARGET_FIELD_UNIVERSAL_IDENTIFIER,
-    applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
-    objectMetadataId: TIMELINE_ACTIVITY_OBJECT_ID,
-    relationTargetObjectMetadataId: TARGET_OBJECT_ID,
-    type: FieldMetadataType.MORPH_RELATION,
-    morphId: targetMorphId,
-    name: targetFieldName,
-    universalSettings: {
-      relationType: RelationType.MANY_TO_ONE,
-      joinColumnName: targetJoinColumnName,
-    },
-  };
   const validateBuildAndRunLegacyWorkspaceMigration = jest
     .fn()
     .mockResolvedValue(migrationResult);
@@ -57,7 +43,11 @@ const buildCommand = ({
               id: TIMELINE_ACTIVITY_OBJECT_ID,
               universalIdentifier:
                 STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+              nameSingular: 'timelineActivity',
+              namePlural: 'timelineActivities',
+              isCustom: false,
               fieldIds: [TARGET_FIELD_ID],
+              indexMetadataIds: [TARGET_INDEX_ID],
             },
             [TARGET_OBJECT_UNIVERSAL_IDENTIFIER]: {
               id: TARGET_OBJECT_ID,
@@ -74,10 +64,60 @@ const buildCommand = ({
         },
         flatFieldMetadataMaps: {
           byUniversalIdentifier: {
-            [TARGET_FIELD_UNIVERSAL_IDENTIFIER]: targetFieldMetadata,
+            [TARGET_FIELD_UNIVERSAL_IDENTIFIER]: {
+              id: TARGET_FIELD_ID,
+              universalIdentifier: TARGET_FIELD_UNIVERSAL_IDENTIFIER,
+              applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+              objectMetadataId: TIMELINE_ACTIVITY_OBJECT_ID,
+              relationTargetObjectMetadataId: TARGET_OBJECT_ID,
+              type: FieldMetadataType.MORPH_RELATION,
+              morphId:
+                STANDARD_OBJECTS.timelineActivity.morphIds.targetMorphId
+                  .morphId,
+              name: targetFieldName,
+              label: 'PhoneNumber',
+              isUnique: false,
+              isSystemSideEffect: true,
+              universalSettings: {
+                relationType: RelationType.MANY_TO_ONE,
+                joinColumnName: targetJoinColumnName,
+              },
+            },
           },
           universalIdentifierById: {
             [TARGET_FIELD_ID]: TARGET_FIELD_UNIVERSAL_IDENTIFIER,
+          },
+          universalIdentifiersByApplicationId: {},
+        },
+        flatIndexMaps: {
+          byUniversalIdentifier: {
+            [TARGET_INDEX_UNIVERSAL_IDENTIFIER]: {
+              id: TARGET_INDEX_ID,
+              universalIdentifier: TARGET_INDEX_UNIVERSAL_IDENTIFIER,
+              applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+              objectMetadataId: TIMELINE_ACTIVITY_OBJECT_ID,
+              name: 'IDX_STALE_TARGET_PHONE_NUMBER_ID',
+              isUnique: false,
+              indexWhereClause: null,
+              flatIndexFieldMetadatas: [
+                {
+                  fieldMetadataId: TARGET_FIELD_ID,
+                  order: 0,
+                  subFieldName: null,
+                },
+              ],
+              universalFlatIndexFieldMetadatas: [
+                {
+                  fieldMetadataUniversalIdentifier:
+                    TARGET_FIELD_UNIVERSAL_IDENTIFIER,
+                  order: 0,
+                  subFieldName: null,
+                },
+              ],
+            },
+          },
+          universalIdentifierById: {
+            [TARGET_INDEX_ID]: TARGET_INDEX_UNIVERSAL_IDENTIFIER,
           },
           universalIdentifiersByApplicationId: {},
         },
@@ -103,7 +143,7 @@ const runCommand = (
   });
 
 describe('RepairTimelineActivityTargetFieldNamesCommand', () => {
-  it('renames a stale target field and its join column from current object metadata', async () => {
+  it('submits the renamed field and its recomputed index under the owning application', async () => {
     const { command, validateBuildAndRunLegacyWorkspaceMigration } =
       buildCommand();
 
@@ -122,9 +162,22 @@ describe('RepairTimelineActivityTargetFieldNamesCommand', () => {
               expect.objectContaining({
                 universalIdentifier: TARGET_FIELD_UNIVERSAL_IDENTIFIER,
                 name: 'targetPhoneNumber2',
+                label: 'PhoneNumber2',
                 universalSettings: expect.objectContaining({
                   joinColumnName: 'targetPhoneNumber2Id',
                 }),
+              }),
+            ],
+          },
+          index: {
+            flatEntityToCreate: [],
+            flatEntityToDelete: [],
+            flatEntityToUpdate: [
+              expect.objectContaining({
+                universalIdentifier: TARGET_INDEX_UNIVERSAL_IDENTIFIER,
+                name: expect.not.stringMatching(
+                  /^IDX_STALE_TARGET_PHONE_NUMBER_ID$/,
+                ),
               }),
             ],
           },
@@ -145,14 +198,19 @@ describe('RepairTimelineActivityTargetFieldNamesCommand', () => {
     expect(validateBuildAndRunLegacyWorkspaceMigration).not.toHaveBeenCalled();
   });
 
-  it('ignores morph fields outside the timeline target morph', async () => {
+  it('warns and runs no migration when a repair is not safe to apply', async () => {
     const { command, validateBuildAndRunLegacyWorkspaceMigration } =
       buildCommand({
-        targetMorphId: '00000000-0000-4000-8000-000000000008',
+        targetFieldName: 'targetPhoneNumber2',
+        targetJoinColumnName: 'targetPhoneNumberId',
       });
+    const warnSpy = jest.spyOn(command['logger'], 'warn');
 
     await runCommand(command);
 
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped 1 unrepairable'),
+    );
     expect(validateBuildAndRunLegacyWorkspaceMigration).not.toHaveBeenCalled();
   });
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/__tests__/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/__tests__/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command.spec.ts
@@ -1,0 +1,177 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { RepairTimelineActivityTargetFieldNamesCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const WORKSPACE_ID = '00000000-0000-4000-8000-000000000001';
+const TIMELINE_ACTIVITY_OBJECT_ID = '00000000-0000-4000-8000-000000000002';
+const TARGET_OBJECT_ID = '00000000-0000-4000-8000-000000000003';
+const TARGET_OBJECT_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-000000000004';
+const TARGET_FIELD_ID = '00000000-0000-4000-8000-000000000005';
+const TARGET_FIELD_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-000000000006';
+const APPLICATION_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-000000000007';
+
+const buildCommand = ({
+  targetObjectNameSingular = 'phoneNumber2',
+  targetFieldName = 'targetPhoneNumber',
+  targetJoinColumnName = 'targetPhoneNumberId',
+  targetMorphId = STANDARD_OBJECTS.timelineActivity.morphIds.targetMorphId
+    .morphId,
+  migrationResult = { status: 'success' },
+}: {
+  targetObjectNameSingular?: string;
+  targetFieldName?: string;
+  targetJoinColumnName?: string;
+  targetMorphId?: string;
+  migrationResult?: { status: 'success' | 'fail' };
+} = {}) => {
+  const targetFieldMetadata = {
+    id: TARGET_FIELD_ID,
+    universalIdentifier: TARGET_FIELD_UNIVERSAL_IDENTIFIER,
+    applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+    objectMetadataId: TIMELINE_ACTIVITY_OBJECT_ID,
+    relationTargetObjectMetadataId: TARGET_OBJECT_ID,
+    type: FieldMetadataType.MORPH_RELATION,
+    morphId: targetMorphId,
+    name: targetFieldName,
+    universalSettings: {
+      relationType: RelationType.MANY_TO_ONE,
+      joinColumnName: targetJoinColumnName,
+    },
+  };
+  const validateBuildAndRunLegacyWorkspaceMigration = jest
+    .fn()
+    .mockResolvedValue(migrationResult);
+  const command = new RepairTimelineActivityTargetFieldNamesCommand(
+    {} as WorkspaceIteratorService,
+    {
+      getOrRecompute: jest.fn().mockResolvedValue({
+        flatObjectMetadataMaps: {
+          byUniversalIdentifier: {
+            [STANDARD_OBJECTS.timelineActivity.universalIdentifier]: {
+              id: TIMELINE_ACTIVITY_OBJECT_ID,
+              universalIdentifier:
+                STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+              fieldIds: [TARGET_FIELD_ID],
+            },
+            [TARGET_OBJECT_UNIVERSAL_IDENTIFIER]: {
+              id: TARGET_OBJECT_ID,
+              universalIdentifier: TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+              nameSingular: targetObjectNameSingular,
+            },
+          },
+          universalIdentifierById: {
+            [TIMELINE_ACTIVITY_OBJECT_ID]:
+              STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+            [TARGET_OBJECT_ID]: TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+          },
+          universalIdentifiersByApplicationId: {},
+        },
+        flatFieldMetadataMaps: {
+          byUniversalIdentifier: {
+            [TARGET_FIELD_UNIVERSAL_IDENTIFIER]: targetFieldMetadata,
+          },
+          universalIdentifierById: {
+            [TARGET_FIELD_ID]: TARGET_FIELD_UNIVERSAL_IDENTIFIER,
+          },
+          universalIdentifiersByApplicationId: {},
+        },
+      }),
+    } as unknown as WorkspaceCacheService,
+    {
+      validateBuildAndRunLegacyWorkspaceMigration,
+    } as unknown as WorkspaceMigrationValidateBuildAndRunService,
+  );
+
+  return { command, validateBuildAndRunLegacyWorkspaceMigration };
+};
+
+const runCommand = (
+  command: RepairTimelineActivityTargetFieldNamesCommand,
+  dryRun = false,
+) =>
+  command.runOnWorkspace({
+    workspaceId: WORKSPACE_ID,
+    options: { dryRun },
+    index: 0,
+    total: 1,
+  });
+
+describe('RepairTimelineActivityTargetFieldNamesCommand', () => {
+  it('renames a stale target field and its join column from current object metadata', async () => {
+    const { command, validateBuildAndRunLegacyWorkspaceMigration } =
+      buildCommand();
+
+    await runCommand(command);
+
+    expect(validateBuildAndRunLegacyWorkspaceMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isSystemBuild: true,
+        workspaceId: WORKSPACE_ID,
+        applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+        allFlatEntityOperationByMetadataName: {
+          fieldMetadata: {
+            flatEntityToCreate: [],
+            flatEntityToDelete: [],
+            flatEntityToUpdate: [
+              expect.objectContaining({
+                universalIdentifier: TARGET_FIELD_UNIVERSAL_IDENTIFIER,
+                name: 'targetPhoneNumber2',
+                universalSettings: expect.objectContaining({
+                  joinColumnName: 'targetPhoneNumber2Id',
+                }),
+              }),
+            ],
+          },
+        },
+      }),
+    );
+  });
+
+  it('does nothing when the target field already matches the object name', async () => {
+    const { command, validateBuildAndRunLegacyWorkspaceMigration } =
+      buildCommand({
+        targetFieldName: 'targetPhoneNumber2',
+        targetJoinColumnName: 'targetPhoneNumber2Id',
+      });
+
+    await runCommand(command);
+
+    expect(validateBuildAndRunLegacyWorkspaceMigration).not.toHaveBeenCalled();
+  });
+
+  it('ignores morph fields outside the timeline target morph', async () => {
+    const { command, validateBuildAndRunLegacyWorkspaceMigration } =
+      buildCommand({
+        targetMorphId: '00000000-0000-4000-8000-000000000008',
+      });
+
+    await runCommand(command);
+
+    expect(validateBuildAndRunLegacyWorkspaceMigration).not.toHaveBeenCalled();
+  });
+
+  it('does not mutate metadata during a dry run', async () => {
+    const { command, validateBuildAndRunLegacyWorkspaceMigration } =
+      buildCommand();
+
+    await runCommand(command, true);
+
+    expect(validateBuildAndRunLegacyWorkspaceMigration).not.toHaveBeenCalled();
+  });
+
+  it('fails when the workspace migration is rejected', async () => {
+    const { command } = buildCommand({
+      migrationResult: { status: 'fail' },
+    });
+
+    await expect(runCommand(command)).rejects.toThrow(
+      'Failed to repair timeline activity target fields',
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/utils/__tests__/build-timeline-activity-target-field-repairs.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/utils/__tests__/build-timeline-activity-target-field-repairs.util.spec.ts
@@ -1,0 +1,430 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { buildTimelineActivityTargetFieldRepairs } from 'src/database/commands/upgrade-version-command/2-35/utils/build-timeline-activity-target-field-repairs.util';
+import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
+
+const TIMELINE_ACTIVITY_OBJECT_ID = '00000000-0000-4000-8000-000000000002';
+const APPLICATION_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-000000000007';
+const TARGET_MORPH_ID =
+  STANDARD_OBJECTS.timelineActivity.morphIds.targetMorphId.morphId;
+
+type TargetObjectFixture = {
+  nameSingular: string;
+};
+
+type TargetFieldFixture = {
+  name: string;
+  joinColumnName: string;
+  targetObjectKey: string;
+  morphId?: string;
+  relationType?: RelationType;
+  label?: string;
+  isSystemSideEffect?: boolean;
+  withIndex?: boolean;
+};
+
+const objectId = (key: string) => `object-id-${key}`;
+const objectUniversalIdentifier = (key: string) => `object-uid-${key}`;
+const fieldId = (name: string) => `field-id-${name}`;
+const fieldUniversalIdentifier = (name: string) => `field-uid-${name}`;
+const indexId = (name: string) => `index-id-${name}`;
+const indexUniversalIdentifier = (name: string) => `index-uid-${name}`;
+
+const buildFlatEntityMaps = ({
+  targetObjects,
+  targetFields,
+  includeTimelineActivityObject = true,
+}: {
+  targetObjects: Record<string, TargetObjectFixture>;
+  targetFields: TargetFieldFixture[];
+  includeTimelineActivityObject?: boolean;
+}) => {
+  const indexedFields = targetFields.filter(
+    ({ withIndex }) => withIndex === true,
+  );
+
+  const timelineActivityFlatObjectMetadata = {
+    id: TIMELINE_ACTIVITY_OBJECT_ID,
+    universalIdentifier: STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+    applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+    nameSingular: 'timelineActivity',
+    namePlural: 'timelineActivities',
+    isCustom: false,
+    fieldIds: targetFields.map(({ name }) => fieldId(name)),
+    indexMetadataIds: indexedFields.map(({ name }) => indexId(name)),
+  };
+
+  const flatObjectMetadataMaps = {
+    byUniversalIdentifier: {
+      ...(includeTimelineActivityObject
+        ? {
+            [STANDARD_OBJECTS.timelineActivity.universalIdentifier]:
+              timelineActivityFlatObjectMetadata,
+          }
+        : {}),
+      ...Object.fromEntries(
+        Object.entries(targetObjects).map(([key, { nameSingular }]) => [
+          objectUniversalIdentifier(key),
+          {
+            id: objectId(key),
+            universalIdentifier: objectUniversalIdentifier(key),
+            applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+            nameSingular,
+          },
+        ]),
+      ),
+    },
+    universalIdentifierById: {
+      ...(includeTimelineActivityObject
+        ? {
+            [TIMELINE_ACTIVITY_OBJECT_ID]:
+              STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+          }
+        : {}),
+      ...Object.fromEntries(
+        Object.keys(targetObjects).map((key) => [
+          objectId(key),
+          objectUniversalIdentifier(key),
+        ]),
+      ),
+    },
+    universalIdentifiersByApplicationId: {},
+  };
+
+  const flatFieldMetadataMaps = {
+    byUniversalIdentifier: Object.fromEntries(
+      targetFields.map((targetField) => [
+        fieldUniversalIdentifier(targetField.name),
+        {
+          id: fieldId(targetField.name),
+          universalIdentifier: fieldUniversalIdentifier(targetField.name),
+          applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+          objectMetadataId: TIMELINE_ACTIVITY_OBJECT_ID,
+          relationTargetObjectMetadataId: objectId(targetField.targetObjectKey),
+          type: FieldMetadataType.MORPH_RELATION,
+          morphId: targetField.morphId ?? TARGET_MORPH_ID,
+          name: targetField.name,
+          label: targetField.label ?? 'Stale label',
+          isUnique: false,
+          isSystemSideEffect: targetField.isSystemSideEffect ?? true,
+          universalSettings: {
+            relationType: targetField.relationType ?? RelationType.MANY_TO_ONE,
+            joinColumnName: targetField.joinColumnName,
+          },
+        },
+      ]),
+    ),
+    universalIdentifierById: Object.fromEntries(
+      targetFields.map(({ name }) => [
+        fieldId(name),
+        fieldUniversalIdentifier(name),
+      ]),
+    ),
+    universalIdentifiersByApplicationId: {},
+  };
+
+  const flatIndexMaps = {
+    byUniversalIdentifier: Object.fromEntries(
+      indexedFields.map(({ name }) => [
+        indexUniversalIdentifier(name),
+        {
+          id: indexId(name),
+          universalIdentifier: indexUniversalIdentifier(name),
+          applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+          objectMetadataId: TIMELINE_ACTIVITY_OBJECT_ID,
+          name: `IDX_STALE_${name}`,
+          isUnique: false,
+          indexWhereClause: null,
+          flatIndexFieldMetadatas: [
+            { fieldMetadataId: fieldId(name), order: 0, subFieldName: null },
+          ],
+          universalFlatIndexFieldMetadatas: [
+            {
+              fieldMetadataUniversalIdentifier: fieldUniversalIdentifier(name),
+              order: 0,
+              subFieldName: null,
+            },
+          ],
+        },
+      ]),
+    ),
+    universalIdentifierById: Object.fromEntries(
+      indexedFields.map(({ name }) => [
+        indexId(name),
+        indexUniversalIdentifier(name),
+      ]),
+    ),
+    universalIdentifiersByApplicationId: {},
+  };
+
+  return {
+    flatObjectMetadataMaps,
+    flatFieldMetadataMaps,
+    flatIndexMaps,
+  } as unknown as Pick<
+    AllFlatEntityMaps,
+    'flatObjectMetadataMaps' | 'flatFieldMetadataMaps' | 'flatIndexMaps'
+  >;
+};
+
+describe('buildTimelineActivityTargetFieldRepairs', () => {
+  it('renames a stale target field and its join column from current object metadata', () => {
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+          },
+        ],
+      }),
+    );
+
+    expect(skippedRepairs).toEqual([]);
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].flatFieldMetadataToUpdate.name).toBe(
+      'targetPhoneNumber2',
+    );
+    expect(
+      repairs[0].flatFieldMetadataToUpdate.universalSettings.joinColumnName,
+    ).toBe('targetPhoneNumber2Id');
+  });
+
+  it('realigns the label of a system side effect field with the target object name', () => {
+    const { repairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+            label: 'PhoneNumber',
+          },
+        ],
+      }),
+    );
+
+    expect(repairs[0].flatFieldMetadataToUpdate.label).toBe('PhoneNumber2');
+  });
+
+  it('leaves the label untouched when the field is not a system side effect', () => {
+    const { repairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+            label: 'Curated label',
+            isSystemSideEffect: false,
+          },
+        ],
+      }),
+    );
+
+    expect(repairs[0].flatFieldMetadataToUpdate.label).toBe('Curated label');
+  });
+
+  it('recomputes the name of the indexes covering the renamed join column', () => {
+    const { repairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+            withIndex: true,
+          },
+        ],
+      }),
+    );
+
+    expect(repairs[0].flatIndexMetadatasToUpdate).toHaveLength(1);
+    expect(repairs[0].flatIndexMetadatasToUpdate[0].name).not.toBe(
+      'IDX_STALE_targetPhoneNumber',
+    );
+    expect(repairs[0].flatIndexMetadatasToUpdate[0].universalIdentifier).toBe(
+      indexUniversalIdentifier('targetPhoneNumber'),
+    );
+  });
+
+  it('does nothing when the target field already matches the object name', () => {
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber2',
+            joinColumnName: 'targetPhoneNumber2Id',
+            targetObjectKey: 'phoneNumber',
+          },
+        ],
+      }),
+    );
+
+    expect(repairs).toEqual([]);
+    expect(skippedRepairs).toEqual([]);
+  });
+
+  it('skips instead of repairing a join column that drifted on its own', () => {
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber2',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+          },
+        ],
+      }),
+    );
+
+    expect(repairs).toEqual([]);
+    expect(skippedRepairs).toEqual([
+      'targetPhoneNumber2 (join column is targetPhoneNumberId, expected targetPhoneNumber2Id, needs manual repair)',
+    ]);
+  });
+
+  it('skips a rename that would collide with a field already holding the name', () => {
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: {
+          renamed: { nameSingular: 'person' },
+          person: { nameSingular: 'person' },
+        },
+        targetFields: [
+          {
+            name: 'targetContact',
+            joinColumnName: 'targetContactId',
+            targetObjectKey: 'renamed',
+          },
+          {
+            name: 'targetPerson',
+            joinColumnName: 'targetPersonId',
+            targetObjectKey: 'person',
+          },
+        ],
+      }),
+    );
+
+    expect(repairs).toEqual([]);
+    expect(skippedRepairs).toEqual([
+      'targetContact -> targetPerson (name already taken on timelineActivity)',
+    ]);
+  });
+
+  it('lets a later candidate reuse a name freed by an accepted rename', () => {
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: {
+          phoneNumber: { nameSingular: 'phoneNumber2' },
+          contact: { nameSingular: 'phoneNumber' },
+        },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+          },
+          {
+            name: 'targetContact',
+            joinColumnName: 'targetContactId',
+            targetObjectKey: 'contact',
+          },
+        ],
+      }),
+    );
+
+    expect(skippedRepairs).toEqual([]);
+    expect(
+      repairs.map(({ flatFieldMetadataToUpdate }) => [
+        flatFieldMetadataToUpdate.universalIdentifier,
+        flatFieldMetadataToUpdate.name,
+      ]),
+    ).toEqual([
+      [fieldUniversalIdentifier('targetPhoneNumber'), 'targetPhoneNumber2'],
+      [fieldUniversalIdentifier('targetContact'), 'targetPhoneNumber'],
+    ]);
+  });
+
+  it('ignores morph fields outside the timeline target morph', () => {
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+            morphId: '00000000-0000-4000-8000-000000000008',
+          },
+        ],
+      }),
+    );
+
+    expect(repairs).toEqual([]);
+    expect(skippedRepairs).toEqual([]);
+  });
+
+  it('ignores the one to many leg of the morph relation', () => {
+    const { repairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+            relationType: RelationType.ONE_TO_MANY,
+          },
+        ],
+      }),
+    );
+
+    expect(repairs).toEqual([]);
+  });
+
+  it('returns nothing when the workspace has no timeline activity object', () => {
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: { phoneNumber: { nameSingular: 'phoneNumber2' } },
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+          },
+        ],
+        includeTimelineActivityObject: false,
+      }),
+    );
+
+    expect(repairs).toEqual([]);
+    expect(skippedRepairs).toEqual([]);
+  });
+
+  it('ignores a field whose target object is gone', () => {
+    const { repairs, skippedRepairs } = buildTimelineActivityTargetFieldRepairs(
+      buildFlatEntityMaps({
+        targetObjects: {},
+        targetFields: [
+          {
+            name: 'targetPhoneNumber',
+            joinColumnName: 'targetPhoneNumberId',
+            targetObjectKey: 'phoneNumber',
+          },
+        ],
+      }),
+    );
+
+    expect(repairs).toEqual([]);
+    expect(skippedRepairs).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/utils/build-timeline-activity-target-field-repairs.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/utils/build-timeline-activity-target-field-repairs.util.ts
@@ -1,0 +1,170 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import { capitalize, isDefined } from 'twenty-shared/utils';
+
+import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util';
+import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
+import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { findFieldRelatedIndexes } from 'src/engine/metadata-modules/flat-field-metadata/utils/find-field-related-index.util';
+import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { recomputeIndexOnFlatFieldMetadataNameUpdate } from 'src/engine/metadata-modules/flat-field-metadata/utils/recompute-index-on-flat-field-metadata-name-update.util';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+import { type UniversalFlatIndexMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-index-metadata.type';
+
+export type TimelineActivityTargetFieldRepair = {
+  flatFieldMetadataToUpdate: UniversalFlatFieldMetadata<FieldMetadataType.MORPH_RELATION>;
+  flatIndexMetadatasToUpdate: UniversalFlatIndexMetadata[];
+};
+
+export type TimelineActivityTargetFieldRepairs = {
+  repairs: TimelineActivityTargetFieldRepair[];
+  skippedRepairs: string[];
+};
+
+type BuildTimelineActivityTargetFieldRepairsArgs = Pick<
+  AllFlatEntityMaps,
+  'flatObjectMetadataMaps' | 'flatFieldMetadataMaps' | 'flatIndexMaps'
+>;
+
+const EMPTY_REPAIRS: TimelineActivityTargetFieldRepairs = {
+  repairs: [],
+  skippedRepairs: [],
+};
+
+export const buildTimelineActivityTargetFieldRepairs = ({
+  flatObjectMetadataMaps,
+  flatFieldMetadataMaps,
+  flatIndexMaps,
+}: BuildTimelineActivityTargetFieldRepairsArgs): TimelineActivityTargetFieldRepairs => {
+  const timelineActivityFlatObjectMetadata =
+    findFlatEntityByUniversalIdentifier({
+      flatEntityMaps: flatObjectMetadataMaps,
+      universalIdentifier:
+        STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+    });
+
+  if (!isDefined(timelineActivityFlatObjectMetadata)) {
+    return EMPTY_REPAIRS;
+  }
+
+  const timelineActivityFlatFieldMetadatas =
+    getFlatFieldsFromFlatObjectMetadata(
+      timelineActivityFlatObjectMetadata,
+      flatFieldMetadataMaps,
+    );
+
+  // Renaming into a name another field already holds would fail validation for
+  // the whole workspace, so track occupancy and let accepted renames free their
+  // former name for a later candidate.
+  const takenFieldNames = new Set(
+    timelineActivityFlatFieldMetadatas.map(({ name }) => name),
+  );
+
+  return timelineActivityFlatFieldMetadatas.reduce<TimelineActivityTargetFieldRepairs>(
+    (accumulator, flatFieldMetadata) => {
+      if (
+        !isFlatFieldMetadataOfType(
+          flatFieldMetadata,
+          FieldMetadataType.MORPH_RELATION,
+        ) ||
+        flatFieldMetadata.morphId !==
+          STANDARD_OBJECTS.timelineActivity.morphIds.targetMorphId.morphId ||
+        flatFieldMetadata.universalSettings.relationType !==
+          RelationType.MANY_TO_ONE ||
+        !isDefined(flatFieldMetadata.relationTargetObjectMetadataId)
+      ) {
+        return accumulator;
+      }
+
+      const targetFlatObjectMetadata = findFlatEntityByIdInFlatEntityMaps({
+        flatEntityMaps: flatObjectMetadataMaps,
+        flatEntityId: flatFieldMetadata.relationTargetObjectMetadataId,
+      });
+
+      if (!isDefined(targetFlatObjectMetadata)) {
+        return accumulator;
+      }
+
+      const expectedName = `target${capitalize(
+        targetFlatObjectMetadata.nameSingular,
+      )}`;
+      const expectedJoinColumnName = computeMorphOrRelationFieldJoinColumnName({
+        name: expectedName,
+      });
+
+      if (flatFieldMetadata.name === expectedName) {
+        // The runner derives the column rename from the field name alone, so a
+        // join column that drifted on its own cannot be repaired here without
+        // pointing the metadata at a column that was never renamed.
+        if (
+          flatFieldMetadata.universalSettings.joinColumnName !==
+          expectedJoinColumnName
+        ) {
+          return {
+            ...accumulator,
+            skippedRepairs: [
+              ...accumulator.skippedRepairs,
+              `${flatFieldMetadata.name} (join column is ${flatFieldMetadata.universalSettings.joinColumnName}, expected ${expectedJoinColumnName}, needs manual repair)`,
+            ],
+          };
+        }
+
+        return accumulator;
+      }
+
+      if (takenFieldNames.has(expectedName)) {
+        return {
+          ...accumulator,
+          skippedRepairs: [
+            ...accumulator.skippedRepairs,
+            `${flatFieldMetadata.name} -> ${expectedName} (name already taken on timelineActivity)`,
+          ],
+        };
+      }
+
+      takenFieldNames.delete(flatFieldMetadata.name);
+      takenFieldNames.add(expectedName);
+
+      const flatIndexMetadatasToUpdate =
+        recomputeIndexOnFlatFieldMetadataNameUpdate({
+          flatFieldMetadataMaps,
+          flatObjectMetadata: timelineActivityFlatObjectMetadata,
+          fromFlatFieldMetadata: flatFieldMetadata,
+          toFlatFieldMetadata: {
+            name: expectedName,
+            isUnique: flatFieldMetadata.isUnique,
+          },
+          relatedFlatIndexMetadata: findFieldRelatedIndexes({
+            flatFieldMetadata,
+            flatObjectMetadata: timelineActivityFlatObjectMetadata,
+            flatIndexMaps,
+          }),
+        });
+
+      return {
+        skippedRepairs: accumulator.skippedRepairs,
+        repairs: [
+          ...accumulator.repairs,
+          {
+            flatFieldMetadataToUpdate: {
+              ...flatFieldMetadata,
+              name: expectedName,
+              label:
+                flatFieldMetadata.isSystemSideEffect === true
+                  ? capitalize(targetFlatObjectMetadata.nameSingular)
+                  : flatFieldMetadata.label,
+              universalSettings: {
+                ...flatFieldMetadata.universalSettings,
+                joinColumnName: expectedJoinColumnName,
+              },
+            },
+            flatIndexMetadatasToUpdate,
+          },
+        ],
+      };
+    },
+    EMPTY_REPAIRS,
+  );
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes #24726. Carries its commit unchanged, then hardens the repair so it matches what the engine already does when an object is renamed.

## Why

`renameRelatedMorphFieldOnObjectNamesUpdate` is the path that renames these target morph legs whenever an object is renamed. The repair command reimplemented a subset of it and drifted in four ways, all reproduced against the command before changing it:

- **The label went stale.** The canonical path sets `label = capitalize(newNameSingular)` for `isSystemSideEffect` legs. The repair renamed `name` and `joinColumnName` only, leaving a field named `targetPhoneNumber2` labeled "PhoneNumber".
- **No index operations were emitted.** The canonical path returns `morphRelatedFlatIndexesToUpdate` from `recomputeIndexOnFlatFieldMetadataNameUpdate`, and index names are derived from field names via `computeFlatIndexNameOrThrow`. The repair passed only `fieldMetadata`, and `validateBuildAndRunLegacyWorkspaceMigration` sets `skipSideEffectExpandEngine: true`, so nothing generated them.
- **A join column that drifted on its own was made worse.** The trigger fired when either `name` or `joinColumnName` mismatched, but `UpdateFieldActionHandlerService` renames the physical column exclusively inside `if (isDefined(update.name))`. When only the join column was stale, the emitted update was metadata-only and pointed `settings.joinColumnName` at a column that was never renamed — and reads resolve through `getJoinColumnNameForRelationField`, which prefers `settings.joinColumnName`.
- **No collision guard.** `validateFlatFieldMetadataNameAvailability` runs on update, so renaming into an occupied name fails validation and throws — on exactly the damaged workspaces this targets. #24001 already skips this case (`fieldNameIsTaken`), which is evidence drifted duplicates exist in these workspaces.

## What changed

- Extracted the repair computation into `build-timeline-activity-target-field-repairs.util.ts`, unit-tested directly with no `as unknown as` DI casts (addresses the cubic nit on #24726).
- Recomputes the label of `isSystemSideEffect` legs from the target object, matching the canonical path. Non-system legs keep their curated label.
- Emits the recomputed join-column indexes under the `index` operation key.
- Skips, with a warning, a rename that would collide with a field already holding the expected name. An accepted rename frees its former name for a later candidate, so a chain of shifted names still resolves; a mutual swap is skipped rather than half-applied.
- Skips, with a warning, a join column that drifted without its field name, since this path cannot rename the column.

Unchanged: timestamp `1787641226000`, command name, scope (MANY_TO_ONE legs on `timelineActivity` carrying the target morph id), and the per-application grouping.

## Merge order with #24001

These are complementary — #24001 restores *missing* standard default-relation pairs, this repairs *misnamed* ones — but they both edit `2-35-upgrade-version-command.module.ts` and the merge-queue `upgrade-mutation-guard` fails a new command whose timestamp is `<= existing max` in the version directory. #24001 is `1787582101000` and this is `1787641226000`, so **#24001 must merge first**; the reverse order forces Thomas to re-slot his timestamp. That ordering is also the right runtime order: restore missing pairs, then repair renames.

## Validation

```
$ npx jest packages/twenty-server/src/database/commands/upgrade-version-command/2-35
Test Suites: 3 passed, 3 total
Tests:       23 passed, 23 total

$ npx tsgo -p tsconfig.json --noEmit          # packages/twenty-server
0 errors

$ npx oxlint --type-aware --type-check src/database/commands/upgrade-version-command/2-35/
Found 0 warnings and 0 errors.

$ npx prettier --check
All matched files use Prettier code style!
```

New util coverage:

```
buildTimelineActivityTargetFieldRepairs
  ✓ renames a stale target field and its join column from current object metadata
  ✓ realigns the label of a system side effect field with the target object name
  ✓ leaves the label untouched when the field is not a system side effect
  ✓ recomputes the name of the indexes covering the renamed join column
  ✓ does nothing when the target field already matches the object name
  ✓ skips instead of repairing a join column that drifted on its own
  ✓ skips a rename that would collide with a field already holding the name
  ✓ lets a later candidate reuse a name freed by an accepted rename
  ✓ ignores morph fields outside the timeline target morph
  ✓ ignores the one to many leg of the morph relation
  ✓ returns nothing when the workspace has no timeline activity object
  ✓ ignores a field whose target object is gone
```

No Postgres or Docker was available in this environment, so the physical column and index behavior is established by reading `update-field-action-handler.service.ts` and `workspace-migration-validate-build-and-run-service.ts` rather than by executing a migration. An integration test covering an actual rename is the remaining gap.

## Still open

This repairs *misnamed* legs only. If the leg for the object in the reported error is *missing* rather than misnamed, this is a no-op and #24001 is the fix — worth confirming against the affected workspace before relying on either.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0a982ed-ecc9-4e4f-9790-155ad4319fb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0a982ed-ecc9-4e4f-9790-155ad4319fb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

