### PR TITLE
Add Exa to marketplace vetted applications

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-marketplace/constants/marketplace-vetted-applications.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-marketplace/constants/marketplace-vetted-applications.constant.ts
@@ -14,4 +14,8 @@ export const MARKETPLACE_VETTED_APPLICATIONS: {
     universalIdentifier: '66a504cc-0a75-410e-a43f-cdeae1db1522',
     position: 3,
   },
+  {
+    universalIdentifier: '2b7f4a2e-9c4b-4a11-b63c-2e5e7d3f5a9a',
+    position: 4,
+  },
 ];


### PR DESCRIPTION
Adds Exa (`2b7f4a2e-9c4b-4a11-b63c-2e5e7d3f5a9a`) to `MARKETPLACE_VETTED_APPLICATIONS` at position 4, so it is marked as vetted by the marketplace catalog sync.