### PR TITLE
fix(workflow): exclude soft-deleted workspaces from the core-consistency cron

### DIFF
--- a/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
@@ -28,6 +28,7 @@ export type WorkspaceIteratorArgs = {
 
 export type WorkspaceIteratorContext = {
   workspaceId: string;
+  databaseSchema?: string;
   dataSource?: DataSource;
   index: number;
   total: number;
@@ -122,6 +123,7 @@ export class WorkspaceIteratorService {
 
             await callback({
               workspaceId,
+              databaseSchema: workspace?.databaseSchema ?? undefined,
               dataSource,
               index,
               total: workspaceIdsToProcess.length,

--- a/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
@@ -17,9 +17,6 @@ import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspac
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceMigrationRunnerException } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception';
 
-// Deterministic partition of the workspace fleet: a workspace belongs to shard
-// mod(first uuid byte, total), so iterating shard 0..total-1 covers every
-// workspace exactly once.
 export type WorkspaceIteratorShard = {
   index: number;
   total: number;

--- a/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
@@ -8,7 +8,7 @@ import {
   WorkspaceActivationStatus,
 } from 'twenty-shared/workspace';
 import { isDefined } from 'twenty-shared/utils';
-import { DataSource, MoreThanOrEqual, Repository } from 'typeorm';
+import { DataSource, MoreThanOrEqual, Raw, Repository } from 'typeorm';
 
 import { CommandShutdownService } from 'src/database/commands/command-runners/command-shutdown.service';
 import { activationStatusIn } from 'src/database/commands/command-runners/utils/activation-status-in.util';
@@ -17,11 +17,20 @@ import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspac
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceMigrationRunnerException } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception';
 
+// Deterministic partition of the workspace fleet: a workspace belongs to shard
+// mod(first uuid byte, total), so iterating shard 0..total-1 covers every
+// workspace exactly once.
+export type WorkspaceIteratorShard = {
+  index: number;
+  total: number;
+};
+
 export type WorkspaceIteratorArgs = {
   workspaceIds?: string[];
   activationStatuses?: WorkspaceActivationStatus[];
   startFromWorkspaceId?: string;
   workspaceCountLimit?: number;
+  shard?: WorkspaceIteratorShard;
   dryRun?: boolean;
   callback: (context: WorkspaceIteratorContext) => Promise<void>;
 };
@@ -168,11 +177,29 @@ export class WorkspaceIteratorService {
   private async fetchWorkspaceIds(
     options: Pick<
       WorkspaceIteratorArgs,
-      'activationStatuses' | 'startFromWorkspaceId' | 'workspaceCountLimit'
+      | 'activationStatuses'
+      | 'startFromWorkspaceId'
+      | 'workspaceCountLimit'
+      | 'shard'
     >,
   ): Promise<string[]> {
     const activationStatuses =
       options.activationStatuses ?? DEFAULT_ACTIVATION_STATUSES;
+    const shard = options.shard;
+
+    if (isDefined(shard)) {
+      if (isDefined(options.startFromWorkspaceId)) {
+        throw new Error(
+          'Cannot combine shard with startFromWorkspaceId in workspace iterator',
+        );
+      }
+
+      if (shard.index < 0 || shard.index >= shard.total || shard.total > 256) {
+        throw new Error(
+          `Invalid workspace iterator shard ${shard.index}/${shard.total}`,
+        );
+      }
+    }
 
     const workspaces = await this.workspaceRepository.find({
       select: ['id'],
@@ -180,6 +207,15 @@ export class WorkspaceIteratorService {
         activationStatus: activationStatusIn(activationStatuses),
         ...(options.startFromWorkspaceId
           ? { id: MoreThanOrEqual(options.startFromWorkspaceId) }
+          : {}),
+        ...(isDefined(shard)
+          ? {
+              id: Raw(
+                (alias) =>
+                  `mod(get_byte(uuid_send(${alias}), 0), :shardTotal) = :shardIndex`,
+                { shardTotal: shard.total, shardIndex: shard.index },
+              ),
+            }
           : {}),
       },
       order: { id: 'ASC' },

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -36,7 +36,9 @@ export class WorkflowCoreConsistencyService {
       await this.coreDataSource.query(
         `SELECT id AS "workspaceId", "databaseSchema"
          FROM core."workspace"
-         WHERE "activationStatus" IN ('ACTIVE', 'SUSPENDED') AND "databaseSchema" IS NOT NULL`,
+         WHERE "activationStatus" IN ('ACTIVE', 'SUSPENDED')
+           AND "deletedAt" IS NULL
+           AND "databaseSchema" IS NOT NULL`,
       );
 
     for (const { workspaceId, databaseSchema } of workspaces) {

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -2,9 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 
 import { isDefined } from 'twenty-shared/utils';
-import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
-import { DataSource, In, IsNull, Not, Repository } from 'typeorm';
+import { PROVISIONED_WORKSPACE_ACTIVATION_STATUSES } from 'twenty-shared/workspace';
+import { DataSource, IsNull, Not, Repository } from 'typeorm';
 
+import { activationStatusIn } from 'src/database/commands/command-runners/utils/activation-status-in.util';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
@@ -39,10 +40,9 @@ export class WorkflowCoreConsistencyService {
     const workspaces = await this.workspaceRepository.find({
       select: ['id', 'databaseSchema'],
       where: {
-        activationStatus: In([
-          WorkspaceActivationStatus.ACTIVE,
-          WorkspaceActivationStatus.SUSPENDED,
-        ]),
+        activationStatus: activationStatusIn(
+          PROVISIONED_WORKSPACE_ACTIVATION_STATUSES,
+        ),
         databaseSchema: Not(IsNull()),
       },
     });

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -17,7 +17,8 @@ import {
 
 type DriftCounts = Record<string, number>;
 
-const SHARD_TOTAL = 8;
+const CRON_INTERVAL_HOURS = 3;
+const SHARD_TOTAL = 24 / CRON_INTERVAL_HOURS;
 
 // Detect drift between the workspace source-of-truth records and their core
 // mirror. The dual-write is best-effort (async, not transactional), so core can
@@ -36,11 +37,10 @@ export class WorkflowCoreConsistencyService {
   ) {}
 
   async runConsistencyCheck(): Promise<void> {
-    // The cron fires every 3 hours; sharding by fire hour spreads the fleet
-    // over the 8 daily runs so each workspace is checked once a day instead of
-    // every run.
     const shard = {
-      index: Math.floor(new Date().getUTCHours() / 3) % SHARD_TOTAL,
+      index:
+        Math.floor(new Date().getUTCHours() / CRON_INTERVAL_HOURS) %
+        SHARD_TOTAL,
       total: SHARD_TOTAL,
     };
 

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -2,10 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 
 import { isDefined } from 'twenty-shared/utils';
-import { PROVISIONED_WORKSPACE_ACTIVATION_STATUSES } from 'twenty-shared/workspace';
-import { DataSource, IsNull, Not, Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 
-import { activationStatusIn } from 'src/database/commands/command-runners/utils/activation-status-in.util';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
@@ -31,34 +30,32 @@ export class WorkflowCoreConsistencyService {
     private readonly coreDataSource: DataSource,
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
+    private readonly workspaceIteratorService: WorkspaceIteratorService,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly metricsService: MetricsService,
     private readonly exceptionHandlerService: ExceptionHandlerService,
   ) {}
 
   async runConsistencyCheck(): Promise<void> {
-    const workspaces = await this.workspaceRepository.find({
-      select: ['id', 'databaseSchema'],
-      where: {
-        activationStatus: activationStatusIn(
-          PROVISIONED_WORKSPACE_ACTIVATION_STATUSES,
-        ),
-        databaseSchema: Not(IsNull()),
+    const report = await this.workspaceIteratorService.iterate({
+      callback: async ({ workspaceId }) => {
+        const workspace = await this.workspaceRepository.findOne({
+          select: ['databaseSchema'],
+          where: { id: workspaceId },
+        });
+
+        if (!isDefined(workspace?.databaseSchema)) {
+          return;
+        }
+
+        await this.checkWorkspace(workspaceId, workspace.databaseSchema);
       },
     });
 
-    for (const { id: workspaceId, databaseSchema } of workspaces) {
-      if (!isDefined(databaseSchema)) {
-        continue;
-      }
-
-      try {
-        await this.checkWorkspace(workspaceId, databaseSchema);
-      } catch (error) {
-        this.exceptionHandlerService.captureExceptions([error], {
-          workspace: { id: workspaceId },
-        });
-      }
+    for (const { workspaceId, error } of report.fail) {
+      this.exceptionHandlerService.captureExceptions([error], {
+        workspace: { id: workspaceId },
+      });
     }
   }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -1,12 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectDataSource } from '@nestjs/typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 
 import { isDefined } from 'twenty-shared/utils';
-import { DataSource } from 'typeorm';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import { DataSource, In, IsNull, Not, Repository } from 'typeorm';
 
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import {
@@ -26,22 +28,30 @@ export class WorkflowCoreConsistencyService {
   constructor(
     @InjectDataSource()
     private readonly coreDataSource: DataSource,
+    @InjectRepository(WorkspaceEntity)
+    private readonly workspaceRepository: Repository<WorkspaceEntity>,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly metricsService: MetricsService,
     private readonly exceptionHandlerService: ExceptionHandlerService,
   ) {}
 
   async runConsistencyCheck(): Promise<void> {
-    const workspaces: Array<{ workspaceId: string; databaseSchema: string }> =
-      await this.coreDataSource.query(
-        `SELECT id AS "workspaceId", "databaseSchema"
-         FROM core."workspace"
-         WHERE "activationStatus" IN ('ACTIVE', 'SUSPENDED')
-           AND "deletedAt" IS NULL
-           AND "databaseSchema" IS NOT NULL`,
-      );
+    const workspaces = await this.workspaceRepository.find({
+      select: ['id', 'databaseSchema'],
+      where: {
+        activationStatus: In([
+          WorkspaceActivationStatus.ACTIVE,
+          WorkspaceActivationStatus.SUSPENDED,
+        ]),
+        databaseSchema: Not(IsNull()),
+      },
+    });
 
-    for (const { workspaceId, databaseSchema } of workspaces) {
+    for (const { id: workspaceId, databaseSchema } of workspaces) {
+      if (!isDefined(databaseSchema)) {
+        continue;
+      }
+
       try {
         await this.checkWorkspace(workspaceId, databaseSchema);
       } catch (error) {

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -1,14 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { InjectDataSource } from '@nestjs/typeorm';
 
 import { isDefined } from 'twenty-shared/utils';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import {
@@ -28,8 +27,6 @@ export class WorkflowCoreConsistencyService {
   constructor(
     @InjectDataSource()
     private readonly coreDataSource: DataSource,
-    @InjectRepository(WorkspaceEntity)
-    private readonly workspaceRepository: Repository<WorkspaceEntity>,
     private readonly workspaceIteratorService: WorkspaceIteratorService,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly metricsService: MetricsService,
@@ -38,17 +35,12 @@ export class WorkflowCoreConsistencyService {
 
   async runConsistencyCheck(): Promise<void> {
     const report = await this.workspaceIteratorService.iterate({
-      callback: async ({ workspaceId }) => {
-        const workspace = await this.workspaceRepository.findOne({
-          select: ['databaseSchema'],
-          where: { id: workspaceId },
-        });
-
-        if (!isDefined(workspace?.databaseSchema)) {
+      callback: async ({ workspaceId, databaseSchema }) => {
+        if (!isDefined(databaseSchema)) {
           return;
         }
 
-        await this.checkWorkspace(workspaceId, workspace.databaseSchema);
+        await this.checkWorkspace(workspaceId, databaseSchema);
       },
     });
 
@@ -59,53 +51,79 @@ export class WorkflowCoreConsistencyService {
     }
   }
 
+  // Single statement instead of one shouldCheck + four aggregate queries: the
+  // cron visits every provisioned workspace every run, so per-workspace query
+  // count dominates its cost.
   private async checkWorkspace(
     workspaceId: string,
     schema: string,
   ): Promise<void> {
-    const [{ shouldCheck }] = await this.coreDataSource.query(
-      `SELECT (
-         EXISTS (SELECT 1 FROM "${schema}"."workflow" WHERE "deletedAt" IS NULL)
-         OR EXISTS (SELECT 1 FROM core."workflow" WHERE "workspaceId" = $1)
-       ) AS "shouldCheck"`,
-      [workspaceId],
-    );
-
-    if (!shouldCheck) {
-      return;
-    }
-
-    await this.checkWorkflowSync(workspaceId, schema);
-    await this.checkWorkflowVersionSync(workspaceId, schema);
-    await this.checkAutomatedTriggerSync(workspaceId, schema);
-  }
-
-  private async checkWorkflowSync(
-    workspaceId: string,
-    schema: string,
-  ): Promise<void> {
-    const [counts] = await this.coreDataSource.query(
+    const [counts]: [
+      {
+        workflowTotal: number;
+        workflowUnlinked: number;
+        workflowMissingCore: number;
+        workflowFieldMismatch: number;
+        workflowOrphanCore: number;
+        coreWorkflowTotal: number;
+        versionUnlinked: number;
+        versionMissingCore: number;
+        versionFieldMismatch: number;
+        versionOrphanCore: number;
+      },
+    ] = await this.coreDataSource.query(
       `SELECT
-         count(*) FILTER (WHERE wf."coreWorkflowId" IS NULL)::int AS unlinked,
-         count(*) FILTER (WHERE wf."coreWorkflowId" IS NOT NULL AND c.id IS NULL)::int AS "missingCore",
-         count(*) FILTER (WHERE c.id IS NOT NULL AND (
-           wf.name IS DISTINCT FROM c.name
-           OR NULLIF(wf."lastPublishedVersionId", '') IS DISTINCT FROM c."lastPublishedVersionId"::text
-         ))::int AS "fieldMismatch"
-       FROM "${schema}"."workflow" wf
-       LEFT JOIN core."workflow" c
-         ON c.id = wf."coreWorkflowId" AND c."workspaceId" = $1
-       WHERE wf."deletedAt" IS NULL`,
-      [workspaceId],
-    );
-
-    const [{ orphanCore }] = await this.coreDataSource.query(
-      `SELECT count(*)::int AS "orphanCore"
-       FROM core."workflow" c
-       WHERE c."workspaceId" = $1
-         AND NOT EXISTS (
-           SELECT 1 FROM "${schema}"."workflow" wf WHERE wf."coreWorkflowId" = c.id
-         )`,
+         wf."workflowTotal", wf."workflowUnlinked", wf."workflowMissingCore", wf."workflowFieldMismatch",
+         wfo."coreWorkflowTotal", wfo."workflowOrphanCore",
+         wv."versionUnlinked", wv."versionMissingCore", wv."versionFieldMismatch",
+         wvo."versionOrphanCore"
+       FROM (
+         SELECT
+           count(*)::int AS "workflowTotal",
+           count(*) FILTER (WHERE wf."coreWorkflowId" IS NULL)::int AS "workflowUnlinked",
+           count(*) FILTER (WHERE wf."coreWorkflowId" IS NOT NULL AND c.id IS NULL)::int AS "workflowMissingCore",
+           count(*) FILTER (WHERE c.id IS NOT NULL AND (
+             wf.name IS DISTINCT FROM c.name
+             OR NULLIF(wf."lastPublishedVersionId", '') IS DISTINCT FROM c."lastPublishedVersionId"::text
+           ))::int AS "workflowFieldMismatch"
+         FROM "${schema}"."workflow" wf
+         LEFT JOIN core."workflow" c
+           ON c.id = wf."coreWorkflowId" AND c."workspaceId" = $1
+         WHERE wf."deletedAt" IS NULL
+       ) wf
+       CROSS JOIN (
+         SELECT
+           count(*)::int AS "coreWorkflowTotal",
+           count(*) FILTER (WHERE NOT EXISTS (
+             SELECT 1 FROM "${schema}"."workflow" wf WHERE wf."coreWorkflowId" = c.id
+           ))::int AS "workflowOrphanCore"
+         FROM core."workflow" c
+         WHERE c."workspaceId" = $1
+       ) wfo
+       CROSS JOIN (
+         SELECT
+           count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NULL)::int AS "versionUnlinked",
+           count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NOT NULL AND c.id IS NULL)::int AS "versionMissingCore",
+           count(*) FILTER (WHERE c.id IS NOT NULL AND (
+             c.status::text IS DISTINCT FROM wf.status::text
+             OR c."workflowId" IS DISTINCT FROM wf."workflowId"
+             OR c.steps IS DISTINCT FROM wf.steps
+             OR c.triggers IS DISTINCT FROM (
+               CASE WHEN wf.trigger IS NULL THEN NULL ELSE jsonb_build_array(wf.trigger) END
+             )
+           ))::int AS "versionFieldMismatch"
+         FROM "${schema}"."workflowVersion" wf
+         LEFT JOIN core."workflowVersion" c
+           ON c.id = wf."coreWorkflowVersionId" AND c."workspaceId" = $1
+         WHERE wf."deletedAt" IS NULL
+       ) wv
+       CROSS JOIN (
+         SELECT count(*) FILTER (WHERE NOT EXISTS (
+           SELECT 1 FROM "${schema}"."workflowVersion" wf WHERE wf."coreWorkflowVersionId" = c.id
+         ))::int AS "versionOrphanCore"
+         FROM core."workflowVersion" c
+         WHERE c."workspaceId" = $1
+       ) wvo`,
       [workspaceId],
     );
 
@@ -114,45 +132,11 @@ export class WorkflowCoreConsistencyService {
       workspaceId,
       'workflow',
       {
-        unlinked: counts.unlinked,
-        missingCore: counts.missingCore,
-        fieldMismatch: counts.fieldMismatch,
-        orphanCore,
+        unlinked: counts.workflowUnlinked,
+        missingCore: counts.workflowMissingCore,
+        fieldMismatch: counts.workflowFieldMismatch,
+        orphanCore: counts.workflowOrphanCore,
       },
-    );
-  }
-
-  private async checkWorkflowVersionSync(
-    workspaceId: string,
-    schema: string,
-  ): Promise<void> {
-    const [counts] = await this.coreDataSource.query(
-      `SELECT
-         count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NULL)::int AS unlinked,
-         count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NOT NULL AND c.id IS NULL)::int AS "missingCore",
-         count(*) FILTER (WHERE c.id IS NOT NULL AND (
-           c.status::text IS DISTINCT FROM wf.status::text
-           OR c."workflowId" IS DISTINCT FROM wf."workflowId"
-           OR c.steps IS DISTINCT FROM wf.steps
-           OR c.triggers IS DISTINCT FROM (
-             CASE WHEN wf.trigger IS NULL THEN NULL ELSE jsonb_build_array(wf.trigger) END
-           )
-         ))::int AS "fieldMismatch"
-       FROM "${schema}"."workflowVersion" wf
-       LEFT JOIN core."workflowVersion" c
-         ON c.id = wf."coreWorkflowVersionId" AND c."workspaceId" = $1
-       WHERE wf."deletedAt" IS NULL`,
-      [workspaceId],
-    );
-
-    const [{ orphanCore }] = await this.coreDataSource.query(
-      `SELECT count(*)::int AS "orphanCore"
-       FROM core."workflowVersion" c
-       WHERE c."workspaceId" = $1
-         AND NOT EXISTS (
-           SELECT 1 FROM "${schema}"."workflowVersion" wf WHERE wf."coreWorkflowVersionId" = c.id
-         )`,
-      [workspaceId],
     );
 
     this.emitDrift(
@@ -160,12 +144,19 @@ export class WorkflowCoreConsistencyService {
       workspaceId,
       'workflowVersion',
       {
-        unlinked: counts.unlinked,
-        missingCore: counts.missingCore,
-        fieldMismatch: counts.fieldMismatch,
-        orphanCore,
+        unlinked: counts.versionUnlinked,
+        missingCore: counts.versionMissingCore,
+        fieldMismatch: counts.versionFieldMismatch,
+        orphanCore: counts.versionOrphanCore,
       },
     );
+
+    const hasWorkflows =
+      counts.workflowTotal > 0 || counts.coreWorkflowTotal > 0;
+
+    if (hasWorkflows) {
+      await this.checkAutomatedTriggerSync(workspaceId, schema);
+    }
   }
 
   private async checkAutomatedTriggerSync(

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -17,6 +17,8 @@ import {
 
 type DriftCounts = Record<string, number>;
 
+const SHARD_TOTAL = 8;
+
 // Detect drift between the workspace source-of-truth records and their core
 // mirror. The dual-write is best-effort (async, not transactional), so core can
 // silently fall out of sync; this quantifies that per workspace as metrics.
@@ -34,7 +36,16 @@ export class WorkflowCoreConsistencyService {
   ) {}
 
   async runConsistencyCheck(): Promise<void> {
+    // The cron fires every 3 hours; sharding by fire hour spreads the fleet
+    // over the 8 daily runs so each workspace is checked once a day instead of
+    // every run.
+    const shard = {
+      index: Math.floor(new Date().getUTCHours() / 3) % SHARD_TOTAL,
+      total: SHARD_TOTAL,
+    };
+
     const report = await this.workspaceIteratorService.iterate({
+      shard,
       callback: async ({ workspaceId, databaseSchema }) => {
         if (!isDefined(databaseSchema)) {
           return;
@@ -51,79 +62,53 @@ export class WorkflowCoreConsistencyService {
     }
   }
 
-  // Single statement instead of one shouldCheck + four aggregate queries: the
-  // cron visits every provisioned workspace every run, so per-workspace query
-  // count dominates its cost.
   private async checkWorkspace(
     workspaceId: string,
     schema: string,
   ): Promise<void> {
-    const [counts]: [
-      {
-        workflowTotal: number;
-        workflowUnlinked: number;
-        workflowMissingCore: number;
-        workflowFieldMismatch: number;
-        workflowOrphanCore: number;
-        coreWorkflowTotal: number;
-        versionUnlinked: number;
-        versionMissingCore: number;
-        versionFieldMismatch: number;
-        versionOrphanCore: number;
-      },
-    ] = await this.coreDataSource.query(
+    const [{ shouldCheck }] = await this.coreDataSource.query(
+      `SELECT (
+         EXISTS (SELECT 1 FROM "${schema}"."workflow" WHERE "deletedAt" IS NULL)
+         OR EXISTS (SELECT 1 FROM core."workflow" WHERE "workspaceId" = $1)
+       ) AS "shouldCheck"`,
+      [workspaceId],
+    );
+
+    if (!shouldCheck) {
+      return;
+    }
+
+    await this.checkWorkflowSync(workspaceId, schema);
+    await this.checkWorkflowVersionSync(workspaceId, schema);
+    await this.checkAutomatedTriggerSync(workspaceId, schema);
+  }
+
+  private async checkWorkflowSync(
+    workspaceId: string,
+    schema: string,
+  ): Promise<void> {
+    const [counts] = await this.coreDataSource.query(
       `SELECT
-         wf."workflowTotal", wf."workflowUnlinked", wf."workflowMissingCore", wf."workflowFieldMismatch",
-         wfo."coreWorkflowTotal", wfo."workflowOrphanCore",
-         wv."versionUnlinked", wv."versionMissingCore", wv."versionFieldMismatch",
-         wvo."versionOrphanCore"
-       FROM (
-         SELECT
-           count(*)::int AS "workflowTotal",
-           count(*) FILTER (WHERE wf."coreWorkflowId" IS NULL)::int AS "workflowUnlinked",
-           count(*) FILTER (WHERE wf."coreWorkflowId" IS NOT NULL AND c.id IS NULL)::int AS "workflowMissingCore",
-           count(*) FILTER (WHERE c.id IS NOT NULL AND (
-             wf.name IS DISTINCT FROM c.name
-             OR NULLIF(wf."lastPublishedVersionId", '') IS DISTINCT FROM c."lastPublishedVersionId"::text
-           ))::int AS "workflowFieldMismatch"
-         FROM "${schema}"."workflow" wf
-         LEFT JOIN core."workflow" c
-           ON c.id = wf."coreWorkflowId" AND c."workspaceId" = $1
-         WHERE wf."deletedAt" IS NULL
-       ) wf
-       CROSS JOIN (
-         SELECT
-           count(*)::int AS "coreWorkflowTotal",
-           count(*) FILTER (WHERE NOT EXISTS (
-             SELECT 1 FROM "${schema}"."workflow" wf WHERE wf."coreWorkflowId" = c.id
-           ))::int AS "workflowOrphanCore"
-         FROM core."workflow" c
-         WHERE c."workspaceId" = $1
-       ) wfo
-       CROSS JOIN (
-         SELECT
-           count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NULL)::int AS "versionUnlinked",
-           count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NOT NULL AND c.id IS NULL)::int AS "versionMissingCore",
-           count(*) FILTER (WHERE c.id IS NOT NULL AND (
-             c.status::text IS DISTINCT FROM wf.status::text
-             OR c."workflowId" IS DISTINCT FROM wf."workflowId"
-             OR c.steps IS DISTINCT FROM wf.steps
-             OR c.triggers IS DISTINCT FROM (
-               CASE WHEN wf.trigger IS NULL THEN NULL ELSE jsonb_build_array(wf.trigger) END
-             )
-           ))::int AS "versionFieldMismatch"
-         FROM "${schema}"."workflowVersion" wf
-         LEFT JOIN core."workflowVersion" c
-           ON c.id = wf."coreWorkflowVersionId" AND c."workspaceId" = $1
-         WHERE wf."deletedAt" IS NULL
-       ) wv
-       CROSS JOIN (
-         SELECT count(*) FILTER (WHERE NOT EXISTS (
-           SELECT 1 FROM "${schema}"."workflowVersion" wf WHERE wf."coreWorkflowVersionId" = c.id
-         ))::int AS "versionOrphanCore"
-         FROM core."workflowVersion" c
-         WHERE c."workspaceId" = $1
-       ) wvo`,
+         count(*) FILTER (WHERE wf."coreWorkflowId" IS NULL)::int AS unlinked,
+         count(*) FILTER (WHERE wf."coreWorkflowId" IS NOT NULL AND c.id IS NULL)::int AS "missingCore",
+         count(*) FILTER (WHERE c.id IS NOT NULL AND (
+           wf.name IS DISTINCT FROM c.name
+           OR NULLIF(wf."lastPublishedVersionId", '') IS DISTINCT FROM c."lastPublishedVersionId"::text
+         ))::int AS "fieldMismatch"
+       FROM "${schema}"."workflow" wf
+       LEFT JOIN core."workflow" c
+         ON c.id = wf."coreWorkflowId" AND c."workspaceId" = $1
+       WHERE wf."deletedAt" IS NULL`,
+      [workspaceId],
+    );
+
+    const [{ orphanCore }] = await this.coreDataSource.query(
+      `SELECT count(*)::int AS "orphanCore"
+       FROM core."workflow" c
+       WHERE c."workspaceId" = $1
+         AND NOT EXISTS (
+           SELECT 1 FROM "${schema}"."workflow" wf WHERE wf."coreWorkflowId" = c.id
+         )`,
       [workspaceId],
     );
 
@@ -132,11 +117,45 @@ export class WorkflowCoreConsistencyService {
       workspaceId,
       'workflow',
       {
-        unlinked: counts.workflowUnlinked,
-        missingCore: counts.workflowMissingCore,
-        fieldMismatch: counts.workflowFieldMismatch,
-        orphanCore: counts.workflowOrphanCore,
+        unlinked: counts.unlinked,
+        missingCore: counts.missingCore,
+        fieldMismatch: counts.fieldMismatch,
+        orphanCore,
       },
+    );
+  }
+
+  private async checkWorkflowVersionSync(
+    workspaceId: string,
+    schema: string,
+  ): Promise<void> {
+    const [counts] = await this.coreDataSource.query(
+      `SELECT
+         count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NULL)::int AS unlinked,
+         count(*) FILTER (WHERE wf."coreWorkflowVersionId" IS NOT NULL AND c.id IS NULL)::int AS "missingCore",
+         count(*) FILTER (WHERE c.id IS NOT NULL AND (
+           c.status::text IS DISTINCT FROM wf.status::text
+           OR c."workflowId" IS DISTINCT FROM wf."workflowId"
+           OR c.steps IS DISTINCT FROM wf.steps
+           OR c.triggers IS DISTINCT FROM (
+             CASE WHEN wf.trigger IS NULL THEN NULL ELSE jsonb_build_array(wf.trigger) END
+           )
+         ))::int AS "fieldMismatch"
+       FROM "${schema}"."workflowVersion" wf
+       LEFT JOIN core."workflowVersion" c
+         ON c.id = wf."coreWorkflowVersionId" AND c."workspaceId" = $1
+       WHERE wf."deletedAt" IS NULL`,
+      [workspaceId],
+    );
+
+    const [{ orphanCore }] = await this.coreDataSource.query(
+      `SELECT count(*)::int AS "orphanCore"
+       FROM core."workflowVersion" c
+       WHERE c."workspaceId" = $1
+         AND NOT EXISTS (
+           SELECT 1 FROM "${schema}"."workflowVersion" wf WHERE wf."coreWorkflowVersionId" = c.id
+         )`,
+      [workspaceId],
     );
 
     this.emitDrift(
@@ -144,19 +163,12 @@ export class WorkflowCoreConsistencyService {
       workspaceId,
       'workflowVersion',
       {
-        unlinked: counts.versionUnlinked,
-        missingCore: counts.versionMissingCore,
-        fieldMismatch: counts.versionFieldMismatch,
-        orphanCore: counts.versionOrphanCore,
+        unlinked: counts.unlinked,
+        missingCore: counts.missingCore,
+        fieldMismatch: counts.fieldMismatch,
+        orphanCore,
       },
     );
-
-    const hasWorkflows =
-      counts.workflowTotal > 0 || counts.coreWorkflowTotal > 0;
-
-    if (hasWorkflows) {
-      await this.checkAutomatedTriggerSync(workspaceId, schema);
-    }
   }
 
   private async checkAutomatedTriggerSync(

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/workflow-core-consistency.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/workflow-core-consistency.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -11,6 +12,7 @@ import { WorkflowCoreConsistencyService } from 'src/modules/workflow/workflow-co
 @Module({
   imports: [
     TypeOrmModule.forFeature([WorkspaceEntity]),
+    WorkspaceIteratorModule,
     MetricsModule,
     WorkspaceCacheModule,
   ],

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/workflow-core-consistency.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/workflow-core-consistency.module.ts
@@ -1,21 +1,14 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkflowCoreConsistencyCronCommand } from 'src/modules/workflow/workflow-core-consistency/crons/commands/workflow-core-consistency-cron.command';
 import { WorkflowCoreConsistencyCronJob } from 'src/modules/workflow/workflow-core-consistency/crons/jobs/workflow-core-consistency-cron.job';
 import { WorkflowCoreConsistencyService } from 'src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([WorkspaceEntity]),
-    WorkspaceIteratorModule,
-    MetricsModule,
-    WorkspaceCacheModule,
-  ],
+  imports: [WorkspaceIteratorModule, MetricsModule, WorkspaceCacheModule],
   providers: [
     WorkflowCoreConsistencyService,
     WorkflowCoreConsistencyCronJob,

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/workflow-core-consistency.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/workflow-core-consistency.module.ts
@@ -1,13 +1,19 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkflowCoreConsistencyCronCommand } from 'src/modules/workflow/workflow-core-consistency/crons/commands/workflow-core-consistency-cron.command';
 import { WorkflowCoreConsistencyCronJob } from 'src/modules/workflow/workflow-core-consistency/crons/jobs/workflow-core-consistency-cron.job';
 import { WorkflowCoreConsistencyService } from 'src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service';
 
 @Module({
-  imports: [MetricsModule, WorkspaceCacheModule],
+  imports: [
+    TypeOrmModule.forFeature([WorkspaceEntity]),
+    MetricsModule,
+    WorkspaceCacheModule,
+  ],
   providers: [
     WorkflowCoreConsistencyService,
     WorkflowCoreConsistencyCronJob,


### PR DESCRIPTION
## Context

The workflow core-consistency cron enumerated workspaces with raw SQL filtering on `activationStatus IN ('ACTIVE', 'SUSPENDED')` only. Raw SQL bypasses the ORM soft-delete filter, so the cron also scanned soft-deleted workspaces awaiting hard deletion.

Those workspaces are skipped by the upgrade pipeline (`WorkspaceIteratorService` excludes soft-deleted rows), so their schemas can lag behind upgrade commands forever. On the dev cluster, three workspaces soft-deleted on June 4 are stuck pre-2.23 and lack the `coreWorkflowId` column, producing [TWENTY-SERVER-JMH](https://twenty-v7.sentry.io/issues/7654702516/) (`column wf.coreWorkflowId does not exist`) on every cron run since. They can never converge: the cron checks them, the upgrade never touches them.

## What this does

Replaces the hand-rolled raw-SQL enumeration and loop with `WorkspaceIteratorService.iterate` — the same abstraction the upgrade pipeline and app-install flows use. The iterator owns the workspace scope (`PROVISIONED_WORKSPACE_ACTIVATION_STATUSES`, soft-delete-aware through the entity's `@DeleteDateColumn`), the per-workspace error isolation, and the workspace context setup; the cron just reports the iterator's failures to Sentry as before. Workspaces without a `databaseSchema` are skipped.

The cron's scope is now provably identical to what the upgrade covers (CREATED, ACTIVE, SUSPENDED, not soft-deleted). CREATED workspaces are newly included, which is consistent: they are provisioned and upgraded, and the existing `shouldCheck` fast path skips them when they have no workflows.

The per-workspace drift checks remain raw SQL since they join workspace-schema tables against core tables.

## Query volume

The cron previously visited every provisioned workspace every 3 hours. Instead of touching the whole fleet each run, the fleet is now split into 8 deterministic shards (`mod(first uuid byte, 8)`) and each run only checks the shard matching its fire hour, so every workspace is still checked exactly once a day at an eighth of the per-run cost. The shard filter is a generic `shard` option on `WorkspaceIteratorService` applied in SQL, so out-of-shard workspaces cost nothing.

`WorkspaceIteratorContext` also exposes `databaseSchema` (the iterator already fetches the row), so the callback doesn't re-fetch it. The drift checks themselves keep their original one-query-per-concern shape for readability.

Shard distribution verified against the dev database: 66 provisioned workspaces spread 5-11 per shard.

Fixes TWENTY-SERVER-JMH
