### PR TITLE
Push activity-target junction handling further

### DIFF
--- a/packages/twenty-front/src/modules/activities/hooks/__tests__/useActivities.test.tsx
+++ b/packages/twenty-front/src/modules/activities/hooks/__tests__/useActivities.test.tsx
@@ -34,7 +34,6 @@ const mockActivity = {
     markdown: 'My Body',
   },
   assignee: null,
-  taskTargets: [],
 } satisfies Task;
 
 describe('useActivities', () => {

--- a/packages/twenty-front/src/modules/activities/hooks/__tests__/useCreateActivityInDB.test.tsx
+++ b/packages/twenty-front/src/modules/activities/hooks/__tests__/useCreateActivityInDB.test.tsx
@@ -4,6 +4,7 @@ import { act, renderHook } from '@testing-library/react';
 import { createOneActivityOperationSignatureFactory } from '@/activities/graphql/operation-signatures/factories/createOneActivityOperationSignatureFactory';
 import { useCreateActivityInDB } from '@/activities/hooks/useCreateActivityInDB';
 import { type Task } from '@/activities/types/Task';
+import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { generateCreateOneRecordMutation } from '@/object-metadata/utils/generateCreateOneRecordMutation';
 import { getRecordFromRecordNode } from '@/object-record/cache/utils/getRecordFromRecordNode';
@@ -95,7 +96,10 @@ describe('useCreateActivityInDB', () => {
     expect(mockResult).toHaveBeenCalled();
     expect(jotaiStore.get(recordStoreFamilyState.atomFamily(id))).toMatchObject(
       {
-        taskTargets: [],
+        [getActivityTargetJunctionConfig({
+          activityObjectMetadata: taskMetadataItem,
+          objectMetadataItems: getTestEnrichedObjectMetadataItemsMock(),
+        })?.activityTargetField.name ?? 'taskTargets']: [],
       },
     );
   });

--- a/packages/twenty-front/src/modules/activities/hooks/useActivities.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useActivities.ts
@@ -11,6 +11,7 @@ import {
   type RecordGqlOperationOrderBy,
 } from 'twenty-shared/types';
 import { getRecordsFromRecordConnection } from '@/object-record/cache/utils/getRecordsFromRecordConnection';
+import { getRelatedRecordFromJunction } from '@/object-record/record-field/ui/utils/junction/getRelatedRecordFromJunction';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -31,9 +32,10 @@ export const useActivities = <T extends Task | Note>({
   const updateActivitiesInStore = useCallback(
     (activityTargets: ActivityTarget[], activityRelationFieldName: string) => {
       for (const activityTarget of activityTargets) {
-        const activity = activityTarget[activityRelationFieldName] as
-          | T
-          | undefined;
+        const activity = getRelatedRecordFromJunction<T>(
+          activityTarget,
+          activityRelationFieldName,
+        );
 
         if (!isDefined(activity)) {
           continue;
@@ -61,34 +63,43 @@ export const useActivities = <T extends Task | Note>({
     limit,
   });
 
-  const activities = activityTargets
-    .map((activityTarget) => {
-      return activityTarget[activityRelationFieldName] as T | undefined;
-    })
-    .filter(isDefined) as T[];
+  const activities = isDefined(activityRelationFieldName)
+    ? activityTargets
+        .map((activityTarget) =>
+          getRelatedRecordFromJunction<T>(
+            activityTarget,
+            activityRelationFieldName,
+          ),
+        )
+        .filter(isDefined)
+    : [];
 
   const fetchMoreActivities = async () => {
     const result = await fetchMoreActivityTargets();
 
-    if (!isDefined(result?.data)) {
+    if (!isDefined(result?.data) || !isDefined(activityRelationFieldName)) {
       return [];
     }
 
-    const activityTargets = getRecordsFromRecordConnection<ActivityTarget>({
-      recordConnection: result.data,
-    });
+    const fetchedActivityTargets =
+      getRecordsFromRecordConnection<ActivityTarget>({
+        recordConnection: result.data,
+      });
 
-    updateActivitiesInStore(activityTargets, activityRelationFieldName);
+    updateActivitiesInStore(fetchedActivityTargets, activityRelationFieldName);
 
-    return activityTargets
-      .map((activityTarget) => {
-        return activityTarget[activityRelationFieldName] as T | undefined;
-      })
-      .filter(isDefined) as T[];
+    return fetchedActivityTargets
+      .map((activityTarget) =>
+        getRelatedRecordFromJunction<T>(
+          activityTarget,
+          activityRelationFieldName,
+        ),
+      )
+      .filter(isDefined);
   };
 
   return {
-    activities: activities as T[],
+    activities,
     loading: loadingActivityTargets,
     totalCountActivities: totalCountActivityTargets,
     fetchMoreActivities,

--- a/packages/twenty-front/src/modules/activities/hooks/useActivityTargetFieldName.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useActivityTargetFieldName.ts
@@ -1,0 +1,20 @@
+import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { type CoreObjectNameSingular } from 'twenty-shared/types';
+
+export const useActivityTargetFieldName = (
+  activityObjectNameSingular:
+    | CoreObjectNameSingular.Note
+    | CoreObjectNameSingular.Task,
+) => {
+  const { objectMetadataItem } = useObjectMetadataItem({
+    objectNameSingular: activityObjectNameSingular,
+  });
+  const { objectMetadataItems } = useObjectMetadataItems();
+
+  return getActivityTargetJunctionConfig({
+    activityObjectMetadata: objectMetadataItem,
+    objectMetadataItems,
+  })?.activityTargetField.name;
+};

--- a/packages/twenty-front/src/modules/activities/hooks/useActivityTargetsForTargetableObjects.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useActivityTargetsForTargetableObjects.ts
@@ -6,11 +6,13 @@ import {
 import { findActivityTargetsOperationSignatureFactory } from '@/activities/graphql/operation-signatures/factories/findActivityTargetsOperationSignatureFactory';
 import { type ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
 import { type ActivityTarget } from '@/activities/types/ActivityTarget';
+import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
 import { getActivityTargetsFilter } from '@/activities/utils/getActivityTargetsFilter';
 import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { isDefined } from 'twenty-shared/utils';
 
 export const useActivityTargetsForTargetableObjects = ({
   objectNameSingular,
@@ -36,42 +38,43 @@ export const useActivityTargetsForTargetableObjects = ({
   const objectMetadataItems = useAtomStateValue<EnrichedObjectMetadataItem[]>(
     objectMetadataItemsSelector,
   );
-  const FIND_ACTIVITY_TARGETS_OPERATION_SIGNATURE =
-    findActivityTargetsOperationSignatureFactory({
-      objectNameSingular,
-      objectMetadataItems,
-    });
-
-  const activityTargetObjectMetadata = objectMetadataItems.find(
-    (objectMetadataItem) =>
-      objectMetadataItem.nameSingular ===
-      FIND_ACTIVITY_TARGETS_OPERATION_SIGNATURE.objectNameSingular,
-  );
-
-  if (!activityTargetObjectMetadata) {
-    throw new Error('Activity target object metadata is missing');
-  }
 
   const activityObjectMetadata = objectMetadataItems.find(
     (objectMetadataItem) =>
       objectMetadataItem.nameSingular === objectNameSingular,
   );
 
-  const activityRelationFieldName = activityTargetObjectMetadata.fields.find(
-    (fieldMetadataItem) =>
-      fieldMetadataItem.relation?.targetObjectMetadata.id ===
-      activityObjectMetadata?.id,
-  )?.name;
+  const junctionConfig = isDefined(activityObjectMetadata)
+    ? getActivityTargetJunctionConfig({
+        activityObjectMetadata,
+        objectMetadataItems,
+      })
+    : null;
 
-  if (!activityRelationFieldName) {
-    throw new Error('Activity relation metadata is missing');
-  }
+  const activityRelationFieldName = junctionConfig?.sourceField?.name;
+  const shouldSkip =
+    skip === true ||
+    !isDefined(junctionConfig) ||
+    !isDefined(activityRelationFieldName);
 
-  const activityTargetsFilter = getActivityTargetsFilter({
-    targetableObjects,
-    activityTargetObjectMetadata,
-    objectMetadataItems,
-  });
+  const FIND_ACTIVITY_TARGETS_OPERATION_SIGNATURE = shouldSkip
+    ? {
+        objectNameSingular,
+        variables: {},
+        fields: {},
+      }
+    : findActivityTargetsOperationSignatureFactory({
+        objectNameSingular,
+        objectMetadataItems,
+      });
+
+  const activityTargetsFilter = isDefined(junctionConfig)
+    ? getActivityTargetsFilter({
+        targetableObjects,
+        activityTargetObjectMetadata: junctionConfig.junctionObjectMetadata,
+        objectMetadataItems,
+      })
+    : {};
 
   // TODO: We want to optimistically remove from this request
   //   If we are on a show page and we remove the current show page object corresponding activity target
@@ -83,12 +86,15 @@ export const useActivityTargetsForTargetableObjects = ({
     fetchMoreRecords: fetchMoreActivityTargets,
     hasNextPage,
   } = useFindManyRecords<ActivityTarget>({
-    skip,
+    skip: shouldSkip,
     objectNameSingular:
       FIND_ACTIVITY_TARGETS_OPERATION_SIGNATURE.objectNameSingular,
     filter: activityTargetsFilter,
     recordGqlFields: FIND_ACTIVITY_TARGETS_OPERATION_SIGNATURE.fields,
-    onCompleted: (records) => onCompleted?.(records, activityRelationFieldName),
+    onCompleted: (records) =>
+      isDefined(activityRelationFieldName)
+        ? onCompleted?.(records, activityRelationFieldName)
+        : undefined,
     orderBy: activityTargetsOrderByVariables,
     limit,
   });

--- a/packages/twenty-front/src/modules/activities/hooks/useCreateActivityInDB.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useCreateActivityInDB.ts
@@ -16,6 +16,7 @@ import { recordStoreFamilyState } from '@/object-record/record-store/states/reco
 import { createOneActivityOperationSignatureFactory } from '@/activities/graphql/operation-signatures/factories/createOneActivityOperationSignatureFactory';
 import { type ActivityTarget } from '@/activities/types/ActivityTarget';
 import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
+import { getRecordArrayField } from '@/object-record/utils/getRecordArrayField';
 import { capitalize, isDefined } from 'twenty-shared/utils';
 
 export const useCreateActivityInDB = ({
@@ -78,10 +79,10 @@ export const useCreateActivityInDB = ({
         throw new Error('Activity target relation metadata is missing');
       }
 
-      const activityTargetsToCreate =
-        (activityToCreate[
-          activityTargetFieldName as keyof ActivityForEditor
-        ] as ActivityTarget[] | undefined) ?? [];
+      const activityTargetsToCreate = getRecordArrayField<ActivityTarget>(
+        activityToCreate,
+        activityTargetFieldName,
+      );
 
       if (isNonEmptyArray(activityTargetsToCreate)) {
         await createManyActivityTargets({

--- a/packages/twenty-front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
@@ -15,7 +15,10 @@ import { useCreateManyRecords } from '@/object-record/hooks/useCreateManyRecords
 import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
 import { findTargetFieldInfo } from '@/object-record/record-field/ui/utils/junction/findTargetFieldInfo';
 import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
-import { isDefined } from 'twenty-shared/utils';
+import {
+  computeRelationGqlFieldJoinColumnName,
+  isDefined,
+} from 'twenty-shared/utils';
 
 export const useOpenCreateActivityDrawer = ({
   activityObjectNameSingular,
@@ -85,12 +88,13 @@ export const useOpenCreateActivityDrawer = ({
     });
 
     if (targetableObjects.length > 0) {
-      const sourceFieldInfo = findTargetFieldInfo(
-        activityTargetObjectMetadata?.fields ?? [],
-        activityObjectMetadata?.id ?? '',
-        objectMetadataItems,
-      );
-      const sourceJoinColumnName = sourceFieldInfo?.joinColumnName;
+      const sourceJoinColumnName = isDefined(
+        activityTargetJunctionConfig?.sourceField,
+      )
+        ? computeRelationGqlFieldJoinColumnName({
+            name: activityTargetJunctionConfig.sourceField.name,
+          })
+        : undefined;
 
       if (
         !isDefined(activityTargetObjectMetadata) ||

--- a/packages/twenty-front/src/modules/activities/hooks/usePrepareFindManyActivitiesQuery.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/usePrepareFindManyActivitiesQuery.ts
@@ -11,8 +11,10 @@ import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordF
 import { useUpsertFindManyRecordsQueryInCache } from '@/object-record/cache/hooks/useUpsertFindManyRecordsQueryInCache';
 import { getRecordFromCache } from '@/object-record/cache/utils/getRecordFromCache';
 import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { getRelatedRecordIdFromJunction } from '@/object-record/record-field/ui/utils/junction/getRelatedRecordIdFromJunction';
 import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { getRecordArrayField } from '@/object-record/utils/getRecordArrayField';
 import { isDefined } from 'twenty-shared/utils';
 import { sortByAscString } from '~/utils/array/sortByAscString';
 
@@ -54,7 +56,7 @@ export const usePrepareFindManyActivitiesQuery = ({
         targetableObject.targetObjectNameSingular,
     );
 
-    if (!targetableObjectMetadataItem) {
+    if (!isDefined(targetableObjectMetadataItem)) {
       throw new Error(
         `Cannot find object metadata item for targetable object ${targetableObject.targetObjectNameSingular}`,
       );
@@ -74,7 +76,7 @@ export const usePrepareFindManyActivitiesQuery = ({
     });
 
     if (!isDefined(junctionConfig?.sourceField)) {
-      throw new Error('Activity target junction metadata is invalid');
+      return;
     }
 
     const activityRelationFieldName = junctionConfig.sourceField.name;
@@ -87,23 +89,24 @@ export const usePrepareFindManyActivitiesQuery = ({
         activityTargetObjectMetadataId,
     )?.name;
 
-    const activityTargets =
-      (isDefined(activityTargetFieldName)
-        ? (targetableObjectRecord?.[activityTargetFieldName] as
-            | ActivityTarget[]
-            | undefined)
-        : undefined) ?? [];
+    if (!isDefined(activityTargetFieldName)) {
+      return;
+    }
+
+    const activityTargets = getRecordArrayField<ActivityTarget>(
+      targetableObjectRecord,
+      activityTargetFieldName,
+    );
 
     const activityIds = [
       ...new Set(
         activityTargets
-          .map((activityTarget) => {
-            const activity = activityTarget[activityRelationFieldName] as
-              | ObjectRecord
-              | undefined;
-
-            return activity?.id;
-          })
+          .map((activityTarget) =>
+            getRelatedRecordIdFromJunction({
+              junctionRecord: activityTarget,
+              relationFieldName: activityRelationFieldName,
+            }),
+          )
           .filter(isDefined),
       ),
     ];

--- a/packages/twenty-front/src/modules/activities/notes/components/NoteTile.tsx
+++ b/packages/twenty-front/src/modules/activities/notes/components/NoteTile.tsx
@@ -106,30 +106,29 @@ export const NoteTile = ({
         <StyledNoteTitle>{note.title ?? t`Task Title`}</StyledNoteTitle>
         <StyledCardContent>{body}</StyledCardContent>
       </StyledCardDetailsContainer>
-      {isDefined(activityTargetFieldName) &&
-        isDefined(componentInstanceId) && (
-          <StyledFooter>
-            <FieldContextProvider
-              objectNameSingular={CoreObjectNameSingular.Note}
-              objectRecordId={note.id}
-              fieldMetadataName={activityTargetFieldName}
-              fieldPosition={0}
-              isDisplayModeFixHeight
+      {isDefined(activityTargetFieldName) && isDefined(componentInstanceId) && (
+        <StyledFooter>
+          <FieldContextProvider
+            objectNameSingular={CoreObjectNameSingular.Note}
+            objectRecordId={note.id}
+            fieldMetadataName={activityTargetFieldName}
+            fieldPosition={0}
+            isDisplayModeFixHeight
+          >
+            <RecordFieldsScopeContextProvider
+              value={{
+                scopeInstanceId: note.id,
+              }}
             >
-              <RecordFieldsScopeContextProvider
-                value={{
-                  scopeInstanceId: note.id,
-                }}
+              <RecordFieldComponentInstanceContext.Provider
+                value={{ instanceId: componentInstanceId }}
               >
-                <RecordFieldComponentInstanceContext.Provider
-                  value={{ instanceId: componentInstanceId }}
-                >
-                  <RecordInlineCell instanceIdPrefix={instanceIdPrefix} />
-                </RecordFieldComponentInstanceContext.Provider>
-              </RecordFieldsScopeContextProvider>
-            </FieldContextProvider>
-          </StyledFooter>
-        )}
+                <RecordInlineCell instanceIdPrefix={instanceIdPrefix} />
+              </RecordFieldComponentInstanceContext.Provider>
+            </RecordFieldsScopeContextProvider>
+          </FieldContextProvider>
+        </StyledFooter>
+      )}
     </StyledCard>
   );
 };

--- a/packages/twenty-front/src/modules/activities/notes/components/NoteTile.tsx
+++ b/packages/twenty-front/src/modules/activities/notes/components/NoteTile.tsx
@@ -2,11 +2,9 @@ import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 
 import { useActivityFieldComponentInstanceId } from '@/activities/hooks/useActivityFieldComponentInstanceId';
+import { useActivityTargetFieldName } from '@/activities/hooks/useActivityTargetFieldName';
 import { type Note } from '@/activities/types/Note';
 import { getActivityPreview } from '@/activities/utils/getActivityPreview';
-import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
-import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
-import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useOpenRecordInSidePanel } from '@/side-panel/hooks/useOpenRecordInSidePanel';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { RecordFieldsScopeContextProvider } from '@/object-record/record-field-list/contexts/RecordFieldsScopeContext';
@@ -82,26 +80,18 @@ export const NoteTile = ({
 
   const body = getActivityPreview(note?.bodyV2?.blocknote ?? null);
 
-  const { objectMetadataItem } = useObjectMetadataItem({
-    objectNameSingular: CoreObjectNameSingular.Note,
-  });
-  const { objectMetadataItems } = useObjectMetadataItems();
-  const activityTargetFieldName = getActivityTargetJunctionConfig({
-    activityObjectMetadata: objectMetadataItem,
-    objectMetadataItems,
-  })?.activityTargetField.name;
-
-  if (!isDefined(activityTargetFieldName)) {
-    throw new Error('Note target junction metadata is missing');
-  }
-
+  const activityTargetFieldName = useActivityTargetFieldName(
+    CoreObjectNameSingular.Note,
+  );
   const instanceIdPrefix =
     useActivityFieldComponentInstanceId('note-card-targets');
-  const componentInstanceId = getRecordFieldInputInstanceId({
-    recordId: note.id,
-    fieldName: activityTargetFieldName,
-    prefix: instanceIdPrefix,
-  });
+  const componentInstanceId = isDefined(activityTargetFieldName)
+    ? getRecordFieldInputInstanceId({
+        recordId: note.id,
+        fieldName: activityTargetFieldName,
+        prefix: instanceIdPrefix,
+      })
+    : undefined;
 
   return (
     <StyledCard isSingleNote={isSingleNote}>
@@ -116,27 +106,30 @@ export const NoteTile = ({
         <StyledNoteTitle>{note.title ?? t`Task Title`}</StyledNoteTitle>
         <StyledCardContent>{body}</StyledCardContent>
       </StyledCardDetailsContainer>
-      <StyledFooter>
-        <FieldContextProvider
-          objectNameSingular={CoreObjectNameSingular.Note}
-          objectRecordId={note.id}
-          fieldMetadataName={activityTargetFieldName}
-          fieldPosition={0}
-          isDisplayModeFixHeight
-        >
-          <RecordFieldsScopeContextProvider
-            value={{
-              scopeInstanceId: note.id,
-            }}
-          >
-            <RecordFieldComponentInstanceContext.Provider
-              value={{ instanceId: componentInstanceId }}
+      {isDefined(activityTargetFieldName) &&
+        isDefined(componentInstanceId) && (
+          <StyledFooter>
+            <FieldContextProvider
+              objectNameSingular={CoreObjectNameSingular.Note}
+              objectRecordId={note.id}
+              fieldMetadataName={activityTargetFieldName}
+              fieldPosition={0}
+              isDisplayModeFixHeight
             >
-              <RecordInlineCell instanceIdPrefix={instanceIdPrefix} />
-            </RecordFieldComponentInstanceContext.Provider>
-          </RecordFieldsScopeContextProvider>
-        </FieldContextProvider>
-      </StyledFooter>
+              <RecordFieldsScopeContextProvider
+                value={{
+                  scopeInstanceId: note.id,
+                }}
+              >
+                <RecordFieldComponentInstanceContext.Provider
+                  value={{ instanceId: componentInstanceId }}
+                >
+                  <RecordInlineCell instanceIdPrefix={instanceIdPrefix} />
+                </RecordFieldComponentInstanceContext.Provider>
+              </RecordFieldsScopeContextProvider>
+            </FieldContextProvider>
+          </StyledFooter>
+        )}
     </StyledCard>
   );
 };

--- a/packages/twenty-front/src/modules/activities/tasks/components/TaskRow.tsx
+++ b/packages/twenty-front/src/modules/activities/tasks/components/TaskRow.tsx
@@ -6,10 +6,8 @@ import { beautifyExactDate, hasDatePassed } from '~/utils/date-utils';
 
 import { ActivityRow } from '@/activities/components/ActivityRow';
 import { useActivityFieldComponentInstanceId } from '@/activities/hooks/useActivityFieldComponentInstanceId';
+import { useActivityTargetFieldName } from '@/activities/hooks/useActivityTargetFieldName';
 import { type Task } from '@/activities/types/Task';
-import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
-import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
-import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useOpenRecordInSidePanel } from '@/side-panel/hooks/useOpenRecordInSidePanel';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { StopPropagationContainer } from '@/object-record/record-board/record-board-card/components/StopPropagationContainer';
@@ -99,26 +97,18 @@ export const TaskRow = ({ task }: { task: Task }) => {
 
   const { completeTask } = useCompleteTask(task);
 
-  const { objectMetadataItem } = useObjectMetadataItem({
-    objectNameSingular: CoreObjectNameSingular.Task,
-  });
-  const { objectMetadataItems } = useObjectMetadataItems();
-  const activityTargetFieldName = getActivityTargetJunctionConfig({
-    activityObjectMetadata: objectMetadataItem,
-    objectMetadataItems,
-  })?.activityTargetField.name;
-
-  if (!isDefined(activityTargetFieldName)) {
-    throw new Error('Task target junction metadata is missing');
-  }
-
+  const activityTargetFieldName = useActivityTargetFieldName(
+    CoreObjectNameSingular.Task,
+  );
   const instanceIdPrefix =
     useActivityFieldComponentInstanceId('task-row-targets');
-  const componentInstanceId = getRecordFieldInputInstanceId({
-    recordId: task.id,
-    fieldName: activityTargetFieldName,
-    prefix: instanceIdPrefix,
-  });
+  const componentInstanceId = isDefined(activityTargetFieldName)
+    ? getRecordFieldInputInstanceId({
+        recordId: task.id,
+        fieldName: activityTargetFieldName,
+        prefix: instanceIdPrefix,
+      })
+    : undefined;
 
   return (
     <ActivityRow
@@ -157,33 +147,34 @@ export const TaskRow = ({ task }: { task: Task }) => {
             {beautifyExactDate(task.dueAt)}
           </StyledDueDate>
         )}
-        {
-          <StyledActivityTargetsContainer>
-            <FieldContextProvider
-              objectNameSingular={CoreObjectNameSingular.Task}
-              objectRecordId={task.id}
-              fieldMetadataName={activityTargetFieldName}
-              fieldPosition={0}
-              showLabel={false}
-              maxWidth={200}
-              isDisplayModeFixHeight
-            >
-              <RecordFieldsScopeContextProvider
-                value={{
-                  scopeInstanceId: task.id,
-                }}
+        {isDefined(activityTargetFieldName) &&
+          isDefined(componentInstanceId) && (
+            <StyledActivityTargetsContainer>
+              <FieldContextProvider
+                objectNameSingular={CoreObjectNameSingular.Task}
+                objectRecordId={task.id}
+                fieldMetadataName={activityTargetFieldName}
+                fieldPosition={0}
+                showLabel={false}
+                maxWidth={200}
+                isDisplayModeFixHeight
               >
-                <StopPropagationContainer>
-                  <RecordFieldComponentInstanceContext.Provider
-                    value={{ instanceId: componentInstanceId }}
-                  >
-                    <RecordInlineCell instanceIdPrefix={instanceIdPrefix} />
-                  </RecordFieldComponentInstanceContext.Provider>
-                </StopPropagationContainer>
-              </RecordFieldsScopeContextProvider>
-            </FieldContextProvider>
-          </StyledActivityTargetsContainer>
-        }
+                <RecordFieldsScopeContextProvider
+                  value={{
+                    scopeInstanceId: task.id,
+                  }}
+                >
+                  <StopPropagationContainer>
+                    <RecordFieldComponentInstanceContext.Provider
+                      value={{ instanceId: componentInstanceId }}
+                    >
+                      <RecordInlineCell instanceIdPrefix={instanceIdPrefix} />
+                    </RecordFieldComponentInstanceContext.Provider>
+                  </StopPropagationContainer>
+                </RecordFieldsScopeContextProvider>
+              </FieldContextProvider>
+            </StyledActivityTargetsContainer>
+          )}
       </StyledRightSideContainer>
     </ActivityRow>
   );

--- a/packages/twenty-front/src/modules/activities/tasks/hooks/__tests__/useCompleteTask.test.tsx
+++ b/packages/twenty-front/src/modules/activities/tasks/hooks/__tests__/useCompleteTask.test.tsx
@@ -21,7 +21,6 @@ const task: Task = {
   updatedAt: '2024-03-15T07:33:14.212Z',
   assignee: null,
   assigneeId: null,
-  taskTargets: [],
   __typename: 'Task',
 };
 

--- a/packages/twenty-front/src/modules/activities/types/Activity.ts
+++ b/packages/twenty-front/src/modules/activities/types/Activity.ts
@@ -1,4 +1,4 @@
-export type Activity = Record<string, unknown> & {
+export type Activity = {
   id: string;
   createdAt: string;
   updatedAt: string;

--- a/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityTargetJunctionConfig.test.ts
+++ b/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityTargetJunctionConfig.test.ts
@@ -1,0 +1,57 @@
+import { getActivityTargetJunctionConfig } from '@/activities/utils/getActivityTargetJunctionConfig';
+import { CoreObjectNameSingular } from 'twenty-shared/types';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+
+describe('getActivityTargetJunctionConfig', () => {
+  const objectMetadataItems = getTestEnrichedObjectMetadataItemsMock();
+
+  it.each([
+    {
+      objectNameSingular: CoreObjectNameSingular.Note,
+      junctionObjectNameSingular: CoreObjectNameSingular.NoteTarget,
+      activityTargetFieldName: 'noteTargets',
+      sourceFieldName: 'note',
+    },
+    {
+      objectNameSingular: CoreObjectNameSingular.Task,
+      junctionObjectNameSingular: CoreObjectNameSingular.TaskTarget,
+      activityTargetFieldName: 'taskTargets',
+      sourceFieldName: 'task',
+    },
+  ])(
+    'resolves the $objectNameSingular morph junction from metadata',
+    ({
+      objectNameSingular,
+      junctionObjectNameSingular,
+      activityTargetFieldName,
+      sourceFieldName,
+    }) => {
+      const activityObjectMetadata =
+        getMockObjectMetadataItemOrThrow(objectNameSingular);
+
+      expect(
+        getActivityTargetJunctionConfig({
+          activityObjectMetadata,
+          objectMetadataItems,
+        }),
+      ).toMatchObject({
+        activityTargetField: { name: activityTargetFieldName },
+        junctionObjectMetadata: { nameSingular: junctionObjectNameSingular },
+        sourceField: { name: sourceFieldName },
+        isMorphRelation: true,
+      });
+    },
+  );
+
+  it('returns null when the object has no morph junction relation', () => {
+    const companyMetadata = getMockObjectMetadataItemOrThrow('company');
+
+    expect(
+      getActivityTargetJunctionConfig({
+        activityObjectMetadata: companyMetadata,
+        objectMetadataItems,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/twenty-front/src/modules/activities/utils/getActivityTargetJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/activities/utils/getActivityTargetJunctionConfig.ts
@@ -1,7 +1,15 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  type JunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { isJunctionRelationField } from '@/object-record/record-field/ui/utils/junction/isJunctionRelationField';
 import { isDefined } from 'twenty-shared/utils';
+
+export type ActivityTargetJunctionConfig = JunctionConfig & {
+  activityTargetField: FieldMetadataItem;
+};
 
 export const getActivityTargetJunctionConfig = ({
   activityObjectMetadata,
@@ -9,7 +17,7 @@ export const getActivityTargetJunctionConfig = ({
 }: {
   activityObjectMetadata: EnrichedObjectMetadataItem;
   objectMetadataItems: EnrichedObjectMetadataItem[];
-}) => {
+}): ActivityTargetJunctionConfig | null => {
   for (const fieldMetadataItem of activityObjectMetadata.fields) {
     if (!isJunctionRelationField(fieldMetadataItem)) {
       continue;

--- a/packages/twenty-front/src/modules/activities/utils/getActivityTargetsFilter.ts
+++ b/packages/twenty-front/src/modules/activities/utils/getActivityTargetsFilter.ts
@@ -12,7 +12,7 @@ export const getActivityTargetsFilter = ({
     ActivityTargetableObject,
     'id' | 'targetObjectNameSingular'
   >[];
-  activityTargetObjectMetadata: EnrichedObjectMetadataItem;
+  activityTargetObjectMetadata: Pick<EnrichedObjectMetadataItem, 'fields'>;
   objectMetadataItems: EnrichedObjectMetadataItem[];
 }) => {
   const findManyActivityTargetsQueryFilter = Object.fromEntries(

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useActiveFieldMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useActiveFieldMetadataItems.ts
@@ -15,10 +15,7 @@ export const useActiveFieldMetadataItems = ({
         ? dedupeMorphRelationFieldMetadataItems(
             objectMetadataItem.readableFields.filter(
               ({ id, isActive, isSystem, name }) =>
-                isActiveFieldMetadataItem({
-                  objectNameSingular: objectMetadataItem.nameSingular,
-                  fieldMetadata: { isActive, isSystem, name },
-                }) ||
+                isActiveFieldMetadataItem({ isActive, isSystem, name }) ||
                 // Allow label identifier field even if it's a system field
                 id === objectMetadataItem.labelIdentifierFieldMetadataId,
             ),

--- a/packages/twenty-front/src/modules/object-metadata/utils/__tests__/isActiveFieldMetadataItem.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/__tests__/isActiveFieldMetadataItem.test.ts
@@ -3,48 +3,36 @@ import { isActiveFieldMetadataItem } from '@/object-metadata/utils/isActiveField
 describe('isActiveFieldMetadataItem', () => {
   it('should return false for inactive fields', () => {
     const res = isActiveFieldMetadataItem({
-      fieldMetadata: { isActive: false, isSystem: false, name: 'fieldName' },
-      objectNameSingular: 'objectNameSingular',
+      isActive: false,
+      isSystem: false,
+      name: 'fieldName',
     });
     expect(res).toBe(false);
   });
 
   it('should return true for active fields', () => {
     const res = isActiveFieldMetadataItem({
-      fieldMetadata: { isActive: true, isSystem: false, name: 'fieldName' },
-      objectNameSingular: 'objectNameSingular',
+      isActive: true,
+      isSystem: false,
+      name: 'fieldName',
     });
     expect(res).toBe(true);
   });
 
   it('should return false for hidden system fields', () => {
     const res = isActiveFieldMetadataItem({
-      fieldMetadata: { isActive: true, isSystem: true, name: 'position' },
-      objectNameSingular: 'objectNameSingular',
+      isActive: true,
+      isSystem: true,
+      name: 'position',
     });
     expect(res).toBe(false);
   });
 
-  it('should return false for non hidden system fields', () => {
+  it('should return true for non hidden system fields', () => {
     const res = isActiveFieldMetadataItem({
-      fieldMetadata: { isActive: true, isSystem: true, name: 'fieldName' },
-      objectNameSingular: 'objectNameSingular',
-    });
-    expect(res).toBe(true);
-  });
-
-  it('should return true for note targets', () => {
-    const res = isActiveFieldMetadataItem({
-      fieldMetadata: { isActive: true, isSystem: false, name: 'noteTargets' },
-      objectNameSingular: 'note',
-    });
-    expect(res).toBe(true);
-  });
-
-  it('should return true for task targets', () => {
-    const res = isActiveFieldMetadataItem({
-      fieldMetadata: { isActive: true, isSystem: false, name: 'taskTargets' },
-      objectNameSingular: 'task',
+      isActive: true,
+      isSystem: true,
+      name: 'fieldName',
     });
     expect(res).toBe(true);
   });

--- a/packages/twenty-front/src/modules/object-metadata/utils/isActiveFieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/isActiveFieldMetadataItem.ts
@@ -1,27 +1,11 @@
-import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { isHiddenSystemField } from '@/object-metadata/utils/isHiddenSystemField';
 
-type IsFieldMetadataAvailableForViewFieldArgs = {
-  objectNameSingular: string;
-  fieldMetadata: Pick<FieldMetadataItem, 'name' | 'isSystem' | 'isActive'>;
-};
-
-export const isActiveFieldMetadataItem = ({
-  objectNameSingular,
-  fieldMetadata,
-}: IsFieldMetadataAvailableForViewFieldArgs) => {
+export const isActiveFieldMetadataItem = (
+  fieldMetadata: Pick<FieldMetadataItem, 'name' | 'isSystem' | 'isActive'>,
+) => {
   if (fieldMetadata.isActive === false) {
     return false;
-  }
-
-  if (
-    (objectNameSingular === CoreObjectNameSingular.Note &&
-      fieldMetadata.name === 'noteTargets') ||
-    (objectNameSingular === CoreObjectNameSingular.Task &&
-      fieldMetadata.name === 'taskTargets')
-  ) {
-    return true;
   }
 
   if (isHiddenSystemField(fieldMetadata)) {

--- a/packages/twenty-front/src/modules/object-record/record-field/states/visibleRecordFieldsComponentSelector.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/states/visibleRecordFieldsComponentSelector.ts
@@ -66,11 +66,7 @@ const filterVisibleAndReadableRecordFields = (
         objectMetadataItem.labelIdentifierFieldMetadataId;
 
       const isActive =
-        isLabelIdentifier ||
-        isActiveFieldMetadataItem({
-          objectNameSingular: objectMetadataItem.nameSingular,
-          fieldMetadata: fieldMetadataItem,
-        });
+        isLabelIdentifier || isActiveFieldMetadataItem(fieldMetadataItem);
 
       const isReadable = objectMetadataItem.readableFields.some(
         findById(fieldMetadataItem.id),

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/getRelatedRecordFromJunction.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/getRelatedRecordFromJunction.test.ts
@@ -1,0 +1,63 @@
+import { getRelatedRecordFromJunction } from '@/object-record/record-field/ui/utils/junction/getRelatedRecordFromJunction';
+import { getRelatedRecordIdFromJunction } from '@/object-record/record-field/ui/utils/junction/getRelatedRecordIdFromJunction';
+
+describe('getRelatedRecordFromJunction', () => {
+  it('reads a nested related record by field name', () => {
+    expect(
+      getRelatedRecordFromJunction(
+        {
+          task: { id: 'task-1', title: 'Follow up' },
+        },
+        'task',
+      ),
+    ).toEqual({ id: 'task-1', title: 'Follow up' });
+  });
+
+  it('returns undefined when the nested record is missing', () => {
+    expect(getRelatedRecordFromJunction({}, 'task')).toBeUndefined();
+    expect(
+      getRelatedRecordFromJunction({ task: 'task-1' }, 'task'),
+    ).toBeUndefined();
+  });
+});
+
+describe('getRelatedRecordIdFromJunction', () => {
+  it('prefers the join column when both the join column and nested record exist', () => {
+    expect(
+      getRelatedRecordIdFromJunction({
+        junctionRecord: {
+          taskId: 'task-from-join-column',
+          task: { id: 'task-from-nested-record' },
+        },
+        relationFieldName: 'task',
+      }),
+    ).toBe('task-from-join-column');
+  });
+
+  it('uses the join column when the nested relation is missing', () => {
+    expect(
+      getRelatedRecordIdFromJunction({
+        junctionRecord: { taskId: 'task-1' },
+        relationFieldName: 'task',
+      }),
+    ).toBe('task-1');
+  });
+
+  it('falls back to the nested related record id', () => {
+    expect(
+      getRelatedRecordIdFromJunction({
+        junctionRecord: { task: { id: 'task-2' } },
+        relationFieldName: 'task',
+      }),
+    ).toBe('task-2');
+  });
+
+  it('returns undefined when neither the join column nor nested record is present', () => {
+    expect(
+      getRelatedRecordIdFromJunction({
+        junctionRecord: {},
+        relationFieldName: 'task',
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getRelatedRecordFromJunction.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getRelatedRecordFromJunction.ts
@@ -1,0 +1,19 @@
+import { isObjectWithId } from '@/object-record/record-field/ui/utils/junction/isObjectWithId';
+import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+
+export const getRelatedRecordFromJunction = <
+  TRecord extends { id: string } = ObjectRecord,
+>(
+  junctionRecord: object,
+  relationFieldName: string,
+): TRecord | undefined => {
+  const relatedRecord = (junctionRecord as Record<string, unknown>)[
+    relationFieldName
+  ];
+
+  if (!isObjectWithId(relatedRecord)) {
+    return undefined;
+  }
+
+  return relatedRecord as TRecord;
+};

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getRelatedRecordIdFromJunction.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getRelatedRecordIdFromJunction.ts
@@ -1,8 +1,7 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
 import { getRelatedRecordFromJunction } from '@/object-record/record-field/ui/utils/junction/getRelatedRecordFromJunction';
-import {
-  computeRelationGqlFieldJoinColumnName,
-  isNonEmptyString,
-} from 'twenty-shared/utils';
+import { computeRelationGqlFieldJoinColumnName } from 'twenty-shared/utils';
 
 export const getRelatedRecordIdFromJunction = ({
   junctionRecord,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getRelatedRecordIdFromJunction.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getRelatedRecordIdFromJunction.ts
@@ -1,0 +1,26 @@
+import { getRelatedRecordFromJunction } from '@/object-record/record-field/ui/utils/junction/getRelatedRecordFromJunction';
+import {
+  computeRelationGqlFieldJoinColumnName,
+  isNonEmptyString,
+} from 'twenty-shared/utils';
+
+export const getRelatedRecordIdFromJunction = ({
+  junctionRecord,
+  relationFieldName,
+}: {
+  junctionRecord: object;
+  relationFieldName: string;
+}): string | undefined => {
+  const joinColumnName = computeRelationGqlFieldJoinColumnName({
+    name: relationFieldName,
+  });
+  const joinColumnValue = (junctionRecord as Record<string, unknown>)[
+    joinColumnName
+  ];
+
+  if (isNonEmptyString(joinColumnValue)) {
+    return joinColumnValue;
+  }
+
+  return getRelatedRecordFromJunction(junctionRecord, relationFieldName)?.id;
+};

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getReverseJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getReverseJunctionConfig.ts
@@ -17,12 +17,7 @@ type GetReverseJunctionConfigArgs = {
   objectMetadataItems: JunctionObjectMetadataItem[];
 };
 
-const reverseJunctionConfigCache = new WeakMap<
-  JunctionObjectMetadataItem[],
-  Map<string, ReverseJunctionConfig | null>
->();
-
-const resolveReverseJunctionConfig = ({
+export const getReverseJunctionConfig = ({
   junctionObjectMetadataId,
   sourceObjectMetadataId,
   objectMetadataItems,
@@ -76,36 +71,4 @@ const resolveReverseJunctionConfig = ({
   }
 
   return null;
-};
-
-export const getReverseJunctionConfig = (
-  args: GetReverseJunctionConfigArgs,
-): ReverseJunctionConfig | null => {
-  const {
-    junctionObjectMetadataId,
-    sourceObjectMetadataId,
-    objectMetadataItems,
-  } = args;
-
-  if (
-    !isDefined(junctionObjectMetadataId) ||
-    !isDefined(sourceObjectMetadataId)
-  ) {
-    return null;
-  }
-
-  const cacheKey = `${junctionObjectMetadataId}:${sourceObjectMetadataId}`;
-  const cachedConfigs = reverseJunctionConfigCache.get(objectMetadataItems);
-
-  if (cachedConfigs?.has(cacheKey)) {
-    return cachedConfigs.get(cacheKey) ?? null;
-  }
-
-  const resolvedConfig = resolveReverseJunctionConfig(args);
-  const configs = cachedConfigs ?? new Map();
-
-  configs.set(cacheKey, resolvedConfig);
-  reverseJunctionConfigCache.set(objectMetadataItems, configs);
-
-  return resolvedConfig;
 };

--- a/packages/twenty-front/src/modules/object-record/utils/__tests__/getRecordArrayField.test.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/__tests__/getRecordArrayField.test.ts
@@ -1,0 +1,20 @@
+import { getRecordArrayField } from '@/object-record/utils/getRecordArrayField';
+
+describe('getRecordArrayField', () => {
+  it('returns the array stored under a runtime field name', () => {
+    expect(
+      getRecordArrayField<{ id: string }>(
+        { taskTargets: [{ id: 'target-1' }] },
+        'taskTargets',
+      ),
+    ).toEqual([{ id: 'target-1' }]);
+  });
+
+  it('returns an empty array when the field is missing or not an array', () => {
+    expect(getRecordArrayField(undefined, 'taskTargets')).toEqual([]);
+    expect(getRecordArrayField({ taskTargets: null }, 'taskTargets')).toEqual(
+      [],
+    );
+    expect(getRecordArrayField({}, 'taskTargets')).toEqual([]);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/utils/getRecordArrayField.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/getRecordArrayField.ts
@@ -1,0 +1,14 @@
+import { isDefined } from 'twenty-shared/utils';
+
+export const getRecordArrayField = <TItem>(
+  record: object | null | undefined,
+  fieldName: string,
+): TItem[] => {
+  if (!isDefined(record)) {
+    return [];
+  }
+
+  const value = (record as Record<string, unknown>)[fieldName];
+
+  return Array.isArray(value) ? value : [];
+};

--- a/packages/twenty-front/src/modules/side-panel/pages/search/hooks/useSidePanelSearchRecordPreviewFields.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/search/hooks/useSidePanelSearchRecordPreviewFields.ts
@@ -24,11 +24,7 @@ export const useSidePanelSearchRecordPreviewFields = (
     }
 
     const readableActiveFields = objectMetadataItem.readableFields.filter(
-      (fieldMetadata) =>
-        isActiveFieldMetadataItem({
-          objectNameSingular: objectMetadataItem.nameSingular,
-          fieldMetadata,
-        }),
+      (fieldMetadata) => isActiveFieldMetadataItem(fieldMetadata),
     );
 
     const sortedViewFields = [...view.viewFields].sort(

--- a/packages/twenty-front/src/testing/graphqlMocks.ts
+++ b/packages/twenty-front/src/testing/graphqlMocks.ts
@@ -26,7 +26,6 @@ import { mockedStandardObjectMetadataQueryResult } from '~/testing/mock-data/gen
 import { mockedRoles } from '~/testing/mock-data/generated/metadata/roles/mock-roles-data';
 import { mockedCommandMenuItems } from '~/testing/mock-data/generated/metadata/command-menu-items/mock-command-menu-items-data';
 
-import { type Task } from '@/activities/types/Task';
 import { FIND_MINIMAL_METADATA } from '@/metadata-store/graphql/queries/findMinimalMetadata';
 import {
   getConnectionTypename,
@@ -35,6 +34,7 @@ import {
 } from 'twenty-shared/utils';
 import { getEmptyPageInfo } from '@/object-record/cache/utils/getEmptyPageInfo';
 import { getRecordFromRecordNode } from '@/object-record/cache/utils/getRecordFromRecordNode';
+import { getRecordArrayField } from '@/object-record/utils/getRecordArrayField';
 import { mockedApiKeys } from '~/testing/mock-data/generated/metadata/api-keys/mock-api-keys-data';
 import { mockedMinimalMetadata } from '~/testing/mock-data/generated/metadata/minimal/mock-minimal-metadata';
 import { mockedNavigationMenuItems } from '~/testing/mock-data/generated/metadata/navigation-menu-items/mock-navigation-menu-items-data';
@@ -53,7 +53,7 @@ const duplicateCompanyMock = {
 };
 
 const flatTaskRecords = mockedTaskRecords.map((record) =>
-  getRecordFromRecordNode<Task>({ recordNode: record }),
+  getRecordFromRecordNode({ recordNode: record }),
 );
 
 // Wraps raw server-fetched records (which already have correct field shapes)
@@ -446,8 +446,8 @@ export const graphqlMocks = {
       });
     }),
     graphql.query('FindManyTaskTargets', () => {
-      const taskTargetNodes = flatTaskRecords.flatMap(
-        (task) => task.taskTargets ?? [],
+      const taskTargetNodes = flatTaskRecords.flatMap((task) =>
+        getRecordArrayField(task, 'taskTargets'),
       );
 
       return HttpResponse.json({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #24766. That PR already routes task/note targets through generic junction metadata. This takes the leftover special-casing and review nits a step further.

## What changed
- Reuse `getActivityTargetJunctionConfig` (including `sourceField`) as the single source of truth instead of re-deriving the activity relation by hand
- Read activity IDs from the junction join column first, with a nested-record fallback, so cache-prep still works when the nested activity object is missing
- Replace `Record<string, unknown>` / `as` casts with typed accessors (`getRecordArrayField`, `getRelatedRecordFromJunction`, `getRelatedRecordIdFromJunction`)
- Stop throwing during Note/Task tile render when junction metadata is absent; skip the target cell instead
- Drop the module-level WeakMap cache on `getReverseJunctionConfig`
- Remove the leftover hardcoded `noteTargets`/`taskTargets` special case from `isActiveFieldMetadataItem`

## Validation
- `npx tsgo -p packages/twenty-front/tsconfig.json --noEmit`
- `npx nx lint:diff-with-main twenty-front`
- 11 Jest suites, 27 tests passed (accessors, junction config, activity hooks, field visibility)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8fc10d4-673b-46f7-a017-0be8040df643?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8fc10d4-673b-46f7-a017-0be8040df643&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

