### PR TITLE
Fix create event snapshots after inserts

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/__tests__/workspace-repository.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/__tests__/workspace-repository.spec.ts
@@ -1,0 +1,138 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
+import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
+import { type QueryExecutor } from 'src/engine/twenty-orm/executor/types/query-executor.type';
+import { type WorkspaceTableShape } from 'src/engine/twenty-orm/table-shape/types/workspace-table-shape.type';
+
+describe('WorkspaceRepository', () => {
+  it('should emit create events from the inserted rows when the event snapshot read is empty', async () => {
+    const objectMetadataId = 'company-object-id';
+    const workspaceId = 'workspace-id';
+    const recordId = 'record-id';
+    const fieldIds = ['id-field-id', 'name-field-id'];
+
+    const flatObjectMetadata = {
+      id: objectMetadataId,
+      workspaceId,
+      nameSingular: 'company',
+      namePlural: 'companies',
+      fieldIds,
+      universalIdentifier: objectMetadataId,
+    } as FlatObjectMetadata;
+
+    const idFieldMetadata = {
+      id: fieldIds[0],
+      objectMetadataId,
+      name: 'id',
+      type: FieldMetadataType.UUID,
+      universalIdentifier: fieldIds[0],
+    } as FlatFieldMetadata;
+    const nameFieldMetadata = {
+      id: fieldIds[1],
+      objectMetadataId,
+      name: 'name',
+      type: FieldMetadataType.TEXT,
+      universalIdentifier: fieldIds[1],
+    } as FlatFieldMetadata;
+    const flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata> = {
+      byUniversalIdentifier: {
+        [fieldIds[0]]: idFieldMetadata,
+        [fieldIds[1]]: nameFieldMetadata,
+      },
+      universalIdentifierById: {
+        [fieldIds[0]]: fieldIds[0],
+        [fieldIds[1]]: fieldIds[1],
+      },
+      universalIdentifiersByApplicationId: {},
+    };
+    const flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata> = {
+      byUniversalIdentifier: {
+        [objectMetadataId]: flatObjectMetadata,
+      },
+      universalIdentifierById: {
+        [objectMetadataId]: objectMetadataId,
+      },
+      universalIdentifiersByApplicationId: {},
+    };
+    const tableShape: WorkspaceTableShape = {
+      objectMetadataId,
+      nameSingular: 'company',
+      schemaName: 'workspace_test',
+      tableName: 'company',
+      columnShapeByColumnName: {
+        id: {
+          columnName: 'id',
+          fieldMetadataId: fieldIds[0],
+          fieldName: 'id',
+          fieldMetadataType: FieldMetadataType.UUID,
+        },
+        name: {
+          columnName: 'name',
+          fieldMetadataId: fieldIds[1],
+          fieldName: 'name',
+          fieldMetadataType: FieldMetadataType.TEXT,
+        },
+      },
+      columnNames: ['id', 'name'],
+      relationShapeByFieldName: {},
+      hasDeletedAtColumn: false,
+    };
+    const emitDatabaseBatchEvent = jest.fn();
+    const executor: QueryExecutor = {
+      execute: jest.fn(async (statement) =>
+        statement.text.startsWith('INSERT')
+          ? [{ id: recordId, name: 'Acme' }]
+          : [],
+      ),
+    };
+    let repository: WorkspaceRepository;
+
+    repository = new WorkspaceRepository({
+      tableShape,
+      flatObjectMetadata,
+      internalContext: {
+        workspaceId,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        objectIdByNameSingular: { company: objectMetadataId },
+        eventEmitterService: { emitDatabaseBatchEvent },
+        coreDataSource: { getRepository: jest.fn() },
+      } as unknown as WorkspaceInternalContext,
+      authContext: {} as WorkspaceAuthContext,
+      executor,
+      objectRecordsPermissions: {},
+      shouldBypassPermissionChecks: true,
+      tableShapeByObjectMetadataId: () => tableShape,
+      flatObjectMetadataByObjectMetadataId: () => flatObjectMetadata,
+      getRepositoryForObjectMetadataId: () => repository,
+      isTransactional: false,
+      runInNewTransaction: async () => {
+        throw new Error('Not used in this test');
+      },
+    });
+
+    const insertResult = await repository.runInsert({
+      records: [{ id: recordId, name: 'Acme' }],
+      columnsToReturn: ['id'],
+    });
+
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect(insertResult.raw).toEqual([{ id: recordId }]);
+    expect(emitDatabaseBatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'created',
+        events: [
+          expect.objectContaining({
+            recordId,
+            properties: { after: { id: recordId, name: 'Acme' } },
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
@@ -922,19 +922,33 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
       tableShape: this.options.tableShape,
       columnNames,
       rows,
-      returningColumns: columnsToReturn,
+      returningColumns: this.options.tableShape.columnNames,
     });
 
-    const rawRows = await this.executeRaw<ObjectRecord>(sql, parameters);
+    const insertedRows = await this.executeRaw<ObjectRecord>(sql, parameters);
 
     if (isDefined(filesFieldFileIds)) {
       await this.filesFieldSync.updateFileEntityRecords(filesFieldFileIds);
     }
 
+    const columnsToReturnSet = new Set(columnsToReturn);
+    const rawRows =
+      columnsToReturn.length === 0
+        ? []
+        : insertedRows.map(
+            (record) =>
+              Object.fromEntries(
+                Object.entries(record).filter(([columnName]) =>
+                  columnsToReturnSet.has(columnName),
+                ),
+              ) as ObjectRecord,
+          );
     const generatedMaps = this.formatResult<ObjectRecord[]>(rawRows);
-    const insertedIds = rawRows.map((row) => row.id).filter(isNonEmptyString);
+    const insertedIds = insertedRows
+      .map((row) => row.id)
+      .filter(isNonEmptyString);
 
-    await this.emitCreateEvents(insertedIds);
+    this.emitCreateEvents(this.formatResult<ObjectRecord[]>(insertedRows));
 
     return {
       identifiers: insertedIds.map((id) => ({ id })),
@@ -1134,16 +1148,10 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
     };
   }
 
-  private async emitCreateEvents(insertedIds: string[]): Promise<void> {
-    if (insertedIds.length === 0) {
+  private emitCreateEvents(recordsAfter: ObjectRecord[]): void {
+    if (recordsAfter.length === 0) {
       return;
     }
-
-    const recordsAfter = await this.buildIdsEventSnapshotQueryBuilder(
-      insertedIds,
-    ).getMany<ObjectRecord>({ noFormatting: true });
-
-    const formattedAfter = this.formatResult<ObjectRecord[]>(recordsAfter);
 
     for (const action of [
       DatabaseEventAction.CREATED,
@@ -1155,7 +1163,7 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
         flatFieldMetadataMaps:
           this.options.internalContext.flatFieldMetadataMaps,
         workspaceId: this.options.internalContext.workspaceId,
-        recordsAfter: formattedAfter,
+        recordsAfter,
         authContext: this.options.authContext,
       });
 

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
@@ -931,16 +931,16 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
       await this.filesFieldSync.updateFileEntityRecords(filesFieldFileIds);
     }
 
-    const columnsToReturnSet = new Set(columnsToReturn);
     const rawRows =
       columnsToReturn.length === 0
         ? []
         : insertedRows.map(
             (record) =>
               Object.fromEntries(
-                Object.entries(record).filter(([columnName]) =>
-                  columnsToReturnSet.has(columnName),
-                ),
+                columnsToReturn.map((columnName) => [
+                  columnName,
+                  record[columnName],
+                ]),
               ) as ObjectRecord,
           );
     const generatedMaps = this.formatResult<ObjectRecord[]>(rawRows);

--- a/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
@@ -1,4 +1,5 @@
 import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
 import { destroyOneOperationFactory } from 'test/integration/graphql/utils/destroy-one-operation-factory.util';
 import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
 import { updateManyOperationFactory } from 'test/integration/graphql/utils/update-many-operation-factory.util';
@@ -26,6 +27,7 @@ const TIMELINE_ACTIVITY_GQL_FIELDS = `
   linkedObjectMetadataId
   targetCompanyId
   targetPersonId
+  targetOpportunityId
   targetNoteId
   targetTaskId
 `;
@@ -41,6 +43,7 @@ type TimelineActivityRow = {
   linkedObjectMetadataId: string | null;
   targetCompanyId: string | null;
   targetPersonId: string | null;
+  targetOpportunityId: string | null;
   targetNoteId: string | null;
   targetTaskId: string | null;
 };
@@ -55,6 +58,27 @@ const createRecord = async ({
   const response = await makeGraphqlAPIRequest(
     createOneOperationFactory({
       objectMetadataSingularName,
+      gqlFields: 'id',
+      data,
+    }),
+  );
+
+  expect(response.body.errors).toBeUndefined();
+};
+
+const createRecords = async ({
+  objectMetadataSingularName,
+  objectMetadataPluralName,
+  data,
+}: {
+  objectMetadataSingularName: string;
+  objectMetadataPluralName: string;
+  data: object[];
+}): Promise<void> => {
+  const response = await makeGraphqlAPIRequest(
+    createManyOperationFactory({
+      objectMetadataSingularName,
+      objectMetadataPluralName,
       gqlFields: 'id',
       data,
     }),
@@ -157,6 +181,7 @@ const timelineActivityTypeIdForOrThrow = (
 };
 
 const NOTE_UNIVERSAL_IDENTIFIER = STANDARD_OBJECTS.note.universalIdentifier;
+const TASK_UNIVERSAL_IDENTIFIER = STANDARD_OBJECTS.task.universalIdentifier;
 const MESSAGE_UNIVERSAL_IDENTIFIER =
   STANDARD_OBJECTS.message.universalIdentifier;
 const CALENDAR_EVENT_UNIVERSAL_IDENTIFIER =
@@ -179,6 +204,11 @@ const ROUTED_CALENDAR_EVENT_PARTICIPANT_ID =
   '20202020-7171-4000-8000-000000000015';
 const ATTACHMENT_ID = '20202020-7171-4000-8000-000000000016';
 const ORM_V2_COMPOSITE_COMPANY_ID = '20202020-7171-4000-8000-000000000017';
+const ACTIVITY_OPPORTUNITY_ID = '20202020-7171-4000-8000-000000000018';
+const ACTIVITY_NOTE_ID = '20202020-7171-4000-8000-000000000019';
+const ACTIVITY_TASK_ID = '20202020-7171-4000-8000-000000000020';
+const ACTIVITY_NOTE_TARGET_ID = '20202020-7171-4000-8000-000000000021';
+const ACTIVITY_TASK_TARGET_ID = '20202020-7171-4000-8000-000000000022';
 const BATCH_COMPANY_IDS = [
   '20202020-7171-4000-8000-000000000008',
   '20202020-7171-4000-8000-000000000009',
@@ -186,6 +216,20 @@ const BATCH_COMPANY_IDS = [
 
 const CREATED_RECORD_IDS: { objectMetadataSingularName: string; id: string }[] =
   [
+    {
+      objectMetadataSingularName: 'taskTarget',
+      id: ACTIVITY_TASK_TARGET_ID,
+    },
+    {
+      objectMetadataSingularName: 'noteTarget',
+      id: ACTIVITY_NOTE_TARGET_ID,
+    },
+    { objectMetadataSingularName: 'task', id: ACTIVITY_TASK_ID },
+    { objectMetadataSingularName: 'note', id: ACTIVITY_NOTE_ID },
+    {
+      objectMetadataSingularName: 'opportunity',
+      id: ACTIVITY_OPPORTUNITY_ID,
+    },
     { objectMetadataSingularName: 'attachment', id: ATTACHMENT_ID },
     {
       objectMetadataSingularName: 'calendarEventParticipant',
@@ -581,6 +625,92 @@ describe('timeline activity write path (integration)', () => {
 
       expect(timelineActivities).toHaveLength(1);
       expect(timelineActivities[0].linkedRecordId).toBe(NOTE_ID);
+    });
+  });
+
+  describe('activities linked to an opportunity', () => {
+    it('should emit activity own and linked events through createMany targets', async () => {
+      await createRecord({
+        objectMetadataSingularName: 'opportunity',
+        data: {
+          id: ACTIVITY_OPPORTUNITY_ID,
+          name: 'Activity target opportunity',
+        },
+      });
+      await createRecord({
+        objectMetadataSingularName: 'note',
+        data: { id: ACTIVITY_NOTE_ID, title: 'Opportunity note' },
+      });
+      await createRecord({
+        objectMetadataSingularName: 'task',
+        data: { id: ACTIVITY_TASK_ID, title: 'Opportunity task' },
+      });
+
+      await createRecords({
+        objectMetadataSingularName: 'noteTarget',
+        objectMetadataPluralName: 'noteTargets',
+        data: [
+          {
+            id: ACTIVITY_NOTE_TARGET_ID,
+            noteId: ACTIVITY_NOTE_ID,
+            targetOpportunityId: ACTIVITY_OPPORTUNITY_ID,
+          },
+        ],
+      });
+      await createRecords({
+        objectMetadataSingularName: 'taskTarget',
+        objectMetadataPluralName: 'taskTargets',
+        data: [
+          {
+            id: ACTIVITY_TASK_TARGET_ID,
+            taskId: ACTIVITY_TASK_ID,
+            targetOpportunityId: ACTIVITY_OPPORTUNITY_ID,
+          },
+        ],
+      });
+
+      const activityCases = [
+        {
+          activityId: ACTIVITY_NOTE_ID,
+          activityUniversalIdentifier: NOTE_UNIVERSAL_IDENTIFIER,
+          targetFieldName: 'targetNoteId',
+        },
+        {
+          activityId: ACTIVITY_TASK_ID,
+          activityUniversalIdentifier: TASK_UNIVERSAL_IDENTIFIER,
+          targetFieldName: 'targetTaskId',
+        },
+      ];
+
+      for (const {
+        activityId,
+        activityUniversalIdentifier,
+        targetFieldName,
+      } of activityCases) {
+        const ownTimelineActivities = await findTimelineActivities({
+          [targetFieldName]: { eq: activityId },
+          timelineActivityTypeId: {
+            eq: timelineActivityTypeIdForOrThrow('created'),
+          },
+        });
+
+        expect(ownTimelineActivities).toHaveLength(1);
+
+        const opportunityTimelineActivities = await findTimelineActivities({
+          targetOpportunityId: { eq: ACTIVITY_OPPORTUNITY_ID },
+          timelineActivityTypeId: {
+            eq: timelineActivityTypeIdForOrThrow(
+              'linked',
+              activityUniversalIdentifier,
+            ),
+          },
+        });
+
+        expect(opportunityTimelineActivities).toHaveLength(1);
+        expect(opportunityTimelineActivities[0].linkedRecordId).toBe(
+          activityId,
+        );
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- emit ORM create events from the rows returned by INSERT rather than a follow-up SELECT
- preserve the caller-requested insert result shape while returning all physical columns internally for the event snapshot
- cover note and task creation linked to an opportunity through createMany targets, matching the UI write path

## Reproduction and root cause

The opportunity UI reproduced the missing note/task timeline activity. On main, the existing timeline integration suite passed all 13 cases because local PostgreSQL returned the immediate post-insert SELECT consistently. A new repository regression test simulates that SELECT returning no rows after a successful insert; it failed on main because no CREATED or UPSERTED event was emitted.

The immediate post-insert re-select predates ORM v2: the legacy TypeORM WorkspaceInsertQueryBuilder used the same pattern, and #24145 intentionally carried it forward when create/upsert moved to the v2 write path. The migration did not introduce the underlying failure mechanism. Using INSERT RETURNING as the event after-image removes this inherited consistency window and one database round trip.

## Verification

- repository regression test: 1 passed
- timeline write-path integration suite: 14 passed
- twenty-server direct typecheck: passed
- targeted type-aware oxlint: passed
- targeted oxfmt check: passed
- git diff check: passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
