### PR TITLE
Drop the V2 suffix from the core workspace ORM classes

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
@@ -15,7 +15,7 @@ import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { fetchImageWithTypeFromUrl } from 'src/utils/image';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { type PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
@@ -169,7 +169,7 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
     personRepository,
     cursor,
   }: {
-    personRepository: WorkspaceRepositoryV2<PersonWorkspaceEntity>;
+    personRepository: WorkspaceRepository<PersonWorkspaceEntity>;
     cursor: string;
   }): Promise<PersonWorkspaceEntity[]> {
     return personRepository.find({
@@ -191,7 +191,7 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
     avatarUrl: string;
     workspaceId: string;
     fieldMetadataUniversalIdentifier: string;
-    personRepository: WorkspaceRepositoryV2<PersonWorkspaceEntity>;
+    personRepository: WorkspaceRepository<PersonWorkspaceEntity>;
   }): Promise<'migrated' | 'skipped' | 'failed'> {
     const imageData = await this.downloadImage({
       imageUrl: avatarUrl,
@@ -289,7 +289,7 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
     personId: string;
     fileId: string;
     workspaceId: string;
-    personRepository: WorkspaceRepositoryV2<PersonWorkspaceEntity>;
+    personRepository: WorkspaceRepository<PersonWorkspaceEntity>;
   }): Promise<boolean> {
     try {
       const person = await personRepository.findOne({

--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
@@ -31,10 +31,10 @@ import {
 } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
-import { type WorkspaceDataSourceV2 } from 'src/engine/twenty-orm/datasource/workspace-data-source';
-import { WorkspaceDataSourceV2Service } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceDataSource } from 'src/engine/twenty-orm/datasource/workspace-data-source';
+import { WorkspaceDataSourceService } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 const EMPTY_RELATION_SENTINEL_RECORD_ID =
@@ -61,13 +61,13 @@ type ProcessNestedRelationsArgs<T extends ObjectRecord = ObjectRecord> = {
 @Injectable()
 export class ProcessNestedRelationsHelper {
   constructor(
-    private readonly workspaceDataSourceV2Service: WorkspaceDataSourceV2Service,
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
   ) {}
 
   public async processNestedRelations<T extends ObjectRecord = ObjectRecord>(
     args: ProcessNestedRelationsArgs<T>,
   ): Promise<void> {
-    const dataSource = this.workspaceDataSourceV2Service.getDataSource({
+    const dataSource = this.workspaceDataSourceService.getDataSource({
       useReplica: args.useReplica ?? false,
     });
 
@@ -95,7 +95,7 @@ export class ProcessNestedRelationsHelper {
       rolePermissionConfig,
       selectedFields,
     }: ProcessNestedRelationsArgs<T>,
-    dataSource: WorkspaceDataSourceV2,
+    dataSource: WorkspaceDataSource,
     relationQueryLimiter: ConcurrencyLimiter,
   ): Promise<void> {
     const processRelationTasks = Object.entries(relations).map(
@@ -154,7 +154,7 @@ export class ProcessNestedRelationsHelper {
     limit: number;
     authContext: WorkspaceAuthContext;
     useReplica: boolean;
-    dataSource: WorkspaceDataSourceV2;
+    dataSource: WorkspaceDataSource;
     rolePermissionConfig?: RolePermissionConfig;
     relationQueryLimiter: ConcurrencyLimiter;
     selectedFields: Record<string, unknown>;
@@ -388,8 +388,8 @@ export class ProcessNestedRelationsHelper {
     sourceFieldName,
     targetObjectNameSingular,
   }: {
-    referenceQueryBuilder: WorkspaceSelectQueryBuilderV2;
-    targetObjectRepository: WorkspaceRepositoryV2;
+    referenceQueryBuilder: WorkspaceSelectQueryBuilder;
+    targetObjectRepository: WorkspaceRepository;
     column: string;
     // oxlint-disable-next-line typescript/no-explicit-any
     ids: any[];
@@ -485,7 +485,7 @@ export class ProcessNestedRelationsHelper {
     ids,
     perParentLimit,
   }: {
-    targetObjectRepository: WorkspaceRepositoryV2;
+    targetObjectRepository: WorkspaceRepository;
     targetObjectNameSingular: string;
     column: string;
     ids: string[];

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -70,8 +70,8 @@ import {
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
-import { WorkspaceDataSourceV2Service } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { WorkspaceDataSourceService } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { type MutationKind } from 'src/engine/twenty-orm/sql/utils/build-mutation-statement.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
@@ -113,7 +113,7 @@ export abstract class CommonBaseQueryRunnerService<
   @Inject()
   protected readonly featureFlagService: FeatureFlagService;
   @Inject()
-  protected readonly workspaceDataSourceV2Service: WorkspaceDataSourceV2Service;
+  protected readonly workspaceDataSourceService: WorkspaceDataSourceService;
 
   protected abstract readonly operationName: CommonQueryNames;
 
@@ -352,7 +352,7 @@ export abstract class CommonBaseQueryRunnerService<
       );
     }
 
-    const repository = this.workspaceDataSourceV2Service
+    const repository = this.workspaceDataSourceService
       .getDataSource({ useReplica: this.isReadOnly })
       .getRepository<ObjectLiteral>(
         queryRunnerContext.flatObjectMetadata.nameSingular,
@@ -377,14 +377,14 @@ export abstract class CommonBaseQueryRunnerService<
   }: Pick<
     CommonExtendedQueryRunnerContext,
     'rolePermissionConfig' | 'flatObjectMetadata'
-  >): WorkspaceRepositoryV2 {
+  >): WorkspaceRepository {
     this.metricsService.incrementCounterBy({
       key: MetricsKeys.OrmV2ReadPathUsed,
       amount: 1,
       attributes: { operation: this.operationName },
     });
 
-    return this.workspaceDataSourceV2Service
+    return this.workspaceDataSourceService
       .getDataSource({ useReplica: this.isReadOnly })
       .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);
   }
@@ -396,14 +396,14 @@ export abstract class CommonBaseQueryRunnerService<
   }: Pick<
     CommonExtendedQueryRunnerContext,
     'rolePermissionConfig' | 'flatObjectMetadata'
-  >): WorkspaceRepositoryV2 {
+  >): WorkspaceRepository {
     this.metricsService.incrementCounterBy({
       key: MetricsKeys.OrmV2WritePathUsed,
       amount: 1,
       attributes: { operation: this.operationName },
     });
 
-    return this.workspaceDataSourceV2Service
+    return this.workspaceDataSourceService
       .getDataSource({ useReplica: false })
       .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);
   }
@@ -469,7 +469,7 @@ export abstract class CommonBaseQueryRunnerService<
   }: {
     records: Partial<ObjectRecord>[];
     queryRunnerContext: CommonExtendedQueryRunnerContext;
-    writeRepository: WorkspaceRepositoryV2;
+    writeRepository: WorkspaceRepository;
   }): Promise<Partial<ObjectRecord>[]> {
     const { flatObjectMetadata, flatFieldMetadataMaps, rolePermissionConfig } =
       queryRunnerContext;
@@ -486,7 +486,7 @@ export abstract class CommonBaseQueryRunnerService<
       return records;
     }
 
-    const workspaceDataSource = this.workspaceDataSourceV2Service.getDataSource(
+    const workspaceDataSource = this.workspaceDataSourceService.getDataSource(
       {
         useReplica: false,
       },

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -486,11 +486,9 @@ export abstract class CommonBaseQueryRunnerService<
       return records;
     }
 
-    const workspaceDataSource = this.workspaceDataSourceService.getDataSource(
-      {
-        useReplica: false,
-      },
-    );
+    const workspaceDataSource = this.workspaceDataSourceService.getDataSource({
+      useReplica: false,
+    });
 
     const connectQueryRunner: ConnectQueryRunner = async ({
       connectQueryConfig,

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
@@ -46,7 +46,7 @@ import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-module
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { assertMutationNotOnRemoteObject } from 'src/engine/metadata-modules/object-metadata/utils/assert-mutation-not-on-remote-object.util';
-import { WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
 
 @Injectable()
@@ -215,7 +215,7 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     workspaceId,
     queryRunnerContext,
   }: {
-    repository: WorkspaceRepositoryV2<ObjectLiteral>;
+    repository: WorkspaceRepository<ObjectLiteral>;
     flatObjectMetadata: FlatObjectMetadata;
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
@@ -271,7 +271,7 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     workspaceId,
     queryRunnerContext,
   }: {
-    repository: WorkspaceRepositoryV2<ObjectLiteral>;
+    repository: WorkspaceRepository<ObjectLiteral>;
     flatObjectMetadata: FlatObjectMetadata;
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
@@ -381,7 +381,7 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     args,
     conflictingFieldGroups,
   }: {
-    repository: WorkspaceRepositoryV2<ObjectLiteral>;
+    repository: WorkspaceRepository<ObjectLiteral>;
     flatObjectMetadata: FlatObjectMetadata;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     args: CreateManyQueryArgs;
@@ -526,7 +526,7 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     flatObjectMetadata: FlatObjectMetadata;
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
-    repository: WorkspaceRepositoryV2<ObjectLiteral>;
+    repository: WorkspaceRepository<ObjectLiteral>;
     selectedFieldsResult: CommonSelectedFieldsResult;
   }): Promise<ObjectRecord[]> {
     const queryBuilder = repository.createQueryBuilder(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-many-query-runner.service.ts
@@ -35,7 +35,7 @@ import { buildCursorPage } from 'src/engine/api/utils/build-cursor-page.util';
 import { getNonToOneJoinAliases } from 'src/engine/api/common/utils/get-non-to-one-join-aliases.util';
 import { getPageInfo } from 'src/engine/api/common/utils/get-page-info.util';
 import { ProcessAggregateHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
 import { buildOrderByColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-order-by-columns-to-select';
 import { getCursor } from 'src/engine/api/graphql/graphql-query-runner/utils/cursors.util';
@@ -73,7 +73,7 @@ export class CommonFindManyQueryRunnerService extends CommonBaseQueryRunnerServi
 
     const readRepository = this.getReadRepository(queryRunnerContext);
 
-    const queryBuilder: WorkspaceSelectQueryBuilderV2 =
+    const queryBuilder: WorkspaceSelectQueryBuilder =
       readRepository.createQueryBuilder(flatObjectMetadata.nameSingular);
 
     const aggregateQueryBuilder = queryBuilder.clone();

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
@@ -54,7 +54,7 @@ import { ViewFilterGroupService } from 'src/engine/metadata-modules/view-filter-
 import { ViewFilterService } from 'src/engine/metadata-modules/view-filter/services/view-filter.service';
 import { ViewService } from 'src/engine/metadata-modules/view/services/view.service';
 import { formatColumnNameForRelationField } from 'src/engine/twenty-orm/utils/format-column-name-for-relation-field.util';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 @Injectable()
 export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerService<
@@ -305,7 +305,7 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
   }: {
     args: GroupByQueryArgs;
     appliedFilters: ObjectRecordFilter;
-    queryBuilder: WorkspaceSelectQueryBuilderV2;
+    queryBuilder: WorkspaceSelectQueryBuilder;
     flatObjectMetadata: FlatObjectMetadata;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     workspaceId: string;
@@ -341,7 +341,7 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
     selectedFieldsResult,
     groupLimit,
   }: {
-    queryBuilder: WorkspaceSelectQueryBuilderV2;
+    queryBuilder: WorkspaceSelectQueryBuilder;
     groupByDefinitions: GroupByDefinition[];
     selectedFieldsResult: CommonSelectedFieldsResult;
     groupLimit?: number;
@@ -364,7 +364,7 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
     groupByFields,
     objectAlias,
   }: {
-    queryBuilder: WorkspaceSelectQueryBuilderV2;
+    queryBuilder: WorkspaceSelectQueryBuilder;
     groupByFields: GroupByField[];
     objectAlias: string;
   }): void {

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -367,7 +367,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       attributes: { operation: this.operationName },
     });
 
-    return this.workspaceDataSourceV2Service
+    return this.workspaceDataSourceService
       .getDataSource({ useReplica: false })
       .transaction(async (transactionScope) => {
         for (const relationField of this.getRelationFieldsPointingToCurrentObject(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/build-mutation-query-builder-v2.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/build-mutation-query-builder-v2.util.ts
@@ -1,11 +1,11 @@
 import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { type GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 
 type BuildMutationQueryBuilderV2Args = {
-  repository: WorkspaceRepositoryV2;
+  repository: WorkspaceRepository;
   alias: string;
   filter: Partial<ObjectRecordFilter>;
   commonQueryParser: GraphqlQueryParser;
@@ -17,7 +17,7 @@ export const buildMutationQueryBuilderV2 = ({
   filter,
   commonQueryParser,
 }: BuildMutationQueryBuilderV2Args): {
-  selectQueryBuilder: WorkspaceSelectQueryBuilderV2;
+  selectQueryBuilder: WorkspaceSelectQueryBuilder;
   rowLevelPermissionsApplied: boolean;
 } => {
   const filteredQueryBuilder = repository.createQueryBuilder(alias);

--- a/packages/twenty-server/src/engine/api/common/types/common-extended-query-runner-context.type.ts
+++ b/packages/twenty-server/src/engine/api/common/types/common-extended-query-runner-context.type.ts
@@ -4,7 +4,7 @@ import { type FeatureFlagKey } from 'twenty-shared/types';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { type CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
 import { type GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
 
 export type CommonExtendedQueryRunnerContext = Omit<
@@ -13,7 +13,7 @@ export type CommonExtendedQueryRunnerContext = Omit<
 > & {
   authContext: WorkspaceAuthContext;
   rolePermissionConfig: RolePermissionConfig;
-  repository: WorkspaceRepositoryV2<ObjectLiteral>;
+  repository: WorkspaceRepository<ObjectLiteral>;
   commonQueryParser: GraphqlQueryParser;
   featureFlagsMap: Record<FeatureFlagKey, boolean>;
 };

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/__tests__/graphql-query-filter-condition.parser.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/__tests__/graphql-query-filter-condition.parser.spec.ts
@@ -4,7 +4,7 @@ import {
 } from 'test/utils/create-where-expression-recorder.util';
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { GraphqlQueryFilterConditionParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-condition.parser';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
@@ -57,7 +57,7 @@ const flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata> = {
 
 const outerQueryBuilder = {
   objectRecordsPermissions: {},
-} as unknown as WorkspaceSelectQueryBuilderV2;
+} as unknown as WorkspaceSelectQueryBuilder;
 
 const recordFilterEntries = (filter: Record<string, unknown>) => {
   const recorder = createWhereExpressionRecorder();

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-condition.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-condition.parser.ts
@@ -8,7 +8,7 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 import { GraphqlQueryFilterFieldParser } from './graphql-query-filter-field.parser';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 export class GraphqlQueryFilterConditionParser {
   private queryFilterFieldParser: GraphqlQueryFilterFieldParser;
@@ -28,10 +28,10 @@ export class GraphqlQueryFilterConditionParser {
   }
 
   public parse(
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
     objectNameSingular: string,
     filter: Partial<ObjectRecordFilter>,
-  ): WorkspaceSelectQueryBuilderV2 {
+  ): WorkspaceSelectQueryBuilder {
     if (!filter || Object.keys(filter).length === 0) {
       return queryBuilder;
     }
@@ -52,7 +52,7 @@ export class GraphqlQueryFilterConditionParser {
 
   public applyFilterEntriesToWhereBrackets(
     innerQueryBuilder: WhereExpressionBuilder,
-    outerQueryBuilder: WorkspaceSelectQueryBuilderV2,
+    outerQueryBuilder: WorkspaceSelectQueryBuilder,
     objectNameSingular: string,
     filter: Partial<ObjectRecordFilter>,
   ): void {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -29,7 +29,7 @@ import {
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 
 import { GraphqlQueryFilterConditionParser } from './graphql-query-filter-condition.parser';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 export class GraphqlQueryFilterFieldParser {
   private flatObjectMetadata: FlatObjectMetadata;
@@ -61,7 +61,7 @@ export class GraphqlQueryFilterFieldParser {
 
   public parse(
     queryBuilder: WhereExpressionBuilder,
-    outerQueryBuilder: WorkspaceSelectQueryBuilderV2,
+    outerQueryBuilder: WorkspaceSelectQueryBuilder,
     objectNameSingular: string,
     key: string,
     // oxlint-disable-next-line typescript/no-explicit-any
@@ -144,7 +144,7 @@ export class GraphqlQueryFilterFieldParser {
 
   private parseRelationSubFilter(
     queryBuilder: WhereExpressionBuilder,
-    outerQueryBuilder: WorkspaceSelectQueryBuilderV2,
+    outerQueryBuilder: WorkspaceSelectQueryBuilder,
     parentAlias: string,
     fieldMetadata: FlatFieldMetadata,
     filterValue: Partial<ObjectRecordFilter>,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
@@ -24,7 +24,7 @@ import { addRelationJoinAliasToQueryBuilder } from 'src/engine/api/graphql/graph
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 export class GraphqlQueryParser {
   private flatObjectMetadata: FlatObjectMetadata;
@@ -62,11 +62,11 @@ export class GraphqlQueryParser {
 
   public applyFilterToBuilder(
     // oxlint-disable-next-line typescript/no-explicit-any
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
     objectNameSingular: string,
     recordFilter: Partial<ObjectRecordFilter>,
     // oxlint-disable-next-line typescript/no-explicit-any
-  ): WorkspaceSelectQueryBuilderV2 {
+  ): WorkspaceSelectQueryBuilder {
     return this.filterConditionParser.parse(
       queryBuilder,
       objectNameSingular,
@@ -76,10 +76,10 @@ export class GraphqlQueryParser {
 
   public applyDeletedAtToBuilder(
     // oxlint-disable-next-line typescript/no-explicit-any
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
     recordFilter: Partial<ObjectRecordFilter>,
     // oxlint-disable-next-line typescript/no-explicit-any
-  ): WorkspaceSelectQueryBuilderV2 {
+  ): WorkspaceSelectQueryBuilder {
     if (this.checkForDeletedAtFilter(recordFilter)) {
       queryBuilder.withDeleted();
     }
@@ -120,7 +120,7 @@ export class GraphqlQueryParser {
 
   public applyOrderToBuilder(
     // oxlint-disable-next-line typescript/no-explicit-any
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
     orderBy: ObjectRecordOrderBy | OrderByWithGroupBy,
     objectNameSingular: string,
     isForwardPagination = true,
@@ -148,7 +148,7 @@ export class GraphqlQueryParser {
 
   public addRelationOrderColumnsToBuilder(
     // oxlint-disable-next-line typescript/no-explicit-any
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
     parsedOrderBy: Record<string, OrderByClause>,
     objectNameSingular: string,
     columnsToSelect: Record<string, boolean>,
@@ -225,11 +225,11 @@ export class GraphqlQueryParser {
 
   public applyGroupByOrderToBuilder(
     // oxlint-disable-next-line typescript/no-explicit-any
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
     orderBy: ObjectRecordOrderBy | OrderByWithGroupBy,
     groupByFields: GroupByField[],
     // oxlint-disable-next-line typescript/no-explicit-any
-  ): WorkspaceSelectQueryBuilderV2 {
+  ): WorkspaceSelectQueryBuilder {
     const parsedOrderBys = this.orderGroupByParser.parse({
       orderBy,
       groupByFields,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util.ts
@@ -1,7 +1,7 @@
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 type AddRelationJoinAliasToQueryBuilderArgs = {
-  queryBuilder: WorkspaceSelectQueryBuilderV2;
+  queryBuilder: WorkspaceSelectQueryBuilder;
   parentAlias: string;
   relationName: string;
 };

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/apply-filter-entries-to-where-expression.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/apply-filter-entries-to-where-expression.util.ts
@@ -1,10 +1,10 @@
 import { Brackets, NotBrackets, type WhereExpressionBuilder } from 'typeorm';
 
 import { type GraphqlQueryFilterFieldParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 type FilterWalkContext = {
-  outerQueryBuilder: WorkspaceSelectQueryBuilderV2;
+  outerQueryBuilder: WorkspaceSelectQueryBuilder;
   objectNameSingular: string;
   fieldParser: GraphqlQueryFilterFieldParser;
   useDirectTableReference: boolean;
@@ -19,7 +19,7 @@ export const applyFilterEntriesToWhereExpression = ({
   useDirectTableReference = false,
 }: {
   whereExpression: WhereExpressionBuilder;
-  outerQueryBuilder: WorkspaceSelectQueryBuilderV2;
+  outerQueryBuilder: WorkspaceSelectQueryBuilder;
   objectNameSingular: string;
   filter: Record<string, unknown>;
   fieldParser: GraphqlQueryFilterFieldParser;

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
@@ -29,8 +29,8 @@ import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runne
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 
 @Injectable()
 export class GroupByWithRecordsV2Service {
@@ -51,12 +51,12 @@ export class GroupByWithRecordsV2Service {
     offsetForRecords,
     nestedRelationsReadPathOptions,
   }: {
-    queryBuilderWithGroupBy: WorkspaceSelectQueryBuilderV2;
-    queryBuilderWithFiltersAndWithoutGroupBy: WorkspaceSelectQueryBuilderV2;
+    queryBuilderWithGroupBy: WorkspaceSelectQueryBuilder;
+    queryBuilderWithFiltersAndWithoutGroupBy: WorkspaceSelectQueryBuilder;
     groupByDefinitions: GroupByDefinition[];
     selectedFieldsResult: CommonSelectedFieldsResult;
     queryRunnerContext: CommonExtendedQueryRunnerContext;
-    readRepository: WorkspaceRepositoryV2;
+    readRepository: WorkspaceRepository;
     orderByForRecords: ObjectRecordOrderBy;
     groupLimit?: number;
     offsetForRecords?: number;
@@ -158,7 +158,7 @@ export class GroupByWithRecordsV2Service {
     flatFieldMetadataMaps,
     offsetForRecords,
   }: {
-    subQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    subQueryBuilder: WorkspaceSelectQueryBuilder;
     columnsToSelect: Record<string, boolean>;
     groupsResult: Array<Record<string, unknown>>;
     groupByDefinitions: GroupByDefinition[];
@@ -245,7 +245,7 @@ export class GroupByWithRecordsV2Service {
   }: {
     groupByDefinitions: GroupByDefinition[];
     orderByForRecords: ObjectRecordOrderBy;
-    subQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    subQueryBuilder: WorkspaceSelectQueryBuilder;
     flatObjectMetadata: FlatObjectMetadata;
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper.ts
@@ -3,7 +3,7 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type AggregationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util';
 import { formatColumnNamesFromCompositeFieldAndSubfields } from 'src/engine/twenty-orm/utils/format-column-names-from-composite-field-and-subfield.util';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 export class ProcessAggregateHelper {
   public static addSelectedAggregatedFieldsQueriesToQueryBuilder = ({
@@ -13,7 +13,7 @@ export class ProcessAggregateHelper {
   }: {
     selectedAggregatedFields: Record<string, AggregationField>;
     // oxlint-disable-next-line typescript/no-explicit-any
-    queryBuilder: WorkspaceSelectQueryBuilderV2;
+    queryBuilder: WorkspaceSelectQueryBuilder;
     objectMetadataNameSingular: string;
   }) => {
     queryBuilder.select([]);

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -52,7 +52,7 @@ import { getEffectiveImageIdentifierFieldMetadataId } from 'src/engine/metadata-
 import { SEARCH_VECTOR_FIELD } from 'src/engine/metadata-modules/search-field-metadata/constants/search-vector-field.constants';
 import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
@@ -214,7 +214,7 @@ export class SearchService {
     filter,
     after,
   }: {
-    entityManager: WorkspaceRepositoryV2<Entity>;
+    entityManager: WorkspaceRepository<Entity>;
     rolePermissionConfig?: RolePermissionConfig;
     flatObjectMetadata: FlatObjectMetadata;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
@@ -267,7 +267,7 @@ export class SearchService {
     filter,
     after,
   }: {
-    entityManager: WorkspaceRepositoryV2<Entity>;
+    entityManager: WorkspaceRepository<Entity>;
     flatObjectMetadata: FlatObjectMetadata;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     searchTerms: string;
@@ -382,7 +382,7 @@ export class SearchService {
     limit,
     filter,
   }: {
-    entityManager: WorkspaceRepositoryV2<Entity>;
+    entityManager: WorkspaceRepository<Entity>;
     rolePermissionConfig?: RolePermissionConfig;
     flatObjectMetadata: FlatObjectMetadata;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
@@ -14,7 +14,7 @@ import {
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
-import { WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
@@ -276,7 +276,7 @@ export class WorkflowVersionCoreSyncService {
   async writeWorkflowVersionAndMirror(
     workspaceId: string,
     write: (
-      workflowVersionRepository: WorkspaceRepositoryV2<WorkflowVersionWorkspaceEntity>,
+      workflowVersionRepository: WorkspaceRepository<WorkflowVersionWorkspaceEntity>,
       transactionScope: WorkspaceTransactionScope,
     ) => Promise<string>,
   ): Promise<void> {

--- a/packages/twenty-server/src/engine/twenty-orm/README.md
+++ b/packages/twenty-server/src/engine/twenty-orm/README.md
@@ -38,8 +38,8 @@ per object type rather than thousands, and it can be rebuilt or discarded freely
 |---|---|
 | `sql/` | named-parameter compiler: `:name` / `:...list` to `$1..$n` |
 | `table-shape/` | `WorkspaceTableShape` and its builder from flat field metadata |
-| `query-builder/` | `WorkspaceSelectQueryBuilderV2` and `WorkspaceMutationQueryBuilderV2`, the TypeORM-shaped builders |
-| `repository/` | `WorkspaceRepositoryV2`, permissions and result formatting |
+| `query-builder/` | `WorkspaceSelectQueryBuilder` and `WorkspaceMutationQueryBuilder`, the TypeORM-shaped builders |
+| `repository/` | `WorkspaceRepository`, permissions and result formatting |
 | `datasource/` | pool ownership and per-request data source |
 | `executor/` | statement execution against a `pg` pool |
 
@@ -123,7 +123,7 @@ subquery with the v2 builder and runs the composed outer query through
 
 ## Writes: delete, destroy, restore and (most) update route through v2
 
-`WorkspaceMutationQueryBuilderV2` generates `UPDATE` / `DELETE` / soft-delete / restore
+`WorkspaceMutationQueryBuilder` generates `UPDATE` / `DELETE` / soft-delete / restore
 statements with `RETURNING`, reusing the same primitives as the select builder
 (`quoteColumn`, the shared where renderer, the `mapRowToEntity` decode) plus a `SET`
 generator. The select builder morphs into it: `.update()` / `.delete()` / `.softDelete()`
@@ -134,7 +134,7 @@ the TypeORM surface the mutation runners already call.
 route to this path through the shared `runFilteredMutation` on the base runner. Each
 builds the filtered v2 select builder with `buildMutationQueryBuilderV2` (which rewrites a
 relation-traversal filter into an `id IN (subquery)` predicate, RLS inside the subquery)
-and hands it to `WorkspaceRepositoryV2.runMutation`, which owns the choreography the v1
+and hands it to `WorkspaceRepository.runMutation`, which owns the choreography the v1
 mutation builders own: apply the row-level predicate, validate the write with the matching
 operation type, snapshot the affected rows before and after through a permission-bypassing
 all-columns select, run the statement, and emit the batch event(s) through the shared
@@ -188,7 +188,7 @@ Deliberate choices, the SQL ones asserted by exact-SQL unit tests:
 ## Writes: create (non-upsert insert) routes through v2
 
 `createMany` (and `createOne`) route their non-upsert insert through
-`WorkspaceRepositoryV2.runInsert`: records flatten through `formatData`, insert with
+`WorkspaceRepository.runInsert`: records flatten through `formatData`, insert with
 `buildInsertStatement` (a multi-row `INSERT ... VALUES ... RETURNING`, `DEFAULT` for the
 columns a given row omits so Postgres column defaults apply), validate the insert
 permission over the inserted columns, and emit `CREATED` then `UPSERTED` from an
@@ -199,7 +199,7 @@ all-columns re-select of the inserted ids — matching the v1 insert builder. Re
 
 ## Transactions and merge
 
-`WorkspaceDataSourceV2.transaction(work)` checks a client out of the pool, wraps `work` in
+`WorkspaceDataSource.transaction(work)` checks a client out of the pool, wraps `work` in
 `BEGIN` / `COMMIT` (rolling back and rethrowing on error), and hands `work` a scope whose
 `getRepository` returns repositories bound to that client through a `ClientQueryExecutor`,
 so every statement and event snapshot inside runs on the one connection.
@@ -235,7 +235,7 @@ update, upsert, delete, and merge — whatever field types it touches (scalars, 
 relation join columns, relation `{connect}` / `{disconnect}`, and files fields). Nothing on
 the write path falls back to v1 on the value of its input.
 
-`WorkspaceSelectQueryBuilderV2.leftJoin` can render a to-many join when the caller passes
+`WorkspaceSelectQueryBuilder.leftJoin` can render a to-many join when the caller passes
 `allowToManyJoin`. It renders as a `DISTINCT ON (foreignKey)` derived table ordered by
 `foreignKey, id`, so each parent keeps exactly one representative child row (its lowest-id
 live child) and the join never multiplies parent rows — record ranking and paging stay

--- a/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.service.ts
@@ -83,11 +83,7 @@ export class WorkspaceDataSourceService
     }
   }
 
-  getDataSource({
-    useReplica,
-  }: {
-    useReplica: boolean;
-  }): WorkspaceDataSource {
+  getDataSource({ useReplica }: { useReplica: boolean }): WorkspaceDataSource {
     const pool = useReplica
       ? (this.replicaPool ?? this.primaryPool)
       : this.primaryPool;

--- a/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.service.ts
@@ -17,7 +17,7 @@ import {
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
-import { WorkspaceDataSourceV2 } from 'src/engine/twenty-orm/datasource/workspace-data-source';
+import { WorkspaceDataSource } from 'src/engine/twenty-orm/datasource/workspace-data-source';
 import {
   TwentyOrmV2Exception,
   TwentyOrmV2ExceptionCode,
@@ -38,10 +38,10 @@ const DATE_ONLY_POOL_TYPES: PoolConfig['types'] = {
 };
 
 @Injectable()
-export class WorkspaceDataSourceV2Service
+export class WorkspaceDataSourceService
   implements OnModuleInit, OnApplicationShutdown
 {
-  private readonly logger = new Logger(WorkspaceDataSourceV2Service.name);
+  private readonly logger = new Logger(WorkspaceDataSourceService.name);
   private primaryPool: Pool | null = null;
   private replicaPool: Pool | null = null;
 
@@ -87,21 +87,21 @@ export class WorkspaceDataSourceV2Service
     useReplica,
   }: {
     useReplica: boolean;
-  }): WorkspaceDataSourceV2 {
+  }): WorkspaceDataSource {
     const pool = useReplica
       ? (this.replicaPool ?? this.primaryPool)
       : this.primaryPool;
 
     if (!isDefined(pool)) {
       throw new TwentyOrmV2Exception(
-        'WorkspaceDataSourceV2Service has not been initialized. Make sure the module has been initialized.',
+        'WorkspaceDataSourceService has not been initialized. Make sure the module has been initialized.',
         TwentyOrmV2ExceptionCode.UNSUPPORTED_OPERATION,
       );
     }
 
     const workspaceContext = getWorkspaceContext();
 
-    return new WorkspaceDataSourceV2({
+    return new WorkspaceDataSource({
       pool,
       internalContext: this.buildInternalContext(workspaceContext),
       authContext: workspaceContext.authContext,

--- a/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.ts
@@ -14,13 +14,13 @@ import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
 import { ClientQueryExecutor } from 'src/engine/twenty-orm/executor/client-query-executor';
 import { PoolQueryExecutor } from 'src/engine/twenty-orm/executor/pool-query-executor';
-import { type QueryExecutorV2 } from 'src/engine/twenty-orm/executor/types/query-executor.type';
+import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
 import {
   TwentyOrmV2Exception,
   TwentyOrmV2ExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
 import { runInRollbackSafeTransaction } from 'src/engine/twenty-orm/datasource/utils/run-in-rollback-safe-transaction.util';
-import { WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/types/workspace-table-shape.type';
 import { buildWorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/utils/build-workspace-table-shape.util';
 import { resolveObjectRecordsPermissions } from 'src/engine/twenty-orm/utils/resolve-object-records-permissions.util';
@@ -34,14 +34,14 @@ export type WorkspaceTransactionScopeV2 = {
   getRepository: (
     nameSingular: string,
     rolePermissionConfig?: RolePermissionConfig,
-  ) => WorkspaceRepositoryV2;
+  ) => WorkspaceRepository;
   executeRawQuery: (
     sql: string,
     parameters?: unknown[],
   ) => Promise<Record<string, unknown>[]>;
 };
 
-export class WorkspaceDataSourceV2 {
+export class WorkspaceDataSource {
   private readonly pool: Pool;
   private readonly internalContext: WorkspaceInternalContext;
   private readonly authContext: WorkspaceAuthContext;
@@ -67,7 +67,7 @@ export class WorkspaceDataSourceV2 {
   getRepository<T extends ObjectLiteral = ObjectRecord>(
     nameSingular: string,
     rolePermissionConfig?: RolePermissionConfig,
-  ): WorkspaceRepositoryV2<T> {
+  ): WorkspaceRepository<T> {
     return this.buildRepository<T>({
       nameSingular,
       rolePermissionConfig,
@@ -94,7 +94,7 @@ export class WorkspaceDataSourceV2 {
   }
 
   private async runInClientTransaction<T>(
-    work: (executor: QueryExecutorV2) => Promise<T>,
+    work: (executor: QueryExecutor) => Promise<T>,
   ): Promise<T> {
     return runInRollbackSafeTransaction({
       pool: this.pool,
@@ -110,9 +110,9 @@ export class WorkspaceDataSourceV2 {
   }: {
     nameSingular: string;
     rolePermissionConfig?: RolePermissionConfig;
-    executor: QueryExecutorV2;
+    executor: QueryExecutor;
     isTransactional?: boolean;
-  }): WorkspaceRepositoryV2<T> {
+  }): WorkspaceRepository<T> {
     const objectMetadataId =
       this.internalContext.objectIdByNameSingular[nameSingular];
 
@@ -141,9 +141,9 @@ export class WorkspaceDataSourceV2 {
   }: {
     objectMetadataId: string;
     rolePermissionConfig?: RolePermissionConfig;
-    executor: QueryExecutorV2;
+    executor: QueryExecutor;
     isTransactional?: boolean;
-  }): WorkspaceRepositoryV2<T> {
+  }): WorkspaceRepository<T> {
     const flatObjectMetadata =
       this.getFlatObjectMetadataOrThrow(objectMetadataId);
 
@@ -153,7 +153,7 @@ export class WorkspaceDataSourceV2 {
         objectPermissionsByRoleId: this.objectPermissionsByRoleId,
       });
 
-    return new WorkspaceRepositoryV2<T>({
+    return new WorkspaceRepository<T>({
       tableShape: this.getTableShape(objectMetadataId),
       flatObjectMetadata,
       internalContext: this.internalContext,

--- a/packages/twenty-server/src/engine/twenty-orm/executor/client-query-executor.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/executor/client-query-executor.ts
@@ -2,9 +2,9 @@ import { type PoolClient } from 'pg';
 
 import { type CompiledStatement } from 'src/engine/twenty-orm/sql/utils/compile-named-parameters.util';
 import { computeTwentyOrmV2Exception } from 'src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.util';
-import { type QueryExecutorV2 } from 'src/engine/twenty-orm/executor/types/query-executor.type';
+import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
 
-export class ClientQueryExecutor implements QueryExecutorV2 {
+export class ClientQueryExecutor implements QueryExecutor {
   private readonly client: PoolClient;
 
   constructor({ client }: { client: PoolClient }) {

--- a/packages/twenty-server/src/engine/twenty-orm/executor/pool-query-executor.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/executor/pool-query-executor.ts
@@ -2,9 +2,9 @@ import { type Pool } from 'pg';
 
 import { type CompiledStatement } from 'src/engine/twenty-orm/sql/utils/compile-named-parameters.util';
 import { computeTwentyOrmV2Exception } from 'src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.util';
-import { type QueryExecutorV2 } from 'src/engine/twenty-orm/executor/types/query-executor.type';
+import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
 
-export class PoolQueryExecutor implements QueryExecutorV2 {
+export class PoolQueryExecutor implements QueryExecutor {
   private readonly pool: Pool;
 
   constructor({ pool }: { pool: Pool }) {

--- a/packages/twenty-server/src/engine/twenty-orm/executor/types/query-executor.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/executor/types/query-executor.type.ts
@@ -1,5 +1,5 @@
 import { type CompiledStatement } from 'src/engine/twenty-orm/sql/utils/compile-named-parameters.util';
 
-export type QueryExecutorV2 = {
+export type QueryExecutor = {
   execute: (statement: CompiledStatement) => Promise<Record<string, unknown>[]>;
 };

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource.module.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource.module.ts
@@ -13,7 +13,7 @@ import { WorkspaceFeatureFlagsMapCacheModule } from 'src/engine/metadata-modules
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
 import { WorkspaceORMEntityMetadatasCacheService } from 'src/engine/twenty-orm/workspace-orm-entity-metadatas-cache.service';
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
-import { WorkspaceDataSourceV2Service } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
+import { WorkspaceDataSourceService } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/workspace-event-emitter.module';
@@ -38,10 +38,10 @@ import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/
   ],
   providers: [
     GlobalWorkspaceOrmManager,
-    WorkspaceDataSourceV2Service,
+    WorkspaceDataSourceService,
     WorkspaceORMEntityMetadatasCacheService,
     provideWorkspaceScopedRepository(FeatureFlagEntity),
   ],
-  exports: [GlobalWorkspaceOrmManager, WorkspaceDataSourceV2Service],
+  exports: [GlobalWorkspaceOrmManager, WorkspaceDataSourceService],
 })
 export class GlobalWorkspaceDataSourceModule {}

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-orm.manager.ts
@@ -14,8 +14,8 @@ import {
   withWorkspaceContext,
 } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import type { RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
-import { WorkspaceDataSourceV2Service } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { WorkspaceDataSourceService } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { convertClassNameToObjectMetadataName } from 'src/engine/workspace-manager/utils/convert-class-to-object-metadata-name.util';
 
@@ -23,28 +23,28 @@ import { convertClassNameToObjectMetadataName } from 'src/engine/workspace-manag
 export class GlobalWorkspaceOrmManager {
   constructor(
     private readonly workspaceCacheService: WorkspaceCacheService,
-    private readonly workspaceDataSourceV2Service: WorkspaceDataSourceV2Service,
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
   ) {}
 
   async getRepository<T extends ObjectLiteral>(
     workspaceEntity: Type<T>,
     permissionOptions?: RolePermissionConfig,
-  ): Promise<WorkspaceRepositoryV2<T>>;
+  ): Promise<WorkspaceRepository<T>>;
 
   async getRepository<T extends ObjectLiteral>(
     objectMetadataName: string,
     permissionOptions?: RolePermissionConfig,
-  ): Promise<WorkspaceRepositoryV2<T>>;
+  ): Promise<WorkspaceRepository<T>>;
 
   async getRepository<T extends ObjectLiteral>(
     workspaceEntityOrObjectMetadataName: Type<T> | string,
     permissionOptions?: RolePermissionConfig,
-  ): Promise<WorkspaceRepositoryV2<T>> {
+  ): Promise<WorkspaceRepository<T>> {
     const objectMetadataName = this.resolveObjectMetadataName(
       workspaceEntityOrObjectMetadataName,
     );
 
-    return this.workspaceDataSourceV2Service
+    return this.workspaceDataSourceService
       .getDataSource({ useReplica: false })
       .getRepository<T>(objectMetadataName, permissionOptions);
   }
@@ -64,18 +64,18 @@ export class GlobalWorkspaceOrmManager {
   async runInWorkspaceTransaction<T>(
     work: (transactionScope: WorkspaceTransactionScope) => Promise<T>,
   ): Promise<T> {
-    return this.workspaceDataSourceV2Service
+    return this.workspaceDataSourceService
       .getDataSource({ useReplica: false })
       .transaction((transactionScope) =>
         work({
           getRepository: <T extends ObjectLiteral = ObjectRecord>(
             objectMetadataName: string,
             rolePermissionConfig?: RolePermissionConfig,
-          ): WorkspaceRepositoryV2<T> =>
+          ): WorkspaceRepository<T> =>
             transactionScope.getRepository(
               objectMetadataName,
               rolePermissionConfig,
-            ) as unknown as WorkspaceRepositoryV2<T>,
+            ) as unknown as WorkspaceRepository<T>,
           executeRawQuery: (sql, parameters) =>
             transactionScope.executeRawQuery(sql, parameters),
         }),

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-mutation-query-builder.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-mutation-query-builder.spec.ts
@@ -3,7 +3,7 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { TwentyOrmV2Exception } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
 import { type CompiledStatement } from 'src/engine/twenty-orm/sql/utils/compile-named-parameters.util';
-import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/types/workspace-table-shape.type';
 
 const SCHEMA_NAME = 'workspace_1wgvd1injqtife6y4rvfbu3h5';
@@ -74,7 +74,7 @@ const buildBuilders = ({
 }: { rows?: Record<string, unknown>[] } = {}) => {
   const executedStatements: CompiledStatement[] = [];
 
-  const selectQueryBuilder = new WorkspaceSelectQueryBuilderV2('person', {
+  const selectQueryBuilder = new WorkspaceSelectQueryBuilder('person', {
     tableShape: personTableShape,
     executor: {
       execute: async (statement) => {
@@ -92,7 +92,7 @@ const buildBuilders = ({
   return { selectQueryBuilder, executedStatements };
 };
 
-describe('WorkspaceMutationQueryBuilderV2', () => {
+describe('WorkspaceMutationQueryBuilder', () => {
   it('should build a soft delete that stamps deletedAt and updatedAt', () => {
     const { selectQueryBuilder } = buildBuilders();
 
@@ -221,7 +221,7 @@ describe('WorkspaceMutationQueryBuilderV2', () => {
       hasDeletedAtColumn: false,
     };
 
-    const selectQueryBuilder = new WorkspaceSelectQueryBuilderV2('person', {
+    const selectQueryBuilder = new WorkspaceSelectQueryBuilder('person', {
       tableShape: shapeWithoutDeletedAt,
       executor: { execute: async () => [] },
       objectRecordsPermissions: {},
@@ -279,7 +279,7 @@ describe('WorkspaceMutationQueryBuilderV2', () => {
       columnNames: ['id', 'deletedAt'],
     };
 
-    const selectQueryBuilder = new WorkspaceSelectQueryBuilderV2('person', {
+    const selectQueryBuilder = new WorkspaceSelectQueryBuilder('person', {
       tableShape: shapeWithoutUpdatedAt,
       executor: { execute: async () => [] },
       objectRecordsPermissions: {},

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-hydration.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-hydration.spec.ts
@@ -4,7 +4,7 @@ import {
   buildQueryBuilder,
 } from 'src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-test-shapes.util';
 
-describe('WorkspaceSelectQueryBuilderV2 joined hydration', () => {
+describe('WorkspaceSelectQueryBuilder joined hydration', () => {
   it('should project every joined column for a leftJoinAndSelect', () => {
     const { queryBuilder } = buildQueryBuilder();
 

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-joins.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-joins.spec.ts
@@ -4,7 +4,7 @@ import {
   buildQueryBuilder,
 } from 'src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-test-shapes.util';
 
-describe('WorkspaceSelectQueryBuilderV2 joins', () => {
+describe('WorkspaceSelectQueryBuilder joins', () => {
   it('should join a to-one relation on its foreign key', () => {
     const { queryBuilder } = buildQueryBuilder();
 

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-order-group.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-order-group.spec.ts
@@ -1,6 +1,6 @@
 import { buildQueryBuilder } from 'src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-test-shapes.util';
 
-describe('WorkspaceSelectQueryBuilderV2 order, group and distinct', () => {
+describe('WorkspaceSelectQueryBuilder order, group and distinct', () => {
   it('should render order by with direction and nulls handling', () => {
     const { queryBuilder } = buildQueryBuilder();
 

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-relation-where.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-relation-where.spec.ts
@@ -6,7 +6,7 @@ import { TwentyOrmV2Exception } from 'src/engine/twenty-orm/exceptions/twenty-or
 import { applyFindOptionsToQueryBuilder } from 'src/engine/twenty-orm/query-builder/utils/apply-find-options.util';
 import { buildQueryBuilder } from 'src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-test-shapes.util';
 
-describe('WorkspaceSelectQueryBuilderV2 relation-keyed where', () => {
+describe('WorkspaceSelectQueryBuilder relation-keyed where', () => {
   it('should filter a to-many relation with a correlated EXISTS instead of a join', () => {
     const { queryBuilder } = buildQueryBuilder();
 

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-selection.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-selection.spec.ts
@@ -1,4 +1,4 @@
-import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import {
   SCHEMA_NAME,
   buildColumn,
@@ -9,7 +9,7 @@ import {
 import { buildColumnResultAlias } from 'src/engine/twenty-orm/sql/utils/build-column-result-alias.util';
 import { TwentyOrmV2Exception } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
 
-describe('WorkspaceSelectQueryBuilderV2 selection', () => {
+describe('WorkspaceSelectQueryBuilder selection', () => {
   it('should select the requested columns with alias-prefixed output names', () => {
     const { queryBuilder } = buildQueryBuilder();
 
@@ -239,7 +239,7 @@ describe('WorkspaceSelectQueryBuilderV2 selection', () => {
   });
 
   it('should restore the previous limit when getOne fails', async () => {
-    const failingBuilder = new WorkspaceSelectQueryBuilderV2('person', {
+    const failingBuilder = new WorkspaceSelectQueryBuilder('person', {
       tableShape: personTableShape,
       executor: {
         execute: async () => {

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-test-shapes.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-test-shapes.util.ts
@@ -1,7 +1,7 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
-import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { type CompiledStatement } from 'src/engine/twenty-orm/sql/utils/compile-named-parameters.util';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/types/workspace-table-shape.type';
 
@@ -92,7 +92,7 @@ export const buildQueryBuilder = ({
 } = {}) => {
   const executedStatements: CompiledStatement[] = [];
 
-  const queryBuilder = new WorkspaceSelectQueryBuilderV2('person', {
+  const queryBuilder = new WorkspaceSelectQueryBuilder('person', {
     tableShape,
     executor: {
       execute: async (statement) => {

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-timeline-messaging.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-timeline-messaging.spec.ts
@@ -3,11 +3,11 @@ import {
   SCHEMA_NAME,
   buildColumn,
 } from 'src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-test-shapes.util';
-import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { type CompiledStatement } from 'src/engine/twenty-orm/sql/utils/compile-named-parameters.util';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/types/workspace-table-shape.type';
 
-describe('WorkspaceSelectQueryBuilderV2 timeline messaging parity', () => {
+describe('WorkspaceSelectQueryBuilder timeline messaging parity', () => {
   const buildShape = (
     objectMetadataId: string,
     nameSingular: string,
@@ -157,7 +157,7 @@ describe('WorkspaceSelectQueryBuilderV2 timeline messaging parity', () => {
   ) => {
     const executedStatements: CompiledStatement[] = [];
 
-    const queryBuilder = new WorkspaceSelectQueryBuilderV2(alias, {
+    const queryBuilder = new WorkspaceSelectQueryBuilder(alias, {
       tableShape,
       executor: {
         execute: async (statement) => {

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-where.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-where.spec.ts
@@ -3,7 +3,7 @@ import { And, Equal, In, LessThan, Not } from 'typeorm';
 import { TwentyOrmV2Exception } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
 import { buildQueryBuilder } from 'src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-test-shapes.util';
 
-describe('WorkspaceSelectQueryBuilderV2 where', () => {
+describe('WorkspaceSelectQueryBuilder where', () => {
   it('should nest a bracketed condition built by the shared parsers', () => {
     const { queryBuilder } = buildQueryBuilder();
 

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/utils/__tests__/apply-find-options.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/utils/__tests__/apply-find-options.util.spec.ts
@@ -8,7 +8,7 @@ import {
   normalizeFindOptionsRelations,
   splitFindOptionsOrder,
 } from 'src/engine/twenty-orm/query-builder/utils/apply-find-options.util';
-import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/types/workspace-table-shape.type';
 
 const SCHEMA_NAME = 'workspace_test';
@@ -37,7 +37,7 @@ const personTableShape: WorkspaceTableShape = {
 };
 
 const buildQueryBuilder = () =>
-  new WorkspaceSelectQueryBuilderV2('person', {
+  new WorkspaceSelectQueryBuilder('person', {
     tableShape: personTableShape,
     executor: { execute: async () => [] },
     objectRecordsPermissions: {},
@@ -198,7 +198,7 @@ const threadShape: WorkspaceTableShape = {
 };
 
 const buildThreadQueryBuilder = () =>
-  new WorkspaceSelectQueryBuilderV2('thread', {
+  new WorkspaceSelectQueryBuilder('thread', {
     tableShape: threadShape,
     executor: { execute: async () => [] },
     objectRecordsPermissions: {},

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/utils/__tests__/apply-mutation-criteria.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/utils/__tests__/apply-mutation-criteria.util.spec.ts
@@ -2,7 +2,7 @@ import { FieldMetadataType } from 'twenty-shared/types';
 
 import { TwentyOrmV2Exception } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
 import { applyMutationCriteriaToQueryBuilder } from 'src/engine/twenty-orm/query-builder/utils/apply-mutation-criteria.util';
-import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/types/workspace-table-shape.type';
 
 const buildColumn = (columnName: string) => ({
@@ -28,7 +28,7 @@ const personTableShape: WorkspaceTableShape = {
 };
 
 const buildQueryBuilder = () =>
-  new WorkspaceSelectQueryBuilderV2('person', {
+  new WorkspaceSelectQueryBuilder('person', {
     tableShape: personTableShape,
     executor: { execute: async () => [] },
     objectRecordsPermissions: {},

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/utils/apply-find-options.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/utils/apply-find-options.util.ts
@@ -1,6 +1,6 @@
 import { isDefined } from 'twenty-shared/utils';
 
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import {
   type FindOptionsSelectLike,
   type ObjectWhereLike,
@@ -60,7 +60,7 @@ const normalizeSelect = (select: FindOptionsSelectV2): FindOptionsSelectLike =>
     : select;
 
 const applyWhere = (
-  queryBuilder: WorkspaceSelectQueryBuilderV2,
+  queryBuilder: WorkspaceSelectQueryBuilder,
   where: ObjectWhereLike | ObjectWhereLike[],
 ): void => {
   if (!Array.isArray(where)) {
@@ -132,7 +132,7 @@ const toDedupOrder = (order: OrderByConditionLike): ToManyDedupOrder[] =>
   }));
 
 const applyRelationOrderEntry = (
-  queryBuilder: WorkspaceSelectQueryBuilderV2,
+  queryBuilder: WorkspaceSelectQueryBuilder,
   relationFieldName: string,
   relationOrder: OrderByConditionLike,
 ): void => {
@@ -161,7 +161,7 @@ const applyRelationOrderEntry = (
 };
 
 const applyOrder = (
-  queryBuilder: WorkspaceSelectQueryBuilderV2,
+  queryBuilder: WorkspaceSelectQueryBuilder,
   order: FindOptionsOrderV2,
 ): void => {
   for (const [key, value] of Object.entries(order)) {
@@ -185,9 +185,9 @@ const toOrderByArguments = (
     : [key, value.order ?? 'ASC', value.nulls];
 
 export const applyFindOptionsToQueryBuilder = (
-  queryBuilder: WorkspaceSelectQueryBuilderV2,
+  queryBuilder: WorkspaceSelectQueryBuilder,
   options?: FindOptionsV2,
-): WorkspaceSelectQueryBuilderV2 => {
+): WorkspaceSelectQueryBuilder => {
   if (!isDefined(options)) {
     return queryBuilder;
   }

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/utils/apply-mutation-criteria.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/utils/apply-mutation-criteria.util.ts
@@ -4,7 +4,7 @@ import {
   TwentyOrmV2Exception,
   TwentyOrmV2ExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { type ObjectWhereLike } from 'src/engine/twenty-orm/query-builder/types/query-builder.type';
 
 export type MutationCriteria =
@@ -19,9 +19,9 @@ const isPlainObject = (value: unknown): value is ObjectWhereLike =>
   Object.getPrototypeOf(value) === Object.prototype;
 
 export const applyMutationCriteriaToQueryBuilder = (
-  queryBuilder: WorkspaceSelectQueryBuilderV2,
+  queryBuilder: WorkspaceSelectQueryBuilder,
   criteria: MutationCriteria,
-): WorkspaceSelectQueryBuilderV2 => {
+): WorkspaceSelectQueryBuilder => {
   if (typeof criteria === 'string') {
     if (criteria.length === 0) {
       throw new TwentyOrmV2Exception(

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/workspace-mutation-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/workspace-mutation-query-builder.ts
@@ -4,7 +4,7 @@ import {
   TwentyOrmV2Exception,
   TwentyOrmV2ExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
-import { type QueryExecutorV2 } from 'src/engine/twenty-orm/executor/types/query-executor.type';
+import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
 import {
   buildColumnNameByResultAlias,
   mapRowToEntity,
@@ -26,7 +26,7 @@ const DELETED_AT_COLUMN_NAME = 'deletedAt';
 
 export type MutationQueryBuilderV2Context = {
   tableShape: WorkspaceTableShape;
-  executor: QueryExecutorV2;
+  executor: QueryExecutor;
   formatResult: <T>(records: unknown) => T;
 };
 
@@ -35,7 +35,7 @@ export type MutationResultV2 = {
   generatedMaps: any[];
 };
 
-export class WorkspaceMutationQueryBuilderV2 {
+export class WorkspaceMutationQueryBuilder {
   readonly alias: string;
   readonly tableShape: WorkspaceTableShape;
 

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/workspace-select-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/workspace-select-query-builder.ts
@@ -8,7 +8,7 @@ import {
   TwentyOrmV2Exception,
   TwentyOrmV2ExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
-import { type QueryExecutorV2 } from 'src/engine/twenty-orm/executor/types/query-executor.type';
+import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
 import {
   type ExpressionMapLike,
   type FindOptionsLike,
@@ -20,7 +20,7 @@ import {
   isObjectWhereLike,
   isWhereFactoryLike,
 } from 'src/engine/twenty-orm/query-builder/types/query-builder.type';
-import { WorkspaceMutationQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-mutation-query-builder';
+import { WorkspaceMutationQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-mutation-query-builder';
 import { type MutationKind } from 'src/engine/twenty-orm/sql/utils/build-mutation-statement.util';
 import { buildOrderByClauses } from 'src/engine/twenty-orm/sql/utils/build-order-by-clauses.util';
 import { collectReferencedColumnNames } from 'src/engine/twenty-orm/sql/utils/collect-referenced-column-names.util';
@@ -62,16 +62,16 @@ const isNestedWhereObject = (value: unknown): value is ObjectWhereLike =>
 
 export type QueryBuilderV2Context = {
   tableShape: WorkspaceTableShape;
-  executor: QueryExecutorV2;
+  executor: QueryExecutor;
   objectRecordsPermissions: ObjectsPermissions;
   tableShapeByObjectMetadataId: (
     objectMetadataId: string,
   ) => WorkspaceTableShape;
-  onBeforeExecute: (queryBuilder: WorkspaceSelectQueryBuilderV2) => void;
+  onBeforeExecute: (queryBuilder: WorkspaceSelectQueryBuilder) => void;
   formatResult: <T>(records: unknown) => T;
 };
 
-export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
+export class WorkspaceSelectQueryBuilder implements WhereExpressionLike {
   readonly alias: string;
   readonly tableShape: WorkspaceTableShape;
   readonly objectRecordsPermissions: ObjectsPermissions;
@@ -119,8 +119,8 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     };
   }
 
-  clone(): WorkspaceSelectQueryBuilderV2 {
-    const cloned = new WorkspaceSelectQueryBuilderV2(this.alias, this.context);
+  clone(): WorkspaceSelectQueryBuilder {
+    const cloned = new WorkspaceSelectQueryBuilder(this.alias, this.context);
 
     cloned.whereClauses.push(...this.whereClauses);
     cloned.existsFilterClauses.push(
@@ -167,7 +167,7 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     return this.appendWhere('and', condition, parameters);
   }
 
-  copyWhereFrom(source: WorkspaceSelectQueryBuilderV2): this {
+  copyWhereFrom(source: WorkspaceSelectQueryBuilder): this {
     this.whereClauses.push(...source.whereClauses);
     this.existsFilterClauses.push(
       ...source.existsFilterClauses.map((existsFilterClause) => ({
@@ -731,25 +731,25 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     return this.getReferencedColumnNamesByAlias()[this.alias] ?? [];
   }
 
-  update(): WorkspaceMutationQueryBuilderV2 {
+  update(): WorkspaceMutationQueryBuilder {
     return this.toMutationQueryBuilder('update');
   }
 
-  delete(): WorkspaceMutationQueryBuilderV2 {
+  delete(): WorkspaceMutationQueryBuilder {
     return this.toMutationQueryBuilder('delete');
   }
 
-  softDelete(): WorkspaceMutationQueryBuilderV2 {
+  softDelete(): WorkspaceMutationQueryBuilder {
     return this.toMutationQueryBuilder('soft-delete');
   }
 
-  restore(): WorkspaceMutationQueryBuilderV2 {
+  restore(): WorkspaceMutationQueryBuilder {
     return this.toMutationQueryBuilder('restore');
   }
 
   private toMutationQueryBuilder(
     kind: MutationKind,
-  ): WorkspaceMutationQueryBuilderV2 {
+  ): WorkspaceMutationQueryBuilder {
     if (this.joinClauses.length > 0) {
       throw new TwentyOrmV2Exception(
         `A mutation cannot carry a relation join; rewrite the filter as an "id IN (subquery)" predicate first`,
@@ -766,7 +766,7 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
       );
     }
 
-    return new WorkspaceMutationQueryBuilderV2({
+    return new WorkspaceMutationQueryBuilder({
       alias: this.alias,
       kind,
       context: {
@@ -789,7 +789,7 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     }
 
     if (isWhereFactoryLike(condition)) {
-      const nestedBuilder = new WorkspaceSelectQueryBuilderV2(
+      const nestedBuilder = new WorkspaceSelectQueryBuilder(
         this.alias,
         this.context,
       );
@@ -955,7 +955,7 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
       );
     }
 
-    const nestedBuilder = new WorkspaceSelectQueryBuilderV2(alias, {
+    const nestedBuilder = new WorkspaceSelectQueryBuilder(alias, {
       ...this.context,
       tableShape: targetTableShape,
     });

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
@@ -114,9 +114,7 @@ type WorkspaceRepositoryV2Options = {
   ) => Promise<T>;
 };
 
-export class WorkspaceRepository<
-  TEntity extends ObjectLiteral = ObjectRecord,
-> {
+export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
   readonly objectRecordsPermissions: ObjectsPermissions;
 
   private readonly options: WorkspaceRepositoryV2Options;

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
@@ -34,7 +34,7 @@ import {
   TwentyOrmV2Exception,
   TwentyOrmV2ExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm-v2.exception';
-import { type QueryExecutorV2 } from 'src/engine/twenty-orm/executor/types/query-executor.type';
+import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
 import {
   buildInsertStatement,
   type InsertRowValue,
@@ -70,7 +70,7 @@ import {
   getUpdateEventColumnsToReturn,
   mergeReturnedUpdateTimestamps,
 } from 'src/engine/twenty-orm/repository/utils/update-event-records.util';
-import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { compileNamedParameters } from 'src/engine/twenty-orm/sql/utils/compile-named-parameters.util';
 import { escapeIdentifier } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
 import { serializeJsonbWriteValue } from 'src/engine/twenty-orm/sql/utils/serialize-jsonb-write-value.util';
@@ -94,7 +94,7 @@ type WorkspaceRepositoryV2Options = {
   flatObjectMetadata: FlatObjectMetadata;
   internalContext: WorkspaceInternalContext;
   authContext: WorkspaceAuthContext;
-  executor: QueryExecutorV2;
+  executor: QueryExecutor;
   objectRecordsPermissions: ObjectsPermissions;
   shouldBypassPermissionChecks: boolean;
   tableShapeByObjectMetadataId: (
@@ -105,16 +105,16 @@ type WorkspaceRepositoryV2Options = {
   ) => FlatObjectMetadata;
   getRepositoryForObjectMetadataId: (
     objectMetadataId: string,
-  ) => WorkspaceRepositoryV2;
+  ) => WorkspaceRepository;
   isTransactional: boolean;
   runInNewTransaction: <T>(
     work: (
-      transactionalRepository: WorkspaceRepositoryV2<ObjectLiteral>,
+      transactionalRepository: WorkspaceRepository<ObjectLiteral>,
     ) => Promise<T>,
   ) => Promise<T>;
 };
 
-export class WorkspaceRepositoryV2<
+export class WorkspaceRepository<
   TEntity extends ObjectLiteral = ObjectRecord,
 > {
   readonly objectRecordsPermissions: ObjectsPermissions;
@@ -143,8 +143,8 @@ export class WorkspaceRepositoryV2<
     return this.options.executor.execute(compiled) as Promise<T[]>;
   }
 
-  createQueryBuilder(alias?: string): WorkspaceSelectQueryBuilderV2 {
-    return new WorkspaceSelectQueryBuilderV2(
+  createQueryBuilder(alias?: string): WorkspaceSelectQueryBuilder {
+    return new WorkspaceSelectQueryBuilder(
       alias ?? this.options.tableShape.nameSingular,
       {
         tableShape: this.options.tableShape,
@@ -157,7 +157,7 @@ export class WorkspaceRepositoryV2<
     );
   }
 
-  private createPermissionBypassingQueryBuilder(): WorkspaceSelectQueryBuilderV2 {
+  private createPermissionBypassingQueryBuilder(): WorkspaceSelectQueryBuilder {
     return this.buildBypassingEventSelectQueryBuilder(
       this.options.tableShape.nameSingular,
     );
@@ -189,7 +189,7 @@ export class WorkspaceRepositoryV2<
   }
 
   applyWriteRowLevelPermissions(
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
   ): void {
     this.applyRowLevelPermissionPredicates(queryBuilder);
   }
@@ -447,7 +447,7 @@ export class WorkspaceRepositoryV2<
     records: ObjectRecord[];
     fieldName: string;
     joinColumnName?: string;
-    targetRepository: WorkspaceRepositoryV2;
+    targetRepository: WorkspaceRepository;
     nestedRelations?: FindOptionsRelationsV2;
   }): Promise<void> {
     if (!isDefined(joinColumnName)) {
@@ -488,7 +488,7 @@ export class WorkspaceRepositoryV2<
     records: ObjectRecord[];
     fieldName: string;
     relationShape: WorkspaceRelationShape;
-    targetRepository: WorkspaceRepositoryV2;
+    targetRepository: WorkspaceRepository;
     nestedRelations?: FindOptionsRelationsV2;
     withDeleted: boolean;
     order?: OrderByConditionLike;
@@ -667,7 +667,7 @@ export class WorkspaceRepositoryV2<
   }
 
   private runAtomically<T>(
-    work: (repository: WorkspaceRepositoryV2<ObjectLiteral>) => Promise<T>,
+    work: (repository: WorkspaceRepository<ObjectLiteral>) => Promise<T>,
   ): Promise<T> {
     return this.options.isTransactional
       ? work(this)
@@ -1167,8 +1167,8 @@ export class WorkspaceRepositoryV2<
 
   private buildBypassingEventSelectQueryBuilder(
     alias: string,
-  ): WorkspaceSelectQueryBuilderV2 {
-    return new WorkspaceSelectQueryBuilderV2(alias, {
+  ): WorkspaceSelectQueryBuilder {
+    return new WorkspaceSelectQueryBuilder(alias, {
       tableShape: this.options.tableShape,
       executor: this.options.executor,
       objectRecordsPermissions: this.options.objectRecordsPermissions,
@@ -1180,7 +1180,7 @@ export class WorkspaceRepositoryV2<
 
   private buildIdsEventSnapshotQueryBuilder(
     ids: string[],
-  ): WorkspaceSelectQueryBuilderV2 {
+  ): WorkspaceSelectQueryBuilder {
     return this.buildBypassingEventSelectQueryBuilder(
       this.options.tableShape.nameSingular,
     )
@@ -1195,7 +1195,7 @@ export class WorkspaceRepositoryV2<
     columnsToReturn,
     data,
   }: {
-    selectQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    selectQueryBuilder: WorkspaceSelectQueryBuilder;
     rowLevelPermissionsApplied: boolean;
     kind: MutationKind;
     columnsToReturn: string[];
@@ -1321,7 +1321,7 @@ export class WorkspaceRepositoryV2<
     columnsToReturn,
     setColumns,
   }: {
-    selectQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    selectQueryBuilder: WorkspaceSelectQueryBuilder;
     kind: MutationKind;
     columnsToReturn: string[];
     setColumns?: Record<string, unknown>;
@@ -1345,8 +1345,8 @@ export class WorkspaceRepositoryV2<
   }
 
   private buildEventSnapshotQueryBuilder(
-    source: WorkspaceSelectQueryBuilderV2,
-  ): WorkspaceSelectQueryBuilderV2 {
+    source: WorkspaceSelectQueryBuilder,
+  ): WorkspaceSelectQueryBuilder {
     return this.buildBypassingEventSelectQueryBuilder(source.alias)
       .copyWhereFrom(source)
       .withDeleted();
@@ -1431,13 +1431,13 @@ export class WorkspaceRepositoryV2<
     }
   }
 
-  private onBeforeExecute(queryBuilder: WorkspaceSelectQueryBuilderV2): void {
+  private onBeforeExecute(queryBuilder: WorkspaceSelectQueryBuilder): void {
     this.applyRowLevelPermissionPredicates(queryBuilder);
     this.validateQueryIsPermitted(queryBuilder);
   }
 
   private validateQueryIsPermitted(
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
   ): void {
     if (this.options.shouldBypassPermissionChecks) {
       return;
@@ -1473,7 +1473,7 @@ export class WorkspaceRepositoryV2<
   }
 
   private applyRowLevelPermissionPredicates(
-    queryBuilder: WorkspaceSelectQueryBuilderV2,
+    queryBuilder: WorkspaceSelectQueryBuilder,
   ): void {
     if (this.options.shouldBypassPermissionChecks) {
       return;
@@ -1509,7 +1509,7 @@ export class WorkspaceRepositoryV2<
     alias,
     flatObjectMetadata,
   }: {
-    queryBuilder: WorkspaceSelectQueryBuilderV2;
+    queryBuilder: WorkspaceSelectQueryBuilder;
     alias: string;
     flatObjectMetadata: FlatObjectMetadata;
   }): void {

--- a/packages/twenty-server/src/engine/twenty-orm/sql/utils/__tests__/sql-injection-invariants.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/sql/utils/__tests__/sql-injection-invariants.spec.ts
@@ -1,6 +1,6 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { compileNamedParameters } from 'src/engine/twenty-orm/sql/utils/compile-named-parameters.util';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/types/workspace-table-shape.type';
 
@@ -40,7 +40,7 @@ const buildTableShape = (columnNames: string[]): WorkspaceTableShape => ({
 });
 
 const buildQueryBuilder = (columnNames = ['id', 'name', 'deletedAt']) =>
-  new WorkspaceSelectQueryBuilderV2('person', {
+  new WorkspaceSelectQueryBuilder('person', {
     tableShape: buildTableShape(columnNames),
     executor: { execute: async () => [] },
     objectRecordsPermissions: {},

--- a/packages/twenty-server/src/engine/twenty-orm/types/workspace-transaction-scope.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/types/workspace-transaction-scope.type.ts
@@ -3,13 +3,13 @@ import { type ObjectLiteral } from 'typeorm';
 import { type ObjectRecord } from 'twenty-shared/types';
 
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 
 export type WorkspaceTransactionScope = {
   getRepository: <T extends ObjectLiteral = ObjectRecord>(
     objectMetadataName: string,
     rolePermissionConfig?: RolePermissionConfig,
-  ) => WorkspaceRepositoryV2<T>;
+  ) => WorkspaceRepository<T>;
   executeRawQuery: (
     sql: string,
     parameters?: unknown[],

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -12,7 +12,7 @@ import { type DeepPartial, ILike } from 'typeorm';
 
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CompanyWorkspaceEntity } from 'src/modules/company/standard-objects/company.workspace-entity';
 import { extractDomainFromLink } from 'src/modules/contact-creation-manager/utils/extract-domain-from-link.util';
@@ -230,7 +230,7 @@ export class CreateCompanyService {
   }
 
   private async getLastCompanyPosition(
-    companyRepository: WorkspaceRepositoryV2<CompanyWorkspaceEntity>,
+    companyRepository: WorkspaceRepository<CompanyWorkspaceEntity>,
   ): Promise<number> {
     const lastCompanyPosition = await companyRepository.maximum(
       'position',

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
@@ -4,7 +4,7 @@ import { type FullNameMetadata } from 'twenty-shared/types';
 import { DeepPartial } from 'typeorm';
 
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
 
@@ -116,7 +116,7 @@ export class CreatePersonService {
   }
 
   private async getLastPersonPosition(
-    personRepository: WorkspaceRepositoryV2<PersonWorkspaceEntity>,
+    personRepository: WorkspaceRepository<PersonWorkspaceEntity>,
   ): Promise<number> {
     const lastPersonPosition = await personRepository.maximum(
       'position',

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
@@ -6,7 +6,7 @@ import { ActorFromAuthContextService } from 'src/engine/core-modules/actor/servi
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { PageLayoutDuplicationService } from 'src/engine/metadata-modules/page-layout/services/page-layout-duplication.service';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { DuplicatedDashboardDTO } from 'src/modules/dashboard/dtos/duplicated-dashboard.dto';
 import {
   DashboardException,
@@ -103,7 +103,7 @@ export class DashboardDuplicationService {
   private async createDuplicatedDashboard(
     originalDashboard: DashboardWorkspaceEntity,
     newPageLayoutId: string,
-    dashboardRepository: WorkspaceRepositoryV2<DashboardWorkspaceEntity>,
+    dashboardRepository: WorkspaceRepository<DashboardWorkspaceEntity>,
     authContext: WorkspaceAuthContext,
   ): Promise<DashboardWorkspaceEntity> {
     const newTitle = appendCopySuffix(originalDashboard.title ?? '');

--- a/packages/twenty-server/src/modules/match-participant/utils/__tests__/add-person-email-filters-to-query-builder.util.spec.ts
+++ b/packages/twenty-server/src/modules/match-participant/utils/__tests__/add-person-email-filters-to-query-builder.util.spec.ts
@@ -1,6 +1,6 @@
 import { type EachTestingContext } from 'twenty-shared/testing';
 import { addPersonEmailFiltersToQueryBuilder } from 'src/modules/match-participant/utils/add-person-email-filters-to-query-builder';
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 type AddPersonEmailFiltersToQueryBuilderTestCase = EachTestingContext<{
   emails: string[];
@@ -81,7 +81,7 @@ interface QueryBuilderCall {
 
 let queryBuilderCalls: QueryBuilderCall[] = [];
 
-const mockQueryBuilder: Partial<WorkspaceSelectQueryBuilderV2> = {
+const mockQueryBuilder: Partial<WorkspaceSelectQueryBuilder> = {
   select: jest.fn().mockImplementation((...args) => {
     queryBuilderCalls.push({ method: 'select', args });
 
@@ -120,7 +120,7 @@ describe('addPersonEmailFiltersToQueryBuilder', () => {
     ({ context: { emails, excludePersonIds, description } }) => {
       const result = addPersonEmailFiltersToQueryBuilder({
         queryBuilder:
-          mockQueryBuilder as unknown as WorkspaceSelectQueryBuilderV2,
+          mockQueryBuilder as unknown as WorkspaceSelectQueryBuilder,
         emails,
         excludePersonIds,
       });

--- a/packages/twenty-server/src/modules/match-participant/utils/add-person-email-filters-to-query-builder.ts
+++ b/packages/twenty-server/src/modules/match-participant/utils/add-person-email-filters-to-query-builder.ts
@@ -1,7 +1,7 @@
-import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 export interface AddPersonEmailFiltersToQueryBuilderOptions {
-  queryBuilder: WorkspaceSelectQueryBuilderV2;
+  queryBuilder: WorkspaceSelectQueryBuilder;
   emails: string[];
   excludePersonIds?: string[];
 }
@@ -11,7 +11,7 @@ export function addPersonEmailFiltersToQueryBuilder({
   queryBuilder,
   emails,
   excludePersonIds = [],
-}: AddPersonEmailFiltersToQueryBuilderOptions): WorkspaceSelectQueryBuilderV2 {
+}: AddPersonEmailFiltersToQueryBuilderOptions): WorkspaceSelectQueryBuilder {
   const normalizedEmails = emails.map((email) => email.toLowerCase());
 
   queryBuilder = queryBuilder

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -5,7 +5,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { In, MoreThan } from 'typeorm';
 
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { type MessageThreadWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-thread.workspace-entity';
@@ -234,7 +234,7 @@ export class MessagingMessageCleanerService {
   }
 
   private async findReferencedMessageIds(
-    messageChannelMessageAssociationRepository: WorkspaceRepositoryV2<MessageChannelMessageAssociationWorkspaceEntity>,
+    messageChannelMessageAssociationRepository: WorkspaceRepository<MessageChannelMessageAssociationWorkspaceEntity>,
     messageIds: string[],
   ): Promise<string[]> {
     const associations = await messageChannelMessageAssociationRepository.find({
@@ -246,7 +246,7 @@ export class MessagingMessageCleanerService {
   }
 
   private async findReferencedThreadIds(
-    messageRepository: WorkspaceRepositoryV2<MessageWorkspaceEntity>,
+    messageRepository: WorkspaceRepository<MessageWorkspaceEntity>,
     threadIds: string[],
   ): Promise<string[]> {
     const messages = await messageRepository.find({

--- a/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
+++ b/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
@@ -7,7 +7,7 @@ import { In, MoreThan, type ObjectLiteral } from 'typeorm';
 import { objectRecordDiffMerge } from 'src/engine/core-modules/event-emitter/utils/object-record-diff-merge';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type TimelineActivityPayload } from 'src/modules/timeline/types/timeline-activity-payload';
 import {
@@ -194,7 +194,7 @@ export class TimelineActivityRepository {
     objectSingularName,
     payloads,
   }: {
-    timelineActivityRepository: WorkspaceRepositoryV2<ObjectLiteral>;
+    timelineActivityRepository: WorkspaceRepository<ObjectLiteral>;
     objectSingularName: string;
     payloads: TimelineActivityPayloadWorkspaceIdAndObjectSingularName['payloads'];
   }) {
@@ -232,7 +232,7 @@ export class TimelineActivityRepository {
     objectSingularName,
     payloads,
   }: {
-    timelineActivityRepository: WorkspaceRepositoryV2<ObjectLiteral>;
+    timelineActivityRepository: WorkspaceRepository<ObjectLiteral>;
     objectSingularName: string;
     payloads: TimelineActivityPayloadWorkspaceIdAndObjectSingularName['payloads'];
   }) {
@@ -262,7 +262,7 @@ export class TimelineActivityRepository {
     timelineActivityRepository,
     merges,
   }: {
-    timelineActivityRepository: WorkspaceRepositoryV2<ObjectLiteral>;
+    timelineActivityRepository: WorkspaceRepository<ObjectLiteral>;
     merges: {
       id: string;
       properties: Partial<ObjectRecord>;

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -21,7 +21,7 @@ import {
 import { LogicFunctionFromSourceService } from 'src/engine/metadata-modules/logic-function/services/logic-function-from-source.service';
 import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowCommonException,
@@ -400,7 +400,7 @@ export class WorkflowCommonWorkspaceService {
     workspaceId,
     operation,
   }: {
-    workflowVersionRepository: WorkspaceRepositoryV2<WorkflowVersionWorkspaceEntity>;
+    workflowVersionRepository: WorkspaceRepository<WorkflowVersionWorkspaceEntity>;
     workspaceId: string;
     workflowId: string;
     operation: 'restore' | 'delete' | 'destroy';
@@ -492,7 +492,7 @@ export class WorkflowCommonWorkspaceService {
     workspaceId,
     operation,
   }: {
-    workflowVersionRepository: WorkspaceRepositoryV2<WorkflowVersionWorkspaceEntity>;
+    workflowVersionRepository: WorkspaceRepository<WorkflowVersionWorkspaceEntity>;
     workflowId: string;
     workspaceId: string;
     operation: 'restore' | 'delete' | 'destroy';

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -8,7 +8,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowVersionStatus,
@@ -182,7 +182,7 @@ export class WorkflowStatusesUpdateJob {
     workflowVersionRepository,
   }: {
     workflowId: string;
-    workflowVersionRepository: WorkspaceRepositoryV2<WorkflowVersionWorkspaceEntity>;
+    workflowVersionRepository: WorkspaceRepository<WorkflowVersionWorkspaceEntity>;
   }) {
     const workflowVersions = await workflowVersionRepository.find({
       where: {

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -13,7 +13,7 @@ import { CommandMenuItemAvailabilityType } from 'src/engine/metadata-modules/com
 import { EngineComponentKey } from 'src/engine/metadata-modules/command-menu-item/enums/engine-component-key.enum';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
-import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
 import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
@@ -266,7 +266,7 @@ export class WorkflowTriggerWorkspaceService {
   private async performActivationSteps(
     workflow: WorkflowWorkspaceEntity,
     workflowVersion: WorkflowVersionWorkspaceEntity,
-    workflowVersionRepository: WorkspaceRepositoryV2<WorkflowVersionWorkspaceEntity>,
+    workflowVersionRepository: WorkspaceRepository<WorkflowVersionWorkspaceEntity>,
     workspaceId: string,
   ) {
     const previousPublishedVersionId = workflow.lastPublishedVersionId;
@@ -368,7 +368,7 @@ export class WorkflowTriggerWorkspaceService {
 
   private async performDeactivationSteps(
     workflowVersionId: string,
-    workflowVersionRepository: WorkspaceRepositoryV2<WorkflowVersionWorkspaceEntity>,
+    workflowVersionRepository: WorkspaceRepository<WorkflowVersionWorkspaceEntity>,
     workspaceId: string,
   ) {
     const workflowVersionNullable = await workflowVersionRepository.findOne({


### PR DESCRIPTION
## What

Third of the five PRs splitting #24759 (after #24761 and #24768). With the files already in place from the paths-only move, this drops the `V2` suffix from the core classes. Pure identifier renames, no file moves:

- `WorkspaceRepositoryV2` → `WorkspaceRepository` (and the `workspaceRepositoryV2` properties)
- `WorkspaceSelectQueryBuilderV2` → `WorkspaceSelectQueryBuilder`, `WorkspaceMutationQueryBuilderV2` → `WorkspaceMutationQueryBuilder`
- `WorkspaceDataSourceV2` → `WorkspaceDataSource`, `WorkspaceDataSourceV2Service` → `WorkspaceDataSourceService` (name freed by the `WorkspaceSchemaService` rename in #24761)
- `QueryExecutorV2` → `QueryExecutor`

Review rule: the diff is +229/−229 across 55 files and every hunk swaps exactly one of these identifier pairs.

## Notes for CI

One committed upgrade command (the 2-22 person-avatar migration) gets a type-annotation rename only, so the PR carries the `ci:allow-previous-version-upgrade-mutation` label.

## Coming next

The manager and module rename (`GlobalWorkspaceOrmManager` → `WorkspaceOrmManager`, `GlobalWorkspaceDataSourceModule` → `TwentyOrmModule`), then the internal leftovers.

## Verification

- `tsgo --noEmit` clean, `oxlint --type-aware` clean on the 54 changed files, `oxfmt --check src/` clean
- All twenty-orm unit suites pass (405 tests)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

