### PR TITLE
fix(server): attach service and pod identity to exported metrics

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -70,6 +70,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
     "@opentelemetry/exporter-prometheus": "^0.219.0",
+    "@opentelemetry/resources": "^2.8.0",
     "@opentelemetry/sdk-metrics": "^2.8.0",
     "@react-pdf/renderer": "^4.1.6",
     "@sentry/nestjs": "^10.59.0",

--- a/packages/twenty-server/src/instrument.ts
+++ b/packages/twenty-server/src/instrument.ts
@@ -1,8 +1,10 @@
+import os from 'os';
 import process from 'process';
 
 import { metrics as otelMetrics } from '@opentelemetry/api';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
+import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
   AggregationTemporality,
   ConsoleMetricExporter,
@@ -123,6 +125,10 @@ const prometheusExporter = meterDrivers.includes(MeterDriver.Prometheus)
   : null;
 
 const meterProvider = new MeterProvider({
+  resource: resourceFromAttributes({
+    'service.name': process.env.OTEL_SERVICE_NAME ?? 'twenty-server',
+    'k8s.pod.name': process.env.HOSTNAME ?? os.hostname(),
+  }),
   readers: [
     ...(meterDrivers.includes(MeterDriver.Console)
       ? [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13354,6 +13354,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/core@npm:2.10.0":
+  version: 2.10.0
+  resolution: "@opentelemetry/core@npm:2.10.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/fe79c3f77881c5cdd5cff17825f847536fb7882d8c7e26356081ab20c1a16910ae54ffb1deb49ec34293cc2da5bf8501f30acb51e7e159184f2320ebba958c3f
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/core@npm:2.8.0, @opentelemetry/core@npm:^2.6.1":
   version: 2.8.0
   resolution: "@opentelemetry/core@npm:2.8.0"
@@ -13444,6 +13455,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   checksum: 10c0/60948bf1a69b9f3f5173cb4db7f317bd24399379a899254519af3f00d22b1da1caf27eb3d893c6118de8984e6d22484750cf924b52dc499bd6e9b8aac9089ef6
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:^2.8.0":
+  version: 2.10.0
+  resolution: "@opentelemetry/resources@npm:2.10.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.10.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/23e227a7fee39f93fee9b956fd7e46558807df633ee5a00b0ce0aed11bef587bf03489e02c330e8e414ab6fe4f011c8fe4d5b03a1fbd0003481f29a428bb9433
   languageName: node
   linkType: hard
 
@@ -49442,6 +49465,7 @@ __metadata:
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/exporter-metrics-otlp-http": "npm:^0.219.0"
     "@opentelemetry/exporter-prometheus": "npm:^0.219.0"
+    "@opentelemetry/resources": "npm:^2.8.0"
     "@opentelemetry/sdk-metrics": "npm:^2.8.0"
     "@react-pdf/renderer": "npm:^4.1.6"
     "@sentry/nestjs": "npm:^10.59.0"


### PR DESCRIPTION
## Context

The `MeterProvider` in `instrument.ts` is created without a resource, so every metric exported through the OTLP pipeline lands in ClickHouse with `ResourceAttributes: {'service.name': 'unknown_service:node', ...}` and no pod identity. Fleet-level questions are answerable (max event-loop utilization, pool saturation) but per-pod attribution is impossible: prod currently shows some pod pinned at event-loop utilization 1.0 at every minute of the day and a core pool at 40/40 with up to 83 queued requests, and there is no way to tell which deployment or pod it is. (The Prometheus scrape path is unaffected — it gets pod labels from the scraper.)

## What this does

Gives the `MeterProvider` a resource with `service.name` (`OTEL_SERVICE_NAME` env, default `twenty-server`) and `k8s.pod.name` (`HOSTNAME`, which Kubernetes sets to the pod name; `os.hostname()` fallback locally). Pod names encode the deployment (`twenty-server-worker-default-*`, `twenty-server-*`), so this is enough to attribute any ClickHouse-backed panel per component and per pod.

Adds `@opentelemetry/resources` as a direct dependency — it was already in the tree at 2.8.0 via `@opentelemetry/sdk-metrics`, so the lockfile change is descriptor-only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

