### PR TITLE
Retry workspace migrations aborted as postgres deadlock victims

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -27,8 +27,12 @@ import {
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception';
 import { WorkspaceMigrationRunnerActionHandlerRegistryService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/registry/workspace-migration-runner-action-handler-registry.service';
 import { buildPreallocatedIdByUniversalIdentifierFromActions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/build-preallocated-id-by-universal-identifier-from-actions.util';
+import { isDeadlockWorkspaceMigrationRunnerException } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/is-deadlock-workspace-migration-runner-exception.util';
 import { type AfterCommitSideEffect } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/after-commit-side-effect.type';
 import { type MetadataEvent } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event';
+
+const WORKSPACE_MIGRATION_RUN_MAX_ATTEMPTS = 3;
+const WORKSPACE_MIGRATION_RUN_RETRY_DELAY_MS = 200;
 
 @Injectable()
 export class WorkspaceMigrationRunnerService {
@@ -212,30 +216,55 @@ export class WorkspaceMigrationRunnerService {
     metadataEvents: MetadataEvent[];
     hasSchemaMetadataChanged: boolean;
   }> => {
-    const runStart = performance.now();
+    let attempt = 1;
 
-    try {
-      const result = await this.executeRun(args);
+    while (true) {
+      const runStart = performance.now();
 
-      this.metricsService.recordHistogram({
-        key: MetricsKeys.WorkspaceMigrationRunDurationMs,
-        value: performance.now() - runStart,
-        unit: 'ms',
-        attributes: { status: 'success' },
-        bucketBoundaries: WORKSPACE_MIGRATION_DURATION_MS_BUCKET_BOUNDARIES,
-      });
+      try {
+        const result = await this.executeRun(args);
 
-      return result;
-    } catch (error) {
-      this.metricsService.recordHistogram({
-        key: MetricsKeys.WorkspaceMigrationRunDurationMs,
-        value: performance.now() - runStart,
-        unit: 'ms',
-        attributes: { status: 'fail' },
-        bucketBoundaries: WORKSPACE_MIGRATION_DURATION_MS_BUCKET_BOUNDARIES,
-      });
+        this.metricsService.recordHistogram({
+          key: MetricsKeys.WorkspaceMigrationRunDurationMs,
+          value: performance.now() - runStart,
+          unit: 'ms',
+          attributes: { status: 'success' },
+          bucketBoundaries: WORKSPACE_MIGRATION_DURATION_MS_BUCKET_BOUNDARIES,
+        });
 
-      throw error;
+        return result;
+      } catch (error) {
+        this.metricsService.recordHistogram({
+          key: MetricsKeys.WorkspaceMigrationRunDurationMs,
+          value: performance.now() - runStart,
+          unit: 'ms',
+          attributes: { status: 'fail' },
+          bucketBoundaries: WORKSPACE_MIGRATION_DURATION_MS_BUCKET_BOUNDARIES,
+        });
+
+        // The full transaction was rolled back, so re-running it from scratch
+        // is safe; the writes we deadlocked against hold their locks until they
+        // commit, so the retry simply queues behind them.
+        if (
+          attempt < WORKSPACE_MIGRATION_RUN_MAX_ATTEMPTS &&
+          isDeadlockWorkspaceMigrationRunnerException(error)
+        ) {
+          this.logger.warn(
+            `Migration run aborted as a deadlock victim (attempt ${attempt}/${WORKSPACE_MIGRATION_RUN_MAX_ATTEMPTS}), retrying`,
+            'Runner',
+          );
+
+          attempt += 1;
+
+          await new Promise((resolve) =>
+            setTimeout(resolve, WORKSPACE_MIGRATION_RUN_RETRY_DELAY_MS),
+          );
+
+          continue;
+        }
+
+        throw error;
+      }
     }
   };
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/is-deadlock-workspace-migration-runner-exception.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/is-deadlock-workspace-migration-runner-exception.util.spec.ts
@@ -1,0 +1,91 @@
+import { QueryFailedError } from 'typeorm';
+
+import { type AllUniversalWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-action-common';
+import {
+  WorkspaceMigrationRunnerException,
+  WorkspaceMigrationRunnerExceptionCode,
+  type WorkspaceMigrationRunnerExecutionErrors,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception';
+import { isDeadlockWorkspaceMigrationRunnerException } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/is-deadlock-workspace-migration-runner-exception.util';
+
+const buildQueryFailedError = (code: string): QueryFailedError => {
+  const driverError = new Error('deadlock detected');
+
+  Object.assign(driverError, { code });
+
+  return new QueryFailedError('DROP INDEX "IDX_abc"', [], driverError);
+};
+
+const buildExecutionFailedException = (
+  errors: WorkspaceMigrationRunnerExecutionErrors,
+): WorkspaceMigrationRunnerException =>
+  new WorkspaceMigrationRunnerException({
+    action: {
+      type: 'delete',
+      metadataName: 'index',
+      universalIdentifier: '20202020-0000-4000-8000-000000000001',
+    } as AllUniversalWorkspaceMigrationAction,
+    errors,
+    code: WorkspaceMigrationRunnerExceptionCode.EXECUTION_FAILED,
+  });
+
+describe('isDeadlockWorkspaceMigrationRunnerException', () => {
+  it('returns true when the workspace schema error is a postgres deadlock', () => {
+    expect(
+      isDeadlockWorkspaceMigrationRunnerException(
+        buildExecutionFailedException({
+          workspaceSchema: buildQueryFailedError('40P01'),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true when the metadata error is a postgres deadlock', () => {
+    expect(
+      isDeadlockWorkspaceMigrationRunnerException(
+        buildExecutionFailedException({
+          metadata: buildQueryFailedError('40P01'),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for other postgres errors', () => {
+    expect(
+      isDeadlockWorkspaceMigrationRunnerException(
+        buildExecutionFailedException({
+          workspaceSchema: buildQueryFailedError('42P07'),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for plain errors', () => {
+    expect(
+      isDeadlockWorkspaceMigrationRunnerException(
+        buildExecutionFailedException({
+          workspaceSchema: new Error('deadlock detected'),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for runner exceptions without execution errors', () => {
+    expect(
+      isDeadlockWorkspaceMigrationRunnerException(
+        new WorkspaceMigrationRunnerException({
+          message: 'deadlock detected',
+          code: WorkspaceMigrationRunnerExceptionCode.INTERNAL_SERVER_ERROR,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for non runner exceptions', () => {
+    expect(
+      isDeadlockWorkspaceMigrationRunnerException(
+        buildQueryFailedError('40P01'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/is-deadlock-workspace-migration-runner-exception.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/is-deadlock-workspace-migration-runner-exception.util.ts
@@ -1,0 +1,17 @@
+import { QueryFailedError } from 'typeorm';
+
+import { POSTGRESQL_ERROR_CODES } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-codes.constants';
+import { WorkspaceMigrationRunnerException } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception';
+
+const isPostgresDeadlockError = (error: Error | undefined): boolean =>
+  error instanceof QueryFailedError &&
+  (error.driverError as { code?: string } | undefined)?.code ===
+    POSTGRESQL_ERROR_CODES.DEADLOCK_DETECTED;
+
+export const isDeadlockWorkspaceMigrationRunnerException = (
+  error: unknown,
+): boolean =>
+  error instanceof WorkspaceMigrationRunnerException &&
+  [error.errors?.metadata, error.errors?.workspaceSchema].some(
+    isPostgresDeadlockError,
+  );


### PR DESCRIPTION
## Context

Split out of #24804, which deflakes the upsert integration suite by waiting for background jobs before deleting the fixture object. This PR addresses the same race where no such wait is possible: production.

## Problem

Deleting an object runs one migration transaction taking AccessExclusiveLocks across the object table and every related table carrying its join columns (timelineActivity, favorite, attachment, ...). Background jobs (timeline activity, audit log, workflow runs) write to those tables continuously, and each insert referencing the object implicitly waits for a share lock on the object table for its foreign key check while holding a write lock on its own table. When a user deletes an object while such a write is in flight, postgres detects the lock cycle and kills the migration as the deadlock victim (40P01). The user sees "An unexpected error occurred" for an operation that succeeds if they simply click again.

The writer's lock order (own table first, foreign key target second) is implicit in postgres foreign key enforcement, so it cannot be coordinated with migration action order; retrying the aborted transaction is the standard treatment for this error class.

## What this does

`WorkspaceMigrationRunnerService.run` retries the full run up to 3 times with a 200ms pause when the failure was a deadlock. This is safe because the failed attempt's transaction is fully rolled back and its caches invalidated before rethrowing, so a fresh run starts from clean state and simply queues behind the competing writer's locks. After 3 attempts the original error still surfaces, so a genuine lock bug cannot be masked; each retry is logged and each attempt is recorded in the existing run-duration metric.

Deadlock detection is a pure util that digs the 40P01 code out of the `EXECUTION_FAILED` exception's metadata and workspaceSchema errors.

## Verification

- New util spec (6 tests).
- Full `upsert.integration-spec.ts` run against a freshly reset test database passes with this change (7 tests).
- oxlint, oxfmt and typecheck clean on touched files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

