### PR TITLE
fix(server): require ROLES permission to bind a role to an API key

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
@@ -69,9 +69,15 @@ export class ApiKeyResolver {
     }
   }
 
-  // Minting an API key requires an ACCESS token — derived PLAYGROUND tokens
-  // and API keys must not escalate into a long-lived credential.
-  @UseGuards(RequireAccessTokenGuard)
+  // API_KEYS_AND_WEBHOOKS (class guard) gates managing API keys. Creating one
+  // also assigns it a role, so it additionally requires ROLES, the permission
+  // that governs role assignment, so a key can't be granted a role its creator
+  // is not allowed to grant. RequireAccessTokenGuard keeps derived PLAYGROUND
+  // tokens and API keys from escalating into a long-lived credential.
+  @UseGuards(
+    RequireAccessTokenGuard,
+    SettingsPermissionGuard(PermissionFlagType.ROLES),
+  )
   @Mutation(() => ApiKeyEntity)
   async createApiKey(
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -113,7 +119,13 @@ export class ApiKeyResolver {
     return this.apiKeyService.revoke(input.id, workspace.id);
   }
 
-  @UseGuards(RequireAccessTokenGuard)
+  // Requires ROLES on top of API_KEYS_AND_WEBHOOKS: binding a role to an API
+  // key must require the role-assignment permission to prevent privilege
+  // escalation.
+  @UseGuards(
+    RequireAccessTokenGuard,
+    SettingsPermissionGuard(PermissionFlagType.ROLES),
+  )
   @Mutation(() => Boolean)
   async assignRoleToApiKey(
     @AuthWorkspace() workspace: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
@@ -69,11 +69,9 @@ export class ApiKeyResolver {
     }
   }
 
-  // API_KEYS_AND_WEBHOOKS (class guard) gates managing API keys. Creating one
-  // also assigns it a role, so it additionally requires ROLES, the permission
-  // that governs role assignment, so a key can't be granted a role its creator
-  // is not allowed to grant. RequireAccessTokenGuard keeps derived PLAYGROUND
-  // tokens and API keys from escalating into a long-lived credential.
+  // Creating a key assigns it a role, so it also requires ROLES to prevent
+  // binding a role above the caller's own. RequireAccessTokenGuard blocks
+  // minting from derived PLAYGROUND tokens.
   @UseGuards(
     RequireAccessTokenGuard,
     SettingsPermissionGuard(PermissionFlagType.ROLES),
@@ -119,9 +117,7 @@ export class ApiKeyResolver {
     return this.apiKeyService.revoke(input.id, workspace.id);
   }
 
-  // Requires ROLES on top of API_KEYS_AND_WEBHOOKS: binding a role to an API
-  // key must require the role-assignment permission to prevent privilege
-  // escalation.
+  // Binding a role to an API key requires ROLES to prevent privilege escalation.
   @UseGuards(
     RequireAccessTokenGuard,
     SettingsPermissionGuard(PermissionFlagType.ROLES),

--- a/packages/twenty-server/src/engine/core-modules/api-key/controllers/api-key.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/controllers/api-key.controller.ts
@@ -67,9 +67,12 @@ export class ApiKeyController {
     return this.apiKeyService.findById(id, workspace.id);
   }
 
-  // Minting an API key requires an ACCESS token — derived PLAYGROUND tokens
-  // and API keys must not escalate into a long-lived credential.
-  @UseGuards(RequireAccessTokenGuard)
+  // Creating a key assigns it a role, so it also requires ROLES to prevent
+  // binding a role above the caller's own.
+  @UseGuards(
+    RequireAccessTokenGuard,
+    SettingsPermissionGuard(PermissionFlagType.ROLES),
+  )
   @Post()
   async create(
     @Body() createApiKeyDto: CreateApiKeyInput,

--- a/packages/twenty-server/test/integration/graphql/suites/settings-permissions/api-key-role-assignment-permission.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/settings-permissions/api-key-role-assignment-permission.integration-spec.ts
@@ -1,0 +1,152 @@
+import gql from 'graphql-tag';
+import request from 'supertest';
+import { deleteOneRoleOperationFactory } from 'test/integration/graphql/utils/delete-one-role-operation-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { findOneRoleByLabel } from 'test/integration/metadata/suites/role/utils/find-one-role-by-label.util';
+import { updateWorkspaceMemberRole } from 'test/integration/metadata/suites/role/utils/update-workspace-member-role.util';
+import { PermissionFlagType } from 'twenty-shared/constants';
+
+import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+const client = request(`http://localhost:${APP_PORT}`);
+
+describe('API key role assignment permission', () => {
+  let customRoleId: string;
+  let adminRoleId: string;
+  let originalMemberRoleId: string;
+  let apiKeyId: string;
+
+  const createApiKeyAsJony = (roleId: string) =>
+    makeMetadataAPIRequest(
+      {
+        query: gql`
+          mutation CreateApiKey($input: CreateApiKeyInput!) {
+            createApiKey(input: $input) {
+              id
+            }
+          }
+        `,
+        variables: {
+          input: {
+            name: 'Escalation attempt',
+            expiresAt: '2099-01-01T00:00:00Z',
+            roleId,
+          },
+        },
+      },
+      APPLE_JONY_MEMBER_ACCESS_TOKEN,
+    );
+
+  beforeAll(async () => {
+    originalMemberRoleId = (await findOneRoleByLabel({ label: 'Member' })).id;
+    adminRoleId = (await findOneRoleByLabel({ label: 'Admin' })).id;
+
+    const createRoleResponse = await makeMetadataAPIRequest({
+      query: gql`
+        mutation CreateOneRole {
+          createOneRole(
+            createRoleInput: {
+              label: "Api Keys Only Role"
+              canUpdateAllSettings: false
+              canReadAllObjectRecords: true
+              canUpdateAllObjectRecords: true
+              canSoftDeleteAllObjectRecords: false
+              canDestroyAllObjectRecords: false
+            }
+          ) {
+            id
+          }
+        }
+      `,
+    });
+
+    customRoleId = createRoleResponse.body.data.createOneRole.id;
+
+    await makeMetadataAPIRequest({
+      query: gql`
+        mutation UpsertPermissionFlags {
+          upsertPermissionFlags(
+            upsertPermissionFlagsInput: {
+              roleId: "${customRoleId}"
+              permissionFlagKeys: ["${PermissionFlagType.API_KEYS_AND_WEBHOOKS}"]
+            }
+          ) {
+            id
+          }
+        }
+      `,
+    });
+
+    const createApiKeyResponse = await makeMetadataAPIRequest({
+      query: gql`
+        mutation CreateApiKey($input: CreateApiKeyInput!) {
+          createApiKey(input: $input) {
+            id
+          }
+        }
+      `,
+      variables: {
+        input: {
+          name: 'Seed key',
+          expiresAt: '2099-01-01T00:00:00Z',
+          roleId: adminRoleId,
+        },
+      },
+    });
+
+    apiKeyId = createApiKeyResponse.body.data.createApiKey.id;
+
+    await updateWorkspaceMemberRole({
+      input: {
+        roleId: customRoleId,
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+      },
+      expectToFail: false,
+    });
+  });
+
+  afterAll(async () => {
+    await updateWorkspaceMemberRole({
+      input: {
+        roleId: originalMemberRoleId,
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+      },
+      expectToFail: false,
+    });
+
+    await testDataSource
+      .query('DELETE FROM core."apiKey" WHERE id = $1', [apiKeyId])
+      .catch(() => {});
+
+    await client
+      .post('/metadata')
+      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+      .send(deleteOneRoleOperationFactory(customRoleId));
+  });
+
+  it('denies creating an API key with the Admin role when the caller lacks ROLES permission', async () => {
+    const response = await createApiKeyAsJony(adminRoleId);
+
+    expect(response.body.data?.createApiKey ?? null).toBeNull();
+    expect(response.body.errors).toBeDefined();
+    expect(response.body.errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+  });
+
+  it('denies assigning a role to an API key when the caller lacks ROLES permission', async () => {
+    const response = await makeMetadataAPIRequest(
+      {
+        query: gql`
+          mutation AssignRoleToApiKey($apiKeyId: UUID!, $roleId: UUID!) {
+            assignRoleToApiKey(apiKeyId: $apiKeyId, roleId: $roleId)
+          }
+        `,
+        variables: { apiKeyId, roleId: adminRoleId },
+      },
+      APPLE_JONY_MEMBER_ACCESS_TOKEN,
+    );
+
+    expect(response.body.errors).toBeDefined();
+    expect(response.body.errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+  });
+});


### PR DESCRIPTION
## What

Binding a role to an API key is gated only by the `API_KEYS_AND_WEBHOOKS` permission, while assigning a role to a workspace member requires `ROLES`. Because `createApiKey` always assigns a role (`roleId` is required) and `assignRoleToApiKey` sets one, a member whose role has `API_KEYS_AND_WEBHOOKS` but not `ROLES` could mint an API key bound to a more-privileged role than their own.

## Functional change

`createApiKey` and `assignRoleToApiKey` now also require `PermissionFlagType.ROLES` (on top of the class-level `API_KEYS_AND_WEBHOOKS`), matching how role assignment to members is protected. The two permissions:

- `API_KEYS_AND_WEBHOOKS`: manage API keys and webhooks (list/create/update/revoke).
- `ROLES`: assign roles. Required whenever an operation binds a role, including binding one to an API key.

Read-only and non-role operations (`apiKeys`, `apiKey`, `getApiKeyRoles`, `updateApiKey`, `revokeApiKey`) are unchanged and still require only `API_KEYS_AND_WEBHOOKS`.

## Test

Integration test: a member whose custom role has only `API_KEYS_AND_WEBHOOKS` is denied `createApiKey` with the Admin role and `assignRoleToApiKey`, both returning FORBIDDEN.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

