### PR TITLE
Surface the workspace blocklist in Communication settings

### DIFF
--- a/packages/twenty-front/src/modules/accounts/types/BlocklistItem.ts
+++ b/packages/twenty-front/src/modules/accounts/types/BlocklistItem.ts
@@ -1,7 +1,10 @@
+import { type BlocklistScope } from 'twenty-shared/types';
+
 export type BlocklistItem = {
   id: string;
   handle: string;
-  workspaceMemberId: string;
+  scope: BlocklistScope;
+  workspaceMemberId: string | null;
   createdAt: string;
   __typename: 'BlocklistItem';
 };

--- a/packages/twenty-front/src/modules/settings/accounts/components/__stories__/mockedBlocklist.ts
+++ b/packages/twenty-front/src/modules/settings/accounts/components/__stories__/mockedBlocklist.ts
@@ -1,11 +1,13 @@
 import { formatISO, parseISO, subDays, subHours } from 'date-fns';
 
 import { type BlocklistItem } from '@/accounts/types/BlocklistItem';
+import { BlocklistScope } from 'twenty-shared/types';
 
 export const mockedBlocklist: BlocklistItem[] = [
   {
     id: '1',
     handle: 'test1@twenty.com',
+    scope: BlocklistScope.WORKSPACE_MEMBER,
     workspaceMemberId: '1',
     createdAt:
       formatISO(subHours(parseISO('2023-04-26T10:12:42.33625+00:00'), 2)) ?? '',
@@ -14,6 +16,7 @@ export const mockedBlocklist: BlocklistItem[] = [
   {
     id: '2',
     handle: 'test2@twenty.com',
+    scope: BlocklistScope.WORKSPACE_MEMBER,
     workspaceMemberId: '1',
     createdAt:
       formatISO(subDays(parseISO('2023-04-26T10:12:42.33625+00:00'), 2)) ?? '',
@@ -22,6 +25,7 @@ export const mockedBlocklist: BlocklistItem[] = [
   {
     id: '3',
     handle: 'test3@twenty.com',
+    scope: BlocklistScope.WORKSPACE_MEMBER,
     workspaceMemberId: '1',
     createdAt:
       formatISO(subDays(parseISO('2023-04-26T10:12:42.33625+00:00'), 3)) ?? '',
@@ -30,6 +34,7 @@ export const mockedBlocklist: BlocklistItem[] = [
   {
     id: '4',
     handle: '@twenty.com',
+    scope: BlocklistScope.WORKSPACE_MEMBER,
     workspaceMemberId: '1',
     createdAt:
       formatISO(subDays(parseISO('2023-04-26T10:12:42.33625+00:00'), 4)) ?? '',

--- a/packages/twenty-front/src/modules/settings/hooks/useSettingsNavigationItems.tsx
+++ b/packages/twenty-front/src/modules/settings/hooks/useSettingsNavigationItems.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlagKey, SettingsPath } from 'twenty-shared/types';
+import { SettingsPath } from 'twenty-shared/types';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { currentUserState } from '@/auth/states/currentUserState';
@@ -12,7 +12,6 @@ import {
   type NavigationDrawerItemModifier,
 } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerItem';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import {
@@ -73,9 +72,6 @@ const useSettingsNavigationItems = (): SettingsNavigationSection[] => {
     isNonEmptyString(supportChat.supportFrontChatId);
 
   const permissionMap = usePermissionFlagMap();
-  const isEmailGroupFeatureEnabled = useIsFeatureEnabled(
-    FeatureFlagKey.IS_EMAIL_GROUP_ENABLED,
-  );
   return [
     {
       label: t`User`,
@@ -177,9 +173,7 @@ const useSettingsNavigationItems = (): SettingsNavigationSection[] => {
           label: t`Communication`,
           path: SettingsPath.WorkspaceCommunications,
           Icon: IconMessageCircle,
-          isHidden:
-            !isEmailGroupFeatureEnabled ||
-            !permissionMap[PermissionFlagType.WORKSPACE],
+          isHidden: !permissionMap[PermissionFlagType.WORKSPACE],
         },
       ],
     },

--- a/packages/twenty-front/src/modules/settings/security/components/SettingsSecuritySettings.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/SettingsSecuritySettings.tsx
@@ -6,11 +6,9 @@ import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { authProvidersState } from '@/client-config/states/authProvidersState';
 import { isClickHouseConfiguredState } from '@/client-config/states/isClickHouseConfiguredState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
-import { Separator } from '@/settings/components/Separator';
 import { SettingsEnterpriseFeatureGateCard } from '@/settings/components/SettingsEnterpriseFeatureGateCard';
 import { SettingsOptionCardContentButton } from '@/settings/components/SettingsOptions/SettingsOptionCardContentButton';
 import { SettingsOptionCardContentCounter } from '@/settings/components/SettingsOptions/SettingsOptionCardContentCounter';
-import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
 import { SettingsRoleDefaultRole } from '@/settings/roles/components/SettingsRolesDefaultRole';
 import { SettingsRolesQueryEffect } from '@/settings/roles/components/SettingsRolesQueryEffect';
 import { useSettingsAllRoles } from '@/settings/roles/hooks/useSettingsAllRoles';
@@ -25,12 +23,7 @@ import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { useMutation } from '@apollo/client/react';
-import {
-  IconClockHour8,
-  IconHistory,
-  IconMail,
-  IconTrash,
-} from 'twenty-ui/icon';
+import { IconClockHour8, IconHistory, IconTrash } from 'twenty-ui/icon';
 import { H2Title } from 'twenty-ui/typography';
 import { Section } from 'twenty-ui/layout';
 import { Card } from 'twenty-ui/surfaces';
@@ -115,33 +108,6 @@ export const SettingsSecuritySettings = () => {
     });
 
     saveTrashRetention(value);
-  };
-
-  const handleSyncInternalEmailsChange = (value: boolean) => {
-    if (!currentWorkspace) {
-      return;
-    }
-
-    if (value === currentWorkspace.isInternalMessagesImportEnabled) {
-      return;
-    }
-
-    setCurrentWorkspace({
-      ...currentWorkspace,
-      isInternalMessagesImportEnabled: value,
-    });
-
-    updateWorkspace({
-      variables: {
-        input: {
-          isInternalMessagesImportEnabled: value,
-        },
-      },
-    }).catch((err) => {
-      enqueueErrorSnackBar({
-        apolloError: CombinedGraphQLErrors.is(err) ? err : undefined,
-      });
-    });
   };
 
   const handleEventLogRetentionDaysChange = (value: number) => {
@@ -281,17 +247,6 @@ export const SettingsSecuritySettings = () => {
               onChange={handleTrashRetentionDaysChange}
               minValue={0}
               showButtons={false}
-            />
-            <Separator />
-            <SettingsOptionCardContentToggle
-              Icon={IconMail}
-              title={t`Sync Internal Emails`}
-              description={t`Include emails where all participants share the same domain.`}
-              checked={
-                currentWorkspace?.isInternalMessagesImportEnabled ?? false
-              }
-              onChange={handleSyncInternalEmailsChange}
-              advancedMode
             />
           </Card>
         </Section>

--- a/packages/twenty-front/src/modules/settings/workspace/components/SettingsWorkspaceBlocklistSection.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace/components/SettingsWorkspaceBlocklistSection.tsx
@@ -1,37 +1,22 @@
 import { type BlocklistItem } from '@/accounts/types/BlocklistItem';
-import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
-import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useCreateManyRecords } from '@/object-record/hooks/useCreateManyRecords';
 import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { SettingsAccountsBlocklistInput } from '@/settings/accounts/components/SettingsAccountsBlocklistInput';
 import { SettingsAccountsBlocklistTable } from '@/settings/accounts/components/SettingsAccountsBlocklistTable';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useLingui } from '@lingui/react/macro';
 import { BlocklistScope, CoreObjectNameSingular } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
-import { H2Title } from 'twenty-ui/typography';
 import { Section } from 'twenty-ui/layout';
+import { H2Title } from 'twenty-ui/typography';
 
-export const SettingsAccountsBlocklistSection = () => {
+export const SettingsWorkspaceBlocklistSection = () => {
   const { t } = useLingui();
 
-  const currentWorkspaceMember = useAtomStateValue(currentWorkspaceMemberState);
-  const currentWorkspace = useAtomStateValue(currentWorkspaceState);
-
-  const currentWorkspaceMemberId = currentWorkspaceMember?.id ?? '';
-
-  const isInternalMessagesImportEnabled =
-    currentWorkspace?.isInternalMessagesImportEnabled ?? false;
-
-  const { records: blocklist } = useFindManyRecords<BlocklistItem>({
+  const { records: workspaceBlocklist } = useFindManyRecords<BlocklistItem>({
     objectNameSingular: CoreObjectNameSingular.Blocklist,
     filter: {
-      workspaceMemberId: {
-        in: [currentWorkspaceMemberId],
-      },
+      scope: { eq: BlocklistScope.WORKSPACE },
     },
-    skip: !isDefined(currentWorkspaceMember),
   });
 
   const { createManyRecords: createBlocklistItems } =
@@ -48,15 +33,11 @@ export const SettingsAccountsBlocklistSection = () => {
   };
 
   const updateBlockedEmailList = (handles: string[]) => {
-    if (!isDefined(currentWorkspaceMember)) return;
     createBlocklistItems({
-      recordsToCreate: [...new Set(handles)].map((handle) => {
-        return {
-          handle,
-          scope: BlocklistScope.WORKSPACE_MEMBER,
-          workspaceMemberId: currentWorkspaceMember.id,
-        };
-      }),
+      recordsToCreate: [...new Set(handles)].map((handle) => ({
+        handle,
+        scope: BlocklistScope.WORKSPACE,
+      })),
     });
   };
 
@@ -64,18 +45,14 @@ export const SettingsAccountsBlocklistSection = () => {
     <Section>
       <H2Title
         title={t`Blocklist`}
-        description={
-          isInternalMessagesImportEnabled
-            ? t`Exclude the following people and domains from my email sync.`
-            : t`Exclude the following people and domains from my email sync. Internal conversations will not be imported`
-        }
+        description={t`Exclude the following people and domains from the email and calendar sync of every workspace member`}
       />
       <SettingsAccountsBlocklistInput
-        blockedEmailOrDomainList={blocklist.map((item) => item.handle)}
+        blockedEmailOrDomainList={workspaceBlocklist.map((item) => item.handle)}
         updateBlockedEmailList={updateBlockedEmailList}
       />
       <SettingsAccountsBlocklistTable
-        blocklist={blocklist}
+        blocklist={workspaceBlocklist}
         handleBlockedEmailRemove={handleBlockedEmailRemove}
       />
     </Section>

--- a/packages/twenty-front/src/modules/settings/workspace/components/SettingsWorkspaceEmailGroupSection.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace/components/SettingsWorkspaceEmailGroupSection.tsx
@@ -1,17 +1,63 @@
+import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
+import { useContext } from 'react';
 
 import { type MessageChannel } from '@/accounts/types/MessageChannel';
 import { useMyMessageChannels } from '@/settings/accounts/hooks/useMyMessageChannels';
+import { SettingsCard } from '@/settings/components/SettingsCard';
 import { SettingsTableListSection } from '@/settings/components/SettingsTableListSection';
 import { SettingsWorkspaceEmailChannelDomainStatusCell } from '@/settings/workspace/components/SettingsWorkspaceEmailChannelDomainStatusCell';
 import { SettingsWorkspaceEmailGroupSourceCell } from '@/settings/workspace/components/SettingsWorkspaceEmailGroupSourceCell';
-import { MessageChannelType, SettingsPath } from 'twenty-shared/types';
+import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
+import {
+  FeatureFlagKey,
+  MessageChannelType,
+  SettingsPath,
+} from 'twenty-shared/types';
+import { IconMail } from 'twenty-ui/icon';
+import { Section } from 'twenty-ui/layout';
+import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { H2Title } from 'twenty-ui/typography';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
+
+const StyledCardsColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[2]};
+`;
 
 export const SettingsWorkspaceEmailGroupSection = () => {
   const { t } = useLingui();
+  const { theme } = useContext(ThemeContext);
   const navigateSettings = useNavigateSettings();
   const { channels } = useMyMessageChannels();
+
+  const isEmailGroupFeatureEnabled = useIsFeatureEnabled(
+    FeatureFlagKey.IS_EMAIL_GROUP_ENABLED,
+  );
+
+  const title = t`Channels`;
+  const description = t`Addresses your workspace uses to send and receive email from shared inboxes`;
+
+  if (!isEmailGroupFeatureEnabled) {
+    return (
+      <Section>
+        <H2Title title={title} description={description} />
+        <StyledCardsColumn>
+          <SettingsCard
+            Icon={
+              <IconMail
+                size={theme.icon.size.lg}
+                stroke={theme.icon.stroke.md}
+              />
+            }
+            title={t`Manage channels`}
+            soon
+          />
+        </StyledCardsColumn>
+      </Section>
+    );
+  }
 
   const emailGroupChannels = channels.filter(
     (channel) => channel.type === MessageChannelType.EMAIL_GROUP,
@@ -19,8 +65,8 @@ export const SettingsWorkspaceEmailGroupSection = () => {
 
   return (
     <SettingsTableListSection<MessageChannel>
-      title={t`Channels`}
-      description={t`Addresses your workspace uses to send and receive email from shared inboxes`}
+      title={title}
+      description={description}
       items={emailGroupChannels}
       columns={[
         { label: t`Email`, Cell: SettingsWorkspaceEmailGroupSourceCell },

--- a/packages/twenty-front/src/modules/settings/workspace/components/SettingsWorkspaceEmailSyncSection.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace/components/SettingsWorkspaceEmailSyncSection.tsx
@@ -1,0 +1,69 @@
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
+import { useMutation } from '@apollo/client/react';
+import { useLingui } from '@lingui/react/macro';
+import { isDefined } from 'twenty-shared/utils';
+import { IconMail } from 'twenty-ui/icon';
+import { Section } from 'twenty-ui/layout';
+import { Card } from 'twenty-ui/surfaces';
+import { H2Title } from 'twenty-ui/typography';
+import { UpdateWorkspaceDocument } from '~/generated-metadata/graphql';
+
+export const SettingsWorkspaceEmailSyncSection = () => {
+  const { t } = useLingui();
+
+  const [currentWorkspace, setCurrentWorkspace] = useAtomState(
+    currentWorkspaceState,
+  );
+  const { enqueueErrorSnackBar } = useSnackBar();
+  const [updateWorkspace] = useMutation(UpdateWorkspaceDocument);
+
+  const handleSyncInternalEmailsChange = (value: boolean) => {
+    if (!isDefined(currentWorkspace)) {
+      return;
+    }
+
+    if (value === currentWorkspace.isInternalMessagesImportEnabled) {
+      return;
+    }
+
+    setCurrentWorkspace({
+      ...currentWorkspace,
+      isInternalMessagesImportEnabled: value,
+    });
+
+    updateWorkspace({
+      variables: {
+        input: {
+          isInternalMessagesImportEnabled: value,
+        },
+      },
+    }).catch((err) => {
+      enqueueErrorSnackBar({
+        apolloError: CombinedGraphQLErrors.is(err) ? err : undefined,
+      });
+    });
+  };
+
+  return (
+    <Section>
+      <H2Title
+        title={t`Sync`}
+        description={t`Control what the workspace imports from connected mailboxes and calendars`}
+      />
+      <Card rounded>
+        <SettingsOptionCardContentToggle
+          Icon={IconMail}
+          title={t`Sync Internal Emails`}
+          description={t`Include emails where all participants share the same domain.`}
+          checked={currentWorkspace?.isInternalMessagesImportEnabled ?? false}
+          onChange={handleSyncInternalEmailsChange}
+          advancedMode
+        />
+      </Card>
+    </Section>
+  );
+};

--- a/packages/twenty-front/src/pages/settings/communications/SettingsWorkspaceCommunications.tsx
+++ b/packages/twenty-front/src/pages/settings/communications/SettingsWorkspaceCommunications.tsx
@@ -3,7 +3,9 @@ import { useLingui } from '@lingui/react/macro';
 
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { SettingsDiscoveryHeroCard } from '@/settings/components/SettingsDiscoveryHeroCard';
+import { SettingsWorkspaceBlocklistSection } from '@/settings/workspace/components/SettingsWorkspaceBlocklistSection';
 import { SettingsWorkspaceEmailGroupSection } from '@/settings/workspace/components/SettingsWorkspaceEmailGroupSection';
+import { SettingsWorkspaceEmailSyncSection } from '@/settings/workspace/components/SettingsWorkspaceEmailSyncSection';
 import { SettingsPageLayout } from '@/settings/components/layout/SettingsPageLayout';
 import { SettingsTabBar } from '@/settings/components/layout/SettingsTabBar';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
@@ -61,10 +63,6 @@ export const SettingsWorkspaceCommunications = () => {
     },
   ];
 
-  if (!isEmailGroupFeatureEnabled) {
-    return null;
-  }
-
   return (
     <SettingsPageLayout
       title={t`Communication`}
@@ -106,10 +104,13 @@ export const SettingsWorkspaceCommunications = () => {
                 />
               }
               title={t`Manage unsubscribe`}
+              soon={!isEmailGroupFeatureEnabled}
               onClick={() => navigateSettings(SettingsPath.Unsubscribe)}
             />
           </StyledCardsColumn>
         </Section>
+        <SettingsWorkspaceEmailSyncSection />
+        <SettingsWorkspaceBlocklistSection />
       </SettingsPageContainer>
     </SettingsPageLayout>
   );


### PR DESCRIPTION
Adds the workspace-wide blocklist table and moves the workspace email
controls out of Security. The Communication page no longer hides behind
IS_EMAIL_GROUP_ENABLED, otherwise the blocklist settings are unreachable
unless an admin flips the flag; the email group sections render as
disabled "Soon" cards while it is off.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

