### PR TITLE
Make getRepository synchronous

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command.ts
@@ -162,7 +162,7 @@ export class MigrateAiAgentTextToJsonResponseFormatCommand extends ProvisionedWo
     agentIds: string[],
   ): Promise<void> {
     const workflowVersionRepository =
-      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+      this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command.ts
@@ -80,19 +80,19 @@ export class MigrateMessagingInfrastructureToMetadataCommand extends Provisioned
     const isDryRun = options.dryRun ?? false;
 
     const connectedAccountWorkspaceRepository =
-      await this.workspaceOrmManager.getRepository<LegacyConnectedAccountWorkspaceEntity>('connectedAccount',
+      this.workspaceOrmManager.getRepository<LegacyConnectedAccountWorkspaceEntity>('connectedAccount',
       );
 
     const messageChannelWorkspaceRepository =
-      await this.workspaceOrmManager.getRepository<MessageChannelEntity>('messageChannel',
+      this.workspaceOrmManager.getRepository<MessageChannelEntity>('messageChannel',
       );
 
     const calendarChannelWorkspaceRepository =
-      await this.workspaceOrmManager.getRepository<CalendarChannelEntity>('calendarChannel',
+      this.workspaceOrmManager.getRepository<CalendarChannelEntity>('calendarChannel',
       );
 
     const messageFolderWorkspaceRepository =
-      await this.workspaceOrmManager.getRepository<MessageFolderEntity>('messageFolder',
+      this.workspaceOrmManager.getRepository<MessageFolderEntity>('messageFolder',
       );
 
     const connectedAccounts = await connectedAccountWorkspaceRepository.find();
@@ -365,7 +365,7 @@ export class MigrateMessagingInfrastructureToMetadataCommand extends Provisioned
     workspaceId: string,
   ): Promise<Map<string, string>> {
     const workspaceMemberRepository =
-      await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>('workspaceMember',
+      this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>('workspaceMember',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-15/2-15-workspace-command-1800000001000-migrate-manual-trigger-variables-to-payload.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-15/2-15-workspace-command-1800000001000-migrate-manual-trigger-variables-to-payload.command.ts
@@ -57,7 +57,7 @@ export class MigrateManualTriggerVariablesToPayloadCommand extends ProvisionedWo
     }
 
     const workflowVersionRepository =
-      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+      this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783526282685-backfill-workflow-version-to-core.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783526282685-backfill-workflow-version-to-core.command.ts
@@ -36,7 +36,7 @@ export class BackfillWorkflowVersionToCoreCommand extends ProvisionedWorkspaceCo
         await this.workspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowVersionRepository =
-              await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+              this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command.ts
@@ -91,7 +91,7 @@ export class MigratePersonAvatarUrlToAvatarFileCommand extends ProvisionedWorksp
     }
 
     const personRepository =
-      await this.workspaceOrmManager.getRepository<PersonWorkspaceEntity>('person',
+      this.workspaceOrmManager.getRepository<PersonWorkspaceEntity>('person',
         { shouldBypassPermissionChecks: true },
       );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
@@ -53,7 +53,7 @@ export class BackfillWorkflowVersionCoreLinksCommand extends ProvisionedWorkspac
         await this.workspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowVersionRepository =
-              await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+              this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command.ts
@@ -51,7 +51,7 @@ export class BackfillWorkflowCoreLinksCommand extends ProvisionedWorkspaceComman
         await this.workspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowRepository =
-              await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>('workflow',
+              this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>('workflow',
                 { shouldBypassPermissionChecks: true },
               );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command.ts
@@ -50,7 +50,7 @@ export class RepairOrphanCoreWorkflowVersionsCommand extends ProvisionedWorkspac
       await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowVersionRepository =
-            await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
+            this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion',
               { shouldBypassPermissionChecks: true },
             );
 

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
@@ -49,7 +49,7 @@ export class ApprovedAccessDomainResolver {
     const workspaceMember =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-connected-account.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-connected-account.service.ts
@@ -60,7 +60,7 @@ export class CreateConnectedAccountService {
       });
 
       const workspaceMemberRepo =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           rolePermissionConfig ?? undefined,
         );

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
@@ -83,7 +83,7 @@ export class AccessTokenService {
       workspaceMemberId =
         await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
           const workspaceMemberRepository =
-            await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
@@ -29,7 +29,7 @@ export class UpdateSubscriptionQuantityJob {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -62,7 +62,7 @@ export class TimelineCalendarEventService {
       // timeline rather than a denied one
       // https://github.com/twentyhq/core-team-issues/issues/2777
       const calendarEventRepository =
-        await this.workspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
           'calendarEvent',
           { shouldBypassPermissionChecks: true },
         );
@@ -116,7 +116,7 @@ export class TimelineCalendarEventService {
       });
 
       const callRecordingRepository =
-        await this.workspaceOrmManager.getRepository<CallRecordingWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<CallRecordingWorkspaceEntity>(
           'callRecording',
         );
 
@@ -177,7 +177,7 @@ export class TimelineCalendarEventService {
 
       // Resolve current user's userWorkspaceId (workspaceMember → userId → userWorkspace)
       const workspaceMemberRepo =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
@@ -51,7 +51,7 @@ export class TimelineMessagingService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageThreadRepository =
-        await this.workspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
           'messageThread',
         );
 
@@ -124,7 +124,7 @@ export class TimelineMessagingService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageParticipantRepository =
-        await this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
           'messageParticipant',
         );
 
@@ -234,7 +234,7 @@ export class TimelineMessagingService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -260,7 +260,7 @@ export class TimelineMessagingService {
       const currentUserWorkspaceId = currentUserWorkspace.id;
 
       const messageThreadRepository =
-        await this.workspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
           'messageThread',
         );
 

--- a/packages/twenty-server/src/engine/core-modules/record-position/services/record-position.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-position/services/record-position.service.ts
@@ -161,7 +161,7 @@ export class RecordPositionService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const repository = await this.workspaceOrmManager.getRepository(
+      const repository = this.workspaceOrmManager.getRepository(
         objectMetadata.nameSingular,
         {
           shouldBypassPermissionChecks: true,
@@ -185,7 +185,7 @@ export class RecordPositionService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const repository = await this.workspaceOrmManager.getRepository(
+      const repository = this.workspaceOrmManager.getRepository(
         objectMetadata.nameSingular,
         {
           shouldBypassPermissionChecks: true,
@@ -206,7 +206,7 @@ export class RecordPositionService {
 
     const result = await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        const repository = await this.workspaceOrmManager.getRepository(
+        const repository = this.workspaceOrmManager.getRepository(
           objectMetadata.nameSingular,
           {
             shouldBypassPermissionChecks: true,
@@ -229,7 +229,7 @@ export class RecordPositionService {
 
     const result = await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        const repository = await this.workspaceOrmManager.getRepository(
+        const repository = this.workspaceOrmManager.getRepository(
           objectMetadata.nameSingular,
           {
             shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/services/related-person-ids.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/services/related-person-ids.service.ts
@@ -83,7 +83,7 @@ export class RelatedPersonIdsService {
       }
 
       const repository =
-        await this.workspaceOrmManager.getRepository<RelationWalkRecord>(
+        this.workspaceOrmManager.getRepository<RelationWalkRecord>(
           hop.queryObjectNameSingular,
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -119,7 +119,7 @@ export class SearchService {
                 }) ?? undefined;
 
               const repository =
-                await this.workspaceOrmManager.getRepository<ObjectRecord>(
+                this.workspaceOrmManager.getRepository<ObjectRecord>(
                   flatObjectMetadata.nameSingular,
                   rolePermissionConfig,
                 );

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
@@ -275,7 +275,7 @@ export class EmailComposerService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const messageRepository =
-        await this.workspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<MessageWorkspaceEntity>(
           'message',
         );
 
@@ -292,7 +292,7 @@ export class EmailComposerService {
       }
 
       const associationRepository =
-        await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
           'messageChannelMessageAssociation',
         );
 

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/navigate-tool/navigate-app-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/navigate-tool/navigate-app-tool.ts
@@ -335,11 +335,10 @@ export class NavigateAppTool implements Tool {
 
     const records = await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        const repository =
-          await this.workspaceOrmManager.getRepository<ObjectRecord>(
-            objectNameSingular,
-            { shouldBypassPermissionChecks: true },
-          );
+        const repository = this.workspaceOrmManager.getRepository<ObjectRecord>(
+          objectNameSingular,
+          { shouldBypassPermissionChecks: true },
+        );
 
         return repository.find({
           select: selectColumns,

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -164,7 +164,7 @@ export class UserWorkspaceService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -488,7 +488,7 @@ export class UserWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/user/jobs/update-workspace-member-email.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/jobs/update-workspace-member-email.job.ts
@@ -37,7 +37,7 @@ export class UpdateWorkspaceMemberEmailJob {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -106,7 +106,7 @@ export class UserService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -135,7 +135,7 @@ export class UserService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -218,7 +218,7 @@ export class UserService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -241,7 +241,7 @@ export class UserService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -329,7 +329,7 @@ export class UserService {
     const workspaceMembers =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
@@ -394,7 +394,7 @@ export class UserService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
@@ -22,7 +22,7 @@ export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheP
     const flatWorkspaceMemberMaps =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -407,7 +407,7 @@ export class UserResolver {
     const workspaceMemberToDelete =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
@@ -99,7 +99,7 @@ export class WorkflowTriggerController {
       const { workflow } =
         await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
           const workflowRepository =
-            await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+            this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
               'workflow',
               { shouldBypassPermissionChecks: true },
             );
@@ -126,7 +126,7 @@ export class WorkflowTriggerController {
           }
 
           const workflowVersionRepository =
-            await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+            this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
               'workflowVersion',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -84,7 +84,7 @@ export class WorkflowTriggerResolver {
     const workspaceMember =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-core-sync.service.ts
@@ -135,7 +135,7 @@ export class WorkflowCoreSyncService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceWorkflowRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
           'workflow',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
@@ -338,7 +338,7 @@ export class WorkflowVersionCoreSyncService {
     const coreWorkflowVersionIds =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workflowVersionRepository =
-          await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
             'workflowVersion',
             { shouldBypassPermissionChecks: true },
           );
@@ -362,7 +362,7 @@ export class WorkflowVersionCoreSyncService {
   ): Promise<void> {
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -393,7 +393,7 @@ export class WorkflowVersionCoreSyncService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceWorkflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
@@ -62,7 +62,7 @@ export class WorkspaceInvitationResolver {
     const workspaceMember =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
@@ -98,7 +98,7 @@ export class WorkspaceInvitationResolver {
     const workspaceMember =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service.ts
@@ -66,7 +66,7 @@ export class AgentActorContextService {
     const workspaceMember =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository('workspaceMember', {
+          this.workspaceOrmManager.getRepository('workspaceMember', {
             shouldBypassPermissionChecks: true,
           });
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/workspace-setup-chat.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/workspace-setup-chat.service.ts
@@ -270,7 +270,7 @@ export class WorkspaceSetupChatService {
       const workspaceMember =
         await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
           const workspaceMemberRepository =
-            await this.workspaceOrmManager.getRepository('workspaceMember', {
+            this.workspaceOrmManager.getRepository('workspaceMember', {
               shouldBypassPermissionChecks: true,
             });
 

--- a/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-record-identifier.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-record-identifier.service.ts
@@ -79,7 +79,7 @@ export class NavigationMenuItemRecordIdentifierService {
           return null;
         }
 
-        const repository = await this.workspaceOrmManager.getRepository(
+        const repository = this.workspaceOrmManager.getRepository(
           objectMetadata.nameSingular,
           rolePermissionConfig,
         );

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout/services/page-layout.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout/services/page-layout.service.ts
@@ -562,7 +562,7 @@ export class PageLayoutService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const dashboardRepository = await this.workspaceOrmManager.getRepository(
+      const dashboardRepository = this.workspaceOrmManager.getRepository(
         'dashboard',
         {
           shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
@@ -225,7 +225,7 @@ export class UserRoleService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );
@@ -272,7 +272,7 @@ export class UserRoleService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
@@ -151,7 +151,7 @@ export class ViewQueryParamsService {
 
     try {
       const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
           'workspaceMember',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/engine/trash-cleanup/services/trash-cleanup.service.ts
+++ b/packages/twenty-server/src/engine/trash-cleanup/services/trash-cleanup.service.ts
@@ -102,10 +102,9 @@ export class TrashCleanupService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const repository = await this.workspaceOrmManager.getRepository(
-        objectName,
-        { shouldBypassPermissionChecks: true },
-      );
+      const repository = this.workspaceOrmManager.getRepository(objectName, {
+        shouldBypassPermissionChecks: true,
+      });
 
       let deleted = 0;
 

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-orm.manager.ts
@@ -26,20 +26,20 @@ export class WorkspaceOrmManager {
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
   ) {}
 
-  async getRepository<T extends ObjectLiteral>(
+  getRepository<T extends ObjectLiteral>(
     workspaceEntity: Type<T>,
     permissionOptions?: RolePermissionConfig,
-  ): Promise<WorkspaceRepository<T>>;
+  ): WorkspaceRepository<T>;
 
-  async getRepository<T extends ObjectLiteral>(
+  getRepository<T extends ObjectLiteral>(
     objectMetadataName: string,
     permissionOptions?: RolePermissionConfig,
-  ): Promise<WorkspaceRepository<T>>;
+  ): WorkspaceRepository<T>;
 
-  async getRepository<T extends ObjectLiteral>(
+  getRepository<T extends ObjectLiteral>(
     workspaceEntityOrObjectMetadataName: Type<T> | string,
     permissionOptions?: RolePermissionConfig,
-  ): Promise<WorkspaceRepository<T>> {
+  ): WorkspaceRepository<T> {
     const objectMetadataName = this.resolveObjectMetadataName(
       workspaceEntityOrObjectMetadataName,
     );

--- a/packages/twenty-server/src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
+++ b/packages/twenty-server/src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
@@ -103,7 +103,7 @@ export class BlocklistValidationService {
     const currentWorkspaceMember =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository(
+          this.workspaceOrmManager.getRepository(
             WorkspaceMemberWorkspaceEntity,
             { shouldBypassPermissionChecks: true },
           );
@@ -185,7 +185,7 @@ export class BlocklistValidationService {
     const currentWorkspaceMember =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository(
+          this.workspaceOrmManager.getRepository(
             WorkspaceMemberWorkspaceEntity,
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
+++ b/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
@@ -15,7 +15,7 @@ export class BlocklistRepository {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const blockListRepository = await this.workspaceOrmManager.getRepository(
+      const blockListRepository = this.workspaceOrmManager.getRepository(
         BlocklistWorkspaceEntity,
         {
           shouldBypassPermissionChecks: true,
@@ -35,7 +35,7 @@ export class BlocklistRepository {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const blockListRepository = await this.workspaceOrmManager.getRepository(
+      const blockListRepository = this.workspaceOrmManager.getRepository(
         BlocklistWorkspaceEntity,
       );
 

--- a/packages/twenty-server/src/modules/calendar/blocklist-manager/jobs/blocklist-reimport-calendar-events.job.ts
+++ b/packages/twenty-server/src/modules/calendar/blocklist-manager/jobs/blocklist-reimport-calendar-events.job.ts
@@ -44,7 +44,7 @@ export class BlocklistReimportCalendarEventsJob {
     await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository('workspaceMember', {
+          this.workspaceOrmManager.getRepository('workspaceMember', {
             shouldBypassPermissionChecks: true,
           });
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
@@ -94,7 +94,7 @@ export class CalendarEventsImportService {
           });
 
           const workspaceMemberRepository =
-            await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );
@@ -154,7 +154,7 @@ export class CalendarEventsImportService {
             );
           }
           const calendarChannelEventAssociationRepository =
-            await this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+            this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
               'calendarChannelEventAssociation',
             );
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -61,7 +61,7 @@ export class CalendarFetchEventsService {
 
           if (calendarEventIdsToDelete.length > 0) {
             const calendarChannelEventAssociationRepository =
-              await this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+              this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
                 'calendarChannelEventAssociation',
               );
 

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -37,7 +37,7 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
     return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const calendarChannelEventAssociationRepository =
-          await this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
             'calendarChannelEventAssociation',
           );
 

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
@@ -70,18 +70,17 @@ export class CreateCompanyAndPersonService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const personRepository = await this.workspaceOrmManager.getRepository(
+      const personRepository = this.workspaceOrmManager.getRepository(
         PersonWorkspaceEntity,
         {
           shouldBypassPermissionChecks: true,
         },
       );
 
-      const workspaceMemberRepository =
-        await this.workspaceOrmManager.getRepository(
-          WorkspaceMemberWorkspaceEntity,
-          { shouldBypassPermissionChecks: true },
-        );
+      const workspaceMemberRepository = this.workspaceOrmManager.getRepository(
+        WorkspaceMemberWorkspaceEntity,
+        { shouldBypassPermissionChecks: true },
+      );
 
       const workspaceMembers = await workspaceMemberRepository.find();
 
@@ -202,7 +201,7 @@ export class CreateCompanyAndPersonService {
     const accountOwner =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository(
+          this.workspaceOrmManager.getRepository(
             WorkspaceMemberWorkspaceEntity,
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -55,7 +55,7 @@ export class CreateCompanyService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const companyRepository = await this.workspaceOrmManager.getRepository(
+      const companyRepository = this.workspaceOrmManager.getRepository(
         CompanyWorkspaceEntity,
         {
           shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
@@ -21,7 +21,7 @@ export class CreatePersonService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const personRepository = await this.workspaceOrmManager.getRepository(
+      const personRepository = this.workspaceOrmManager.getRepository(
         PersonWorkspaceEntity,
         { shouldBypassPermissionChecks: true },
       );
@@ -51,7 +51,7 @@ export class CreatePersonService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const personRepository = await this.workspaceOrmManager.getRepository(
+      const personRepository = this.workspaceOrmManager.getRepository(
         PersonWorkspaceEntity,
         {
           shouldBypassPermissionChecks: true,
@@ -83,7 +83,7 @@ export class CreatePersonService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const personRepository = await this.workspaceOrmManager.getRepository(
+      const personRepository = this.workspaceOrmManager.getRepository(
         PersonWorkspaceEntity,
         {
           shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/modules/dashboard-sync/services/dashboard-sync.service.ts
+++ b/packages/twenty-server/src/modules/dashboard-sync/services/dashboard-sync.service.ts
@@ -64,10 +64,12 @@ export class DashboardSyncService {
 
     try {
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-        const dashboardRepository =
-          await this.workspaceOrmManager.getRepository('dashboard', {
+        const dashboardRepository = this.workspaceOrmManager.getRepository(
+          'dashboard',
+          {
             shouldBypassPermissionChecks: true,
-          });
+          },
+        );
 
         await dashboardRepository.update({ pageLayoutId }, { updatedAt });
       }, authContext);

--- a/packages/twenty-server/src/modules/dashboard/chart-data/services/chart-relation-label.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/services/chart-relation-label.service.ts
@@ -203,7 +203,7 @@ export class ChartRelationLabelService {
             return [];
           }
 
-          const repository = await this.workspaceOrmManager.getRepository(
+          const repository = this.workspaceOrmManager.getRepository(
             targetFlatObjectMetadata.nameSingular,
             rolePermissionConfig,
           );

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
@@ -35,7 +35,7 @@ export class DashboardDuplicationService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const dashboardRepository =
-        await this.workspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
           'dashboard',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-to-page-layout-sync.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-to-page-layout-sync.service.ts
@@ -54,7 +54,7 @@ export class DashboardToPageLayoutSyncService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const dashboardRepository =
-        await this.workspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
           'dashboard',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/dashboard/tools/__tests__/get-dashboard.tool.spec.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/__tests__/get-dashboard.tool.spec.ts
@@ -108,7 +108,7 @@ describe('get_dashboard tool', () => {
         executeInWorkspaceContext: jest
           .fn()
           .mockImplementation(async (fn) => fn()),
-        getRepository: jest.fn().mockResolvedValue({
+        getRepository: jest.fn().mockReturnValue({
           findOne: jest.fn().mockResolvedValue(dashboard),
         }),
       },

--- a/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
@@ -241,7 +241,7 @@ const createDashboardRecord = async (
   const authContext = buildSystemAuthContext(context.workspaceId);
 
   return deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
-    const dashboardRepository = await deps.workspaceOrmManager.getRepository(
+    const dashboardRepository = deps.workspaceOrmManager.getRepository(
       'dashboard',
       {
         shouldBypassPermissionChecks: true,

--- a/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
@@ -70,10 +70,9 @@ export const createGetDashboardTool = (
 
       const dashboard =
         await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
-          const repo = await deps.workspaceOrmManager.getRepository(
-            'dashboard',
-            { shouldBypassPermissionChecks: true },
-          );
+          const repo = deps.workspaceOrmManager.getRepository('dashboard', {
+            shouldBypassPermissionChecks: true,
+          });
 
           return repo.findOne({ where: { id: parameters.dashboardId } });
         }, authContext);

--- a/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
@@ -30,10 +30,9 @@ export const createListDashboardsTool = (
 
       const dashboards =
         await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
-          const repo = await deps.workspaceOrmManager.getRepository(
-            'dashboard',
-            { shouldBypassPermissionChecks: true },
-          );
+          const repo = deps.workspaceOrmManager.getRepository('dashboard', {
+            shouldBypassPermissionChecks: true,
+          });
 
           return repo.find({ take: limit, order: { position: 'ASC' } });
         }, authContext);

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign-statistics.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign-statistics.service.ts
@@ -23,7 +23,7 @@ export class MessageCampaignStatisticsService {
     campaignId: string;
   }): Promise<void> {
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const messageRepository = await this.workspaceOrmManager.getRepository(
+      const messageRepository = this.workspaceOrmManager.getRepository(
         MessageWorkspaceEntity,
         { shouldBypassPermissionChecks: true },
       );
@@ -55,7 +55,7 @@ export class MessageCampaignStatisticsService {
           CAMPAIGN_MESSAGE_DELIVERY_STATUS.COMPLAINED,
         ) ?? 0;
 
-      const campaignRepository = await this.workspaceOrmManager.getRepository(
+      const campaignRepository = this.workspaceOrmManager.getRepository(
         MessageCampaignWorkspaceEntity,
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -74,7 +74,7 @@ export class MatchParticipantService<
         );
       }
 
-      return await this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+      return this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
         objectMetadataName,
       );
     }
@@ -85,7 +85,7 @@ export class MatchParticipantService<
       );
     }
 
-    return await this.workspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
+    return this.workspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
       objectMetadataName,
     );
   }
@@ -101,10 +101,9 @@ export class MatchParticipantService<
     }
 
     const personRepository =
-      await this.workspaceOrmManager.getRepository<PersonWorkspaceEntity>(
-        'person',
-        { shouldBypassPermissionChecks: true },
-      );
+      this.workspaceOrmManager.getRepository<PersonWorkspaceEntity>('person', {
+        shouldBypassPermissionChecks: true,
+      });
 
     const participantRepository = await this.getParticipantRepository({
       objectMetadataName,
@@ -112,7 +111,7 @@ export class MatchParticipantService<
     });
 
     const workspaceMemberRepository =
-      await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+      this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
@@ -54,7 +54,7 @@ export class BlocklistItemDeleteMessagesJob {
         );
 
         const blocklistRepository =
-          await this.workspaceOrmManager.getRepository<BlocklistWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<BlocklistWorkspaceEntity>(
             'blocklist',
           );
 
@@ -84,18 +84,18 @@ export class BlocklistItemDeleteMessagesJob {
         );
 
         const messageChannelMessageAssociationRepository =
-          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );
 
         const messageParticipantRepository =
-          await this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
             'messageParticipant',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-reimport-messages.job.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-reimport-messages.job.ts
@@ -47,7 +47,7 @@ export class BlocklistReimportMessagesJob {
     await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -38,7 +38,7 @@ export class ApplyMessagesVisibilityRestrictionsService {
     return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
-          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 
@@ -70,7 +70,7 @@ export class ApplyMessagesVisibilityRestrictionsService {
         );
 
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
@@ -385,7 +385,7 @@ export class MessageChannelSyncStatusService {
     });
 
     const workspaceMemberRepository =
-      await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+      this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service.ts
@@ -40,12 +40,12 @@ export class MessagingDeleteFolderMessagesService {
     await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageFolderAssociationRepository =
-          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
             'messageChannelMessageAssociationMessageFolder',
           );
 
         const messageChannelMessageAssociationRepository =
-          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
@@ -43,7 +43,7 @@ export class MessagingDeleteGroupEmailMessagesService {
     return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
-          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -148,7 +148,7 @@ export class MessagingMessageListFetchService {
           );
 
           const messageChannelMessageAssociationRepository =
-            await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+            this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
               'messageChannelMessageAssociation',
             );
 
@@ -344,7 +344,7 @@ export class MessagingMessageListFetchService {
     messageExternalIds: string[],
   ) {
     const messageChannelMessageAssociationRepository =
-      await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+      this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
         'messageChannelMessageAssociation',
       );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
@@ -155,7 +155,7 @@ export class MessagingMessagesImportService {
           });
 
           const workspaceMemberRepository =
-            await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
               'workspaceMember',
               { shouldBypassPermissionChecks: true },
             );

--- a/packages/twenty-server/src/modules/messaging/message-outbound-manager/services/messaging-draft-send.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-outbound-manager/services/messaging-draft-send.service.ts
@@ -67,7 +67,7 @@ export class MessagingDraftSendService {
     return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const messageChannelMessageAssociationRepository =
-          await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
           );
 
@@ -135,7 +135,7 @@ export class MessagingDraftSendService {
       await this.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const messageChannelMessageAssociationRepository =
-            await this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+            this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
               'messageChannelMessageAssociation',
             );
 

--- a/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
@@ -27,7 +27,7 @@ export class NotePostQueryHookService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const noteTargetRepository =
-        await this.workspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
           'noteTarget',
         );
 
@@ -51,7 +51,7 @@ export class NotePostQueryHookService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const noteTargetRepository =
-        await this.workspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
           'noteTarget',
         );
 

--- a/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
@@ -27,7 +27,7 @@ export class TaskPostQueryHookService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const taskTargetRepository =
-        await this.workspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
           'taskTarget',
         );
 
@@ -51,7 +51,7 @@ export class TaskPostQueryHookService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const taskTargetRepository =
-        await this.workspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
           'taskTarget',
         );
 

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity-target-query.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity-target-query.service.ts
@@ -50,7 +50,7 @@ export class TimelineActivityTargetQueryService {
     const { junctionObjectNameSingular, junctionSourceJoinColumnName } =
       rule.targetShape;
 
-    const junctionRepository = await this.workspaceOrmManager.getRepository(
+    const junctionRepository = this.workspaceOrmManager.getRepository(
       junctionObjectNameSingular,
       { shouldBypassPermissionChecks: true },
     );
@@ -109,7 +109,7 @@ export class TimelineActivityTargetQueryService {
       return sourceRecordsByRecordId;
     }
 
-    const repository = await this.workspaceOrmManager.getRepository(
+    const repository = this.workspaceOrmManager.getRepository(
       rule.sourceFlatObjectMetadata.nameSingular,
       { shouldBypassPermissionChecks: true },
     );

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
@@ -487,13 +487,12 @@ export class TimelineActivityService {
       return events;
     }
 
-    const workspaceMemberRepository =
-      await this.workspaceOrmManager.getRepository(
-        WorkspaceMemberWorkspaceEntity,
-        {
-          shouldBypassPermissionChecks: true,
-        },
-      );
+    const workspaceMemberRepository = this.workspaceOrmManager.getRepository(
+      WorkspaceMemberWorkspaceEntity,
+      {
+        shouldBypassPermissionChecks: true,
+      },
+    );
 
     const workspaceMembers = await workspaceMemberRepository.findBy({
       userId: In(userIds),

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -81,7 +81,7 @@ export class WorkflowCommonWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -162,7 +162,7 @@ export class WorkflowCommonWorkspaceService {
     const workflows = await this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
         const workflowRepository =
-          await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
             'workflow',
             { shouldBypassPermissionChecks: true },
           );
@@ -314,19 +314,19 @@ export class WorkflowCommonWorkspaceService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
 
       const workflowRunRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );
 
       const workflowAutomatedTriggerRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
@@ -51,7 +51,7 @@ export class WorkflowVersionValidationWorkspaceService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -133,7 +133,7 @@ export class WorkflowVersionValidationWorkspaceService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -763,7 +763,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
               .filter((field) => field.type === FieldMetadataType.RELATION)
               .map((field) => field.name);
 
-            const repository = await this.workspaceOrmManager.getRepository(
+            const repository = this.workspaceOrmManager.getRepository(
               field.settings.objectName,
               { shouldBypassPermissionChecks: true },
             );
@@ -922,7 +922,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -991,7 +991,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
@@ -60,7 +60,7 @@ export class WorkflowVersionWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -189,7 +189,7 @@ export class WorkflowVersionWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const workflowRepository = await this.workspaceOrmManager.getRepository(
+      const workflowRepository = this.workspaceOrmManager.getRepository(
         'workflow',
         {
           shouldBypassPermissionChecks: true,
@@ -197,7 +197,7 @@ export class WorkflowVersionWorkspaceService {
       );
 
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -371,7 +371,7 @@ export class WorkflowVersionWorkspaceService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/__tests__/draft-email.workflow-action.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/__tests__/draft-email.workflow-action.spec.ts
@@ -67,9 +67,7 @@ describe('DraftEmailWorkflowAction', () => {
           provide: WorkspaceOrmManager,
           useValue: {
             executeInWorkspaceContext: jest.fn((callback) => callback()),
-            getRepository: jest
-              .fn()
-              .mockResolvedValue(workspaceMemberRepository),
+            getRepository: jest.fn().mockReturnValue(workspaceMemberRepository),
           },
         },
         {

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/__tests__/send-email.workflow-action.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/__tests__/send-email.workflow-action.spec.ts
@@ -71,9 +71,7 @@ describe('SendEmailWorkflowAction', () => {
           provide: WorkspaceOrmManager,
           useValue: {
             executeInWorkspaceContext: jest.fn((callback) => callback()),
-            getRepository: jest
-              .fn()
-              .mockResolvedValue(workspaceMemberRepository),
+            getRepository: jest.fn().mockReturnValue(workspaceMemberRepository),
           },
         },
         {

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/email-workflow-action.base.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/email-workflow-action.base.ts
@@ -127,7 +127,7 @@ export abstract class EmailWorkflowActionBase extends ToolBackedWorkflowAction<W
     workspaceMemberId: string,
   ): Promise<WorkspaceMemberWorkspaceEntity | null> {
     const workspaceMemberRepository =
-      await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+      this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
         'workspaceMember',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
@@ -139,11 +139,10 @@ export class WorkflowCleanWorkflowRunsCronJob {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
-        const workflowRunRepository =
-          await this.workspaceOrmManager.getRepository(
-            WorkflowRunWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
+        const workflowRunRepository = this.workspaceOrmManager.getRepository(
+          WorkflowRunWorkspaceEntity,
+          { shouldBypassPermissionChecks: true },
+        );
 
         const hasOldRuns = await workflowRunRepository.exists({
           where: getRunsToCleanFindOptions(),

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -50,11 +50,10 @@ export class WorkflowHandleStaledRunsWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const workflowRunRepository =
-        await this.workspaceOrmManager.getRepository(
-          WorkflowRunWorkspaceEntity,
-          { shouldBypassPermissionChecks: true },
-        );
+      const workflowRunRepository = this.workspaceOrmManager.getRepository(
+        WorkflowRunWorkspaceEntity,
+        { shouldBypassPermissionChecks: true },
+      );
 
       const staledRunsCount = await workflowRunRepository.count({
         where: getStaledRunsFindOptions(),
@@ -280,11 +279,10 @@ export class WorkflowHandleStaledRunsWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const workflowRunRepository =
-        await this.workspaceOrmManager.getRepository(
-          WorkflowRunWorkspaceEntity,
-          { shouldBypassPermissionChecks: true },
-        );
+      const workflowRunRepository = this.workspaceOrmManager.getRepository(
+        WorkflowRunWorkspaceEntity,
+        { shouldBypassPermissionChecks: true },
+      );
 
       const runIds: string[] = [];
       let page: WorkflowRunWorkspaceEntity[];

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -50,11 +50,10 @@ export class WorkflowRunEnqueueWorkspaceService {
       const authContext = buildSystemAuthContext(workspaceId);
 
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-        const workflowRunRepository =
-          await this.workspaceOrmManager.getRepository(
-            WorkflowRunWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
+        const workflowRunRepository = this.workspaceOrmManager.getRepository(
+          WorkflowRunWorkspaceEntity,
+          { shouldBypassPermissionChecks: true },
+        );
 
         const notStartedRunsCount = isCacheMode
           ? await this.workflowThrottlingWorkspaceService.getNotStartedRunsCountFromCache(

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
@@ -76,11 +76,10 @@ export class WorkflowThrottlingWorkspaceService {
 
     const currentlyNotStartedWorkflowRunCount =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-        const workflowRunRepository =
-          await this.workspaceOrmManager.getRepository(
-            WorkflowRunWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
+        const workflowRunRepository = this.workspaceOrmManager.getRepository(
+          WorkflowRunWorkspaceEntity,
+          { shouldBypassPermissionChecks: true },
+        );
 
         return workflowRunRepository.count({
           where: NOT_STARTED_RUNS_FIND_OPTIONS,
@@ -103,11 +102,10 @@ export class WorkflowThrottlingWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-      const workflowRunRepository =
-        await this.workspaceOrmManager.getRepository(
-          WorkflowRunWorkspaceEntity,
-          { shouldBypassPermissionChecks: true },
-        );
+      const workflowRunRepository = this.workspaceOrmManager.getRepository(
+        WorkflowRunWorkspaceEntity,
+        { shouldBypassPermissionChecks: true },
+      );
 
       return workflowRunRepository.count({
         where: NOT_STARTED_RUNS_FIND_OPTIONS,

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/command/delete-workflow-runs.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/command/delete-workflow-runs.command.ts
@@ -51,7 +51,7 @@ export class DeleteWorkflowRunsCommand extends ProvisionedWorkspaceCommandRunner
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       try {
         const workflowRunRepository =
-          await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
             'workflowRun',
             { shouldBypassPermissionChecks: true },
           );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -57,7 +57,7 @@ export class WorkflowRunWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRunRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );
@@ -68,7 +68,7 @@ export class WorkflowRunWorkspaceService {
           workflowVersionId,
         });
 
-      const workflowRepository = await this.workspaceOrmManager.getRepository(
+      const workflowRepository = this.workspaceOrmManager.getRepository(
         'workflow',
         {
           shouldBypassPermissionChecks: true,
@@ -362,7 +362,7 @@ export class WorkflowRunWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRunRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );
@@ -408,7 +408,7 @@ export class WorkflowRunWorkspaceService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRunRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
           'workflowRun',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -96,13 +96,13 @@ export class WorkflowStatusesUpdateJob {
     workflowId: string;
   }): Promise<void> {
     const workflowRepository =
-      await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+      this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
         'workflow',
         { shouldBypassPermissionChecks: true },
       );
 
     const workflowVersionRepository =
-      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+      this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
         'workflowVersion',
         { shouldBypassPermissionChecks: true },
       );
@@ -139,13 +139,13 @@ export class WorkflowStatusesUpdateJob {
     statusUpdate: WorkflowVersionStatusUpdate;
   }): Promise<void> {
     const workflowRepository =
-      await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+      this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
         'workflow',
         { shouldBypassPermissionChecks: true },
       );
 
     const workflowVersionRepository =
-      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+      this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
         'workflowVersion',
         { shouldBypassPermissionChecks: true },
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/delete-workflow.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/delete-workflow.tool.spec.ts
@@ -8,7 +8,7 @@ const buildTool = () => {
   };
   const workspaceOrmManager = {
     executeInWorkspaceContext: jest.fn((callback: () => unknown) => callback()),
-    getRepository: jest.fn().mockResolvedValue(workflowRepository),
+    getRepository: jest.fn().mockReturnValue(workflowRepository),
   };
   const workflowCommonService = {
     handleWorkflowSubEntities: jest.fn().mockResolvedValue(undefined),

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-current-version.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-current-version.tool.spec.ts
@@ -21,11 +21,11 @@ const buildDeps = ({
 }) => {
   const getRepositoryMock = jest.fn();
 
-  getRepositoryMock.mockResolvedValueOnce({
+  getRepositoryMock.mockReturnValueOnce({
     findOne: jest.fn().mockResolvedValue(workflow),
   });
 
-  getRepositoryMock.mockResolvedValueOnce({
+  getRepositoryMock.mockReturnValueOnce({
     find: jest.fn().mockResolvedValue(versions),
   });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-run.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/get-workflow-run.tool.spec.ts
@@ -11,7 +11,7 @@ const ROLE_ID = '20202020-cccc-4d02-bf25-6aeccf7ea419';
 const buildDeps = (findOneResult: unknown) => ({
   workspaceOrmManager: {
     executeInWorkspaceContext: jest.fn().mockImplementation(async (fn) => fn()),
-    getRepository: jest.fn().mockResolvedValue({
+    getRepository: jest.fn().mockReturnValue({
       findOne: jest.fn().mockResolvedValue(findOneResult),
     }),
   },

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/list-workflow-runs.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/list-workflow-runs.tool.spec.ts
@@ -9,7 +9,7 @@ const ROLE_ID = '20202020-cccc-4d02-bf25-6aeccf7ea419';
 const buildDeps = (findResult: unknown[]) => ({
   workspaceOrmManager: {
     executeInWorkspaceContext: jest.fn().mockImplementation(async (fn) => fn()),
-    getRepository: jest.fn().mockResolvedValue({
+    getRepository: jest.fn().mockReturnValue({
       find: jest.fn().mockResolvedValue(findResult),
     }),
   },
@@ -90,7 +90,7 @@ describe('list_workflow_runs tool', () => {
         executeInWorkspaceContext: jest
           .fn()
           .mockImplementation(async (fn) => fn()),
-        getRepository: jest.fn().mockResolvedValue({ find: findMock }),
+        getRepository: jest.fn().mockReturnValue({ find: findMock }),
       },
     };
     const context = buildContext();

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/update-agent.tool.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/__tests__/update-agent.tool.spec.ts
@@ -26,7 +26,7 @@ const buildTool = ({
     find: jest.fn().mockResolvedValue(draftVersions),
   };
   const workspaceOrmManager = {
-    getRepository: jest.fn().mockResolvedValue(workflowVersionRepository),
+    getRepository: jest.fn().mockReturnValue(workflowVersionRepository),
   };
   const flatEntityMapsCacheService = {
     invalidateFlatEntityMaps: jest.fn().mockResolvedValue(undefined),

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-complete-workflow.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-complete-workflow.tool.ts
@@ -222,7 +222,7 @@ const createWorkflow = async ({
   const authContext = buildSystemAuthContext(context.workspaceId);
 
   return deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
-    const workflowRepository = await deps.workspaceOrmManager.getRepository(
+    const workflowRepository = deps.workspaceOrmManager.getRepository(
       'workflow',
       context.rolePermissionConfig,
     );
@@ -309,7 +309,7 @@ const updateWorkflowStatus = async ({
   const authContext = buildSystemAuthContext(context.workspaceId);
 
   await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
-    const workflowRepository = await deps.workspaceOrmManager.getRepository(
+    const workflowRepository = deps.workspaceOrmManager.getRepository(
       'workflow',
       context.rolePermissionConfig,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow.tool.ts
@@ -40,7 +40,7 @@ export const createDeleteWorkflowTool = (
       const deleteResult =
         await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
           const workflowRepository =
-            await deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+            deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
               'workflow',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
@@ -43,7 +43,7 @@ export const createGetWorkflowCurrentVersionTool = (
       return await deps.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRepository =
-            await deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+            deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
               'workflow',
               context.rolePermissionConfig,
             );
@@ -60,7 +60,7 @@ export const createGetWorkflowCurrentVersionTool = (
           }
 
           const workflowVersionRepository =
-            await deps.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+            deps.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
               'workflowVersion',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-run.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-run.tool.ts
@@ -40,7 +40,7 @@ export const createGetWorkflowRunTool = (
       return await deps.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRunRepository =
-            await deps.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+            deps.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
               'workflowRun',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflow-runs.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflow-runs.tool.ts
@@ -57,7 +57,7 @@ export const createListWorkflowRunsTool = (
       return await deps.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRunRepository =
-            await deps.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+            deps.workspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
               'workflowRun',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflows.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/list-workflows.tool.ts
@@ -41,7 +41,7 @@ export const createListWorkflowsTool = (
       return await deps.workspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRepository =
-            await deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+            deps.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
               'workflow',
               context.rolePermissionConfig,
             );

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-agent.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-agent.tool.ts
@@ -73,7 +73,7 @@ const resyncAiAgentStepOutputSchemas = async (
   });
 
   const workflowVersionRepository =
-    await deps.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+    deps.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
       'workflowVersion',
       { shouldBypassPermissionChecks: true },
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
@@ -41,7 +41,7 @@ export class AutomatedTriggerWorkspaceService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowAutomatedTriggerRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
         );
 
@@ -76,7 +76,7 @@ export class AutomatedTriggerWorkspaceService {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowAutomatedTriggerRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
         );
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
@@ -52,7 +52,7 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
 
   beforeEach(async () => {
     workspaceOrmManager = {
-      getRepository: jest.fn().mockResolvedValue(mockRepository),
+      getRepository: jest.fn().mockReturnValue(mockRepository),
       executeInWorkspaceContext: jest
         .fn()
         .mockImplementation((fn: () => any, _authContext?: any) => fn()),

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
@@ -308,11 +308,10 @@ export class WorkflowDatabaseEventTriggerListener {
           continue;
         }
 
-        const relatedObjectRepository =
-          await this.workspaceOrmManager.getRepository(
-            relatedObjectMetadataNameSingular,
-            { shouldBypassPermissionChecks: true },
-          );
+        const relatedObjectRepository = this.workspaceOrmManager.getRepository(
+          relatedObjectMetadataNameSingular,
+          { shouldBypassPermissionChecks: true },
+        );
 
         const relatedRecords = await relatedObjectRepository.find({
           where: { id: In(joinRecordIds) },
@@ -411,7 +410,7 @@ export class WorkflowDatabaseEventTriggerListener {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowAutomatedTriggerRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           automatedTriggerTableName,
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
@@ -38,7 +38,7 @@ export class WorkflowTriggerJob {
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
           'workflow',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -102,7 +102,7 @@ export class WorkflowTriggerWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );
@@ -117,7 +117,7 @@ export class WorkflowTriggerWorkspaceService {
         );
 
       const workflowRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
           'workflow',
           { shouldBypassPermissionChecks: true },
         );
@@ -204,7 +204,7 @@ export class WorkflowTriggerWorkspaceService {
 
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowVersionRepository =
-        await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           'workflowVersion',
           { shouldBypassPermissionChecks: true },
         );

--- a/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-delete-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-delete-one.post-query.hook.ts
@@ -49,7 +49,7 @@ export class WorkspaceMemberDeleteOnePostQueryHook implements WorkspacePostQuery
     const workspaceMember =
       await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
         const workspaceMemberRepository =
-          await this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             'workspaceMember',
             { shouldBypassPermissionChecks: true },
           );


### PR DESCRIPTION
## What

`WorkspaceOrmManager.getRepository` has been synchronous inside since the v2 cutover: resolving the datasource and constructing the repository involve no awaiting. The `Promise` return type survived from the v1 era (where building a repository could hit the datasource cache) and only forced a ceremonial `await` at every call site.

- The manager's three overloads drop `async` and return `WorkspaceRepository<T>` directly.
- The `await` disappears from all ~170 call sites (a `+177/−177` symmetric diff outside the mock fixes).
- Spec mocks switch from `mockResolvedValue` to `mockReturnValue` for `getRepository`, so they hand back repositories rather than promises — necessary because `await`ing a non-promise is legal TypeScript, meaning the compiler alone cannot prove this conversion complete. The full unit suite (913 suites, 6,547 tests) plus multiline-aware grep sweeps for leftover awaited calls and resolved-value mocks are the proof.

## Notes for CI

Eight committed upgrade commands lose an `await` keyword only, so the PR carries the `ci:allow-previous-version-upgrade-mutation` label.

## Coming next

A stacked PR (based on this branch) folds the replica choice into the manager so the datasource service stops being a second entry point, dedupes the two identical transaction-scope types, removes the `ConnectQueryRunner` callback indirection, and replaces the TypeORM-mimicking `expressionMap` shim with a first-class join-aliases accessor.

## Verification

- `tsgo --noEmit` clean, `oxlint --type-aware` and `oxfmt --check src/` clean
- Full unit suite green: 913 suites, 6,547 tests


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

