### PR TITLE
Fix campaign page scrolling

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutVerticalList.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutVerticalList.test.tsx
@@ -125,7 +125,6 @@ describe('PageLayoutVerticalList', () => {
       makeWidget('emails', WidgetType.EMAILS),
       makeWidget('email-thread', WidgetType.EMAIL_THREAD),
       makeWidget('files', WidgetType.FILES),
-      makeWidget('message-campaign-body', WidgetType.MESSAGE_CAMPAIGN_BODY),
       makeWidget('notes', WidgetType.NOTES),
       makeWidget('tasks', WidgetType.TASKS),
       makeWidget('workflow', WidgetType.WORKFLOW),
@@ -155,6 +154,26 @@ describe('PageLayoutVerticalList', () => {
         .getByTestId('fields')
         .closest('.page-layout-viewport-filling-widget-slot'),
     ).toBeNull();
+  });
+
+  it('keeps campaign documents fit-content so the tab owns scrolling', () => {
+    render(
+      <PageLayoutVerticalList
+        isInEditMode={false}
+        widgets={[
+          makeWidget('message-campaign-body', WidgetType.MESSAGE_CAMPAIGN_BODY),
+        ]}
+      />,
+    );
+
+    expect(
+      screen
+        .getByTestId('message-campaign-body')
+        .closest('.page-layout-viewport-filling-widget-slot'),
+    ).toBeNull();
+    expect(
+      screen.getByTestId('message-campaign-body-sortable-cell'),
+    ).toHaveAttribute('data-fill', 'false');
   });
 
   it('gives a lone Canvas front component viewport-filling sizing', () => {

--- a/packages/twenty-front/src/modules/page-layout/widgets/utils/__tests__/isViewportFillingWidgetType.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/utils/__tests__/isViewportFillingWidgetType.test.ts
@@ -14,7 +14,7 @@ const expectedIsViewportFillingByWidgetType = {
   [WidgetType.FRONT_COMPONENT]: false,
   [WidgetType.GRAPH]: false,
   [WidgetType.IFRAME]: false,
-  [WidgetType.MESSAGE_CAMPAIGN_BODY]: true,
+  [WidgetType.MESSAGE_CAMPAIGN_BODY]: false,
   [WidgetType.MESSAGE_CAMPAIGN_DETAILS]: false,
   [WidgetType.NOTES]: true,
   [WidgetType.RECORD_TABLE]: false,

--- a/packages/twenty-front/src/modules/page-layout/widgets/utils/isViewportFillingWidgetType.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/utils/isViewportFillingWidgetType.ts
@@ -10,7 +10,6 @@ export const isViewportFillingWidgetType = (
     case WidgetType.EMAILS:
     case WidgetType.EMAIL_THREAD:
     case WidgetType.FILES:
-    case WidgetType.MESSAGE_CAMPAIGN_BODY:
     case WidgetType.NOTES:
     case WidgetType.TASKS:
     case WidgetType.TIMELINE:
@@ -25,6 +24,10 @@ export const isViewportFillingWidgetType = (
 
     case WidgetType.RECORD_TABLE:
       // Record tables keep their own interactive frame and are not collapsed.
+      return false;
+
+    case WidgetType.MESSAGE_CAMPAIGN_BODY:
+      // Campaign documents grow with their content so the tab owns scrolling.
       return false;
 
     case WidgetType.MESSAGE_CAMPAIGN_DETAILS:


### PR DESCRIPTION
## Summary

- treat message campaign bodies as fit-content widgets
- let the page layout scroll wrapper own the full campaign document height
- add regression coverage for campaign sizing in vertical-list layouts

## Root cause

The unified vertical-list layout classified message campaign bodies as viewport-filling. That fixed the widget slot to one viewport and clipped overflow, but the campaign surface did not own a scroll container. Long campaign content therefore overflowed inside the clipped slot while the page scroll wrapper saw no overflow.

Campaigns should scroll as full documents, so this change removes them from the viewport-filling category instead of adding an inner widget scrollbar.

## Testing

- focused Jest suites: 36 tests passed
- diff lint: clean
- formatting and git diff checks: clean

A direct full twenty-front typecheck was attempted in a fresh worktree; it was blocked by the unrelated missing generated twenty-front-component-renderer artifact. The changed files compile in the focused Jest suites and pass type-aware diff lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

