### PR TITLE
Let a front component element opt into preventDefault

### DIFF
--- a/packages/twenty-front-component-renderer/src/host/elements/utils/__tests__/buildHostReactPropsFromRemoteProps.test.ts
+++ b/packages/twenty-front-component-renderer/src/host/elements/utils/__tests__/buildHostReactPropsFromRemoteProps.test.ts
@@ -213,4 +213,49 @@ describe('buildHostReactPropsFromRemoteProps', () => {
     expect('onClick' in result).toBe(false);
     expect(result['data-state']).toBe('open');
   });
+
+  it('should keep preventDefaultOn out of the DOM props', () => {
+    const result = buildHostReactPropsFromRemoteProps(
+      { preventDefaultOn: ['keydown:Enter'], id: 'keep' },
+      'textarea',
+    );
+
+    expect(result).toEqual({ id: 'keep' });
+  });
+
+  it('should apply preventDefaultOn to the element handlers', () => {
+    const onKeyDown = jest.fn();
+    const preventDefault = jest.fn();
+
+    const result = buildHostReactPropsFromRemoteProps(
+      { onKeyDown, preventDefaultOn: ['keydown:Enter'] },
+      'textarea',
+    );
+
+    (result.onKeyDown as (event: unknown) => void)({
+      type: 'keydown',
+      key: 'Enter',
+      preventDefault,
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(onKeyDown).toHaveBeenCalledWith({ type: 'keydown', key: 'Enter' });
+  });
+
+  it('should ignore a preventDefaultOn that is not a list of strings', () => {
+    const preventDefault = jest.fn();
+
+    const result = buildHostReactPropsFromRemoteProps(
+      { onKeyDown: jest.fn(), preventDefaultOn: 'keydown:Enter' },
+      'textarea',
+    );
+
+    (result.onKeyDown as (event: unknown) => void)({
+      type: 'keydown',
+      key: 'Enter',
+      preventDefault,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
 });

--- a/packages/twenty-front-component-renderer/src/host/elements/utils/__tests__/preventDefaultOn.integration.test.tsx
+++ b/packages/twenty-front-component-renderer/src/host/elements/utils/__tests__/preventDefaultOn.integration.test.tsx
@@ -1,0 +1,94 @@
+import { createElement } from 'react';
+import { render } from '@testing-library/react';
+
+import { buildHostReactPropsFromRemoteProps } from '../buildHostReactPropsFromRemoteProps';
+
+/**
+ * The unit tests call the wrapped handler directly. These render the element
+ * React actually renders and dispatch the event the browser actually
+ * dispatches, because that is the part the guest cannot reach: whether the
+ * default is still suppressible by the time the host sees the event.
+ */
+describe('preventDefaultOn, through React and the DOM', () => {
+  const renderTextarea = (remoteProps: Record<string, unknown>) => {
+    const hostProps = buildHostReactPropsFromRemoteProps(
+      remoteProps,
+      'textarea',
+    );
+
+    // `createElement` and not JSX spread: the props are built at runtime by the host, and
+    // the repo forbids spreading them into an element (react/jsx-props-no-spreading).
+    const { container } = render(
+      createElement('textarea', { 'data-testid': 'composer', ...hostProps }),
+    );
+
+    const element = container.querySelector('textarea');
+
+    if (element === null) {
+      throw new Error('the textarea did not render');
+    }
+
+    return element;
+  };
+
+  const pressEnter = (element: Element, init: KeyboardEventInit = {}) => {
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    });
+
+    element.dispatchEvent(event);
+
+    return event;
+  };
+
+  it('should leave the default in place when the element does not opt in', () => {
+    const onKeyDown = jest.fn();
+    const element = renderTextarea({ onKeyDown });
+
+    const event = pressEnter(element);
+
+    expect(onKeyDown).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('should suppress the default for an opted-in key', () => {
+    const onKeyDown = jest.fn();
+    const element = renderTextarea({
+      onKeyDown,
+      preventDefaultOn: ['keydown:Enter'],
+    });
+
+    const event = pressEnter(element);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onKeyDown).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'keydown', key: 'Enter' }),
+    );
+  });
+
+  // A composer sends on Enter and inserts a newline on Shift+Enter, so the
+  // opt-in must not swallow the second one.
+  it('should leave Shift+Enter alone when only Enter is opted in', () => {
+    const element = renderTextarea({
+      onKeyDown: jest.fn(),
+      preventDefaultOn: ['keydown:Enter'],
+    });
+
+    const event = pressEnter(element, { shiftKey: true });
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('should not reach the DOM as an attribute', () => {
+    const element = renderTextarea({
+      onKeyDown: jest.fn(),
+      preventDefaultOn: ['keydown:Enter'],
+    });
+
+    expect(element.getAttribute('preventDefaultOn')).toBeNull();
+    expect(element.getAttribute('preventdefaulton')).toBeNull();
+  });
+});

--- a/packages/twenty-front-component-renderer/src/host/elements/utils/buildHostReactPropsFromRemoteProps.ts
+++ b/packages/twenty-front-component-renderer/src/host/elements/utils/buildHostReactPropsFromRemoteProps.ts
@@ -9,7 +9,32 @@ import { parseCssString } from '@/host/elements/utils/parseCssString';
 import { wrapEventHandler } from '@/host/events/utils/wrapEventHandler';
 import { type SerializedEventData } from '@/types/SerializedEventData';
 
-const INTERNAL_PROPS = new Set(['element', 'receiver', 'components', 'ref']);
+// `preventDefaultOn` is instruction for the host, not an attribute: it says
+// which events must have their default suppressed while the real event is
+// still in hand, so it never reaches the DOM.
+const PREVENT_DEFAULT_PROP = 'preventDefaultOn';
+
+const INTERNAL_PROPS = new Set([
+  'element',
+  'receiver',
+  'components',
+  'ref',
+  PREVENT_DEFAULT_PROP,
+]);
+
+const readPreventDefaultRules = (
+  remoteProps: Record<string, unknown>,
+): readonly string[] | undefined => {
+  const value = remoteProps[PREVENT_DEFAULT_PROP];
+
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const rules = value.filter((rule): rule is string => typeof rule === 'string');
+
+  return rules.length > 0 ? rules : undefined;
+};
 
 // Both spellings are indexed: dblclick arrives as ondblclick or onDoubleClick.
 const LOWERCASE_EVENT_PROP_TO_REACT_PROP: Record<string, string> =
@@ -27,6 +52,7 @@ export const buildHostReactPropsFromRemoteProps = (
   htmlTag: string,
 ): Record<string, unknown> => {
   const hostReactProps: Record<string, unknown> = {};
+  const preventDefaultRules = readPreventDefaultRules(remoteProps);
 
   for (const [remotePropName, remotePropValue] of Object.entries(remoteProps)) {
     if (INTERNAL_PROPS.has(remotePropName) || isUndefined(remotePropValue)) {
@@ -49,6 +75,7 @@ export const buildHostReactPropsFromRemoteProps = (
       if (isDefined(reactPropName) && isFunction(remotePropValue)) {
         hostReactProps[reactPropName] = wrapEventHandler(
           remotePropValue as (detail: SerializedEventData) => void,
+          preventDefaultRules,
         );
       }
       continue;

--- a/packages/twenty-front-component-renderer/src/host/elements/utils/buildHostReactPropsFromRemoteProps.ts
+++ b/packages/twenty-front-component-renderer/src/host/elements/utils/buildHostReactPropsFromRemoteProps.ts
@@ -31,7 +31,9 @@ const readPreventDefaultRules = (
     return undefined;
   }
 
-  const rules = value.filter((rule): rule is string => typeof rule === 'string');
+  const rules = value.filter(
+    (rule): rule is string => typeof rule === 'string',
+  );
 
   return rules.length > 0 ? rules : undefined;
 };

--- a/packages/twenty-front-component-renderer/src/host/events/utils/__tests__/matchesPreventDefaultRule.test.ts
+++ b/packages/twenty-front-component-renderer/src/host/events/utils/__tests__/matchesPreventDefaultRule.test.ts
@@ -1,0 +1,59 @@
+import { matchesPreventDefaultRule } from '../matchesPreventDefaultRule';
+
+describe('matchesPreventDefaultRule', () => {
+  it('should match on the event type alone', () => {
+    expect(matchesPreventDefaultRule('submit', { type: 'submit' })).toBe(true);
+    expect(matchesPreventDefaultRule('submit', { type: 'click' })).toBe(false);
+  });
+
+  it('should match a key only when the type matches too', () => {
+    expect(
+      matchesPreventDefaultRule('keydown:Enter', { type: 'keydown', key: 'Enter' }),
+    ).toBe(true);
+    expect(
+      matchesPreventDefaultRule('keydown:Enter', { type: 'keyup', key: 'Enter' }),
+    ).toBe(false);
+    expect(
+      matchesPreventDefaultRule('keydown:Enter', { type: 'keydown', key: 'a' }),
+    ).toBe(false);
+  });
+
+  // The composer case: Enter sends, Shift+Enter must still insert a newline.
+  it('should treat modifiers as an exact set', () => {
+    expect(
+      matchesPreventDefaultRule('keydown:Enter', {
+        type: 'keydown',
+        key: 'Enter',
+        shiftKey: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      matchesPreventDefaultRule('keydown:Shift+Enter', {
+        type: 'keydown',
+        key: 'Enter',
+        shiftKey: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      matchesPreventDefaultRule('keydown:Shift+Enter', {
+        type: 'keydown',
+        key: 'Enter',
+      }),
+    ).toBe(false);
+  });
+
+  it('should ignore the order and the casing of modifiers', () => {
+    const event = {
+      type: 'keydown',
+      key: 's',
+      metaKey: true,
+      shiftKey: true,
+    };
+
+    expect(matchesPreventDefaultRule('keydown:Meta+Shift+s', event)).toBe(true);
+    expect(matchesPreventDefaultRule('keydown:shift+meta+s', event)).toBe(true);
+    expect(matchesPreventDefaultRule('keydown:Meta+s', event)).toBe(false);
+  });
+});

--- a/packages/twenty-front-component-renderer/src/host/events/utils/__tests__/matchesPreventDefaultRule.test.ts
+++ b/packages/twenty-front-component-renderer/src/host/events/utils/__tests__/matchesPreventDefaultRule.test.ts
@@ -8,10 +8,16 @@ describe('matchesPreventDefaultRule', () => {
 
   it('should match a key only when the type matches too', () => {
     expect(
-      matchesPreventDefaultRule('keydown:Enter', { type: 'keydown', key: 'Enter' }),
+      matchesPreventDefaultRule('keydown:Enter', {
+        type: 'keydown',
+        key: 'Enter',
+      }),
     ).toBe(true);
     expect(
-      matchesPreventDefaultRule('keydown:Enter', { type: 'keyup', key: 'Enter' }),
+      matchesPreventDefaultRule('keydown:Enter', {
+        type: 'keyup',
+        key: 'Enter',
+      }),
     ).toBe(false);
     expect(
       matchesPreventDefaultRule('keydown:Enter', { type: 'keydown', key: 'a' }),

--- a/packages/twenty-front-component-renderer/src/host/events/utils/__tests__/wrapEventHandler.test.ts
+++ b/packages/twenty-front-component-renderer/src/host/events/utils/__tests__/wrapEventHandler.test.ts
@@ -20,4 +20,66 @@ describe('wrapEventHandler', () => {
 
     expect(handler).toHaveBeenCalledWith({ type: 'click' });
   });
+
+  it('should leave the default alone when no rule is given', () => {
+    const preventDefault = jest.fn();
+
+    wrapEventHandler(jest.fn())({ type: 'keydown', key: 'Enter', preventDefault });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('should prevent the default on a matching rule, before the handler runs', () => {
+    const calls: string[] = [];
+    const preventDefault = jest.fn(() => calls.push('preventDefault'));
+    const handler = jest.fn(() => calls.push('handler'));
+
+    wrapEventHandler(handler, ['keydown:Enter'])({
+      type: 'keydown',
+      key: 'Enter',
+      preventDefault,
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    // The order is the point: the guest's handler cannot do this itself, because
+    // by the time it runs the host has already returned to the browser.
+    expect(calls).toEqual(['preventDefault', 'handler']);
+  });
+
+  it('should not prevent the default on a rule that does not match', () => {
+    const preventDefault = jest.fn();
+
+    wrapEventHandler(jest.fn(), ['keydown:Enter'])({
+      type: 'keydown',
+      key: 'Enter',
+      shiftKey: true,
+      preventDefault,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('should still call the handler when it prevents the default', () => {
+    const handler = jest.fn();
+
+    wrapEventHandler(handler, ['submit'])({
+      type: 'submit',
+      preventDefault: jest.fn(),
+    });
+
+    expect(handler).toHaveBeenCalledWith({ type: 'submit' });
+  });
+
+  it('should survive an event that cannot be prevented', () => {
+    const handler = jest.fn();
+
+    expect(() =>
+      wrapEventHandler(handler, ['keydown:Enter'])({
+        type: 'keydown',
+        key: 'Enter',
+      }),
+    ).not.toThrow();
+
+    expect(handler).toHaveBeenCalled();
+  });
 });

--- a/packages/twenty-front-component-renderer/src/host/events/utils/__tests__/wrapEventHandler.test.ts
+++ b/packages/twenty-front-component-renderer/src/host/events/utils/__tests__/wrapEventHandler.test.ts
@@ -24,7 +24,11 @@ describe('wrapEventHandler', () => {
   it('should leave the default alone when no rule is given', () => {
     const preventDefault = jest.fn();
 
-    wrapEventHandler(jest.fn())({ type: 'keydown', key: 'Enter', preventDefault });
+    wrapEventHandler(jest.fn())({
+      type: 'keydown',
+      key: 'Enter',
+      preventDefault,
+    });
 
     expect(preventDefault).not.toHaveBeenCalled();
   });

--- a/packages/twenty-front-component-renderer/src/host/events/utils/matchesPreventDefaultRule.ts
+++ b/packages/twenty-front-component-renderer/src/host/events/utils/matchesPreventDefaultRule.ts
@@ -1,0 +1,58 @@
+const MODIFIER_FLAGS = ['alt', 'ctrl', 'meta', 'shift'] as const;
+
+type ModifierFlag = (typeof MODIFIER_FLAGS)[number];
+
+type EventLike = {
+  type?: unknown;
+  key?: unknown;
+  altKey?: unknown;
+  ctrlKey?: unknown;
+  metaKey?: unknown;
+  shiftKey?: unknown;
+};
+
+const isHeld = (event: EventLike, modifier: ModifierFlag): boolean =>
+  event[`${modifier}Key` as keyof EventLike] === true;
+
+/**
+ * Does `rule` describe this event?
+ *
+ * A rule is `<type>` or `<type>:<combo>`, where the combo is a `key` value
+ * optionally prefixed with modifiers — `submit`, `keydown:Enter`,
+ * `keydown:Shift+Enter`. Modifier order does not matter, and the match on them
+ * is exact: `keydown:Enter` is plain Enter and does not fire for Shift+Enter,
+ * which is what lets a composer send on one and insert a newline on the other.
+ */
+export const matchesPreventDefaultRule = (
+  rule: string,
+  event: EventLike,
+): boolean => {
+  const separatorIndex = rule.indexOf(':');
+  const type = separatorIndex === -1 ? rule : rule.slice(0, separatorIndex);
+
+  if (type !== event.type) {
+    return false;
+  }
+
+  if (separatorIndex === -1) {
+    return true;
+  }
+
+  const parts = rule
+    .slice(separatorIndex + 1)
+    .split('+')
+    .map((part) => part.trim())
+    .filter((part) => part !== '');
+
+  const key = parts.pop();
+
+  if (key === undefined || key !== event.key) {
+    return false;
+  }
+
+  const required = new Set(parts.map((part) => part.toLowerCase()));
+
+  return MODIFIER_FLAGS.every(
+    (modifier) => required.has(modifier) === isHeld(event, modifier),
+  );
+};

--- a/packages/twenty-front-component-renderer/src/host/events/utils/wrapEventHandler.ts
+++ b/packages/twenty-front-component-renderer/src/host/events/utils/wrapEventHandler.ts
@@ -1,8 +1,35 @@
+import { matchesPreventDefaultRule } from '@/host/events/utils/matchesPreventDefaultRule';
 import { serializeEvent } from '@/host/events/utils/serializeEvent';
 import { type SerializedEventData } from '@/types/SerializedEventData';
 
+type PreventableEvent = { preventDefault?: () => void };
+
+/**
+ * A front component's handler runs on the other side of the thread boundary, so
+ * the event it receives is serialized data and not the event itself. Calling
+ * `preventDefault()` there reaches nothing: by then the host has returned and
+ * the browser has already run the default action.
+ *
+ * `preventDefaultOn` closes that gap declaratively. The rules travel with the
+ * element, the host reads them synchronously while it still holds the real
+ * event, and the guest keeps saying what it wants rather than how to get it.
+ */
 export const wrapEventHandler =
-  (handler: (detail: SerializedEventData) => void) =>
+  (
+    handler: (detail: SerializedEventData) => void,
+    preventDefaultRules?: readonly string[],
+  ) =>
   (event: unknown): void => {
-    handler(serializeEvent(event));
+    const detail = serializeEvent(event);
+
+    if (
+      preventDefaultRules !== undefined &&
+      preventDefaultRules.some((rule) =>
+        matchesPreventDefaultRule(rule, detail),
+      )
+    ) {
+      (event as PreventableEvent)?.preventDefault?.();
+    }
+
+    handler(detail);
   };


### PR DESCRIPTION
Closes #25838

### `preventDefault()` cannot work inside a front component

A front component's handlers run on the other side of the thread boundary. `wrapEventHandler`
serializes the event and forwards the data:

```ts
export const wrapEventHandler =
  (handler: (detail: SerializedEventData) => void) =>
  (event: unknown): void => {
    handler(serializeEvent(event));
  };
```

The event itself never crosses, and by the time the guest's handler runs the host has returned and
the browser has performed the default action. So `preventDefault()` in a front component is a no-op
by construction — not a bug in any one call site.

### Why it is easy to misread as an app bug

A composer that sends on Enter looks correct from the guest's side:

```tsx
onKeyDown={(event) => {
  if (event.key === 'Enter' && !event.shiftKey) {
    event.preventDefault();
    submit();          // sends, then setDraft('')
  }
}}
```

What actually happens, measured on a real app:

- the message is sent, once — no duplicate;
- the newline is inserted anyway, against the DOM value from *before* React cleared the draft;
- the textarea is left holding the sent text plus `\n`, while React's state is `''`;
- because the state did not change, there is no re-render to correct the DOM.

The trailing `\n` is what identifies the cause. And it does not stay cosmetic: the next keystroke
hands `onChange` the whole textarea contents, so the following message goes out with the previous
one prepended — visible to the recipient.

```
left in the box:        "hola\n"
what onChange then sees: "hola\nnext message"
```

Clicking the send button is unaffected, which is what makes the report confusing when it arrives:
the same component clears correctly by mouse and not by keyboard.

### The shape of the fix

The default has to be prevented while the host still holds the event, so the guest can only declare
intent, never act on it. `preventDefaultOn` travels with the element and is read synchronously:

```tsx
<textarea onKeyDown={send} preventDefaultOn={['keydown:Enter']} />
```

A rule is `<type>` or `<type>:<combo>` — `submit`, `keydown:Enter`, `keydown:Shift+Enter`.
Modifiers are matched as an exact set, so `keydown:Enter` does not fire for Shift+Enter; that is
what lets a composer send on one and insert a newline on the other. Order and casing of modifiers
do not matter.

The prop is instruction for the host rather than an attribute, so it is filtered out of the DOM
props, and an element that does not use it behaves exactly as before.

### Tests

`matchesPreventDefaultRule` covers type-only rules, key rules, the exact-modifier semantics and the
ordering/casing; `wrapEventHandler` covers that the default is left alone without rules, prevented
before the handler runs with a matching one, untouched by a non-matching one, and that a
non-preventable event does not throw. The prop builder covers that `preventDefaultOn` is kept out
of the DOM props, reaches the handlers, and is ignored when it is not a list of strings.

Verified red before green: with the two source files reverted, three of the new tests fail and the
25 pre-existing ones still pass.

One caveat on my side: `nx lint` for this package needs `twenty-oxlint-rules/dist`, which I could
not build in my checkout, so the lint gate is unverified — the diff is small and follows the
surrounding style, but I would rather say so than imply it ran.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


