### PR TITLE
Drop the ignored workspaceId argument from getRepository

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command.ts
@@ -162,9 +162,7 @@ export class MigrateAiAgentTextToJsonResponseFormatCommand extends ProvisionedWo
     agentIds: string[],
   ): Promise<void> {
     const workflowVersionRepository =
-      await this.twentyORMGlobalManager.getRepository<WorkflowVersionWorkspaceEntity>(
-        workspaceId,
-        'workflowVersion',
+      await this.twentyORMGlobalManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command.ts
@@ -80,27 +80,19 @@ export class MigrateMessagingInfrastructureToMetadataCommand extends Provisioned
     const isDryRun = options.dryRun ?? false;
 
     const connectedAccountWorkspaceRepository =
-      await this.twentyORMGlobalManager.getRepository<LegacyConnectedAccountWorkspaceEntity>(
-        workspaceId,
-        'connectedAccount',
+      await this.twentyORMGlobalManager.getRepository<LegacyConnectedAccountWorkspaceEntity>('connectedAccount',
       );
 
     const messageChannelWorkspaceRepository =
-      await this.twentyORMGlobalManager.getRepository<MessageChannelEntity>(
-        workspaceId,
-        'messageChannel',
+      await this.twentyORMGlobalManager.getRepository<MessageChannelEntity>('messageChannel',
       );
 
     const calendarChannelWorkspaceRepository =
-      await this.twentyORMGlobalManager.getRepository<CalendarChannelEntity>(
-        workspaceId,
-        'calendarChannel',
+      await this.twentyORMGlobalManager.getRepository<CalendarChannelEntity>('calendarChannel',
       );
 
     const messageFolderWorkspaceRepository =
-      await this.twentyORMGlobalManager.getRepository<MessageFolderEntity>(
-        workspaceId,
-        'messageFolder',
+      await this.twentyORMGlobalManager.getRepository<MessageFolderEntity>('messageFolder',
       );
 
     const connectedAccounts = await connectedAccountWorkspaceRepository.find();
@@ -373,9 +365,7 @@ export class MigrateMessagingInfrastructureToMetadataCommand extends Provisioned
     workspaceId: string,
   ): Promise<Map<string, string>> {
     const workspaceMemberRepository =
-      await this.twentyORMGlobalManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-        workspaceId,
-        'workspaceMember',
+      await this.twentyORMGlobalManager.getRepository<WorkspaceMemberWorkspaceEntity>('workspaceMember',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-15/2-15-workspace-command-1800000001000-migrate-manual-trigger-variables-to-payload.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-15/2-15-workspace-command-1800000001000-migrate-manual-trigger-variables-to-payload.command.ts
@@ -57,9 +57,7 @@ export class MigrateManualTriggerVariablesToPayloadCommand extends ProvisionedWo
     }
 
     const workflowVersionRepository =
-      await this.twentyORMGlobalManager.getRepository<WorkflowVersionWorkspaceEntity>(
-        workspaceId,
-        'workflowVersion',
+      await this.twentyORMGlobalManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783526282685-backfill-workflow-version-to-core.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783526282685-backfill-workflow-version-to-core.command.ts
@@ -36,9 +36,7 @@ export class BackfillWorkflowVersionToCoreCommand extends ProvisionedWorkspaceCo
         await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowVersionRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-                workspaceId,
-                'workflowVersion',
+              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
@@ -91,9 +91,7 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
     }
 
     const personRepository =
-      await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
-        workspaceId,
-        'person',
+      await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>('person',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
@@ -53,9 +53,7 @@ export class BackfillWorkflowVersionCoreLinksCommand extends ProvisionedWorkspac
         await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowVersionRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-                workspaceId,
-                'workflowVersion',
+              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command.ts
@@ -51,9 +51,7 @@ export class BackfillWorkflowCoreLinksCommand extends ProvisionedWorkspaceComman
         await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-                workspaceId,
-                'workflow',
+              await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>('workflow',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.ts
@@ -50,9 +50,7 @@ export class RepairOrphanCoreWorkflowVersionsCommand extends ProvisionedWorkspac
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowVersionRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-              workspaceId,
-              'workflowVersion',
+            await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
               { shouldBypassPermissionChecks: true },
             );
 

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
@@ -51,7 +51,6 @@ export class ApprovedAccessDomainResolver {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              currentWorkspace.id,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-connected-account.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-connected-account.service.ts
@@ -61,7 +61,6 @@ export class CreateConnectedAccountService {
 
       const workspaceMemberRepo =
         await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          workspaceId,
           'workspaceMember',
           rolePermissionConfig ?? undefined,
         );

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
@@ -85,7 +85,6 @@ export class AccessTokenService {
           async () => {
             const workspaceMemberRepository =
               await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-                workspaceId,
                 'workspaceMember',
                 { shouldBypassPermissionChecks: true },
               );

--- a/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
@@ -30,7 +30,6 @@ export class UpdateSubscriptionQuantityJob {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          data.workspaceId,
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -64,7 +64,6 @@ export class TimelineCalendarEventService {
         // https://github.com/twentyhq/core-team-issues/issues/2777
         const calendarEventRepository =
           await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
-            workspaceId,
             'calendarEvent',
             { shouldBypassPermissionChecks: true },
           );
@@ -121,7 +120,6 @@ export class TimelineCalendarEventService {
 
         const callRecordingRepository =
           await this.globalWorkspaceOrmManager.getRepository<CallRecordingWorkspaceEntity>(
-            workspaceId,
             'callRecording',
           );
 
@@ -183,7 +181,6 @@ export class TimelineCalendarEventService {
         // Resolve current user's userWorkspaceId (workspaceMember → userId → userWorkspace)
         const workspaceMemberRepo =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
@@ -53,7 +53,6 @@ export class TimelineMessagingService {
       async () => {
         const messageThreadRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
-            workspaceId,
             'messageThread',
           );
 
@@ -130,7 +129,6 @@ export class TimelineMessagingService {
       async () => {
         const messageParticipantRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
-            workspaceId,
             'messageParticipant',
           );
 
@@ -244,7 +242,6 @@ export class TimelineMessagingService {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
@@ -273,7 +270,6 @@ export class TimelineMessagingService {
 
         const messageThreadRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
-            workspaceId,
             'messageThread',
           );
 

--- a/packages/twenty-server/src/engine/core-modules/record-position/services/record-position.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-position/services/record-position.service.ts
@@ -165,7 +165,6 @@ export class RecordPositionService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const repository = await this.globalWorkspaceOrmManager.getRepository(
-          workspaceId,
           objectMetadata.nameSingular,
           {
             shouldBypassPermissionChecks: true,
@@ -192,7 +191,6 @@ export class RecordPositionService {
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const repository = await this.globalWorkspaceOrmManager.getRepository(
-        workspaceId,
         objectMetadata.nameSingular,
         {
           shouldBypassPermissionChecks: true,
@@ -215,7 +213,6 @@ export class RecordPositionService {
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const repository = await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             objectMetadata.nameSingular,
             {
               shouldBypassPermissionChecks: true,
@@ -240,7 +237,6 @@ export class RecordPositionService {
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const repository = await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             objectMetadata.nameSingular,
             {
               shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/services/related-person-ids.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/services/related-person-ids.service.ts
@@ -58,7 +58,6 @@ export class RelatedPersonIdsService {
 
         for (const relationPath of relationPaths) {
           const personIdsForPath = await this.walkRelationPath({
-            workspaceId,
             recordId,
             relationPath,
           });
@@ -73,11 +72,9 @@ export class RelatedPersonIdsService {
   }
 
   private async walkRelationPath({
-    workspaceId,
     recordId,
     relationPath,
   }: {
-    workspaceId: string;
     recordId: string;
     relationPath: RelationPathToPerson;
   }): Promise<string[]> {
@@ -90,7 +87,6 @@ export class RelatedPersonIdsService {
 
       const repository =
         await this.globalWorkspaceOrmManager.getRepository<RelationWalkRecord>(
-          workspaceId,
           hop.queryObjectNameSingular,
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/search/search.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/search.resolver.ts
@@ -76,7 +76,6 @@ export class SearchResolver {
         includedObjectNameSingulars,
         excludedObjectNameSingulars,
         after,
-        workspaceId: workspace.id,
       });
 
     return await this.searchService.computeSearchObjectResults({

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -87,11 +87,9 @@ export class SearchService {
     limit,
     filter,
     after,
-    workspaceId,
   }: {
     flatObjectMetadatas: FlatObjectMetadata[];
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
-    workspaceId: string;
   } & SearchArgs) {
     const filteredObjectMetadataItems = this.filterObjectMetadataItems({
       flatObjectMetadatas,
@@ -122,7 +120,6 @@ export class SearchService {
 
               const repository =
                 await this.globalWorkspaceOrmManager.getRepository<ObjectRecord>(
-                  workspaceId,
                   flatObjectMetadata.nameSingular,
                   rolePermissionConfig,
                 );

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
@@ -283,7 +283,6 @@ export class EmailComposerService {
       async () => {
         const messageRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
-            workspaceId,
             'message',
           );
 
@@ -301,7 +300,6 @@ export class EmailComposerService {
 
         const associationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            workspaceId,
             'messageChannelMessageAssociation',
           );
 

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/navigate-tool/navigate-app-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/navigate-tool/navigate-app-tool.ts
@@ -338,7 +338,6 @@ export class NavigateAppTool implements Tool {
         async () => {
           const repository =
             await this.globalWorkspaceOrmManager.getRepository<ObjectRecord>(
-              workspaceId,
               objectNameSingular,
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -162,7 +162,6 @@ export class UserWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          workspaceId,
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -489,7 +488,6 @@ export class UserWorkspaceService {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/engine/core-modules/user/jobs/update-workspace-member-email.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/jobs/update-workspace-member-email.job.ts
@@ -38,7 +38,6 @@ export class UpdateWorkspaceMemberEmailJob {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          workspace.id,
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -108,7 +108,6 @@ export class UserService {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspace.id,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
@@ -141,7 +140,6 @@ export class UserService {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspace.id,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
@@ -228,7 +226,6 @@ export class UserService {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspace.id,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
@@ -255,7 +252,6 @@ export class UserService {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspace.id,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
@@ -347,7 +343,6 @@ export class UserService {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspaceId,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );
@@ -415,7 +410,6 @@ export class UserService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          workspaceId,
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
@@ -26,7 +26,6 @@ export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheP
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspaceId,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -409,7 +409,6 @@ export class UserResolver {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspace.id,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );
@@ -513,7 +512,6 @@ export class UserResolver {
     const workspaceMemberRepository =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () =>
         this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          workspace.id,
           'workspaceMember',
           {
             shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
@@ -101,7 +101,6 @@ export class WorkflowTriggerController {
           async () => {
             const workflowRepository =
               await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-                workspaceId,
                 'workflow',
                 { shouldBypassPermissionChecks: true },
               );
@@ -129,7 +128,6 @@ export class WorkflowTriggerController {
 
             const workflowVersionRepository =
               await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-                workspaceId,
                 'workflowVersion',
                 { shouldBypassPermissionChecks: true },
               );

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -86,7 +86,6 @@ export class WorkflowTriggerResolver {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspace.id,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-core-sync.service.ts
@@ -136,7 +136,6 @@ export class WorkflowCoreSyncService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceWorkflowRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-          workspaceId,
           'workflow',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
@@ -340,7 +340,6 @@ export class WorkflowVersionCoreSyncService {
         async () => {
           const workflowVersionRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-              workspaceId,
               'workflowVersion',
               { shouldBypassPermissionChecks: true },
             );
@@ -367,7 +366,6 @@ export class WorkflowVersionCoreSyncService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-          workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -399,7 +397,6 @@ export class WorkflowVersionCoreSyncService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceWorkflowVersionRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-          workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
@@ -64,7 +64,6 @@ export class WorkspaceInvitationResolver {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspace.id,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );
@@ -104,7 +103,6 @@ export class WorkspaceInvitationResolver {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspace.id,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service.ts
@@ -68,7 +68,6 @@ export class AgentActorContextService {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository(
-              workspaceId,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/workspace-setup-chat.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/workspace-setup-chat.service.ts
@@ -272,7 +272,6 @@ export class WorkspaceSetupChatService {
           async () => {
             const workspaceMemberRepository =
               await this.globalWorkspaceOrmManager.getRepository(
-                workspaceId,
                 'workspaceMember',
                 { shouldBypassPermissionChecks: true },
               );

--- a/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-record-identifier.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-record-identifier.service.ts
@@ -81,7 +81,6 @@ export class NavigationMenuItemRecordIdentifierService {
           }
 
           const repository = await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             objectMetadata.nameSingular,
             rolePermissionConfig,
           );

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout/services/page-layout.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout/services/page-layout.service.ts
@@ -563,11 +563,9 @@ export class PageLayoutService {
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const dashboardRepository =
-        await this.globalWorkspaceOrmManager.getRepository(
-          workspaceId,
-          'dashboard',
-          { shouldBypassPermissionChecks: true },
-        );
+        await this.globalWorkspaceOrmManager.getRepository('dashboard', {
+          shouldBypassPermissionChecks: true,
+        });
 
       const dashboards = await dashboardRepository.find({
         where: {

--- a/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
@@ -227,7 +227,6 @@ export class UserRoleService {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
@@ -278,7 +277,6 @@ export class UserRoleService {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
@@ -154,7 +154,6 @@ export class ViewQueryParamsService {
     try {
       const workspaceMemberRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          workspaceId,
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
@@ -69,7 +69,6 @@ export class ViewQueryParamsService {
     });
 
     const timeZone = await this.getWorkspaceMemberTimezoneIfAvailable(
-      workspaceId,
       currentWorkspaceMemberId,
     );
 
@@ -144,7 +143,6 @@ export class ViewQueryParamsService {
   }
 
   private async getWorkspaceMemberTimezoneIfAvailable(
-    workspaceId: string,
     currentWorkspaceMemberId?: string,
   ): Promise<string> {
     if (!isDefined(currentWorkspaceMemberId)) {

--- a/packages/twenty-server/src/engine/trash-cleanup/services/trash-cleanup.service.ts
+++ b/packages/twenty-server/src/engine/trash-cleanup/services/trash-cleanup.service.ts
@@ -104,7 +104,6 @@ export class TrashCleanupService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const repository = await this.globalWorkspaceOrmManager.getRepository(
-          workspaceId,
           objectName,
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
@@ -27,19 +27,16 @@ export class GlobalWorkspaceOrmManager {
   ) {}
 
   async getRepository<T extends ObjectLiteral>(
-    workspaceId: string,
     workspaceEntity: Type<T>,
     permissionOptions?: RolePermissionConfig,
   ): Promise<WorkspaceRepositoryV2<T>>;
 
   async getRepository<T extends ObjectLiteral>(
-    workspaceId: string,
     objectMetadataName: string,
     permissionOptions?: RolePermissionConfig,
   ): Promise<WorkspaceRepositoryV2<T>>;
 
   async getRepository<T extends ObjectLiteral>(
-    _workspaceId: string,
     workspaceEntityOrObjectMetadataName: Type<T> | string,
     permissionOptions?: RolePermissionConfig,
   ): Promise<WorkspaceRepositoryV2<T>> {
@@ -49,10 +46,7 @@ export class GlobalWorkspaceOrmManager {
 
     return this.workspaceDataSourceV2Service
       .getDataSource({ useReplica: false })
-      .getRepository(
-        objectMetadataName,
-        permissionOptions,
-      ) as unknown as WorkspaceRepositoryV2<T>;
+      .getRepository<T>(objectMetadataName, permissionOptions);
   }
 
   private resolveObjectMetadataName<T extends ObjectLiteral>(

--- a/packages/twenty-server/src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
+++ b/packages/twenty-server/src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
@@ -105,7 +105,6 @@ export class BlocklistValidationService {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository(
-              workspaceId,
               WorkspaceMemberWorkspaceEntity,
               { shouldBypassPermissionChecks: true },
             );
@@ -191,7 +190,6 @@ export class BlocklistValidationService {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository(
-              workspaceId,
               WorkspaceMemberWorkspaceEntity,
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
+++ b/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
@@ -20,7 +20,6 @@ export class BlocklistRepository {
       async () => {
         const blockListRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             BlocklistWorkspaceEntity,
             {
               shouldBypassPermissionChecks: true,
@@ -45,7 +44,6 @@ export class BlocklistRepository {
       async () => {
         const blockListRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             BlocklistWorkspaceEntity,
           );
 

--- a/packages/twenty-server/src/modules/calendar/blocklist-manager/jobs/blocklist-reimport-calendar-events.job.ts
+++ b/packages/twenty-server/src/modules/calendar/blocklist-manager/jobs/blocklist-reimport-calendar-events.job.ts
@@ -45,7 +45,6 @@ export class BlocklistReimportCalendarEventsJob {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
@@ -95,7 +95,6 @@ export class CalendarEventsImportService {
 
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspaceId,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );
@@ -156,7 +155,6 @@ export class CalendarEventsImportService {
           }
           const calendarChannelEventAssociationRepository =
             await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
-              workspaceId,
               'calendarChannelEventAssociation',
             );
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -62,7 +62,6 @@ export class CalendarFetchEventsService {
           if (calendarEventIdsToDelete.length > 0) {
             const calendarChannelEventAssociationRepository =
               await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
-                workspaceId,
                 'calendarChannelEventAssociation',
               );
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
@@ -177,7 +177,6 @@ export class CalendarEventParticipantService {
           participants: savedParticipants,
           objectMetadataName: 'calendarEventParticipant',
           matchWith: 'workspaceMemberAndPerson',
-          workspaceId,
           transactionScope,
         });
       },

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -38,7 +38,6 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
       async () => {
         const calendarChannelEventAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
-            workspaceId,
             'calendarChannelEventAssociation',
           );
 

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
@@ -73,7 +73,6 @@ export class CreateCompanyAndPersonService {
       async () => {
         const personRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             PersonWorkspaceEntity,
             {
               shouldBypassPermissionChecks: true,
@@ -82,7 +81,6 @@ export class CreateCompanyAndPersonService {
 
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             WorkspaceMemberWorkspaceEntity,
             { shouldBypassPermissionChecks: true },
           );
@@ -210,7 +208,6 @@ export class CreateCompanyAndPersonService {
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository(
-              workspaceId,
               WorkspaceMemberWorkspaceEntity,
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -58,7 +58,6 @@ export class CreateCompanyService {
       async () => {
         const companyRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             CompanyWorkspaceEntity,
             {
               shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
@@ -26,11 +26,8 @@ export class CreatePersonService {
       async () => {
         const personRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             PersonWorkspaceEntity,
-            {
-              shouldBypassPermissionChecks: true,
-            },
+            { shouldBypassPermissionChecks: true },
           );
 
         const lastPersonPosition =
@@ -63,7 +60,6 @@ export class CreatePersonService {
       async () => {
         const personRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             PersonWorkspaceEntity,
             {
               shouldBypassPermissionChecks: true,
@@ -100,7 +96,6 @@ export class CreatePersonService {
       async () => {
         const personRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             PersonWorkspaceEntity,
             {
               shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/modules/dashboard-sync/services/dashboard-sync.service.ts
+++ b/packages/twenty-server/src/modules/dashboard-sync/services/dashboard-sync.service.ts
@@ -66,11 +66,9 @@ export class DashboardSyncService {
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const dashboardRepository =
-            await this.globalWorkspaceOrmManager.getRepository(
-              workspaceId,
-              'dashboard',
-              { shouldBypassPermissionChecks: true },
-            );
+            await this.globalWorkspaceOrmManager.getRepository('dashboard', {
+              shouldBypassPermissionChecks: true,
+            });
 
           await dashboardRepository.update({ pageLayoutId }, { updatedAt });
         },

--- a/packages/twenty-server/src/modules/dashboard/chart-data/services/bar-chart-data.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/services/bar-chart-data.service.ts
@@ -170,7 +170,6 @@ export class BarChartDataService {
                   subFieldName: configuration.secondaryAxisGroupBySubFieldName,
                 }
               : undefined,
-          workspaceId,
           authContext,
           flatObjectMetadataMaps,
           flatFieldMetadataMaps,

--- a/packages/twenty-server/src/modules/dashboard/chart-data/services/chart-relation-label.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/services/chart-relation-label.service.ts
@@ -25,7 +25,6 @@ type ResolveRelationLabelsParams = {
   rawResults: GroupByRawResult[];
   primaryAxis: ChartRelationLabelAxisInput;
   secondaryAxis?: ChartRelationLabelAxisInput;
-  workspaceId: string;
   authContext: WorkspaceAuthContext;
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
@@ -43,7 +42,6 @@ export class ChartRelationLabelService {
     rawResults,
     primaryAxis,
     secondaryAxis,
-    workspaceId,
     authContext,
     flatObjectMetadataMaps,
     flatFieldMetadataMaps,
@@ -76,7 +74,6 @@ export class ChartRelationLabelService {
 
     const rawLabelsByTargetObjectId = await this.fetchRawLabelsPerTargetObject({
       resolvableAxes,
-      workspaceId,
       authContext,
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,
@@ -110,13 +107,11 @@ export class ChartRelationLabelService {
 
   private async fetchRawLabelsPerTargetObject({
     resolvableAxes,
-    workspaceId,
     authContext,
     flatObjectMetadataMaps,
     flatFieldMetadataMaps,
   }: {
     resolvableAxes: ResolvableChartRelationAxis[];
-    workspaceId: string;
     authContext: WorkspaceAuthContext;
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
@@ -161,7 +156,6 @@ export class ChartRelationLabelService {
             targetFlatObjectMetadata,
             labelIdentifierColumnNames,
             recordIds: [...recordIds],
-            workspaceId,
             authContext,
             flatObjectMetadataMaps,
             flatFieldMetadataMaps,
@@ -186,7 +180,6 @@ export class ChartRelationLabelService {
     targetFlatObjectMetadata,
     labelIdentifierColumnNames,
     recordIds,
-    workspaceId,
     authContext,
     flatObjectMetadataMaps,
     flatFieldMetadataMaps,
@@ -194,7 +187,6 @@ export class ChartRelationLabelService {
     targetFlatObjectMetadata: FlatObjectMetadata;
     labelIdentifierColumnNames: string[];
     recordIds: string[];
-    workspaceId: string;
     authContext: WorkspaceAuthContext;
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
@@ -214,7 +206,6 @@ export class ChartRelationLabelService {
           }
 
           const repository = await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             targetFlatObjectMetadata.nameSingular,
             rolePermissionConfig,
           );

--- a/packages/twenty-server/src/modules/dashboard/chart-data/services/line-chart-data.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/services/line-chart-data.service.ts
@@ -178,7 +178,6 @@ export class LineChartDataService {
                   subFieldName: configuration.secondaryAxisGroupBySubFieldName,
                 }
               : undefined,
-          workspaceId,
           authContext,
           flatObjectMetadataMaps,
           flatFieldMetadataMaps,

--- a/packages/twenty-server/src/modules/dashboard/chart-data/services/pie-chart-data.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/services/pie-chart-data.service.ts
@@ -137,7 +137,6 @@ export class PieChartDataService {
             groupByField,
             subFieldName: configuration.groupBySubFieldName,
           },
-          workspaceId,
           authContext,
           flatObjectMetadataMaps,
           flatFieldMetadataMaps,

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
@@ -37,7 +37,6 @@ export class DashboardDuplicationService {
       async () => {
         const dashboardRepository =
           await this.globalWorkspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
-            workspaceId,
             'dashboard',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-to-page-layout-sync.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-to-page-layout-sync.service.ts
@@ -55,7 +55,6 @@ export class DashboardToPageLayoutSyncService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const dashboardRepository =
         await this.globalWorkspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
-          workspaceId,
           'dashboard',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
@@ -242,11 +242,9 @@ const createDashboardRecord = async (
 
   return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
     const dashboardRepository =
-      await deps.globalWorkspaceOrmManager.getRepository(
-        context.workspaceId,
-        'dashboard',
-        { shouldBypassPermissionChecks: true },
-      );
+      await deps.globalWorkspaceOrmManager.getRepository('dashboard', {
+        shouldBypassPermissionChecks: true,
+      });
 
     const position = await deps.recordPositionService.buildRecordPosition({
       value: 'first',

--- a/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
@@ -74,7 +74,6 @@ export const createGetDashboardTool = (
         await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const repo = await deps.globalWorkspaceOrmManager.getRepository(
-              context.workspaceId,
               'dashboard',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
@@ -32,7 +32,6 @@ export const createListDashboardsTool = (
         await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const repo = await deps.globalWorkspaceOrmManager.getRepository(
-              context.workspaceId,
               'dashboard',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign-draft.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign-draft.service.ts
@@ -54,7 +54,7 @@ export class MessageCampaignDraftService {
     entity: Type<T>,
     roleId: string,
   ) {
-    return this.globalWorkspaceOrmManager.getRepository(workspaceId, entity, {
+    return this.globalWorkspaceOrmManager.getRepository(entity, {
       unionOf: [roleId],
     });
   }

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign-draft.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign-draft.service.ts
@@ -50,7 +50,6 @@ export class MessageCampaignDraftService {
   ) {}
 
   private getRoleScopedRepository<T extends ObjectLiteral>(
-    workspaceId: string,
     entity: Type<T>,
     roleId: string,
   ) {
@@ -97,7 +96,6 @@ export class MessageCampaignDraftService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const campaignRepository = await this.getRoleScopedRepository(
-          workspaceId,
           MessageCampaignWorkspaceEntity,
           roleId,
         );

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign-statistics.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign-statistics.service.ts
@@ -27,7 +27,6 @@ export class MessageCampaignStatisticsService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageRepository =
         await this.globalWorkspaceOrmManager.getRepository(
-          workspaceId,
           MessageWorkspaceEntity,
           { shouldBypassPermissionChecks: true },
         );
@@ -61,7 +60,6 @@ export class MessageCampaignStatisticsService {
 
       const campaignRepository =
         await this.globalWorkspaceOrmManager.getRepository(
-          workspaceId,
           MessageCampaignWorkspaceEntity,
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
@@ -135,7 +135,7 @@ export class MessageCampaignService {
     entity: Type<T>,
     roleId: string,
   ) {
-    return this.globalWorkspaceOrmManager.getRepository(workspaceId, entity, {
+    return this.globalWorkspaceOrmManager.getRepository(entity, {
       unionOf: [roleId],
     });
   }
@@ -144,7 +144,7 @@ export class MessageCampaignService {
     workspaceId: string,
     entity: Type<T>,
   ) {
-    return this.globalWorkspaceOrmManager.getRepository(workspaceId, entity, {
+    return this.globalWorkspaceOrmManager.getRepository(entity, {
       shouldBypassPermissionChecks: true,
     });
   }

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
@@ -131,7 +131,6 @@ export class MessageCampaignService {
   ) {}
 
   private getRoleScopedRepository<T extends ObjectLiteral>(
-    workspaceId: string,
     entity: Type<T>,
     roleId: string,
   ) {
@@ -140,10 +139,7 @@ export class MessageCampaignService {
     });
   }
 
-  private getSystemRepository<T extends ObjectLiteral>(
-    workspaceId: string,
-    entity: Type<T>,
-  ) {
+  private getSystemRepository<T extends ObjectLiteral>(entity: Type<T>) {
     return this.globalWorkspaceOrmManager.getRepository(entity, {
       shouldBypassPermissionChecks: true,
     });
@@ -184,7 +180,6 @@ export class MessageCampaignService {
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const rawRecipients = await this.resolveRecipientsFromList(
-            workspaceId,
             listId,
             roleId,
           );
@@ -195,7 +190,6 @@ export class MessageCampaignService {
           );
 
           const campaignRepository = await this.getRoleScopedRepository(
-            workspaceId,
             MessageCampaignWorkspaceEntity,
             roleId,
           );
@@ -311,7 +305,6 @@ export class MessageCampaignService {
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const campaignRepository = await this.getSystemRepository(
-        workspaceId,
         MessageCampaignWorkspaceEntity,
       );
 
@@ -339,7 +332,6 @@ export class MessageCampaignService {
       const allRecipients = [...recipientsByMessageId.values()];
 
       const messageRepository = await this.getSystemRepository(
-        workspaceId,
         MessageWorkspaceEntity,
       );
 
@@ -397,7 +389,6 @@ export class MessageCampaignService {
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageRepository = await this.getSystemRepository(
-        workspaceId,
         MessageWorkspaceEntity,
       );
 
@@ -414,7 +405,6 @@ export class MessageCampaignService {
       }
 
       const campaignRepository = await this.getSystemRepository(
-        workspaceId,
         MessageCampaignWorkspaceEntity,
       );
 
@@ -427,7 +417,6 @@ export class MessageCampaignService {
       }
 
       const personRepository = await this.getSystemRepository(
-        workspaceId,
         PersonWorkspaceEntity,
       );
 
@@ -529,7 +518,6 @@ export class MessageCampaignService {
         });
 
         const associationRepository = await this.getSystemRepository(
-          workspaceId,
           MessageChannelMessageAssociationWorkspaceEntity,
         );
 
@@ -557,7 +545,6 @@ export class MessageCampaignService {
   }): Promise<void> {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageRepository = await this.getSystemRepository(
-        workspaceId,
         MessageWorkspaceEntity,
       );
 
@@ -591,7 +578,6 @@ export class MessageCampaignService {
     roleId: string,
   ): Promise<SendableDraftCampaign> {
     const campaignRepository = await this.getRoleScopedRepository(
-      workspaceId,
       MessageCampaignWorkspaceEntity,
       roleId,
     );
@@ -734,7 +720,6 @@ export class MessageCampaignService {
     campaignId: string,
   ): Promise<void> {
     const messageRepository = await this.getSystemRepository(
-      workspaceId,
       MessageWorkspaceEntity,
     );
 
@@ -757,7 +742,6 @@ export class MessageCampaignService {
     });
 
     const campaignRepository = await this.getSystemRepository(
-      workspaceId,
       MessageCampaignWorkspaceEntity,
     );
 
@@ -820,7 +804,6 @@ export class MessageCampaignService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const rawRecipients = await this.resolveRecipientsFromList(
-          workspaceId,
           listId,
           roleId,
         );
@@ -875,12 +858,10 @@ export class MessageCampaignService {
   }
 
   private async resolveRecipientsFromList(
-    workspaceId: string,
     listId: string,
     roleId: string,
   ): Promise<RawCampaignRecipient[]> {
     const listMemberRepository = await this.getRoleScopedRepository(
-      workspaceId,
       MessageListMemberWorkspaceEntity,
       roleId,
     );
@@ -890,14 +871,12 @@ export class MessageCampaignService {
     });
 
     return this.loadRecipientsByPersonIds(
-      workspaceId,
       members.map((member) => member.personId),
       roleId,
     );
   }
 
   private async loadRecipientsByPersonIds(
-    workspaceId: string,
     personIds: string[],
     roleId: string,
   ): Promise<RawCampaignRecipient[]> {
@@ -906,7 +885,6 @@ export class MessageCampaignService {
     }
 
     const personRepository = await this.getRoleScopedRepository(
-      workspaceId,
       PersonWorkspaceEntity,
       roleId,
     );

--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -17,7 +17,6 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 type ObjectMetadataName = 'messageParticipant' | 'calendarEventParticipant';
 
 type GetParticipantRepositoryArgs = {
-  workspaceId: string;
   objectMetadataName: ObjectMetadataName;
   transactionScope?: WorkspaceTransactionScope;
 };
@@ -53,7 +52,6 @@ type MatchParticipantsArgs<
   participants: ParticipantWorkspaceEntity[];
   objectMetadataName: ObjectMetadataName;
   matchWith: 'workspaceMemberOnly' | 'personOnly' | 'workspaceMemberAndPerson';
-  workspaceId: string;
   transactionScope?: WorkspaceTransactionScope;
 };
 
@@ -68,7 +66,6 @@ export class MatchParticipantService<
   ) {}
 
   private async getParticipantRepository({
-    workspaceId,
     objectMetadataName,
     transactionScope,
   }: GetParticipantRepositoryArgs) {
@@ -80,7 +77,6 @@ export class MatchParticipantService<
       }
 
       return await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
-        workspaceId,
         objectMetadataName,
       );
     }
@@ -92,7 +88,6 @@ export class MatchParticipantService<
     }
 
     return await this.globalWorkspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
-      workspaceId,
       objectMetadataName,
     );
   }
@@ -101,7 +96,6 @@ export class MatchParticipantService<
     participants,
     objectMetadataName,
     matchWith = 'workspaceMemberAndPerson',
-    workspaceId,
     transactionScope,
   }: MatchParticipantsArgs<ParticipantWorkspaceEntity>) {
     if (participants.length === 0) {
@@ -110,20 +104,17 @@ export class MatchParticipantService<
 
     const personRepository =
       await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
-        workspaceId,
         'person',
         { shouldBypassPermissionChecks: true },
       );
 
     const participantRepository = await this.getParticipantRepository({
-      workspaceId,
       objectMetadataName,
       transactionScope,
     });
 
     const workspaceMemberRepository =
       await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-        workspaceId,
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );
@@ -219,7 +210,6 @@ export class MatchParticipantService<
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const participantRepository = await this.getParticipantRepository({
-        workspaceId,
         objectMetadataName,
       });
 
@@ -240,7 +230,6 @@ export class MatchParticipantService<
         matchWith: 'workspaceMemberOnly',
         participants: tobeRematchedParticipants as ParticipantWorkspaceEntity[],
         objectMetadataName,
-        workspaceId,
       });
     }, authContext);
   }
@@ -254,7 +243,6 @@ export class MatchParticipantService<
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const participantRepository = await this.getParticipantRepository({
-        workspaceId,
         objectMetadataName,
       });
 
@@ -297,7 +285,6 @@ export class MatchParticipantService<
         matchWith: 'personOnly',
         participants: tobeRematchedParticipants,
         objectMetadataName,
-        workspaceId,
       });
     }, authContext);
   }

--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
@@ -55,7 +55,6 @@ export class BlocklistItemDeleteMessagesJob {
 
         const blocklistRepository =
           await this.globalWorkspaceOrmManager.getRepository<BlocklistWorkspaceEntity>(
-            workspaceId,
             'blocklist',
           );
 
@@ -86,20 +85,17 @@ export class BlocklistItemDeleteMessagesJob {
 
         const messageChannelMessageAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            workspaceId,
             'messageChannelMessageAssociation',
           );
 
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
 
         const messageParticipantRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
-            workspaceId,
             'messageParticipant',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-reimport-messages.job.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-reimport-messages.job.ts
@@ -48,7 +48,6 @@ export class BlocklistReimportMessagesJob {
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -39,7 +39,6 @@ export class ApplyMessagesVisibilityRestrictionsService {
       async () => {
         const messageChannelMessageAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            workspaceId,
             'messageChannelMessageAssociation',
           );
 
@@ -72,7 +71,6 @@ export class ApplyMessagesVisibilityRestrictionsService {
 
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
@@ -386,7 +386,6 @@ export class MessageChannelSyncStatusService {
 
     const workspaceMemberRepository =
       await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-        workspaceId,
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service.ts
@@ -41,13 +41,11 @@ export class MessagingDeleteFolderMessagesService {
       async () => {
         const messageFolderAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
-            workspaceId,
             'messageChannelMessageAssociationMessageFolder',
           );
 
         const messageChannelMessageAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            workspaceId,
             'messageChannelMessageAssociation',
           );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
@@ -44,7 +44,6 @@ export class MessagingDeleteGroupEmailMessagesService {
       async () => {
         const messageChannelMessageAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            workspaceId,
             'messageChannelMessageAssociation',
           );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -149,7 +149,6 @@ export class MessagingMessageListFetchService {
 
           const messageChannelMessageAssociationRepository =
             await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-              workspaceId,
               'messageChannelMessageAssociation',
             );
 
@@ -210,7 +209,6 @@ export class MessagingMessageListFetchService {
             ? await this.computeFullSyncMessageChannelMessageAssociationsToDelete(
                 freshMessageChannel,
                 messageExternalIds,
-                workspaceId,
               )
             : [];
 
@@ -344,11 +342,9 @@ export class MessagingMessageListFetchService {
   private async computeFullSyncMessageChannelMessageAssociationsToDelete(
     messageChannel: Pick<MessageChannelEntity, 'id'>,
     messageExternalIds: string[],
-    workspaceId: string,
   ) {
     const messageChannelMessageAssociationRepository =
       await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-        workspaceId,
         'messageChannelMessageAssociation',
       );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
@@ -156,7 +156,6 @@ export class MessagingMessagesImportService {
 
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspaceId,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/modules/messaging/message-outbound-manager/services/messaging-draft-send.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-outbound-manager/services/messaging-draft-send.service.ts
@@ -68,7 +68,6 @@ export class MessagingDraftSendService {
       async () => {
         const messageChannelMessageAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            workspaceId,
             'messageChannelMessageAssociation',
           );
 
@@ -137,7 +136,6 @@ export class MessagingDraftSendService {
         async () => {
           const messageChannelMessageAssociationRepository =
             await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-              workspaceId,
               'messageChannelMessageAssociation',
             );
 

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
@@ -73,7 +73,6 @@ export class MessagingMessageParticipantService {
           participants: createdParticipants,
           objectMetadataName: 'messageParticipant',
           matchWith: 'workspaceMemberAndPerson',
-          workspaceId,
           transactionScope,
         });
       },

--- a/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
@@ -30,7 +30,6 @@ export class NotePostQueryHookService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const noteTargetRepository =
         await this.globalWorkspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
-          workspace.id,
           'noteTarget',
         );
 
@@ -55,7 +54,6 @@ export class NotePostQueryHookService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const noteTargetRepository =
         await this.globalWorkspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
-          workspace.id,
           'noteTarget',
         );
 

--- a/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
@@ -30,7 +30,6 @@ export class TaskPostQueryHookService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const taskTargetRepository =
         await this.globalWorkspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
-          workspace.id,
           'taskTarget',
         );
 
@@ -55,7 +54,6 @@ export class TaskPostQueryHookService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const taskTargetRepository =
         await this.globalWorkspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
-          workspace.id,
           'taskTarget',
         );
 

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity-target-query.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity-target-query.service.ts
@@ -36,11 +36,9 @@ export class TimelineActivityTargetQueryService {
   async resolveTargetsBySourceRecordId({
     rule,
     sourceRecordIds,
-    workspaceId,
   }: {
     rule: TimelineActivityRule;
     sourceRecordIds: string[];
-    workspaceId: string;
   }): Promise<Map<string, ResolvedTimelineActivityTarget[]>> {
     const targetsBySourceRecordId = new Map<
       string,
@@ -56,7 +54,6 @@ export class TimelineActivityTargetQueryService {
 
     const junctionRepository =
       await this.globalWorkspaceOrmManager.getRepository(
-        workspaceId,
         junctionObjectNameSingular,
         { shouldBypassPermissionChecks: true },
       );
@@ -105,11 +102,9 @@ export class TimelineActivityTargetQueryService {
   async findSourceRecordsByRecordId({
     rule,
     recordIds,
-    workspaceId,
   }: {
     rule: TimelineActivityRule;
     recordIds: string[];
-    workspaceId: string;
   }): Promise<Map<string, Record<string, unknown>>> {
     const sourceRecordsByRecordId = new Map<string, Record<string, unknown>>();
 
@@ -118,7 +113,6 @@ export class TimelineActivityTargetQueryService {
     }
 
     const repository = await this.globalWorkspaceOrmManager.getRepository(
-      workspaceId,
       rule.sourceFlatObjectMetadata.nameSingular,
       { shouldBypassPermissionChecks: true },
     );

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
@@ -38,7 +38,6 @@ type BuildPayloadsForRuleArgs = {
   rule: TimelineActivityRule;
   events: ObjectRecordBaseEvent[];
   action: DatabaseEventAction;
-  workspaceId: string;
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
   resolveTimelineActivityType: TimelineActivityTypeResolver;
 };
@@ -148,7 +147,6 @@ export class TimelineActivityService {
           // objects mostly, never pay the workspace member query.
           const enrichedEvents = await this.enrichEventsWithWorkspaceMemberId({
             events: eventsWithoutPositionDiff,
-            workspaceId,
           });
 
           return Promise.all([
@@ -157,7 +155,6 @@ export class TimelineActivityService {
                 rule,
                 events: enrichedEvents,
                 action,
-                workspaceId,
                 flatFieldMetadataMaps,
                 resolveTimelineActivityType,
               }),
@@ -167,7 +164,6 @@ export class TimelineActivityService {
                 rule,
                 events: enrichedEvents,
                 action,
-                workspaceId,
                 flatFieldMetadataMaps,
                 resolveTimelineActivityType,
               }),
@@ -247,7 +243,6 @@ export class TimelineActivityService {
     rule,
     events,
     action,
-    workspaceId,
     flatFieldMetadataMaps,
     resolveTimelineActivityType,
   }: BuildPayloadsForRuleArgs): Promise<TimelineActivityPayload[]> {
@@ -358,7 +353,6 @@ export class TimelineActivityService {
         {
           rule,
           sourceRecordIds: matchingEvents.map((event) => event.recordId),
-          workspaceId,
         },
       );
 
@@ -386,7 +380,6 @@ export class TimelineActivityService {
     rule,
     events,
     action,
-    workspaceId,
     flatFieldMetadataMaps,
     resolveTimelineActivityType,
   }: BuildPayloadsForRuleArgs): Promise<TimelineActivityPayload[]> {
@@ -463,7 +456,6 @@ export class TimelineActivityService {
           recordIds: eventsWithJunctionRecord.map(
             ({ sourceRecordId }) => sourceRecordId,
           ),
-          workspaceId,
         },
       );
 
@@ -489,10 +481,8 @@ export class TimelineActivityService {
 
   private async enrichEventsWithWorkspaceMemberId({
     events,
-    workspaceId,
   }: {
     events: ObjectRecordBaseEvent[];
-    workspaceId: string;
   }): Promise<ObjectRecordBaseEvent[]> {
     const userIds = events.map((event) => event.userId).filter(isDefined);
 
@@ -502,7 +492,6 @@ export class TimelineActivityService {
 
     const workspaceMemberRepository =
       await this.globalWorkspaceOrmManager.getRepository(
-        workspaceId,
         WorkspaceMemberWorkspaceEntity,
         {
           shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -83,7 +83,6 @@ export class WorkflowCommonWorkspaceService {
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
           );
@@ -168,7 +167,6 @@ export class WorkflowCommonWorkspaceService {
         async () => {
           const workflowRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-              workspaceId,
               'workflow',
               { shouldBypassPermissionChecks: true },
             );
@@ -321,21 +319,18 @@ export class WorkflowCommonWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-          workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
 
       const workflowRunRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-          workspaceId,
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );
 
       const workflowAutomatedTriggerRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
-          workspaceId,
           'workflowAutomatedTrigger',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
@@ -52,7 +52,6 @@ export class WorkflowVersionValidationWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-          workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -135,7 +134,6 @@ export class WorkflowVersionValidationWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-          workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -768,7 +768,6 @@ export class WorkflowVersionStepOperationsWorkspaceService {
 
               const repository =
                 await this.globalWorkspaceOrmManager.getRepository(
-                  workspaceId,
                   field.settings.objectName,
                   { shouldBypassPermissionChecks: true },
                 );
@@ -931,7 +930,6 @@ export class WorkflowVersionStepOperationsWorkspaceService {
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
           );
@@ -1008,7 +1006,6 @@ export class WorkflowVersionStepOperationsWorkspaceService {
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
@@ -62,7 +62,6 @@ export class WorkflowVersionWorkspaceService {
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
           );
@@ -195,15 +194,12 @@ export class WorkflowVersionWorkspaceService {
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workflowRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
-            'workflow',
-            { shouldBypassPermissionChecks: true },
-          );
+          await this.globalWorkspaceOrmManager.getRepository('workflow', {
+            shouldBypassPermissionChecks: true,
+          });
 
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
           );
@@ -380,7 +376,6 @@ export class WorkflowVersionWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-          workspaceId,
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/email-workflow-action.base.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/email-workflow-action.base.ts
@@ -101,10 +101,7 @@ export abstract class EmailWorkflowActionBase extends ToolBackedWorkflowAction<W
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        const workspaceMember = await this.findWorkspaceMemberById(
-          senderId,
-          workspaceId,
-        );
+        const workspaceMember = await this.findWorkspaceMemberById(senderId);
 
         if (!isDefined(workspaceMember)) {
           return senderId;
@@ -131,11 +128,9 @@ export abstract class EmailWorkflowActionBase extends ToolBackedWorkflowAction<W
 
   private async findWorkspaceMemberById(
     workspaceMemberId: string,
-    workspaceId: string,
   ): Promise<WorkspaceMemberWorkspaceEntity | null> {
     const workspaceMemberRepository =
       await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-        workspaceId,
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
@@ -141,7 +141,6 @@ export class WorkflowCleanWorkflowRunsCronJob {
       async () => {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             WorkflowRunWorkspaceEntity,
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -52,7 +52,6 @@ export class WorkflowHandleStaledRunsWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRunRepository =
         await this.globalWorkspaceOrmManager.getRepository(
-          workspaceId,
           WorkflowRunWorkspaceEntity,
           { shouldBypassPermissionChecks: true },
         );
@@ -284,7 +283,6 @@ export class WorkflowHandleStaledRunsWorkspaceService {
       async () => {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             WorkflowRunWorkspaceEntity,
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -53,7 +53,6 @@ export class WorkflowRunEnqueueWorkspaceService {
         async () => {
           const workflowRunRepository =
             await this.globalWorkspaceOrmManager.getRepository(
-              workspaceId,
               WorkflowRunWorkspaceEntity,
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
@@ -79,7 +79,6 @@ export class WorkflowThrottlingWorkspaceService {
         async () => {
           const workflowRunRepository =
             await this.globalWorkspaceOrmManager.getRepository(
-              workspaceId,
               WorkflowRunWorkspaceEntity,
               { shouldBypassPermissionChecks: true },
             );
@@ -110,7 +109,6 @@ export class WorkflowThrottlingWorkspaceService {
       async () => {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             WorkflowRunWorkspaceEntity,
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/command/delete-workflow-runs.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/command/delete-workflow-runs.command.ts
@@ -52,7 +52,6 @@ export class DeleteWorkflowRunsCommand extends ProvisionedWorkspaceCommandRunner
       try {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-            workspaceId,
             'workflowRun',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -59,7 +59,6 @@ export class WorkflowRunWorkspaceService {
       async () => {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-            workspaceId,
             'workflowRun',
             { shouldBypassPermissionChecks: true },
           );
@@ -71,11 +70,9 @@ export class WorkflowRunWorkspaceService {
           });
 
         const workflowRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
-            'workflow',
-            { shouldBypassPermissionChecks: true },
-          );
+          await this.globalWorkspaceOrmManager.getRepository('workflow', {
+            shouldBypassPermissionChecks: true,
+          });
 
         const workflow = await workflowRepository.findOne({
           where: {
@@ -368,7 +365,6 @@ export class WorkflowRunWorkspaceService {
       async () => {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-            workspaceId,
             'workflowRun',
             { shouldBypassPermissionChecks: true },
           );
@@ -417,7 +413,6 @@ export class WorkflowRunWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRunRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-          workspaceId,
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -73,7 +73,6 @@ export class WorkflowStatusesUpdateJob {
             event.workflowIds.map((workflowId) =>
               this.handleWorkflowVersionCreatedOrDeleted({
                 workflowId,
-                workspaceId: event.workspaceId,
               }),
             ),
           );
@@ -83,7 +82,6 @@ export class WorkflowStatusesUpdateJob {
             event.statusUpdates.map((statusUpdate) =>
               this.handleWorkflowVersionStatusUpdated({
                 statusUpdate,
-                workspaceId: event.workspaceId,
               }),
             ),
           );
@@ -96,21 +94,17 @@ export class WorkflowStatusesUpdateJob {
 
   private async handleWorkflowVersionCreatedOrDeleted({
     workflowId,
-    workspaceId,
   }: {
     workflowId: string;
-    workspaceId: string;
   }): Promise<void> {
     const workflowRepository =
       await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-        workspaceId,
         'workflow',
         { shouldBypassPermissionChecks: true },
       );
 
     const workflowVersionRepository =
       await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-        workspaceId,
         'workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
@@ -143,21 +137,17 @@ export class WorkflowStatusesUpdateJob {
 
   private async handleWorkflowVersionStatusUpdated({
     statusUpdate,
-    workspaceId,
   }: {
     statusUpdate: WorkflowVersionStatusUpdate;
-    workspaceId: string;
   }): Promise<void> {
     const workflowRepository =
       await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-        workspaceId,
         'workflow',
         { shouldBypassPermissionChecks: true },
       );
 
     const workflowVersionRepository =
       await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-        workspaceId,
         'workflowVersion',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-current-version.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-current-version.tool.spec.ts
@@ -65,17 +65,11 @@ describe('get_workflow_current_version tool', () => {
 
     expect(
       deps.globalWorkspaceOrmManager.getRepository,
-    ).toHaveBeenNthCalledWith(
-      1,
-      WORKSPACE_ID,
-      'workflow',
-      context.rolePermissionConfig,
-    );
+    ).toHaveBeenNthCalledWith(1, 'workflow', context.rolePermissionConfig);
     expect(
       deps.globalWorkspaceOrmManager.getRepository,
     ).toHaveBeenNthCalledWith(
       2,
-      WORKSPACE_ID,
       'workflowVersion',
       context.rolePermissionConfig,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-run.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-run.tool.spec.ts
@@ -38,7 +38,6 @@ describe('get_workflow_run tool', () => {
     await tool.execute({ workflowRunId: WORKFLOW_RUN_ID });
 
     expect(deps.globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
-      WORKSPACE_ID,
       'workflowRun',
       context.rolePermissionConfig,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/list-workflow-runs.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/list-workflow-runs.tool.spec.ts
@@ -36,7 +36,6 @@ describe('list_workflow_runs tool', () => {
     await tool.execute({});
 
     expect(deps.globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
-      WORKSPACE_ID,
       'workflowRun',
       context.rolePermissionConfig,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-complete-workflow.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-complete-workflow.tool.ts
@@ -224,7 +224,6 @@ const createWorkflow = async ({
   return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
     const workflowRepository =
       await deps.globalWorkspaceOrmManager.getRepository(
-        context.workspaceId,
         'workflow',
         context.rolePermissionConfig,
       );
@@ -313,7 +312,6 @@ const updateWorkflowStatus = async ({
   await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
     const workflowRepository =
       await deps.globalWorkspaceOrmManager.getRepository(
-        context.workspaceId,
         'workflow',
         context.rolePermissionConfig,
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow.tool.ts
@@ -42,7 +42,6 @@ export const createDeleteWorkflowTool = (
           async () => {
             const workflowRepository =
               await deps.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-                workspaceId,
                 'workflow',
                 context.rolePermissionConfig,
               );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
@@ -44,7 +44,6 @@ export const createGetWorkflowCurrentVersionTool = (
         async () => {
           const workflowRepository =
             await deps.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-              context.workspaceId,
               'workflow',
               context.rolePermissionConfig,
             );
@@ -62,7 +61,6 @@ export const createGetWorkflowCurrentVersionTool = (
 
           const workflowVersionRepository =
             await deps.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-              context.workspaceId,
               'workflowVersion',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-run.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-run.tool.ts
@@ -41,7 +41,6 @@ export const createGetWorkflowRunTool = (
         async () => {
           const workflowRunRepository =
             await deps.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-              context.workspaceId,
               'workflowRun',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflow-runs.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflow-runs.tool.ts
@@ -58,7 +58,6 @@ export const createListWorkflowRunsTool = (
         async () => {
           const workflowRunRepository =
             await deps.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-              context.workspaceId,
               'workflowRun',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflows.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflows.tool.ts
@@ -42,7 +42,6 @@ export const createListWorkflowsTool = (
         async () => {
           const workflowRepository =
             await deps.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-              context.workspaceId,
               'workflow',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-agent.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-agent.tool.ts
@@ -74,7 +74,6 @@ const resyncAiAgentStepOutputSchemas = async (
 
   const workflowVersionRepository =
     await deps.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-      workspaceId,
       'workflowVersion',
       { shouldBypassPermissionChecks: true },
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
@@ -44,7 +44,6 @@ export class AutomatedTriggerWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowAutomatedTriggerRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
-          workspaceId,
           'workflowAutomatedTrigger',
         );
 
@@ -80,7 +79,6 @@ export class AutomatedTriggerWorkspaceService {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowAutomatedTriggerRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
-          workspaceId,
           'workflowAutomatedTrigger',
         );
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
@@ -310,7 +310,6 @@ export class WorkflowDatabaseEventTriggerListener {
 
         const relatedObjectRepository =
           await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
             relatedObjectMetadataNameSingular,
             { shouldBypassPermissionChecks: true },
           );
@@ -414,7 +413,6 @@ export class WorkflowDatabaseEventTriggerListener {
       async () => {
         const workflowAutomatedTriggerRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
-            workspaceId,
             automatedTriggerTableName,
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
@@ -39,7 +39,6 @@ export class WorkflowTriggerJob {
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-          data.workspaceId,
           'workflow',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -104,7 +104,6 @@ export class WorkflowTriggerWorkspaceService {
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
           );
@@ -122,7 +121,6 @@ export class WorkflowTriggerWorkspaceService {
 
         const workflowRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-            workspaceId,
             'workflow',
             { shouldBypassPermissionChecks: true },
           );
@@ -213,7 +211,6 @@ export class WorkflowTriggerWorkspaceService {
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-delete-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-delete-one.post-query.hook.ts
@@ -51,7 +51,6 @@ export class WorkspaceMemberDeleteOnePostQueryHook implements WorkspacePostQuery
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspace.id,
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );


### PR DESCRIPTION
## What

Second of the three PRs splitting #24745 (after #24747). `getRepository(workspaceId, entityOrName, options)` declared its first parameter as `_workspaceId`: the workspace has come from the AsyncLocalStorage context since the v2 cutover, so the argument did nothing.

- Remove the parameter from the ORM manager's `getRepository` overloads and implementation (which also drops the internal `as unknown as` cast now that the datasource `getRepository` is generic, from #24747).
- Remove the argument from all ~170 call sites.
- Remove the `workspaceId` parameters and argument-type properties that existed only to feed it. The removal cascades a few levels into private helpers (chart data, timeline, match-participant, workflow status) and their callers; every step was compiler-driven.
- Update the three workflow-tool specs that asserted the removed argument.

## Notes for the guard

This retypes calls inside committed upgrade commands (argument removal only, no SQL, timestamp, or up/down logic changes), so the PR carries the `ci:allow-previous-version-upgrade-mutation` label.

## Coming next

Once this merges: merge `twenty-orm-v2/` into `twenty-orm/` and drop the v2 suffixes.

## Verification

- `tsgo --noEmit` clean, `oxlint --type-aware` clean on the 100 changed files, `oxfmt --check src/` clean
- Workflow-tool, match-participant, timeline, workflow-status and chart unit suites pass
- Behavior neutral by construction; `server-integration-test` is the end-to-end proof


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

