### PR TITLE
Rename the workspace ORM manager and module

### DIFF
--- a/packages/twenty-server/src/app.module.ts
+++ b/packages/twenty-server/src/app.module.ts
@@ -33,7 +33,7 @@ import { MiddlewareModule } from 'src/engine/middlewares/middleware.module';
 import { JwtModule } from 'src/engine/core-modules/jwt/jwt.module';
 import { UserSessionModule } from 'src/engine/core-modules/user-session/user-session.module';
 import { RestCoreMiddleware } from 'src/engine/middlewares/rest-core.middleware';
-import { GlobalWorkspaceDataSourceModule } from 'src/engine/twenty-orm/global-workspace-datasource.module';
+import { TwentyOrmModule } from 'src/engine/twenty-orm/twenty-orm.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { UnhandledExceptionFilter } from 'src/filters/unhandled-exception.filter';
 import { ModulesModule } from 'src/modules/modules.module';
@@ -59,7 +59,7 @@ const MIGRATED_REST_METHODS = [
       imports: [GraphQLConfigModule, MetricsModule, DataloaderModule],
       useClass: GraphQLConfigService,
     }),
-    GlobalWorkspaceDataSourceModule,
+    TwentyOrmModule,
     ClickHouseModule,
     CoreEngineModule,
     ModulesModule,

--- a/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
@@ -13,7 +13,7 @@ import { DataSource, MoreThanOrEqual, Raw, Repository } from 'typeorm';
 import { CommandShutdownService } from 'src/database/commands/command-runners/command-shutdown.service';
 import { activationStatusIn } from 'src/database/commands/command-runners/utils/activation-status-in.util';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceMigrationRunnerException } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception';
 
@@ -62,7 +62,7 @@ export class WorkspaceIteratorService {
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
     @InjectDataSource()
     private readonly coreDataSource: DataSource,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly commandShutdownService: CommandShutdownService,
   ) {}
 
@@ -107,36 +107,33 @@ export class WorkspaceIteratorService {
       try {
         const authContext = buildSystemAuthContext(workspaceId);
 
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const workspace = await this.workspaceRepository.findOne({
-              select: ['databaseSchema'],
-              where: { id: workspaceId },
-            });
+        await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+          const workspace = await this.workspaceRepository.findOne({
+            select: ['databaseSchema'],
+            where: { id: workspaceId },
+          });
 
-            const dataSource = isNonEmptyString(workspace?.databaseSchema)
-              ? this.coreDataSource
-              : undefined;
+          const dataSource = isNonEmptyString(workspace?.databaseSchema)
+            ? this.coreDataSource
+            : undefined;
 
-            if (!isDefined(dataSource)) {
-              this.logger.warn(
-                `Could not retrieve a workspace data source for workspace ${workspaceId} ` +
-                  `(index ${index + 1}/${workspaceIdsToProcess.length}): ` +
-                  `workspaceRowFound=${isDefined(workspace)}, ` +
-                  `databaseSchema=${JSON.stringify(workspace?.databaseSchema ?? null)}`,
-              );
-            }
+          if (!isDefined(dataSource)) {
+            this.logger.warn(
+              `Could not retrieve a workspace data source for workspace ${workspaceId} ` +
+                `(index ${index + 1}/${workspaceIdsToProcess.length}): ` +
+                `workspaceRowFound=${isDefined(workspace)}, ` +
+                `databaseSchema=${JSON.stringify(workspace?.databaseSchema ?? null)}`,
+            );
+          }
 
-            await callback({
-              workspaceId,
-              databaseSchema: workspace?.databaseSchema ?? undefined,
-              dataSource,
-              index,
-              total: workspaceIdsToProcess.length,
-            });
-          },
-          authContext,
-        );
+          await callback({
+            workspaceId,
+            databaseSchema: workspace?.databaseSchema ?? undefined,
+            dataSource,
+            index,
+            total: workspaceIdsToProcess.length,
+          });
+        }, authContext);
 
         report.success.push({ workspaceId });
       } catch (error: unknown) {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command.ts
@@ -7,7 +7,7 @@ import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/w
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { type FlatAgent } from 'src/engine/metadata-modules/flat-agent/types/flat-agent.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
 import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
@@ -46,7 +46,7 @@ const TEXT_AGENT_DEFAULT_OUTPUT_SCHEMA = {
 export class MigrateAiAgentTextToJsonResponseFormatCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
-    private readonly twentyORMGlobalManager: GlobalWorkspaceOrmManager,
+    private readonly twentyORMGlobalManager: WorkspaceOrmManager,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly applicationService: ApplicationService,
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command.ts
@@ -46,7 +46,7 @@ const TEXT_AGENT_DEFAULT_OUTPUT_SCHEMA = {
 export class MigrateAiAgentTextToJsonResponseFormatCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
-    private readonly twentyORMGlobalManager: WorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly applicationService: ApplicationService,
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
@@ -162,7 +162,7 @@ export class MigrateAiAgentTextToJsonResponseFormatCommand extends ProvisionedWo
     agentIds: string[],
   ): Promise<void> {
     const workflowVersionRepository =
-      await this.twentyORMGlobalManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command.ts
@@ -43,7 +43,7 @@ type LegacyConnectedAccountWorkspaceEntity = {
 })
 export class MigrateMessagingInfrastructureToMetadataCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
-    private readonly twentyORMGlobalManager: WorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectRepository(MessageChannelEntity)
@@ -80,19 +80,19 @@ export class MigrateMessagingInfrastructureToMetadataCommand extends Provisioned
     const isDryRun = options.dryRun ?? false;
 
     const connectedAccountWorkspaceRepository =
-      await this.twentyORMGlobalManager.getRepository<LegacyConnectedAccountWorkspaceEntity>('connectedAccount',
+      await this.workspaceOrmManager.getRepository<LegacyConnectedAccountWorkspaceEntity>('connectedAccount',
       );
 
     const messageChannelWorkspaceRepository =
-      await this.twentyORMGlobalManager.getRepository<MessageChannelEntity>('messageChannel',
+      await this.workspaceOrmManager.getRepository<MessageChannelEntity>('messageChannel',
       );
 
     const calendarChannelWorkspaceRepository =
-      await this.twentyORMGlobalManager.getRepository<CalendarChannelEntity>('calendarChannel',
+      await this.workspaceOrmManager.getRepository<CalendarChannelEntity>('calendarChannel',
       );
 
     const messageFolderWorkspaceRepository =
-      await this.twentyORMGlobalManager.getRepository<MessageFolderEntity>('messageFolder',
+      await this.workspaceOrmManager.getRepository<MessageFolderEntity>('messageFolder',
       );
 
     const connectedAccounts = await connectedAccountWorkspaceRepository.find();
@@ -365,7 +365,7 @@ export class MigrateMessagingInfrastructureToMetadataCommand extends Provisioned
     workspaceId: string,
   ): Promise<Map<string, string>> {
     const workspaceMemberRepository =
-      await this.twentyORMGlobalManager.getRepository<WorkspaceMemberWorkspaceEntity>('workspaceMember',
+      await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>('workspaceMember',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command.ts
@@ -15,7 +15,7 @@ import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-chan
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 type LegacyConnectedAccountWorkspaceEntity = {
@@ -43,7 +43,7 @@ type LegacyConnectedAccountWorkspaceEntity = {
 })
 export class MigrateMessagingInfrastructureToMetadataCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
-    private readonly twentyORMGlobalManager: GlobalWorkspaceOrmManager,
+    private readonly twentyORMGlobalManager: WorkspaceOrmManager,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectRepository(MessageChannelEntity)

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-15/2-15-workspace-command-1800000001000-migrate-manual-trigger-variables-to-payload.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-15/2-15-workspace-command-1800000001000-migrate-manual-trigger-variables-to-payload.command.ts
@@ -9,7 +9,7 @@ import { rewriteTriggerVariablesToPayload } from 'src/database/commands/upgrade-
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 import { WorkflowTriggerType } from 'src/modules/workflow/workflow-trigger/types/workflow-trigger.type';
@@ -23,7 +23,7 @@ import { WorkflowTriggerType } from 'src/modules/workflow/workflow-trigger/types
 export class MigrateManualTriggerVariablesToPayloadCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
-    private readonly twentyORMGlobalManager: GlobalWorkspaceOrmManager,
+    private readonly twentyORMGlobalManager: WorkspaceOrmManager,
     private readonly workspaceCacheService: WorkspaceCacheService,
   ) {
     super(workspaceIteratorService);

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-15/2-15-workspace-command-1800000001000-migrate-manual-trigger-variables-to-payload.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-15/2-15-workspace-command-1800000001000-migrate-manual-trigger-variables-to-payload.command.ts
@@ -23,7 +23,7 @@ import { WorkflowTriggerType } from 'src/modules/workflow/workflow-trigger/types
 export class MigrateManualTriggerVariablesToPayloadCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
-    private readonly twentyORMGlobalManager: WorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workspaceCacheService: WorkspaceCacheService,
   ) {
     super(workspaceIteratorService);
@@ -57,7 +57,7 @@ export class MigrateManualTriggerVariablesToPayloadCommand extends ProvisionedWo
     }
 
     const workflowVersionRepository =
-      await this.twentyORMGlobalManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783526282685-backfill-workflow-version-to-core.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783526282685-backfill-workflow-version-to-core.command.ts
@@ -7,7 +7,7 @@ import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/w
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
 import { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/workflow/services/workflow-version-core-sync.service';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 
 @RegisteredWorkspaceCommand('2.20.0', 1783526282685)
@@ -19,7 +19,7 @@ import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common
 export class BackfillWorkflowVersionToCoreCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowVersionCoreSyncService: WorkflowVersionCoreSyncService,
   ) {
     super(workspaceIteratorService);
@@ -33,10 +33,10 @@ export class BackfillWorkflowVersionToCoreCommand extends ProvisionedWorkspaceCo
 
     try {
       workspaceWorkflowVersions =
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+        await this.workspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowVersionRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+              await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
@@ -14,7 +14,7 @@ import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/deco
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { fetchImageWithTypeFromUrl } from 'src/utils/image';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
@@ -35,7 +35,7 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly filesFieldService: FilesFieldService,
     private readonly secureHttpClientService: SecureHttpClientService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {
     super(workspaceIteratorService);
   }
@@ -91,7 +91,7 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
     }
 
     const personRepository =
-      await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>('person',
+      await this.workspaceOrmManager.getRepository<PersonWorkspaceEntity>('person',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
@@ -7,7 +7,7 @@ import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
@@ -28,7 +28,7 @@ export class BackfillWorkflowVersionCoreLinksCommand extends ProvisionedWorkspac
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
     private readonly workspaceCacheService: WorkspaceCacheService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {
     super(workspaceIteratorService);
   }
@@ -50,10 +50,10 @@ export class BackfillWorkflowVersionCoreLinksCommand extends ProvisionedWorkspac
 
     try {
       workspaceWorkflowVersions =
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+        await this.workspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowVersionRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+              await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command.ts
@@ -7,7 +7,7 @@ import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
 
@@ -26,7 +26,7 @@ import { type WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standa
 export class BackfillWorkflowCoreLinksCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {
     super(workspaceIteratorService);
   }
@@ -48,10 +48,10 @@ export class BackfillWorkflowCoreLinksCommand extends ProvisionedWorkspaceComman
 
     try {
       workspaceWorkflows =
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+        await this.workspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>('workflow',
+              await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>('workflow',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.ts
@@ -6,7 +6,7 @@ import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
@@ -28,7 +28,7 @@ export class RepairOrphanCoreWorkflowVersionsCommand extends ProvisionedWorkspac
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
     private readonly workspaceCacheService: WorkspaceCacheService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {
     super(workspaceIteratorService);
   }
@@ -47,10 +47,10 @@ export class RepairOrphanCoreWorkflowVersionsCommand extends ProvisionedWorkspac
       // means it was never provisioned, so there is nothing to repair and the
       // orphan query below would fail to resolve its schema table. Skip cleanly
       // like the sibling backfill commands rather than aborting the upgrade.
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowVersionRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+            await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
               { shouldBypassPermissionChecks: true },
             );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/__tests__/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/__tests__/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.spec.ts
@@ -7,7 +7,7 @@ import {
 
 import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { RepairOrphanCoreWorkflowVersionsCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command';
-import { type GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { type WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 const WORKSPACE_ID = '20202020-0000-0000-0000-000000000001';
@@ -66,16 +66,16 @@ const setup = ({
     createQueryRunner: () => queryRunner,
   } as unknown as DataSource;
 
-  const globalWorkspaceOrmManager = {
+  const workspaceOrmManager = {
     executeInWorkspaceContext: (fn: () => Promise<unknown>) => fn(),
     getRepository: () => ({ count }),
-  } as unknown as GlobalWorkspaceOrmManager;
+  } as unknown as WorkspaceOrmManager;
 
   const recompute = jest.fn();
   const command = new RepairOrphanCoreWorkflowVersionsCommand(
     {} as WorkspaceIteratorService,
     { invalidateAndRecompute: recompute } as unknown as WorkspaceCacheService,
-    globalWorkspaceOrmManager,
+    workspaceOrmManager,
   );
 
   const run = (dryRun = false) =>

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -67,7 +67,7 @@ import {
   type ConnectQueryRunner,
   RelationNestedQueries,
 } from 'src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
 import { WorkspaceDataSourceService } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
@@ -95,7 +95,7 @@ export abstract class CommonBaseQueryRunnerService<
   @Inject()
   protected readonly orderByWithGroupByArgProcessor: OrderByWithGroupByArgProcessorService;
   @Inject()
-  protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager;
+  protected readonly workspaceOrmManager: WorkspaceOrmManager;
   @Inject()
   protected readonly processNestedRelationsHelper: ProcessNestedRelationsHelper;
   @Inject()
@@ -162,16 +162,15 @@ export abstract class CommonBaseQueryRunnerService<
       queryRunnerContext,
     );
 
-    const results =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () =>
-          this.executeQueryAndEnrichResults(
-            processedArgs,
-            queryRunnerContext,
-            commonQueryParser,
-          ),
-        authContext,
-      );
+    const results = await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () =>
+        this.executeQueryAndEnrichResults(
+          processedArgs,
+          queryRunnerContext,
+          commonQueryParser,
+        ),
+      authContext,
+    );
 
     return {
       results,

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
@@ -18,7 +18,7 @@ import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
@@ -34,7 +34,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 @MetadataResolver()
 export class ApprovedAccessDomainResolver {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly approvedAccessDomainService: ApprovedAccessDomainService,
   ) {}
 
@@ -47,22 +47,19 @@ export class ApprovedAccessDomainResolver {
     const authContext = buildSystemAuthContext(currentWorkspace.id);
 
     const workspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOneOrFail({
-            where: {
-              userId: currentUser.id,
-            },
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOneOrFail({
+          where: {
+            userId: currentUser.id,
+          },
+        });
+      }, authContext);
 
     return this.approvedAccessDomainService.createApprovedAccessDomain(
       domain,

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-calendar-channel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-calendar-channel.service.ts
@@ -9,7 +9,7 @@ import {
   CalendarChannelVisibility,
 } from 'twenty-shared/types';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 export type CreateCalendarChannelInput = {
@@ -23,9 +23,7 @@ export type CreateCalendarChannelInput = {
 
 @Injectable()
 export class CreateCalendarChannelService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async createCalendarChannel(
     input: CreateCalendarChannelInput,
@@ -41,27 +39,24 @@ export class CreateCalendarChannelService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const newCalendarChannelId = v4();
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const newCalendarChannelId = v4();
 
-        await transactionManager.getRepository(CalendarChannelEntity).save({
-          id: newCalendarChannelId,
-          connectedAccountId,
-          handle,
-          visibility: calendarVisibility || CalendarChannelVisibility.METADATA,
-          syncStatus: skipMessageChannelConfiguration
-            ? CalendarChannelSyncStatus.ONGOING
-            : CalendarChannelSyncStatus.NOT_SYNCED,
-          syncStage: skipMessageChannelConfiguration
-            ? CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING
-            : CalendarChannelSyncStage.PENDING_CONFIGURATION,
-          workspaceId,
-        } as CalendarChannelEntity);
+      await transactionManager.getRepository(CalendarChannelEntity).save({
+        id: newCalendarChannelId,
+        connectedAccountId,
+        handle,
+        visibility: calendarVisibility || CalendarChannelVisibility.METADATA,
+        syncStatus: skipMessageChannelConfiguration
+          ? CalendarChannelSyncStatus.ONGOING
+          : CalendarChannelSyncStatus.NOT_SYNCED,
+        syncStage: skipMessageChannelConfiguration
+          ? CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING
+          : CalendarChannelSyncStage.PENDING_CONFIGURATION,
+        workspaceId,
+      } as CalendarChannelEntity);
 
-        return newCalendarChannelId;
-      },
-      authContext,
-    );
+      return newCalendarChannelId;
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-connected-account.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-connected-account.service.ts
@@ -8,7 +8,7 @@ import { PlaintextString } from 'src/engine/core-modules/secret-encryption/brand
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
@@ -29,7 +29,7 @@ export type CreateConnectedAccountInput = {
 @Injectable()
 export class CreateConnectedAccountService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly connectedAccountTokenEncryptionService: ConnectedAccountTokenEncryptionService,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
@@ -51,7 +51,7 @@ export class CreateConnectedAccountService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceContext = getWorkspaceContext();
       const rolePermissionConfig = resolveRolePermissionConfig({
         authContext,
@@ -60,7 +60,7 @@ export class CreateConnectedAccountService {
       });
 
       const workspaceMemberRepo =
-        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           rolePermissionConfig ?? undefined,
         );

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-message-channel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-message-channel.service.ts
@@ -10,7 +10,7 @@ import {
   MessageChannelType,
   MessageChannelVisibility,
 } from 'twenty-shared/types';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 
@@ -25,9 +25,7 @@ export type CreateMessageChannelInput = {
 
 @Injectable()
 export class CreateMessageChannelService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async createMessageChannel(
     input: CreateMessageChannelInput,
@@ -43,31 +41,28 @@ export class CreateMessageChannelService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const messageChannelRepo =
-          transactionManager.getRepository(MessageChannelEntity);
-        const newMessageChannelId = v4();
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepo =
+        transactionManager.getRepository(MessageChannelEntity);
+      const newMessageChannelId = v4();
 
-        await messageChannelRepo.save({
-          id: newMessageChannelId,
-          connectedAccountId,
-          type: MessageChannelType.EMAIL,
-          handle,
-          visibility: messageVisibility || MessageChannelVisibility.METADATA,
-          syncStatus: skipMessageChannelConfiguration
-            ? MessageChannelSyncStatus.ONGOING
-            : MessageChannelSyncStatus.NOT_SYNCED,
-          syncStage: skipMessageChannelConfiguration
-            ? MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING
-            : MessageChannelSyncStage.PENDING_CONFIGURATION,
-          pendingGroupEmailsAction: MessageChannelPendingGroupEmailsAction.NONE,
-          workspaceId,
-        });
+      await messageChannelRepo.save({
+        id: newMessageChannelId,
+        connectedAccountId,
+        type: MessageChannelType.EMAIL,
+        handle,
+        visibility: messageVisibility || MessageChannelVisibility.METADATA,
+        syncStatus: skipMessageChannelConfiguration
+          ? MessageChannelSyncStatus.ONGOING
+          : MessageChannelSyncStatus.NOT_SYNCED,
+        syncStage: skipMessageChannelConfiguration
+          ? MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING
+          : MessageChannelSyncStage.PENDING_CONFIGURATION,
+        pendingGroupEmailsAction: MessageChannelPendingGroupEmailsAction.NONE,
+        workspaceId,
+      });
 
-        return newMessageChannelId;
-      },
-      authContext,
-    );
+      return newMessageChannelId;
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.ts
@@ -32,7 +32,7 @@ import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   CalendarEventListFetchJob,
@@ -53,7 +53,7 @@ import { isDefined } from 'twenty-shared/utils';
 @Injectable()
 export class GoogleAPIsService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectMessageQueue(MessageQueue.messagingQueue)
     private readonly messageQueueService: MessageQueueService,
     @InjectMessageQueue(MessageQueue.calendarQueue)
@@ -136,264 +136,256 @@ export class GoogleAPIsService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const userWorkspace = await this.userWorkspaceRepository.findOne({
-          where: { userId, workspaceId },
-        });
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const userWorkspace = await this.userWorkspaceRepository.findOne({
+        where: { userId, workspaceId },
+      });
 
-        if (!isDefined(userWorkspace)) {
-          throw new AuthException(
-            `User workspace not found for user ${userId} in workspace ${workspaceId}`,
-            AuthExceptionCode.INVALID_INPUT,
-          );
-        }
+      if (!isDefined(userWorkspace)) {
+        throw new AuthException(
+          `User workspace not found for user ${userId} in workspace ${workspaceId}`,
+          AuthExceptionCode.INVALID_INPUT,
+        );
+      }
 
-        const userWorkspaceId = userWorkspace.id;
+      const userWorkspaceId = userWorkspace.id;
 
-        const connectedAccount = await this.connectedAccountRepository.findOne({
+      const connectedAccount = await this.connectedAccountRepository.findOne({
+        where: {
+          handle,
+          userWorkspaceId,
+          workspaceId,
+          provider: ConnectedAccountProvider.GOOGLE,
+        },
+      });
+
+      const existingAccountId = connectedAccount?.id;
+      const newOrExistingConnectedAccountId = existingAccountId ?? v4();
+      const wasArchived = isDefined(connectedAccount?.archivedAt);
+
+      const existingMessageChannels = await this.messageChannelRepository.find({
+        where: {
+          connectedAccountId: newOrExistingConnectedAccountId,
+          workspaceId,
+        },
+      });
+
+      const existingCalendarChannels =
+        await this.calendarChannelRepository.find({
           where: {
-            handle,
-            userWorkspaceId,
+            connectedAccountId: newOrExistingConnectedAccountId,
             workspaceId,
-            provider: ConnectedAccountProvider.GOOGLE,
           },
         });
 
-        const existingAccountId = connectedAccount?.id;
-        const newOrExistingConnectedAccountId = existingAccountId ?? v4();
-        const wasArchived = isDefined(connectedAccount?.archivedAt);
-
-        const existingMessageChannels =
-          await this.messageChannelRepository.find({
-            where: {
-              connectedAccountId: newOrExistingConnectedAccountId,
-              workspaceId,
-            },
+      await this.messageChannelRepository.manager.transaction(
+        async (transactionManager: EntityManager) => {
+          await this.createConnectedAccountService.createConnectedAccount({
+            workspaceId,
+            connectedAccountId: newOrExistingConnectedAccountId,
+            handle,
+            provider: ConnectedAccountProvider.GOOGLE,
+            accessToken: input.accessToken,
+            refreshToken: input.refreshToken,
+            accountOwnerId: workspaceMemberId,
+            scopes,
+            transactionManager,
           });
 
-        const existingCalendarChannels =
-          await this.calendarChannelRepository.find({
-            where: {
-              connectedAccountId: newOrExistingConnectedAccountId,
-              workspaceId,
-            },
-          });
+          if (existingAccountId) {
+            await this.updateConnectedAccountOnReconnectService.updateConnectedAccountOnReconnect(
+              {
+                workspaceId,
+                connectedAccountId: newOrExistingConnectedAccountId,
+                accessToken: input.accessToken,
+                refreshToken: input.refreshToken,
+                scopes,
+                transactionManager,
+              },
+            );
 
-        await this.messageChannelRepository.manager.transaction(
-          async (transactionManager: EntityManager) => {
-            await this.createConnectedAccountService.createConnectedAccount({
+            await this.accountsToReconnectService.removeAccountToReconnect(
+              userId,
+              workspaceId,
+              newOrExistingConnectedAccountId,
+            );
+          }
+
+          if (
+            isMessagingEnabled &&
+            isMessagingAvailable &&
+            existingMessageChannels.length === 0
+          ) {
+            await this.createMessageChannelService.createMessageChannel({
               workspaceId,
               connectedAccountId: newOrExistingConnectedAccountId,
               handle,
-              provider: ConnectedAccountProvider.GOOGLE,
-              accessToken: input.accessToken,
-              refreshToken: input.refreshToken,
-              accountOwnerId: workspaceMemberId,
-              scopes,
+              messageVisibility,
+              skipMessageChannelConfiguration,
               transactionManager,
             });
-
-            if (existingAccountId) {
-              await this.updateConnectedAccountOnReconnectService.updateConnectedAccountOnReconnect(
-                {
-                  workspaceId,
-                  connectedAccountId: newOrExistingConnectedAccountId,
-                  accessToken: input.accessToken,
-                  refreshToken: input.refreshToken,
-                  scopes,
-                  transactionManager,
-                },
-              );
-
-              await this.accountsToReconnectService.removeAccountToReconnect(
-                userId,
-                workspaceId,
-                newOrExistingConnectedAccountId,
-              );
-            }
-
-            if (
-              isMessagingEnabled &&
-              isMessagingAvailable &&
-              existingMessageChannels.length === 0
-            ) {
-              await this.createMessageChannelService.createMessageChannel({
-                workspaceId,
-                connectedAccountId: newOrExistingConnectedAccountId,
-                handle,
-                messageVisibility,
-                skipMessageChannelConfiguration,
-                transactionManager,
-              });
-            }
-
-            if (
-              isCalendarEnabled &&
-              isCalendarAvailable &&
-              existingCalendarChannels.length === 0
-            ) {
-              await this.createCalendarChannelService.createCalendarChannel({
-                workspaceId,
-                connectedAccountId: newOrExistingConnectedAccountId,
-                handle,
-                calendarVisibility,
-                skipMessageChannelConfiguration,
-                transactionManager,
-              });
-            }
-
-            if (
-              wasArchived &&
-              isMessagingEnabled &&
-              isMessagingAvailable &&
-              existingMessageChannels.length > 0
-            ) {
-              await transactionManager
-                .getRepository(MessageChannelEntity)
-                .update(
-                  {
-                    connectedAccountId: newOrExistingConnectedAccountId,
-                    workspaceId,
-                  },
-                  { isSyncEnabled: true },
-                );
-            }
-
-            if (
-              wasArchived &&
-              isCalendarEnabled &&
-              isCalendarAvailable &&
-              existingCalendarChannels.length > 0
-            ) {
-              await transactionManager
-                .getRepository(CalendarChannelEntity)
-                .update(
-                  {
-                    connectedAccountId: newOrExistingConnectedAccountId,
-                    workspaceId,
-                  },
-                  { isSyncEnabled: true },
-                );
-            }
-          },
-        );
-
-        if (isMessagingEnabled && isMessagingAvailable) {
-          const connectedAccountForAliases =
-            await this.connectedAccountRepository.findOne({
-              where: { id: newOrExistingConnectedAccountId, workspaceId },
-            });
-
-          if (isDefined(connectedAccountForAliases)) {
-            await this.emailAliasManagerService.refreshHandleAliases(
-              connectedAccountForAliases,
-              workspaceId,
-            );
           }
-        }
 
-        if (
-          isMessagingEnabled &&
-          isMessagingAvailable &&
-          existingMessageChannels.length === 0
-        ) {
-          const newMessageChannel = await this.messageChannelRepository.findOne(
-            {
-              where: {
+          if (
+            isCalendarEnabled &&
+            isCalendarAvailable &&
+            existingCalendarChannels.length === 0
+          ) {
+            await this.createCalendarChannelService.createCalendarChannel({
+              workspaceId,
+              connectedAccountId: newOrExistingConnectedAccountId,
+              handle,
+              calendarVisibility,
+              skipMessageChannelConfiguration,
+              transactionManager,
+            });
+          }
+
+          if (
+            wasArchived &&
+            isMessagingEnabled &&
+            isMessagingAvailable &&
+            existingMessageChannels.length > 0
+          ) {
+            await transactionManager.getRepository(MessageChannelEntity).update(
+              {
                 connectedAccountId: newOrExistingConnectedAccountId,
                 workspaceId,
               },
-              relations: ['connectedAccount', 'messageFolders'],
-            },
+              { isSyncEnabled: true },
+            );
+          }
+
+          if (
+            wasArchived &&
+            isCalendarEnabled &&
+            isCalendarAvailable &&
+            existingCalendarChannels.length > 0
+          ) {
+            await transactionManager
+              .getRepository(CalendarChannelEntity)
+              .update(
+                {
+                  connectedAccountId: newOrExistingConnectedAccountId,
+                  workspaceId,
+                },
+                { isSyncEnabled: true },
+              );
+          }
+        },
+      );
+
+      if (isMessagingEnabled && isMessagingAvailable) {
+        const connectedAccountForAliases =
+          await this.connectedAccountRepository.findOne({
+            where: { id: newOrExistingConnectedAccountId, workspaceId },
+          });
+
+        if (isDefined(connectedAccountForAliases)) {
+          await this.emailAliasManagerService.refreshHandleAliases(
+            connectedAccountForAliases,
+            workspaceId,
           );
+        }
+      }
 
-          if (isDefined(newMessageChannel)) {
-            await this.syncMessageFoldersService.syncMessageFolders({
-              messageChannel: newMessageChannel,
-              workspaceId,
-            });
-          }
+      if (
+        isMessagingEnabled &&
+        isMessagingAvailable &&
+        existingMessageChannels.length === 0
+      ) {
+        const newMessageChannel = await this.messageChannelRepository.findOne({
+          where: {
+            connectedAccountId: newOrExistingConnectedAccountId,
+            workspaceId,
+          },
+          relations: ['connectedAccount', 'messageFolders'],
+        });
+
+        if (isDefined(newMessageChannel)) {
+          await this.syncMessageFoldersService.syncMessageFolders({
+            messageChannel: newMessageChannel,
+            workspaceId,
+          });
+        }
+      }
+
+      if (isMessagingEnabled) {
+        const messageChannels = await this.messageChannelRepository.find({
+          where: {
+            connectedAccountId: newOrExistingConnectedAccountId,
+            workspaceId,
+          },
+        });
+
+        if (!isMessagingAvailable && messageChannels.length > 0) {
+          await this.messagingChannelSyncStatusService.markAsFailed(
+            messageChannels.map((channel) => channel.id),
+            workspaceId,
+            MessageChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
+          );
         }
 
-        if (isMessagingEnabled) {
-          const messageChannels = await this.messageChannelRepository.find({
-            where: {
-              connectedAccountId: newOrExistingConnectedAccountId,
-              workspaceId,
-            },
-          });
-
-          if (!isMessagingAvailable && messageChannels.length > 0) {
-            await this.messagingChannelSyncStatusService.markAsFailed(
-              messageChannels.map((channel) => channel.id),
-              workspaceId,
-              MessageChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
-            );
-          }
-
-          if (isMessagingAvailable) {
-            for (const messageChannel of messageChannels) {
-              if (
-                messageChannel.syncStage !==
-                MessageChannelSyncStage.PENDING_CONFIGURATION
-              ) {
-                await this.messagingChannelSyncStatusService.resetAndMarkAsMessagesListFetchPending(
-                  [messageChannel.id],
+        if (isMessagingAvailable) {
+          for (const messageChannel of messageChannels) {
+            if (
+              messageChannel.syncStage !==
+              MessageChannelSyncStage.PENDING_CONFIGURATION
+            ) {
+              await this.messagingChannelSyncStatusService.resetAndMarkAsMessagesListFetchPending(
+                [messageChannel.id],
+                workspaceId,
+              );
+              await this.messageQueueService.add<MessagingMessageListFetchJobData>(
+                MessagingMessageListFetchJob.name,
+                { workspaceId, messageChannelId: messageChannel.id },
+              );
+              this.onboardingRecentMessagesImportService
+                .importRecentMessages({
+                  messageChannelId: messageChannel.id,
                   workspaceId,
-                );
-                await this.messageQueueService.add<MessagingMessageListFetchJobData>(
-                  MessagingMessageListFetchJob.name,
-                  { workspaceId, messageChannelId: messageChannel.id },
-                );
-                this.onboardingRecentMessagesImportService
-                  .importRecentMessages({
-                    messageChannelId: messageChannel.id,
-                    workspaceId,
-                  })
-                  .catch(() => undefined);
-              }
+                })
+                .catch(() => undefined);
             }
           }
         }
+      }
 
-        if (isCalendarEnabled) {
-          const calendarChannels = await this.calendarChannelRepository.find({
-            where: {
-              connectedAccountId: newOrExistingConnectedAccountId,
-              workspaceId,
-            },
-          });
+      if (isCalendarEnabled) {
+        const calendarChannels = await this.calendarChannelRepository.find({
+          where: {
+            connectedAccountId: newOrExistingConnectedAccountId,
+            workspaceId,
+          },
+        });
 
-          if (!isCalendarAvailable && calendarChannels.length > 0) {
-            await this.calendarChannelSyncStatusService.markAsFailedInsufficientPermissionsAndFlushCalendarEventsToImport(
-              calendarChannels.map((channel) => channel.id),
-              workspaceId,
-            );
-          }
+        if (!isCalendarAvailable && calendarChannels.length > 0) {
+          await this.calendarChannelSyncStatusService.markAsFailedInsufficientPermissionsAndFlushCalendarEventsToImport(
+            calendarChannels.map((channel) => channel.id),
+            workspaceId,
+          );
+        }
 
-          if (isCalendarAvailable) {
-            for (const calendarChannel of calendarChannels) {
-              if (
-                calendarChannel.syncStage !==
-                CalendarChannelSyncStage.PENDING_CONFIGURATION
-              ) {
-                await this.calendarChannelSyncStatusService.resetAndMarkAsCalendarEventListFetchPending(
-                  [calendarChannel.id],
-                  workspaceId,
-                );
-                await this.calendarQueueService.add<CalendarEventListFetchJobData>(
-                  CalendarEventListFetchJob.name,
-                  { workspaceId, calendarChannelId: calendarChannel.id },
-                );
-              }
+        if (isCalendarAvailable) {
+          for (const calendarChannel of calendarChannels) {
+            if (
+              calendarChannel.syncStage !==
+              CalendarChannelSyncStage.PENDING_CONFIGURATION
+            ) {
+              await this.calendarChannelSyncStatusService.resetAndMarkAsCalendarEventListFetchPending(
+                [calendarChannel.id],
+                workspaceId,
+              );
+              await this.calendarQueueService.add<CalendarEventListFetchJobData>(
+                CalendarEventListFetchJob.name,
+                { workspaceId, calendarChannelId: calendarChannel.id },
+              );
             }
           }
         }
+      }
 
-        return newOrExistingConnectedAccountId;
-      },
-      authContext,
-    );
+      return newOrExistingConnectedAccountId;
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/microsoft-apis.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/microsoft-apis.service.ts
@@ -30,7 +30,7 @@ import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   CalendarEventListFetchJob,
@@ -51,7 +51,7 @@ import { isDefined } from 'twenty-shared/utils';
 @Injectable()
 export class MicrosoftAPIsService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectMessageQueue(MessageQueue.messagingQueue)
     private readonly messageQueueService: MessageQueueService,
     @InjectMessageQueue(MessageQueue.calendarQueue)
@@ -102,253 +102,241 @@ export class MicrosoftAPIsService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const userWorkspace = await this.userWorkspaceRepository.findOne({
-          where: { userId, workspaceId },
-        });
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const userWorkspace = await this.userWorkspaceRepository.findOne({
+        where: { userId, workspaceId },
+      });
 
-        if (!isDefined(userWorkspace)) {
-          throw new AuthException(
-            `User workspace not found for user ${userId} in workspace ${workspaceId}`,
-            AuthExceptionCode.INVALID_INPUT,
-          );
-        }
+      if (!isDefined(userWorkspace)) {
+        throw new AuthException(
+          `User workspace not found for user ${userId} in workspace ${workspaceId}`,
+          AuthExceptionCode.INVALID_INPUT,
+        );
+      }
 
-        const userWorkspaceId = userWorkspace.id;
+      const userWorkspaceId = userWorkspace.id;
 
-        const connectedAccount = await this.connectedAccountRepository.findOne({
+      const connectedAccount = await this.connectedAccountRepository.findOne({
+        where: {
+          handle,
+          userWorkspaceId: userWorkspaceId,
+          workspaceId,
+          provider: ConnectedAccountProvider.MICROSOFT,
+        },
+      });
+
+      const existingAccountId = connectedAccount?.id;
+      const newOrExistingConnectedAccountId = existingAccountId ?? v4();
+      const wasArchived = isDefined(connectedAccount?.archivedAt);
+
+      const existingMessageChannels = await this.messageChannelRepository.find({
+        where: {
+          connectedAccountId: newOrExistingConnectedAccountId,
+          workspaceId,
+        },
+      });
+
+      const existingCalendarChannels =
+        await this.calendarChannelRepository.find({
           where: {
-            handle,
-            userWorkspaceId: userWorkspaceId,
+            connectedAccountId: newOrExistingConnectedAccountId,
             workspaceId,
-            provider: ConnectedAccountProvider.MICROSOFT,
           },
         });
 
-        const existingAccountId = connectedAccount?.id;
-        const newOrExistingConnectedAccountId = existingAccountId ?? v4();
-        const wasArchived = isDefined(connectedAccount?.archivedAt);
-
-        const existingMessageChannels =
-          await this.messageChannelRepository.find({
-            where: {
-              connectedAccountId: newOrExistingConnectedAccountId,
-              workspaceId,
-            },
+      await this.messageChannelRepository.manager.transaction(
+        async (transactionManager: EntityManager) => {
+          await this.createConnectedAccountService.createConnectedAccount({
+            workspaceId,
+            connectedAccountId: newOrExistingConnectedAccountId,
+            handle,
+            provider: ConnectedAccountProvider.MICROSOFT,
+            accessToken: input.accessToken,
+            refreshToken: input.refreshToken,
+            accountOwnerId: workspaceMemberId,
+            scopes,
+            transactionManager,
           });
 
-        const existingCalendarChannels =
-          await this.calendarChannelRepository.find({
-            where: {
-              connectedAccountId: newOrExistingConnectedAccountId,
-              workspaceId,
-            },
-          });
+          if (existingAccountId) {
+            await this.updateConnectedAccountOnReconnectService.updateConnectedAccountOnReconnect(
+              {
+                workspaceId,
+                connectedAccountId: newOrExistingConnectedAccountId,
+                accessToken: input.accessToken,
+                refreshToken: input.refreshToken,
+                scopes,
+                transactionManager,
+              },
+            );
 
-        await this.messageChannelRepository.manager.transaction(
-          async (transactionManager: EntityManager) => {
-            await this.createConnectedAccountService.createConnectedAccount({
+            await this.accountsToReconnectService.removeAccountToReconnect(
+              userId,
+              workspaceId,
+              newOrExistingConnectedAccountId,
+            );
+
+            await this.messagingChannelSyncStatusService.resetAndMarkAsMessagesListFetchPending(
+              [newOrExistingConnectedAccountId],
+              workspaceId,
+            );
+
+            await this.calendarChannelSyncStatusService.resetAndMarkAsCalendarEventListFetchPending(
+              [newOrExistingConnectedAccountId],
+              workspaceId,
+            );
+          }
+
+          if (
+            this.twentyConfigService.get(
+              'MESSAGING_PROVIDER_MICROSOFT_ENABLED',
+            ) &&
+            existingMessageChannels.length === 0
+          ) {
+            await this.createMessageChannelService.createMessageChannel({
               workspaceId,
               connectedAccountId: newOrExistingConnectedAccountId,
               handle,
-              provider: ConnectedAccountProvider.MICROSOFT,
-              accessToken: input.accessToken,
-              refreshToken: input.refreshToken,
-              accountOwnerId: workspaceMemberId,
-              scopes,
+              messageVisibility,
+              skipMessageChannelConfiguration,
               transactionManager,
             });
+          }
 
-            if (existingAccountId) {
-              await this.updateConnectedAccountOnReconnectService.updateConnectedAccountOnReconnect(
+          if (
+            this.twentyConfigService.get(
+              'CALENDAR_PROVIDER_MICROSOFT_ENABLED',
+            ) &&
+            existingCalendarChannels.length === 0
+          ) {
+            await this.createCalendarChannelService.createCalendarChannel({
+              workspaceId,
+              connectedAccountId: newOrExistingConnectedAccountId,
+              handle,
+              calendarVisibility,
+              skipMessageChannelConfiguration,
+              transactionManager,
+            });
+          }
+
+          if (wasArchived && existingMessageChannels.length > 0) {
+            await transactionManager.getRepository(MessageChannelEntity).update(
+              {
+                connectedAccountId: newOrExistingConnectedAccountId,
+                workspaceId,
+              },
+              { isSyncEnabled: true },
+            );
+          }
+
+          if (wasArchived && existingCalendarChannels.length > 0) {
+            await transactionManager
+              .getRepository(CalendarChannelEntity)
+              .update(
                 {
-                  workspaceId,
                   connectedAccountId: newOrExistingConnectedAccountId,
-                  accessToken: input.accessToken,
-                  refreshToken: input.refreshToken,
-                  scopes,
-                  transactionManager,
+                  workspaceId,
                 },
+                { isSyncEnabled: true },
               );
+          }
+        },
+      );
 
-              await this.accountsToReconnectService.removeAccountToReconnect(
-                userId,
-                workspaceId,
-                newOrExistingConnectedAccountId,
-              );
+      if (
+        this.twentyConfigService.get('MESSAGING_PROVIDER_MICROSOFT_ENABLED')
+      ) {
+        const connectedAccountForAliases =
+          await this.connectedAccountRepository.findOne({
+            where: { id: newOrExistingConnectedAccountId, workspaceId },
+          });
 
-              await this.messagingChannelSyncStatusService.resetAndMarkAsMessagesListFetchPending(
-                [newOrExistingConnectedAccountId],
-                workspaceId,
-              );
+        if (isDefined(connectedAccountForAliases)) {
+          await this.emailAliasManagerService.refreshHandleAliases(
+            connectedAccountForAliases,
+            workspaceId,
+          );
+        }
+      }
 
-              await this.calendarChannelSyncStatusService.resetAndMarkAsCalendarEventListFetchPending(
-                [newOrExistingConnectedAccountId],
-                workspaceId,
-              );
-            }
-
-            if (
-              this.twentyConfigService.get(
-                'MESSAGING_PROVIDER_MICROSOFT_ENABLED',
-              ) &&
-              existingMessageChannels.length === 0
-            ) {
-              await this.createMessageChannelService.createMessageChannel({
-                workspaceId,
-                connectedAccountId: newOrExistingConnectedAccountId,
-                handle,
-                messageVisibility,
-                skipMessageChannelConfiguration,
-                transactionManager,
-              });
-            }
-
-            if (
-              this.twentyConfigService.get(
-                'CALENDAR_PROVIDER_MICROSOFT_ENABLED',
-              ) &&
-              existingCalendarChannels.length === 0
-            ) {
-              await this.createCalendarChannelService.createCalendarChannel({
-                workspaceId,
-                connectedAccountId: newOrExistingConnectedAccountId,
-                handle,
-                calendarVisibility,
-                skipMessageChannelConfiguration,
-                transactionManager,
-              });
-            }
-
-            if (wasArchived && existingMessageChannels.length > 0) {
-              await transactionManager
-                .getRepository(MessageChannelEntity)
-                .update(
-                  {
-                    connectedAccountId: newOrExistingConnectedAccountId,
-                    workspaceId,
-                  },
-                  { isSyncEnabled: true },
-                );
-            }
-
-            if (wasArchived && existingCalendarChannels.length > 0) {
-              await transactionManager
-                .getRepository(CalendarChannelEntity)
-                .update(
-                  {
-                    connectedAccountId: newOrExistingConnectedAccountId,
-                    workspaceId,
-                  },
-                  { isSyncEnabled: true },
-                );
-            }
+      if (
+        this.twentyConfigService.get('MESSAGING_PROVIDER_MICROSOFT_ENABLED') &&
+        existingMessageChannels.length === 0
+      ) {
+        const newMessageChannel = await this.messageChannelRepository.findOne({
+          where: {
+            connectedAccountId: newOrExistingConnectedAccountId,
+            workspaceId,
           },
+          relations: ['connectedAccount', 'messageFolders'],
+        });
+
+        if (isDefined(newMessageChannel)) {
+          await this.syncMessageFoldersService.syncMessageFolders({
+            messageChannel: newMessageChannel,
+            workspaceId,
+          });
+        }
+      }
+
+      if (
+        this.twentyConfigService.get('MESSAGING_PROVIDER_MICROSOFT_ENABLED')
+      ) {
+        const messageChannels = await this.messageChannelRepository.find({
+          where: {
+            connectedAccountId: newOrExistingConnectedAccountId,
+            workspaceId,
+          },
+        });
+
+        for (const messageChannel of messageChannels) {
+          if (
+            messageChannel.syncStage !==
+            MessageChannelSyncStage.PENDING_CONFIGURATION
+          ) {
+            await this.messageQueueService.add<MessagingMessageListFetchJobData>(
+              MessagingMessageListFetchJob.name,
+              {
+                workspaceId,
+                messageChannelId: messageChannel.id,
+              },
+            );
+            this.onboardingRecentMessagesImportService
+              .importRecentMessages({
+                messageChannelId: messageChannel.id,
+                workspaceId,
+              })
+              .catch(() => undefined);
+          }
+        }
+      }
+
+      if (this.twentyConfigService.get('CALENDAR_PROVIDER_MICROSOFT_ENABLED')) {
+        const calendarChannels = await this.calendarChannelRepository.find({
+          where: {
+            connectedAccountId: newOrExistingConnectedAccountId,
+            workspaceId,
+          },
+        });
+
+        const syncableCalendarChannels = calendarChannels.filter(
+          (calendarChannel) =>
+            calendarChannel.syncStage !==
+            CalendarChannelSyncStage.PENDING_CONFIGURATION,
         );
 
-        if (
-          this.twentyConfigService.get('MESSAGING_PROVIDER_MICROSOFT_ENABLED')
-        ) {
-          const connectedAccountForAliases =
-            await this.connectedAccountRepository.findOne({
-              where: { id: newOrExistingConnectedAccountId, workspaceId },
-            });
-
-          if (isDefined(connectedAccountForAliases)) {
-            await this.emailAliasManagerService.refreshHandleAliases(
-              connectedAccountForAliases,
-              workspaceId,
-            );
-          }
-        }
-
-        if (
-          this.twentyConfigService.get(
-            'MESSAGING_PROVIDER_MICROSOFT_ENABLED',
-          ) &&
-          existingMessageChannels.length === 0
-        ) {
-          const newMessageChannel = await this.messageChannelRepository.findOne(
+        for (const calendarChannel of syncableCalendarChannels) {
+          await this.calendarQueueService.add<CalendarEventListFetchJobData>(
+            CalendarEventListFetchJob.name,
             {
-              where: {
-                connectedAccountId: newOrExistingConnectedAccountId,
-                workspaceId,
-              },
-              relations: ['connectedAccount', 'messageFolders'],
+              calendarChannelId: calendarChannel.id,
+              workspaceId,
             },
           );
-
-          if (isDefined(newMessageChannel)) {
-            await this.syncMessageFoldersService.syncMessageFolders({
-              messageChannel: newMessageChannel,
-              workspaceId,
-            });
-          }
         }
+      }
 
-        if (
-          this.twentyConfigService.get('MESSAGING_PROVIDER_MICROSOFT_ENABLED')
-        ) {
-          const messageChannels = await this.messageChannelRepository.find({
-            where: {
-              connectedAccountId: newOrExistingConnectedAccountId,
-              workspaceId,
-            },
-          });
-
-          for (const messageChannel of messageChannels) {
-            if (
-              messageChannel.syncStage !==
-              MessageChannelSyncStage.PENDING_CONFIGURATION
-            ) {
-              await this.messageQueueService.add<MessagingMessageListFetchJobData>(
-                MessagingMessageListFetchJob.name,
-                {
-                  workspaceId,
-                  messageChannelId: messageChannel.id,
-                },
-              );
-              this.onboardingRecentMessagesImportService
-                .importRecentMessages({
-                  messageChannelId: messageChannel.id,
-                  workspaceId,
-                })
-                .catch(() => undefined);
-            }
-          }
-        }
-
-        if (
-          this.twentyConfigService.get('CALENDAR_PROVIDER_MICROSOFT_ENABLED')
-        ) {
-          const calendarChannels = await this.calendarChannelRepository.find({
-            where: {
-              connectedAccountId: newOrExistingConnectedAccountId,
-              workspaceId,
-            },
-          });
-
-          const syncableCalendarChannels = calendarChannels.filter(
-            (calendarChannel) =>
-              calendarChannel.syncStage !==
-              CalendarChannelSyncStage.PENDING_CONFIGURATION,
-          );
-
-          for (const calendarChannel of syncableCalendarChannels) {
-            await this.calendarQueueService.add<CalendarEventListFetchJobData>(
-              CalendarEventListFetchJob.name,
-              {
-                calendarChannelId: calendarChannel.id,
-                workspaceId,
-              },
-            );
-          }
-        }
-
-        return newOrExistingConnectedAccountId;
-      },
-      authContext,
-    );
+      return newOrExistingConnectedAccountId;
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/update-connected-account-on-reconnect.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/update-connected-account-on-reconnect.service.ts
@@ -5,7 +5,7 @@ import { EntityManager } from 'typeorm';
 import { PlaintextString } from 'src/engine/core-modules/secret-encryption/branded-strings';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 export type UpdateConnectedAccountOnReconnectInput = {
@@ -20,7 +20,7 @@ export type UpdateConnectedAccountOnReconnectInput = {
 @Injectable()
 export class UpdateConnectedAccountOnReconnectService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly connectedAccountTokenEncryptionService: ConnectedAccountTokenEncryptionService,
   ) {}
 
@@ -47,7 +47,7 @@ export class UpdateConnectedAccountOnReconnectService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       await input.transactionManager
         .getRepository(ConnectedAccountEntity)
         .update(

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
@@ -30,7 +30,7 @@ import { UserEntity } from 'src/engine/core-modules/user/user.entity';
 import { userValidator } from 'src/engine/core-modules/user/user.validate';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceNotFoundDefaultError } from 'src/engine/core-modules/workspace/workspace.exception';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
@@ -44,7 +44,7 @@ export class AccessTokenService {
     private readonly userRepository: Repository<UserEntity>,
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
     private readonly userSessionService: UserSessionService,
@@ -81,33 +81,30 @@ export class AccessTokenService {
       const authContext = buildSystemAuthContext(workspaceId);
 
       workspaceMemberId =
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const workspaceMemberRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-                'workspaceMember',
-                { shouldBypassPermissionChecks: true },
-              );
-
-            const workspaceMember = await workspaceMemberRepository.findOne({
-              where: { userId: user.id },
-            });
-
-            assertIsDefinedOrThrow(
-              workspaceMember,
-              new AuthException(
-                'User is not a member of the workspace',
-                AuthExceptionCode.FORBIDDEN_EXCEPTION,
-                {
-                  userFriendlyMessage: msg`User is not a member of the workspace.`,
-                },
-              ),
+        await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+          const workspaceMemberRepository =
+            await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+              'workspaceMember',
+              { shouldBypassPermissionChecks: true },
             );
 
-            return workspaceMember.id;
-          },
-          authContext,
-        );
+          const workspaceMember = await workspaceMemberRepository.findOne({
+            where: { userId: user.id },
+          });
+
+          assertIsDefinedOrThrow(
+            workspaceMember,
+            new AuthException(
+              'User is not a member of the workspace',
+              AuthExceptionCode.FORBIDDEN_EXCEPTION,
+              {
+                userFriendlyMessage: msg`User is not a member of the workspace.`,
+              },
+            ),
+          );
+
+          return workspaceMember.id;
+        }, authContext);
     }
 
     return { user, workspace, userWorkspace, workspaceMemberId };

--- a/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
@@ -6,7 +6,7 @@ import { BillingSubscriptionUpdateService } from 'src/engine/core-modules/billin
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 export type UpdateSubscriptionQuantityJobData = { workspaceId: string };
@@ -20,16 +20,16 @@ export class UpdateSubscriptionQuantityJob {
 
   constructor(
     private readonly billingSubscriptionUpdateService: BillingSubscriptionUpdateService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   @Process(UpdateSubscriptionQuantityJob.name)
   async handle(data: UpdateSubscriptionQuantityJobData): Promise<void> {
     const authContext = buildSystemAuthContext(data.workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -14,7 +14,7 @@ import { RelatedPersonIdsService } from 'src/engine/core-modules/related-person-
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 import { type CallRecordingStatus } from 'src/modules/call-recording/common/enums/call-recording-status.enum';
@@ -24,7 +24,7 @@ import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-membe
 @Injectable()
 export class TimelineCalendarEventService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(CalendarChannelEntity)
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
     @InjectRepository(ConnectedAccountEntity)
@@ -50,288 +50,280 @@ export class TimelineCalendarEventService {
   }): Promise<TimelineCalendarEventsWithTotalDTO> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const offset = (page - 1) * pageSize;
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const offset = (page - 1) * pageSize;
 
-        // Runs under a system auth context, which resolves no role, so without
-        // this the participant relations (person, workspaceMember) are read with
-        // empty permissions and denied for everyone. Channel-level redaction of
-        // title and description below is what gates the caller's access.
-        // TODO run under the caller's role via resolveRolePermissionConfig instead
-        // of bypassing, once roles that cannot read person degrade to a redacted
-        // timeline rather than a denied one
-        // https://github.com/twentyhq/core-team-issues/issues/2777
-        const calendarEventRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
-            'calendarEvent',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const totalNumberOfCalendarEvents = await calendarEventRepository.count(
-          {
-            where: {
-              calendarEventParticipants: {
-                personId: Any(personIds),
-              },
-            },
-          },
+      // Runs under a system auth context, which resolves no role, so without
+      // this the participant relations (person, workspaceMember) are read with
+      // empty permissions and denied for everyone. Channel-level redaction of
+      // title and description below is what gates the caller's access.
+      // TODO run under the caller's role via resolveRolePermissionConfig instead
+      // of bypassing, once roles that cannot read person degrade to a redacted
+      // timeline rather than a denied one
+      // https://github.com/twentyhq/core-team-issues/issues/2777
+      const calendarEventRepository =
+        await this.workspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
+          'calendarEvent',
+          { shouldBypassPermissionChecks: true },
         );
 
-        const calendarEventIds = await calendarEventRepository.find({
-          where: {
-            calendarEventParticipants: {
-              personId: Any(personIds),
-            },
+      const totalNumberOfCalendarEvents = await calendarEventRepository.count({
+        where: {
+          calendarEventParticipants: {
+            personId: Any(personIds),
           },
-          select: {
-            id: true,
-            startsAt: true,
-          },
-          skip: offset,
-          take: pageSize,
-          order: {
-            startsAt: 'DESC',
-          },
-        });
+        },
+      });
 
-        const ids = calendarEventIds.map(({ id }) => id);
+      const calendarEventIds = await calendarEventRepository.find({
+        where: {
+          calendarEventParticipants: {
+            personId: Any(personIds),
+          },
+        },
+        select: {
+          id: true,
+          startsAt: true,
+        },
+        skip: offset,
+        take: pageSize,
+        order: {
+          startsAt: 'DESC',
+        },
+      });
 
-        if (ids.length <= 0) {
-          return {
-            totalNumberOfCalendarEvents,
-            timelineCalendarEvents: [],
-            relatedPersonIds: personIds,
-          };
+      const ids = calendarEventIds.map(({ id }) => id);
+
+      if (ids.length <= 0) {
+        return {
+          totalNumberOfCalendarEvents,
+          timelineCalendarEvents: [],
+          relatedPersonIds: personIds,
+        };
+      }
+
+      const [events] = await calendarEventRepository.findAndCount({
+        where: {
+          id: Any(ids),
+        },
+        relations: {
+          calendarEventParticipants: {
+            person: true,
+            workspaceMember: true,
+          },
+          calendarChannelEventAssociations: true,
+        },
+      });
+
+      const callRecordingRepository =
+        await this.workspaceOrmManager.getRepository<CallRecordingWorkspaceEntity>(
+          'callRecording',
+        );
+
+      const callRecordings = await callRecordingRepository.find({
+        where: {
+          calendarEventId: Any(ids),
+        },
+        select: {
+          id: true,
+          status: true,
+          applicationId: true,
+          calendarEventId: true,
+        },
+      });
+
+      const callRecordingsByCalendarEventId = callRecordings.reduce<
+        Map<
+          string,
+          {
+            id: string;
+            status: CallRecordingStatus;
+            applicationId: string | null;
+          }[]
+        >
+      >((acc, callRecording) => {
+        if (!isDefined(callRecording.calendarEventId)) {
+          return acc;
         }
 
-        const [events] = await calendarEventRepository.findAndCount({
-          where: {
-            id: Any(ids),
-          },
-          relations: {
-            calendarEventParticipants: {
-              person: true,
-              workspaceMember: true,
-            },
-            calendarChannelEventAssociations: true,
-          },
+        const existing = acc.get(callRecording.calendarEventId) ?? [];
+
+        existing.push({
+          id: callRecording.id,
+          status: callRecording.status,
+          applicationId: callRecording.applicationId ?? null,
         });
+        acc.set(callRecording.calendarEventId, existing);
 
-        const callRecordingRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CallRecordingWorkspaceEntity>(
-            'callRecording',
-          );
+        return acc;
+      }, new Map());
 
-        const callRecordings = await callRecordingRepository.find({
-          where: {
-            calendarEventId: Any(ids),
-          },
-          select: {
-            id: true,
-            status: true,
-            applicationId: true,
-            calendarEventId: true,
-          },
-        });
-
-        const callRecordingsByCalendarEventId = callRecordings.reduce<
-          Map<
-            string,
-            {
-              id: string;
-              status: CallRecordingStatus;
-              applicationId: string | null;
-            }[]
-          >
-        >((acc, callRecording) => {
-          if (!isDefined(callRecording.calendarEventId)) {
-            return acc;
-          }
-
-          const existing = acc.get(callRecording.calendarEventId) ?? [];
-
-          existing.push({
-            id: callRecording.id,
-            status: callRecording.status,
-            applicationId: callRecording.applicationId ?? null,
-          });
-          acc.set(callRecording.calendarEventId, existing);
-
-          return acc;
-        }, new Map());
-
-        const allCalendarChannelIds = [
-          ...new Set(
-            events.flatMap((event) =>
-              event.calendarChannelEventAssociations.map(
-                (association) => association.calendarChannelId,
-              ),
+      const allCalendarChannelIds = [
+        ...new Set(
+          events.flatMap((event) =>
+            event.calendarChannelEventAssociations.map(
+              (association) => association.calendarChannelId,
             ),
           ),
-        ];
+        ),
+      ];
 
-        const calendarChannels =
-          allCalendarChannelIds.length > 0
-            ? await this.calendarChannelRepository.find({
-                where: { id: In(allCalendarChannelIds), workspaceId },
-              })
-            : [];
+      const calendarChannels =
+        allCalendarChannelIds.length > 0
+          ? await this.calendarChannelRepository.find({
+              where: { id: In(allCalendarChannelIds), workspaceId },
+            })
+          : [];
 
-        // Resolve current user's userWorkspaceId (workspaceMember → userId → userWorkspace)
-        const workspaceMemberRepo =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const currentMember = await workspaceMemberRepo.findOne({
-          where: { id: currentWorkspaceMemberId },
-          select: { userId: true },
-        });
-
-        const currentUserWorkspaceId = currentMember
-          ? ((
-              await this.userWorkspaceRepository.findOne({
-                where: { userId: currentMember.userId, workspaceId },
-                select: { id: true },
-              })
-            )?.id ?? null)
-          : null;
-
-        const connectedAccountIds = [
-          ...new Set(
-            calendarChannels.map((channel) => channel.connectedAccountId),
-          ),
-        ];
-
-        const ownedAccountIds =
-          connectedAccountIds.length > 0 && currentUserWorkspaceId
-            ? new Set(
-                (
-                  await this.connectedAccountRepository.find({
-                    where: {
-                      id: In(connectedAccountIds),
-                      userWorkspaceId: currentUserWorkspaceId,
-                    },
-                    select: { id: true },
-                  })
-                ).map((a) => a.id),
-              )
-            : new Set<string>();
-
-        const calendarChannelMap = new Map(
-          calendarChannels.map((channel) => [
-            channel.id,
-            {
-              visibility: channel.visibility,
-              isOwnedByCurrentUser: ownedAccountIds.has(
-                channel.connectedAccountId,
-              ),
-            },
-          ]),
+      // Resolve current user's userWorkspaceId (workspaceMember → userId → userWorkspace)
+      const workspaceMemberRepo =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
         );
 
-        const orderedEvents = events.sort(
-          (a, b) => ids.indexOf(a.id) - ids.indexOf(b.id),
-        );
+      const currentMember = await workspaceMemberRepo.findOne({
+        where: { id: currentWorkspaceMemberId },
+        select: { userId: true },
+      });
 
-        const timelineCalendarEventPromises = orderedEvents.map(
-          async (event) => {
-            const participantPromises = event.calendarEventParticipants.map(
-              async (participant) => {
-                const personAvatarFileUrl =
-                  await this.fileUrlService.signFirstFilesFieldFileUrl({
-                    filesFieldValue: participant.person?.avatarFile,
-                    workspaceId,
-                  });
+      const currentUserWorkspaceId = currentMember
+        ? ((
+            await this.userWorkspaceRepository.findOne({
+              where: { userId: currentMember.userId, workspaceId },
+              select: { id: true },
+            })
+          )?.id ?? null)
+        : null;
 
-                return {
-                  calendarEventId: event.id,
-                  personId: participant.personId ?? null,
-                  workspaceMemberId: participant.workspaceMemberId ?? null,
-                  firstName:
-                    participant.person?.name?.firstName ||
-                    participant.workspaceMember?.name.firstName ||
-                    '',
-                  lastName:
-                    participant.person?.name?.lastName ||
-                    participant.workspaceMember?.name.lastName ||
-                    '',
-                  displayName:
-                    participant.person?.name?.firstName ||
-                    participant.person?.name?.lastName ||
-                    participant.workspaceMember?.name.firstName ||
-                    participant.workspaceMember?.name.lastName ||
-                    participant.displayName ||
-                    participant.handle ||
-                    '',
-                  avatarUrl:
-                    personAvatarFileUrl ||
-                    participant.person?.avatarUrl ||
-                    participant.workspaceMember?.avatarUrl ||
-                    '',
-                  handle: participant.handle ?? '',
-                };
-              },
-            );
+      const connectedAccountIds = [
+        ...new Set(
+          calendarChannels.map((channel) => channel.connectedAccountId),
+        ),
+      ];
 
-            const participants = await Promise.all(participantPromises);
+      const ownedAccountIds =
+        connectedAccountIds.length > 0 && currentUserWorkspaceId
+          ? new Set(
+              (
+                await this.connectedAccountRepository.find({
+                  where: {
+                    id: In(connectedAccountIds),
+                    userWorkspaceId: currentUserWorkspaceId,
+                  },
+                  select: { id: true },
+                })
+              ).map((a) => a.id),
+            )
+          : new Set<string>();
 
-            const hasFullAccess = event.calendarChannelEventAssociations.some(
-              (association) => {
-                const channel = calendarChannelMap.get(
-                  association.calendarChannelId,
-                );
+      const calendarChannelMap = new Map(
+        calendarChannels.map((channel) => [
+          channel.id,
+          {
+            visibility: channel.visibility,
+            isOwnedByCurrentUser: ownedAccountIds.has(
+              channel.connectedAccountId,
+            ),
+          },
+        ]),
+      );
 
-                return (
-                  channel?.visibility === 'SHARE_EVERYTHING' ||
-                  channel?.isOwnedByCurrentUser
-                );
-              },
-            );
+      const orderedEvents = events.sort(
+        (a, b) => ids.indexOf(a.id) - ids.indexOf(b.id),
+      );
 
-            const visibility = hasFullAccess
-              ? CalendarChannelVisibility.SHARE_EVERYTHING
-              : CalendarChannelVisibility.METADATA;
+      const timelineCalendarEventPromises = orderedEvents.map(async (event) => {
+        const participantPromises = event.calendarEventParticipants.map(
+          async (participant) => {
+            const personAvatarFileUrl =
+              await this.fileUrlService.signFirstFilesFieldFileUrl({
+                filesFieldValue: participant.person?.avatarFile,
+                workspaceId,
+              });
 
             return {
-              ...omit(event, [
-                'calendarEventParticipants',
-                'calendarChannelEventAssociations',
-              ]),
-              title:
-                visibility === CalendarChannelVisibility.METADATA
-                  ? FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED
-                  : (event.title ?? ''),
-              description:
-                visibility === CalendarChannelVisibility.METADATA
-                  ? FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED
-                  : (event.description ?? ''),
-              startsAt: event.startsAt as unknown as Date,
-              endsAt: event.endsAt as unknown as Date,
-              participants,
-              callRecordings:
-                callRecordingsByCalendarEventId.get(event.id) ?? [],
-              visibility,
-              location: event.location ?? '',
-              conferenceSolution: event.conferenceSolution ?? '',
+              calendarEventId: event.id,
+              personId: participant.personId ?? null,
+              workspaceMemberId: participant.workspaceMemberId ?? null,
+              firstName:
+                participant.person?.name?.firstName ||
+                participant.workspaceMember?.name.firstName ||
+                '',
+              lastName:
+                participant.person?.name?.lastName ||
+                participant.workspaceMember?.name.lastName ||
+                '',
+              displayName:
+                participant.person?.name?.firstName ||
+                participant.person?.name?.lastName ||
+                participant.workspaceMember?.name.firstName ||
+                participant.workspaceMember?.name.lastName ||
+                participant.displayName ||
+                participant.handle ||
+                '',
+              avatarUrl:
+                personAvatarFileUrl ||
+                participant.person?.avatarUrl ||
+                participant.workspaceMember?.avatarUrl ||
+                '',
+              handle: participant.handle ?? '',
             };
           },
         );
 
-        const timelineCalendarEvents = await Promise.all(
-          timelineCalendarEventPromises,
+        const participants = await Promise.all(participantPromises);
+
+        const hasFullAccess = event.calendarChannelEventAssociations.some(
+          (association) => {
+            const channel = calendarChannelMap.get(
+              association.calendarChannelId,
+            );
+
+            return (
+              channel?.visibility === 'SHARE_EVERYTHING' ||
+              channel?.isOwnedByCurrentUser
+            );
+          },
         );
 
+        const visibility = hasFullAccess
+          ? CalendarChannelVisibility.SHARE_EVERYTHING
+          : CalendarChannelVisibility.METADATA;
+
         return {
-          totalNumberOfCalendarEvents,
-          timelineCalendarEvents,
-          relatedPersonIds: personIds,
+          ...omit(event, [
+            'calendarEventParticipants',
+            'calendarChannelEventAssociations',
+          ]),
+          title:
+            visibility === CalendarChannelVisibility.METADATA
+              ? FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED
+              : (event.title ?? ''),
+          description:
+            visibility === CalendarChannelVisibility.METADATA
+              ? FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED
+              : (event.description ?? ''),
+          startsAt: event.startsAt as unknown as Date,
+          endsAt: event.endsAt as unknown as Date,
+          participants,
+          callRecordings: callRecordingsByCalendarEventId.get(event.id) ?? [],
+          visibility,
+          location: event.location ?? '',
+          conferenceSolution: event.conferenceSolution ?? '',
         };
-      },
-      authContext,
-    );
+      });
+
+      const timelineCalendarEvents = await Promise.all(
+        timelineCalendarEventPromises,
+      );
+
+      return {
+        totalNumberOfCalendarEvents,
+        timelineCalendarEvents,
+        relatedPersonIds: personIds,
+      };
+    }, authContext);
   }
 
   async getCalendarEventsFromObjectRecord({

--- a/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
@@ -12,7 +12,7 @@ import { type TimelineThreadDTO } from 'src/engine/core-modules/messaging/dtos/t
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageParticipantWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-participant.workspace-entity';
 import { type MessageThreadWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-thread.workspace-entity';
@@ -21,7 +21,7 @@ import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-membe
 @Injectable()
 export class TimelineMessagingService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     @InjectRepository(ConnectedAccountEntity)
@@ -49,72 +49,69 @@ export class TimelineMessagingService {
   }> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const messageThreadRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
-            'messageThread',
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageThreadRepository =
+        await this.workspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+          'messageThread',
+        );
 
-        const totalNumberOfThreads = await messageThreadRepository
-          .createQueryBuilder('messageThread')
-          .innerJoin('messageThread.messages', 'messages')
-          .innerJoin('messages.messageParticipants', 'messageParticipants')
-          .where('messageParticipants.personId IN(:...personIds)', {
-            personIds,
-          })
-          .groupBy('messageThread.id')
-          .getCount();
+      const totalNumberOfThreads = await messageThreadRepository
+        .createQueryBuilder('messageThread')
+        .innerJoin('messageThread.messages', 'messages')
+        .innerJoin('messages.messageParticipants', 'messageParticipants')
+        .where('messageParticipants.personId IN(:...personIds)', {
+          personIds,
+        })
+        .groupBy('messageThread.id')
+        .getCount();
 
-        const threadIdsQuery = await messageThreadRepository
-          .createQueryBuilder('messageThread')
-          .select('messageThread.id', 'id')
-          .addSelect('MAX(messages.receivedAt)', 'max_received_at')
-          .innerJoin('messageThread.messages', 'messages')
-          .innerJoin('messages.messageParticipants', 'messageParticipants')
-          .where('messageParticipants.personId IN (:...personIds)', {
-            personIds,
-          })
-          .groupBy('messageThread.id')
-          .orderBy('max_received_at', 'DESC')
-          .offset(offset)
-          .limit(pageSize)
-          .getRawMany();
+      const threadIdsQuery = await messageThreadRepository
+        .createQueryBuilder('messageThread')
+        .select('messageThread.id', 'id')
+        .addSelect('MAX(messages.receivedAt)', 'max_received_at')
+        .innerJoin('messageThread.messages', 'messages')
+        .innerJoin('messages.messageParticipants', 'messageParticipants')
+        .where('messageParticipants.personId IN (:...personIds)', {
+          personIds,
+        })
+        .groupBy('messageThread.id')
+        .orderBy('max_received_at', 'DESC')
+        .offset(offset)
+        .limit(pageSize)
+        .getRawMany();
 
-        const messageThreadIds = threadIdsQuery.map((thread) => thread.id);
+      const messageThreadIds = threadIdsQuery.map((thread) => thread.id);
 
-        const messageThreads = await messageThreadRepository.find({
-          where: {
-            id: In(messageThreadIds),
+      const messageThreads = await messageThreadRepository.find({
+        where: {
+          id: In(messageThreadIds),
+        },
+        order: {
+          messages: {
+            receivedAt: 'DESC',
           },
-          order: {
-            messages: {
-              receivedAt: 'DESC',
-            },
-          },
-          relations: ['messages'],
-        });
+        },
+        relations: ['messages'],
+      });
 
-        return {
-          messageThreads: messageThreads.map((messageThread) => {
-            const lastMessage = messageThread.messages[0];
-            const firstMessage =
-              messageThread.messages[messageThread.messages.length - 1];
+      return {
+        messageThreads: messageThreads.map((messageThread) => {
+          const lastMessage = messageThread.messages[0];
+          const firstMessage =
+            messageThread.messages[messageThread.messages.length - 1];
 
-            return {
-              id: messageThread.id,
-              subject: firstMessage.subject ?? '',
-              lastMessageBody: lastMessage.text ?? '',
-              lastMessageReceivedAt: lastMessage.receivedAt ?? new Date(),
-              numberOfMessagesInThread: messageThread.messages.length,
-              lastMessageIsDraft: lastMessage.isDraft ?? false,
-            };
-          }),
-          totalNumberOfThreads,
-        };
-      },
-      authContext,
-    );
+          return {
+            id: messageThread.id,
+            subject: firstMessage.subject ?? '',
+            lastMessageBody: lastMessage.text ?? '',
+            lastMessageReceivedAt: lastMessage.receivedAt ?? new Date(),
+            numberOfMessagesInThread: messageThread.messages.length,
+            lastMessageIsDraft: lastMessage.isDraft ?? false,
+          };
+        }),
+        totalNumberOfThreads,
+      };
+    }, authContext);
   }
 
   public async getThreadParticipantsByThreadId(
@@ -125,108 +122,105 @@ export class TimelineMessagingService {
   }> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const messageParticipantRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
-            'messageParticipant',
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageParticipantRepository =
+        await this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+          'messageParticipant',
+        );
+
+      const threadParticipants = await messageParticipantRepository
+        .createQueryBuilder()
+        .select('messageParticipant')
+        .addSelect('message.messageThreadId')
+        .addSelect('message.receivedAt')
+        .leftJoinAndSelect('messageParticipant.person', 'person')
+        .leftJoinAndSelect(
+          'messageParticipant.workspaceMember',
+          'workspaceMember',
+        )
+        .leftJoin('messageParticipant.message', 'message')
+        .where('message.messageThreadId = ANY(:messageThreadIds)', {
+          messageThreadIds,
+        })
+        .andWhere('messageParticipant.role = :role', {
+          role: MessageParticipantRole.FROM,
+        })
+        .orderBy('message.messageThreadId')
+        .distinctOn(['message.messageThreadId', 'messageParticipant.handle'])
+        .getMany<MessageParticipantWorkspaceEntity>();
+
+      const orderedThreadParticipants = threadParticipants.sort(
+        (a, b) =>
+          (a.message.receivedAt ?? new Date()).getTime() -
+          (b.message.receivedAt ?? new Date()).getTime(),
+      );
+
+      const threadParticipantPromises = orderedThreadParticipants.map(
+        async (threadParticipant) => {
+          const personAvatarFileUrl =
+            await this.fileUrlService.signFirstFilesFieldFileUrl({
+              filesFieldValue: threadParticipant.person?.avatarFile,
+              workspaceId,
+            });
+
+          return {
+            ...threadParticipant,
+            person: {
+              id: threadParticipant.person?.id,
+              name: {
+                //oxlint-disable-next-line
+                //@ts-ignore
+                firstName: threadParticipant.person?.nameFirstName,
+                //oxlint-disable-next-line
+                //@ts-ignore
+                lastName: threadParticipant.person?.nameLastName,
+              },
+              avatarUrl:
+                personAvatarFileUrl || threadParticipant.person?.avatarUrl,
+            },
+            workspaceMember: {
+              id: threadParticipant.workspaceMember?.id,
+              name: {
+                //oxlint-disable-next-line
+                //@ts-ignore
+                firstName: threadParticipant.workspaceMember?.nameFirstName,
+                //oxlint-disable-next-line
+                //@ts-ignore
+                lastName: threadParticipant.workspaceMember?.nameLastName,
+              },
+              avatarUrl: threadParticipant.workspaceMember?.avatarUrl,
+            },
+          };
+        },
+      );
+
+      const threadParticipantsWithCompositeFields = await Promise.all(
+        threadParticipantPromises,
+      );
+
+      return threadParticipantsWithCompositeFields.reduce(
+        (threadParticipantsAcc, threadParticipant) => {
+          if (!threadParticipant.message.messageThreadId)
+            return threadParticipantsAcc;
+
+          if (
+            // @ts-expect-error legacy noImplicitAny
+            !threadParticipantsAcc[threadParticipant.message.messageThreadId]
+          )
+            // @ts-expect-error legacy noImplicitAny
+            threadParticipantsAcc[threadParticipant.message.messageThreadId] =
+              [];
+
+          // @ts-expect-error legacy noImplicitAny
+          threadParticipantsAcc[threadParticipant.message.messageThreadId].push(
+            threadParticipant,
           );
 
-        const threadParticipants = await messageParticipantRepository
-          .createQueryBuilder()
-          .select('messageParticipant')
-          .addSelect('message.messageThreadId')
-          .addSelect('message.receivedAt')
-          .leftJoinAndSelect('messageParticipant.person', 'person')
-          .leftJoinAndSelect(
-            'messageParticipant.workspaceMember',
-            'workspaceMember',
-          )
-          .leftJoin('messageParticipant.message', 'message')
-          .where('message.messageThreadId = ANY(:messageThreadIds)', {
-            messageThreadIds,
-          })
-          .andWhere('messageParticipant.role = :role', {
-            role: MessageParticipantRole.FROM,
-          })
-          .orderBy('message.messageThreadId')
-          .distinctOn(['message.messageThreadId', 'messageParticipant.handle'])
-          .getMany<MessageParticipantWorkspaceEntity>();
-
-        const orderedThreadParticipants = threadParticipants.sort(
-          (a, b) =>
-            (a.message.receivedAt ?? new Date()).getTime() -
-            (b.message.receivedAt ?? new Date()).getTime(),
-        );
-
-        const threadParticipantPromises = orderedThreadParticipants.map(
-          async (threadParticipant) => {
-            const personAvatarFileUrl =
-              await this.fileUrlService.signFirstFilesFieldFileUrl({
-                filesFieldValue: threadParticipant.person?.avatarFile,
-                workspaceId,
-              });
-
-            return {
-              ...threadParticipant,
-              person: {
-                id: threadParticipant.person?.id,
-                name: {
-                  //oxlint-disable-next-line
-                  //@ts-ignore
-                  firstName: threadParticipant.person?.nameFirstName,
-                  //oxlint-disable-next-line
-                  //@ts-ignore
-                  lastName: threadParticipant.person?.nameLastName,
-                },
-                avatarUrl:
-                  personAvatarFileUrl || threadParticipant.person?.avatarUrl,
-              },
-              workspaceMember: {
-                id: threadParticipant.workspaceMember?.id,
-                name: {
-                  //oxlint-disable-next-line
-                  //@ts-ignore
-                  firstName: threadParticipant.workspaceMember?.nameFirstName,
-                  //oxlint-disable-next-line
-                  //@ts-ignore
-                  lastName: threadParticipant.workspaceMember?.nameLastName,
-                },
-                avatarUrl: threadParticipant.workspaceMember?.avatarUrl,
-              },
-            };
-          },
-        );
-
-        const threadParticipantsWithCompositeFields = await Promise.all(
-          threadParticipantPromises,
-        );
-
-        return threadParticipantsWithCompositeFields.reduce(
-          (threadParticipantsAcc, threadParticipant) => {
-            if (!threadParticipant.message.messageThreadId)
-              return threadParticipantsAcc;
-
-            if (
-              // @ts-expect-error legacy noImplicitAny
-              !threadParticipantsAcc[threadParticipant.message.messageThreadId]
-            )
-              // @ts-expect-error legacy noImplicitAny
-              threadParticipantsAcc[threadParticipant.message.messageThreadId] =
-                [];
-
-            // @ts-expect-error legacy noImplicitAny
-            threadParticipantsAcc[
-              threadParticipant.message.messageThreadId
-            ].push(threadParticipant);
-
-            return threadParticipantsAcc;
-          },
-          {},
-        );
-      },
-      authContext,
-    );
+          return threadParticipantsAcc;
+        },
+        {},
+      );
+    }, authContext);
   }
 
   public async getThreadVisibilityByThreadId(
@@ -238,130 +232,125 @@ export class TimelineMessagingService {
   }> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const currentMember = await workspaceMemberRepository.findOne({
-          where: { id: workspaceMemberId },
-          select: { userId: true },
-        });
+      const currentMember = await workspaceMemberRepository.findOne({
+        where: { id: workspaceMemberId },
+        select: { userId: true },
+      });
 
-        if (!currentMember) {
-          return {};
-        }
+      if (!currentMember) {
+        return {};
+      }
 
-        const currentUserWorkspace = await this.userWorkspaceRepository.findOne(
-          {
-            where: { userId: currentMember.userId, workspaceId },
+      const currentUserWorkspace = await this.userWorkspaceRepository.findOne({
+        where: { userId: currentMember.userId, workspaceId },
+        select: { id: true },
+      });
+
+      if (!currentUserWorkspace) {
+        return {};
+      }
+
+      const currentUserWorkspaceId = currentUserWorkspace.id;
+
+      const messageThreadRepository =
+        await this.workspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+          'messageThread',
+        );
+
+      const threadChannelRows = await messageThreadRepository
+        .createQueryBuilder()
+        .select('messageThread.id', 'id')
+        .addSelect(
+          'messageChannelMessageAssociation.messageChannelId',
+          'messageChannelId',
+        )
+        .leftJoin('messageThread.messages', 'message')
+        .leftJoin(
+          'message.messageChannelMessageAssociations',
+          'messageChannelMessageAssociation',
+        )
+        .where('messageThread.id = ANY(:messageThreadIds)', {
+          messageThreadIds,
+        })
+        .getRawMany<{ id: string; messageChannelId: string | null }>();
+
+      const allMessageChannelIds = [
+        ...new Set(
+          threadChannelRows
+            .map((row) => row.messageChannelId)
+            .filter((id): id is string => id !== null && id !== undefined),
+        ),
+      ];
+
+      if (allMessageChannelIds.length === 0) {
+        return {};
+      }
+
+      const messageChannels = await this.messageChannelRepository.find({
+        where: { id: In(allMessageChannelIds), workspaceId },
+        select: { id: true, visibility: true, connectedAccountId: true },
+      });
+
+      const allConnectedAccountIds = [
+        ...new Set(
+          messageChannels.map((channel) => channel.connectedAccountId),
+        ),
+      ];
+
+      const ownedAccountIds = new Set(
+        (
+          await this.connectedAccountRepository.find({
+            where: {
+              id: In(allConnectedAccountIds),
+              userWorkspaceId: currentUserWorkspaceId,
+            },
             select: { id: true },
-          },
-        );
-
-        if (!currentUserWorkspace) {
-          return {};
-        }
-
-        const currentUserWorkspaceId = currentUserWorkspace.id;
-
-        const messageThreadRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
-            'messageThread',
-          );
-
-        const threadChannelRows = await messageThreadRepository
-          .createQueryBuilder()
-          .select('messageThread.id', 'id')
-          .addSelect(
-            'messageChannelMessageAssociation.messageChannelId',
-            'messageChannelId',
-          )
-          .leftJoin('messageThread.messages', 'message')
-          .leftJoin(
-            'message.messageChannelMessageAssociations',
-            'messageChannelMessageAssociation',
-          )
-          .where('messageThread.id = ANY(:messageThreadIds)', {
-            messageThreadIds,
           })
-          .getRawMany<{ id: string; messageChannelId: string | null }>();
+        ).map((account) => account.id),
+      );
 
-        const allMessageChannelIds = [
-          ...new Set(
-            threadChannelRows
-              .map((row) => row.messageChannelId)
-              .filter((id): id is string => id !== null && id !== undefined),
-          ),
-        ];
+      const channelVisibilityMap = new Map(
+        messageChannels.map((channel) => [
+          channel.id,
+          ownedAccountIds.has(channel.connectedAccountId)
+            ? MessageChannelVisibility.SHARE_EVERYTHING
+            : channel.visibility,
+        ]),
+      );
 
-        if (allMessageChannelIds.length === 0) {
-          return {};
-        }
+      const visibilityValues = Object.values(MessageChannelVisibility);
 
-        const messageChannels = await this.messageChannelRepository.find({
-          where: { id: In(allMessageChannelIds), workspaceId },
-          select: { id: true, visibility: true, connectedAccountId: true },
-        });
+      const threadVisibilityByThreadId: {
+        [key: string]: MessageChannelVisibility;
+      } = {};
 
-        const allConnectedAccountIds = [
-          ...new Set(
-            messageChannels.map((channel) => channel.connectedAccountId),
-          ),
-        ];
+      for (const { id: threadId, messageChannelId } of threadChannelRows) {
+        if (!messageChannelId) continue;
 
-        const ownedAccountIds = new Set(
-          (
-            await this.connectedAccountRepository.find({
-              where: {
-                id: In(allConnectedAccountIds),
-                userWorkspaceId: currentUserWorkspaceId,
-              },
-              select: { id: true },
-            })
-          ).map((account) => account.id),
-        );
+        const channelVisibility = channelVisibilityMap.get(messageChannelId);
 
-        const channelVisibilityMap = new Map(
-          messageChannels.map((channel) => [
-            channel.id,
-            ownedAccountIds.has(channel.connectedAccountId)
-              ? MessageChannelVisibility.SHARE_EVERYTHING
-              : channel.visibility,
-          ]),
-        );
+        if (!channelVisibility) continue;
 
-        const visibilityValues = Object.values(MessageChannelVisibility);
+        threadVisibilityByThreadId[threadId] =
+          visibilityValues[
+            Math.max(
+              visibilityValues.indexOf(channelVisibility),
+              visibilityValues.indexOf(
+                threadVisibilityByThreadId[threadId] ??
+                  MessageChannelVisibility.METADATA,
+              ),
+            )
+          ];
+      }
 
-        const threadVisibilityByThreadId: {
-          [key: string]: MessageChannelVisibility;
-        } = {};
-
-        for (const { id: threadId, messageChannelId } of threadChannelRows) {
-          if (!messageChannelId) continue;
-
-          const channelVisibility = channelVisibilityMap.get(messageChannelId);
-
-          if (!channelVisibility) continue;
-
-          threadVisibilityByThreadId[threadId] =
-            visibilityValues[
-              Math.max(
-                visibilityValues.indexOf(channelVisibility),
-                visibilityValues.indexOf(
-                  threadVisibilityByThreadId[threadId] ??
-                    MessageChannelVisibility.METADATA,
-                ),
-              )
-            ];
-        }
-
-        return threadVisibilityByThreadId;
-      },
-      authContext,
-    );
+      return threadVisibilityByThreadId;
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/record-position/services/record-position.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-position/services/record-position.service.ts
@@ -4,7 +4,7 @@ import { isNumber } from '@sniptt/guards';
 import { type ObjectRecord } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { sanitizeNumber } from 'src/engine/utils/sanitize-number.utli';
 
@@ -17,9 +17,7 @@ export type RecordPositionServiceCreateArgs = {
 
 @Injectable()
 export class RecordPositionService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async buildRecordPosition({
     objectMetadata,
@@ -162,23 +160,20 @@ export class RecordPositionService {
   ): Promise<{ id: string; position: number } | null> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const repository = await this.globalWorkspaceOrmManager.getRepository(
-          objectMetadata.nameSingular,
-          {
-            shouldBypassPermissionChecks: true,
-          },
-        );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const repository = await this.workspaceOrmManager.getRepository(
+        objectMetadata.nameSingular,
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        const record = await repository.findOneBy({
-          position: positionValue,
-        });
+      const record = await repository.findOneBy({
+        position: positionValue,
+      });
 
-        return record ? { id: record.id, position: record.position } : null;
-      },
-      authContext,
-    );
+      return record ? { id: record.id, position: record.position } : null;
+    }, authContext);
   }
 
   async updatePosition(
@@ -189,8 +184,8 @@ export class RecordPositionService {
   ): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      const repository = await this.globalWorkspaceOrmManager.getRepository(
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const repository = await this.workspaceOrmManager.getRepository(
         objectMetadata.nameSingular,
         {
           shouldBypassPermissionChecks: true,
@@ -209,20 +204,19 @@ export class RecordPositionService {
   ): Promise<number | null> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    const result =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const repository = await this.globalWorkspaceOrmManager.getRepository(
-            objectMetadata.nameSingular,
-            {
-              shouldBypassPermissionChecks: true,
-            },
-          );
+    const result = await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const repository = await this.workspaceOrmManager.getRepository(
+          objectMetadata.nameSingular,
+          {
+            shouldBypassPermissionChecks: true,
+          },
+        );
 
-          return await repository.minimum('position');
-        },
-        authContext,
-      );
+        return await repository.minimum('position');
+      },
+      authContext,
+    );
 
     return sanitizeNumber(result);
   }
@@ -233,20 +227,19 @@ export class RecordPositionService {
   ): Promise<number | null> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    const result =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const repository = await this.globalWorkspaceOrmManager.getRepository(
-            objectMetadata.nameSingular,
-            {
-              shouldBypassPermissionChecks: true,
-            },
-          );
+    const result = await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const repository = await this.workspaceOrmManager.getRepository(
+          objectMetadata.nameSingular,
+          {
+            shouldBypassPermissionChecks: true,
+          },
+        );
 
-          return await repository.maximum('position');
-        },
-        authContext,
-      );
+        return await repository.maximum('position');
+      },
+      authContext,
+    );
 
     return sanitizeNumber(result);
   }

--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/services/related-person-ids.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/services/related-person-ids.service.ts
@@ -8,7 +8,7 @@ import {
   findRelationPathsToPerson,
   type RelationPathToPerson,
 } from 'src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
@@ -19,7 +19,7 @@ type RelationWalkRecord = { id: string } & Record<string, unknown>;
 @Injectable()
 export class RelatedPersonIdsService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workspaceCacheService: WorkspaceCacheService,
   ) {}
 
@@ -52,23 +52,20 @@ export class RelatedPersonIdsService {
       return [];
     }
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const personIds = new Set<string>();
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const personIds = new Set<string>();
 
-        for (const relationPath of relationPaths) {
-          const personIdsForPath = await this.walkRelationPath({
-            recordId,
-            relationPath,
-          });
+      for (const relationPath of relationPaths) {
+        const personIdsForPath = await this.walkRelationPath({
+          recordId,
+          relationPath,
+        });
 
-          personIdsForPath.forEach((personId) => personIds.add(personId));
-        }
+        personIdsForPath.forEach((personId) => personIds.add(personId));
+      }
 
-        return [...personIds];
-      },
-      buildSystemAuthContext(workspaceId),
-    );
+      return [...personIds];
+    }, buildSystemAuthContext(workspaceId));
   }
 
   private async walkRelationPath({
@@ -86,7 +83,7 @@ export class RelatedPersonIdsService {
       }
 
       const repository =
-        await this.globalWorkspaceOrmManager.getRepository<RelationWalkRecord>(
+        await this.workspaceOrmManager.getRepository<RelationWalkRecord>(
           hop.queryObjectNameSingular,
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -51,7 +51,7 @@ import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object
 import { getEffectiveImageIdentifierFieldMetadataId } from 'src/engine/metadata-modules/object-metadata/utils/get-effective-image-identifier-field-metadata-id.util';
 import { SEARCH_VECTOR_FIELD } from 'src/engine/metadata-modules/search-field-metadata/constants/search-vector-field.constants';
 import { resolveEffectiveEntityProperty } from 'src/engine/metadata-modules/utils/resolve-effective-entity-property.util';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
@@ -72,7 +72,7 @@ export class SearchService {
   private readonly logger = new Logger(SearchService.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly fileUrlService: FileUrlService,
     private readonly twentyConfigService: TwentyConfigService,
     private readonly applicationTranslationCatalogService: ApplicationTranslationCatalogService,
@@ -108,7 +108,7 @@ export class SearchService {
     for (const objectMetadataItemChunk of filteredObjectMetadataItemsChunks) {
       const recordsWithObjectMetadataItems = await Promise.all(
         objectMetadataItemChunk.map(async (flatObjectMetadata) => {
-          return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+          return this.workspaceOrmManager.executeInWorkspaceContext(
             async () => {
               const context = getWorkspaceContext();
               const rolePermissionConfig =
@@ -119,7 +119,7 @@ export class SearchService {
                 }) ?? undefined;
 
               const repository =
-                await this.globalWorkspaceOrmManager.getRepository<ObjectRecord>(
+                await this.workspaceOrmManager.getRepository<ObjectRecord>(
                   flatObjectMetadata.nameSingular,
                   rolePermissionConfig,
                 );
@@ -395,7 +395,7 @@ export class SearchService {
     );
 
     try {
-      return await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+      return await this.workspaceOrmManager.runInWorkspaceTransaction(
         async (transactionScope) => {
           await transactionScope.executeRawQuery(
             `SELECT set_config('statement_timeout', $1, true)`,

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
@@ -26,7 +26,7 @@ import { parseCommaSeparatedEmails } from 'src/engine/core-modules/tool/tools/em
 import { selectConnectedAccountIdForCaller } from 'src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-for-caller.util';
 import { type ToolExecutionContext } from 'src/engine/core-modules/tool/types/tool-execution-context.type';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
@@ -45,7 +45,7 @@ export class EmailComposerService {
   private readonly logger = new Logger(EmailComposerService.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectWorkspaceScopedRepository(FileEntity)
@@ -69,28 +69,25 @@ export class EmailComposerService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const connectedAccount = await this.connectedAccountRepository.findOne({
-          where: { id: connectedAccountId, workspaceId },
-          relations: {
-            messageChannels: {
-              messageFolders: true,
-            },
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const connectedAccount = await this.connectedAccountRepository.findOne({
+        where: { id: connectedAccountId, workspaceId },
+        relations: {
+          messageChannels: {
+            messageFolders: true,
           },
-        });
+        },
+      });
 
-        if (!isDefined(connectedAccount)) {
-          throw new EmailToolException(
-            `No connected account found for id '${connectedAccountId}'`,
-            EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
-          );
-        }
+      if (!isDefined(connectedAccount)) {
+        throw new EmailToolException(
+          `No connected account found for id '${connectedAccountId}'`,
+          EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
+        );
+      }
 
-        return connectedAccount;
-      },
-      authContext,
-    );
+      return connectedAccount;
+    }, authContext);
   }
 
   private async getDefaultConnectedAccountIdOrThrow({
@@ -102,40 +99,37 @@ export class EmailComposerService {
   }): Promise<string> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const allAccounts = await this.connectedAccountRepository.find({
-          where: { workspaceId, archivedAt: IsNull() },
-          order: { createdAt: 'ASC', id: 'ASC' },
-        });
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const allAccounts = await this.connectedAccountRepository.find({
+        where: { workspaceId, archivedAt: IsNull() },
+        order: { createdAt: 'ASC', id: 'ASC' },
+      });
 
-        if (!isNonEmptyArray(allAccounts)) {
-          throw new EmailToolException(
-            'No connected accounts found for this workspace',
-            EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
-          );
-        }
+      if (!isNonEmptyArray(allAccounts)) {
+        throw new EmailToolException(
+          'No connected accounts found for this workspace',
+          EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
+        );
+      }
 
-        if (!isDefined(userWorkspaceId)) {
-          return allAccounts[0].id;
-        }
+      if (!isDefined(userWorkspaceId)) {
+        return allAccounts[0].id;
+      }
 
-        const connectedAccountId = selectConnectedAccountIdForCaller({
-          connectedAccounts: allAccounts,
-          userWorkspaceId,
-        });
+      const connectedAccountId = selectConnectedAccountIdForCaller({
+        connectedAccounts: allAccounts,
+        userWorkspaceId,
+      });
 
-        if (!isDefined(connectedAccountId)) {
-          throw new EmailToolException(
-            `No connected account available for user workspace '${userWorkspaceId}'`,
-            EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
-          );
-        }
+      if (!isDefined(connectedAccountId)) {
+        throw new EmailToolException(
+          `No connected account available for user workspace '${userWorkspaceId}'`,
+          EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
+        );
+      }
 
-        return connectedAccountId;
-      },
-      authContext,
-    );
+      return connectedAccountId;
+    }, authContext);
   }
 
   private normalizeRecipients(parameters: ComposeEmailParams): {
@@ -279,56 +273,53 @@ export class EmailComposerService {
   ): Promise<ParentThreadContext> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const messageRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
-            'message',
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageRepository =
+        await this.workspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+          'message',
+        );
 
-        const parentMessage = await messageRepository.findOne({
-          where: { headerMessageId: inReplyTo },
-        });
+      const parentMessage = await messageRepository.findOne({
+        where: { headerMessageId: inReplyTo },
+      });
 
-        if (
-          !isDefined(parentMessage) ||
-          !isDefined(parentMessage.messageThreadId) ||
-          !isDefined(parentMessage.receivedAt)
-        ) {
-          return {};
-        }
+      if (
+        !isDefined(parentMessage) ||
+        !isDefined(parentMessage.messageThreadId) ||
+        !isDefined(parentMessage.receivedAt)
+      ) {
+        return {};
+      }
 
-        const associationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            'messageChannelMessageAssociation',
-          );
+      const associationRepository =
+        await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          'messageChannelMessageAssociation',
+        );
 
-        const [association, ancestorMessages] = await Promise.all([
-          associationRepository.findOne({
-            where: { messageId: parentMessage.id, messageChannelId },
-            select: { messageThreadExternalId: true },
-          }),
-          messageRepository.find({
-            where: {
-              messageThreadId: parentMessage.messageThreadId,
-              receivedAt: LessThanOrEqual(parentMessage.receivedAt),
-            },
-            select: { headerMessageId: true },
-            order: { receivedAt: 'ASC' },
-          }),
-        ]);
+      const [association, ancestorMessages] = await Promise.all([
+        associationRepository.findOne({
+          where: { messageId: parentMessage.id, messageChannelId },
+          select: { messageThreadExternalId: true },
+        }),
+        messageRepository.find({
+          where: {
+            messageThreadId: parentMessage.messageThreadId,
+            receivedAt: LessThanOrEqual(parentMessage.receivedAt),
+          },
+          select: { headerMessageId: true },
+          order: { receivedAt: 'ASC' },
+        }),
+      ]);
 
-        const references = ancestorMessages
-          .map((message) => message.headerMessageId)
-          .filter(isNonEmptyString);
+      const references = ancestorMessages
+        .map((message) => message.headerMessageId)
+        .filter(isNonEmptyString);
 
-        return {
-          threadExternalId: association?.messageThreadExternalId ?? undefined,
-          references: references.length > 0 ? references : undefined,
-        };
-      },
-      authContext,
-    );
+      return {
+        threadExternalId: association?.messageThreadExternalId ?? undefined,
+        references: references.length > 0 ? references : undefined,
+      };
+    }, authContext);
   }
 
   async composeEmail(

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/navigate-tool/navigate-app-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/navigate-tool/navigate-app-tool.ts
@@ -20,7 +20,7 @@ import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object
 import { NavigationMenuItemType } from 'src/engine/metadata-modules/navigation-menu-item/enums/navigation-menu-item-type.enum';
 import { NavigationMenuItemService } from 'src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.service';
 import { ViewService } from 'src/engine/metadata-modules/view/services/view.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 @Injectable()
@@ -37,7 +37,7 @@ export class NavigateAppTool implements Tool {
     private readonly navigationMenuItemService: NavigationMenuItemService,
     private readonly viewService: ViewService,
     private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async execute(
@@ -333,21 +333,20 @@ export class NavigateAppTool implements Tool {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    const records =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const repository =
-            await this.globalWorkspaceOrmManager.getRepository<ObjectRecord>(
-              objectNameSingular,
-              { shouldBypassPermissionChecks: true },
-            );
+    const records = await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const repository =
+          await this.workspaceOrmManager.getRepository<ObjectRecord>(
+            objectNameSingular,
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return repository.find({
-            select: selectColumns,
-          });
-        },
-        authContext,
-      );
+        return repository.find({
+          select: selectColumns,
+        });
+      },
+      authContext,
+    );
 
     const recordsWithDisplayName = records.map((record) => {
       let displayName: string;

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -39,7 +39,7 @@ import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { RoleValidationService } from 'src/engine/metadata-modules/role-validation/services/role-validation.service';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 import { assert } from 'src/utils/assert';
@@ -60,7 +60,7 @@ export class UserWorkspaceService {
     private readonly workspaceDomainsService: WorkspaceDomainsService,
     private readonly loginTokenService: LoginTokenService,
     private readonly approvedAccessDomainService: ApprovedAccessDomainService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly userRoleService: UserRoleService,
     private readonly fileCorePictureService: FileCorePictureService,
     private readonly fileUrlService: FileUrlService,
@@ -159,9 +159,9 @@ export class UserWorkspaceService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -484,22 +484,19 @@ export class UserWorkspaceService {
   }): Promise<WorkspaceMemberWorkspaceEntity | null> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        return workspaceMemberRepository.findOne({
-          where: {
-            id: workspaceMemberId,
-          },
-        });
-      },
-      authContext,
-    );
+      return workspaceMemberRepository.findOne({
+        where: {
+          id: workspaceMemberId,
+        },
+      });
+    }, authContext);
   }
 
   async getWorkspaceMemberOrThrow({

--- a/packages/twenty-server/src/engine/core-modules/user/jobs/update-workspace-member-email.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/jobs/update-workspace-member-email.job.ts
@@ -4,7 +4,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
@@ -22,7 +22,7 @@ export class UpdateWorkspaceMemberEmailJob {
 
   constructor(
     private readonly userWorkspaceService: UserWorkspaceService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   @Process(UpdateWorkspaceMemberEmailJob.name)
@@ -35,9 +35,9 @@ export class UpdateWorkspaceMemberEmailJob {
 
     const authContext = buildSystemAuthContext(workspace.id);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -45,7 +45,7 @@ import {
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { STANDARD_ROLE } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-role.constant';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
@@ -61,7 +61,7 @@ export class UserService {
     private readonly workspaceDomainsService: WorkspaceDomainsService,
     private readonly emailVerificationService: EmailVerificationService,
     private readonly workspaceService: WorkspaceService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly userRoleService: UserRoleService,
     private readonly userWorkspaceService: UserWorkspaceService,
     @InjectMessageQueue(MessageQueue.workspaceQueue)
@@ -104,22 +104,19 @@ export class UserService {
 
     const authContext = buildSystemAuthContext(workspace.id);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        return await workspaceMemberRepository.findOne({
-          where: {
-            userId: user.id,
-          },
-        });
-      },
-      authContext,
-    );
+      return await workspaceMemberRepository.findOne({
+        where: {
+          userId: user.id,
+        },
+      });
+    }, authContext);
   }
 
   async loadWorkspaceMembers(
@@ -136,20 +133,17 @@ export class UserService {
 
     const authContext = buildSystemAuthContext(workspace.id);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        return await workspaceMemberRepository.find({
-          withDeleted: withDeleted,
-        });
-      },
-      authContext,
-    );
+      return await workspaceMemberRepository.find({
+        withDeleted: withDeleted,
+      });
+    }, authContext);
   }
 
   async loadSignedAvatarUrlsByUserId({
@@ -222,21 +216,18 @@ export class UserService {
 
     const authContext = buildSystemAuthContext(workspace.id);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        return await workspaceMemberRepository.find({
-          select: ['id', 'userId', 'avatarUrl'],
-          where: { userId: In(userIds) },
-        });
-      },
-      authContext,
-    );
+      return await workspaceMemberRepository.find({
+        select: ['id', 'userId', 'avatarUrl'],
+        where: { userId: In(userIds) },
+      });
+    }, authContext);
   }
 
   async loadDeletedWorkspaceMembersOnly(
@@ -248,21 +239,18 @@ export class UserService {
 
     const authContext = buildSystemAuthContext(workspace.id);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        return await workspaceMemberRepository.find({
-          where: { deletedAt: Not(IsNull()) },
-          withDeleted: true,
-        });
-      },
-      authContext,
-    );
+      return await workspaceMemberRepository.find({
+        where: { deletedAt: Not(IsNull()) },
+        withDeleted: true,
+      });
+    }, authContext);
   }
 
   async deleteUser(userId: string) {
@@ -339,18 +327,15 @@ export class UserService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     const workspaceMembers =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.find();
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.find();
+      }, authContext);
 
     const userWorkspaceId = userWorkspace.id;
 
@@ -407,9 +392,9 @@ export class UserService {
       });
     }
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
 
 import { FlatWorkspaceMemberMaps } from 'src/engine/core-modules/user/types/flat-workspace-member-maps.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
@@ -14,40 +14,35 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
   packingPonderation: 1,
 })
 export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheProvider<FlatWorkspaceMemberMaps> {
-  constructor(
-    protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {
+  constructor(protected readonly workspaceOrmManager: WorkspaceOrmManager) {
     super();
   }
 
   async computeForCache(workspaceId: string): Promise<FlatWorkspaceMemberMaps> {
     const flatWorkspaceMemberMaps =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          const flatWorkspaceMemberMaps: FlatWorkspaceMemberMaps = {
-            byId: {},
-            idByUserId: {},
-          };
-          const workspaceMembers = await workspaceMemberRepository.find({
-            withDeleted: true,
-          });
+        const flatWorkspaceMemberMaps: FlatWorkspaceMemberMaps = {
+          byId: {},
+          idByUserId: {},
+        };
+        const workspaceMembers = await workspaceMemberRepository.find({
+          withDeleted: true,
+        });
 
-          for (const workspaceMember of workspaceMembers) {
-            flatWorkspaceMemberMaps.byId[workspaceMember.id] = workspaceMember;
-            flatWorkspaceMemberMaps.idByUserId[workspaceMember.userId] =
-              workspaceMember.id;
-          }
+        for (const workspaceMember of workspaceMembers) {
+          flatWorkspaceMemberMaps.byId[workspaceMember.id] = workspaceMember;
+          flatWorkspaceMemberMaps.idByUserId[workspaceMember.userId] =
+            workspaceMember.id;
+        }
 
-          return flatWorkspaceMemberMaps;
-        },
-        buildSystemAuthContext(workspaceId),
-      );
+        return flatWorkspaceMemberMaps;
+      }, buildSystemAuthContext(workspaceId));
 
     return flatWorkspaceMemberMaps;
   }

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -73,7 +73,7 @@ import { type UserWorkspacePermissions } from 'src/engine/metadata-modules/permi
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
 import { fromUserWorkspacePermissionsToUserWorkspacePermissionsDto } from 'src/engine/metadata-modules/role/utils/fromUserWorkspacePermissionsToUserWorkspacePermissionsDto';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { AccountsToReconnectKeys } from 'src/modules/connected-account/types/accounts-to-reconnect-key-value.type';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
@@ -102,7 +102,7 @@ export class UserResolver {
     private readonly permissionsService: PermissionsService,
     private readonly workspaceMemberTranspiler: WorkspaceMemberTranspiler,
     private readonly userWorkspaceService: UserWorkspaceService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   private async getUserWorkspacePermissions({
@@ -405,22 +405,19 @@ export class UserResolver {
     const authContext = buildSystemAuthContext(workspace.id);
 
     const workspaceMemberToDelete =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOne({
-            where: {
-              id: workspaceMemberIdToDelete,
-            },
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOne({
+          where: {
+            id: workspaceMemberIdToDelete,
+          },
+        });
+      }, authContext);
 
     if (!isDefined(workspaceMemberToDelete)) {
       throw new BadRequestException(
@@ -510,8 +507,8 @@ export class UserResolver {
     });
 
     const workspaceMemberRepository =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () =>
-        this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () =>
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           {
             shouldBypassPermissionChecks: true,
@@ -520,7 +517,7 @@ export class UserResolver {
       );
 
     const workspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(() =>
+      await this.workspaceOrmManager.executeInWorkspaceContext(() =>
         workspaceMemberRepository.findOne({
           where: {
             id: input.workspaceMemberId,
@@ -538,7 +535,7 @@ export class UserResolver {
         ...(input.update as Partial<WorkspaceMemberWorkspaceEntity>),
       };
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(() =>
+    await this.workspaceOrmManager.executeInWorkspaceContext(() =>
       workspaceMemberRepository.save(workspaceMemberUpdatePayload),
     );
 

--- a/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
@@ -19,7 +19,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
 import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import {
   TwentyORMException,
   TwentyORMExceptionCode,
@@ -44,7 +44,7 @@ import { WorkflowTriggerWorkspaceService } from 'src/modules/workflow/workflow-t
 )
 export class WorkflowTriggerController {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowTriggerWorkspaceService: WorkflowTriggerWorkspaceService,
     @InjectRepository(WorkspaceEntity)
     protected readonly workspaceRepository: Repository<WorkspaceEntity>,
@@ -97,69 +97,66 @@ export class WorkflowTriggerController {
 
     try {
       const { workflow } =
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const workflowRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-                'workflow',
-                { shouldBypassPermissionChecks: true },
-              );
+        await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+          const workflowRepository =
+            await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+              'workflow',
+              { shouldBypassPermissionChecks: true },
+            );
 
-            const workflow = await workflowRepository.findOne({
-              where: { id: workflowId },
-            });
+          const workflow = await workflowRepository.findOne({
+            where: { id: workflowId },
+          });
 
-            if (!isDefined(workflow)) {
-              throw new WorkflowTriggerException(
-                `[Webhook trigger] Workflow ${workflowId} not found in workspace ${workspaceId}`,
-                WorkflowTriggerExceptionCode.NOT_FOUND,
-              );
-            }
+          if (!isDefined(workflow)) {
+            throw new WorkflowTriggerException(
+              `[Webhook trigger] Workflow ${workflowId} not found in workspace ${workspaceId}`,
+              WorkflowTriggerExceptionCode.NOT_FOUND,
+            );
+          }
 
-            if (
-              !isDefined(workflow.lastPublishedVersionId) ||
-              workflow.lastPublishedVersionId === ''
-            ) {
-              throw new WorkflowTriggerException(
-                `[Webhook trigger] Workflow ${workflowId} has not been activated in workspace ${workspaceId}`,
-                WorkflowTriggerExceptionCode.INVALID_WORKFLOW_STATUS,
-              );
-            }
+          if (
+            !isDefined(workflow.lastPublishedVersionId) ||
+            workflow.lastPublishedVersionId === ''
+          ) {
+            throw new WorkflowTriggerException(
+              `[Webhook trigger] Workflow ${workflowId} has not been activated in workspace ${workspaceId}`,
+              WorkflowTriggerExceptionCode.INVALID_WORKFLOW_STATUS,
+            );
+          }
 
-            const workflowVersionRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-                'workflowVersion',
-                { shouldBypassPermissionChecks: true },
-              );
-            const workflowVersion = await workflowVersionRepository.findOne({
-              where: { id: workflow.lastPublishedVersionId },
-            });
+          const workflowVersionRepository =
+            await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+              'workflowVersion',
+              { shouldBypassPermissionChecks: true },
+            );
+          const workflowVersion = await workflowVersionRepository.findOne({
+            where: { id: workflow.lastPublishedVersionId },
+          });
 
-            if (!isDefined(workflowVersion)) {
-              throw new WorkflowTriggerException(
-                `[Webhook trigger] No workflow version activated for workflow ${workflowId} in workspace ${workspaceId}`,
-                WorkflowTriggerExceptionCode.INVALID_WORKFLOW_VERSION,
-              );
-            }
+          if (!isDefined(workflowVersion)) {
+            throw new WorkflowTriggerException(
+              `[Webhook trigger] No workflow version activated for workflow ${workflowId} in workspace ${workspaceId}`,
+              WorkflowTriggerExceptionCode.INVALID_WORKFLOW_VERSION,
+            );
+          }
 
-            if (workflowVersion.trigger?.type !== WorkflowTriggerType.WEBHOOK) {
-              throw new WorkflowTriggerException(
-                `[Webhook trigger] Workflow ${workflowId} does not have a Webhook trigger in workspace ${workspaceId}`,
-                WorkflowTriggerExceptionCode.INVALID_WORKFLOW_TRIGGER,
-              );
-            }
+          if (workflowVersion.trigger?.type !== WorkflowTriggerType.WEBHOOK) {
+            throw new WorkflowTriggerException(
+              `[Webhook trigger] Workflow ${workflowId} does not have a Webhook trigger in workspace ${workspaceId}`,
+              WorkflowTriggerExceptionCode.INVALID_WORKFLOW_TRIGGER,
+            );
+          }
 
-            if (workflowVersion.status !== WorkflowVersionStatus.ACTIVE) {
-              throw new WorkflowTriggerException(
-                `[Webhook trigger] Workflow version ${workflowVersion.id} is not active in workspace ${workspaceId}`,
-                WorkflowTriggerExceptionCode.INVALID_WORKFLOW_STATUS,
-              );
-            }
+          if (workflowVersion.status !== WorkflowVersionStatus.ACTIVE) {
+            throw new WorkflowTriggerException(
+              `[Webhook trigger] Workflow version ${workflowVersion.id} is not active in workspace ${workspaceId}`,
+              WorkflowTriggerExceptionCode.INVALID_WORKFLOW_STATUS,
+            );
+          }
 
-            return { workflow, workflowVersion };
-          },
-          authContext,
-        );
+          return { workflow, workflowVersion };
+        }, authContext);
 
       const { workflowRunId } =
         await this.workflowTriggerWorkspaceService.runWorkflowVersion({

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -25,7 +25,7 @@ import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.g
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkflowTriggerWorkspaceService } from 'src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
@@ -43,7 +43,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 )
 export class WorkflowTriggerResolver {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowTriggerWorkspaceService: WorkflowTriggerWorkspaceService,
   ) {}
 
@@ -82,22 +82,19 @@ export class WorkflowTriggerResolver {
     const authContext = buildSystemAuthContext(workspace.id);
 
     const workspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOneOrFail({
-            where: {
-              userId: user.id,
-            },
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOneOrFail({
+          where: {
+            userId: user.id,
+          },
+        });
+      }, authContext);
 
     return this.workflowTriggerWorkspaceService.runWorkflowVersion({
       workflowVersionId,

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-core-sync.service.ts
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { WorkflowEntity } from 'src/engine/core-modules/workflow/entities/workflow.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
@@ -25,7 +25,7 @@ export class WorkflowCoreSyncService {
     private readonly coreWorkflowRepository: WorkspaceScopedRepository<WorkflowEntity>,
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workspaceCacheService: WorkspaceCacheService,
   ) {}
 
@@ -133,9 +133,9 @@ export class WorkflowCoreSyncService {
       return;
     }
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceWorkflowRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
           'workflow',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
@@ -12,7 +12,7 @@ import {
   WorkflowVersionStatus,
 } from 'src/engine/core-modules/workflow/entities/workflow-version.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
@@ -30,7 +30,7 @@ export class WorkflowVersionCoreSyncService {
     private readonly coreWorkflowVersionRepository: WorkspaceScopedRepository<WorkflowVersionEntity>,
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workspaceCacheService: WorkspaceCacheService,
   ) {}
 
@@ -280,8 +280,8 @@ export class WorkflowVersionCoreSyncService {
       transactionScope: WorkspaceTransactionScope,
     ) => Promise<string>,
   ): Promise<void> {
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      await this.workspaceOrmManager.runInWorkspaceTransaction(
         async (transactionScope) => {
           const workflowVersionRepository =
             transactionScope.getRepository<WorkflowVersionWorkspaceEntity>(
@@ -336,25 +336,22 @@ export class WorkflowVersionCoreSyncService {
     }
 
     const coreWorkflowVersionIds =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workflowVersionRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-              'workflowVersion',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workflowVersionRepository =
+          await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+            'workflowVersion',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          const versions = await workflowVersionRepository.find({
-            where: { id: In(workflowVersionIds) },
-            withDeleted: true,
-          });
+        const versions = await workflowVersionRepository.find({
+          where: { id: In(workflowVersionIds) },
+          withDeleted: true,
+        });
 
-          return versions
-            .map((version) => version.coreWorkflowVersionId)
-            .filter(isNonEmptyString);
-        },
-        buildSystemAuthContext(workspaceId),
-      );
+        return versions
+          .map((version) => version.coreWorkflowVersionId)
+          .filter(isNonEmptyString);
+      }, buildSystemAuthContext(workspaceId));
 
     await this.deleteFromCore(workspaceId, coreWorkflowVersionIds);
   }
@@ -363,9 +360,9 @@ export class WorkflowVersionCoreSyncService {
     workspaceId: string,
     workflowId: string,
   ): Promise<void> {
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -394,9 +391,9 @@ export class WorkflowVersionCoreSyncService {
       return;
     }
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceWorkflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
@@ -17,7 +17,7 @@ import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.g
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
@@ -35,7 +35,7 @@ import { SendInvitationsInput } from './dtos/send-invitations.input';
 @MetadataResolver()
 export class WorkspaceInvitationResolver {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workspaceInvitationService: WorkspaceInvitationService,
   ) {}
 
@@ -60,22 +60,19 @@ export class WorkspaceInvitationResolver {
     const authContext = buildSystemAuthContext(workspace.id);
 
     const workspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOneOrFail({
-            where: {
-              userId: user.id,
-            },
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOneOrFail({
+          where: {
+            userId: user.id,
+          },
+        });
+      }, authContext);
 
     return this.workspaceInvitationService.resendWorkspaceInvitation(
       appTokenId,
@@ -99,22 +96,19 @@ export class WorkspaceInvitationResolver {
     const authContext = buildSystemAuthContext(workspace.id);
 
     const workspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOneOrFail({
-            where: {
-              userId: user.id,
-            },
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOneOrFail({
+          where: {
+            userId: user.id,
+          },
+        });
+      }, authContext);
 
     return await this.workspaceInvitationService.sendInvitations({
       emails: sendInviteLinkInput.emails,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service.ts
@@ -19,7 +19,7 @@ import {
   PermissionsExceptionCode,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 export type UserContext = {
@@ -44,7 +44,7 @@ export class AgentActorContextService {
   constructor(
     private readonly userWorkspaceService: UserWorkspaceService,
     private readonly userRoleService: UserRoleService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async buildUserAndAgentActorContext(
@@ -64,22 +64,18 @@ export class AgentActorContextService {
     }
 
     const workspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
-
-          return workspaceMemberRepository.findOne({
-            where: {
-              userId: userWorkspace.userId,
-            },
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository('workspaceMember', {
+            shouldBypassPermissionChecks: true,
           });
-        },
-        authContext,
-      );
+
+        return workspaceMemberRepository.findOne({
+          where: {
+            userId: userWorkspace.userId,
+          },
+        });
+      }, authContext);
 
     if (!workspaceMember) {
       throw new AiException(

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/workspace-setup-chat.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/workspace-setup-chat.service.ts
@@ -23,7 +23,7 @@ import { buildWorkspaceSetupChatThreadId } from 'src/engine/metadata-modules/ai/
 import { buildWorkspaceSetupKickoffMessageText } from 'src/engine/metadata-modules/ai/ai-chat/utils/build-workspace-setup-kickoff-message-text.util';
 import { tagAiChatStreamScope } from 'src/engine/metadata-modules/ai/ai-chat/utils/tag-ai-chat-stream-scope.util';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 const WORKSPACE_SETUP_CHAT_THREAD_TITLE = msg`Workspace setup`;
@@ -53,7 +53,7 @@ export class WorkspaceSetupChatService {
     private readonly i18nService: I18nService,
     private readonly agentChatService: AgentChatService,
     private readonly agentChatStreamingService: AgentChatStreamingService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async startWorkspaceSetupChat({
@@ -268,18 +268,14 @@ export class WorkspaceSetupChatService {
   }): Promise<string | null> {
     try {
       const workspaceMember =
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const workspaceMemberRepository =
-              await this.globalWorkspaceOrmManager.getRepository(
-                'workspaceMember',
-                { shouldBypassPermissionChecks: true },
-              );
+        await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+          const workspaceMemberRepository =
+            await this.workspaceOrmManager.getRepository('workspaceMember', {
+              shouldBypassPermissionChecks: true,
+            });
 
-            return workspaceMemberRepository.findOne({ where: { userId } });
-          },
-          buildSystemAuthContext(workspaceId),
-        );
+          return workspaceMemberRepository.findOne({ where: { userId } });
+        }, buildSystemAuthContext(workspaceId));
 
       return workspaceMember?.locale ?? null;
     } catch (error) {

--- a/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-record-identifier.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-record-identifier.service.ts
@@ -11,7 +11,7 @@ import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadat
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { RecordIdentifierDTO } from 'src/engine/metadata-modules/navigation-menu-item/dtos/record-identifier.dto';
 import { getMinimalSelectForRecordIdentifier } from 'src/engine/metadata-modules/navigation-menu-item/utils/get-minimal-select-for-record-identifier.util';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
@@ -21,7 +21,7 @@ import { FileFolder } from 'twenty-shared/types';
 export class NavigationMenuItemRecordIdentifierService {
   constructor(
     private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly fileUrlService: FileUrlService,
     private readonly twentyConfigService: TwentyConfigService,
   ) {}
@@ -66,51 +66,50 @@ export class NavigationMenuItemRecordIdentifierService {
         workspace: { id: workspaceId },
       } as WorkspaceAuthContext);
 
-    const record =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const context = getWorkspaceContext();
-          const rolePermissionConfig = resolveRolePermissionConfig({
-            authContext: context.authContext,
-            userWorkspaceRoleMap: context.userWorkspaceRoleMap,
-            apiKeyRoleMap: context.apiKeyRoleMap,
-          });
+    const record = await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const context = getWorkspaceContext();
+        const rolePermissionConfig = resolveRolePermissionConfig({
+          authContext: context.authContext,
+          userWorkspaceRoleMap: context.userWorkspaceRoleMap,
+          apiKeyRoleMap: context.apiKeyRoleMap,
+        });
 
-          if (!rolePermissionConfig) {
-            return null;
-          }
+        if (!rolePermissionConfig) {
+          return null;
+        }
 
-          const repository = await this.globalWorkspaceOrmManager.getRepository(
-            objectMetadata.nameSingular,
-            rolePermissionConfig,
-          );
+        const repository = await this.workspaceOrmManager.getRepository(
+          objectMetadata.nameSingular,
+          rolePermissionConfig,
+        );
 
-          const alias = objectMetadata.nameSingular;
-          const queryBuilder = repository.createQueryBuilder(alias);
+        const alias = objectMetadata.nameSingular;
+        const queryBuilder = repository.createQueryBuilder(alias);
 
-          queryBuilder.select([]);
+        queryBuilder.select([]);
 
-          for (const column of minimalSelectColumns) {
-            queryBuilder.addSelect(`"${alias}"."${column}"`, column);
-          }
+        for (const column of minimalSelectColumns) {
+          queryBuilder.addSelect(`"${alias}"."${column}"`, column);
+        }
 
-          const rawResult = await queryBuilder
-            .where(`"${alias}".id = :id`, { id: targetRecordId })
-            .getRawOne();
+        const rawResult = await queryBuilder
+          .where(`"${alias}".id = :id`, { id: targetRecordId })
+          .getRawOne();
 
-          if (!isDefined(rawResult)) {
-            return null;
-          }
+        if (!isDefined(rawResult)) {
+          return null;
+        }
 
-          return formatResult<Record<string, unknown>>(
-            rawResult,
-            objectMetadata,
-            flatObjectMetadataMaps,
-            flatFieldMetadataMaps,
-          );
-        },
-        resolvedAuthContext,
-      );
+        return formatResult<Record<string, unknown>>(
+          rawResult,
+          objectMetadata,
+          flatObjectMetadataMaps,
+          flatFieldMetadataMaps,
+        );
+      },
+      resolvedAuthContext,
+    );
 
     if (!isDefined(record)) {
       return null;

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout/services/page-layout.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout/services/page-layout.service.ts
@@ -36,7 +36,7 @@ import { fromFlatPageLayoutWithTabsAndWidgetsToPageLayoutDto } from 'src/engine/
 import { type MetadataCursorPage } from 'src/engine/metadata-modules/pagination/types/metadata-cursor-page.type';
 import { type MetadataCursorPagination } from 'src/engine/metadata-modules/pagination/types/metadata-cursor-pagination.type';
 import { paginateMetadataOrderedItems } from 'src/engine/metadata-modules/pagination/utils/paginate-metadata-ordered-items.util';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceMigrationBuilderException } from 'src/engine/workspace-manager/workspace-migration/exceptions/workspace-migration-builder-exception';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
@@ -45,7 +45,7 @@ import { DashboardSyncService } from 'src/modules/dashboard-sync/services/dashbo
 @Injectable()
 export class PageLayoutService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
     private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
     private readonly applicationService: ApplicationService,
@@ -561,11 +561,13 @@ export class PageLayoutService {
   }): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      const dashboardRepository =
-        await this.globalWorkspaceOrmManager.getRepository('dashboard', {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const dashboardRepository = await this.workspaceOrmManager.getRepository(
+        'dashboard',
+        {
           shouldBypassPermissionChecks: true,
-        });
+        },
+      );
 
       const dashboards = await dashboardRepository.find({
         where: {

--- a/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
@@ -14,7 +14,7 @@ import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-t
 import { RoleTargetService } from 'src/engine/metadata-modules/role-target/services/role-target.service';
 import { RoleValidationService } from 'src/engine/metadata-modules/role-validation/services/role-validation.service';
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
@@ -28,7 +28,7 @@ export class UserRoleService {
     private readonly roleTargetRepository: WorkspaceScopedRepository<RoleTargetEntity>,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly roleTargetService: RoleTargetService,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly roleValidationService: RoleValidationService,
@@ -223,24 +223,21 @@ export class UserRoleService {
         userWorkspaces.map((userWorkspace) => userWorkspace.userId),
       );
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const workspaceMembers = await workspaceMemberRepository.find({
-          where: {
-            userId: In(userIds),
-          },
-        });
+      const workspaceMembers = await workspaceMemberRepository.find({
+        where: {
+          userId: In(userIds),
+        },
+      });
 
-        return workspaceMembers;
-      },
-      authContext,
-    );
+      return workspaceMembers;
+    }, authContext);
   }
 
   private validateNotSelfAssignmentOrThrow({
@@ -273,31 +270,28 @@ export class UserRoleService {
   }): Promise<WorkspaceMemberWorkspaceEntity> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const workspaceMember = await workspaceMemberRepository.findOne({
-          where: {
-            id: workspaceMemberId,
-          },
-        });
+      const workspaceMember = await workspaceMemberRepository.findOne({
+        where: {
+          id: workspaceMemberId,
+        },
+      });
 
-        if (!isDefined(workspaceMember)) {
-          throw new PermissionsException(
-            'Workspace member not found',
-            PermissionsExceptionCode.WORKSPACE_MEMBER_NOT_FOUND,
-          );
-        }
+      if (!isDefined(workspaceMember)) {
+        throw new PermissionsException(
+          'Workspace member not found',
+          PermissionsExceptionCode.WORKSPACE_MEMBER_NOT_FOUND,
+        );
+      }
 
-        return workspaceMember;
-      },
-      authContext,
-    );
+      return workspaceMember;
+    }, authContext);
   }
 
   public async getUserWorkspaceIdsAssignedToRole(

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
@@ -22,7 +22,7 @@ import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-m
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { DEFAULT_TIMEZONE } from 'src/engine/metadata-modules/view/constants/default-timezone.constant';
 import { ViewService } from 'src/engine/metadata-modules/view/services/view.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 export type ViewQueryParams = {
@@ -38,7 +38,7 @@ export class ViewQueryParamsService {
   constructor(
     private readonly viewService: ViewService,
     private readonly flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async resolveViewToQueryParams(
@@ -151,7 +151,7 @@ export class ViewQueryParamsService {
 
     try {
       const workspaceMemberRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/object-metadata-repository/object-metadata-repository.module.ts
+++ b/packages/twenty-server/src/engine/object-metadata-repository/object-metadata-repository.module.ts
@@ -8,7 +8,7 @@ import {
 import { capitalize } from 'twenty-shared/utils';
 
 import { metadataToRepositoryMapping } from 'src/engine/object-metadata-repository/metadata-to-repository.mapping';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { convertClassNameToObjectMetadataName } from 'src/engine/workspace-manager/utils/convert-class-to-object-metadata-name.util';
 
@@ -30,10 +30,10 @@ export class ObjectMetadataRepositoryModule {
         provide: `${capitalize(
           convertClassNameToObjectMetadataName(objectMetadata.name),
         )}Repository`,
-        useFactory: (globalWorkspaceOrmManager: GlobalWorkspaceOrmManager) => {
-          return new repositoryClass(globalWorkspaceOrmManager);
+        useFactory: (workspaceOrmManager: WorkspaceOrmManager) => {
+          return new repositoryClass(workspaceOrmManager);
         },
-        inject: [GlobalWorkspaceOrmManager],
+        inject: [WorkspaceOrmManager],
       };
     });
 

--- a/packages/twenty-server/src/engine/trash-cleanup/services/trash-cleanup.service.ts
+++ b/packages/twenty-server/src/engine/trash-cleanup/services/trash-cleanup.service.ts
@@ -6,7 +6,7 @@ import { In, LessThan } from 'typeorm';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { TRASH_CLEANUP_BATCH_SIZE } from 'src/engine/trash-cleanup/constants/trash-cleanup-batch-size.constant';
 import { TRASH_CLEANUP_MAX_RECORDS_PER_WORKSPACE } from 'src/engine/trash-cleanup/constants/trash-cleanup-max-records-per-workspace.constant';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 export type TrashCleanupInput = {
@@ -23,7 +23,7 @@ export class TrashCleanupService {
 
   constructor(
     private readonly flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async cleanupWorkspaceTrash(input: TrashCleanupInput): Promise<number> {
@@ -101,43 +101,40 @@ export class TrashCleanupService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const repository = await this.globalWorkspaceOrmManager.getRepository(
-          objectName,
-          { shouldBypassPermissionChecks: true },
-        );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const repository = await this.workspaceOrmManager.getRepository(
+        objectName,
+        { shouldBypassPermissionChecks: true },
+      );
 
-        let deleted = 0;
+      let deleted = 0;
 
-        while (deleted < remainingQuota) {
-          const take = Math.min(this.batchSize, remainingQuota - deleted);
+      while (deleted < remainingQuota) {
+        const take = Math.min(this.batchSize, remainingQuota - deleted);
 
-          const recordsToDelete = await repository.find({
-            withDeleted: true,
-            select: ['id'],
-            where: {
-              deletedAt: LessThan(cutoffDate),
-            },
-            order: { deletedAt: 'ASC' },
-            take,
-          });
+        const recordsToDelete = await repository.find({
+          withDeleted: true,
+          select: ['id'],
+          where: {
+            deletedAt: LessThan(cutoffDate),
+          },
+          order: { deletedAt: 'ASC' },
+          take,
+        });
 
-          if (recordsToDelete.length === 0) {
-            break;
-          }
-
-          await repository.delete({
-            id: In(recordsToDelete.map((record) => record.id)),
-          });
-
-          deleted += recordsToDelete.length;
+        if (recordsToDelete.length === 0) {
+          break;
         }
 
-        return deleted;
-      },
-      authContext,
-    );
+        await repository.delete({
+          id: In(recordsToDelete.map((record) => record.id)),
+        });
+
+        deleted += recordsToDelete.length;
+      }
+
+      return deleted;
+    }, authContext);
   }
 
   private calculateCutoffDate(trashRetentionDays: number): Date {

--- a/packages/twenty-server/src/engine/twenty-orm/twenty-orm.module.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/twenty-orm.module.ts
@@ -10,7 +10,7 @@ import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { WorkspaceFeatureFlagsMapCacheModule } from 'src/engine/metadata-modules/workspace-feature-flags-map-cache/workspace-feature-flags-map-cache.module';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { WorkspaceORMEntityMetadatasCacheService } from 'src/engine/twenty-orm/workspace-orm-entity-metadatas-cache.service';
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 import { WorkspaceDataSourceService } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
@@ -37,11 +37,11 @@ import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/
     WorkspaceCacheModule,
   ],
   providers: [
-    GlobalWorkspaceOrmManager,
+    WorkspaceOrmManager,
     WorkspaceDataSourceService,
     WorkspaceORMEntityMetadatasCacheService,
     provideWorkspaceScopedRepository(FeatureFlagEntity),
   ],
-  exports: [GlobalWorkspaceOrmManager, WorkspaceDataSourceService],
+  exports: [WorkspaceOrmManager, WorkspaceDataSourceService],
 })
-export class GlobalWorkspaceDataSourceModule {}
+export class TwentyOrmModule {}

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-orm.manager.ts
@@ -20,7 +20,7 @@ import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/works
 import { convertClassNameToObjectMetadataName } from 'src/engine/workspace-manager/utils/convert-class-to-object-metadata-name.util';
 
 @Injectable()
-export class GlobalWorkspaceOrmManager {
+export class WorkspaceOrmManager {
   constructor(
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/services/twenty-standard-application.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/services/twenty-standard-application.service.ts
@@ -4,7 +4,7 @@ import { ApplicationService } from 'src/engine/core-modules/application/applicat
 import { MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
 import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
 import { getSubFlatEntityMapsByApplicationIdsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/get-sub-flat-entity-maps-by-application-ids-or-throw.util';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { TWENTY_STANDARD_ALL_METADATA_NAME } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-all-metadata-name.constant';
 import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
@@ -19,7 +19,7 @@ export class TwentyStandardApplicationService {
     private readonly applicationService: ApplicationService,
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
     private readonly workspaceCacheService: WorkspaceCacheService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async synchronizeTwentyStandardApplicationOrThrow({

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/twenty-standard-application.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/twenty-standard-application.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { TwentyConfigModule } from 'src/engine/core-modules/twenty-config/twenty-config.module';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
-import { GlobalWorkspaceDataSourceModule } from 'src/engine/twenty-orm/global-workspace-datasource.module';
+import { TwentyOrmModule } from 'src/engine/twenty-orm/twenty-orm.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
 
@@ -16,7 +16,7 @@ import { TwentyStandardApplicationService } from './services/twenty-standard-app
     TwentyConfigModule,
     WorkspaceCacheModule,
     WorkspaceMigrationModule,
-    GlobalWorkspaceDataSourceModule,
+    TwentyOrmModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
   ],
   exports: [TwentyStandardApplicationService],

--- a/packages/twenty-server/src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
+++ b/packages/twenty-server/src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
@@ -14,7 +14,7 @@ import {
   CommonQueryRunnerExceptionCode,
 } from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { isDomain } from 'src/engine/utils/is-domain';
 import { BlocklistRepository } from 'src/modules/blocklist/repositories/blocklist.repository';
@@ -35,7 +35,7 @@ export class BlocklistValidationService {
   constructor(
     @InjectObjectMetadataRepository(BlocklistWorkspaceEntity)
     private readonly blocklistRepository: BlocklistRepository,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   public async validateBlocklistForCreateMany(
@@ -101,20 +101,17 @@ export class BlocklistValidationService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     const currentWorkspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository(
-              WorkspaceMemberWorkspaceEntity,
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository(
+            WorkspaceMemberWorkspaceEntity,
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOneByOrFail({
-            userId,
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOneByOrFail({
+          userId,
+        });
+      }, authContext);
 
     if (
       payload.data.some(
@@ -186,20 +183,17 @@ export class BlocklistValidationService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     const currentWorkspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository(
-              WorkspaceMemberWorkspaceEntity,
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository(
+            WorkspaceMemberWorkspaceEntity,
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOneByOrFail({
-            userId,
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOneByOrFail({
+          userId,
+        });
+      }, authContext);
 
     const currentBlocklist =
       await this.blocklistRepository.getByWorkspaceMemberId(

--- a/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
+++ b/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
@@ -1,14 +1,12 @@
 import { Injectable } from '@nestjs/common';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { BlocklistWorkspaceEntity } from 'src/modules/blocklist/standard-objects/blocklist.workspace-entity';
 
 @Injectable()
 export class BlocklistRepository {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   public async getById(
     id: string,
@@ -16,22 +14,18 @@ export class BlocklistRepository {
   ): Promise<BlocklistWorkspaceEntity | null> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const blockListRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            BlocklistWorkspaceEntity,
-            {
-              shouldBypassPermissionChecks: true,
-            },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const blockListRepository = await this.workspaceOrmManager.getRepository(
+        BlocklistWorkspaceEntity,
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        return blockListRepository.findOneBy({
-          id,
-        });
-      },
-      authContext,
-    );
+      return blockListRepository.findOneBy({
+        id,
+      });
+    }, authContext);
   }
 
   public async getByWorkspaceMemberId(
@@ -40,20 +34,16 @@ export class BlocklistRepository {
   ): Promise<BlocklistWorkspaceEntity[]> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const blockListRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            BlocklistWorkspaceEntity,
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const blockListRepository = await this.workspaceOrmManager.getRepository(
+        BlocklistWorkspaceEntity,
+      );
 
-        return blockListRepository.find({
-          where: {
-            workspaceMemberId,
-          },
-        });
-      },
-      authContext,
-    );
+      return blockListRepository.find({
+        where: {
+          workspaceMemberId,
+        },
+      });
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/calendar/blocklist-manager/jobs/blocklist-reimport-calendar-events.job.ts
+++ b/packages/twenty-server/src/modules/calendar/blocklist-manager/jobs/blocklist-reimport-calendar-events.job.ts
@@ -9,7 +9,7 @@ import { Processor } from 'src/engine/core-modules/message-queue/decorators/proc
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import { type BlocklistWorkspaceEntity } from 'src/modules/blocklist/standard-objects/blocklist.workspace-entity';
@@ -27,7 +27,7 @@ export type BlocklistReimportCalendarEventsJobData = WorkspaceEventBatch<
 })
 export class BlocklistReimportCalendarEventsJob {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(CalendarChannelEntity)
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
     @InjectRepository(UserWorkspaceEntity)
@@ -41,13 +41,12 @@ export class BlocklistReimportCalendarEventsJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+          await this.workspaceOrmManager.getRepository('workspaceMember', {
+            shouldBypassPermissionChecks: true,
+          });
 
         for (const eventPayload of data.events) {
           const workspaceMemberId =

--- a/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
@@ -3,7 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { isDefined } from 'twenty-shared/utils';
 import { In, MoreThan } from 'typeorm';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type CalendarChannelEventAssociationWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel-event-association.workspace-entity';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
@@ -14,9 +14,7 @@ const CALENDAR_CLEANUP_PAGE_SIZE = 500;
 export class CalendarEventCleanerService {
   private readonly logger = new Logger(CalendarEventCleanerService.name);
 
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async deleteCalendarChannelEventAssociationsByChannelId({
     workspaceId,
@@ -27,9 +25,9 @@ export class CalendarEventCleanerService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+        await this.workspaceOrmManager.runInWorkspaceTransaction(
           async (transactionScope) => {
             const calendarChannelEventAssociationRepository =
               transactionScope.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
@@ -67,9 +65,9 @@ export class CalendarEventCleanerService {
   public async cleanWorkspaceCalendarEvents(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+        await this.workspaceOrmManager.runInWorkspaceTransaction(
           async (transactionScope) => {
             const calendarEventRepository =
               transactionScope.getRepository<CalendarEventWorkspaceEntity>(

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/commands/calendar-trigger-event-list-fetch.command.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/commands/calendar-trigger-event-list-fetch.command.ts
@@ -9,7 +9,7 @@ import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decora
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   CalendarEventListFetchJob,
@@ -32,7 +32,7 @@ export class CalendarTriggerEventListFetchCommand extends CommandRunner {
   );
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(CalendarChannelEntity)
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
     @InjectMessageQueue(MessageQueue.calendarQueue)
@@ -53,7 +53,7 @@ export class CalendarTriggerEventListFetchCommand extends CommandRunner {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarChannels = await this.calendarChannelRepository.find({
           where: {

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-event-list-fetch.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-event-list-fetch.job.ts
@@ -7,7 +7,7 @@ import { CalendarChannelSyncStage } from 'twenty-shared/types';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CalendarFetchEventsService } from 'src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
@@ -23,7 +23,7 @@ export type CalendarEventListFetchJobData = {
 })
 export class CalendarEventListFetchJob {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(CalendarChannelEntity)
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
     private readonly calendarFetchEventsService: CalendarFetchEventsService,
@@ -35,7 +35,7 @@ export class CalendarEventListFetchJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarChannel = await this.calendarChannelRepository.findOne({
           where: {

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job.ts
@@ -7,7 +7,7 @@ import { CalendarChannelSyncStage } from 'twenty-shared/types';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CalendarEventsImportService } from 'src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
@@ -24,7 +24,7 @@ export type CalendarEventsImportJobData = {
 export class CalendarEventsImportJob {
   constructor(
     private readonly calendarEventsImportService: CalendarEventsImportService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(CalendarChannelEntity)
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
   ) {}
@@ -35,7 +35,7 @@ export class CalendarEventsImportJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarChannel = await this.calendarChannelRepository.findOne({
           where: {

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job.ts
@@ -8,7 +8,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CALENDAR_ONGOING_STALE_SYNC_STAGES } from 'src/modules/calendar/calendar-event-import-manager/constants/calendar-ongoing-stale-sync-stages.constant';
 import { isSyncStale } from 'src/modules/calendar/calendar-event-import-manager/utils/is-sync-stale.util';
@@ -25,7 +25,7 @@ export type CalendarOngoingStaleJobData = {
 export class CalendarOngoingStaleJob {
   private readonly logger = new Logger(CalendarOngoingStaleJob.name);
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(CalendarChannelEntity)
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
     private readonly calendarChannelSyncStatusService: CalendarChannelSyncStatusService,
@@ -37,7 +37,7 @@ export class CalendarOngoingStaleJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarChannels = await this.calendarChannelRepository.find({
           where: {

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-relaunch-failed-calendar-channel.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-relaunch-failed-calendar-channel.job.ts
@@ -11,7 +11,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 export type CalendarRelaunchFailedCalendarChannelJobData = {
@@ -25,7 +25,7 @@ export type CalendarRelaunchFailedCalendarChannelJobData = {
 })
 export class CalendarRelaunchFailedCalendarChannelJob {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(CalendarChannelEntity)
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
   ) {}
@@ -36,7 +36,7 @@ export class CalendarRelaunchFailedCalendarChannelJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarChannel = await this.calendarChannelRepository.findOne({
           where: {

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
@@ -11,7 +11,7 @@ import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user
 import { type CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { BlocklistRepository } from 'src/modules/blocklist/repositories/blocklist.repository';
 import { BlocklistWorkspaceEntity } from 'src/modules/blocklist/standard-objects/blocklist.workspace-entity';
@@ -38,7 +38,7 @@ export class CalendarEventsImportService {
   constructor(
     @InjectCacheStorage(CacheStorageNamespace.ModuleCalendar)
     private readonly cacheStorage: CacheStorageService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectObjectMetadataRepository(BlocklistWorkspaceEntity)
     private readonly blocklistRepository: BlocklistRepository,
     private readonly calendarEventCleanerService: CalendarEventCleanerService,
@@ -63,7 +63,7 @@ export class CalendarEventsImportService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         try {
           const eventIdsToFetch: string[] = await this.cacheStorage.setPop(
@@ -94,7 +94,7 @@ export class CalendarEventsImportService {
           });
 
           const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );
@@ -154,7 +154,7 @@ export class CalendarEventsImportService {
             );
           }
           const calendarChannelEventAssociationRepository =
-            await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+            await this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
               'calendarChannelEventAssociation',
             );
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -6,7 +6,7 @@ import { Any, Repository } from 'typeorm';
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CalendarEventCleanerService } from 'src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service';
 import {
@@ -25,7 +25,7 @@ export class CalendarFetchEventsService {
   constructor(
     @InjectCacheStorage(CacheStorageNamespace.ModuleCalendar)
     private readonly cacheStorage: CacheStorageService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(CalendarChannelEntity)
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
     private readonly calendarChannelSyncStatusService: CalendarChannelSyncStatusService,
@@ -50,7 +50,7 @@ export class CalendarFetchEventsService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         try {
           const { calendarEventIds, calendarEventIdsToDelete, nextSyncCursor } =
@@ -61,7 +61,7 @@ export class CalendarFetchEventsService {
 
           if (calendarEventIdsToDelete.length > 0) {
             const calendarChannelEventAssociationRepository =
-              await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+              await this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
                 'calendarChannelEventAssociation',
               );
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
@@ -4,7 +4,7 @@ import { Any } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { type CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CalendarEventParticipantService } from 'src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service';
 import { type CalendarChannelEventAssociationWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel-event-association.workspace-entity';
@@ -21,7 +21,7 @@ type FetchedCalendarEventWithDBEvent = {
 @Injectable()
 export class CalendarSaveEventsService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly calendarEventParticipantService: CalendarEventParticipantService,
   ) {}
 
@@ -33,9 +33,9 @@ export class CalendarSaveEventsService {
   ): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+        await this.workspaceOrmManager.runInWorkspaceTransaction(
           async (transactionScope) => {
             const calendarEventRepository =
               transactionScope.getRepository<CalendarEventWorkspaceEntity>(

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
@@ -11,7 +11,7 @@ import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decora
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type CalendarEventParticipantWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event-participant.workspace-entity';
 import { type FetchedCalendarEventParticipant } from 'src/modules/calendar/common/types/fetched-calendar-event';
@@ -35,7 +35,7 @@ type FetchedCalendarEventParticipantWithCalendarEventIdAndExistingId =
 @Injectable()
 export class CalendarEventParticipantService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly matchParticipantService: MatchParticipantService<CalendarEventParticipantWorkspaceEntity>,
     @InjectMessageQueue(MessageQueue.contactCreationQueue)
     private readonly messageQueueService: MessageQueueService,
@@ -58,7 +58,7 @@ export class CalendarEventParticipantService {
   }): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const chunkedParticipantsToUpdate = chunk(participantsToUpdate, 200);
 

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -10,7 +10,7 @@ import { In, Repository } from 'typeorm';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type CalendarChannelEventAssociationWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel-event-association.workspace-entity';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
@@ -18,7 +18,7 @@ import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/s
 @Injectable()
 export class ApplyCalendarEventsVisibilityRestrictionsService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectRepository(UserWorkspaceEntity)
@@ -34,10 +34,10 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarChannelEventAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
             'calendarChannelEventAssociation',
           );
 

--- a/packages/twenty-server/src/modules/calendar/common/services/calendar-channel-sync-status.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/services/calendar-channel-sync-status.service.ts
@@ -15,7 +15,7 @@ import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
 import { AccountsToReconnectKeys } from 'src/modules/connected-account/types/accounts-to-reconnect-key-value.type';
@@ -24,7 +24,7 @@ export class CalendarChannelSyncStatusService {
   private readonly logger = new Logger(CalendarChannelSyncStatusService.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectCacheStorage(CacheStorageNamespace.ModuleCalendar)
     private readonly cacheStorage: CacheStorageService,
     @InjectRepository(CalendarChannelEntity)
@@ -48,7 +48,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },
@@ -76,7 +76,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },
@@ -109,7 +109,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },
@@ -140,7 +140,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },
@@ -165,7 +165,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },
@@ -192,7 +192,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },
@@ -218,7 +218,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },
@@ -267,7 +267,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },
@@ -307,7 +307,7 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.calendarChannelRepository.update(
           { id: In(calendarChannelIds), workspaceId },

--- a/packages/twenty-server/src/modules/connected-account/channel-sync/services/channel-sync.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/channel-sync/services/channel-sync.service.ts
@@ -16,7 +16,7 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   CalendarEventListFetchJob,
@@ -42,7 +42,7 @@ export class ChannelSyncService {
   private readonly logger = new Logger(ChannelSyncService.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectMessageQueue(MessageQueue.messagingQueue)
     private readonly messageQueueService: MessageQueueService,
     @InjectMessageQueue(MessageQueue.calendarQueue)
@@ -70,7 +70,7 @@ export class ChannelSyncService {
   ): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageChannels = await this.messageChannelRepository.find({
         where: {
           connectedAccountId,
@@ -127,7 +127,7 @@ export class ChannelSyncService {
   ): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const calendarChannels = await this.calendarChannelRepository.find({
         where: {
           connectedAccountId,

--- a/packages/twenty-server/src/modules/connected-account/email-alias-manager/services/email-alias-manager.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/email-alias-manager/services/email-alias-manager.service.ts
@@ -7,7 +7,7 @@ import { Repository } from 'typeorm';
 
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { GoogleEmailAliasManagerService } from 'src/modules/connected-account/email-alias-manager/drivers/google/services/google-email-alias-manager.service';
 import { MicrosoftEmailAliasManagerService } from 'src/modules/connected-account/email-alias-manager/drivers/microsoft/services/microsoft-email-alias-manager.service';
@@ -17,7 +17,7 @@ export class EmailAliasManagerService {
   constructor(
     private readonly googleEmailAliasManagerService: GoogleEmailAliasManagerService,
     private readonly microsoftEmailAliasManagerService: MicrosoftEmailAliasManagerService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectRepository(MessageChannelEntity)
@@ -41,7 +41,7 @@ export class EmailAliasManagerService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       await this.connectedAccountRepository.update(
         { id: connectedAccount.id, workspaceId },
         {

--- a/packages/twenty-server/src/modules/connected-account/listeners/connected-account.listener.ts
+++ b/packages/twenty-server/src/modules/connected-account/listeners/connected-account.listener.ts
@@ -8,7 +8,7 @@ import { OnCustomBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { CONNECTED_ACCOUNT_DELETED_EVENT } from 'src/engine/metadata-modules/connected-account/constants/connected-account-deleted.constant';
 import { type ConnectedAccountDeletedEvent } from 'src/engine/metadata-modules/connected-account/types/connected-account-deleted.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CustomWorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/custom-workspace-batch-event.type';
 import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
@@ -16,7 +16,7 @@ import { AccountsToReconnectService } from 'src/modules/connected-account/servic
 @Injectable()
 export class ConnectedAccountListener {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly accountsToReconnectService: AccountsToReconnectService,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
@@ -34,7 +34,7 @@ export class ConnectedAccountListener {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       for (const event of batchEvent.events) {
         const userWorkspace = await this.userWorkspaceRepository.findOne({
           where: { id: event.userWorkspaceId },

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
@@ -21,7 +21,7 @@ import {
   TwentyORMException,
   TwentyORMExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CONTACTS_CREATION_BATCH_SIZE } from 'src/modules/contact-creation-manager/constants/contacts-creation-batch-size.constant';
 import { CreateCompanyService } from 'src/modules/contact-creation-manager/services/create-company.service';
@@ -48,7 +48,7 @@ export class CreateCompanyAndPersonService {
   constructor(
     private readonly createPersonService: CreatePersonService,
     private readonly createCompaniesService: CreateCompanyService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly exceptionHandlerService: ExceptionHandlerService,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
@@ -69,113 +69,109 @@ export class CreateCompanyAndPersonService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const personRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            PersonWorkspaceEntity,
-            {
-              shouldBypassPermissionChecks: true,
-            },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const personRepository = await this.workspaceOrmManager.getRepository(
+        PersonWorkspaceEntity,
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            WorkspaceMemberWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workspaceMembers = await workspaceMemberRepository.find();
-
-        const workspace = await this.workspaceRepository.findOne({
-          where: { id: workspaceId },
-          select: ['id', 'isInternalMessagesImportEnabled'],
-        });
-
-        const peopleToCreateFromOtherCompanies =
-          filterOutContactsThatBelongToSelfOrWorkspaceMembers(
-            contactsToCreate,
-            connectedAccount,
-            workspaceMembers,
-            workspace?.isInternalMessagesImportEnabled ?? false,
-          );
-
-        const { uniqueContacts, uniqueHandles } = getUniqueContactsAndHandles(
-          peopleToCreateFromOtherCompanies,
+      const workspaceMemberRepository =
+        await this.workspaceOrmManager.getRepository(
+          WorkspaceMemberWorkspaceEntity,
+          { shouldBypassPermissionChecks: true },
         );
 
-        if (uniqueHandles.length === 0) {
-          return [];
-        }
+      const workspaceMembers = await workspaceMemberRepository.find();
 
-        const queryBuilder = addPersonEmailFiltersToQueryBuilder({
-          queryBuilder: personRepository.createQueryBuilder('person'),
-          emails: uniqueHandles,
-        });
+      const workspace = await this.workspaceRepository.findOne({
+        where: { id: workspaceId },
+        select: ['id', 'isInternalMessagesImportEnabled'],
+      });
 
-        const alreadyCreatedPeople = await queryBuilder
-          .orderBy('person.createdAt', 'ASC')
-          .withDeleted()
-          .getMany<PersonWorkspaceEntity>();
+      const peopleToCreateFromOtherCompanies =
+        filterOutContactsThatBelongToSelfOrWorkspaceMembers(
+          contactsToCreate,
+          connectedAccount,
+          workspaceMembers,
+          workspace?.isInternalMessagesImportEnabled ?? false,
+        );
 
-        const {
-          contactsThatNeedPersonCreate,
-          contactsThatNeedPersonRestore,
-          peopleToEnrichNames,
+      const { uniqueContacts, uniqueHandles } = getUniqueContactsAndHandles(
+        peopleToCreateFromOtherCompanies,
+      );
+
+      if (uniqueHandles.length === 0) {
+        return [];
+      }
+
+      const queryBuilder = addPersonEmailFiltersToQueryBuilder({
+        queryBuilder: personRepository.createQueryBuilder('person'),
+        emails: uniqueHandles,
+      });
+
+      const alreadyCreatedPeople = await queryBuilder
+        .orderBy('person.createdAt', 'ASC')
+        .withDeleted()
+        .getMany<PersonWorkspaceEntity>();
+
+      const {
+        contactsThatNeedPersonCreate,
+        contactsThatNeedPersonRestore,
+        peopleToEnrichNames,
+        workDomainNamesToCreate,
+        shouldCreateOrRestorePeopleByHandleMap,
+      } =
+        this.computeContactsThatNeedPersonCreateAndRestoreAndWorkDomainNamesToCreate(
+          uniqueContacts,
+          alreadyCreatedPeople,
+          source,
+          connectedAccount,
+          accountOwner,
+        );
+
+      const companiesMap =
+        await this.createCompaniesService.createOrRestoreCompanies(
           workDomainNamesToCreate,
-          shouldCreateOrRestorePeopleByHandleMap,
-        } =
-          this.computeContactsThatNeedPersonCreateAndRestoreAndWorkDomainNamesToCreate(
-            uniqueContacts,
-            alreadyCreatedPeople,
-            source,
-            connectedAccount,
-            accountOwner,
-          );
+          workspaceId,
+        );
 
-        const companiesMap =
-          await this.createCompaniesService.createOrRestoreCompanies(
-            workDomainNamesToCreate,
-            workspaceId,
-          );
-
-        const peopleToCreate = this.formatPeopleToCreateFromContacts({
-          contactsToCreate: contactsThatNeedPersonCreate,
-          createdBy: {
-            source: source,
-            workspaceMember: accountOwner,
-            context: {
-              provider: connectedAccount.provider,
-            },
+      const peopleToCreate = this.formatPeopleToCreateFromContacts({
+        contactsToCreate: contactsThatNeedPersonCreate,
+        createdBy: {
+          source: source,
+          workspaceMember: accountOwner,
+          context: {
+            provider: connectedAccount.provider,
           },
-          companiesMap,
-        });
+        },
+        companiesMap,
+      });
 
-        const createdPeople = await this.createPersonService.createPeople(
-          peopleToCreate,
-          workspaceId,
-        );
+      const createdPeople = await this.createPersonService.createPeople(
+        peopleToCreate,
+        workspaceId,
+      );
 
-        const peopleToRestore = this.formatPeopleToRestoreFromContacts({
-          contactsToRestore: contactsThatNeedPersonRestore,
-          companiesMap,
-          shouldCreateOrRestorePeopleByHandleMap,
-        });
+      const peopleToRestore = this.formatPeopleToRestoreFromContacts({
+        contactsToRestore: contactsThatNeedPersonRestore,
+        companiesMap,
+        shouldCreateOrRestorePeopleByHandleMap,
+      });
 
-        const restoredPeople = await this.createPersonService.restorePeople(
-          peopleToRestore,
-          workspaceId,
-        );
+      const restoredPeople = await this.createPersonService.restorePeople(
+        peopleToRestore,
+        workspaceId,
+      );
 
-        await this.createPersonService.enrichPeopleNames(
-          peopleToEnrichNames,
-          workspaceId,
-        );
+      await this.createPersonService.enrichPeopleNames(
+        peopleToEnrichNames,
+        workspaceId,
+      );
 
-        return { ...createdPeople, ...restoredPeople };
-      },
-      authContext,
-    );
+      return { ...createdPeople, ...restoredPeople };
+    }, authContext);
   }
 
   async createCompaniesAndPeopleAndUpdateParticipants(
@@ -204,20 +200,17 @@ export class CreateCompanyAndPersonService {
     }
 
     const accountOwner =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository(
-              WorkspaceMemberWorkspaceEntity,
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository(
+            WorkspaceMemberWorkspaceEntity,
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOne({
-            where: { userId: userWorkspace.userId },
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOne({
+          where: { userId: userWorkspace.userId },
+        });
+      }, authContext);
 
     for (const contactsBatch of contactsBatches) {
       try {

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -11,7 +11,7 @@ import { isDefined, normalizeUrlOrigin } from 'twenty-shared/utils';
 import { type DeepPartial, ILike } from 'typeorm';
 
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CompanyWorkspaceEntity } from 'src/modules/company/standard-objects/company.workspace-entity';
@@ -34,7 +34,7 @@ export class CreateCompanyService {
   private readonly httpService: AxiosInstance;
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly secureHttpClientService: SecureHttpClientService,
   ) {
     this.httpService = this.secureHttpClientService.getHttpClient({
@@ -54,106 +54,102 @@ export class CreateCompanyService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const companyRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            CompanyWorkspaceEntity,
-            {
-              shouldBypassPermissionChecks: true,
-            },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const companyRepository = await this.workspaceOrmManager.getRepository(
+        CompanyWorkspaceEntity,
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        const companiesWithoutTrailingSlash = companies.map((company) => ({
-          ...company,
-          domainName: company.domainName
-            ? normalizeUrlOrigin(company.domainName)
-            : undefined,
-        }));
+      const companiesWithoutTrailingSlash = companies.map((company) => ({
+        ...company,
+        domainName: company.domainName
+          ? normalizeUrlOrigin(company.domainName)
+          : undefined,
+      }));
 
-        const uniqueCompanies = uniqBy(
-          companiesWithoutTrailingSlash,
-          'domainName',
-        );
-        const conditions = uniqueCompanies.map((companyToCreate) => ({
-          domainName: {
-            primaryLinkUrl: ILike(`%${companyToCreate.domainName}%`),
-          },
-        }));
+      const uniqueCompanies = uniqBy(
+        companiesWithoutTrailingSlash,
+        'domainName',
+      );
+      const conditions = uniqueCompanies.map((companyToCreate) => ({
+        domainName: {
+          primaryLinkUrl: ILike(`%${companyToCreate.domainName}%`),
+        },
+      }));
 
-        const existingCompanies = await companyRepository.find({
-          where: conditions,
-          withDeleted: true,
-        });
-        const existingCompanyIdsMap = this.createCompanyMap(existingCompanies);
+      const existingCompanies = await companyRepository.find({
+        where: conditions,
+        withDeleted: true,
+      });
+      const existingCompanyIdsMap = this.createCompanyMap(existingCompanies);
 
-        const newCompaniesToCreate = uniqueCompanies.filter(
-          (company) =>
-            !existingCompanies.some(
-              (existingCompany) =>
-                existingCompany.domainName &&
-                extractDomainFromLink(
-                  existingCompany.domainName.primaryLinkUrl,
-                ) === company.domainName,
-            ),
-        );
-
-        const companiesToRestore = this.filterCompaniesToRestore(
-          uniqueCompanies,
-          existingCompanies,
-        );
-
-        if (
-          newCompaniesToCreate.length === 0 &&
-          companiesToRestore.length === 0
-        ) {
-          return existingCompanyIdsMap;
-        }
-
-        let lastCompanyPosition =
-          await this.getLastCompanyPosition(companyRepository);
-        const newCompaniesData = await Promise.all(
-          newCompaniesToCreate.map((company) =>
-            this.prepareCompanyData(company, ++lastCompanyPosition),
+      const newCompaniesToCreate = uniqueCompanies.filter(
+        (company) =>
+          !existingCompanies.some(
+            (existingCompany) =>
+              existingCompany.domainName &&
+              extractDomainFromLink(
+                existingCompany.domainName.primaryLinkUrl,
+              ) === company.domainName,
           ),
-        );
+      );
 
-        const createdCompanies = await companyRepository.save(newCompaniesData);
+      const companiesToRestore = this.filterCompaniesToRestore(
+        uniqueCompanies,
+        existingCompanies,
+      );
 
-        const restoredCompanies = await companyRepository.updateMany(
-          companiesToRestore.map((company) => {
-            return {
-              criteria: company.id,
-              partialEntity: {
-                deletedAt: null,
-              },
-            };
-          }),
-        );
+      if (
+        newCompaniesToCreate.length === 0 &&
+        companiesToRestore.length === 0
+      ) {
+        return existingCompanyIdsMap;
+      }
 
-        const formattedRestoredCompanies = restoredCompanies.raw.map(
-          (row: { id: string; domainNamePrimaryLinkUrl: string }) => {
-            return {
-              id: row.id,
-              domainName: {
-                primaryLinkUrl: row.domainNamePrimaryLinkUrl,
-              },
-            };
-          },
-        );
+      let lastCompanyPosition =
+        await this.getLastCompanyPosition(companyRepository);
+      const newCompaniesData = await Promise.all(
+        newCompaniesToCreate.map((company) =>
+          this.prepareCompanyData(company, ++lastCompanyPosition),
+        ),
+      );
 
-        return {
-          ...existingCompanyIdsMap,
-          ...(createdCompanies.length > 0
-            ? this.createCompanyMap(createdCompanies)
-            : {}),
-          ...(formattedRestoredCompanies.length > 0
-            ? this.createCompanyMap(formattedRestoredCompanies)
-            : {}),
-        };
-      },
-      authContext,
-    );
+      const createdCompanies = await companyRepository.save(newCompaniesData);
+
+      const restoredCompanies = await companyRepository.updateMany(
+        companiesToRestore.map((company) => {
+          return {
+            criteria: company.id,
+            partialEntity: {
+              deletedAt: null,
+            },
+          };
+        }),
+      );
+
+      const formattedRestoredCompanies = restoredCompanies.raw.map(
+        (row: { id: string; domainNamePrimaryLinkUrl: string }) => {
+          return {
+            id: row.id,
+            domainName: {
+              primaryLinkUrl: row.domainNamePrimaryLinkUrl,
+            },
+          };
+        },
+      );
+
+      return {
+        ...existingCompanyIdsMap,
+        ...(createdCompanies.length > 0
+          ? this.createCompanyMap(createdCompanies)
+          : {}),
+        ...(formattedRestoredCompanies.length > 0
+          ? this.createCompanyMap(formattedRestoredCompanies)
+          : {}),
+      };
+    }, authContext);
   }
 
   private filterCompaniesToRestore(

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
@@ -3,16 +3,14 @@ import { Injectable } from '@nestjs/common';
 import { type FullNameMetadata } from 'twenty-shared/types';
 import { DeepPartial } from 'typeorm';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
 
 @Injectable()
 export class CreatePersonService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   public async createPeople(
     peopleToCreate: Partial<PersonWorkspaceEntity>[],
@@ -22,28 +20,24 @@ export class CreatePersonService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const personRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            PersonWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const personRepository = await this.workspaceOrmManager.getRepository(
+        PersonWorkspaceEntity,
+        { shouldBypassPermissionChecks: true },
+      );
 
-        const lastPersonPosition =
-          await this.getLastPersonPosition(personRepository);
+      const lastPersonPosition =
+        await this.getLastPersonPosition(personRepository);
 
-        const createdPeople = await personRepository.insert(
-          peopleToCreate.map((person, index) => ({
-            ...person,
-            position: lastPersonPosition + index,
-          })),
-        );
+      const createdPeople = await personRepository.insert(
+        peopleToCreate.map((person, index) => ({
+          ...person,
+          position: lastPersonPosition + index,
+        })),
+      );
 
-        return createdPeople.raw;
-      },
-      authContext,
-    );
+      return createdPeople.raw;
+    }, authContext);
   }
 
   public async restorePeople(
@@ -56,30 +50,26 @@ export class CreatePersonService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const personRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            PersonWorkspaceEntity,
-            {
-              shouldBypassPermissionChecks: true,
-            },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const personRepository = await this.workspaceOrmManager.getRepository(
+        PersonWorkspaceEntity,
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        const restoredPeople = await personRepository.updateMany(
-          people.map(({ personId, companyId }) => ({
-            criteria: personId,
-            partialEntity: {
-              deletedAt: null,
-              companyId,
-            },
-          })),
-        );
+      const restoredPeople = await personRepository.updateMany(
+        people.map(({ personId, companyId }) => ({
+          criteria: personId,
+          partialEntity: {
+            deletedAt: null,
+            companyId,
+          },
+        })),
+      );
 
-        return restoredPeople.raw;
-      },
-      authContext,
-    );
+      return restoredPeople.raw;
+    }, authContext);
   }
 
   public async enrichPeopleNames(
@@ -92,27 +82,23 @@ export class CreatePersonService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const personRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            PersonWorkspaceEntity,
-            {
-              shouldBypassPermissionChecks: true,
-            },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const personRepository = await this.workspaceOrmManager.getRepository(
+        PersonWorkspaceEntity,
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        const enrichedPeople = await personRepository.updateMany(
-          peopleToEnrich.map(({ personId, name }) => ({
-            criteria: personId,
-            partialEntity: { name },
-          })),
-        );
+      const enrichedPeople = await personRepository.updateMany(
+        peopleToEnrich.map(({ personId, name }) => ({
+          criteria: personId,
+          partialEntity: { name },
+        })),
+      );
 
-        return enrichedPeople.raw;
-      },
-      authContext,
-    );
+      return enrichedPeople.raw;
+    }, authContext);
   }
 
   private async getLastPersonPosition(

--- a/packages/twenty-server/src/modules/dashboard-sync/services/dashboard-sync.service.ts
+++ b/packages/twenty-server/src/modules/dashboard-sync/services/dashboard-sync.service.ts
@@ -5,7 +5,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { PageLayoutType } from 'src/engine/metadata-modules/page-layout/enums/page-layout-type.enum';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 @Injectable()
@@ -13,7 +13,7 @@ export class DashboardSyncService {
   private readonly logger = new Logger(DashboardSyncService.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
   ) {}
 
@@ -63,17 +63,14 @@ export class DashboardSyncService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     try {
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const dashboardRepository =
-            await this.globalWorkspaceOrmManager.getRepository('dashboard', {
-              shouldBypassPermissionChecks: true,
-            });
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const dashboardRepository =
+          await this.workspaceOrmManager.getRepository('dashboard', {
+            shouldBypassPermissionChecks: true,
+          });
 
-          await dashboardRepository.update({ pageLayoutId }, { updatedAt });
-        },
-        authContext,
-      );
+        await dashboardRepository.update({ pageLayoutId }, { updatedAt });
+      }, authContext);
     } catch (error) {
       this.logger.error(
         `Failed to update dashboard updatedAt for page layout ${pageLayoutId}: ${error}`,

--- a/packages/twenty-server/src/modules/dashboard/chart-data/services/chart-relation-label.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/services/chart-relation-label.service.ts
@@ -8,7 +8,7 @@ import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/typ
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
@@ -34,9 +34,7 @@ type ResolveRelationLabelsParams = {
 export class ChartRelationLabelService {
   private readonly logger = new Logger(ChartRelationLabelService.name);
 
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async resolveRelationLabels({
     rawResults,
@@ -192,7 +190,7 @@ export class ChartRelationLabelService {
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
   }): Promise<Record<string, unknown>[]> {
     try {
-      return await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      return await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workspaceContext = getWorkspaceContext();
           const rolePermissionConfig = resolveRolePermissionConfig({
@@ -205,7 +203,7 @@ export class ChartRelationLabelService {
             return [];
           }
 
-          const repository = await this.globalWorkspaceOrmManager.getRepository(
+          const repository = await this.workspaceOrmManager.getRepository(
             targetFlatObjectMetadata.nameSingular,
             rolePermissionConfig,
           );

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
@@ -5,7 +5,7 @@ import { appendCopySuffix, isDefined } from 'twenty-shared/utils';
 import { ActorFromAuthContextService } from 'src/engine/core-modules/actor/services/actor-from-auth-context.service';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { PageLayoutDuplicationService } from 'src/engine/metadata-modules/page-layout/services/page-layout-duplication.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { DuplicatedDashboardDTO } from 'src/modules/dashboard/dtos/duplicated-dashboard.dto';
 import {
@@ -22,7 +22,7 @@ export class DashboardDuplicationService {
 
   constructor(
     private readonly pageLayoutDuplicationService: PageLayoutDuplicationService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly actorFromAuthContextService: ActorFromAuthContextService,
   ) {}
 
@@ -33,71 +33,69 @@ export class DashboardDuplicationService {
     const workspace = authContext.workspace;
     const workspaceId = workspace.id;
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const dashboardRepository =
-          await this.globalWorkspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
-            'dashboard',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const dashboardRepository =
+        await this.workspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
+          'dashboard',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const originalDashboard = await dashboardRepository.findOne({
-          where: { id: dashboardId },
-        });
+      const originalDashboard = await dashboardRepository.findOne({
+        where: { id: dashboardId },
+      });
 
-        if (!isDefined(originalDashboard)) {
-          throw new DashboardException(
-            generateDashboardExceptionMessage(
-              DashboardExceptionMessageKey.DASHBOARD_NOT_FOUND,
-              dashboardId,
-            ),
-            DashboardExceptionCode.DASHBOARD_NOT_FOUND,
-          );
-        }
+      if (!isDefined(originalDashboard)) {
+        throw new DashboardException(
+          generateDashboardExceptionMessage(
+            DashboardExceptionMessageKey.DASHBOARD_NOT_FOUND,
+            dashboardId,
+          ),
+          DashboardExceptionCode.DASHBOARD_NOT_FOUND,
+        );
+      }
 
-        if (!isDefined(originalDashboard.pageLayoutId)) {
-          throw new DashboardException(
-            generateDashboardExceptionMessage(
-              DashboardExceptionMessageKey.PAGE_LAYOUT_NOT_FOUND,
-              dashboardId,
-            ),
-            DashboardExceptionCode.PAGE_LAYOUT_NOT_FOUND,
-          );
-        }
+      if (!isDefined(originalDashboard.pageLayoutId)) {
+        throw new DashboardException(
+          generateDashboardExceptionMessage(
+            DashboardExceptionMessageKey.PAGE_LAYOUT_NOT_FOUND,
+            dashboardId,
+          ),
+          DashboardExceptionCode.PAGE_LAYOUT_NOT_FOUND,
+        );
+      }
 
-        try {
-          const newPageLayout =
-            await this.pageLayoutDuplicationService.duplicate({
-              pageLayoutId: originalDashboard.pageLayoutId,
-              workspaceId,
-            });
+      try {
+        const newPageLayout = await this.pageLayoutDuplicationService.duplicate(
+          {
+            pageLayoutId: originalDashboard.pageLayoutId,
+            workspaceId,
+          },
+        );
 
-          const newDashboard = await this.createDuplicatedDashboard(
-            originalDashboard,
-            newPageLayout.id,
-            dashboardRepository,
-            authContext,
-          );
+        const newDashboard = await this.createDuplicatedDashboard(
+          originalDashboard,
+          newPageLayout.id,
+          dashboardRepository,
+          authContext,
+        );
 
-          return {
-            id: newDashboard.id,
-            title: newDashboard.title,
-            pageLayoutId: newDashboard.pageLayoutId,
-            position: newDashboard.position,
-            createdAt: newDashboard.createdAt,
-            updatedAt: newDashboard.updatedAt,
-          };
-        } catch (error) {
-          this.logger.error(
-            `Failed to duplicate dashboard ${dashboardId}: ${error.message}`,
-            error.stack,
-          );
+        return {
+          id: newDashboard.id,
+          title: newDashboard.title,
+          pageLayoutId: newDashboard.pageLayoutId,
+          position: newDashboard.position,
+          createdAt: newDashboard.createdAt,
+          updatedAt: newDashboard.updatedAt,
+        };
+      } catch (error) {
+        this.logger.error(
+          `Failed to duplicate dashboard ${dashboardId}: ${error.message}`,
+          error.stack,
+        );
 
-          throw error;
-        }
-      },
-      authContext,
-    );
+        throw error;
+      }
+    }, authContext);
   }
 
   private async createDuplicatedDashboard(

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-to-page-layout-sync.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-to-page-layout-sync.service.ts
@@ -6,14 +6,14 @@ import { In } from 'typeorm';
 import { PageLayoutTabService } from 'src/engine/metadata-modules/page-layout-tab/services/page-layout-tab.service';
 import { PageLayoutType } from 'src/engine/metadata-modules/page-layout/enums/page-layout-type.enum';
 import { PageLayoutService } from 'src/engine/metadata-modules/page-layout/services/page-layout.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import type { DashboardWorkspaceEntity } from 'src/modules/dashboard/standard-objects/dashboard.workspace-entity';
 
 @Injectable()
 export class DashboardToPageLayoutSyncService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly pageLayoutService: PageLayoutService,
     private readonly pageLayoutTabService: PageLayoutTabService,
   ) {}
@@ -52,9 +52,9 @@ export class DashboardToPageLayoutSyncService {
   }): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const dashboardRepository =
-        await this.globalWorkspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
           'dashboard',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/dashboard/tools/__tests__/get-dashboard.tool.spec.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/__tests__/get-dashboard.tool.spec.ts
@@ -104,7 +104,7 @@ describe('get_dashboard tool', () => {
       pageLayoutService: {
         findByIdOrThrow: jest.fn().mockResolvedValue(pageLayout),
       },
-      globalWorkspaceOrmManager: {
+      workspaceOrmManager: {
         executeInWorkspaceContext: jest
           .fn()
           .mockImplementation(async (fn) => fn()),
@@ -123,7 +123,7 @@ describe('get_dashboard tool', () => {
       deps as unknown as Pick<
         DashboardToolDependencies,
         | 'pageLayoutService'
-        | 'globalWorkspaceOrmManager'
+        | 'workspaceOrmManager'
         | 'flatEntityMapsCacheService'
       >,
       {

--- a/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
@@ -240,11 +240,13 @@ const createDashboardRecord = async (
 ): Promise<string> => {
   const authContext = buildSystemAuthContext(context.workspaceId);
 
-  return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-    const dashboardRepository =
-      await deps.globalWorkspaceOrmManager.getRepository('dashboard', {
+  return deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
+    const dashboardRepository = await deps.workspaceOrmManager.getRepository(
+      'dashboard',
+      {
         shouldBypassPermissionChecks: true,
-      });
+      },
+    );
 
     const position = await deps.recordPositionService.buildRecordPosition({
       value: 'first',

--- a/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
@@ -20,9 +20,7 @@ const getDashboardSchema = z.object({
 export const createGetDashboardTool = (
   deps: Pick<
     DashboardToolDependencies,
-    | 'pageLayoutService'
-    | 'globalWorkspaceOrmManager'
-    | 'flatEntityMapsCacheService'
+    'pageLayoutService' | 'workspaceOrmManager' | 'flatEntityMapsCacheService'
   >,
   context: DashboardToolContext,
 ) => ({
@@ -71,17 +69,14 @@ export const createGetDashboardTool = (
         });
 
       const dashboard =
-        await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const repo = await deps.globalWorkspaceOrmManager.getRepository(
-              'dashboard',
-              { shouldBypassPermissionChecks: true },
-            );
+        await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
+          const repo = await deps.workspaceOrmManager.getRepository(
+            'dashboard',
+            { shouldBypassPermissionChecks: true },
+          );
 
-            return repo.findOne({ where: { id: parameters.dashboardId } });
-          },
-          authContext,
-        );
+          return repo.findOne({ where: { id: parameters.dashboardId } });
+        }, authContext);
 
       if (!isDefined(dashboard)) {
         return {

--- a/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
@@ -17,7 +17,7 @@ const listDashboardsSchema = z.object({
 });
 
 export const createListDashboardsTool = (
-  deps: Pick<DashboardToolDependencies, 'globalWorkspaceOrmManager'>,
+  deps: Pick<DashboardToolDependencies, 'workspaceOrmManager'>,
   context: DashboardToolContext,
 ) => ({
   name: 'list_dashboards' as const,
@@ -29,17 +29,14 @@ export const createListDashboardsTool = (
       const authContext = buildSystemAuthContext(context.workspaceId);
 
       const dashboards =
-        await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const repo = await deps.globalWorkspaceOrmManager.getRepository(
-              'dashboard',
-              { shouldBypassPermissionChecks: true },
-            );
+        await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
+          const repo = await deps.workspaceOrmManager.getRepository(
+            'dashboard',
+            { shouldBypassPermissionChecks: true },
+          );
 
-            return repo.find({ take: limit, order: { position: 'ASC' } });
-          },
-          authContext,
-        );
+          return repo.find({ take: limit, order: { position: 'ASC' } });
+        }, authContext);
 
       const dashboardList = dashboards.map((d) => ({
         id: d.id,

--- a/packages/twenty-server/src/modules/dashboard/tools/services/dashboard-tool.workspace-service.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/services/dashboard-tool.workspace-service.ts
@@ -8,7 +8,7 @@ import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadat
 import { PageLayoutTabService } from 'src/engine/metadata-modules/page-layout-tab/services/page-layout-tab.service';
 import { PageLayoutWidgetService } from 'src/engine/metadata-modules/page-layout-widget/services/page-layout-widget.service';
 import { PageLayoutService } from 'src/engine/metadata-modules/page-layout/services/page-layout.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
 import { createAddDashboardTabTool } from 'src/modules/dashboard/tools/add-dashboard-tab.tool';
 import { createAddDashboardWidgetTool } from 'src/modules/dashboard/tools/add-dashboard-widget.tool';
@@ -27,7 +27,7 @@ export class DashboardToolWorkspaceService {
     pageLayoutService: PageLayoutService,
     pageLayoutTabService: PageLayoutTabService,
     pageLayoutWidgetService: PageLayoutWidgetService,
-    globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    workspaceOrmManager: WorkspaceOrmManager,
     recordPositionService: RecordPositionService,
     applicationService: ApplicationService,
     flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
@@ -36,7 +36,7 @@ export class DashboardToolWorkspaceService {
       pageLayoutService,
       pageLayoutTabService,
       pageLayoutWidgetService,
-      globalWorkspaceOrmManager,
+      workspaceOrmManager,
       recordPositionService,
       applicationService,
       flatEntityMapsCacheService,

--- a/packages/twenty-server/src/modules/dashboard/tools/types/dashboard-tool-dependencies.type.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/types/dashboard-tool-dependencies.type.ts
@@ -4,7 +4,7 @@ import type { PageLayoutTabService } from 'src/engine/metadata-modules/page-layo
 import type { PageLayoutWidgetService } from 'src/engine/metadata-modules/page-layout-widget/services/page-layout-widget.service';
 import type { PageLayoutService } from 'src/engine/metadata-modules/page-layout/services/page-layout.service';
 import type { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
-import type { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import type { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import type { RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
 
 export type DashboardToolDependencies = {
@@ -12,7 +12,7 @@ export type DashboardToolDependencies = {
   pageLayoutTabService: PageLayoutTabService;
   pageLayoutWidgetService: PageLayoutWidgetService;
   flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService;
-  globalWorkspaceOrmManager: GlobalWorkspaceOrmManager;
+  workspaceOrmManager: WorkspaceOrmManager;
   recordPositionService: RecordPositionService;
   applicationService: ApplicationService;
 };

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign-draft.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign-draft.service.ts
@@ -16,7 +16,7 @@ import {
   EmailingDomainExceptionCode,
 } from 'src/engine/core-modules/emailing-domain/exceptions/emailing-domain.exception';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { CampaignVariableService } from 'src/modules/emailing/services/campaign-variable.service';
 import { MessageCampaignWorkspaceEntity } from 'src/modules/emailing/standard-objects/message-campaign.workspace-entity';
 import { collectCampaignVariableNames } from 'src/modules/emailing/utils/collect-campaign-variable-names.util';
@@ -45,7 +45,7 @@ const DEFAULT_CAMPAIGN_NAME = 'Untitled campaign';
 export class MessageCampaignDraftService {
   constructor(
     private readonly userRoleService: UserRoleService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly campaignVariableService: CampaignVariableService,
   ) {}
 
@@ -53,7 +53,7 @@ export class MessageCampaignDraftService {
     entity: Type<T>,
     roleId: string,
   ) {
-    return this.globalWorkspaceOrmManager.getRepository(entity, {
+    return this.workspaceOrmManager.getRepository(entity, {
       unionOf: [roleId],
     });
   }
@@ -93,88 +93,86 @@ export class MessageCampaignDraftService {
       userWorkspaceId,
     });
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const campaignRepository = await this.getRoleScopedRepository(
-          MessageCampaignWorkspaceEntity,
-          roleId,
-        );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const campaignRepository = await this.getRoleScopedRepository(
+        MessageCampaignWorkspaceEntity,
+        roleId,
+      );
 
-        if (!isDefined(campaignId)) {
-          const createdCampaignId = v4();
-          const campaignName = name ?? DEFAULT_CAMPAIGN_NAME;
+      if (!isDefined(campaignId)) {
+        const createdCampaignId = v4();
+        const campaignName = name ?? DEFAULT_CAMPAIGN_NAME;
 
-          await campaignRepository.insert({
-            id: createdCampaignId,
-            name: campaignName,
-            status: MessageCampaignStatus.DRAFT,
-            ...(isDefined(subject) && { subject }),
-            ...(isDefined(stampedDocument) && {
-              bodyTemplate: JSON.stringify(stampedDocument),
-            }),
-          });
-
-          return {
-            campaignId: createdCampaignId,
-            campaignName,
-            created: true,
-            blockCount: stampedDocument?.content?.length,
-            variablesUsed,
-          };
-        }
-
-        if (!isDefined(name) && !isDefined(subject) && !isDefined(body)) {
-          throw new EmailingDomainException(
-            'Nothing to update: provide a name, subject or body',
-            EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_SENDABLE,
-          );
-        }
-
-        const campaign = await campaignRepository.findOne({
-          where: { id: campaignId },
+        await campaignRepository.insert({
+          id: createdCampaignId,
+          name: campaignName,
+          status: MessageCampaignStatus.DRAFT,
+          ...(isDefined(subject) && { subject }),
+          ...(isDefined(stampedDocument) && {
+            bodyTemplate: JSON.stringify(stampedDocument),
+          }),
         });
 
-        if (!isDefined(campaign)) {
-          throw new EmailingDomainException(
-            `Campaign ${campaignId} not found`,
-            EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_FOUND,
-          );
-        }
-
-        if (campaign.status !== MessageCampaignStatus.DRAFT) {
-          throw new EmailingDomainException(
-            `Campaign ${campaignId} is ${campaign.status}; only draft campaigns can be edited`,
-            EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_SENDABLE,
-          );
-        }
-
-        const { affected } = await campaignRepository.update(
-          { id: campaignId, status: MessageCampaignStatus.DRAFT },
-          {
-            ...(isDefined(name) && { name }),
-            ...(isDefined(subject) && { subject }),
-            ...(isDefined(stampedDocument) && {
-              bodyTemplate: JSON.stringify(stampedDocument),
-            }),
-          },
-        );
-
-        if (affected !== 1) {
-          throw new EmailingDomainException(
-            `Campaign ${campaignId} is no longer an editable draft`,
-            EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_SENDABLE,
-          );
-        }
-
         return {
-          campaignId,
-          campaignName: name ?? campaign.name,
-          created: false,
+          campaignId: createdCampaignId,
+          campaignName,
+          created: true,
           blockCount: stampedDocument?.content?.length,
           variablesUsed,
         };
-      },
-    );
+      }
+
+      if (!isDefined(name) && !isDefined(subject) && !isDefined(body)) {
+        throw new EmailingDomainException(
+          'Nothing to update: provide a name, subject or body',
+          EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_SENDABLE,
+        );
+      }
+
+      const campaign = await campaignRepository.findOne({
+        where: { id: campaignId },
+      });
+
+      if (!isDefined(campaign)) {
+        throw new EmailingDomainException(
+          `Campaign ${campaignId} not found`,
+          EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_FOUND,
+        );
+      }
+
+      if (campaign.status !== MessageCampaignStatus.DRAFT) {
+        throw new EmailingDomainException(
+          `Campaign ${campaignId} is ${campaign.status}; only draft campaigns can be edited`,
+          EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_SENDABLE,
+        );
+      }
+
+      const { affected } = await campaignRepository.update(
+        { id: campaignId, status: MessageCampaignStatus.DRAFT },
+        {
+          ...(isDefined(name) && { name }),
+          ...(isDefined(subject) && { subject }),
+          ...(isDefined(stampedDocument) && {
+            bodyTemplate: JSON.stringify(stampedDocument),
+          }),
+        },
+      );
+
+      if (affected !== 1) {
+        throw new EmailingDomainException(
+          `Campaign ${campaignId} is no longer an editable draft`,
+          EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_SENDABLE,
+        );
+      }
+
+      return {
+        campaignId,
+        campaignName: name ?? campaign.name,
+        created: false,
+        blockCount: stampedDocument?.content?.length,
+        variablesUsed,
+      };
+    });
   }
 
   private parseAndStampDocument(body: unknown): EmailDocument {

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign-statistics.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign-statistics.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { CAMPAIGN_MESSAGE_DELIVERY_STATUS } from 'src/engine/core-modules/emailing-domain/constants/campaign.constant';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageCampaignWorkspaceEntity } from 'src/modules/emailing/standard-objects/message-campaign.workspace-entity';
 import { MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
@@ -13,9 +13,7 @@ type DeliveryStatusCountRow = {
 
 @Injectable()
 export class MessageCampaignStatisticsService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async refreshCampaignCounts({
     workspaceId,
@@ -24,12 +22,11 @@ export class MessageCampaignStatisticsService {
     workspaceId: string;
     campaignId: string;
   }): Promise<void> {
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      const messageRepository =
-        await this.globalWorkspaceOrmManager.getRepository(
-          MessageWorkspaceEntity,
-          { shouldBypassPermissionChecks: true },
-        );
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageRepository = await this.workspaceOrmManager.getRepository(
+        MessageWorkspaceEntity,
+        { shouldBypassPermissionChecks: true },
+      );
 
       const deliveryStatusCountRows = await messageRepository
         .createQueryBuilder('message')
@@ -58,11 +55,10 @@ export class MessageCampaignStatisticsService {
           CAMPAIGN_MESSAGE_DELIVERY_STATUS.COMPLAINED,
         ) ?? 0;
 
-      const campaignRepository =
-        await this.globalWorkspaceOrmManager.getRepository(
-          MessageCampaignWorkspaceEntity,
-          { shouldBypassPermissionChecks: true },
-        );
+      const campaignRepository = await this.workspaceOrmManager.getRepository(
+        MessageCampaignWorkspaceEntity,
+        { shouldBypassPermissionChecks: true },
+      );
 
       await campaignRepository.update(
         { id: campaignId },

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign.service.ts
@@ -40,7 +40,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { MessageChannelMetadataService } from 'src/engine/metadata-modules/message-channel/message-channel-metadata.service';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
@@ -117,7 +117,7 @@ export class MessageCampaignService {
     @InjectWorkspaceScopedRepository(EmailingDomainEntity)
     private readonly emailingDomainRepository: WorkspaceScopedRepository<EmailingDomainEntity>,
     private readonly emailingDomainSenderService: EmailingDomainSenderService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectMessageQueue(MessageQueue.emailQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly messageChannelMetadataService: MessageChannelMetadataService,
@@ -134,13 +134,13 @@ export class MessageCampaignService {
     entity: Type<T>,
     roleId: string,
   ) {
-    return this.globalWorkspaceOrmManager.getRepository(entity, {
+    return this.workspaceOrmManager.getRepository(entity, {
       unionOf: [roleId],
     });
   }
 
   private getSystemRepository<T extends ObjectLiteral>(entity: Type<T>) {
-    return this.globalWorkspaceOrmManager.getRepository(entity, {
+    return this.workspaceOrmManager.getRepository(entity, {
       shouldBypassPermissionChecks: true,
     });
   }
@@ -156,20 +156,18 @@ export class MessageCampaignService {
     });
 
     const { fromAddress, listId } =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const sendableCampaign = await this.findSendableDraftCampaignOrThrow(
-            workspaceId,
-            campaignId,
-            roleId,
-          );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const sendableCampaign = await this.findSendableDraftCampaignOrThrow(
+          workspaceId,
+          campaignId,
+          roleId,
+        );
 
-          return {
-            fromAddress: sendableCampaign.fromAddress.primaryEmail,
-            listId: sendableCampaign.listId,
-          };
-        },
-      );
+        return {
+          fromAddress: sendableCampaign.fromAddress.primaryEmail,
+          listId: sendableCampaign.listId,
+        };
+      });
 
     const emailingDomain = await this.findVerifiedEmailingDomainOrThrow(
       workspaceId,
@@ -177,42 +175,40 @@ export class MessageCampaignService {
     );
 
     const { recipients, skipped } =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const rawRecipients = await this.resolveRecipientsFromList(
-            listId,
-            roleId,
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const rawRecipients = await this.resolveRecipientsFromList(
+          listId,
+          roleId,
+        );
+
+        const normalized = normalizeCampaignRecipients(
+          rawRecipients,
+          MAX_CAMPAIGN_RECIPIENTS,
+        );
+
+        const campaignRepository = await this.getRoleScopedRepository(
+          MessageCampaignWorkspaceEntity,
+          roleId,
+        );
+
+        // Conditional update so two concurrent sends cannot both enqueue
+        const { affected } = await campaignRepository.update(
+          { id: campaignId, status: MessageCampaignStatus.DRAFT },
+          { status: MessageCampaignStatus.SENDING },
+        );
+
+        if (affected !== 1) {
+          throw new EmailingDomainException(
+            `Campaign ${campaignId} is no longer a sendable draft`,
+            EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_SENDABLE,
           );
+        }
 
-          const normalized = normalizeCampaignRecipients(
-            rawRecipients,
-            MAX_CAMPAIGN_RECIPIENTS,
-          );
-
-          const campaignRepository = await this.getRoleScopedRepository(
-            MessageCampaignWorkspaceEntity,
-            roleId,
-          );
-
-          // Conditional update so two concurrent sends cannot both enqueue
-          const { affected } = await campaignRepository.update(
-            { id: campaignId, status: MessageCampaignStatus.DRAFT },
-            { status: MessageCampaignStatus.SENDING },
-          );
-
-          if (affected !== 1) {
-            throw new EmailingDomainException(
-              `Campaign ${campaignId} is no longer a sendable draft`,
-              EmailingDomainExceptionCode.MESSAGE_CAMPAIGN_NOT_SENDABLE,
-            );
-          }
-
-          return {
-            recipients: normalized.recipients,
-            skipped: normalized.skipped,
-          };
-        },
-      );
+        return {
+          recipients: normalized.recipients,
+          skipped: normalized.skipped,
+        };
+      });
 
     const messageChannel =
       await this.messageChannelMetadataService.getOrCreateEmailGroupChannel({
@@ -303,7 +299,7 @@ export class MessageCampaignService {
       recipients,
     } = data;
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const campaignRepository = await this.getSystemRepository(
         MessageCampaignWorkspaceEntity,
       );
@@ -387,7 +383,7 @@ export class MessageCampaignService {
       emailingDomainId,
     } = data;
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageRepository = await this.getSystemRepository(
         MessageWorkspaceEntity,
       );
@@ -543,7 +539,7 @@ export class MessageCampaignService {
     providerMessageId: string;
     deliveryStatus: string;
   }): Promise<void> {
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageRepository = await this.getSystemRepository(
         MessageWorkspaceEntity,
       );
@@ -644,7 +640,7 @@ export class MessageCampaignService {
       temporaryExternalId: v4(),
     }));
 
-    await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+    await this.workspaceOrmManager.runInWorkspaceTransaction(
       async (transactionScope) => {
         const messageThreadRepository =
           transactionScope.getRepository<MessageThreadWorkspaceEntity>(
@@ -801,60 +797,58 @@ export class MessageCampaignService {
       userWorkspaceId,
     });
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const rawRecipients = await this.resolveRecipientsFromList(
-          listId,
-          roleId,
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const rawRecipients = await this.resolveRecipientsFromList(
+        listId,
+        roleId,
+      );
+      const totalMembers = rawRecipients.length;
+
+      const { recipients, skipped } = normalizeCampaignRecipients(
+        rawRecipients,
+        MAX_CAMPAIGN_RECIPIENTS,
+      );
+
+      const emails = recipients.map((recipient) => recipient.email);
+
+      const globallySuppressed =
+        await this.messageSuppressionService.getSuppressedAddresses(
+          workspaceId,
+          emails,
         );
-        const totalMembers = rawRecipients.length;
-
-        const { recipients, skipped } = normalizeCampaignRecipients(
-          rawRecipients,
-          MAX_CAMPAIGN_RECIPIENTS,
-        );
-
-        const emails = recipients.map((recipient) => recipient.email);
-
-        const globallySuppressed =
-          await this.messageSuppressionService.getSuppressedAddresses(
+      const topicSuppressed = isNonEmptyString(unsubscribeTopicId)
+        ? await this.messageSuppressionService.getTopicSuppressedAddresses(
             workspaceId,
             emails,
-          );
-        const topicSuppressed = isNonEmptyString(unsubscribeTopicId)
-          ? await this.messageSuppressionService.getTopicSuppressedAddresses(
-              workspaceId,
-              emails,
-              unsubscribeTopicId,
-            )
-          : new Set<string>();
+            unsubscribeTopicId,
+          )
+        : new Set<string>();
 
-        let globallyUnsubscribed = 0;
-        let topicUnsubscribed = 0;
-        let sendable = 0;
+      let globallyUnsubscribed = 0;
+      let topicUnsubscribed = 0;
+      let sendable = 0;
 
-        for (const recipient of recipients) {
-          const normalizedEmail = recipient.email.trim().toLowerCase();
+      for (const recipient of recipients) {
+        const normalizedEmail = recipient.email.trim().toLowerCase();
 
-          if (globallySuppressed.has(normalizedEmail)) {
-            globallyUnsubscribed += 1;
-          } else if (topicSuppressed.has(normalizedEmail)) {
-            topicUnsubscribed += 1;
-          } else {
-            sendable += 1;
-          }
+        if (globallySuppressed.has(normalizedEmail)) {
+          globallyUnsubscribed += 1;
+        } else if (topicSuppressed.has(normalizedEmail)) {
+          topicUnsubscribed += 1;
+        } else {
+          sendable += 1;
         }
+      }
 
-        return {
-          totalMembers,
-          withoutEmail: skipped.noEmail,
-          duplicateEmails: skipped.deduped,
-          globallyUnsubscribed,
-          topicUnsubscribed,
-          sendable,
-        };
-      },
-    );
+      return {
+        totalMembers,
+        withoutEmail: skipped.noEmail,
+        duplicateEmails: skipped.deduped,
+        globallyUnsubscribed,
+        topicUnsubscribed,
+        sendable,
+      };
+    });
   }
 
   private async resolveRecipientsFromList(

--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -4,7 +4,7 @@ import chunk from 'lodash.chunk';
 import { isDefined } from 'twenty-shared/utils';
 import { Any, In } from 'typeorm';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type CalendarEventParticipantWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event-participant.workspace-entity';
@@ -61,9 +61,7 @@ export class MatchParticipantService<
     | CalendarEventParticipantWorkspaceEntity
     | MessageParticipantWorkspaceEntity,
 > {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   private async getParticipantRepository({
     objectMetadataName,
@@ -76,7 +74,7 @@ export class MatchParticipantService<
         );
       }
 
-      return await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+      return await this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
         objectMetadataName,
       );
     }
@@ -87,7 +85,7 @@ export class MatchParticipantService<
       );
     }
 
-    return await this.globalWorkspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
+    return await this.workspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
       objectMetadataName,
     );
   }
@@ -103,7 +101,7 @@ export class MatchParticipantService<
     }
 
     const personRepository =
-      await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<PersonWorkspaceEntity>(
         'person',
         { shouldBypassPermissionChecks: true },
       );
@@ -114,7 +112,7 @@ export class MatchParticipantService<
     });
 
     const workspaceMemberRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );
@@ -208,7 +206,7 @@ export class MatchParticipantService<
   }: MatchParticipantsForWorkspaceMembersArgs) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const participantRepository = await this.getParticipantRepository({
         objectMetadataName,
       });
@@ -241,7 +239,7 @@ export class MatchParticipantService<
   }: MatchParticipantsForPeopleArgs) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const participantRepository = await this.getParticipantRepository({
         objectMetadataName,
       });

--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
@@ -12,7 +12,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import { type BlocklistWorkspaceEntity } from 'src/modules/blocklist/standard-objects/blocklist.workspace-entity';
@@ -32,7 +32,7 @@ export type BlocklistItemDeleteMessagesJobData = WorkspaceEventBatch<
 export class BlocklistItemDeleteMessagesJob {
   constructor(
     private readonly threadCleanerService: MessagingMessageCleanerService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     @InjectRepository(ConnectedAccountEntity)
@@ -47,14 +47,14 @@ export class BlocklistItemDeleteMessagesJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const blocklistItemIds = data.events.map(
           (eventPayload) => eventPayload.recordId,
         );
 
         const blocklistRepository =
-          await this.globalWorkspaceOrmManager.getRepository<BlocklistWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<BlocklistWorkspaceEntity>(
             'blocklist',
           );
 
@@ -84,18 +84,18 @@ export class BlocklistItemDeleteMessagesJob {
         );
 
         const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 
         const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
 
         const messageParticipantRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
             'messageParticipant',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-reimport-messages.job.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-reimport-messages.job.ts
@@ -10,7 +10,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import { type BlocklistWorkspaceEntity } from 'src/modules/blocklist/standard-objects/blocklist.workspace-entity';
@@ -28,7 +28,7 @@ export type BlocklistReimportMessagesJobData = WorkspaceEventBatch<
 })
 export class BlocklistReimportMessagesJob {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     @InjectRepository(ConnectedAccountEntity)
@@ -44,10 +44,10 @@ export class BlocklistReimportMessagesJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -10,7 +10,7 @@ import { In, Repository } from 'typeorm';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
@@ -19,7 +19,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 @Injectable()
 export class ApplyMessagesVisibilityRestrictionsService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectRepository(UserWorkspaceEntity)
@@ -35,10 +35,10 @@ export class ApplyMessagesVisibilityRestrictionsService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 
@@ -70,7 +70,7 @@ export class ApplyMessagesVisibilityRestrictionsService {
         );
 
         const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
@@ -18,7 +18,7 @@ import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
 import { AccountsToReconnectKeys } from 'src/modules/connected-account/types/accounts-to-reconnect-key-value.type';
@@ -31,7 +31,7 @@ export class MessageChannelSyncStatusService {
   constructor(
     @InjectCacheStorage(CacheStorageNamespace.ModuleMessaging)
     private readonly cacheStorage: CacheStorageService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     @InjectRepository(MessageFolderEntity)
@@ -55,7 +55,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -83,7 +83,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -116,7 +116,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -155,7 +155,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -177,7 +177,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -203,7 +203,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -229,7 +229,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -263,7 +263,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -287,7 +287,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -320,7 +320,7 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messageChannelRepository.update(
           { id: In(messageChannelIds), workspaceId },
@@ -385,7 +385,7 @@ export class MessageChannelSyncStatusService {
     });
 
     const workspaceMemberRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/commands/messaging-reset-channel.command.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/commands/messaging-reset-channel.command.ts
@@ -6,7 +6,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageChannelSyncStatusService } from 'src/modules/messaging/common/services/message-channel-sync-status.service';
 import { MessagingMessageCleanerService } from 'src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service';
@@ -25,7 +25,7 @@ export class MessagingResetChannelCommand extends CommandRunner {
   private readonly logger = new Logger(MessagingResetChannelCommand.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     private readonly messagingChannelSyncStatusService: MessageChannelSyncStatusService,
@@ -42,7 +42,7 @@ export class MessagingResetChannelCommand extends CommandRunner {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         this.logger.log(
           `No message channel ID provided, resetting all message channels in workspace ${workspaceId}`,

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -4,7 +4,7 @@ import chunk from 'lodash.chunk';
 import { isDefined } from 'twenty-shared/utils';
 import { In, MoreThan } from 'typeorm';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
@@ -16,9 +16,7 @@ const ORPHAN_CLEANUP_PAGE_SIZE = 500;
 @Injectable()
 export class MessagingMessageCleanerService {
   private readonly logger = new Logger(MessagingMessageCleanerService.name);
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async deleteMessagesChannelMessageAssociationsAndRelatedOrphans({
     workspaceId,
@@ -31,9 +29,9 @@ export class MessagingMessageCleanerService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+        await this.workspaceOrmManager.runInWorkspaceTransaction(
           async (transactionScope) => {
             const messageRepository =
               transactionScope.getRepository<MessageWorkspaceEntity>('message');
@@ -132,9 +130,9 @@ export class MessagingMessageCleanerService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+        await this.workspaceOrmManager.runInWorkspaceTransaction(
           async (transactionScope) => {
             const messageChannelMessageAssociationRepository =
               transactionScope.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
@@ -172,9 +170,9 @@ export class MessagingMessageCleanerService {
   public async cleanOrphanMessagesAndThreads(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+        await this.workspaceOrmManager.runInWorkspaceTransaction(
           async (transactionScope) => {
             const messageThreadRepository =
               transactionScope.getRepository<MessageThreadWorkspaceEntity>(

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.ts
@@ -15,7 +15,7 @@ import {
 
 import { type MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { GmailGetAllFoldersService } from 'src/modules/messaging/message-folder-manager/drivers/gmail/services/gmail-get-all-folders.service';
@@ -29,7 +29,7 @@ import { computeUpdatedFolders } from 'src/modules/messaging/message-folder-mana
 @Injectable()
 export class SyncMessageFoldersService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageFolderEntity)
     private readonly messageFolderRepository: Repository<MessageFolderEntity>,
     private readonly gmailGetAllFoldersService: GmailGetAllFoldersService,
@@ -138,7 +138,7 @@ export class SyncMessageFoldersService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         if (folderIdsToDelete.length > 0) {
           await this.messageFolderRepository.update(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/commands/messaging-trigger-message-list-fetch.command.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/commands/messaging-trigger-message-list-fetch.command.ts
@@ -9,7 +9,7 @@ import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decora
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   MessagingMessageListFetchJob,
@@ -32,7 +32,7 @@ export class MessagingTriggerMessageListFetchCommand extends CommandRunner {
   );
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     @InjectMessageQueue(MessageQueue.messagingQueue)
@@ -53,7 +53,7 @@ export class MessagingTriggerMessageListFetchCommand extends CommandRunner {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannels = await this.messageChannelRepository.find({
           where: {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/inbound-email/services/inbound-email-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/inbound-email/services/inbound-email-import.service.ts
@@ -9,7 +9,7 @@ import { Repository } from 'typeorm';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { InboundEmailMessageSourceResolverService } from 'src/modules/messaging/message-import-manager/drivers/inbound-email/sources/inbound-email-message-source-resolver.service';
 import { type InboundEmailImportOutcome } from 'src/modules/messaging/message-import-manager/drivers/inbound-email/types/inbound-email-import-outcome.type';
@@ -28,7 +28,7 @@ export class InboundEmailImportService {
   constructor(
     private readonly twentyConfigService: TwentyConfigService,
     private readonly inboundEmailMessageSourceResolverService: InboundEmailMessageSourceResolverService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly messagingSaveMessagesAndEnqueueContactCreationService: MessagingSaveMessagesAndEnqueueContactCreationService,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
@@ -106,7 +106,7 @@ export class InboundEmailImportService {
       );
     }
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         await this.messagingSaveMessagesAndEnqueueContactCreationService.saveMessagesAndEnqueueContactCreation(
           [message],

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job.ts
@@ -7,7 +7,7 @@ import { MessageChannelSyncStage } from 'twenty-shared/types';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   MessageImportExceptionHandlerService,
@@ -30,7 +30,7 @@ export class MessagingMessageListFetchJob {
   constructor(
     private readonly messagingMessageListFetchService: MessagingMessageListFetchService,
     private readonly messagingMonitoringService: MessagingMonitoringService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     private readonly messageImportErrorHandlerService: MessageImportExceptionHandlerService,
@@ -48,7 +48,7 @@ export class MessagingMessageListFetchJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannel = await this.messageChannelRepository.findOne({
           where: {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-messages-import.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-messages-import.job.ts
@@ -7,7 +7,7 @@ import { MessageChannelSyncStage } from 'twenty-shared/types';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessagingMessagesImportService } from 'src/modules/messaging/message-import-manager/services/messaging-messages-import.service';
 import { MessagingMonitoringService } from 'src/modules/messaging/monitoring/services/messaging-monitoring.service';
@@ -26,7 +26,7 @@ export class MessagingMessagesImportJob {
   constructor(
     private readonly messagingMessagesImportService: MessagingMessagesImportService,
     private readonly messagingMonitoringService: MessagingMonitoringService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
   ) {}
@@ -43,7 +43,7 @@ export class MessagingMessagesImportJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannel = await this.messageChannelRepository.findOne({
           where: {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job.ts
@@ -8,7 +8,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageChannelSyncStatusService } from 'src/modules/messaging/common/services/message-channel-sync-status.service';
 import { MESSAGING_ONGOING_STALE_SYNC_STAGES } from 'src/modules/messaging/message-import-manager/constants/messaging-ongoing-stale-sync-stages.constant';
@@ -26,7 +26,7 @@ export type MessagingOngoingStaleJobData = {
 export class MessagingOngoingStaleJob {
   private readonly logger = new Logger(MessagingOngoingStaleJob.name);
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     private readonly messageChannelSyncStatusService: MessageChannelSyncStatusService,
@@ -38,7 +38,7 @@ export class MessagingOngoingStaleJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannels = await this.messageChannelRepository.find({
           where: {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-relaunch-failed-message-channel.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-relaunch-failed-message-channel.job.ts
@@ -11,7 +11,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 export type MessagingRelaunchFailedMessageChannelJobData = {
@@ -25,7 +25,7 @@ export type MessagingRelaunchFailedMessageChannelJobData = {
 })
 export class MessagingRelaunchFailedMessageChannelJob {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
   ) {}
@@ -36,7 +36,7 @@ export class MessagingRelaunchFailedMessageChannelJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannel = await this.messageChannelRepository.findOne({
           where: {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-cursor.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-cursor.service.ts
@@ -4,14 +4,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 
 @Injectable()
 export class MessagingCursorService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     @InjectRepository(MessageFolderEntity)
@@ -26,7 +26,7 @@ export class MessagingCursorService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         if (!folderId) {
           await this.messageChannelRepository.update(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service.ts
@@ -4,7 +4,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { In } from 'typeorm';
 
 import { type MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageChannelMessageAssociationMessageFolderWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association-message-folder.workspace-entity';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
@@ -21,7 +21,7 @@ export class MessagingDeleteFolderMessagesService {
 
   constructor(
     private readonly messagingMessageCleanerService: MessagingMessageCleanerService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async deleteFolderMessages(
@@ -37,15 +37,15 @@ export class MessagingDeleteFolderMessagesService {
 
     let totalDeletedCount = 0;
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageFolderAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
             'messageChannelMessageAssociationMessageFolder',
           );
 
         const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
@@ -4,7 +4,7 @@ import chunk from 'lodash.chunk';
 import { MessageParticipantRole } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { MessagingMessageCleanerService } from 'src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service';
@@ -26,7 +26,7 @@ export class MessagingDeleteGroupEmailMessagesService {
   );
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly messagingMessageCleanerService: MessagingMessageCleanerService,
   ) {}
 
@@ -40,10 +40,10 @@ export class MessagingDeleteGroupEmailMessagesService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-folder-association.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-folder-association.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { In } from 'typeorm';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageChannelMessageAssociationMessageFolderWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association-message-folder.workspace-entity';
@@ -11,9 +11,7 @@ import { buildMessageFolderAssociationsToInsert } from 'src/modules/messaging/me
 
 @Injectable()
 export class MessagingMessageFolderAssociationService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async saveMessageFolderAssociations(
     associations: MessageChannelMessageAssociationFolderAssociation[],
@@ -34,7 +32,7 @@ export class MessagingMessageFolderAssociationService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const repository =
           transactionScope.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -14,7 +14,7 @@ import {
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageChannelSyncStatusService } from 'src/modules/messaging/common/services/message-channel-sync-status.service';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
@@ -43,7 +43,7 @@ export class MessagingMessageListFetchService {
     @InjectCacheStorage(CacheStorageNamespace.ModuleMessaging)
     private readonly cacheStorage: CacheStorageService,
     private readonly messageChannelSyncStatusService: MessageChannelSyncStatusService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     private readonly messagingGetMessageListService: MessagingGetMessageListService,
@@ -62,7 +62,7 @@ export class MessagingMessageListFetchService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         try {
           const pendingGroupEmailActionsProcessed =
@@ -148,7 +148,7 @@ export class MessagingMessageListFetchService {
           );
 
           const messageChannelMessageAssociationRepository =
-            await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+            await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
               'messageChannelMessageAssociation',
             );
 
@@ -344,7 +344,7 @@ export class MessagingMessageListFetchService {
     messageExternalIds: string[],
   ) {
     const messageChannelMessageAssociationRepository =
-      await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
         'messageChannelMessageAssociation',
       );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
@@ -4,7 +4,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { In } from 'typeorm';
 import { v4 } from 'uuid';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
@@ -41,9 +41,7 @@ type MessageAccumulator = {
 export class MessagingMessageService {
   private readonly logger = new Logger(MessagingMessageService.name);
 
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   public async saveMessagesWithinTransaction(
     messages: MessageWithParticipants[],
@@ -61,7 +59,7 @@ export class MessagingMessageService {
   }> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
           transactionScope.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
@@ -13,7 +13,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { BlocklistRepository } from 'src/modules/blocklist/repositories/blocklist.repository';
 import { BlocklistWorkspaceEntity } from 'src/modules/blocklist/standard-objects/blocklist.workspace-entity';
@@ -47,7 +47,7 @@ export class MessagingMessagesImportService {
     @InjectObjectMetadataRepository(BlocklistWorkspaceEntity)
     private readonly blocklistRepository: BlocklistRepository,
     private readonly emailAliasManagerService: EmailAliasManagerService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     private readonly messagingGetMessagesService: MessagingGetMessagesService,
@@ -73,7 +73,7 @@ export class MessagingMessagesImportService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         try {
           if (
@@ -155,7 +155,7 @@ export class MessagingMessagesImportService {
           });
 
           const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-process-folder-actions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-process-folder-actions.service.ts
@@ -6,7 +6,7 @@ import { In, Repository } from 'typeorm';
 
 import { type MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageFolderPendingSyncAction } from 'twenty-shared/types';
 import { MessagingDeleteFolderMessagesService } from 'src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service';
@@ -23,7 +23,7 @@ export class MessagingProcessFolderActionsService {
   );
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageFolderEntity)
     private readonly messageFolderRepository: Repository<MessageFolderEntity>,
     private readonly messagingDeleteFolderMessagesService: MessagingDeleteFolderMessagesService,
@@ -112,7 +112,7 @@ export class MessagingProcessFolderActionsService {
     if (processedFolderIds.length > 0 || folderIdsToDelete.length > 0) {
       const authContext = buildSystemAuthContext(workspaceId);
 
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           if (processedFolderIds.length > 0) {
             await this.messageFolderRepository.update(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-process-group-email-actions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-process-group-email-actions.service.ts
@@ -6,7 +6,7 @@ import { Repository } from 'typeorm';
 
 import { MessageChannelPendingGroupEmailsAction } from 'twenty-shared/types';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessagingDeleteGroupEmailMessagesService } from 'src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
@@ -18,7 +18,7 @@ export class MessagingProcessGroupEmailActionsService {
   );
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     @InjectRepository(MessageFolderEntity)
@@ -61,7 +61,7 @@ export class MessagingProcessGroupEmailActionsService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     try {
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           switch (pendingGroupEmailsAction) {
             case MessageChannelPendingGroupEmailsAction.GROUP_EMAILS_DELETION:

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
@@ -11,7 +11,7 @@ import { type MessageChannelEntity } from 'src/engine/metadata-modules/message-c
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import {
@@ -38,7 +38,7 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
     private readonly messageService: MessagingMessageService,
     private readonly messageParticipantService: MessagingMessageParticipantService,
     private readonly messageFolderAssociationService: MessagingMessageFolderAssociationService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async saveMessagesAndEnqueueContactCreation(
@@ -57,9 +57,9 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     const savedMessagesResult =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
-          return this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+          return this.workspaceOrmManager.runInWorkspaceTransaction(
             async (transactionScope) => {
               const {
                 messageExternalIdsAndIdsMap,

--- a/packages/twenty-server/src/modules/messaging/message-outbound-manager/services/messaging-draft-send.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-outbound-manager/services/messaging-draft-send.service.ts
@@ -7,7 +7,7 @@ import { In, Repository } from 'typeorm';
 
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { MessagingMessageCleanerService } from 'src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service';
@@ -18,7 +18,7 @@ import { type SendMessageResult } from 'src/modules/messaging/message-outbound-m
 @Injectable()
 export class MessagingDraftSendService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly messageOutboundService: MessagingMessageOutboundService,
     private readonly messageCleanerService: MessagingMessageCleanerService,
     @InjectRepository(MessageChannelEntity)
@@ -64,10 +64,10 @@ export class MessagingDraftSendService {
   }): Promise<string | undefined> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 
@@ -132,10 +132,10 @@ export class MessagingDraftSendService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     const associations =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const messageChannelMessageAssociationRepository =
-            await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+            await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
               'messageChannelMessageAssociation',
             );
 

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { In } from 'typeorm';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MatchParticipantService } from 'src/modules/match-participant/match-participant.service';
@@ -12,7 +12,7 @@ import { type ParticipantWithMessageId } from 'src/modules/messaging/message-imp
 @Injectable()
 export class MessagingMessageParticipantService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly matchParticipantService: MatchParticipantService<MessageParticipantWorkspaceEntity>,
   ) {}
 
@@ -23,7 +23,7 @@ export class MessagingMessageParticipantService {
   ): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageParticipantRepository =
           transactionScope.getRepository<MessageParticipantWorkspaceEntity>(

--- a/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.job.ts
@@ -11,7 +11,7 @@ import { Processor } from 'src/engine/core-modules/message-queue/decorators/proc
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessagingMonitoringService } from 'src/modules/messaging/monitoring/services/messaging-monitoring.service';
 
@@ -24,7 +24,7 @@ export class MessagingMessageChannelSyncStatusMonitoringCronJob {
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
     private readonly messagingMonitoringService: MessagingMonitoringService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     private readonly exceptionHandlerService: ExceptionHandlerService,
@@ -51,7 +51,7 @@ export class MessagingMessageChannelSyncStatusMonitoringCronJob {
       try {
         const authContext = buildSystemAuthContext(activeWorkspace.id);
 
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+        await this.workspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const messageChannels = await this.messageChannelRepository.find({
               select: ['id', 'syncStatus', 'connectedAccountId'],

--- a/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
@@ -5,15 +5,13 @@ import { In } from 'typeorm';
 
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { WorkspaceNotFoundDefaultError } from 'src/engine/core-modules/workspace/workspace.exception';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { NoteTargetWorkspaceEntity } from 'src/modules/note/standard-objects/note-target.workspace-entity';
 import { NoteWorkspaceEntity } from 'src/modules/note/standard-objects/note.workspace-entity';
 
 @Injectable()
 export class NotePostQueryHookService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async handleNoteTargetsDelete(
     authContext: WorkspaceAuthContext,
@@ -27,9 +25,9 @@ export class NotePostQueryHookService {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const noteTargetRepository =
-        await this.globalWorkspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
           'noteTarget',
         );
 
@@ -51,9 +49,9 @@ export class NotePostQueryHookService {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const noteTargetRepository =
-        await this.globalWorkspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
           'noteTarget',
         );
 

--- a/packages/twenty-server/src/modules/onboarding-recent-messages-import/services/onboarding-recent-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/onboarding-recent-messages-import/services/onboarding-recent-messages-import.service.ts
@@ -9,7 +9,7 @@ import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decora
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageChannelSyncStatusService } from 'src/modules/messaging/common/services/message-channel-sync-status.service';
 import { MessagingMessagesImportService } from 'src/modules/messaging/message-import-manager/services/messaging-messages-import.service';
@@ -27,7 +27,7 @@ export class OnboardingRecentMessagesImportService {
     private readonly cacheStorage: CacheStorageService,
     @InjectRepository(MessageChannelEntity)
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly messageChannelSyncStatusService: MessageChannelSyncStatusService,
     private readonly messagingMessagesImportService: MessagingMessagesImportService,
     private readonly recentMessagesService: RecentMessagesService,
@@ -43,7 +43,7 @@ export class OnboardingRecentMessagesImportService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     try {
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const messageChannel = await this.messageChannelRepository.findOne({
             where: { id: messageChannelId, workspaceId },

--- a/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
@@ -5,15 +5,13 @@ import { In } from 'typeorm';
 
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { WorkspaceNotFoundDefaultError } from 'src/engine/core-modules/workspace/workspace.exception';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { TaskTargetWorkspaceEntity } from 'src/modules/task/standard-objects/task-target.workspace-entity';
 import { TaskWorkspaceEntity } from 'src/modules/task/standard-objects/task.workspace-entity';
 
 @Injectable()
 export class TaskPostQueryHookService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async handleTaskTargetsDelete(
     authContext: WorkspaceAuthContext,
@@ -27,9 +25,9 @@ export class TaskPostQueryHookService {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const taskTargetRepository =
-        await this.globalWorkspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
           'taskTarget',
         );
 
@@ -51,9 +49,9 @@ export class TaskPostQueryHookService {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const taskTargetRepository =
-        await this.globalWorkspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
           'taskTarget',
         );
 

--- a/packages/twenty-server/src/modules/timeline/jobs/upsert-timeline-activity-from-internal-event.job.ts
+++ b/packages/twenty-server/src/modules/timeline/jobs/upsert-timeline-activity-from-internal-event.job.ts
@@ -3,7 +3,7 @@ import { type ObjectRecordNonDestructiveEvent } from 'twenty-shared/database-eve
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import { TimelineActivityService } from 'src/modules/timeline/services/timeline-activity.service';
@@ -12,7 +12,7 @@ import { TimelineActivityService } from 'src/modules/timeline/services/timeline-
 export class UpsertTimelineActivityFromInternalEvent {
   constructor(
     private readonly timelineActivityService: TimelineActivityService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   @Process(UpsertTimelineActivityFromInternalEvent.name)
@@ -23,7 +23,7 @@ export class UpsertTimelineActivityFromInternalEvent {
       return;
     }
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    await this.workspaceOrmManager.executeInWorkspaceContext(
       async () =>
         await this.timelineActivityService.upsertEvents(workspaceEventBatch),
       buildSystemAuthContext(workspaceEventBatch.workspaceId),

--- a/packages/twenty-server/src/modules/timeline/repositories/__tests__/timeline-activity.repository.spec.ts
+++ b/packages/twenty-server/src/modules/timeline/repositories/__tests__/timeline-activity.repository.spec.ts
@@ -1,6 +1,6 @@
 import { type TimelineActivityTypeSnapshot } from 'twenty-shared/timeline';
 
-import { type GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { type WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { TimelineActivityRepository } from 'src/modules/timeline/repositories/timeline-activity.repository';
 
 const WORKSPACE_ID = '20202020-0000-4000-8000-000000000001';
@@ -39,7 +39,7 @@ describe('TimelineActivityRepository', () => {
       update,
       insert,
     };
-    const globalWorkspaceOrmManager = {
+    const workspaceOrmManager = {
       executeInWorkspaceContext: jest.fn(
         async (callback: () => Promise<void>) => callback(),
       ),
@@ -55,10 +55,8 @@ describe('TimelineActivityRepository', () => {
             executeRawQuery: jest.fn().mockResolvedValue([]),
           }),
       ),
-    } as unknown as GlobalWorkspaceOrmManager;
-    const repository = new TimelineActivityRepository(
-      globalWorkspaceOrmManager,
-    );
+    } as unknown as WorkspaceOrmManager;
+    const repository = new TimelineActivityRepository(workspaceOrmManager);
 
     await repository.upsertTimelineActivities({
       objectSingularName: 'person',
@@ -97,7 +95,7 @@ describe('TimelineActivityRepository', () => {
       update: jest.fn().mockResolvedValue(undefined),
       insert: jest.fn().mockResolvedValue(undefined),
     };
-    const globalWorkspaceOrmManager = {
+    const workspaceOrmManager = {
       executeInWorkspaceContext: jest.fn(
         async (callback: () => Promise<void>) => callback(),
       ),
@@ -113,10 +111,8 @@ describe('TimelineActivityRepository', () => {
             executeRawQuery,
           }),
       ),
-    } as unknown as GlobalWorkspaceOrmManager;
-    const repository = new TimelineActivityRepository(
-      globalWorkspaceOrmManager,
-    );
+    } as unknown as WorkspaceOrmManager;
+    const repository = new TimelineActivityRepository(workspaceOrmManager);
 
     await repository.upsertTimelineActivities({
       objectSingularName: 'person',

--- a/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
+++ b/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
@@ -5,7 +5,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { In, MoreThan, type ObjectLiteral } from 'typeorm';
 
 import { objectRecordDiffMerge } from 'src/engine/core-modules/event-emitter/utils/object-record-diff-merge';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
@@ -30,9 +30,7 @@ const ACQUIRE_TIMELINE_ACTIVITY_MERGE_LOCK = `SELECT pg_advisory_xact_lock(hasht
 
 @Injectable()
 export class TimelineActivityRepository {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async upsertTimelineActivities({
     objectSingularName,
@@ -41,8 +39,8 @@ export class TimelineActivityRepository {
   }: TimelineActivityPayloadWorkspaceIdAndObjectSingularName) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      await this.workspaceOrmManager.runInWorkspaceTransaction(
         async (transactionScope) => {
           await this.acquireMergeLocks({
             transactionScope,

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity-target-query.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity-target-query.service.ts
@@ -4,7 +4,7 @@ import { isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
 import { In } from 'typeorm';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type ResolvedTimelineActivityTarget } from 'src/modules/timeline/types/resolved-timeline-activity-target.type';
 import { type TimelineActivityRule } from 'src/modules/timeline/types/timeline-activity-rule.type';
 import { type TimelineActivityRuleTargetJoinColumn } from 'src/modules/timeline/types/timeline-activity-rule-target-join-column.type';
@@ -29,9 +29,7 @@ const readTargetFromRecord = (
 
 @Injectable()
 export class TimelineActivityTargetQueryService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async resolveTargetsBySourceRecordId({
     rule,
@@ -52,11 +50,10 @@ export class TimelineActivityTargetQueryService {
     const { junctionObjectNameSingular, junctionSourceJoinColumnName } =
       rule.targetShape;
 
-    const junctionRepository =
-      await this.globalWorkspaceOrmManager.getRepository(
-        junctionObjectNameSingular,
-        { shouldBypassPermissionChecks: true },
-      );
+    const junctionRepository = await this.workspaceOrmManager.getRepository(
+      junctionObjectNameSingular,
+      { shouldBypassPermissionChecks: true },
+    );
 
     const junctionRows = await junctionRepository.find({
       where: { [junctionSourceJoinColumnName]: In(sourceRecordIds) },
@@ -112,7 +109,7 @@ export class TimelineActivityTargetQueryService {
       return sourceRecordsByRecordId;
     }
 
-    const repository = await this.globalWorkspaceOrmManager.getRepository(
+    const repository = await this.workspaceOrmManager.getRepository(
       rule.sourceFlatObjectMetadata.nameSingular,
       { shouldBypassPermissionChecks: true },
     );

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
@@ -12,7 +12,7 @@ import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/typ
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import { parseEventNameOrThrow } from 'src/engine/workspace-event-emitter/utils/parse-event-name';
@@ -103,7 +103,7 @@ export class TimelineActivityService {
   constructor(
     @InjectObjectMetadataRepository(TimelineActivityWorkspaceEntity)
     private readonly timelineActivityRepository: TimelineActivityRepository,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly timelineActivityRoutingPlanService: TimelineActivityRoutingPlanService,
     private readonly timelineActivityTargetQueryService: TimelineActivityTargetQueryService,
   ) {}
@@ -141,37 +141,34 @@ export class TimelineActivityService {
     });
 
     const payloads = (
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          // Resolved after the rule check so batches without rules, system
-          // objects mostly, never pay the workspace member query.
-          const enrichedEvents = await this.enrichEventsWithWorkspaceMemberId({
-            events: eventsWithoutPositionDiff,
-          });
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        // Resolved after the rule check so batches without rules, system
+        // objects mostly, never pay the workspace member query.
+        const enrichedEvents = await this.enrichEventsWithWorkspaceMemberId({
+          events: eventsWithoutPositionDiff,
+        });
 
-          return Promise.all([
-            ...sourceRules.map((rule) =>
-              this.buildPayloadsForSourceRule({
-                rule,
-                events: enrichedEvents,
-                action,
-                flatFieldMetadataMaps,
-                resolveTimelineActivityType,
-              }),
-            ),
-            ...junctionRules.map((rule) =>
-              this.buildPayloadsForJunctionRule({
-                rule,
-                events: enrichedEvents,
-                action,
-                flatFieldMetadataMaps,
-                resolveTimelineActivityType,
-              }),
-            ),
-          ]);
-        },
-        buildSystemAuthContext(workspaceId),
-      )
+        return Promise.all([
+          ...sourceRules.map((rule) =>
+            this.buildPayloadsForSourceRule({
+              rule,
+              events: enrichedEvents,
+              action,
+              flatFieldMetadataMaps,
+              resolveTimelineActivityType,
+            }),
+          ),
+          ...junctionRules.map((rule) =>
+            this.buildPayloadsForJunctionRule({
+              rule,
+              events: enrichedEvents,
+              action,
+              flatFieldMetadataMaps,
+              resolveTimelineActivityType,
+            }),
+          ),
+        ]);
+      }, buildSystemAuthContext(workspaceId))
     ).flat();
 
     if (payloads.length === 0) {
@@ -491,7 +488,7 @@ export class TimelineActivityService {
     }
 
     const workspaceMemberRepository =
-      await this.globalWorkspaceOrmManager.getRepository(
+      await this.workspaceOrmManager.getRepository(
         WorkspaceMemberWorkspaceEntity,
         {
           shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-create-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-create-many.post-query.hook.ts
@@ -8,7 +8,7 @@ import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/wo
 import { RecordPositionService } from 'src/engine/core-modules/record-position/services/record-position.service';
 import { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/workflow/services/workflow-version-core-sync.service';
 import { WorkspaceNotFoundDefaultError } from 'src/engine/core-modules/workspace/workspace.exception';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import {
   WorkflowVersionStatus,
   type WorkflowVersionWorkspaceEntity,
@@ -21,7 +21,7 @@ import { type WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standa
 })
 export class WorkflowCreateManyPostQueryHook implements WorkspacePostQueryHookInstance {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly recordPositionService: RecordPositionService,
     private readonly workflowVersionCoreSyncService: WorkflowVersionCoreSyncService,
   ) {}
@@ -35,19 +35,18 @@ export class WorkflowCreateManyPostQueryHook implements WorkspacePostQueryHookIn
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    const position =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        () =>
-          this.recordPositionService.buildRecordPosition({
-            value: 'first',
-            objectMetadata: {
-              isCustom: false,
-              nameSingular: 'workflowVersion',
-            },
-            workspaceId: workspace.id,
-          }),
-        authContext,
-      );
+    const position = await this.workspaceOrmManager.executeInWorkspaceContext(
+      () =>
+        this.recordPositionService.buildRecordPosition({
+          value: 'first',
+          objectMetadata: {
+            isCustom: false,
+            nameSingular: 'workflowVersion',
+          },
+          workspaceId: workspace.id,
+        }),
+      authContext,
+    );
 
     for (const workflow of payload) {
       await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -20,7 +20,7 @@ import {
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 import { LogicFunctionFromSourceService } from 'src/engine/metadata-modules/logic-function/services/logic-function-from-source.service';
 import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
@@ -55,7 +55,7 @@ export class WorkflowCommonWorkspaceService {
   private readonly logger = new Logger(WorkflowCommonWorkspaceService.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly logicFunctionFromSourceService: LogicFunctionFromSourceService,
     private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
     private readonly commandMenuItemService: CommandMenuItemService,
@@ -79,30 +79,27 @@ export class WorkflowCommonWorkspaceService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workflowVersion = await workflowVersionRepository.findOne({
-          where: {
-            id: workflowVersionId,
-          },
-        });
-
-        const validWorkflowVersion =
-          await this.getValidWorkflowVersionOrFail(workflowVersion);
-
-        return this.overlayCoreWorkflowVersionContent(
-          workspaceId,
-          validWorkflowVersion,
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
         );
-      },
-      authContext,
-    );
+
+      const workflowVersion = await workflowVersionRepository.findOne({
+        where: {
+          id: workflowVersionId,
+        },
+      });
+
+      const validWorkflowVersion =
+        await this.getValidWorkflowVersionOrFail(workflowVersion);
+
+      return this.overlayCoreWorkflowVersionContent(
+        workspaceId,
+        validWorkflowVersion,
+      );
+    }, authContext);
   }
 
   private async overlayCoreWorkflowVersionContent(
@@ -162,21 +159,20 @@ export class WorkflowCommonWorkspaceService {
       return;
     }
 
-    const workflows =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workflowRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-              'workflow',
-              { shouldBypassPermissionChecks: true },
-            );
+    const workflows = await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const workflowRepository =
+          await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+            'workflow',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workflowRepository.find({
-            where: { id: In(workflowIds) },
-          });
-        },
-        authContext,
-      );
+        return workflowRepository.find({
+          where: { id: In(workflowIds) },
+        });
+      },
+      authContext,
+    );
 
     await Promise.all(
       workflows.map((workflow) =>
@@ -316,21 +312,21 @@ export class WorkflowCommonWorkspaceService {
   }): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
 
       const workflowRunRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );
 
       const workflowAutomatedTriggerRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
           { shouldBypassPermissionChecks: true },
         );
@@ -414,7 +410,7 @@ export class WorkflowCommonWorkspaceService {
       withDeleted: true,
     });
 
-    await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+    await this.workspaceOrmManager.runInWorkspaceTransaction(
       async ({ getRepository }) => {
         const workflowRepository = getRepository<WorkflowWorkspaceEntity>(
           'workflow',

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
@@ -10,7 +10,7 @@ import {
   type UpdateOneResolverArgs,
 } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowQueryValidationException,
@@ -27,7 +27,7 @@ import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/work
 export class WorkflowVersionValidationWorkspaceService {
   constructor(
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async validateWorkflowVersionForCreateOne(
@@ -49,9 +49,9 @@ export class WorkflowVersionValidationWorkspaceService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -131,9 +131,9 @@ export class WorkflowVersionValidationWorkspaceService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-edge/workflow-version-edge.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-edge/workflow-version-edge.workspace-service.ts
@@ -5,7 +5,7 @@ import { TRIGGER_STEP_ID, WorkflowActionType } from 'twenty-shared/workflow';
 
 import { type WorkflowVersionStepChangesDTO } from 'src/engine/core-modules/workflow/dtos/workflow-version-step-changes.dto';
 import { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/workflow/services/workflow-version-core-sync.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowVersionEdgeException,
@@ -22,7 +22,7 @@ import { type WorkflowTrigger } from 'src/modules/workflow/workflow-trigger/type
 @Injectable()
 export class WorkflowVersionEdgeWorkspaceService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
     private readonly workflowVersionCoreSyncService: WorkflowVersionCoreSyncService,
   ) {}
@@ -42,52 +42,49 @@ export class WorkflowVersionEdgeWorkspaceService {
   }): Promise<WorkflowVersionStepChangesDTO> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowVersion =
-          await this.workflowCommonWorkspaceService.getWorkflowVersionOrFail({
-            workflowVersionId,
-            workspaceId,
-          });
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersion =
+        await this.workflowCommonWorkspaceService.getWorkflowVersionOrFail({
+          workflowVersionId,
+          workspaceId,
+        });
 
-        assertWorkflowVersionIsDraft(workflowVersion);
+      assertWorkflowVersionIsDraft(workflowVersion);
 
-        const trigger = workflowVersion.trigger;
-        const steps = workflowVersion.steps || [];
+      const trigger = workflowVersion.trigger;
+      const steps = workflowVersion.steps || [];
 
-        const targetStep = steps.find((step) => step.id === target);
+      const targetStep = steps.find((step) => step.id === target);
 
-        if (!isDefined(targetStep)) {
-          throw new WorkflowVersionEdgeException(
-            `Target step '${target}' not found in workflowVersion '${workflowVersionId}'`,
-            WorkflowVersionEdgeExceptionCode.NOT_FOUND,
-          );
-        }
+      if (!isDefined(targetStep)) {
+        throw new WorkflowVersionEdgeException(
+          `Target step '${target}' not found in workflowVersion '${workflowVersionId}'`,
+          WorkflowVersionEdgeExceptionCode.NOT_FOUND,
+        );
+      }
 
-        const isSourceTrigger = source === TRIGGER_STEP_ID;
+      const isSourceTrigger = source === TRIGGER_STEP_ID;
 
-        if (isSourceTrigger) {
-          return this.createTriggerEdge({
-            trigger,
-            steps,
-            target,
-            workflowVersion,
-            workspaceId,
-          });
-        } else {
-          return this.createStepEdge({
-            trigger,
-            steps,
-            source,
-            target,
-            sourceConnectionOptions,
-            workflowVersion,
-            workspaceId,
-          });
-        }
-      },
-      authContext,
-    );
+      if (isSourceTrigger) {
+        return this.createTriggerEdge({
+          trigger,
+          steps,
+          target,
+          workflowVersion,
+          workspaceId,
+        });
+      } else {
+        return this.createStepEdge({
+          trigger,
+          steps,
+          source,
+          target,
+          sourceConnectionOptions,
+          workflowVersion,
+          workspaceId,
+        });
+      }
+    }, authContext);
   }
 
   async deleteWorkflowVersionEdge({
@@ -105,52 +102,49 @@ export class WorkflowVersionEdgeWorkspaceService {
   }): Promise<WorkflowVersionStepChangesDTO> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowVersion =
-          await this.workflowCommonWorkspaceService.getWorkflowVersionOrFail({
-            workflowVersionId,
-            workspaceId,
-          });
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersion =
+        await this.workflowCommonWorkspaceService.getWorkflowVersionOrFail({
+          workflowVersionId,
+          workspaceId,
+        });
 
-        assertWorkflowVersionIsDraft(workflowVersion);
+      assertWorkflowVersionIsDraft(workflowVersion);
 
-        const trigger = workflowVersion.trigger;
-        const steps = workflowVersion.steps || [];
+      const trigger = workflowVersion.trigger;
+      const steps = workflowVersion.steps || [];
 
-        const targetStep = steps.find((step) => step.id === target);
+      const targetStep = steps.find((step) => step.id === target);
 
-        if (!isDefined(targetStep)) {
-          throw new WorkflowVersionEdgeException(
-            `Target step '${target}' not found in workflowVersion '${workflowVersionId}'`,
-            WorkflowVersionEdgeExceptionCode.NOT_FOUND,
-          );
-        }
+      if (!isDefined(targetStep)) {
+        throw new WorkflowVersionEdgeException(
+          `Target step '${target}' not found in workflowVersion '${workflowVersionId}'`,
+          WorkflowVersionEdgeExceptionCode.NOT_FOUND,
+        );
+      }
 
-        const isSourceTrigger = source === TRIGGER_STEP_ID;
+      const isSourceTrigger = source === TRIGGER_STEP_ID;
 
-        if (isSourceTrigger) {
-          return this.deleteTriggerEdge({
-            trigger,
-            steps,
-            target,
-            workflowVersion,
-            workspaceId,
-          });
-        } else {
-          return this.deleteStepEdge({
-            trigger,
-            steps,
-            source,
-            target,
-            workflowVersion,
-            workspaceId,
-            sourceConnectionOptions,
-          });
-        }
-      },
-      authContext,
-    );
+      if (isSourceTrigger) {
+        return this.deleteTriggerEdge({
+          trigger,
+          steps,
+          target,
+          workflowVersion,
+          workspaceId,
+        });
+      } else {
+        return this.deleteStepEdge({
+          trigger,
+          steps,
+          source,
+          target,
+          workflowVersion,
+          workspaceId,
+          sourceConnectionOptions,
+        });
+      }
+    }, authContext);
   }
 
   private async createTriggerEdge({

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -33,7 +33,7 @@ import { LogicFunctionFromSourceService } from 'src/engine/metadata-modules/logi
 import { findFlatLogicFunctionOrThrow } from 'src/engine/metadata-modules/logic-function/utils/find-flat-logic-function-or-throw.util';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
@@ -74,7 +74,7 @@ const ITERATOR_EMPTY_STEP_POSITION_OFFSET = {
 @Injectable()
 export class WorkflowVersionStepOperationsWorkspaceService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly logicFunctionFromSourceService: LogicFunctionFromSourceService,
     private readonly codeStepBuildService: CodeStepBuildService,
     private readonly agentService: AgentService,
@@ -729,72 +729,66 @@ export class WorkflowVersionStepOperationsWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const responseKeys = Object.keys(response);
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const responseKeys = Object.keys(response);
 
-        const enrichedResponses = await Promise.all(
-          responseKeys.map(async (key) => {
+      const enrichedResponses = await Promise.all(
+        responseKeys.map(async (key) => {
+          // @ts-expect-error legacy noImplicitAny
+          if (!isDefined(response[key])) {
             // @ts-expect-error legacy noImplicitAny
-            if (!isDefined(response[key])) {
-              // @ts-expect-error legacy noImplicitAny
-              return { key, value: response[key] };
-            }
+            return { key, value: response[key] };
+          }
 
-            const field = step.settings.input.find(
-              (field) => field.name === key,
+          const field = step.settings.input.find((field) => field.name === key);
+
+          if (
+            field?.type === 'RECORD' &&
+            field?.settings?.objectName &&
+            // @ts-expect-error legacy noImplicitAny
+            isDefined(response[key].id) &&
+            // @ts-expect-error legacy noImplicitAny
+            isValidUuid(response[key].id)
+          ) {
+            const { flatObjectMetadata, flatFieldMetadataMaps } =
+              await this.workflowCommonWorkspaceService.getObjectMetadataInfo(
+                field.settings.objectName,
+                workspaceId,
+              );
+
+            const relationFieldsNames = getFlatFieldsFromFlatObjectMetadata(
+              flatObjectMetadata,
+              flatFieldMetadataMaps,
+            )
+              .filter((field) => field.type === FieldMetadataType.RELATION)
+              .map((field) => field.name);
+
+            const repository = await this.workspaceOrmManager.getRepository(
+              field.settings.objectName,
+              { shouldBypassPermissionChecks: true },
             );
 
-            if (
-              field?.type === 'RECORD' &&
-              field?.settings?.objectName &&
+            const record = await repository.findOne({
               // @ts-expect-error legacy noImplicitAny
-              isDefined(response[key].id) &&
-              // @ts-expect-error legacy noImplicitAny
-              isValidUuid(response[key].id)
-            ) {
-              const { flatObjectMetadata, flatFieldMetadataMaps } =
-                await this.workflowCommonWorkspaceService.getObjectMetadataInfo(
-                  field.settings.objectName,
-                  workspaceId,
-                );
+              where: { id: response[key].id },
+              relations: relationFieldsNames,
+            });
 
-              const relationFieldsNames = getFlatFieldsFromFlatObjectMetadata(
-                flatObjectMetadata,
-                flatFieldMetadataMaps,
-              )
-                .filter((field) => field.type === FieldMetadataType.RELATION)
-                .map((field) => field.name);
+            return { key, value: record };
+          } else {
+            // @ts-expect-error legacy noImplicitAny
+            return { key, value: response[key] };
+          }
+        }),
+      );
 
-              const repository =
-                await this.globalWorkspaceOrmManager.getRepository(
-                  field.settings.objectName,
-                  { shouldBypassPermissionChecks: true },
-                );
+      return enrichedResponses.reduce((acc, { key, value }) => {
+        // @ts-expect-error legacy noImplicitAny
+        acc[key] = value;
 
-              const record = await repository.findOne({
-                // @ts-expect-error legacy noImplicitAny
-                where: { id: response[key].id },
-                relations: relationFieldsNames,
-              });
-
-              return { key, value: record };
-            } else {
-              // @ts-expect-error legacy noImplicitAny
-              return { key, value: response[key] };
-            }
-          }),
-        );
-
-        return enrichedResponses.reduce((acc, { key, value }) => {
-          // @ts-expect-error legacy noImplicitAny
-          acc[key] = value;
-
-          return acc;
-        }, {});
-      },
-      authContext,
-    );
+        return acc;
+      }, {});
+    }, authContext);
   }
 
   async cloneStep({
@@ -926,64 +920,57 @@ export class WorkflowVersionStepOperationsWorkspaceService {
   }): Promise<WorkflowAction> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workflowVersion = await workflowVersionRepository.findOne({
-          where: {
-            id: workflowVersionId,
-          },
-        });
-
-        if (!isDefined(workflowVersion)) {
-          throw new WorkflowVersionStepException(
-            'WorkflowVersion not found',
-            WorkflowVersionStepExceptionCode.NOT_FOUND,
-          );
-        }
-
-        const existingSteps = workflowVersion.steps ?? [];
-
-        const emptyNodeStep: WorkflowEmptyAction = {
-          id: v4(),
-          name: 'Add an Action',
-          type: WorkflowActionType.EMPTY,
-          valid: true,
-          nextStepIds: [iteratorStepId],
-          settings: {
-            ...BASE_STEP_DEFINITION,
-            input: {},
-          },
-          position: {
-            x:
-              (iteratorPosition?.x ?? 0) +
-              ITERATOR_EMPTY_STEP_POSITION_OFFSET.x,
-            y:
-              (iteratorPosition?.y ?? 0) +
-              ITERATOR_EMPTY_STEP_POSITION_OFFSET.y,
-          },
-        };
-
-        await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
-          workspaceId,
-          async (scopedRepository) => {
-            await scopedRepository.update(workflowVersion.id, {
-              steps: [...existingSteps, emptyNodeStep],
-            });
-
-            return workflowVersion.id;
-          },
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
         );
 
-        return emptyNodeStep;
-      },
-      authContext,
-    );
+      const workflowVersion = await workflowVersionRepository.findOne({
+        where: {
+          id: workflowVersionId,
+        },
+      });
+
+      if (!isDefined(workflowVersion)) {
+        throw new WorkflowVersionStepException(
+          'WorkflowVersion not found',
+          WorkflowVersionStepExceptionCode.NOT_FOUND,
+        );
+      }
+
+      const existingSteps = workflowVersion.steps ?? [];
+
+      const emptyNodeStep: WorkflowEmptyAction = {
+        id: v4(),
+        name: 'Add an Action',
+        type: WorkflowActionType.EMPTY,
+        valid: true,
+        nextStepIds: [iteratorStepId],
+        settings: {
+          ...BASE_STEP_DEFINITION,
+          input: {},
+        },
+        position: {
+          x: (iteratorPosition?.x ?? 0) + ITERATOR_EMPTY_STEP_POSITION_OFFSET.x,
+          y: (iteratorPosition?.y ?? 0) + ITERATOR_EMPTY_STEP_POSITION_OFFSET.y,
+        },
+      };
+
+      await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
+        workspaceId,
+        async (scopedRepository) => {
+          await scopedRepository.update(workflowVersion.id, {
+            steps: [...existingSteps, emptyNodeStep],
+          });
+
+          return workflowVersion.id;
+        },
+      );
+
+      return emptyNodeStep;
+    }, authContext);
   }
 
   async createEmptyNodesForIfElseStep({
@@ -1002,95 +989,90 @@ export class WorkflowVersionStepOperationsWorkspaceService {
   }> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workflowVersion = await workflowVersionRepository.findOne({
-          where: {
-            id: workflowVersionId,
-          },
-        });
-
-        if (!isDefined(workflowVersion)) {
-          throw new WorkflowVersionStepException(
-            'WorkflowVersion not found',
-            WorkflowVersionStepExceptionCode.NOT_FOUND,
-          );
-        }
-
-        const existingSteps = workflowVersion.steps ?? [];
-
-        const ifEmptyNode: WorkflowEmptyAction = {
-          id: v4(),
-          name: 'Add an Action',
-          type: WorkflowActionType.EMPTY,
-          valid: true,
-          settings: {
-            ...BASE_STEP_DEFINITION,
-            input: {},
-          },
-          position: {
-            x: (ifElsePosition?.x ?? 0) + IF_ELSE_BRANCH_POSITION_OFFSETS.IF.x,
-            y: (ifElsePosition?.y ?? 0) + IF_ELSE_BRANCH_POSITION_OFFSETS.IF.y,
-          },
-        };
-
-        const elseEmptyNode: WorkflowEmptyAction = {
-          id: v4(),
-          name: 'Add an Action',
-          type: WorkflowActionType.EMPTY,
-          valid: true,
-          settings: {
-            ...BASE_STEP_DEFINITION,
-            input: {},
-          },
-          position: {
-            x:
-              (ifElsePosition?.x ?? 0) + IF_ELSE_BRANCH_POSITION_OFFSETS.ELSE.x,
-            y:
-              (ifElsePosition?.y ?? 0) + IF_ELSE_BRANCH_POSITION_OFFSETS.ELSE.y,
-          },
-        };
-
-        await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
-          workspaceId,
-          async (scopedRepository) => {
-            await scopedRepository.update(workflowVersion.id, {
-              steps: [...existingSteps, ifEmptyNode, elseEmptyNode],
-            });
-
-            return workflowVersion.id;
-          },
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
         );
 
-        const ifFilterGroupId = v4();
+      const workflowVersion = await workflowVersionRepository.findOne({
+        where: {
+          id: workflowVersionId,
+        },
+      });
 
-        const branches: StepIfElseBranch[] = [
-          {
-            id: v4(),
-            filterGroupId: ifFilterGroupId,
-            nextStepIds: [ifEmptyNode.id],
-          },
-          {
-            id: v4(),
-            nextStepIds: [elseEmptyNode.id],
-          },
-        ];
+      if (!isDefined(workflowVersion)) {
+        throw new WorkflowVersionStepException(
+          'WorkflowVersion not found',
+          WorkflowVersionStepExceptionCode.NOT_FOUND,
+        );
+      }
 
-        return {
-          ifEmptyNode,
-          elseEmptyNode,
-          ifFilterGroupId,
-          branches,
-        };
-      },
-      authContext,
-    );
+      const existingSteps = workflowVersion.steps ?? [];
+
+      const ifEmptyNode: WorkflowEmptyAction = {
+        id: v4(),
+        name: 'Add an Action',
+        type: WorkflowActionType.EMPTY,
+        valid: true,
+        settings: {
+          ...BASE_STEP_DEFINITION,
+          input: {},
+        },
+        position: {
+          x: (ifElsePosition?.x ?? 0) + IF_ELSE_BRANCH_POSITION_OFFSETS.IF.x,
+          y: (ifElsePosition?.y ?? 0) + IF_ELSE_BRANCH_POSITION_OFFSETS.IF.y,
+        },
+      };
+
+      const elseEmptyNode: WorkflowEmptyAction = {
+        id: v4(),
+        name: 'Add an Action',
+        type: WorkflowActionType.EMPTY,
+        valid: true,
+        settings: {
+          ...BASE_STEP_DEFINITION,
+          input: {},
+        },
+        position: {
+          x: (ifElsePosition?.x ?? 0) + IF_ELSE_BRANCH_POSITION_OFFSETS.ELSE.x,
+          y: (ifElsePosition?.y ?? 0) + IF_ELSE_BRANCH_POSITION_OFFSETS.ELSE.y,
+        },
+      };
+
+      await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
+        workspaceId,
+        async (scopedRepository) => {
+          await scopedRepository.update(workflowVersion.id, {
+            steps: [...existingSteps, ifEmptyNode, elseEmptyNode],
+          });
+
+          return workflowVersion.id;
+        },
+      );
+
+      const ifFilterGroupId = v4();
+
+      const branches: StepIfElseBranch[] = [
+        {
+          id: v4(),
+          filterGroupId: ifFilterGroupId,
+          nextStepIds: [ifEmptyNode.id],
+        },
+        {
+          id: v4(),
+          nextStepIds: [elseEmptyNode.id],
+        },
+      ];
+
+      return {
+        ifEmptyNode,
+        elseEmptyNode,
+        ifFilterGroupId,
+        branches,
+      };
+    }, authContext);
   }
 
   async createDraftStep({

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
@@ -13,7 +13,7 @@ import { WithLock } from 'src/engine/core-modules/cache-lock/with-lock.decorator
 import { RecordPositionService } from 'src/engine/core-modules/record-position/services/record-position.service';
 import { type WorkflowStepPositionUpdateInput } from 'src/engine/core-modules/workflow/dtos/update-workflow-step-position-update.input';
 import { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/workflow/services/workflow-version-core-sync.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowVersionStepException,
@@ -38,7 +38,7 @@ import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/work
 @Injectable()
 export class WorkflowVersionWorkspaceService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowVersionStepWorkspaceService: WorkflowVersionStepWorkspaceService,
     private readonly workflowVersionStepOperationsWorkspaceService: WorkflowVersionStepOperationsWorkspaceService,
     private readonly recordPositionService: RecordPositionService,
@@ -58,126 +58,123 @@ export class WorkflowVersionWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const workflowVersionToCopy = await workflowVersionRepository.findOne({
-          where: {
-            id: workflowVersionIdToCopy,
-            workflowId,
-          },
-        });
+      const workflowVersionToCopy = await workflowVersionRepository.findOne({
+        where: {
+          id: workflowVersionIdToCopy,
+          workflowId,
+        },
+      });
 
-        if (!isDefined(workflowVersionToCopy)) {
-          throw new WorkflowVersionStepException(
-            'WorkflowVersion to copy not found',
-            WorkflowVersionStepExceptionCode.NOT_FOUND,
-          );
-        }
+      if (!isDefined(workflowVersionToCopy)) {
+        throw new WorkflowVersionStepException(
+          'WorkflowVersion to copy not found',
+          WorkflowVersionStepExceptionCode.NOT_FOUND,
+        );
+      }
 
-        assertWorkflowVersionTriggerIsDefined(workflowVersionToCopy);
-        assertWorkflowVersionHasSteps(workflowVersionToCopy);
+      assertWorkflowVersionTriggerIsDefined(workflowVersionToCopy);
+      assertWorkflowVersionHasSteps(workflowVersionToCopy);
 
-        const newWorkflowVersionTrigger = workflowVersionToCopy.trigger;
-        const newWorkflowVersionSteps: WorkflowAction[] = [];
+      const newWorkflowVersionTrigger = workflowVersionToCopy.trigger;
+      const newWorkflowVersionSteps: WorkflowAction[] = [];
 
-        for (const step of workflowVersionToCopy.steps) {
-          const duplicatedStep =
-            await this.workflowVersionStepWorkspaceService.createDraftStep({
-              step,
-              workspaceId,
-            });
-
-          newWorkflowVersionSteps.push(duplicatedStep);
-        }
-
-        const existingDraftVersion = await workflowVersionRepository.findOne({
-          where: {
-            workflowId,
-            status: WorkflowVersionStatus.DRAFT,
-          },
-        });
-
-        if (isDefined(existingDraftVersion)) {
-          assertWorkflowVersionIsDraft(existingDraftVersion);
-
-          await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
+      for (const step of workflowVersionToCopy.steps) {
+        const duplicatedStep =
+          await this.workflowVersionStepWorkspaceService.createDraftStep({
+            step,
             workspaceId,
-            async (scopedRepository) => {
-              await scopedRepository.update(existingDraftVersion.id, {
-                steps: newWorkflowVersionSteps,
-                trigger: newWorkflowVersionTrigger,
-              });
+          });
 
-              return existingDraftVersion.id;
-            },
-          );
+        newWorkflowVersionSteps.push(duplicatedStep);
+      }
 
-          return {
-            ...existingDraftVersion,
-            name: existingDraftVersion.name ?? '',
-            steps: newWorkflowVersionSteps,
-            trigger: newWorkflowVersionTrigger,
-          };
-        }
+      const existingDraftVersion = await workflowVersionRepository.findOne({
+        where: {
+          workflowId,
+          status: WorkflowVersionStatus.DRAFT,
+        },
+      });
 
-        const workflowVersionsCount = await workflowVersionRepository.count({
-          where: {
-            workflowId,
-          },
-        });
-
-        const position = await this.recordPositionService.buildRecordPosition({
-          value: 'first',
-          objectMetadata: {
-            isCustom: false,
-            nameSingular: 'workflowVersion',
-          },
-          workspaceId,
-        });
-
-        let draftWorkflowVersion: WorkflowVersionWorkspaceEntity | undefined;
+      if (isDefined(existingDraftVersion)) {
+        assertWorkflowVersionIsDraft(existingDraftVersion);
 
         await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
           workspaceId,
           async (scopedRepository) => {
-            const insertResult = await scopedRepository.insert({
-              workflowId,
-              name: `v${workflowVersionsCount + 1}`,
-              status: WorkflowVersionStatus.DRAFT,
+            await scopedRepository.update(existingDraftVersion.id, {
               steps: newWorkflowVersionSteps,
               trigger: newWorkflowVersionTrigger,
-              position,
             });
 
-            draftWorkflowVersion = insertResult
-              .generatedMaps[0] as WorkflowVersionWorkspaceEntity;
-
-            return draftWorkflowVersion.id;
+            return existingDraftVersion.id;
           },
         );
 
-        if (!isDefined(draftWorkflowVersion)) {
-          throw new WorkflowVersionStepException(
-            'Failed to create draft workflow version',
-            WorkflowVersionStepExceptionCode.NOT_FOUND,
-          );
-        }
-
         return {
-          ...draftWorkflowVersion,
-          name: draftWorkflowVersion.name ?? '',
+          ...existingDraftVersion,
+          name: existingDraftVersion.name ?? '',
           steps: newWorkflowVersionSteps,
           trigger: newWorkflowVersionTrigger,
         };
-      },
-      authContext,
-    );
+      }
+
+      const workflowVersionsCount = await workflowVersionRepository.count({
+        where: {
+          workflowId,
+        },
+      });
+
+      const position = await this.recordPositionService.buildRecordPosition({
+        value: 'first',
+        objectMetadata: {
+          isCustom: false,
+          nameSingular: 'workflowVersion',
+        },
+        workspaceId,
+      });
+
+      let draftWorkflowVersion: WorkflowVersionWorkspaceEntity | undefined;
+
+      await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
+        workspaceId,
+        async (scopedRepository) => {
+          const insertResult = await scopedRepository.insert({
+            workflowId,
+            name: `v${workflowVersionsCount + 1}`,
+            status: WorkflowVersionStatus.DRAFT,
+            steps: newWorkflowVersionSteps,
+            trigger: newWorkflowVersionTrigger,
+            position,
+          });
+
+          draftWorkflowVersion = insertResult
+            .generatedMaps[0] as WorkflowVersionWorkspaceEntity;
+
+          return draftWorkflowVersion.id;
+        },
+      );
+
+      if (!isDefined(draftWorkflowVersion)) {
+        throw new WorkflowVersionStepException(
+          'Failed to create draft workflow version',
+          WorkflowVersionStepExceptionCode.NOT_FOUND,
+        );
+      }
+
+      return {
+        ...draftWorkflowVersion,
+        name: draftWorkflowVersion.name ?? '',
+        steps: newWorkflowVersionSteps,
+        trigger: newWorkflowVersionTrigger,
+      };
+    }, authContext);
   }
 
   async duplicateWorkflow({
@@ -191,175 +188,174 @@ export class WorkflowVersionWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowRepository =
-          await this.globalWorkspaceOrmManager.getRepository('workflow', {
-            shouldBypassPermissionChecks: true,
-          });
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRepository = await this.workspaceOrmManager.getRepository(
+        'workflow',
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const sourceWorkflow = await workflowRepository.findOne({
-          where: {
-            id: workflowIdToDuplicate,
-          },
-        });
-
-        if (!isDefined(sourceWorkflow)) {
-          throw new WorkflowVersionStepException(
-            'Source workflow not found',
-            WorkflowVersionStepExceptionCode.NOT_FOUND,
-          );
-        }
-
-        const sourceVersion = await workflowVersionRepository.findOne({
-          where: {
-            id: workflowVersionIdToCopy,
-            workflowId: workflowIdToDuplicate,
-          },
-        });
-
-        if (!isDefined(sourceVersion)) {
-          throw new WorkflowVersionStepException(
-            'WorkflowVersion to copy not found',
-            WorkflowVersionStepExceptionCode.NOT_FOUND,
-          );
-        }
-
-        assertWorkflowVersionTriggerIsDefined(sourceVersion);
-        assertWorkflowVersionHasSteps(sourceVersion);
-
-        const workflowPosition =
-          await this.recordPositionService.buildRecordPosition({
-            value: 'first',
-            objectMetadata: {
-              isCustom: false,
-              nameSingular: 'workflow',
-            },
-            workspaceId,
-          });
-
-        const insertWorkflowResult = await workflowRepository.insert({
-          name: `${sourceWorkflow.name} (Duplicate)`,
-          statuses: [WorkflowStatus.DRAFT],
-          position: workflowPosition,
-        });
-
-        const newWorkflowId = (
-          insertWorkflowResult.generatedMaps[0] as WorkflowWorkspaceEntity
-        ).id;
-
-        const versionPosition =
-          await this.recordPositionService.buildRecordPosition({
-            value: 'first',
-            objectMetadata: {
-              isCustom: false,
-              nameSingular: 'workflowVersion',
-            },
-            workspaceId,
-          });
-
-        const newTrigger = sourceVersion.trigger;
-        const sourceToClonedPairs: Array<{
-          source: WorkflowAction;
-          duplicated: WorkflowAction;
-        }> = [];
-        const oldToNewIdMap = new Map<string, string>();
-
-        for (const step of sourceVersion.steps ?? []) {
-          const clonedStep =
-            await this.workflowVersionStepOperationsWorkspaceService.cloneStep({
-              step,
-              workspaceId,
-            });
-
-          sourceToClonedPairs.push({
-            source: step,
-            duplicated: clonedStep,
-          });
-          oldToNewIdMap.set(step.id, clonedStep.id);
-        }
-
-        const remappedTrigger = isDefined(newTrigger)
-          ? {
-              ...newTrigger,
-              nextStepIds: (newTrigger.nextStepIds ?? []).map(
-                (oldId) => oldToNewIdMap.get(oldId) ?? oldId,
-              ),
-            }
-          : undefined;
-
-        const remappedSteps: WorkflowAction[] = sourceToClonedPairs.map(
-          ({ source, duplicated }) => {
-            const remappedStep = {
-              ...duplicated,
-              nextStepIds: (source.nextStepIds ?? []).map(
-                (oldId) => oldToNewIdMap.get(oldId) ?? oldId,
-              ),
-            };
-
-            if (
-              source.type === WorkflowActionType.ITERATOR &&
-              isDefined(source.settings?.input?.initialLoopStepIds)
-            ) {
-              remappedStep.settings = {
-                ...remappedStep.settings,
-                input: {
-                  ...remappedStep.settings.input,
-                  initialLoopStepIds:
-                    source.settings.input.initialLoopStepIds.map(
-                      (oldId: string) => oldToNewIdMap.get(oldId) ?? oldId,
-                    ),
-                },
-              };
-            }
-
-            return remappedStep;
-          },
+      const workflowVersionRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
         );
 
-        let newDraftVersion: WorkflowVersionWorkspaceEntity | undefined;
+      const sourceWorkflow = await workflowRepository.findOne({
+        where: {
+          id: workflowIdToDuplicate,
+        },
+      });
 
-        await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
+      if (!isDefined(sourceWorkflow)) {
+        throw new WorkflowVersionStepException(
+          'Source workflow not found',
+          WorkflowVersionStepExceptionCode.NOT_FOUND,
+        );
+      }
+
+      const sourceVersion = await workflowVersionRepository.findOne({
+        where: {
+          id: workflowVersionIdToCopy,
+          workflowId: workflowIdToDuplicate,
+        },
+      });
+
+      if (!isDefined(sourceVersion)) {
+        throw new WorkflowVersionStepException(
+          'WorkflowVersion to copy not found',
+          WorkflowVersionStepExceptionCode.NOT_FOUND,
+        );
+      }
+
+      assertWorkflowVersionTriggerIsDefined(sourceVersion);
+      assertWorkflowVersionHasSteps(sourceVersion);
+
+      const workflowPosition =
+        await this.recordPositionService.buildRecordPosition({
+          value: 'first',
+          objectMetadata: {
+            isCustom: false,
+            nameSingular: 'workflow',
+          },
           workspaceId,
-          async (scopedRepository) => {
-            const insertVersionResult = await scopedRepository.insert({
-              workflowId: newWorkflowId,
-              name: 'v1',
-              status: WorkflowVersionStatus.DRAFT,
-              position: versionPosition,
-              steps: remappedSteps,
-              trigger: remappedTrigger,
-            });
+        });
 
-            newDraftVersion = insertVersionResult
-              .generatedMaps[0] as WorkflowVersionWorkspaceEntity;
+      const insertWorkflowResult = await workflowRepository.insert({
+        name: `${sourceWorkflow.name} (Duplicate)`,
+        statuses: [WorkflowStatus.DRAFT],
+        position: workflowPosition,
+      });
 
-            return newDraftVersion.id;
+      const newWorkflowId = (
+        insertWorkflowResult.generatedMaps[0] as WorkflowWorkspaceEntity
+      ).id;
+
+      const versionPosition =
+        await this.recordPositionService.buildRecordPosition({
+          value: 'first',
+          objectMetadata: {
+            isCustom: false,
+            nameSingular: 'workflowVersion',
           },
+          workspaceId,
+        });
+
+      const newTrigger = sourceVersion.trigger;
+      const sourceToClonedPairs: Array<{
+        source: WorkflowAction;
+        duplicated: WorkflowAction;
+      }> = [];
+      const oldToNewIdMap = new Map<string, string>();
+
+      for (const step of sourceVersion.steps ?? []) {
+        const clonedStep =
+          await this.workflowVersionStepOperationsWorkspaceService.cloneStep({
+            step,
+            workspaceId,
+          });
+
+        sourceToClonedPairs.push({
+          source: step,
+          duplicated: clonedStep,
+        });
+        oldToNewIdMap.set(step.id, clonedStep.id);
+      }
+
+      const remappedTrigger = isDefined(newTrigger)
+        ? {
+            ...newTrigger,
+            nextStepIds: (newTrigger.nextStepIds ?? []).map(
+              (oldId) => oldToNewIdMap.get(oldId) ?? oldId,
+            ),
+          }
+        : undefined;
+
+      const remappedSteps: WorkflowAction[] = sourceToClonedPairs.map(
+        ({ source, duplicated }) => {
+          const remappedStep = {
+            ...duplicated,
+            nextStepIds: (source.nextStepIds ?? []).map(
+              (oldId) => oldToNewIdMap.get(oldId) ?? oldId,
+            ),
+          };
+
+          if (
+            source.type === WorkflowActionType.ITERATOR &&
+            isDefined(source.settings?.input?.initialLoopStepIds)
+          ) {
+            remappedStep.settings = {
+              ...remappedStep.settings,
+              input: {
+                ...remappedStep.settings.input,
+                initialLoopStepIds:
+                  source.settings.input.initialLoopStepIds.map(
+                    (oldId: string) => oldToNewIdMap.get(oldId) ?? oldId,
+                  ),
+              },
+            };
+          }
+
+          return remappedStep;
+        },
+      );
+
+      let newDraftVersion: WorkflowVersionWorkspaceEntity | undefined;
+
+      await this.workflowVersionCoreSyncService.writeWorkflowVersionAndMirror(
+        workspaceId,
+        async (scopedRepository) => {
+          const insertVersionResult = await scopedRepository.insert({
+            workflowId: newWorkflowId,
+            name: 'v1',
+            status: WorkflowVersionStatus.DRAFT,
+            position: versionPosition,
+            steps: remappedSteps,
+            trigger: remappedTrigger,
+          });
+
+          newDraftVersion = insertVersionResult
+            .generatedMaps[0] as WorkflowVersionWorkspaceEntity;
+
+          return newDraftVersion.id;
+        },
+      );
+
+      if (!isDefined(newDraftVersion)) {
+        throw new WorkflowVersionStepException(
+          'Failed to duplicate workflow version',
+          WorkflowVersionStepExceptionCode.NOT_FOUND,
         );
+      }
 
-        if (!isDefined(newDraftVersion)) {
-          throw new WorkflowVersionStepException(
-            'Failed to duplicate workflow version',
-            WorkflowVersionStepExceptionCode.NOT_FOUND,
-          );
-        }
-
-        return {
-          ...newDraftVersion,
-          name: newDraftVersion.name ?? '',
-          steps: remappedSteps,
-          trigger: remappedTrigger ?? null,
-        };
-      },
-      authContext,
-    );
+      return {
+        ...newDraftVersion,
+        name: newDraftVersion.name ?? '',
+        steps: remappedSteps,
+        trigger: remappedTrigger ?? null,
+      };
+    }, authContext);
   }
 
   async updateWorkflowVersionPositions({
@@ -373,9 +369,9 @@ export class WorkflowVersionWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/delay/jobs/resume-delayed-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/delay/jobs/resume-delayed-workflow.job.ts
@@ -7,7 +7,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { RESUME_DELAYED_WORKFLOW_JOB_NAME } from 'src/modules/workflow/workflow-executor/workflow-actions/delay/contants/resume-delayed-workflow-job-name';
@@ -31,7 +31,7 @@ export class ResumeDelayedWorkflowJob {
     @InjectMessageQueue(MessageQueue.workflowQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly workflowRunWorkspaceService: WorkflowRunWorkspaceService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   @Process(RESUME_DELAYED_WORKFLOW_JOB_NAME)
@@ -42,7 +42,7 @@ export class ResumeDelayedWorkflowJob {
   }: ResumeDelayedWorkflowJobData): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       try {
         const workflowRun =
           await this.workflowRunWorkspaceService.getWorkflowRunOrFail({

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/__tests__/draft-email.workflow-action.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/__tests__/draft-email.workflow-action.spec.ts
@@ -5,7 +5,7 @@ import { WorkflowActionType } from 'twenty-shared/workflow';
 import { DraftEmailTool } from 'src/engine/core-modules/tool/tools/email-tool/draft-email-tool';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { DraftEmailWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/mail-sender/draft-email.workflow-action';
 import { type WorkflowActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action-settings.type';
 import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
@@ -64,7 +64,7 @@ describe('DraftEmailWorkflowAction', () => {
           useValue: { setStepLog: mockSetStepLog },
         },
         {
-          provide: GlobalWorkspaceOrmManager,
+          provide: WorkspaceOrmManager,
           useValue: {
             executeInWorkspaceContext: jest.fn((callback) => callback()),
             getRepository: jest

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/__tests__/send-email.workflow-action.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/__tests__/send-email.workflow-action.spec.ts
@@ -5,7 +5,7 @@ import { WorkflowActionType } from 'twenty-shared/workflow';
 import { SendEmailTool } from 'src/engine/core-modules/tool/tools/email-tool/send-email-tool';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { SendEmailWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action';
 import { type WorkflowActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action-settings.type';
 import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
@@ -68,7 +68,7 @@ describe('SendEmailWorkflowAction', () => {
           useValue: { setStepLog: jest.fn() },
         },
         {
-          provide: GlobalWorkspaceOrmManager,
+          provide: WorkspaceOrmManager,
           useValue: {
             executeInWorkspaceContext: jest.fn((callback) => callback()),
             getRepository: jest

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/draft-email.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/draft-email.workflow-action.ts
@@ -7,7 +7,7 @@ import { DraftEmailTool } from 'src/engine/core-modules/tool/tools/email-tool/dr
 import { type Tool } from 'src/engine/core-modules/tool/types/tool.type';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import {
   WorkflowStepExecutorException,
   WorkflowStepExecutorExceptionCode,
@@ -23,7 +23,7 @@ export class DraftEmailWorkflowAction extends EmailWorkflowActionBase {
   constructor(
     private readonly draftEmailTool: DraftEmailTool,
     workflowRunStepLogService: WorkflowRunStepLogWorkspaceService,
-    globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(ConnectedAccountEntity)
     connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectRepository(UserWorkspaceEntity)
@@ -32,7 +32,7 @@ export class DraftEmailWorkflowAction extends EmailWorkflowActionBase {
     super(
       DraftEmailWorkflowAction.name,
       workflowRunStepLogService,
-      globalWorkspaceOrmManager,
+      workspaceOrmManager,
       connectedAccountRepository,
       userWorkspaceRepository,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/email-workflow-action.base.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/email-workflow-action.base.ts
@@ -10,7 +10,7 @@ import { IsNull, type Repository } from 'typeorm';
 import { type ToolOutput } from 'src/engine/core-modules/tool/types/tool-output.type';
 import { type UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowStepExecutorException,
@@ -31,7 +31,7 @@ export abstract class EmailWorkflowActionBase extends ToolBackedWorkflowAction<W
   protected constructor(
     loggerName: string,
     workflowRunStepLogService: WorkflowRunStepLogWorkspaceService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
   ) {
@@ -99,38 +99,35 @@ export abstract class EmailWorkflowActionBase extends ToolBackedWorkflowAction<W
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workspaceMember = await this.findWorkspaceMemberById(senderId);
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMember = await this.findWorkspaceMemberById(senderId);
 
-        if (!isDefined(workspaceMember)) {
-          return senderId;
-        }
+      if (!isDefined(workspaceMember)) {
+        return senderId;
+      }
 
-        const connectedAccountId =
-          await this.findFirstConnectedAccountIdByWorkspaceMember(
-            workspaceMember,
-            workspaceId,
-          );
+      const connectedAccountId =
+        await this.findFirstConnectedAccountIdByWorkspaceMember(
+          workspaceMember,
+          workspaceId,
+        );
 
-        if (!isDefined(connectedAccountId)) {
-          throw new WorkflowStepExecutorException(
-            `No connected account found for workspace member '${senderId}'`,
-            WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
-          );
-        }
+      if (!isDefined(connectedAccountId)) {
+        throw new WorkflowStepExecutorException(
+          `No connected account found for workspace member '${senderId}'`,
+          WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
+        );
+      }
 
-        return connectedAccountId;
-      },
-      authContext,
-    );
+      return connectedAccountId;
+    }, authContext);
   }
 
   private async findWorkspaceMemberById(
     workspaceMemberId: string,
   ): Promise<WorkspaceMemberWorkspaceEntity | null> {
     const workspaceMemberRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action.ts
@@ -7,7 +7,7 @@ import { SendEmailTool } from 'src/engine/core-modules/tool/tools/email-tool/sen
 import { type Tool } from 'src/engine/core-modules/tool/types/tool.type';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import {
   WorkflowStepExecutorException,
   WorkflowStepExecutorExceptionCode,
@@ -23,7 +23,7 @@ export class SendEmailWorkflowAction extends EmailWorkflowActionBase {
   constructor(
     private readonly sendEmailTool: SendEmailTool,
     workflowRunStepLogService: WorkflowRunStepLogWorkspaceService,
-    globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(ConnectedAccountEntity)
     connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectRepository(UserWorkspaceEntity)
@@ -32,7 +32,7 @@ export class SendEmailWorkflowAction extends EmailWorkflowActionBase {
     super(
       SendEmailWorkflowAction.name,
       workflowRunStepLogService,
-      globalWorkspaceOrmManager,
+      workspaceOrmManager,
       connectedAccountRepository,
       userWorkspaceRepository,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -7,7 +7,7 @@ import { Processor } from 'src/engine/core-modules/message-queue/decorators/proc
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
@@ -32,7 +32,7 @@ export class RunWorkflowJob {
     private readonly workflowExecutorWorkspaceService: WorkflowExecutorWorkspaceService,
     private readonly workflowRunWorkspaceService: WorkflowRunWorkspaceService,
     private readonly metricsService: MetricsService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   @Process(RUN_WORKFLOW_JOB_NAME)
@@ -47,7 +47,7 @@ export class RunWorkflowJob {
     );
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       try {
         if (isDefined(stepIdsToRetry)) {
           await this.retryWorkflowExecution({

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
@@ -15,7 +15,7 @@ import { Processor } from 'src/engine/core-modules/message-queue/decorators/proc
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowRunStatus,
@@ -43,7 +43,7 @@ export class WorkflowCleanWorkflowRunsCronJob {
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
     @InjectMessageQueue(MessageQueue.workflowQueue)
     private readonly messageQueueService: MessageQueueService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly exceptionHandlerService: ExceptionHandlerService,
     @InjectCacheStorage(CacheStorageNamespace.ModuleWorkflow)
     private readonly cacheStorageService: CacheStorageService,
@@ -137,10 +137,10 @@ export class WorkflowCleanWorkflowRunsCronJob {
   private async hasRunsToClean(workspaceId: string): Promise<boolean> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+    return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workflowRunRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
+          await this.workspaceOrmManager.getRepository(
             WorkflowRunWorkspaceEntity,
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job.ts
@@ -6,7 +6,7 @@ import { DataSource } from 'typeorm';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
@@ -22,7 +22,7 @@ export class WorkflowCleanWorkflowRunsJob {
   private readonly logger = new Logger(WorkflowCleanWorkflowRunsJob.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectDataSource()
     private readonly dataSource: DataSource,
   ) {}
@@ -38,7 +38,7 @@ export class WorkflowCleanWorkflowRunsJob {
       `[WorkflowCleanWorkflowRunsJob] Starting job for workspace ${workspaceId}`,
     );
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const BATCH_SIZE = 200;
       let totalDeleted = 0;
 

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -13,7 +13,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowRunStatus,
@@ -36,7 +36,7 @@ export class WorkflowHandleStaledRunsWorkspaceService {
     WorkflowHandleStaledRunsWorkspaceService.name,
   );
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowThrottlingWorkspaceService: WorkflowThrottlingWorkspaceService,
     private readonly workflowRunWorkspaceService: WorkflowRunWorkspaceService,
     @InjectMessageQueue(MessageQueue.workflowQueue)
@@ -49,9 +49,9 @@ export class WorkflowHandleStaledRunsWorkspaceService {
   async handleStaledRunsForWorkspace(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRunRepository =
-        await this.globalWorkspaceOrmManager.getRepository(
+        await this.workspaceOrmManager.getRepository(
           WorkflowRunWorkspaceEntity,
           { shouldBypassPermissionChecks: true },
         );
@@ -279,32 +279,29 @@ export class WorkflowHandleStaledRunsWorkspaceService {
   }): Promise<string[]> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowRunRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            WorkflowRunWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRunRepository =
+        await this.workspaceOrmManager.getRepository(
+          WorkflowRunWorkspaceEntity,
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const runIds: string[] = [];
-        let page: WorkflowRunWorkspaceEntity[];
+      const runIds: string[] = [];
+      let page: WorkflowRunWorkspaceEntity[];
 
-        do {
-          page = await workflowRunRepository.find({
-            where: findOptions,
-            select: { id: true },
-            order: { createdAt: 'ASC', id: 'ASC' },
-            take: QUERY_MAX_RECORDS,
-            skip: runIds.length,
-          });
+      do {
+        page = await workflowRunRepository.find({
+          where: findOptions,
+          select: { id: true },
+          order: { createdAt: 'ASC', id: 'ASC' },
+          take: QUERY_MAX_RECORDS,
+          skip: runIds.length,
+        });
 
-          runIds.push(...page.map((workflowRun) => workflowRun.id));
-        } while (page.length === QUERY_MAX_RECORDS);
+        runIds.push(...page.map((workflowRun) => workflowRun.id));
+      } while (page.length === QUERY_MAX_RECORDS);
 
-        return runIds;
-      },
-      authContext,
-    );
+      return runIds;
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -7,7 +7,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowRunStatus,
@@ -24,7 +24,7 @@ export class WorkflowRunEnqueueWorkspaceService {
   private readonly logger = new Logger(WorkflowRunEnqueueWorkspaceService.name);
   constructor(
     private readonly workflowThrottlingWorkspaceService: WorkflowThrottlingWorkspaceService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectMessageQueue(MessageQueue.workflowQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly metricsService: MetricsService,
@@ -49,110 +49,107 @@ export class WorkflowRunEnqueueWorkspaceService {
     try {
       const authContext = buildSystemAuthContext(workspaceId);
 
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workflowRunRepository =
-            await this.globalWorkspaceOrmManager.getRepository(
-              WorkflowRunWorkspaceEntity,
-              { shouldBypassPermissionChecks: true },
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workflowRunRepository =
+          await this.workspaceOrmManager.getRepository(
+            WorkflowRunWorkspaceEntity,
+            { shouldBypassPermissionChecks: true },
+          );
+
+        const notStartedRunsCount = isCacheMode
+          ? await this.workflowThrottlingWorkspaceService.getNotStartedRunsCountFromCache(
+              workspaceId,
+            )
+          : await this.workflowThrottlingWorkspaceService.getNotStartedRunsCountFromDatabase(
+              workspaceId,
             );
 
-          const notStartedRunsCount = isCacheMode
-            ? await this.workflowThrottlingWorkspaceService.getNotStartedRunsCountFromCache(
-                workspaceId,
-              )
-            : await this.workflowThrottlingWorkspaceService.getNotStartedRunsCountFromDatabase(
-                workspaceId,
-              );
+        if (notStartedRunsCount <= 0) {
+          await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
+            workspaceId,
+          );
 
-          if (notStartedRunsCount <= 0) {
+          return;
+        }
+
+        let remainingWorkflowRunToEnqueueCount =
+          await this.workflowThrottlingWorkspaceService.getRemainingRunsToEnqueueCount(
+            workspaceId,
+          );
+
+        let totalEnqueuedCount = 0;
+
+        while (remainingWorkflowRunToEnqueueCount > 0) {
+          const batchSize = Math.min(
+            remainingWorkflowRunToEnqueueCount,
+            QUERY_MAX_RECORDS,
+          );
+
+          const batchRuns = await workflowRunRepository.find({
+            where: NOT_STARTED_RUNS_FIND_OPTIONS,
+            select: {
+              id: true,
+            },
+            order: {
+              createdAt: 'ASC',
+            },
+            take: batchSize,
+          });
+
+          if (batchRuns.length === 0) {
+            break;
+          }
+
+          const batchIds = batchRuns.map(
+            (workflowRun: WorkflowRunWorkspaceEntity) => workflowRun.id,
+          );
+
+          await workflowRunRepository.update(batchIds, {
+            enqueuedAt: new Date().toISOString(),
+            status: WorkflowRunStatus.ENQUEUED,
+          });
+
+          for (const workflowRunId of batchIds) {
+            await this.messageQueueService.add<RunWorkflowJobData>(
+              RunWorkflowJob.name,
+              {
+                workflowRunId,
+                workspaceId,
+              },
+              buildRunWorkflowJobOptions(workflowRunId),
+            );
+          }
+
+          totalEnqueuedCount += batchRuns.length;
+          remainingWorkflowRunToEnqueueCount -= batchRuns.length;
+        }
+
+        if (totalEnqueuedCount === 0) {
+          if (!isCacheMode) {
             await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
               workspaceId,
             );
-
-            return;
           }
 
-          let remainingWorkflowRunToEnqueueCount =
-            await this.workflowThrottlingWorkspaceService.getRemainingRunsToEnqueueCount(
-              workspaceId,
-            );
+          return;
+        }
 
-          let totalEnqueuedCount = 0;
+        await this.workflowThrottlingWorkspaceService.consumeRemainingRunsToEnqueueCount(
+          workspaceId,
+          totalEnqueuedCount,
+        );
 
-          while (remainingWorkflowRunToEnqueueCount > 0) {
-            const batchSize = Math.min(
-              remainingWorkflowRunToEnqueueCount,
-              QUERY_MAX_RECORDS,
-            );
-
-            const batchRuns = await workflowRunRepository.find({
-              where: NOT_STARTED_RUNS_FIND_OPTIONS,
-              select: {
-                id: true,
-              },
-              order: {
-                createdAt: 'ASC',
-              },
-              take: batchSize,
-            });
-
-            if (batchRuns.length === 0) {
-              break;
-            }
-
-            const batchIds = batchRuns.map(
-              (workflowRun: WorkflowRunWorkspaceEntity) => workflowRun.id,
-            );
-
-            await workflowRunRepository.update(batchIds, {
-              enqueuedAt: new Date().toISOString(),
-              status: WorkflowRunStatus.ENQUEUED,
-            });
-
-            for (const workflowRunId of batchIds) {
-              await this.messageQueueService.add<RunWorkflowJobData>(
-                RunWorkflowJob.name,
-                {
-                  workflowRunId,
-                  workspaceId,
-                },
-                buildRunWorkflowJobOptions(workflowRunId),
-              );
-            }
-
-            totalEnqueuedCount += batchRuns.length;
-            remainingWorkflowRunToEnqueueCount -= batchRuns.length;
-          }
-
-          if (totalEnqueuedCount === 0) {
-            if (!isCacheMode) {
-              await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
-                workspaceId,
-              );
-            }
-
-            return;
-          }
-
-          await this.workflowThrottlingWorkspaceService.consumeRemainingRunsToEnqueueCount(
+        if (isCacheMode) {
+          await this.workflowThrottlingWorkspaceService.decreaseWorkflowRunNotStartedCount(
             workspaceId,
             totalEnqueuedCount,
           );
-
-          if (isCacheMode) {
-            await this.workflowThrottlingWorkspaceService.decreaseWorkflowRunNotStartedCount(
-              workspaceId,
-              totalEnqueuedCount,
-            );
-          } else {
-            await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
-              workspaceId,
-            );
-          }
-        },
-        authContext,
-      );
+        } else {
+          await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
+            workspaceId,
+          );
+        }
+      }, authContext);
     } catch (error) {
       try {
         await this.metricsService.incrementCounterForEvent({

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
@@ -5,7 +5,7 @@ import { CacheStorageService } from 'src/engine/core-modules/cache-storage/servi
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
 import { ThrottlerService } from 'src/engine/core-modules/throttler/throttler.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { NOT_STARTED_RUNS_FIND_OPTIONS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/not-started-runs-find-options';
@@ -15,7 +15,7 @@ export class WorkflowThrottlingWorkspaceService {
   constructor(
     @InjectCacheStorage(CacheStorageNamespace.ModuleWorkflow)
     private readonly cacheStorage: CacheStorageService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly throttlerService: ThrottlerService,
     private readonly twentyConfigService: TwentyConfigService,
   ) {}
@@ -75,20 +75,17 @@ export class WorkflowThrottlingWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     const currentlyNotStartedWorkflowRunCount =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workflowRunRepository =
-            await this.globalWorkspaceOrmManager.getRepository(
-              WorkflowRunWorkspaceEntity,
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workflowRunRepository =
+          await this.workspaceOrmManager.getRepository(
+            WorkflowRunWorkspaceEntity,
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workflowRunRepository.count({
-            where: NOT_STARTED_RUNS_FIND_OPTIONS,
-          });
-        },
-        authContext,
-      );
+        return workflowRunRepository.count({
+          where: NOT_STARTED_RUNS_FIND_OPTIONS,
+        });
+      }, authContext);
 
     await this.setWorkflowRunNotStartedCount(
       workspaceId,
@@ -105,20 +102,17 @@ export class WorkflowThrottlingWorkspaceService {
   ): Promise<number> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowRunRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            WorkflowRunWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRunRepository =
+        await this.workspaceOrmManager.getRepository(
+          WorkflowRunWorkspaceEntity,
+          { shouldBypassPermissionChecks: true },
+        );
 
-        return workflowRunRepository.count({
-          where: NOT_STARTED_RUNS_FIND_OPTIONS,
-        });
-      },
-      authContext,
-    );
+      return workflowRunRepository.count({
+        where: NOT_STARTED_RUNS_FIND_OPTIONS,
+      });
+    }, authContext);
   }
 
   async acquireWorkflowEnqueueLock(

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/command/delete-workflow-runs.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/command/delete-workflow-runs.command.ts
@@ -4,7 +4,7 @@ import { LessThan } from 'typeorm';
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 
@@ -16,7 +16,7 @@ export class DeleteWorkflowRunsCommand extends ProvisionedWorkspaceCommandRunner
   private createdBeforeDate: string | undefined;
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
   ) {
     super(workspaceIteratorService);
@@ -48,10 +48,10 @@ export class DeleteWorkflowRunsCommand extends ProvisionedWorkspaceCommandRunner
   }: RunOnWorkspaceArgs): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       try {
         const workflowRunRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+          await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
             'workflowRun',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -9,7 +9,7 @@ import { WithLock } from 'src/engine/core-modules/cache-lock/with-lock.decorator
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import { RecordPositionService } from 'src/engine/core-modules/record-position/services/record-position.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowRunStatus,
@@ -27,7 +27,7 @@ import {
 @Injectable()
 export class WorkflowRunWorkspaceService {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
     private readonly recordPositionService: RecordPositionService,
     private readonly metricsService: MetricsService,
@@ -55,84 +55,83 @@ export class WorkflowRunWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowRunRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-            'workflowRun',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workflowVersion =
-          await this.workflowCommonWorkspaceService.getWorkflowVersionOrFail({
-            workspaceId,
-            workflowVersionId,
-          });
-
-        const workflowRepository =
-          await this.globalWorkspaceOrmManager.getRepository('workflow', {
-            shouldBypassPermissionChecks: true,
-          });
-
-        const workflow = await workflowRepository.findOne({
-          where: {
-            id: workflowVersion.workflowId,
-          },
-        });
-
-        if (!workflow) {
-          throw new WorkflowRunException(
-            'Workflow id is invalid',
-            WorkflowRunExceptionCode.WORKFLOW_RUN_INVALID,
-          );
-        }
-
-        const position = await this.recordPositionService.buildRecordPosition({
-          value: 'first',
-          objectMetadata: {
-            isCustom: false,
-            nameSingular: 'workflowRun',
-          },
-          workspaceId,
-        });
-
-        const initState = this.getInitState(
-          workflowVersion,
-          triggerPayload,
-          error,
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRunRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+          'workflowRun',
+          { shouldBypassPermissionChecks: true },
         );
 
-        const lastWorkflowRun = await workflowRunRepository.findOne({
-          where: {
-            workflowId: workflow.id,
-          },
-          order: { createdAt: 'DESC' },
+      const workflowVersion =
+        await this.workflowCommonWorkspaceService.getWorkflowVersionOrFail({
+          workspaceId,
+          workflowVersionId,
         });
 
-        const workflowRunCountMatch = lastWorkflowRun?.name?.match(/#(\d+)/);
+      const workflowRepository = await this.workspaceOrmManager.getRepository(
+        'workflow',
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        const workflowRunCount = workflowRunCountMatch
-          ? parseInt(workflowRunCountMatch[1], 10)
-          : 0;
+      const workflow = await workflowRepository.findOne({
+        where: {
+          id: workflowVersion.workflowId,
+        },
+      });
 
-        const workflowRun = {
-          id: workflowRunId ?? v4(),
-          name: `#${workflowRunCount + 1} - ${workflow.name}`,
-          workflowVersionId,
-          createdBy,
+      if (!workflow) {
+        throw new WorkflowRunException(
+          'Workflow id is invalid',
+          WorkflowRunExceptionCode.WORKFLOW_RUN_INVALID,
+        );
+      }
+
+      const position = await this.recordPositionService.buildRecordPosition({
+        value: 'first',
+        objectMetadata: {
+          isCustom: false,
+          nameSingular: 'workflowRun',
+        },
+        workspaceId,
+      });
+
+      const initState = this.getInitState(
+        workflowVersion,
+        triggerPayload,
+        error,
+      );
+
+      const lastWorkflowRun = await workflowRunRepository.findOne({
+        where: {
           workflowId: workflow.id,
-          status,
-          position,
-          state: initState,
-          enqueuedAt: status === WorkflowRunStatus.ENQUEUED ? new Date() : null,
-        };
+        },
+        order: { createdAt: 'DESC' },
+      });
 
-        await workflowRunRepository.insert(workflowRun);
+      const workflowRunCountMatch = lastWorkflowRun?.name?.match(/#(\d+)/);
 
-        return workflowRun.id;
-      },
-      authContext,
-    );
+      const workflowRunCount = workflowRunCountMatch
+        ? parseInt(workflowRunCountMatch[1], 10)
+        : 0;
+
+      const workflowRun = {
+        id: workflowRunId ?? v4(),
+        name: `#${workflowRunCount + 1} - ${workflow.name}`,
+        workflowVersionId,
+        createdBy,
+        workflowId: workflow.id,
+        status,
+        position,
+        state: initState,
+        enqueuedAt: status === WorkflowRunStatus.ENQUEUED ? new Date() : null,
+      };
+
+      await workflowRunRepository.insert(workflowRun);
+
+      return workflowRun.id;
+    }, authContext);
   }
 
   @WithLock('workflowRunId')
@@ -361,20 +360,17 @@ export class WorkflowRunWorkspaceService {
   }): Promise<WorkflowRunWorkspaceEntity | null> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowRunRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-            'workflowRun',
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRunRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+          'workflowRun',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        return await workflowRunRepository.findOne({
-          where: { id: workflowRunId },
-        });
-      },
-      authContext,
-    );
+      return await workflowRunRepository.findOne({
+        where: { id: workflowRunId },
+      });
+    }, authContext);
   }
 
   async getWorkflowRunOrFail({
@@ -410,9 +406,9 @@ export class WorkflowRunWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRunRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -7,7 +7,7 @@ import { computeCoreWorkflowStatuses } from 'src/engine/core-modules/workflow/ut
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
@@ -57,15 +57,13 @@ export type WorkflowVersionBatchDelete = {
 export class WorkflowStatusesUpdateJob {
   protected readonly logger = new Logger(WorkflowStatusesUpdateJob.name);
 
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   @Process(WorkflowStatusesUpdateJob.name)
   async handle(event: WorkflowVersionBatchEvent): Promise<void> {
     const authContext = buildSystemAuthContext(event.workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       switch (event.type) {
         case WorkflowVersionEventType.CREATE:
         case WorkflowVersionEventType.DELETE:
@@ -98,13 +96,13 @@ export class WorkflowStatusesUpdateJob {
     workflowId: string;
   }): Promise<void> {
     const workflowRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
         'workflow',
         { shouldBypassPermissionChecks: true },
       );
 
     const workflowVersionRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
         'workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
@@ -141,13 +139,13 @@ export class WorkflowStatusesUpdateJob {
     statusUpdate: WorkflowVersionStatusUpdate;
   }): Promise<void> {
     const workflowRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
         'workflow',
         { shouldBypassPermissionChecks: true },
       );
 
     const workflowVersionRepository =
-      await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
         'workflowVersion',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/services/workflow-tool.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/services/workflow-tool.workspace-service.ts
@@ -7,7 +7,7 @@ import { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/workflow
 import { AgentService } from 'src/engine/metadata-modules/ai/ai-agent/agent.service';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { LogicFunctionFromSourceService } from 'src/engine/metadata-modules/logic-function/services/logic-function-from-source.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import { WorkflowSchemaWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service';
@@ -53,7 +53,7 @@ export class WorkflowToolWorkspaceService {
     workflowTriggerService: WorkflowTriggerWorkspaceService,
     workflowSchemaService: WorkflowSchemaWorkspaceService,
     workflowValidationService: WorkflowValidationWorkspaceService,
-    globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    workspaceOrmManager: WorkspaceOrmManager,
     recordPositionService: RecordPositionService,
     logicFunctionFromSourceService: LogicFunctionFromSourceService,
     flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
@@ -69,7 +69,7 @@ export class WorkflowToolWorkspaceService {
       workflowTriggerService,
       workflowSchemaService,
       workflowValidationService,
-      globalWorkspaceOrmManager,
+      workspaceOrmManager,
       recordPositionService,
       logicFunctionFromSourceService,
       flatEntityMapsCacheService,

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/delete-workflow.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/delete-workflow.tool.spec.ts
@@ -6,7 +6,7 @@ const buildTool = () => {
   const workflowRepository = {
     softDelete: jest.fn().mockResolvedValue({ affected: 1 }),
   };
-  const globalWorkspaceOrmManager = {
+  const workspaceOrmManager = {
     executeInWorkspaceContext: jest.fn((callback: () => unknown) => callback()),
     getRepository: jest.fn().mockResolvedValue(workflowRepository),
   };
@@ -16,7 +16,7 @@ const buildTool = () => {
 
   const tool = createDeleteWorkflowTool(
     {
-      globalWorkspaceOrmManager,
+      workspaceOrmManager,
       workflowCommonService,
     } as never,
     {
@@ -28,7 +28,7 @@ const buildTool = () => {
   return {
     tool,
     workflowRepository,
-    globalWorkspaceOrmManager,
+    workspaceOrmManager,
     workflowCommonService,
   };
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-current-version.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-current-version.tool.spec.ts
@@ -30,7 +30,7 @@ const buildDeps = ({
   });
 
   return {
-    globalWorkspaceOrmManager: {
+    workspaceOrmManager: {
       executeInWorkspaceContext: jest
         .fn()
         .mockImplementation(async (fn) => fn()),
@@ -54,21 +54,18 @@ describe('get_workflow_current_version tool', () => {
     });
 
     const tool = createGetWorkflowCurrentVersionTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 
     await tool.execute({ workflowId: WORKFLOW_ID });
 
-    expect(
-      deps.globalWorkspaceOrmManager.getRepository,
-    ).toHaveBeenNthCalledWith(1, 'workflow', context.rolePermissionConfig);
-    expect(
-      deps.globalWorkspaceOrmManager.getRepository,
-    ).toHaveBeenNthCalledWith(
+    expect(deps.workspaceOrmManager.getRepository).toHaveBeenNthCalledWith(
+      1,
+      'workflow',
+      context.rolePermissionConfig,
+    );
+    expect(deps.workspaceOrmManager.getRepository).toHaveBeenNthCalledWith(
       2,
       'workflowVersion',
       context.rolePermissionConfig,
@@ -100,10 +97,7 @@ describe('get_workflow_current_version tool', () => {
     });
 
     const tool = createGetWorkflowCurrentVersionTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 
@@ -126,10 +120,7 @@ describe('get_workflow_current_version tool', () => {
     const deps = buildDeps({ workflow: null, versions: [] });
 
     const tool = createGetWorkflowCurrentVersionTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 
@@ -144,10 +135,7 @@ describe('get_workflow_current_version tool', () => {
     const deps = buildDeps({ workflow: { id: WORKFLOW_ID }, versions: [] });
 
     const tool = createGetWorkflowCurrentVersionTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-run.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-run.tool.spec.ts
@@ -9,7 +9,7 @@ const WORKFLOW_RUN_ID = '20202020-bbbb-4d02-bf25-6aeccf7ea419';
 const ROLE_ID = '20202020-cccc-4d02-bf25-6aeccf7ea419';
 
 const buildDeps = (findOneResult: unknown) => ({
-  globalWorkspaceOrmManager: {
+  workspaceOrmManager: {
     executeInWorkspaceContext: jest.fn().mockImplementation(async (fn) => fn()),
     getRepository: jest.fn().mockResolvedValue({
       findOne: jest.fn().mockResolvedValue(findOneResult),
@@ -28,16 +28,13 @@ describe('get_workflow_run tool', () => {
     const context = buildContext();
 
     const tool = createGetWorkflowRunTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 
     await tool.execute({ workflowRunId: WORKFLOW_RUN_ID });
 
-    expect(deps.globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+    expect(deps.workspaceOrmManager.getRepository).toHaveBeenCalledWith(
       'workflowRun',
       context.rolePermissionConfig,
     );
@@ -75,10 +72,7 @@ describe('get_workflow_run tool', () => {
     const context = buildContext();
 
     const tool = createGetWorkflowRunTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 
@@ -104,10 +98,7 @@ describe('get_workflow_run tool', () => {
     const context = buildContext();
 
     const tool = createGetWorkflowRunTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/list-workflow-runs.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/list-workflow-runs.tool.spec.ts
@@ -7,7 +7,7 @@ const WORKSPACE_ID = '20202020-aaaa-4d02-bf25-6aeccf7ea419';
 const ROLE_ID = '20202020-cccc-4d02-bf25-6aeccf7ea419';
 
 const buildDeps = (findResult: unknown[]) => ({
-  globalWorkspaceOrmManager: {
+  workspaceOrmManager: {
     executeInWorkspaceContext: jest.fn().mockImplementation(async (fn) => fn()),
     getRepository: jest.fn().mockResolvedValue({
       find: jest.fn().mockResolvedValue(findResult),
@@ -26,16 +26,13 @@ describe('list_workflow_runs tool', () => {
     const context = buildContext();
 
     const tool = createListWorkflowRunsTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 
     await tool.execute({});
 
-    expect(deps.globalWorkspaceOrmManager.getRepository).toHaveBeenCalledWith(
+    expect(deps.workspaceOrmManager.getRepository).toHaveBeenCalledWith(
       'workflowRun',
       context.rolePermissionConfig,
     );
@@ -69,10 +66,7 @@ describe('list_workflow_runs tool', () => {
     const context = buildContext();
 
     const tool = createListWorkflowRunsTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 
@@ -92,7 +86,7 @@ describe('list_workflow_runs tool', () => {
   it('should apply filters when provided', async () => {
     const findMock = jest.fn().mockResolvedValue([]);
     const deps = {
-      globalWorkspaceOrmManager: {
+      workspaceOrmManager: {
         executeInWorkspaceContext: jest
           .fn()
           .mockImplementation(async (fn) => fn()),
@@ -102,10 +96,7 @@ describe('list_workflow_runs tool', () => {
     const context = buildContext();
 
     const tool = createListWorkflowRunsTool(
-      deps as unknown as Pick<
-        WorkflowToolDependencies,
-        'globalWorkspaceOrmManager'
-      >,
+      deps as unknown as Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
       context,
     );
 

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/update-agent.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/update-agent.tool.spec.ts
@@ -25,7 +25,7 @@ const buildTool = ({
   const workflowVersionRepository = {
     find: jest.fn().mockResolvedValue(draftVersions),
   };
-  const globalWorkspaceOrmManager = {
+  const workspaceOrmManager = {
     getRepository: jest.fn().mockResolvedValue(workflowVersionRepository),
   };
   const flatEntityMapsCacheService = {
@@ -36,7 +36,7 @@ const buildTool = ({
     {
       agentService,
       workflowVersionStepService,
-      globalWorkspaceOrmManager,
+      workspaceOrmManager,
       flatEntityMapsCacheService,
     } as never,
     { workspaceId: WORKSPACE_ID },
@@ -46,7 +46,7 @@ const buildTool = ({
     tool,
     agentService,
     workflowVersionStepService,
-    globalWorkspaceOrmManager,
+    workspaceOrmManager,
     flatEntityMapsCacheService,
   };
 };
@@ -92,10 +92,11 @@ describe('createUpdateAgentTool', () => {
 
   it('should not resync when responseFormat is not provided', async () => {
     const step = buildAiAgentStep(AGENT_ID);
-    const { tool, workflowVersionStepService, globalWorkspaceOrmManager } =
-      buildTool({
+    const { tool, workflowVersionStepService, workspaceOrmManager } = buildTool(
+      {
         draftVersions: [{ id: 'version-1', status: 'DRAFT', steps: [step] }],
-      });
+      },
+    );
 
     const result = (await tool.execute({
       agentId: AGENT_ID,
@@ -103,7 +104,7 @@ describe('createUpdateAgentTool', () => {
     } as never)) as Record<string, unknown>;
 
     expect(result.success).toBe(true);
-    expect(globalWorkspaceOrmManager.getRepository).not.toHaveBeenCalled();
+    expect(workspaceOrmManager.getRepository).not.toHaveBeenCalled();
     expect(
       workflowVersionStepService.updateWorkflowVersionStep,
     ).not.toHaveBeenCalled();

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-complete-workflow.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-complete-workflow.tool.ts
@@ -56,7 +56,7 @@ type CreateCompleteWorkflowToolDeps = Pick<
   | 'workflowVersionService'
   | 'workflowVersionEdgeService'
   | 'workflowTriggerService'
-  | 'globalWorkspaceOrmManager'
+  | 'workspaceOrmManager'
   | 'recordPositionService'
   | 'workflowValidationService'
   | 'workflowVersionCoreSyncService'
@@ -221,12 +221,11 @@ const createWorkflow = async ({
 }): Promise<string> => {
   const authContext = buildSystemAuthContext(context.workspaceId);
 
-  return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-    const workflowRepository =
-      await deps.globalWorkspaceOrmManager.getRepository(
-        'workflow',
-        context.rolePermissionConfig,
-      );
+  return deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
+    const workflowRepository = await deps.workspaceOrmManager.getRepository(
+      'workflow',
+      context.rolePermissionConfig,
+    );
 
     const workflowPosition =
       await deps.recordPositionService.buildRecordPosition({
@@ -309,12 +308,11 @@ const updateWorkflowStatus = async ({
 }) => {
   const authContext = buildSystemAuthContext(context.workspaceId);
 
-  await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-    const workflowRepository =
-      await deps.globalWorkspaceOrmManager.getRepository(
-        'workflow',
-        context.rolePermissionConfig,
-      );
+  await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
+    const workflowRepository = await deps.workspaceOrmManager.getRepository(
+      'workflow',
+      context.rolePermissionConfig,
+    );
 
     await workflowRepository.update(workflowId, {
       statuses: [WorkflowStatus.ACTIVE],

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow.tool.ts
@@ -22,7 +22,7 @@ type DeleteWorkflowInput = z.infer<typeof deleteWorkflowSchema>;
 export const createDeleteWorkflowTool = (
   deps: Pick<
     WorkflowToolDependencies,
-    'globalWorkspaceOrmManager' | 'workflowCommonService'
+    'workspaceOrmManager' | 'workflowCommonService'
   >,
   context: DeleteWorkflowToolContext,
 ) => ({
@@ -38,18 +38,15 @@ export const createDeleteWorkflowTool = (
       const authContext = buildSystemAuthContext(workspaceId);
 
       const deleteResult =
-        await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const workflowRepository =
-              await deps.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-                'workflow',
-                context.rolePermissionConfig,
-              );
+        await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
+          const workflowRepository =
+            await deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+              'workflow',
+              context.rolePermissionConfig,
+            );
 
-            return workflowRepository.softDelete(workflowId);
-          },
-          authContext,
-        );
+          return workflowRepository.softDelete(workflowId);
+        }, authContext);
 
       if (!isDefined(deleteResult.affected)) {
         return {

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
@@ -29,7 +29,7 @@ type GetWorkflowCurrentVersionInput = z.infer<
 >;
 
 export const createGetWorkflowCurrentVersionTool = (
-  deps: Pick<WorkflowToolDependencies, 'globalWorkspaceOrmManager'>,
+  deps: Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
   context: GetWorkflowCurrentVersionToolContext,
 ) => ({
   name: 'get_workflow_current_version' as const,
@@ -40,10 +40,10 @@ export const createGetWorkflowCurrentVersionTool = (
     try {
       const authContext = buildSystemAuthContext(context.workspaceId);
 
-      return await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      return await deps.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRepository =
-            await deps.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+            await deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
               'workflow',
               context.rolePermissionConfig,
             );
@@ -60,7 +60,7 @@ export const createGetWorkflowCurrentVersionTool = (
           }
 
           const workflowVersionRepository =
-            await deps.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+            await deps.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
               'workflowVersion',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-run.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-run.tool.ts
@@ -26,7 +26,7 @@ const FAILED_STEP_STATUSES: StepStatus[] = [
 ];
 
 export const createGetWorkflowRunTool = (
-  deps: Pick<WorkflowToolDependencies, 'globalWorkspaceOrmManager'>,
+  deps: Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
   context: GetWorkflowRunToolContext,
 ) => ({
   name: 'get_workflow_run' as const,
@@ -37,10 +37,10 @@ export const createGetWorkflowRunTool = (
     try {
       const authContext = buildSystemAuthContext(context.workspaceId);
 
-      return await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      return await deps.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRunRepository =
-            await deps.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+            await deps.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
               'workflowRun',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflow-runs.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflow-runs.tool.ts
@@ -43,7 +43,7 @@ const listWorkflowRunsSchema = z.object({
 type ListWorkflowRunsInput = z.infer<typeof listWorkflowRunsSchema>;
 
 export const createListWorkflowRunsTool = (
-  deps: Pick<WorkflowToolDependencies, 'globalWorkspaceOrmManager'>,
+  deps: Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
   context: ListWorkflowRunsToolContext,
 ) => ({
   name: 'list_workflow_runs' as const,
@@ -54,10 +54,10 @@ export const createListWorkflowRunsTool = (
     try {
       const authContext = buildSystemAuthContext(context.workspaceId);
 
-      return await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      return await deps.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRunRepository =
-            await deps.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+            await deps.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
               'workflowRun',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflows.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflows.tool.ts
@@ -27,7 +27,7 @@ const listWorkflowsSchema = z.object({
 type ListWorkflowsInput = z.infer<typeof listWorkflowsSchema>;
 
 export const createListWorkflowsTool = (
-  deps: Pick<WorkflowToolDependencies, 'globalWorkspaceOrmManager'>,
+  deps: Pick<WorkflowToolDependencies, 'workspaceOrmManager'>,
   context: ListWorkflowsToolContext,
 ) => ({
   name: 'list_workflows' as const,
@@ -38,10 +38,10 @@ export const createListWorkflowsTool = (
     try {
       const authContext = buildSystemAuthContext(context.workspaceId);
 
-      return await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      return await deps.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRepository =
-            await deps.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+            await deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
               'workflow',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-agent.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-agent.tool.ts
@@ -62,7 +62,7 @@ const resyncAiAgentStepOutputSchemas = async (
   deps: Pick<
     WorkflowToolDependencies,
     | 'workflowVersionStepService'
-    | 'globalWorkspaceOrmManager'
+    | 'workspaceOrmManager'
     | 'flatEntityMapsCacheService'
   >,
   { workspaceId, agentId }: { workspaceId: string; agentId: string },
@@ -73,7 +73,7 @@ const resyncAiAgentStepOutputSchemas = async (
   });
 
   const workflowVersionRepository =
-    await deps.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+    await deps.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
       'workflowVersion',
       { shouldBypassPermissionChecks: true },
     );
@@ -112,7 +112,7 @@ export const createUpdateAgentTool = (
     WorkflowToolDependencies,
     | 'agentService'
     | 'workflowVersionStepService'
-    | 'globalWorkspaceOrmManager'
+    | 'workspaceOrmManager'
     | 'flatEntityMapsCacheService'
   >,
   context: WorkflowToolContext,

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/types/workflow-tool-dependencies.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/types/workflow-tool-dependencies.type.ts
@@ -3,7 +3,7 @@ import type { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/wor
 import type { AgentService } from 'src/engine/metadata-modules/ai/ai-agent/agent.service';
 import type { LogicFunctionFromSourceService } from 'src/engine/metadata-modules/logic-function/services/logic-function-from-source.service';
 import type { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
-import type { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import type { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import type { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import type { WorkflowSchemaWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service';
 import type { WorkflowValidationWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.workspace-service';
@@ -21,7 +21,7 @@ export type WorkflowToolDependencies = {
   workflowTriggerService: WorkflowTriggerWorkspaceService;
   workflowSchemaService: WorkflowSchemaWorkspaceService;
   workflowValidationService: WorkflowValidationWorkspaceService;
-  globalWorkspaceOrmManager: GlobalWorkspaceOrmManager;
+  workspaceOrmManager: WorkspaceOrmManager;
   recordPositionService: RecordPositionService;
   logicFunctionFromSourceService: LogicFunctionFromSourceService;
   flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService;

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { isDefined } from 'twenty-shared/utils';
 
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
@@ -12,9 +12,7 @@ import { type AutomatedTriggerSettings } from 'src/modules/workflow/workflow-tri
 
 @Injectable()
 export class AutomatedTriggerWorkspaceService {
-  constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   async addAutomatedTrigger({
     workflowId,
@@ -41,9 +39,9 @@ export class AutomatedTriggerWorkspaceService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowAutomatedTriggerRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
         );
 
@@ -76,9 +74,9 @@ export class AutomatedTriggerWorkspaceService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowAutomatedTriggerRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
         );
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
@@ -3,7 +3,7 @@ import { Test, type TestingModule } from '@nestjs/testing';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { type WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
@@ -13,7 +13,7 @@ import { WorkflowTriggerJob } from 'src/modules/workflow/workflow-trigger/jobs/w
 
 describe('WorkflowDatabaseEventTriggerListener', () => {
   let listener: WorkflowDatabaseEventTriggerListener;
-  let globalWorkspaceOrmManager: jest.Mocked<GlobalWorkspaceOrmManager>;
+  let workspaceOrmManager: jest.Mocked<WorkspaceOrmManager>;
   let messageQueueService: jest.Mocked<MessageQueueService>;
   let featureFlagService: jest.Mocked<FeatureFlagService>;
   let workspaceCacheService: jest.Mocked<WorkspaceCacheService>;
@@ -51,7 +51,7 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
     }) as FlatObjectMetadata;
 
   beforeEach(async () => {
-    globalWorkspaceOrmManager = {
+    workspaceOrmManager = {
       getRepository: jest.fn().mockResolvedValue(mockRepository),
       executeInWorkspaceContext: jest
         .fn()
@@ -75,8 +75,8 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
       providers: [
         WorkflowDatabaseEventTriggerListener,
         {
-          provide: GlobalWorkspaceOrmManager,
-          useValue: globalWorkspaceOrmManager,
+          provide: WorkspaceOrmManager,
+          useValue: workspaceOrmManager,
         },
         {
           provide: MessageQueueService,

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
@@ -25,7 +25,7 @@ import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-m
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { isCachedDatabaseEventTrigger } from 'src/engine/core-modules/workflow/utils/cached-workflow-automated-trigger.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
@@ -66,7 +66,7 @@ export class WorkflowDatabaseEventTriggerListener {
   );
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectMessageQueue(MessageQueue.workflowQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
@@ -269,7 +269,7 @@ export class WorkflowDatabaseEventTriggerListener {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const { fieldIdByJoinColumnName } = buildFieldMapsFromFlatObjectMetadata(
         flatFieldMetadataMaps,
         flatObjectMetadata,
@@ -309,7 +309,7 @@ export class WorkflowDatabaseEventTriggerListener {
         }
 
         const relatedObjectRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
+          await this.workspaceOrmManager.getRepository(
             relatedObjectMetadataNameSingular,
             { shouldBypassPermissionChecks: true },
           );
@@ -409,27 +409,24 @@ export class WorkflowDatabaseEventTriggerListener {
 
     const automatedTriggerTableName = 'workflowAutomatedTrigger';
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowAutomatedTriggerRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
-            automatedTriggerTableName,
-            { shouldBypassPermissionChecks: true },
-          );
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowAutomatedTriggerRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+          automatedTriggerTableName,
+          { shouldBypassPermissionChecks: true },
+        );
 
-        return workflowAutomatedTriggerRepository.find({
-          where: {
-            type: AutomatedTriggerType.DATABASE_EVENT,
-            settings: Raw(
-              () =>
-                `"${automatedTriggerTableName}"."settings"->>'eventName' = :eventName`,
-              { eventName: databaseEventName },
-            ),
-          },
-        });
-      },
-      buildSystemAuthContext(workspaceId),
-    );
+      return workflowAutomatedTriggerRepository.find({
+        where: {
+          type: AutomatedTriggerType.DATABASE_EVENT,
+          settings: Raw(
+            () =>
+              `"${automatedTriggerTableName}"."settings"->>'eventName' = :eventName`,
+            { eventName: databaseEventName },
+          ),
+        },
+      });
+    }, buildSystemAuthContext(workspaceId));
   }
 
   private shouldTriggerJob({

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
@@ -7,7 +7,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkflowVersionStatus } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 import { type WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
@@ -27,7 +27,7 @@ const DEFAULT_WORKFLOW_NAME = 'Workflow';
 export class WorkflowTriggerJob {
   private readonly logger = new Logger(WorkflowTriggerJob.name);
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
     private readonly workflowRunnerWorkspaceService: WorkflowRunnerWorkspaceService,
   ) {}
@@ -36,9 +36,9 @@ export class WorkflowTriggerJob {
   async handle(data: WorkflowTriggerJobData): Promise<void> {
     const authContext = buildSystemAuthContext(data.workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRepository =
-        await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+        await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
           'workflow',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -12,7 +12,7 @@ import { CommandMenuItemService } from 'src/engine/metadata-modules/command-menu
 import { CommandMenuItemAvailabilityType } from 'src/engine/metadata-modules/command-menu-item/enums/command-menu-item-availability-type.enum';
 import { EngineComponentKey } from 'src/engine/metadata-modules/command-menu-item/enums/engine-component-key.enum';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
@@ -55,7 +55,7 @@ export class WorkflowTriggerWorkspaceService {
   private readonly logger = new Logger(WorkflowTriggerWorkspaceService.name);
 
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
     private readonly codeStepBuildService: CodeStepBuildService,
     private readonly workflowRunnerWorkspaceService: WorkflowRunnerWorkspaceService,
@@ -100,70 +100,65 @@ export class WorkflowTriggerWorkspaceService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workflowVersionNullable = await workflowVersionRepository.findOne(
-          {
-            where: { id: workflowVersionId },
-          },
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
         );
 
-        const workflowVersion =
-          await this.workflowCommonWorkspaceService.getValidWorkflowVersionOrFail(
-            workflowVersionNullable,
-          );
+      const workflowVersionNullable = await workflowVersionRepository.findOne({
+        where: { id: workflowVersionId },
+      });
 
-        const workflowRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
-            'workflow',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workflow = await workflowRepository.findOne({
-          where: { id: workflowVersion.workflowId },
-        });
-
-        if (!workflow) {
-          throw new WorkflowTriggerException(
-            'No workflow found',
-            WorkflowTriggerExceptionCode.INVALID_WORKFLOW_VERSION,
-          );
-        }
-
-        assertVersionCanBeActivated(workflowVersion, workflow);
-
-        await this.assertPickRecordLoadBalanceConfigIsValid({
-          steps: workflowVersion.steps ?? [],
-          workspaceId,
-        });
-
-        await this.codeStepBuildService.buildCodeStepsFromSourceForSteps({
-          workspaceId,
-          steps: workflowVersion.steps ?? [],
-        });
-
-        await this.codeStepBuildService.switchCodeStepLogicFunctionsToPrebuilt({
-          workspaceId,
-          steps: workflowVersion.steps ?? [],
-        });
-
-        await this.performActivationSteps(
-          workflow,
-          workflowVersion,
-          workflowVersionRepository,
-          workspaceId,
+      const workflowVersion =
+        await this.workflowCommonWorkspaceService.getValidWorkflowVersionOrFail(
+          workflowVersionNullable,
         );
 
-        return true;
-      },
-      authContext,
-    );
+      const workflowRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+          'workflow',
+          { shouldBypassPermissionChecks: true },
+        );
+
+      const workflow = await workflowRepository.findOne({
+        where: { id: workflowVersion.workflowId },
+      });
+
+      if (!workflow) {
+        throw new WorkflowTriggerException(
+          'No workflow found',
+          WorkflowTriggerExceptionCode.INVALID_WORKFLOW_VERSION,
+        );
+      }
+
+      assertVersionCanBeActivated(workflowVersion, workflow);
+
+      await this.assertPickRecordLoadBalanceConfigIsValid({
+        steps: workflowVersion.steps ?? [],
+        workspaceId,
+      });
+
+      await this.codeStepBuildService.buildCodeStepsFromSourceForSteps({
+        workspaceId,
+        steps: workflowVersion.steps ?? [],
+      });
+
+      await this.codeStepBuildService.switchCodeStepLogicFunctionsToPrebuilt({
+        workspaceId,
+        steps: workflowVersion.steps ?? [],
+      });
+
+      await this.performActivationSteps(
+        workflow,
+        workflowVersion,
+        workflowVersionRepository,
+        workspaceId,
+      );
+
+      return true;
+    }, authContext);
   }
 
   private async assertPickRecordLoadBalanceConfigIsValid({
@@ -207,24 +202,21 @@ export class WorkflowTriggerWorkspaceService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        await this.performDeactivationSteps(
-          workflowVersionId,
-          workflowVersionRepository,
-          workspaceId,
+    return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
         );
 
-        return true;
-      },
-      authContext,
-    );
+      await this.performDeactivationSteps(
+        workflowVersionId,
+        workflowVersionRepository,
+        workspaceId,
+      );
+
+      return true;
+    }, authContext);
   }
 
   async stopWorkflowRun(workflowRunId: string, workspaceId: string) {
@@ -288,7 +280,7 @@ export class WorkflowTriggerWorkspaceService {
       workspaceId,
     );
 
-    await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+    await this.workspaceOrmManager.runInWorkspaceTransaction(
       async (transactionScope) => {
         const transactionalWorkflowRepository =
           transactionScope.getRepository<WorkflowWorkspaceEntity>('workflow', {
@@ -386,7 +378,7 @@ export class WorkflowTriggerWorkspaceService {
 
     await this.deleteCommandMenuItem(workflowVersion, workspaceId);
 
-    await this.globalWorkspaceOrmManager.runInWorkspaceTransaction(
+    await this.workspaceOrmManager.runInWorkspaceTransaction(
       async (transactionScope) => {
         await transactionScope
           .getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion', {

--- a/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-delete-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-delete-one.post-query.hook.ts
@@ -15,7 +15,7 @@ import {
   PermissionsException,
   PermissionsExceptionCode,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-orm.manager';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @WorkspaceQueryHook({
@@ -24,7 +24,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 })
 export class WorkspaceMemberDeleteOnePostQueryHook implements WorkspacePostQueryHookInstance {
   constructor(
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
     private readonly userWorkspaceService: UserWorkspaceService,
@@ -47,23 +47,20 @@ export class WorkspaceMemberDeleteOnePostQueryHook implements WorkspacePostQuery
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
     const workspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+        const workspaceMemberRepository =
+          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return workspaceMemberRepository.findOne({
-            where: {
-              id: targettedWorkspaceMemberId,
-            },
-            withDeleted: true,
-          });
-        },
-        authContext,
-      );
+        return workspaceMemberRepository.findOne({
+          where: {
+            id: targettedWorkspaceMemberId,
+          },
+          withDeleted: true,
+        });
+      }, authContext);
 
     if (!isDefined(workspaceMember)) {
       throw new PermissionsException(

--- a/packages/twenty-server/src/queue-worker/queue-worker.module.ts
+++ b/packages/twenty-server/src/queue-worker/queue-worker.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { CoreEngineModule } from 'src/engine/core-modules/core-engine.module';
 import { JobsModule } from 'src/engine/core-modules/message-queue/jobs.module';
 import { MessageQueueModule } from 'src/engine/core-modules/message-queue/message-queue.module';
-import { GlobalWorkspaceDataSourceModule } from 'src/engine/twenty-orm/global-workspace-datasource.module';
+import { TwentyOrmModule } from 'src/engine/twenty-orm/twenty-orm.module';
 import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/workspace-event-emitter.module';
 
 @Module({
@@ -12,7 +12,7 @@ import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/
     MessageQueueModule.registerExplorer(),
     WorkspaceEventEmitterModule,
     JobsModule,
-    GlobalWorkspaceDataSourceModule,
+    TwentyOrmModule,
   ],
 })
 export class QueueWorkerModule {}


### PR DESCRIPTION
## What

Fourth of the five PRs splitting #24759 (after #24761, #24768 and #24774). The widest rename of the sequence, and deliberately isolated for that reason: every service injects the manager, so this one identifier pair dominates the file count.

- `GlobalWorkspaceOrmManager` → `WorkspaceOrmManager`, and the injected `globalWorkspaceOrmManager` property → `workspaceOrmManager` everywhere.
- `GlobalWorkspaceDataSourceModule` → `TwentyOrmModule` (it has been the twenty-orm module in all but name since it absorbed the v2 module in #24761).
- The two files follow: `workspace-orm.manager.ts` and `twenty-orm.module.ts`.

The `Global` prefix referred to the global workspace datasource that was deleted with ORM v1.

Review rule: 161 files, +718/−718, and every hunk swaps one of the three identifier pairs or one of the two file paths. Nothing else changes.

## Notes for CI

Nine committed upgrade commands get the property and import renames only (no SQL, timestamp, or up/down logic changes), so the PR carries the `ci:allow-previous-version-upgrade-mutation` label.

## Coming next

The last one: internal leftovers (find-option types, builder contexts, repository options type, group-by service, and the README sweep).

## Verification

- `tsgo --noEmit` clean, `oxlint --type-aware` clean on the 161 changed files, `oxfmt --check src/` clean
- twenty-orm and workflow-tool unit suites pass (50 suites, 430 tests)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

