### PR TITLE
fix(server): only honor approved access domains when email verification is required

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/utils/__tests__/get-joinable-workspaces-from-approved-access-domains.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/utils/__tests__/get-joinable-workspaces-from-approved-access-domains.util.spec.ts
@@ -1,0 +1,55 @@
+import { getJoinableWorkspacesFromApprovedAccessDomains } from 'src/engine/core-modules/approved-access-domain/utils/get-joinable-workspaces-from-approved-access-domains.util';
+import { WorkspaceDiscoverability } from 'src/engine/core-modules/workspace/types/workspace-discoverability.type';
+
+describe('getJoinableWorkspacesFromApprovedAccessDomains', () => {
+  const publicWorkspace = {
+    id: 'workspace-1',
+    workspaceDiscoverability: WorkspaceDiscoverability.PUBLIC,
+  };
+
+  it('should return public workspaces the user is not already a member of', () => {
+    expect(
+      getJoinableWorkspacesFromApprovedAccessDomains({
+        approvedAccessDomains: [{ workspace: publicWorkspace }],
+        alreadyMemberWorkspaceIds: [],
+      }),
+    ).toEqual([{ workspace: publicWorkspace }]);
+  });
+
+  it('should skip approved-domain rows whose workspace did not load (orphaned/soft-deleted)', () => {
+    expect(
+      getJoinableWorkspacesFromApprovedAccessDomains({
+        approvedAccessDomains: [
+          { workspace: null },
+          { workspace: publicWorkspace },
+        ],
+        alreadyMemberWorkspaceIds: [],
+      }),
+    ).toEqual([{ workspace: publicWorkspace }]);
+  });
+
+  it('should skip non-public workspaces', () => {
+    expect(
+      getJoinableWorkspacesFromApprovedAccessDomains({
+        approvedAccessDomains: [
+          {
+            workspace: {
+              id: 'workspace-2',
+              workspaceDiscoverability: WorkspaceDiscoverability.HIDDEN,
+            },
+          },
+        ],
+        alreadyMemberWorkspaceIds: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it('should skip workspaces the user is already a member of', () => {
+    expect(
+      getJoinableWorkspacesFromApprovedAccessDomains({
+        approvedAccessDomains: [{ workspace: publicWorkspace }],
+        alreadyMemberWorkspaceIds: ['workspace-1'],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/utils/__tests__/is-email-in-approved-access-domains.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/utils/__tests__/is-email-in-approved-access-domains.util.spec.ts
@@ -1,0 +1,45 @@
+import { isEmailInApprovedAccessDomains } from 'src/engine/core-modules/approved-access-domain/utils/is-email-in-approved-access-domains.util';
+
+describe('isEmailInApprovedAccessDomains', () => {
+  const approvedAccessDomains = [{ domain: 'twenty.com', isValidated: true }];
+
+  it('should deny when email verification is not required, even on a validated domain', () => {
+    expect(
+      isEmailInApprovedAccessDomains({
+        email: 'tata@twenty.com',
+        approvedAccessDomains,
+        isEmailVerificationRequired: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('should grant a matching validated domain when email verification is required', () => {
+    expect(
+      isEmailInApprovedAccessDomains({
+        email: 'tata@twenty.com',
+        approvedAccessDomains,
+        isEmailVerificationRequired: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('should deny when the matching domain is not validated', () => {
+    expect(
+      isEmailInApprovedAccessDomains({
+        email: 'tata@twenty.com',
+        approvedAccessDomains: [{ domain: 'twenty.com', isValidated: false }],
+        isEmailVerificationRequired: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('should deny when the email domain does not match any approved domain', () => {
+    expect(
+      isEmailInApprovedAccessDomains({
+        email: 'tata@evil.com',
+        approvedAccessDomains,
+        isEmailVerificationRequired: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/utils/get-joinable-workspaces-from-approved-access-domains.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/utils/get-joinable-workspaces-from-approved-access-domains.util.ts
@@ -1,0 +1,27 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { WorkspaceDiscoverability } from 'src/engine/core-modules/workspace/types/workspace-discoverability.type';
+
+export const getJoinableWorkspacesFromApprovedAccessDomains = <
+  TWorkspace extends {
+    id: string;
+    workspaceDiscoverability: WorkspaceDiscoverability;
+  },
+>({
+  approvedAccessDomains,
+  alreadyMemberWorkspaceIds,
+}: {
+  approvedAccessDomains: { workspace: TWorkspace | null }[];
+  alreadyMemberWorkspaceIds: string[];
+}): { workspace: TWorkspace }[] => {
+  return approvedAccessDomains
+    .map((approvedAccessDomain) => approvedAccessDomain.workspace)
+    .filter(isDefined)
+    .filter(
+      (workspace) =>
+        workspace.workspaceDiscoverability ===
+          WorkspaceDiscoverability.PUBLIC &&
+        !alreadyMemberWorkspaceIds.includes(workspace.id),
+    )
+    .map((workspace) => ({ workspace }));
+};

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/utils/is-email-in-approved-access-domains.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/utils/is-email-in-approved-access-domains.util.ts
@@ -1,0 +1,27 @@
+import { type ApprovedAccessDomainEntity } from 'src/engine/core-modules/approved-access-domain/approved-access-domain.entity';
+import { getDomainFromEmail } from 'src/utils/get-domain-from-email';
+
+export const isEmailInApprovedAccessDomains = ({
+  email,
+  approvedAccessDomains,
+  isEmailVerificationRequired,
+}: {
+  email: string;
+  approvedAccessDomains: Pick<
+    ApprovedAccessDomainEntity,
+    'domain' | 'isValidated'
+  >[];
+  isEmailVerificationRequired: boolean;
+}): boolean => {
+  if (!isEmailVerificationRequired) {
+    return false;
+  }
+
+  const emailDomain = getDomainFromEmail(email);
+
+  return approvedAccessDomains.some(
+    (approvedAccessDomain) =>
+      approvedAccessDomain.isValidated &&
+      approvedAccessDomain.domain === emailDomain,
+  );
+};

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -73,7 +73,7 @@ import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/worksp
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
-import { getDomainFromEmail } from 'src/utils/get-domain-from-email';
+import { isEmailInApprovedAccessDomains } from 'src/engine/core-modules/approved-access-domain/utils/is-email-in-approved-access-domains.util';
 
 @Injectable()
 // oxlint-disable-next-line twenty/inject-workspace-repository
@@ -904,11 +904,14 @@ export class AuthService {
         : userData.existingUser.email;
 
     if (
-      workspace?.approvedAccessDomains.some(
-        (trustDomain) =>
-          trustDomain.isValidated &&
-          trustDomain.domain === getDomainFromEmail(email),
-      )
+      isDefined(workspace) &&
+      isEmailInApprovedAccessDomains({
+        email,
+        approvedAccessDomains: workspace.approvedAccessDomains,
+        isEmailVerificationRequired: this.twentyConfigService.get(
+          'IS_EMAIL_VERIFICATION_REQUIRED',
+        ),
+      })
     ) {
       return;
     }

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -11,6 +11,8 @@ import { FileStorageExceptionCode } from 'src/engine/core-modules/file-storage/i
 
 import { type AppTokenEntity } from 'src/engine/core-modules/app-token/app-token.entity';
 import { ApprovedAccessDomainService } from 'src/engine/core-modules/approved-access-domain/services/approved-access-domain.service';
+import { getJoinableWorkspacesFromApprovedAccessDomains } from 'src/engine/core-modules/approved-access-domain/utils/get-joinable-workspaces-from-approved-access-domains.util';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import {
   AuthException,
   AuthExceptionCode,
@@ -66,6 +68,7 @@ export class UserWorkspaceService {
     private readonly fileUrlService: FileUrlService,
     private readonly onboardingService: OnboardingService,
     private readonly coreEntityCacheService: CoreEntityCacheService,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {}
 
   async findById(id: string): Promise<UserWorkspaceEntity | null> {
@@ -391,18 +394,17 @@ export class UserWorkspaceService {
     );
 
     // Email-domain discovery is the only "listing" source: PUBLIC only.
-    const workspacesFromApprovedAccessDomain = (
-      await this.approvedAccessDomainService.findValidatedApprovedAccessDomainWithWorkspacesAndSSOIdentityProvidersDomain(
-        getDomainFromEmailOrThrow(email),
-      )
+    const workspacesFromApprovedAccessDomain = this.twentyConfigService.get(
+      'IS_EMAIL_VERIFICATION_REQUIRED',
     )
-      .filter(
-        ({ workspace }) =>
-          !alreadyMemberWorkspacesIds.includes(workspace.id) &&
-          workspace.workspaceDiscoverability ===
-            WorkspaceDiscoverability.PUBLIC,
-      )
-      .map(({ workspace }) => ({ workspace }));
+      ? getJoinableWorkspacesFromApprovedAccessDomains({
+          approvedAccessDomains:
+            await this.approvedAccessDomainService.findValidatedApprovedAccessDomainWithWorkspacesAndSSOIdentityProvidersDomain(
+              getDomainFromEmailOrThrow(email),
+            ),
+          alreadyMemberWorkspaceIds: alreadyMemberWorkspacesIds,
+        })
+      : [];
 
     const workspacesFromApprovedAccessDomainIds =
       workspacesFromApprovedAccessDomain.map(({ workspace }) => workspace.id);


### PR DESCRIPTION
## What

Approved access domains grant workspace access from an email's domain. That is only meaningful when the instance proves the user owns the email, which is guaranteed by email verification.

## Functional changes

1. **Approved-domain access now requires `IS_EMAIL_VERIFICATION_REQUIRED`.** It was previously applied unconditionally; it is now honored only when email verification is enabled — in both the sign-in-up access check (`checkAccessForSignIn`) and the workspace-picker listing (`findAvailableWorkspacesByEmail`). When verification is not required, approved-domain trust is inert. Instances with verification enabled are unaffected.
2. **Approved-domain rows whose related workspace no longer loads are skipped.** `findAvailableWorkspacesByEmail` previously read `workspace.id` unconditionally and threw when a row's workspace was missing (e.g. soft-deleted); such rows are now filtered out.

## Refactor (no behavior change)

The domain-match predicate and the PUBLIC / already-member filters are unchanged — relocated into `isEmailInApprovedAccessDomains` and `getJoinableWorkspacesFromApprovedAccessDomains` so the two functional changes above are isolated and unit-testable.

## Tests

Unit tests for both utils, covering the verification gating and the missing-workspace case.
