### PR TITLE
Partners app: listed-brief Discord ping and digest runbook (1.7.0)

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-partners",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/twenty-partners/src/application-config.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/application-config.ts
@@ -20,7 +20,7 @@ export default defineApplication({
     DISCORD_WEBHOOK_URL: {
       universalIdentifier: '7056c98a-e7e1-4dba-8a40-b578f30b3479',
       description:
-        'Discord incoming webhook URL. When set, a notification is posted to this channel each time the application form creates a new Partner, and each time the public marketplace form submits a client brief (brief details, contact name and company, and the referring partner). Leave empty to disable both. Set per-workspace in Settings → Apps → Twenty Partners → Variables.',
+        'Discord incoming webhook URL. When set, a notification is posted to this channel each time the application form creates a new Partner, each time the public marketplace form submits a client brief (brief details, contact name and company, and the referring partner), and each time a brief is hand-listed on the marketplace. Leave empty to disable all three. Set per-workspace in Settings → Apps → Twenty Partners → Variables.',
       isSecret: true,
     },
     PARTNER_APP_FRONTEND_URL: {

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/intake/mappers/brief-embed.mapper.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/intake/mappers/brief-embed.mapper.ts
@@ -1,4 +1,9 @@
 import { TWENTY_BLUE } from 'src/modules/shared/connector/discord/config';
+import {
+  inlineField,
+  truncate,
+  trimTrailingSlash,
+} from 'src/modules/shared/connector/discord/embed-text.util';
 import { type DiscordField } from 'src/modules/shared/connector/discord/types';
 import { type SubmitClientBriefInput } from 'src/modules/opportunity/intake/mappers/build-requirements-text.mapper';
 import { type ReferringPartner } from 'src/modules/opportunity/intake/services/submit-client-brief.service';
@@ -12,7 +17,6 @@ export type BriefForEmbed = {
 
 const NEED_MAX = 600;
 const REQUIREMENTS_MAX = 300;
-const INLINE_MAX = 256;
 const PARTNER_NAME_MAX = 100;
 const NO_PARTNER_LABEL = 'Marketplace listing';
 const SPACER: DiscordField = { name: '​', value: '​', inline: true };
@@ -22,11 +26,6 @@ const HOSTING_LABEL: Record<'CLOUD' | 'SELF_HOSTING', string> = {
   SELF_HOSTING: 'Self-hosting',
 };
 
-const truncate = (value: string, max: number): string =>
-  value.length <= max ? value : `${value.slice(0, max - 1)}…`;
-
-const trimTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
-
 // Discord packs three inline fields per row, so a group with fewer than three
 // would pull the next group's fields up into its row. Pad every group to three.
 const pushInlineRow = (target: DiscordField[], row: DiscordField[]): void => {
@@ -34,13 +33,6 @@ const pushInlineRow = (target: DiscordField[], row: DiscordField[]): void => {
   target.push(...row);
   for (let index = row.length; index < 3; index += 1) target.push(SPACER);
 };
-
-// Every inline value comes from the unbounded public brief form; Discord rejects
-// the whole payload above 1024 chars per field, which the caller then swallows.
-const inlineField = (name: string, value: string | undefined | null): DiscordField[] =>
-  isNonEmptyString(value)
-    ? [{ name, value: truncate(value.trim(), INLINE_MAX), inline: true }]
-    : [];
 
 const buildReferredBy = (
   partner: ReferringPartner | null,

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/graphql/queries/get-listed-brief-details.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/graphql/queries/get-listed-brief-details.ts
@@ -1,0 +1,21 @@
+import type { CoreApiClient } from 'twenty-client-sdk/core';
+
+// List form on purpose: the single-record read throws `Record not found` for an unknown id.
+export function getListedBriefDetails(client: CoreApiClient, opportunityId: string) {
+  return client.query({
+    opportunities: {
+      __args: { filter: { id: { eq: opportunityId } }, first: 1 },
+      edges: {
+        node: {
+          id: true,
+          name: true,
+          need: true,
+          requirements: true,
+          company: { name: true },
+          pointOfContact: { name: { firstName: true, lastName: true } },
+          referredByPartner: { name: true },
+        },
+      },
+    },
+  });
+}

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/on-opportunity-listed.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/on-opportunity-listed.logic-function.ts
@@ -15,7 +15,7 @@ export const handler = async (
 ): Promise<Record<string, unknown>> => {
   const { before, after, updatedFields } = payload.properties;
   if (!updatedFields?.includes('isListed') || !after?.id) return {};
-  if (before?.isListed === true || after.isListed !== true) {
+  if (before?.isListed || !after.isListed) {
     return { skipped: true, reason: 'not_a_listing_flip' };
   }
 

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/on-opportunity-listed.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/on-opportunity-listed.logic-function.ts
@@ -1,0 +1,35 @@
+import { type CoreSchema } from 'twenty-client-sdk/core';
+import {
+  type DatabaseEventPayload,
+  defineLogicFunction,
+  type ObjectRecordUpdateEvent,
+} from 'twenty-sdk/define';
+
+import { ON_OPPORTUNITY_LISTED_FN_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import { notifyListedBrief } from 'src/modules/opportunity/matching/services/notify-listed-brief.service';
+
+// The public form is NOT this function's job: form briefs are born listed and never
+// flip, so the in-route ping covers them. This covers hand-listing and imports.
+export const handler = async (
+  payload: DatabaseEventPayload<ObjectRecordUpdateEvent<CoreSchema.Opportunity>>,
+): Promise<Record<string, unknown>> => {
+  const { before, after, updatedFields } = payload.properties;
+  if (!updatedFields?.includes('isListed') || !after?.id) return {};
+  if (before?.isListed === true || after.isListed !== true) {
+    return { skipped: true, reason: 'not_a_listing_flip' };
+  }
+
+  const notified = await notifyListedBrief(after.id);
+  return { notified, opportunityId: after.id };
+};
+
+export default defineLogicFunction({
+  universalIdentifier: ON_OPPORTUNITY_LISTED_FN_UNIVERSAL_IDENTIFIER,
+  name: 'on-opportunity-listed',
+  timeoutSeconds: 15,
+  handler,
+  databaseEventTriggerSettings: {
+    eventName: 'opportunity.updated',
+    updatedFields: ['isListed'],
+  },
+});

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/on-opportunity-listed.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/on-opportunity-listed.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { notifyMock } = vi.hoisted(() => ({ notifyMock: vi.fn() }));
+vi.mock('src/modules/opportunity/matching/services/notify-listed-brief.service', () => ({
+  notifyListedBrief: notifyMock,
+}));
+
+import { handler } from './on-opportunity-listed.logic-function';
+
+const OPP = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+const event = (
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+  updatedFields: string[] = ['isListed'],
+) => ({ properties: { before, after, updatedFields } }) as never;
+
+describe('on-opportunity-listed', () => {
+  beforeEach(() => {
+    notifyMock.mockReset();
+    notifyMock.mockResolvedValue(true);
+  });
+
+  it('notifies when isListed flips from false to true', async () => {
+    const result = await handler(event({ id: OPP, isListed: false }, { id: OPP, isListed: true }));
+    expect(notifyMock).toHaveBeenCalledWith(OPP);
+    expect(result).toEqual({ notified: true, opportunityId: OPP });
+  });
+
+  it('reports notified: false when the ping did not go out', async () => {
+    notifyMock.mockResolvedValue(false);
+    const result = await handler(event({ id: OPP, isListed: false }, { id: OPP, isListed: true }));
+    expect(result).toEqual({ notified: false, opportunityId: OPP });
+  });
+
+  it('stays silent when isListed flips to false', async () => {
+    const result = await handler(event({ id: OPP, isListed: true }, { id: OPP, isListed: false }));
+    expect(notifyMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ skipped: true, reason: 'not_a_listing_flip' });
+  });
+
+  it('stays silent when isListed was already true', async () => {
+    const result = await handler(event({ id: OPP, isListed: true }, { id: OPP, isListed: true }));
+    expect(notifyMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ skipped: true, reason: 'not_a_listing_flip' });
+  });
+
+  it('returns without notifying when the payload carries no record id', async () => {
+    const result = await handler(event({ isListed: false }, { isListed: true }));
+    expect(notifyMock).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+  });
+
+  it('returns without notifying when isListed is not in updatedFields', async () => {
+    const result = await handler(
+      event({ id: OPP, isListed: true }, { id: OPP, isListed: true }, ['stage']),
+    );
+    expect(notifyMock).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+  });
+});

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/services/notify-listed-brief.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/services/notify-listed-brief.service.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryMock, postWebhookMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  postWebhookMock: vi.fn(),
+}));
+vi.mock('twenty-client-sdk/core', () => ({
+  CoreApiClient: vi.fn(function () {
+    return { query: queryMock };
+  }),
+}));
+vi.mock('src/modules/shared/connector/discord/discord.connector', () => ({
+  postWebhook: postWebhookMock,
+}));
+
+import { notifyListedBrief } from './notify-listed-brief.service';
+
+const OPP = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+const briefResult = (node: Record<string, unknown> | undefined) => ({
+  opportunities: { edges: node === undefined ? [] : [{ node }] },
+});
+
+describe('notifyListedBrief', () => {
+  beforeEach(() => {
+    vi.stubEnv('DISCORD_WEBHOOK_URL', 'https://discord.test/hook');
+    vi.stubEnv('PARTNER_APP_FRONTEND_URL', 'https://crm.test/');
+    queryMock.mockReset();
+    postWebhookMock.mockReset();
+    postWebhookMock.mockResolvedValue(true);
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('posts one embed built from the record', async () => {
+    queryMock.mockResolvedValue(
+      briefResult({
+        id: OPP,
+        name: 'Acme — marketplace brief',
+        need: 'Migrate 40 seats to Twenty',
+        requirements: 'Hosting: Cloud\nSeats: 40',
+        company: { name: 'Acme' },
+        pointOfContact: { name: { firstName: 'Jane', lastName: 'Doe' } },
+        referredByPartner: { name: 'Meridian Craft' },
+      }),
+    );
+    await notifyListedBrief(OPP);
+    expect(postWebhookMock).toHaveBeenCalledTimes(1);
+    const [url, payload, label] = postWebhookMock.mock.calls[0];
+    expect(url).toBe('https://discord.test/hook');
+    expect(label).toBe('notify-listed-brief');
+    const embed = payload.embeds[0];
+    expect(embed.title).toBe('Brief listed on the marketplace');
+    expect(embed.description).toBe('Migrate 40 seats to Twenty');
+    expect(embed.url).toBe(`https://crm.test/object/opportunity/${OPP}`);
+    expect(embed.fields).toEqual([
+      { name: 'Company', value: 'Acme', inline: true },
+      { name: 'Contact', value: 'Jane Doe', inline: true },
+      { name: 'Referred by', value: 'Meridian Craft', inline: true },
+      { name: 'Requirements', value: 'Hosting: Cloud\nSeats: 40' },
+    ]);
+  });
+
+  it('does nothing without a webhook url', async () => {
+    vi.stubEnv('DISCORD_WEBHOOK_URL', '');
+    await expect(notifyListedBrief(OPP)).resolves.toBe(false);
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(postWebhookMock).not.toHaveBeenCalled();
+  });
+
+  it('reports false when the opportunity is missing (empty edges)', async () => {
+    queryMock.mockResolvedValue(briefResult(undefined));
+    await expect(notifyListedBrief(OPP)).resolves.toBe(false);
+    expect(postWebhookMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows a read failure and reports false', async () => {
+    queryMock.mockRejectedValue(new Error('boom'));
+    await expect(notifyListedBrief(OPP)).resolves.toBe(false);
+  });
+
+  it('swallows a webhook failure and reports false', async () => {
+    queryMock.mockResolvedValue(briefResult({ id: OPP, name: 'n', need: 'x' }));
+    postWebhookMock.mockRejectedValue(new Error('discord down'));
+    await expect(notifyListedBrief(OPP)).resolves.toBe(false);
+  });
+
+  it('omits empty fields and falls back to the name as description', async () => {
+    queryMock.mockResolvedValue(briefResult({ id: OPP, name: 'Acme — marketplace brief' }));
+    await notifyListedBrief(OPP);
+    const embed = postWebhookMock.mock.calls[0][1].embeds[0];
+    expect(embed.description).toBe('Acme — marketplace brief');
+    expect(embed.fields).toEqual([]);
+  });
+});

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/services/notify-listed-brief.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/services/notify-listed-brief.service.ts
@@ -5,18 +5,17 @@ import {
   TWENTY_BLUE,
 } from 'src/modules/shared/connector/discord/config';
 import { postWebhook } from 'src/modules/shared/connector/discord/discord.connector';
+import {
+  inlineField,
+  truncate,
+  trimTrailingSlash,
+} from 'src/modules/shared/connector/discord/embed-text.util';
 import { type DiscordField } from 'src/modules/shared/connector/discord/types';
 import { getListedBriefDetails } from 'src/modules/opportunity/matching/graphql/queries/get-listed-brief-details';
 import { isNonEmptyString } from 'src/modules/shared/utils/is-non-empty-string.util';
 
 const NEED_MAX = 600;
 const REQUIREMENTS_MAX = 300;
-
-const truncate = (value: string, max: number): string =>
-  value.length <= max ? value : `${value.slice(0, max - 1)}…`;
-
-const inline = (name: string, value: string | undefined | null): DiscordField[] =>
-  isNonEmptyString(value) ? [{ name, value, inline: true }] : [];
 
 export async function notifyListedBrief(opportunityId: string): Promise<boolean> {
   const webhookUrl = process.env[DISCORD_WEBHOOK_ENV_VAR];
@@ -31,9 +30,9 @@ export async function notifyListedBrief(opportunityId: string): Promise<boolean>
       .filter(isNonEmptyString)
       .join(' ');
     const fields: DiscordField[] = [
-      ...inline('Company', brief.company?.name),
-      ...inline('Contact', contact),
-      ...inline('Referred by', brief.referredByPartner?.name),
+      ...inlineField('Company', brief.company?.name),
+      ...inlineField('Contact', contact),
+      ...inlineField('Referred by', brief.referredByPartner?.name),
     ];
     if (isNonEmptyString(brief.requirements)) {
       fields.push({ name: 'Requirements', value: truncate(brief.requirements.trim(), REQUIREMENTS_MAX) });
@@ -48,7 +47,7 @@ export async function notifyListedBrief(opportunityId: string): Promise<boolean>
     };
     const frontendUrl = process.env.PARTNER_APP_FRONTEND_URL;
     if (isNonEmptyString(frontendUrl)) {
-      embed.url = `${frontendUrl.replace(/\/+$/, '')}/object/opportunity/${brief.id}`;
+      embed.url = `${trimTrailingSlash(frontendUrl)}/object/opportunity/${brief.id}`;
     }
 
     return await postWebhook(webhookUrl, { embeds: [embed] }, 'notify-listed-brief');

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/services/notify-listed-brief.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/opportunity/matching/services/notify-listed-brief.service.ts
@@ -1,0 +1,59 @@
+import { CoreApiClient } from 'twenty-client-sdk/core';
+
+import {
+  DISCORD_WEBHOOK_ENV_VAR,
+  TWENTY_BLUE,
+} from 'src/modules/shared/connector/discord/config';
+import { postWebhook } from 'src/modules/shared/connector/discord/discord.connector';
+import { type DiscordField } from 'src/modules/shared/connector/discord/types';
+import { getListedBriefDetails } from 'src/modules/opportunity/matching/graphql/queries/get-listed-brief-details';
+import { isNonEmptyString } from 'src/modules/shared/utils/is-non-empty-string.util';
+
+const NEED_MAX = 600;
+const REQUIREMENTS_MAX = 300;
+
+const truncate = (value: string, max: number): string =>
+  value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+
+const inline = (name: string, value: string | undefined | null): DiscordField[] =>
+  isNonEmptyString(value) ? [{ name, value, inline: true }] : [];
+
+export async function notifyListedBrief(opportunityId: string): Promise<boolean> {
+  const webhookUrl = process.env[DISCORD_WEBHOOK_ENV_VAR];
+  if (!isNonEmptyString(webhookUrl)) return false;
+
+  try {
+    const result = await getListedBriefDetails(new CoreApiClient(), opportunityId);
+    const brief = result.opportunities?.edges?.[0]?.node;
+    if (!brief) return false;
+
+    const contact = [brief.pointOfContact?.name?.firstName, brief.pointOfContact?.name?.lastName]
+      .filter(isNonEmptyString)
+      .join(' ');
+    const fields: DiscordField[] = [
+      ...inline('Company', brief.company?.name),
+      ...inline('Contact', contact),
+      ...inline('Referred by', brief.referredByPartner?.name),
+    ];
+    if (isNonEmptyString(brief.requirements)) {
+      fields.push({ name: 'Requirements', value: truncate(brief.requirements.trim(), REQUIREMENTS_MAX) });
+    }
+
+    const embed: Record<string, unknown> = {
+      title: 'Brief listed on the marketplace',
+      description: isNonEmptyString(brief.need) ? truncate(brief.need.trim(), NEED_MAX) : brief.name,
+      color: TWENTY_BLUE,
+      timestamp: new Date().toISOString(),
+      fields,
+    };
+    const frontendUrl = process.env.PARTNER_APP_FRONTEND_URL;
+    if (isNonEmptyString(frontendUrl)) {
+      embed.url = `${frontendUrl.replace(/\/+$/, '')}/object/opportunity/${brief.id}`;
+    }
+
+    return await postWebhook(webhookUrl, { embeds: [embed] }, 'notify-listed-brief');
+  } catch {
+    // Best-effort: a read or Discord failure must never fail the trigger.
+    return false;
+  }
+}

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/shared/connector/discord/embed-text.util.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/shared/connector/discord/embed-text.util.ts
@@ -1,0 +1,16 @@
+import { type DiscordField } from 'src/modules/shared/connector/discord/types';
+import { isNonEmptyString } from 'src/modules/shared/utils/is-non-empty-string.util';
+
+export const INLINE_MAX = 256;
+
+export const truncate = (value: string, max: number): string =>
+  value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+
+export const trimTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
+
+// Discord rejects the whole payload above 1024 chars per field; bound every
+// inline value so one long record field cannot silently drop a notification.
+export const inlineField = (name: string, value: string | undefined | null): DiscordField[] =>
+  isNonEmptyString(value)
+    ? [{ name, value: truncate(value.trim(), INLINE_MAX), inline: true }]
+    : [];

--- a/packages/twenty-apps/internal/twenty-partners/src/workflows/README.md
+++ b/packages/twenty-apps/internal/twenty-partners/src/workflows/README.md
@@ -1,74 +1,26 @@
 # Manual workflows runbook
 
-The Twenty Partners app relies on two **manual-trigger workflows** built in the Twenty
-workspace UI. The SDK has no `defineWorkflow`, so these are documented setup steps — not
-shipped in the app manifest.
+The Twenty Partners app relies on two workflows built in the Twenty workspace UI: one
+**manual-trigger workflow** and one **cron workflow**. The SDK has no `defineWorkflow`, so
+these are documented setup steps — not shipped in the app manifest.
 
-**Rebuild both workflows in every workspace** where the app is installed (local bundles,
-staging, prod). After `yarn twenty install`, prod is empty until an admin follows this
-runbook.
+**Rebuild both workflows in every workspace** where the app is installed (local
+bundles, staging, prod). After `yarn twenty install`, prod is empty until an admin follows
+this runbook.
 
 ## Prerequisites
 
 - Twenty Partners app installed and synced (`yarn twenty apply`).
-- **Partner role** already grants the **WORKFLOWS** permission flag (shipped in the app).
-  Partners need this to see **Run workflow → Apply** on a brief. Admins run **Mark as
-  Winner** with their own role (no special flag beyond workflow access).
+- The **WORKFLOWS** permission flag is no longer needed for apply: the apply path now
+  ships in the app manifest as a command menu item. Admins run **Mark as Winner** with
+  their own role (no special flag beyond workflow access).
 
 ---
 
-## 1. Apply to Brief
-
-Partner self-apply on an **Opportunity** (brief). Creates an **Application** and lets
-`on-application-created` resolve the Partner from the clicking member.
-
-### Build (Settings → Workflows)
-
-1. Open **Workflows** (sidebar or Settings) and click **+ New workflow**.
-2. Name it **Apply to Brief** (the published label can be shortened to **Apply**).
-3. Open the trigger node (**Manual trigger**).
-4. Set **Availability** to **Single record**.
-5. Choose object **Opportunity**.
-6. Add an action: **Create Record**.
-7. Set **Object** to **Application**.
-8. Map exactly these two fields — **nothing else**:
-   - **Opportunity** → `{{trigger.record.id}}`
-   - **Partner User** → `{{trigger.workspaceMember}}` *(mandatory — see note below)*
-9. **Publish** (activate) the workflow version.
-
-**Partner User is mandatory.** The Partner role's row-level security on Application is
-`partnerUser IS the current member`, and the server validates it against the row as
-submitted. A **Create Record** without **Partner User** fails with *"Record does not
-satisfy row-level security constraints of your current role"*. `on-application-created`
-runs after the insert, so it cannot rescue it. Partner User is writable only because it is
-the RLS predicate field — the server exempts those from the role's field locks.
-
-**Map no other field.** Every remaining Application field is locked for the Partner role,
-so adding one (e.g. **State** → `APPLIED`) fails the insert with *"no permission to write
-field …"*. `state` defaults to `APPLIED` on its own.
-
-**Order of operations.** On a workspace that already runs the app:
-
-1. Publish this workflow version first — the strict predicate rejects every apply until the
-   Partner User mapping is live. If the workflow already exists, edit it instead: add
-   **Partner User**, remove every other mapping, republish.
-2. `yarn rls:configure` (`:prod`) — narrows the Application predicate to `partnerUser IS me`.
-
-Rows created before the narrowing carry no `partnerUser`, so the predicate hides them from
-their own partner. The app's post-install logic function stamps them during `app:install`,
-before step 2 runs. No manual step.
-
-### Expected UI (partner)
-
-On an **Opportunity** record (e.g. from **Open Briefs**), command menu → **Run workflow
-→ Apply**.
-
----
-
-## 2. Mark as Winner
+## 1. Mark as Winner
 
 Admin assigns the winning partner on the linked **Opportunity**. Fires
-`on-opportunity-partner-won`, which cascades Application states to **WON** / **BACKUP**.
+`on-opportunity-partner-won`, which cascades Application states to **WON** / **DECLINED**.
 
 ### Build (Settings → Workflows)
 
@@ -90,14 +42,52 @@ On an **Application** record, command menu → **Run workflow → Mark as Winner
 
 ---
 
+## 2. Daily digest
+
+Nudges validated partners once a day when new briefs appear: count + link, no brief
+details. Zero new briefs → no email. Hand-built per workspace — workflows are workspace
+metadata and do not travel with the app.
+
+Validated structure (local, 2026-08-25):
+
+1. Trigger — **Cron, daily 07:00**. (A test build may use a manual trigger; switch to
+   cron before relying on it.)
+2. **Find Records** `Search new opp` — Opportunity, `Creation date` is relative
+   `PAST_1_DAY` and `isListed` is true. Raise the record limit well above the editor
+   default of 1.
+3. **Find Records** `Search Partners` — Partner, `Validation Stage` is `VALIDATED`.
+   Raise the record limit as well.
+4. **Iterator** over the partners from step 3. Inside the loop:
+   - **Find Records** `Search people partner` — Person whose `Partner → Id` is
+     `{{currentItem.id}}`. The workflow engine loads no relations, so this extra search
+     is what resolves the partner's contact email.
+   - **If/Else** — continue only when the person search returned an email.
+   - **Send Email** — from the workspace's connected mailbox, to the found person email.
+     Subject and body carry the count from step 2 and the prod marketplace link.
+5. Publish and confirm the version shows ACTIVE.
+
+Prod prerequisites: a connected mailbox (Settings → Accounts) and the app installed.
+
+### Local email testing (never prod)
+
+Run smtp4dev:
+`docker run --rm -d --name smtp4dev -p 8090:80 -p 2525:25 -p 1143:143 rnwood/smtp4dev`.
+Set `OUTBOUND_HTTP_SAFE_MODE_ENABLED` to false (Settings → Admin Panel → Config
+Variables) — safe mode blocks private hosts for IMAP/SMTP on purpose. Connect an
+IMAP/SMTP account with host `host.docker.internal` (SMTP 2525, IMAP 1143, no TLS, any
+credentials). Mails land at http://localhost:8090. `EMAIL_DRIVER` env vars are the
+system mailer, not this — leave them alone.
+
+---
+
 ## Per-workspace checklist
 
-| Step | Apply to Brief | Mark as Winner |
+| Step | Mark as Winner | Daily Digest |
 | --- | --- | --- |
-| Trigger | Manual, single **Opportunity** | Manual, single **Application** |
-| Action | Create **Application** | Update linked **Opportunity** |
-| Published label | **Apply** (on brief) | **Mark as Winner** (on application) |
-| Who runs it | Partner (WORKFLOWS flag) | Admin |
+| Trigger | Manual, single **Application** | Cron, daily |
+| Action | Update linked **Opportunity** | Send Email per partner via person lookup |
+| Published label | **Mark as Winner** (on application) | **Daily Digest** |
+| Who runs it | Admin | Application role |
 
 Repeat for each workspace after install. Workflows are workspace metadata — they do not
 travel with `deploy` / `install`.


### PR DESCRIPTION
Targets `rashad/partners-apply-feature`, not `main`.

Part 5 of 5, stack root: `rashad/partners-website-brief-modal`. Closes the 1.7.0 release.

Part 3 made marketplace briefs list themselves, so nobody sees a new listing unless they open the CRM. This adds the compensating control.

**The ping.** `on-opportunity-listed` fires on an `isListed` flip from false to true and calls `notify-listed-brief`, which posts one Discord embed with the need, company, contact, referring partner, requirements and a deep link to the record. Both the read and the webhook are best-effort: a failure reports `false` and never fails the trigger.

**Scope.** The public form is not this trigger's job — form briefs are born listed and never flip, so the in-route ping already covers them. This covers hand-listing and imports.

**Also here.** `src/workflows/README.md` refreshed to describe the current trigger set, the `DISCORD_WEBHOOK_URL` description updated to name the third notification, and the app version bumped to 1.7.0 (the earlier slices keep main's 1.6.5, so only this one publishes).

`yarn test:unit`: 291 passing, 40 files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

