### PR TITLE
One entry point for workspace data and fewer migration-era seams

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
@@ -31,8 +31,7 @@ import {
 } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
-import { type WorkspaceDataSource } from 'src/engine/twenty-orm/datasource/workspace-data-source';
-import { WorkspaceDataSourceService } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
@@ -60,20 +59,13 @@ type ProcessNestedRelationsArgs<T extends ObjectRecord = ObjectRecord> = {
 
 @Injectable()
 export class ProcessNestedRelationsHelper {
-  constructor(
-    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
-  ) {}
+  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   public async processNestedRelations<T extends ObjectRecord = ObjectRecord>(
     args: ProcessNestedRelationsArgs<T>,
   ): Promise<void> {
-    const dataSource = this.workspaceDataSourceService.getDataSource({
-      useReplica: args.useReplica ?? false,
-    });
-
     await this.processNestedRelationsWithLimiter(
       args,
-      dataSource,
       createConcurrencyLimiter(NESTED_RELATION_QUERY_MAX_CONCURRENCY),
     );
   }
@@ -95,7 +87,6 @@ export class ProcessNestedRelationsHelper {
       rolePermissionConfig,
       selectedFields,
     }: ProcessNestedRelationsArgs<T>,
-    dataSource: WorkspaceDataSource,
     relationQueryLimiter: ConcurrencyLimiter,
   ): Promise<void> {
     const processRelationTasks = Object.entries(relations).map(
@@ -112,7 +103,6 @@ export class ProcessNestedRelationsHelper {
           limit,
           authContext,
           useReplica,
-          dataSource,
           rolePermissionConfig,
           relationQueryLimiter,
           selectedFields:
@@ -137,7 +127,6 @@ export class ProcessNestedRelationsHelper {
     limit,
     authContext,
     useReplica,
-    dataSource,
     rolePermissionConfig,
     relationQueryLimiter,
     selectedFields,
@@ -154,7 +143,6 @@ export class ProcessNestedRelationsHelper {
     limit: number;
     authContext: WorkspaceAuthContext;
     useReplica: boolean;
-    dataSource: WorkspaceDataSource;
     rolePermissionConfig?: RolePermissionConfig;
     relationQueryLimiter: ConcurrencyLimiter;
     selectedFields: Record<string, unknown>;
@@ -204,9 +192,10 @@ export class ProcessNestedRelationsHelper {
         fieldMaps,
       });
 
-    const targetObjectRepository = dataSource.getRepository(
+    const targetObjectRepository = this.workspaceOrmManager.getRepository(
       targetObjectMetadata.nameSingular,
       rolePermissionConfig,
+      { useReplica },
     );
 
     const targetObjectNameSingular = targetObjectMetadata.nameSingular;
@@ -318,7 +307,6 @@ export class ProcessNestedRelationsHelper {
           rolePermissionConfig,
           selectedFields,
         },
-        dataSource,
         relationQueryLimiter,
       );
     }

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -63,14 +63,10 @@ import {
   PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
-import {
-  type ConnectQueryRunner,
-  RelationNestedQueries,
-} from 'src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries';
+import { RelationNestedQueries } from 'src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
-import { WorkspaceDataSourceService } from 'src/engine/twenty-orm/datasource/workspace-data-source.service';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { type MutationKind } from 'src/engine/twenty-orm/sql/utils/build-mutation-statement.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
@@ -112,8 +108,6 @@ export abstract class CommonBaseQueryRunnerService<
   protected readonly metricsService: MetricsService;
   @Inject()
   protected readonly featureFlagService: FeatureFlagService;
-  @Inject()
-  protected readonly workspaceDataSourceService: WorkspaceDataSourceService;
 
   protected abstract readonly operationName: CommonQueryNames;
 
@@ -351,12 +345,11 @@ export abstract class CommonBaseQueryRunnerService<
       );
     }
 
-    const repository = this.workspaceDataSourceService
-      .getDataSource({ useReplica: this.isReadOnly })
-      .getRepository<ObjectLiteral>(
-        queryRunnerContext.flatObjectMetadata.nameSingular,
-        rolePermissionConfig,
-      );
+    const repository = this.workspaceOrmManager.getRepository<ObjectLiteral>(
+      queryRunnerContext.flatObjectMetadata.nameSingular,
+      rolePermissionConfig,
+      { useReplica: this.isReadOnly },
+    );
 
     return {
       ...queryRunnerContext,
@@ -383,9 +376,11 @@ export abstract class CommonBaseQueryRunnerService<
       attributes: { operation: this.operationName },
     });
 
-    return this.workspaceDataSourceService
-      .getDataSource({ useReplica: this.isReadOnly })
-      .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);
+    return this.workspaceOrmManager.getRepository(
+      flatObjectMetadata.nameSingular,
+      rolePermissionConfig,
+      { useReplica: this.isReadOnly },
+    );
   }
 
   // Writes always hit the primary, so useReplica is pinned false regardless of isReadOnly.
@@ -402,9 +397,10 @@ export abstract class CommonBaseQueryRunnerService<
       attributes: { operation: this.operationName },
     });
 
-    return this.workspaceDataSourceService
-      .getDataSource({ useReplica: false })
-      .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);
+    return this.workspaceOrmManager.getRepository(
+      flatObjectMetadata.nameSingular,
+      rolePermissionConfig,
+    );
   }
 
   protected async runFilteredMutation({
@@ -476,6 +472,8 @@ export abstract class CommonBaseQueryRunnerService<
 
     const relationNestedQueries = new RelationNestedQueries(
       writeRepository.getInternalContext(),
+      this.workspaceOrmManager,
+      rolePermissionConfig,
     );
 
     const relationNestedConfig =
@@ -485,35 +483,10 @@ export abstract class CommonBaseQueryRunnerService<
       return records;
     }
 
-    const workspaceDataSource = this.workspaceDataSourceService.getDataSource({
-      useReplica: false,
-    });
-
-    const connectQueryRunner: ConnectQueryRunner = async ({
-      connectQueryConfig,
-      clause,
-      parameters,
-    }) => {
-      const targetObjectName = connectQueryConfig.targetObjectName;
-      const targetQueryBuilder = workspaceDataSource
-        .getRepository(targetObjectName, rolePermissionConfig)
-        .createQueryBuilder(targetObjectName);
-
-      targetQueryBuilder.select([]);
-      targetQueryBuilder.addSelect(`"${targetObjectName}"."id"`, 'id');
-
-      for (const [field] of connectQueryConfig.recordToConnectConditions[0]) {
-        targetQueryBuilder.addSelect(`"${targetObjectName}"."${field}"`, field);
-      }
-
-      return targetQueryBuilder.where(clause, parameters).getRawMany();
-    };
-
     const resolvedRecords =
       await relationNestedQueries.processRelationNestedQueries({
         entities: records,
         relationNestedConfig,
-        connectQueryRunner,
       });
 
     const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -367,9 +367,8 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       attributes: { operation: this.operationName },
     });
 
-    return this.workspaceDataSourceService
-      .getDataSource({ useReplica: false })
-      .transaction(async (transactionScope) => {
+    return this.workspaceOrmManager.runInWorkspaceTransaction(
+      async (transactionScope) => {
         for (const relationField of this.getRelationFieldsPointingToCurrentObject(
           queryRunnerContext,
         )) {
@@ -428,7 +427,8 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
         }
 
         return updatedRecords[0];
-      });
+      },
+    );
   }
 
   private async processNestedRelations({

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/build-mutation-query-builder.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/build-mutation-query-builder.util.ts
@@ -24,8 +24,7 @@ export const buildMutationQueryBuilder = ({
 
   commonQueryParser.applyFilterToBuilder(filteredQueryBuilder, alias, filter);
 
-  const hasRelationTraversal =
-    filteredQueryBuilder.expressionMap.joinAttributes.length > 0;
+  const hasRelationTraversal = filteredQueryBuilder.getJoinAliases().length > 0;
 
   if (!hasRelationTraversal) {
     return {

--- a/packages/twenty-server/src/engine/api/common/utils/get-non-to-one-join-aliases.util.ts
+++ b/packages/twenty-server/src/engine/api/common/utils/get-non-to-one-join-aliases.util.ts
@@ -1,23 +1,10 @@
-import { type Alias } from 'typeorm/query-builder/Alias';
-import { type RelationMetadata } from 'typeorm/metadata/RelationMetadata';
+import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
-import { isDefined } from 'twenty-shared/utils';
-
-type QueryBuilderWithJoinAttributes = {
-  expressionMap: {
-    joinAttributes: {
-      alias: Pick<Alias, 'name'>;
-      relation?: Pick<RelationMetadata, 'isOneToMany' | 'isManyToMany'>;
-    }[];
-  };
-};
-
+// Aliases whose join can duplicate root rows: to-many joins break row-level LIMIT
 export const getNonToOneJoinAliases = (
-  queryBuilder: QueryBuilderWithJoinAttributes,
+  queryBuilder: WorkspaceSelectQueryBuilder,
 ): string[] =>
-  queryBuilder.expressionMap.joinAttributes
-    .filter(
-      ({ relation }) =>
-        !isDefined(relation) || relation.isOneToMany || relation.isManyToMany,
-    )
-    .map(({ alias }) => alias.name);
+  queryBuilder
+    .getJoinAliases()
+    .filter(({ isToMany }) => isToMany)
+    .map(({ name }) => name);

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util.ts
@@ -11,9 +11,9 @@ export const addRelationJoinAliasToQueryBuilder = ({
   parentAlias,
   relationName,
 }: AddRelationJoinAliasToQueryBuilderArgs): void => {
-  const alreadyJoined = queryBuilder.expressionMap.joinAttributes.some(
-    (joinAttribute) => joinAttribute.alias.name === relationName,
-  );
+  const alreadyJoined = queryBuilder
+    .getJoinAliases()
+    .some((joinAlias) => joinAlias.name === relationName);
 
   if (alreadyJoined) {
     return;

--- a/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.ts
@@ -12,6 +12,7 @@ import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-m
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
+import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { ClientQueryExecutor } from 'src/engine/twenty-orm/executor/client-query-executor';
 import { PoolQueryExecutor } from 'src/engine/twenty-orm/executor/pool-query-executor';
 import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
@@ -29,17 +30,6 @@ const tableShapeCacheByFlatObjectMetadataMaps = new WeakMap<
   object,
   Map<string, WorkspaceTableShape>
 >();
-
-export type WorkspaceDataSourceTransactionScope = {
-  getRepository: (
-    nameSingular: string,
-    rolePermissionConfig?: RolePermissionConfig,
-  ) => WorkspaceRepository;
-  executeRawQuery: (
-    sql: string,
-    parameters?: unknown[],
-  ) => Promise<Record<string, unknown>[]>;
-};
 
 export class WorkspaceDataSource {
   private readonly pool: Pool;
@@ -76,12 +66,15 @@ export class WorkspaceDataSource {
   }
 
   async transaction<T>(
-    work: (transactionScope: WorkspaceDataSourceTransactionScope) => Promise<T>,
+    work: (transactionScope: WorkspaceTransactionScope) => Promise<T>,
   ): Promise<T> {
     return this.runInClientTransaction((executor) =>
       work({
-        getRepository: (nameSingular, rolePermissionConfig) =>
-          this.buildRepository({
+        getRepository: <T extends ObjectLiteral = ObjectRecord>(
+          nameSingular: string,
+          rolePermissionConfig?: RolePermissionConfig,
+        ) =>
+          this.buildRepository<T>({
             nameSingular,
             rolePermissionConfig,
             executor,

--- a/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
@@ -156,11 +156,11 @@ export class RelationNestedQueries {
         connectQueryConfig.targetObjectName,
       );
 
-      const recordsToConnect = await this.fetchRecordsToConnect(
+      const recordsToConnect = await this.fetchRecordsToConnect({
         connectQueryConfig,
         clause,
         parameters,
-      );
+      });
 
       allRecordsToConnectWithConfig.push([
         connectQueryConfig,
@@ -171,11 +171,15 @@ export class RelationNestedQueries {
     return allRecordsToConnectWithConfig;
   }
 
-  private async fetchRecordsToConnect(
-    connectQueryConfig: RelationConnectQueryConfig,
-    clause: string,
-    parameters: Record<string, unknown>,
-  ): Promise<Record<string, unknown>[]> {
+  private async fetchRecordsToConnect({
+    connectQueryConfig,
+    clause,
+    parameters,
+  }: {
+    connectQueryConfig: RelationConnectQueryConfig;
+    clause: string;
+    parameters: Record<string, unknown>;
+  }): Promise<Record<string, unknown>[]> {
     const targetObjectName = connectQueryConfig.targetObjectName;
     const targetQueryBuilder = this.workspaceOrmManager
       .getRepository(targetObjectName, this.rolePermissionConfig)

--- a/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/field-operations/relation-nested-queries/relation-nested-queries.ts
@@ -5,6 +5,9 @@ import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialE
 
 import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
 
+import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
+import { type WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
+
 import { type QueryDeepPartialEntityWithNestedRelationFields } from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-nested-relation-fields.type';
 import { type RelationConnectQueryConfig } from 'src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type';
 import {
@@ -22,17 +25,19 @@ import { extractNestedRelationFieldsByEntityIndex } from 'src/engine/twenty-orm/
 import { getAssociatedRelationFieldName } from 'src/engine/twenty-orm/utils/get-associated-relation-field-name.util';
 import { getObjectMetadataFromEntityTarget } from 'src/engine/twenty-orm/utils/get-object-metadata-from-entity-target.util';
 
-export type ConnectQueryRunner = (args: {
-  connectQueryConfig: RelationConnectQueryConfig;
-  clause: string;
-  parameters: Record<string, unknown>;
-}) => Promise<Record<string, unknown>[]>;
-
 export class RelationNestedQueries {
   private readonly internalContext: WorkspaceInternalContext;
+  private readonly workspaceOrmManager: WorkspaceOrmManager;
+  private readonly rolePermissionConfig?: RolePermissionConfig;
 
-  constructor(internalContext: WorkspaceInternalContext) {
+  constructor(
+    internalContext: WorkspaceInternalContext,
+    workspaceOrmManager: WorkspaceOrmManager,
+    rolePermissionConfig?: RolePermissionConfig,
+  ) {
     this.internalContext = internalContext;
+    this.workspaceOrmManager = workspaceOrmManager;
+    this.rolePermissionConfig = rolePermissionConfig;
   }
 
   prepareNestedRelationQueries<Entity extends ObjectLiteral>(
@@ -87,7 +92,6 @@ export class RelationNestedQueries {
   async processRelationNestedQueries<Entity extends ObjectLiteral>({
     entities,
     relationNestedConfig,
-    connectQueryRunner,
   }: {
     entities:
       | QueryDeepPartialEntityWithNestedRelationFields<Entity>[]
@@ -96,7 +100,6 @@ export class RelationNestedQueries {
       RelationConnectQueryConfig[],
       RelationDisconnectQueryFieldsByEntityIndex,
     ];
-    connectQueryRunner: ConnectQueryRunner;
   }): Promise<QueryDeepPartialEntity<Entity>[]> {
     const entitiesArray = Array.isArray(entities) ? entities : [entities];
 
@@ -113,7 +116,6 @@ export class RelationNestedQueries {
     const updatedEntitiesWithConnect = await this.processRelationConnect({
       entities: updatedEntitiesWithDisconnect,
       relationConnectQueryConfigs,
-      connectQueryRunner,
     });
 
     return updatedEntitiesWithConnect;
@@ -122,17 +124,14 @@ export class RelationNestedQueries {
   private async processRelationConnect<Entity extends ObjectLiteral>({
     entities,
     relationConnectQueryConfigs,
-    connectQueryRunner,
   }: {
     entities: QueryDeepPartialEntityWithNestedRelationFields<Entity>[];
     relationConnectQueryConfigs: RelationConnectQueryConfig[];
-    connectQueryRunner: ConnectQueryRunner;
   }): Promise<QueryDeepPartialEntity<Entity>[]> {
     if (relationConnectQueryConfigs.length === 0) return entities;
 
     const recordsToConnectWithConfig = await this.executeConnectQueries(
       relationConnectQueryConfigs,
-      connectQueryRunner,
     );
 
     const updatedEntities = this.updateEntitiesWithRecordToConnectId<Entity>(
@@ -145,7 +144,6 @@ export class RelationNestedQueries {
 
   private async executeConnectQueries(
     relationConnectQueryConfigs: RelationConnectQueryConfig[],
-    connectQueryRunner: ConnectQueryRunner,
   ): Promise<[RelationConnectQueryConfig, Record<string, unknown>[]][]> {
     const allRecordsToConnectWithConfig: [
       RelationConnectQueryConfig,
@@ -158,11 +156,11 @@ export class RelationNestedQueries {
         connectQueryConfig.targetObjectName,
       );
 
-      const recordsToConnect = await connectQueryRunner({
+      const recordsToConnect = await this.fetchRecordsToConnect(
         connectQueryConfig,
         clause,
         parameters,
-      });
+      );
 
       allRecordsToConnectWithConfig.push([
         connectQueryConfig,
@@ -171,6 +169,26 @@ export class RelationNestedQueries {
     }
 
     return allRecordsToConnectWithConfig;
+  }
+
+  private async fetchRecordsToConnect(
+    connectQueryConfig: RelationConnectQueryConfig,
+    clause: string,
+    parameters: Record<string, unknown>,
+  ): Promise<Record<string, unknown>[]> {
+    const targetObjectName = connectQueryConfig.targetObjectName;
+    const targetQueryBuilder = this.workspaceOrmManager
+      .getRepository(targetObjectName, this.rolePermissionConfig)
+      .createQueryBuilder(targetObjectName);
+
+    targetQueryBuilder.select([]);
+    targetQueryBuilder.addSelect(`"${targetObjectName}"."id"`, 'id');
+
+    for (const [field] of connectQueryConfig.recordToConnectConditions[0]) {
+      targetQueryBuilder.addSelect(`"${targetObjectName}"."${field}"`, field);
+    }
+
+    return targetQueryBuilder.where(clause, parameters).getRawMany();
   }
 
   private updateEntitiesWithRecordToConnectId<Entity extends ObjectLiteral>(

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-joins.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-joins.spec.ts
@@ -64,11 +64,8 @@ describe('WorkspaceSelectQueryBuilder joins', () => {
     queryBuilder.setFindOptions({ select: { id: true } });
     queryBuilder.leftJoin('person.people', 'people');
 
-    expect(queryBuilder.expressionMap.joinAttributes).toEqual([
-      {
-        alias: { name: 'people' },
-        relation: { isOneToMany: true, isManyToMany: false },
-      },
+    expect(queryBuilder.getJoinAliases()).toEqual([
+      { name: 'people', isToMany: true },
     ]);
     expect(() => queryBuilder.getQuery()).toThrow(TwentyOrmException);
   });

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-relation-where.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/__tests__/workspace-select-query-builder-relation-where.spec.ts
@@ -121,9 +121,7 @@ describe('WorkspaceSelectQueryBuilder relation-keyed where', () => {
       .where({ people: { name: Equal('Twenty') } });
 
     expect(
-      queryBuilder.expressionMap.joinAttributes.map(
-        (joinAttribute) => joinAttribute.alias.name,
-      ),
+      queryBuilder.getJoinAliases().map((joinAlias) => joinAlias.name),
     ).toContain('person_people_filter');
     expect(
       queryBuilder.getJoinedTableShape('person_people_filter')?.nameSingular,

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/types/query-builder.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/types/query-builder.type.ts
@@ -57,11 +57,3 @@ export type FindOptionsSelectLike = Record<string, boolean>;
 export type FindOptionsLike = {
   select?: FindOptionsSelectLike;
 };
-
-export type ExpressionMapLike = {
-  queryType: 'select';
-  joinAttributes: {
-    alias: { name: string };
-    relation: { isOneToMany: boolean; isManyToMany: boolean };
-  }[];
-};

--- a/packages/twenty-server/src/engine/twenty-orm/query-builder/workspace-select-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/query-builder/workspace-select-query-builder.ts
@@ -10,7 +10,6 @@ import {
 } from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
 import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
 import {
-  type ExpressionMapLike,
   type FindOptionsLike,
   type ObjectWhereLike,
   type OrderByConditionLike,
@@ -100,23 +99,17 @@ export class WorkspaceSelectQueryBuilder implements WhereExpressionLike {
     this.context = context;
   }
 
-  get expressionMap(): ExpressionMapLike {
-    return {
-      queryType: 'select',
-      joinAttributes: [
-        ...this.joinClauses.map((joinClause) => ({
-          alias: { name: joinClause.alias },
-          relation: {
-            isOneToMany: joinClause.relationType === RelationType.ONE_TO_MANY,
-            isManyToMany: false,
-          },
-        })),
-        ...this.existsFilterClauses.map((existsFilterClause) => ({
-          alias: { name: existsFilterClause.alias },
-          relation: { isOneToMany: false, isManyToMany: false },
-        })),
-      ],
-    };
+  getJoinAliases(): { name: string; isToMany: boolean }[] {
+    return [
+      ...this.joinClauses.map((joinClause) => ({
+        name: joinClause.alias,
+        isToMany: joinClause.relationType === RelationType.ONE_TO_MANY,
+      })),
+      ...this.existsFilterClauses.map((existsFilterClause) => ({
+        name: existsFilterClause.alias,
+        isToMany: false,
+      })),
+    ];
   }
 
   clone(): WorkspaceSelectQueryBuilder {

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
@@ -1489,10 +1489,8 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
       flatObjectMetadata: this.options.flatObjectMetadata,
     });
 
-    for (const joinAttribute of queryBuilder.expressionMap.joinAttributes) {
-      const joinedTableShape = queryBuilder.getJoinedTableShape(
-        joinAttribute.alias.name,
-      );
+    for (const joinAlias of queryBuilder.getJoinAliases()) {
+      const joinedTableShape = queryBuilder.getJoinedTableShape(joinAlias.name);
 
       if (!isDefined(joinedTableShape)) {
         continue;
@@ -1500,7 +1498,7 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
 
       this.applyRowLevelPermissionPredicateForAlias({
         queryBuilder,
-        alias: joinAttribute.alias.name,
+        alias: joinAlias.name,
         flatObjectMetadata: this.options.flatObjectMetadataByObjectMetadataId(
           joinedTableShape.objectMetadataId,
         ),

--- a/packages/twenty-server/src/engine/twenty-orm/twenty-orm.module.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/twenty-orm.module.ts
@@ -42,6 +42,6 @@ import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/
     WorkspaceORMEntityMetadatasCacheService,
     provideWorkspaceScopedRepository(FeatureFlagEntity),
   ],
-  exports: [WorkspaceOrmManager, WorkspaceDataSourceService],
+  exports: [WorkspaceOrmManager],
 })
 export class TwentyOrmModule {}

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-orm.manager.ts
@@ -26,26 +26,29 @@ export class WorkspaceOrmManager {
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
   ) {}
 
-  getRepository<T extends ObjectLiteral>(
+  getRepository<T extends ObjectLiteral = ObjectRecord>(
     workspaceEntity: Type<T>,
     permissionOptions?: RolePermissionConfig,
+    repositoryOptions?: { useReplica?: boolean },
   ): WorkspaceRepository<T>;
 
-  getRepository<T extends ObjectLiteral>(
+  getRepository<T extends ObjectLiteral = ObjectRecord>(
     objectMetadataName: string,
     permissionOptions?: RolePermissionConfig,
+    repositoryOptions?: { useReplica?: boolean },
   ): WorkspaceRepository<T>;
 
-  getRepository<T extends ObjectLiteral>(
+  getRepository<T extends ObjectLiteral = ObjectRecord>(
     workspaceEntityOrObjectMetadataName: Type<T> | string,
     permissionOptions?: RolePermissionConfig,
+    repositoryOptions?: { useReplica?: boolean },
   ): WorkspaceRepository<T> {
     const objectMetadataName = this.resolveObjectMetadataName(
       workspaceEntityOrObjectMetadataName,
     );
 
     return this.workspaceDataSourceService
-      .getDataSource({ useReplica: false })
+      .getDataSource({ useReplica: repositoryOptions?.useReplica ?? false })
       .getRepository<T>(objectMetadataName, permissionOptions);
   }
 
@@ -66,20 +69,7 @@ export class WorkspaceOrmManager {
   ): Promise<T> {
     return this.workspaceDataSourceService
       .getDataSource({ useReplica: false })
-      .transaction((transactionScope) =>
-        work({
-          getRepository: <T extends ObjectLiteral = ObjectRecord>(
-            objectMetadataName: string,
-            rolePermissionConfig?: RolePermissionConfig,
-          ): WorkspaceRepository<T> =>
-            transactionScope.getRepository(
-              objectMetadataName,
-              rolePermissionConfig,
-            ) as unknown as WorkspaceRepository<T>,
-          executeRawQuery: (sql, parameters) =>
-            transactionScope.executeRawQuery(sql, parameters),
-        }),
-      );
+      .transaction(work);
   }
 
   async executeInWorkspaceContext<T>(


### PR DESCRIPTION
## What

Stacked on #24803 (base retargets to main when it merges). Four simplifications that fell out of the post-consolidation review, each removing a migration-era seam:

- **One entry point** — `getRepository` gains a `{ useReplica }` option, the two API-layer bypasses (`CommonBaseQueryRunnerService`, `ProcessNestedRelationsHelper`) go through the manager, and `TwentyOrmModule` stops exporting `WorkspaceDataSourceService`. The nested-relations helper also stops threading a datasource through four private methods; it threads nothing, since `useReplica` was already an argument.
- **One transaction scope** — the two byte-identical scope types collapse into `WorkspaceTransactionScope`, and `runInWorkspaceTransaction` hands the datasource scope through untouched instead of re-wrapping both methods in pass-through lambdas (which also removes an `as unknown as` cast).
- **No more `ConnectQueryRunner`** — `RelationNestedQueries` builds its connect target queries itself. The callback existed to decouple the class from v1 versus v2 query building, a distinction that no longer exists; its only consumer shed twenty lines of runner plumbing.
- **No more TypeORM cosplay** — the select builder's `expressionMap` getter (which mimicked TypeORM's shape for four readers that all only wanted join aliases) becomes a first-class `getJoinAliases(): { name, isToMany }[]`, and `ExpressionMapLike` is deleted.

## Verification

- `tsgo --noEmit` clean, `oxlint --type-aware` and `oxfmt --check src/` clean
- twenty-orm, api/common, nested-relations and merge suites pass (93 suites, 835 tests)
- Grep gates: `expressionMap`, `ExpressionMapLike`, `ConnectQueryRunner` and `WorkspaceDataSourceTransactionScope` no longer appear
- No committed upgrade command is touched


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

