### PR TITLE
fix(oauth): remove unsupported `iss` parameter advertisement from discovery

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/oauth-discovery.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/oauth-discovery.controller.ts
@@ -57,9 +57,7 @@ export class OAuthDiscoveryController {
       token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
       revocation_endpoint_auth_methods_supported: ['client_secret_post'],
       introspection_endpoint_auth_methods_supported: ['client_secret_post'],
-      // RFC 9207: advertise `iss` in authorization responses to defend against
-      // OAuth mix-up attacks. Required by OAuth 2.1 security BCP.
-      authorization_response_iss_parameter_supported: true,
+
       ...(cliRegistration
         ? { cli_client_id: cliRegistration.oAuthClientId }
         : {}),


### PR DESCRIPTION
## Description
Fixes #24153 by removing the `authorization_response_iss_parameter_supported: true` flag from the OAuth discovery metadata.

Since the `/authorize` flow does not actually append the `iss` parameter to the redirect URI, advertising support for it causes strict MCP clients (like Claude Code, which enforces RFC 9207) to throw an `Issuer mismatch` error on every fresh login. By removing the advertisement, clients will no longer expect the parameter, allowing OAuth authorization to complete successfully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

