### PR TITLE
fix(last-contact): scope app record permissions

### DIFF
--- a/packages/twenty-apps/public/last-contact/CHANGELOG.md
+++ b/packages/twenty-apps/public/last-contact/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Limit the app role to reading synced messages, calendar events, and their participants, and to reading and updating people, companies, and opportunities. The app no longer requests read and edit access to every record type.
+
 ## 1.2.3
 
 - Rework the last-contact backfill into a single fan-out instead of a logic function that called its own HTTP route in a loop with blocking sleeps. On install it counts people, opportunities and companies and enqueues one job per record batch via `enqueueJob`. Each job receives its batch id and processes the matching record window (offset pagination). Jobs are staggered with `delayMs` to stay under the hosted API rate limiting.

--- a/packages/twenty-apps/public/last-contact/CHANGELOG.md
+++ b/packages/twenty-apps/public/last-contact/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.2.4
 
 - Limit the app role to reading synced messages, calendar events, and their participants, and to reading and updating people, companies, and opportunities. The app no longer requests read and edit access to every record type.
 

--- a/packages/twenty-apps/public/last-contact/package.json
+++ b/packages/twenty-apps/public/last-contact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/last-contact",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/public/last-contact/src/__tests__/default-role.test.ts
+++ b/packages/twenty-apps/public/last-contact/src/__tests__/default-role.test.ts
@@ -1,0 +1,55 @@
+import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
+import { describe, expect, it } from 'vitest';
+
+import defaultRole from 'src/default-role';
+
+const permissionFor = (objectUniversalIdentifier: string) =>
+  defaultRole.config?.objectPermissions?.find(
+    (permission) =>
+      permission.objectUniversalIdentifier === objectUniversalIdentifier,
+  );
+
+describe('default role', () => {
+  it('only grants write access to the CRM records with last-contact fields', () => {
+    expect(defaultRole.success).toBe(true);
+    expect(defaultRole.config).toMatchObject({
+      canReadAllObjectRecords: false,
+      canUpdateAllObjectRecords: false,
+      canSoftDeleteAllObjectRecords: false,
+      canDestroyAllObjectRecords: false,
+    });
+
+    for (const objectUniversalIdentifier of [
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person.universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.company.universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.opportunity.universalIdentifier,
+    ]) {
+      expect(permissionFor(objectUniversalIdentifier)).toMatchObject({
+        canReadObjectRecords: true,
+        canUpdateObjectRecords: true,
+        canSoftDeleteObjectRecords: false,
+        canDestroyObjectRecords: false,
+      });
+    }
+  });
+
+  it('keeps interaction source records read-only', () => {
+    for (const objectUniversalIdentifier of [
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.message.universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.messageParticipant
+        .universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.calendarEvent.universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.calendarEventParticipant
+        .universalIdentifier,
+    ]) {
+      expect(permissionFor(objectUniversalIdentifier)).toMatchObject({
+        canReadObjectRecords: true,
+        canUpdateObjectRecords: false,
+        canSoftDeleteObjectRecords: false,
+        canDestroyObjectRecords: false,
+      });
+    }
+
+    expect(defaultRole.config?.objectPermissions).toHaveLength(7);
+  });
+});

--- a/packages/twenty-apps/public/last-contact/src/default-role.ts
+++ b/packages/twenty-apps/public/last-contact/src/default-role.ts
@@ -1,4 +1,7 @@
-import { defineApplicationRole } from 'twenty-sdk/define';
+import {
+  defineApplicationRole,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
+} from 'twenty-sdk/define';
 
 import {
   APP_DISPLAY_NAME,
@@ -7,10 +10,44 @@ import {
 
 export default defineApplicationRole({
   universalIdentifier: DEFAULT_ROLE_UNIVERSAL_IDENTIFIER,
-  label: `${APP_DISPLAY_NAME} default function role`,
-  description: `${APP_DISPLAY_NAME} default function role`,
-  canReadAllObjectRecords: true,
-  canUpdateAllObjectRecords: true,
+  label: `${APP_DISPLAY_NAME} function role`,
+  description:
+    'Reads synced email and calendar interactions, then updates last-contact fields on people, companies, and opportunities.',
+  canReadAllObjectRecords: false,
+  canUpdateAllObjectRecords: false,
   canSoftDeleteAllObjectRecords: false,
   canDestroyAllObjectRecords: false,
+  canUpdateAllSettings: false,
+  canBeAssignedToAgents: false,
+  canBeAssignedToUsers: false,
+  canBeAssignedToApiKeys: false,
+  objectPermissions: [
+    ...[
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person.universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.company.universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.opportunity.universalIdentifier,
+    ].map((objectUniversalIdentifier) => ({
+      objectUniversalIdentifier,
+      canReadObjectRecords: true,
+      canUpdateObjectRecords: true,
+      canSoftDeleteObjectRecords: false,
+      canDestroyObjectRecords: false,
+    })),
+    ...[
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.message.universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.messageParticipant
+        .universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.calendarEvent.universalIdentifier,
+      STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.calendarEventParticipant
+        .universalIdentifier,
+    ].map((objectUniversalIdentifier) => ({
+      objectUniversalIdentifier,
+      canReadObjectRecords: true,
+      canUpdateObjectRecords: false,
+      canSoftDeleteObjectRecords: false,
+      canDestroyObjectRecords: false,
+    })),
+  ],
+  fieldPermissions: [],
+  permissionFlagUniversalIdentifiers: [],
 });


### PR DESCRIPTION
### Motivation

- The Last Contact app previously granted broad read/update access via its default role which is more permissive than needed for its behavior; the intent is to adopt least-privilege so the app only touches the record types it manages.
- Constrain the runtime role so logic functions and agents can read interaction source records (messages/calendar events) but only read/update the CRM records that hold last-contact fields (people, companies, opportunities). 

### Description

- Narrowed the default application role in `src/default-role.ts` to disable global `canReadAllObjectRecords`/`canUpdateAllObjectRecords` and replaced them with explicit `objectPermissions` for only People, Company, Opportunity (read+write) and for Message, MessageParticipant, CalendarEvent, CalendarEventParticipant (read-only). 
- Adjusted the role label/description and turned off settings, delete/destroy capabilities, and assignment flags for the function role. 
- Added a unit test `src/__tests__/default-role.test.ts` that asserts the role enables only the intended object permissions and keeps interaction sources read-only. 
- Bumped the Last Contact app to `1.2.4` and documented the permission change in the package `CHANGELOG.md`. 

### Testing

- `yarn lint` run in `packages/twenty-apps/public/last-contact` completed with no warnings or errors. 
- `yarn typecheck` run in the package completed successfully. 
- `yarn test:unit` run in the package passed (unit suite reported all tests green: 12 files, 40 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d983914bc832fbfa2621e61d88b14)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

