### PR TITLE
fix(server): migrate legacy IS_NOT_NULL workflow filter operand to IS_NOT_EMPTY

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-upgrade-version-command.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { RewriteIsNotNullWorkflowFilterOperandsCommand } from 'src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787700000000-rewrite-is-not-null-workflow-filter-operands.command';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+
+@Module({
+  imports: [WorkspaceIteratorModule, WorkspaceCacheModule],
+  providers: [RewriteIsNotNullWorkflowFilterOperandsCommand],
+})
+export class V2_36_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787700000000-rewrite-is-not-null-workflow-filter-operands.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787700000000-rewrite-is-not-null-workflow-filter-operands.command.ts
@@ -1,0 +1,173 @@
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { rewriteIsNotNullFilterOperands } from 'src/database/commands/upgrade-version-command/2-36/utils/rewrite-is-not-null-filter-operands.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type UniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-maps.type';
+import { type WorkflowAutomatedTriggerWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
+import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+
+@RegisteredWorkspaceCommand('2.36.0', 1787700000000)
+@Command({
+  name: 'upgrade:2-36:rewrite-is-not-null-workflow-filter-operands',
+  description:
+    'Rewrite the legacy IS_NOT_NULL filter operand to IS_NOT_EMPTY in workflow if-else/filter steps and database-event trigger filters, which otherwise throws at runtime',
+})
+export class RewriteIsNotNullWorkflowFilterOperandsCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    // Empty/partially-provisioned workspaces lack the workflow objects;
+    // fetching the repository for a missing entity throws, so skip them.
+    const { flatObjectMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+      ]);
+
+    await this.rewriteWorkflowVersions({
+      workspaceId,
+      flatObjectMetadataMaps,
+      isDryRun,
+    });
+
+    await this.rewriteAutomatedTriggers({
+      workspaceId,
+      flatObjectMetadataMaps,
+      isDryRun,
+    });
+  }
+
+  // if-else and filter step conditions live in workflowVersion.steps; the
+  // stored trigger snapshot lives in workflowVersion.trigger.
+  private async rewriteWorkflowVersions({
+    workspaceId,
+    flatObjectMetadataMaps,
+    isDryRun,
+  }: {
+    workspaceId: string;
+    flatObjectMetadataMaps: UniversalFlatEntityMaps<FlatObjectMetadata>;
+    isDryRun: boolean;
+  }): Promise<void> {
+    const workflowVersionObject =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier: STANDARD_OBJECTS.workflowVersion.universalIdentifier,
+      });
+
+    if (!isDefined(workflowVersionObject)) {
+      return;
+    }
+
+    const workflowVersionRepository =
+      await this.workspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        'workflowVersion',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const allVersions = await workflowVersionRepository.find();
+
+    let updatedCount = 0;
+
+    for (const version of allVersions) {
+      const migratedSteps = rewriteIsNotNullFilterOperands(version.steps);
+      const migratedTrigger = rewriteIsNotNullFilterOperands(version.trigger);
+
+      if (!migratedSteps.changed && !migratedTrigger.changed) {
+        continue;
+      }
+
+      updatedCount++;
+
+      if (isDryRun) {
+        continue;
+      }
+
+      await workflowVersionRepository.update(version.id, {
+        ...(migratedSteps.changed ? { steps: migratedSteps.value } : {}),
+        ...(migratedTrigger.changed ? { trigger: migratedTrigger.value } : {}),
+      });
+    }
+
+    if (updatedCount > 0) {
+      this.logger.log(
+        `${isDryRun ? '[DRY RUN] ' : ''}Rewrote IS_NOT_NULL operands in ${updatedCount} workflow version(s) for workspace ${workspaceId}`,
+      );
+    }
+  }
+
+  // Active database-event triggers are evaluated from workflowAutomatedTrigger
+  // records at fire time, not from the workflowVersion snapshot.
+  private async rewriteAutomatedTriggers({
+    workspaceId,
+    flatObjectMetadataMaps,
+    isDryRun,
+  }: {
+    workspaceId: string;
+    flatObjectMetadataMaps: UniversalFlatEntityMaps<FlatObjectMetadata>;
+    isDryRun: boolean;
+  }): Promise<void> {
+    const automatedTriggerObject =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier:
+          STANDARD_OBJECTS.workflowAutomatedTrigger.universalIdentifier,
+      });
+
+    if (!isDefined(automatedTriggerObject)) {
+      return;
+    }
+
+    const automatedTriggerRepository =
+      await this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+        'workflowAutomatedTrigger',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const allTriggers = await automatedTriggerRepository.find();
+
+    let updatedCount = 0;
+
+    for (const trigger of allTriggers) {
+      const migratedSettings = rewriteIsNotNullFilterOperands(trigger.settings);
+
+      if (!migratedSettings.changed) {
+        continue;
+      }
+
+      updatedCount++;
+
+      if (isDryRun) {
+        continue;
+      }
+
+      await automatedTriggerRepository.update(trigger.id, {
+        settings: migratedSettings.value,
+      });
+    }
+
+    if (updatedCount > 0) {
+      this.logger.log(
+        `${isDryRun ? '[DRY RUN] ' : ''}Rewrote IS_NOT_NULL operands in ${updatedCount} automated trigger(s) for workspace ${workspaceId}`,
+      );
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787700000000-rewrite-is-not-null-workflow-filter-operands.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787700000000-rewrite-is-not-null-workflow-filter-operands.command.ts
@@ -36,8 +36,6 @@ export class RewriteIsNotNullWorkflowFilterOperandsCommand extends ProvisionedWo
   }: RunOnWorkspaceArgs): Promise<void> {
     const isDryRun = options.dryRun ?? false;
 
-    // Empty/partially-provisioned workspaces lack the workflow objects;
-    // fetching the repository for a missing entity throws, so skip them.
     const { flatObjectMetadataMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
         'flatObjectMetadataMaps',
@@ -56,8 +54,6 @@ export class RewriteIsNotNullWorkflowFilterOperandsCommand extends ProvisionedWo
     });
   }
 
-  // if-else and filter step conditions live in workflowVersion.steps; the
-  // stored trigger snapshot lives in workflowVersion.trigger.
   private async rewriteWorkflowVersions({
     workspaceId,
     flatObjectMetadataMaps,
@@ -114,8 +110,6 @@ export class RewriteIsNotNullWorkflowFilterOperandsCommand extends ProvisionedWo
     }
   }
 
-  // Active database-event triggers are evaluated from workflowAutomatedTrigger
-  // records at fire time, not from the workflowVersion snapshot.
   private async rewriteAutomatedTriggers({
     workspaceId,
     flatObjectMetadataMaps,
@@ -164,10 +158,18 @@ export class RewriteIsNotNullWorkflowFilterOperandsCommand extends ProvisionedWo
       });
     }
 
-    if (updatedCount > 0) {
-      this.logger.log(
-        `${isDryRun ? '[DRY RUN] ' : ''}Rewrote IS_NOT_NULL operands in ${updatedCount} automated trigger(s) for workspace ${workspaceId}`,
-      );
+    if (updatedCount === 0) {
+      return;
     }
+
+    if (!isDryRun) {
+      await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
+        'workflowAutomatedTriggerMaps',
+      ]);
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Rewrote IS_NOT_NULL operands in ${updatedCount} automated trigger(s) for workspace ${workspaceId}`,
+    );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/utils/__tests__/rewrite-is-not-null-filter-operands.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/utils/__tests__/rewrite-is-not-null-filter-operands.util.spec.ts
@@ -1,0 +1,95 @@
+import { rewriteIsNotNullFilterOperands } from 'src/database/commands/upgrade-version-command/2-36/utils/rewrite-is-not-null-filter-operands.util';
+
+describe('rewriteIsNotNullFilterOperands', () => {
+  it('rewrites IS_NOT_NULL operand to IS_NOT_EMPTY inside stepFilters', () => {
+    const steps = [
+      {
+        type: 'IF_ELSE',
+        settings: {
+          input: {
+            stepFilters: [
+              { id: 'a', type: 'UUID', operand: 'IS_NOT_NULL', value: '' },
+            ],
+          },
+        },
+      },
+    ];
+
+    const { value, changed } = rewriteIsNotNullFilterOperands(steps);
+
+    expect(changed).toBe(true);
+    expect(value[0].settings.input.stepFilters[0].operand).toBe('IS_NOT_EMPTY');
+  });
+
+  it('rewrites the deprecated isNotNull operand to IS_NOT_EMPTY', () => {
+    const { value, changed } = rewriteIsNotNullFilterOperands({
+      stepFilters: [{ operand: 'isNotNull' }],
+    });
+
+    expect(changed).toBe(true);
+    expect(value.stepFilters[0].operand).toBe('IS_NOT_EMPTY');
+  });
+
+  it('rewrites operands in trigger filter settings', () => {
+    const trigger = {
+      type: 'DATABASE_EVENT',
+      settings: {
+        eventName: 'company.updated',
+        filter: {
+          stepFilters: [{ operand: 'IS_NOT_NULL' }],
+          stepFilterGroups: [],
+        },
+      },
+    };
+
+    const { value, changed } = rewriteIsNotNullFilterOperands(trigger);
+
+    expect(changed).toBe(true);
+    expect(value.settings.filter.stepFilters[0].operand).toBe('IS_NOT_EMPTY');
+  });
+
+  it('leaves other operands untouched', () => {
+    const steps = [
+      { settings: { input: { stepFilters: [{ operand: 'IS_NOT_EMPTY' }] } } },
+      { settings: { input: { stepFilters: [{ operand: 'IS' }] } } },
+    ];
+
+    const { value, changed } = rewriteIsNotNullFilterOperands(steps);
+
+    expect(changed).toBe(false);
+    expect(value).toBe(steps);
+  });
+
+  it('does not touch a filter value that merely contains the operand string', () => {
+    const { value, changed } = rewriteIsNotNullFilterOperands({
+      stepFilters: [{ operand: 'CONTAINS', value: 'IS_NOT_NULL' }],
+    });
+
+    expect(changed).toBe(false);
+    expect(value.stepFilters[0].value).toBe('IS_NOT_NULL');
+  });
+
+  it('is idempotent', () => {
+    const input = { stepFilters: [{ operand: 'IS_NOT_NULL' }] };
+
+    const firstPass = rewriteIsNotNullFilterOperands(input);
+    const secondPass = rewriteIsNotNullFilterOperands(firstPass.value);
+
+    expect(firstPass.changed).toBe(true);
+    expect(secondPass.changed).toBe(false);
+    expect(secondPass.value).toEqual({
+      stepFilters: [{ operand: 'IS_NOT_EMPTY' }],
+    });
+  });
+
+  it('returns null/undefined unchanged', () => {
+    expect(rewriteIsNotNullFilterOperands(null)).toEqual({
+      value: null,
+      changed: false,
+    });
+    expect(rewriteIsNotNullFilterOperands(undefined)).toEqual({
+      value: undefined,
+      changed: false,
+    });
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/utils/rewrite-is-not-null-filter-operands.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/utils/rewrite-is-not-null-filter-operands.util.ts
@@ -1,10 +1,5 @@
 import { isDefined } from 'twenty-shared/utils';
 
-// IS_NOT_NULL (and its deprecated 'isNotNull' form) is a legacy filter operand
-// semantically identical to IS_NOT_EMPTY. The workflow filter evaluators only
-// implement IS_NOT_EMPTY, so stored IS_NOT_NULL operands throw at runtime.
-// Rewriting the exact serialized "operand" pair keeps this precise (a filter
-// value that merely contains the string is never touched) and idempotent.
 const LEGACY_NOT_NULL_OPERAND_FRAGMENTS = [
   '"operand":"IS_NOT_NULL"',
   '"operand":"isNotNull"',

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/utils/rewrite-is-not-null-filter-operands.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/utils/rewrite-is-not-null-filter-operands.util.ts
@@ -1,0 +1,35 @@
+import { isDefined } from 'twenty-shared/utils';
+
+// IS_NOT_NULL (and its deprecated 'isNotNull' form) is a legacy filter operand
+// semantically identical to IS_NOT_EMPTY. The workflow filter evaluators only
+// implement IS_NOT_EMPTY, so stored IS_NOT_NULL operands throw at runtime.
+// Rewriting the exact serialized "operand" pair keeps this precise (a filter
+// value that merely contains the string is never touched) and idempotent.
+const LEGACY_NOT_NULL_OPERAND_FRAGMENTS = [
+  '"operand":"IS_NOT_NULL"',
+  '"operand":"isNotNull"',
+];
+
+const IS_NOT_EMPTY_OPERAND_FRAGMENT = '"operand":"IS_NOT_EMPTY"';
+
+export const rewriteIsNotNullFilterOperands = <TValue>(
+  value: TValue,
+): { value: TValue; changed: boolean } => {
+  if (!isDefined(value)) {
+    return { value, changed: false };
+  }
+
+  const serialized = JSON.stringify(value);
+
+  const rewritten = LEGACY_NOT_NULL_OPERAND_FRAGMENTS.reduce(
+    (accumulator, fragment) =>
+      accumulator.split(fragment).join(IS_NOT_EMPTY_OPERAND_FRAGMENT),
+    serialized,
+  );
+
+  if (rewritten === serialized) {
+    return { value, changed: false };
+  }
+
+  return { value: JSON.parse(rewritten) as TValue, changed: true };
+};

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -28,6 +28,7 @@ import { V2_32_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
 import { V2_33_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-33/2-33-upgrade-version-command.module';
 import { V2_34_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-34/2-34-upgrade-version-command.module';
 import { V2_35_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-35/2-35-upgrade-version-command.module';
+import { V2_36_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-36/2-36-upgrade-version-command.module';
 import { V2_4_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-4/2-4-upgrade-version-command.module';
 import { V2_5_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-5/2-5-upgrade-version-command.module';
 import { V2_7_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-7/2-7-upgrade-version-command.module';
@@ -69,6 +70,7 @@ import { V2_9_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-
     V2_33_UpgradeVersionCommandModule,
     V2_34_UpgradeVersionCommandModule,
     V2_35_UpgradeVersionCommandModule,
+    V2_36_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}


### PR DESCRIPTION
## Problem

Workflow if-else/filter conditions (and database-event trigger filters) on UUID and relation fields sometimes store the legacy `IS_NOT_NULL` operand. It is semantically identical to `IS_NOT_EMPTY`, but the workflow filter evaluators (`evaluate-filter-conditions.util.ts`) only implement `IS_NOT_EMPTY`, so evaluating those conditions throws at runtime:

```
Error: Operand IS_NOT_NULL not supported for uuid filter
```

Sentry: [7456648252](https://twenty-v7.sentry.io/issues/7456648252/) — 547 events over 4 months across 6 workspaces (concentrated in 2, both still firing). The UI no longer emits `IS_NOT_NULL` for these field types, so this is stale stored data in existing workflows, not a new-data bug.

## Fix

A `2.36.0` workspace upgrade command that rewrites `IS_NOT_NULL` (and its deprecated `isNotNull` form) to `IS_NOT_EMPTY` in every place a `stepFilters` array is persisted:

- `workflowVersion.steps` — if-else / filter step conditions (the reported throw site)
- `workflowVersion.trigger` — the stored trigger snapshot
- `workflowAutomatedTrigger.settings` — active database-event triggers are evaluated from this table at fire time, not from the version snapshot, so it is a second latent throw site

The rewrite is a pure util that matches the exact serialized `"operand":"…"` pair (so a filter *value* that merely contains the string is never touched), is idempotent, and null-safe. Supports `--dry-run`.

## Testing

- 7 unit tests on the util (steps, deprecated form, trigger settings, no-op, value-not-touched, idempotency, null/undefined)
- `oxlint --type-aware`: clean
- typecheck: clean on the new files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

