### PR TITLE
feat(server): log in-flight jobs when the worker event loop stalls

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.explorer.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.explorer.ts
@@ -188,12 +188,11 @@ export class MessageQueueExplorer implements OnModuleInit {
     queueName: MessageQueue,
   ) {
     queue.work(async (job) => {
-      const jobData = job.data as { workspaceId?: string } | undefined;
       const stallMonitorToken =
         this.eventLoopStallMonitorService.registerJobStart({
           queueName,
           jobName: job.name,
-          workspaceId: jobData?.workspaceId,
+          workspaceId: job.data?.workspaceId,
         });
 
       try {

--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.explorer.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.explorer.ts
@@ -20,6 +20,7 @@ import { MessageQueueMetadataAccessor } from 'src/engine/core-modules/message-qu
 import { type MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { MESSAGE_QUEUE_WORKER_CONFIG } from 'src/engine/core-modules/message-queue/message-queue-worker-config.constant';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { EventLoopStallMonitorService } from 'src/engine/core-modules/message-queue/services/event-loop-stall-monitor.service';
 import { getQueueToken } from 'src/engine/core-modules/message-queue/utils/get-queue-token.util';
 import { shouldCreateWorkerForQueue } from 'src/engine/core-modules/message-queue/utils/should-create-worker-for-queue.util';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
@@ -44,6 +45,7 @@ export class MessageQueueExplorer implements OnModuleInit {
     private readonly metadataScanner: MetadataScanner,
     private readonly exceptionHandlerService: ExceptionHandlerService,
     private readonly twentyConfigService: TwentyConfigService,
+    private readonly eventLoopStallMonitorService: EventLoopStallMonitorService,
   ) {}
 
   onModuleInit() {
@@ -104,6 +106,7 @@ export class MessageQueueExplorer implements OnModuleInit {
         processorGroupCollection,
         messageQueueService,
         MESSAGE_QUEUE_WORKER_CONFIG[queueName].workerOptions,
+        queueName,
       );
     }
   }
@@ -182,10 +185,23 @@ export class MessageQueueExplorer implements OnModuleInit {
     processorGroupCollection: ProcessorGroup[],
     queue: MessageQueueService,
     options: MessageQueueWorkerOptions,
+    queueName: MessageQueue,
   ) {
     queue.work(async (job) => {
-      for (const processorGroup of processorGroupCollection) {
-        await this.handleProcessor(processorGroup, job);
+      const jobData = job.data as { workspaceId?: string } | undefined;
+      const stallMonitorToken =
+        this.eventLoopStallMonitorService.registerJobStart({
+          queueName,
+          jobName: job.name,
+          workspaceId: jobData?.workspaceId,
+        });
+
+      try {
+        for (const processorGroup of processorGroupCollection) {
+          await this.handleProcessor(processorGroup, job);
+        }
+      } finally {
+        this.eventLoopStallMonitorService.registerJobEnd(stallMonitorToken);
       }
     }, options);
   }

--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.module.ts
@@ -4,6 +4,7 @@ import { DiscoveryModule } from '@nestjs/core';
 import { MessageQueueCoreModule } from 'src/engine/core-modules/message-queue/message-queue-core.module';
 import { MessageQueueMetadataAccessor } from 'src/engine/core-modules/message-queue/message-queue-metadata.accessor';
 import { MessageQueueExplorer } from 'src/engine/core-modules/message-queue/message-queue.explorer';
+import { EventLoopStallMonitorService } from 'src/engine/core-modules/message-queue/services/event-loop-stall-monitor.service';
 import {
   type ASYNC_OPTIONS_TYPE,
   type OPTIONS_TYPE,
@@ -23,7 +24,11 @@ export class MessageQueueModule {
     return {
       module: MessageQueueModule,
       imports: [DiscoveryModule],
-      providers: [MessageQueueExplorer, MessageQueueMetadataAccessor],
+      providers: [
+        MessageQueueExplorer,
+        MessageQueueMetadataAccessor,
+        EventLoopStallMonitorService,
+      ],
     };
   }
 

--- a/packages/twenty-server/src/engine/core-modules/message-queue/services/event-loop-stall-monitor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/services/event-loop-stall-monitor.service.ts
@@ -1,0 +1,93 @@
+import {
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+
+const TICK_INTERVAL_MS = 500;
+const STALL_THRESHOLD_MS = 2_000;
+
+type RunningJob = {
+  queueName: string;
+  jobName: string;
+  workspaceId?: string;
+  startedAt: number;
+};
+
+// A stalled event loop cannot be observed from within the stalled code, but a
+// timer that fires late reveals both the stall duration and which jobs were in
+// flight while it happened.
+@Injectable()
+export class EventLoopStallMonitorService
+  implements OnModuleInit, OnModuleDestroy
+{
+  private readonly logger = new Logger(EventLoopStallMonitorService.name);
+
+  private readonly runningJobs = new Map<symbol, RunningJob>();
+  private tickHandle?: NodeJS.Timeout;
+  private lastTickAt = 0;
+
+  onModuleInit() {
+    this.lastTickAt = Date.now();
+    this.tickHandle = setInterval(() => this.tick(), TICK_INTERVAL_MS);
+    this.tickHandle.unref();
+  }
+
+  onModuleDestroy() {
+    if (this.tickHandle) {
+      clearInterval(this.tickHandle);
+    }
+  }
+
+  registerJobStart({
+    queueName,
+    jobName,
+    workspaceId,
+  }: {
+    queueName: string;
+    jobName: string;
+    workspaceId?: string;
+  }): symbol {
+    const token = Symbol(jobName);
+
+    this.runningJobs.set(token, {
+      queueName,
+      jobName,
+      workspaceId,
+      startedAt: Date.now(),
+    });
+
+    return token;
+  }
+
+  registerJobEnd(token: symbol) {
+    this.runningJobs.delete(token);
+  }
+
+  private tick() {
+    const now = Date.now();
+    const stallMs = now - this.lastTickAt - TICK_INTERVAL_MS;
+
+    this.lastTickAt = now;
+
+    if (stallMs < STALL_THRESHOLD_MS) {
+      return;
+    }
+
+    const jobs = [...this.runningJobs.values()]
+      .map(
+        (runningJob) =>
+          `${runningJob.queueName}/${runningJob.jobName}` +
+          (runningJob.workspaceId
+            ? ` workspace=${runningJob.workspaceId}`
+            : '') +
+          ` elapsedMs=${now - runningJob.startedAt}`,
+      )
+      .join('; ');
+
+    this.logger.warn(
+      `Event loop stalled for ${stallMs}ms with ${this.runningJobs.size} job(s) in flight: ${jobs || 'none'}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/message-queue/services/event-loop-stall-monitor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/services/event-loop-stall-monitor.service.ts
@@ -5,28 +5,32 @@ import {
   type OnModuleInit,
 } from '@nestjs/common';
 
+import { isNonEmptyString } from '@sniptt/guards';
+import { isDefined } from 'twenty-shared/utils';
+
 const TICK_INTERVAL_MS = 500;
 const STALL_THRESHOLD_MS = 5_000;
+const LOG_MIN_INTERVAL_MS = 30_000;
 
-type RunningJob = {
+type MonitoredJob = {
   queueName: string;
   jobName: string;
   workspaceId?: string;
   startedAt: number;
+  endedAt?: number;
 };
 
-// A stalled event loop cannot be observed from within the stalled code, but a
-// timer that fires late reveals both the stall duration and which jobs were in
-// flight while it happened.
 @Injectable()
 export class EventLoopStallMonitorService
   implements OnModuleInit, OnModuleDestroy
 {
   private readonly logger = new Logger(EventLoopStallMonitorService.name);
 
-  private readonly runningJobs = new Map<symbol, RunningJob>();
+  private readonly jobs = new Map<symbol, MonitoredJob>();
   private tickHandle?: NodeJS.Timeout;
   private lastTickAt = 0;
+  private lastLogAt = 0;
+  private suppressedStallCount = 0;
 
   onModuleInit() {
     this.lastTickAt = Date.now();
@@ -35,7 +39,7 @@ export class EventLoopStallMonitorService
   }
 
   onModuleDestroy() {
-    if (this.tickHandle) {
+    if (isDefined(this.tickHandle)) {
       clearInterval(this.tickHandle);
     }
   }
@@ -51,7 +55,7 @@ export class EventLoopStallMonitorService
   }): symbol {
     const token = Symbol(jobName);
 
-    this.runningJobs.set(token, {
+    this.jobs.set(token, {
       queueName,
       jobName,
       workspaceId,
@@ -61,33 +65,74 @@ export class EventLoopStallMonitorService
     return token;
   }
 
+  // Jobs are kept until the next tick instead of being removed: after a long
+  // synchronous block, the job's finally runs in a microtask before the
+  // overdue timer fires, so removing it here would hide the stalling job from
+  // the very log line meant to name it.
   registerJobEnd(token: symbol) {
-    this.runningJobs.delete(token);
+    const job = this.jobs.get(token);
+
+    if (isDefined(job)) {
+      job.endedAt = Date.now();
+    }
   }
 
   private tick() {
     const now = Date.now();
-    const stallMs = now - this.lastTickAt - TICK_INTERVAL_MS;
+    const previousTickAt = this.lastTickAt;
+    const stallMs = now - previousTickAt - TICK_INTERVAL_MS;
 
     this.lastTickAt = now;
 
-    if (stallMs < STALL_THRESHOLD_MS) {
-      return;
+    if (stallMs >= STALL_THRESHOLD_MS) {
+      if (now - this.lastLogAt >= LOG_MIN_INTERVAL_MS) {
+        this.logStall({ stallMs, now, previousTickAt });
+        this.lastLogAt = now;
+        this.suppressedStallCount = 0;
+      } else {
+        this.suppressedStallCount += 1;
+      }
     }
 
-    const jobs = [...this.runningJobs.values()]
+    for (const [token, job] of this.jobs) {
+      if (isDefined(job.endedAt) && job.endedAt < previousTickAt) {
+        this.jobs.delete(token);
+      }
+    }
+  }
+
+  private logStall({
+    stallMs,
+    now,
+    previousTickAt,
+  }: {
+    stallMs: number;
+    now: number;
+    previousTickAt: number;
+  }) {
+    const inFlight = [...this.jobs.values()].filter(
+      (job) => !isDefined(job.endedAt) || job.endedAt >= previousTickAt,
+    );
+
+    const jobs = inFlight
       .map(
-        (runningJob) =>
-          `${runningJob.queueName}/${runningJob.jobName}` +
-          (runningJob.workspaceId
-            ? ` workspace=${runningJob.workspaceId}`
+        (job) =>
+          `${job.queueName}/${job.jobName}` +
+          (isNonEmptyString(job.workspaceId)
+            ? ` workspace=${job.workspaceId}`
             : '') +
-          ` elapsedMs=${now - runningJob.startedAt}`,
+          ` elapsedMs=${(job.endedAt ?? now) - job.startedAt}` +
+          (isDefined(job.endedAt) ? ' (just finished)' : ''),
       )
       .join('; ');
 
+    const suppressedSuffix =
+      this.suppressedStallCount > 0
+        ? ` (${this.suppressedStallCount} earlier stall(s) not logged)`
+        : '';
+
     this.logger.warn(
-      `Event loop stalled for ${stallMs}ms with ${this.runningJobs.size} job(s) in flight: ${jobs || 'none'}`,
+      `Event loop stalled for ${stallMs}ms with ${inFlight.length} job(s) in flight${suppressedSuffix}: ${isNonEmptyString(jobs) ? jobs : 'none'}`,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/message-queue/services/event-loop-stall-monitor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/services/event-loop-stall-monitor.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 
 const TICK_INTERVAL_MS = 500;
-const STALL_THRESHOLD_MS = 2_000;
+const STALL_THRESHOLD_MS = 5_000;
 
 type RunningJob = {
   queueName: string;

--- a/packages/twenty-server/src/instrument.ts
+++ b/packages/twenty-server/src/instrument.ts
@@ -50,13 +50,6 @@ if (process.env.EXCEPTION_HANDLER_DRIVER === ExceptionHandlerDriver.SENTRY) {
     value: process.env.SENTRY_TRACES_SAMPLE_RATE,
     fallback: 0.1,
   });
-  // Continuous profiling covers event-loop stalls that happen outside sampled
-  // transactions; transaction-based profiling cannot see them.
-  const profileSessionSampleRate = parseSampleRate({
-    value: process.env.SENTRY_PROFILE_SESSION_SAMPLE_RATE,
-    fallback: 0,
-  });
-  const isContinuousProfilingEnabled = profileSessionSampleRate > 0;
 
   Sentry.init({
     environment: process.env.SENTRY_ENVIRONMENT,
@@ -94,17 +87,10 @@ if (process.env.EXCEPTION_HANDLER_DRIVER === ExceptionHandlerDriver.SENTRY) {
     tracesSampleRate,
     tracesSampler: ({ name, inheritOrSampleWith }) =>
       name.startsWith('ai.') ? 1 : inheritOrSampleWith(tracesSampleRate),
-    ...(isContinuousProfilingEnabled
-      ? {
-          profileSessionSampleRate,
-          profileLifecycle: 'manual' as const,
-        }
-      : {
-          profilesSampleRate: parseSampleRate({
-            value: process.env.SENTRY_PROFILES_SAMPLE_RATE,
-            fallback: 0.01,
-          }),
-        }),
+    profilesSampleRate: parseSampleRate({
+      value: process.env.SENTRY_PROFILES_SAMPLE_RATE,
+      fallback: 0.01,
+    }),
     maxValueLength: 8192,
     sendDefaultPii: true,
     debug: process.env.NODE_ENV === NodeEnvironment.DEVELOPMENT,
@@ -132,10 +118,6 @@ if (process.env.EXCEPTION_HANDLER_DRIVER === ExceptionHandlerDriver.SENTRY) {
       return span;
     },
   });
-
-  if (isContinuousProfilingEnabled) {
-    Sentry.profiler.startProfiler();
-  }
 }
 
 const prometheusExporter = meterDrivers.includes(MeterDriver.Prometheus)

--- a/packages/twenty-server/src/instrument.ts
+++ b/packages/twenty-server/src/instrument.ts
@@ -50,6 +50,13 @@ if (process.env.EXCEPTION_HANDLER_DRIVER === ExceptionHandlerDriver.SENTRY) {
     value: process.env.SENTRY_TRACES_SAMPLE_RATE,
     fallback: 0.1,
   });
+  // Continuous profiling covers event-loop stalls that happen outside sampled
+  // transactions; transaction-based profiling cannot see them.
+  const profileSessionSampleRate = parseSampleRate({
+    value: process.env.SENTRY_PROFILE_SESSION_SAMPLE_RATE,
+    fallback: 0,
+  });
+  const isContinuousProfilingEnabled = profileSessionSampleRate > 0;
 
   Sentry.init({
     environment: process.env.SENTRY_ENVIRONMENT,
@@ -87,10 +94,17 @@ if (process.env.EXCEPTION_HANDLER_DRIVER === ExceptionHandlerDriver.SENTRY) {
     tracesSampleRate,
     tracesSampler: ({ name, inheritOrSampleWith }) =>
       name.startsWith('ai.') ? 1 : inheritOrSampleWith(tracesSampleRate),
-    profilesSampleRate: parseSampleRate({
-      value: process.env.SENTRY_PROFILES_SAMPLE_RATE,
-      fallback: 0.01,
-    }),
+    ...(isContinuousProfilingEnabled
+      ? {
+          profileSessionSampleRate,
+          profileLifecycle: 'manual' as const,
+        }
+      : {
+          profilesSampleRate: parseSampleRate({
+            value: process.env.SENTRY_PROFILES_SAMPLE_RATE,
+            fallback: 0.01,
+          }),
+        }),
     maxValueLength: 8192,
     sendDefaultPii: true,
     debug: process.env.NODE_ENV === NodeEnvironment.DEVELOPMENT,
@@ -118,6 +132,10 @@ if (process.env.EXCEPTION_HANDLER_DRIVER === ExceptionHandlerDriver.SENTRY) {
       return span;
     },
   });
+
+  if (isContinuousProfilingEnabled) {
+    Sentry.profiler.startProfiler();
+  }
 }
 
 const prometheusExporter = meterDrivers.includes(MeterDriver.Prometheus)


### PR DESCRIPTION
## Context

The Query Read Timeout investigation (Aug 25) proved worker pods freeze their event loop for 10-30s (Sentry breadcrumb silence ending at the exact error millisecond, BullMQ lock-renewal failures in the same windows), timing out every in-flight query on the pod. What we cannot yet name is which job holds the loop.

## What this does

Adds `EventLoopStallMonitorService`: a 500ms unref'd interval measures its own scheduling drift; when a tick fires more than 5s late, it logs the stall duration plus every job in flight at that moment (queue, job name, workspaceId, elapsed). Jobs register/unregister in `MessageQueueExplorer` around processing. A stalled loop cannot observe itself from inside — a late timer reveals both the stall and its suspects.

Sample output (one WARN per stall, so tens of lines per day fleet-wide):

```
WARN [EventLoopStallMonitorService] Event loop stalled for 27431ms with 4 job(s) in flight: messaging-queue/MessagingMessagesImportJob workspace=cbee49b7 elapsedMs=31204; entity-events-to-db-queue/UpsertTimelineActivityFromInternalEvent workspace=d46df29e elapsedMs=27811; workflow-queue/RunWorkflowJob workspace=6f6b2cc0 elapsedMs=27515; calendar-queue/CalendarEventsImportJob workspace=21fc27f4 elapsedMs=2103
```

Jobs whose elapsed matches or exceeds the stall duration were running through the freeze (suspects); small elapsed means they started just before the late tick (bystanders).

An earlier commit added env-gated Sentry continuous profiling as a second instrument; it was reverted in-branch — we first try to attribute the freezes with the existing transaction profiles and this stall log.
