### PR TITLE
feat(settings): edit the object default layout from the data model page

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -22,6 +22,8 @@ import { FieldMetadataType, SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import {
   IconChevronRight,
+  IconEyeOff,
+  IconGripVertical,
   IconMinus,
   IconPlus,
   useIcons,
@@ -40,6 +42,9 @@ type SettingsObjectFieldItemTableRowProps = {
   status: 'active' | 'disabled';
   mode: 'view' | 'new-field';
   isMostlyEmpty?: boolean;
+  showDragGrip?: boolean;
+  isVisibleInLayout?: boolean;
+  onToggleVisibility?: () => void;
 };
 
 export const OBJECT_FIELD_TABLE_ROW_GRID_TEMPLATE_COLUMNS =
@@ -65,11 +70,36 @@ const StyledIconChevronRightContainer = styled.span`
   display: flex;
 `;
 
+const StyledGripContainer = styled.span`
+  align-items: center;
+  color: ${themeCssVariables.font.color.extraLight};
+  cursor: grab;
+  display: flex;
+`;
+
+const StyledRowWrapper = styled.div`
+  .settings-field-visibility-toggle {
+    opacity: 0;
+  }
+
+  &:hover .settings-field-visibility-toggle {
+    opacity: 1;
+  }
+`;
+
+const StyledVisibilityToggleContainer = styled.span`
+  align-items: center;
+  display: flex;
+`;
+
 export const SettingsObjectFieldItemTableRow = ({
   settingsObjectDetailTableItem,
   mode,
   status,
   isMostlyEmpty = false,
+  showDragGrip = false,
+  isVisibleInLayout = true,
+  onToggleVisibility,
 }: SettingsObjectFieldItemTableRowProps) => {
   const { theme } = useContext(ThemeContext);
   const { t } = useLingui();
@@ -134,6 +164,14 @@ export const SettingsObjectFieldItemTableRow = ({
     { objectMetadataItemId: objectMetadataItem.id },
   );
 
+  const handleToggleVisibility = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.stopPropagation();
+    event.preventDefault();
+    onToggleVisibility?.();
+  };
+
   const handleToggleField = () => {
     setSettingsObjectFields((previousFields) => {
       const newFields = isDefined(previousFields)
@@ -167,125 +205,155 @@ export const SettingsObjectFieldItemTableRow = ({
       : relationObjectMetadataItem?.labelPlural;
 
   return (
-    <TableRow
-      gridTemplateColumns={OBJECT_FIELD_TABLE_ROW_GRID_TEMPLATE_COLUMNS}
-      onClick={mode === 'view' ? navigateToFieldEdit : undefined}
-    >
-      <UndecoratedLink to={linkToNavigate}>
-        <TableCell
-          color={themeCssVariables.font.color.primary}
-          gap={themeCssVariables.spacing[2]}
-        >
-          {isDefined(Icon) && (
-            <Icon
-              style={{
-                minWidth: theme.icon.size.md,
-              }}
-              size={theme.icon.size.md}
-              stroke={theme.icon.stroke.sm}
-            />
-          )}
-          <StyledNameContainer>
-            <StyledNameLabel title={fieldMetadataItem.label}>
-              {fieldMetadataItem.label}
-            </StyledNameLabel>
-            {!fieldMetadataItem.isActive && (
-              <SettingsNameCellSecondaryLabel>
-                {t`Deactivated`}
-              </SettingsNameCellSecondaryLabel>
-            )}
-            {fieldMetadataItem.isActive && isMostlyEmpty && (
-              <>
-                <SettingsNameCellSecondaryLabel id={mostlyEmptyLabelId}>
-                  {t`Mostly empty`}
-                </SettingsNameCellSecondaryLabel>
-                <AppTooltip
-                  anchorSelect={`#${mostlyEmptyLabelId}`}
-                  content={t`Appears filled in fewer than 5% of ${objectMetadataItem.labelPlural}. Fields that stay empty can be deactivated.`}
-                  delay={TooltipDelay.shortDelay}
-                />
-              </>
-            )}
-          </StyledNameContainer>
-        </TableCell>
-      </UndecoratedLink>
-
-      <TableCell>
-        <SettingsItemTypeTag
-          item={{
-            applicationId: fieldMetadataItem.applicationId,
-          }}
-        />
-      </TableCell>
-      <TableCell>
-        <SettingsObjectFieldDataType
-          Icon={RelationIcon}
-          label={label}
-          labelDetail={
-            fieldMetadataItem.settings?.type === 'percentage' ? '%' : undefined
-          }
-          to={
-            isRelatedObjectLinkable
-              ? getSettingsPath(SettingsPath.Objects, {
-                  objectNamePlural: relationObjectMetadataItem.namePlural,
-                })
-              : undefined
-          }
-          value={fieldType}
-          onClick={(e) => {
-            if (isRelatedObjectLinkable) {
-              e.stopPropagation();
-            }
-          }}
-        />
-      </TableCell>
-      <TableCell
-        align="center"
-        padding={`0 ${themeCssVariables.spacing[1]} 0 ${themeCssVariables.spacing[2]}`}
+    <StyledRowWrapper>
+      <TableRow
+        gridTemplateColumns={OBJECT_FIELD_TABLE_ROW_GRID_TEMPLATE_COLUMNS}
+        onClick={mode === 'view' ? navigateToFieldEdit : undefined}
       >
-        {status === 'active' ? (
-          mode === 'view' ? (
-            <UndecoratedLink to={linkToNavigate}>
-              <StyledIconChevronRightContainer>
-                <IconChevronRight
+        <UndecoratedLink to={linkToNavigate}>
+          <TableCell
+            color={themeCssVariables.font.color.primary}
+            gap={themeCssVariables.spacing[2]}
+          >
+            {showDragGrip && (
+              <StyledGripContainer>
+                <IconGripVertical
                   size={theme.icon.size.md}
                   stroke={theme.icon.stroke.sm}
                 />
-              </StyledIconChevronRightContainer>
-            </UndecoratedLink>
-          ) : (
-            canToggleField && (
-              <LightIconButton
-                Icon={IconMinus}
-                accent="tertiary"
-                onClick={handleToggleField}
+              </StyledGripContainer>
+            )}
+            {isDefined(Icon) && (
+              <Icon
+                style={{
+                  minWidth: theme.icon.size.md,
+                }}
+                size={theme.icon.size.md}
+                stroke={theme.icon.stroke.sm}
               />
+            )}
+            <StyledNameContainer>
+              <StyledNameLabel title={fieldMetadataItem.label}>
+                {fieldMetadataItem.label}
+              </StyledNameLabel>
+              {!fieldMetadataItem.isActive && (
+                <SettingsNameCellSecondaryLabel>
+                  {t`Deactivated`}
+                </SettingsNameCellSecondaryLabel>
+              )}
+              {fieldMetadataItem.isActive && isMostlyEmpty && (
+                <>
+                  <SettingsNameCellSecondaryLabel id={mostlyEmptyLabelId}>
+                    {t`Mostly empty`}
+                  </SettingsNameCellSecondaryLabel>
+                  <AppTooltip
+                    anchorSelect={`#${mostlyEmptyLabelId}`}
+                    content={t`Appears filled in fewer than 5% of ${objectMetadataItem.labelPlural}. Fields that stay empty can be deactivated.`}
+                    delay={TooltipDelay.shortDelay}
+                  />
+                </>
+              )}
+              {isDefined(onToggleVisibility) && canToggleField && (
+                <StyledVisibilityToggleContainer
+                  className={
+                    isVisibleInLayout
+                      ? 'settings-field-visibility-toggle'
+                      : undefined
+                  }
+                >
+                  <LightIconButton
+                    Icon={IconEyeOff}
+                    accent={isVisibleInLayout ? 'tertiary' : 'secondary'}
+                    onClick={handleToggleVisibility}
+                  />
+                </StyledVisibilityToggleContainer>
+              )}
+            </StyledNameContainer>
+          </TableCell>
+        </UndecoratedLink>
+
+        <TableCell>
+          <SettingsItemTypeTag
+            item={{
+              applicationId: fieldMetadataItem.applicationId,
+            }}
+          />
+        </TableCell>
+        <TableCell>
+          <SettingsObjectFieldDataType
+            Icon={RelationIcon}
+            label={label}
+            labelDetail={
+              fieldMetadataItem.settings?.type === 'percentage'
+                ? '%'
+                : undefined
+            }
+            to={
+              isRelatedObjectLinkable
+                ? getSettingsPath(SettingsPath.Objects, {
+                    objectNamePlural: relationObjectMetadataItem.namePlural,
+                  })
+                : undefined
+            }
+            value={fieldType}
+            onClick={(e) => {
+              if (isRelatedObjectLinkable) {
+                e.stopPropagation();
+              }
+            }}
+          />
+        </TableCell>
+        <TableCell
+          align="center"
+          padding={`0 ${themeCssVariables.spacing[1]} 0 ${themeCssVariables.spacing[2]}`}
+        >
+          {status === 'active' ? (
+            mode === 'view' ? (
+              <UndecoratedLink to={linkToNavigate}>
+                <StyledIconChevronRightContainer>
+                  <IconChevronRight
+                    size={theme.icon.size.md}
+                    stroke={theme.icon.stroke.sm}
+                  />
+                </StyledIconChevronRightContainer>
+              </UndecoratedLink>
+            ) : (
+              canToggleField && (
+                <LightIconButton
+                  Icon={IconMinus}
+                  accent="tertiary"
+                  onClick={handleToggleField}
+                />
+              )
             )
-          )
-        ) : mode === 'view' ? (
-          <SettingsObjectFieldInactiveActionDropdown
-            isCustomField={getIsMetadataItemCustom(fieldMetadataItem)}
-            isSystemField={fieldMetadataItem.isSystem === true}
-            readonly={readonly}
-            fieldMetadataItemId={fieldMetadataItem.id}
-            onEdit={navigateToFieldEdit}
-            onActivate={() =>
-              activateMetadataField(fieldMetadataItem.id, objectMetadataItem.id)
-            }
-            onDelete={() =>
-              deleteOneFieldMetadataItem({
-                idToDelete: fieldMetadataItem.id,
-              })
-            }
-          />
-        ) : (
-          <LightIconButton
-            Icon={IconPlus}
-            accent="tertiary"
-            onClick={handleToggleField}
-          />
-        )}
-      </TableCell>
-    </TableRow>
+          ) : mode === 'view' ? (
+            <SettingsObjectFieldInactiveActionDropdown
+              isCustomField={getIsMetadataItemCustom(fieldMetadataItem)}
+              isSystemField={fieldMetadataItem.isSystem === true}
+              readonly={readonly}
+              fieldMetadataItemId={fieldMetadataItem.id}
+              onEdit={navigateToFieldEdit}
+              onActivate={() =>
+                activateMetadataField(
+                  fieldMetadataItem.id,
+                  objectMetadataItem.id,
+                )
+              }
+              onDelete={() =>
+                deleteOneFieldMetadataItem({
+                  idToDelete: fieldMetadataItem.id,
+                })
+              }
+            />
+          ) : (
+            <LightIconButton
+              Icon={IconPlus}
+              accent="tertiary"
+              onClick={handleToggleField}
+            />
+          )}
+        </TableCell>
+      </TableRow>
+    </StyledRowWrapper>
   );
 };

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -19,6 +19,7 @@ import { useLingui } from '@lingui/react/macro';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomFamilyState } from '@/ui/utilities/state/jotai/hooks/useSetAtomFamilyState';
 import { FieldMetadataType, SettingsPath } from 'twenty-shared/types';
+import { DragDropItemSortableHandle } from '@/ui/utilities/drag-and-drop/components/DragDropItemSortableHandle';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import {
   IconChevronRight,
@@ -216,12 +217,14 @@ export const SettingsObjectFieldItemTableRow = ({
             gap={themeCssVariables.spacing[2]}
           >
             {showDragGrip && (
-              <StyledGripContainer>
-                <IconGripVertical
-                  size={theme.icon.size.md}
-                  stroke={theme.icon.stroke.sm}
-                />
-              </StyledGripContainer>
+              <DragDropItemSortableHandle>
+                <StyledGripContainer>
+                  <IconGripVertical
+                    size={theme.icon.size.md}
+                    stroke={theme.icon.stroke.sm}
+                  />
+                </StyledGripContainer>
+              </DragDropItemSortableHandle>
             )}
             {isDefined(Icon) && (
               <Icon

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -78,19 +78,18 @@ const StyledGripContainer = styled.span`
   display: flex;
 `;
 
-const StyledRowWrapper = styled.div`
-  .settings-field-visibility-toggle {
-    opacity: 0;
-  }
-
-  &:hover .settings-field-visibility-toggle {
-    opacity: 1;
-  }
-`;
-
-const StyledVisibilityToggleContainer = styled.span`
+const StyledVisibilityToggleContainer = styled.span<{
+  isAlwaysShown: boolean;
+}>`
   align-items: center;
   display: flex;
+  opacity: ${({ isAlwaysShown }) => (isAlwaysShown ? 1 : 0)};
+`;
+
+const StyledRowWrapper = styled.div`
+  &:hover ${StyledVisibilityToggleContainer} {
+    opacity: 1;
+  }
 `;
 
 export const SettingsObjectFieldItemTableRow = ({
@@ -258,11 +257,7 @@ export const SettingsObjectFieldItemTableRow = ({
               )}
               {isDefined(onToggleVisibility) && canToggleField && (
                 <StyledVisibilityToggleContainer
-                  className={
-                    isVisibleInLayout
-                      ? 'settings-field-visibility-toggle'
-                      : undefined
-                  }
+                  isAlwaysShown={!isVisibleInLayout}
                 >
                   <LightIconButton
                     Icon={IconEyeOff}

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -43,6 +43,7 @@ type SettingsObjectFieldItemTableRowProps = {
   status: 'active' | 'disabled';
   mode: 'view' | 'new-field';
   isMostlyEmpty?: boolean;
+  hasDragGripGutter?: boolean;
   showDragGrip?: boolean;
   isVisibleInLayout?: boolean;
   onToggleVisibility?: () => void;
@@ -78,6 +79,11 @@ const StyledGripContainer = styled.span`
   display: flex;
 `;
 
+const StyledGripGutter = styled.span<{ gutterWidth: number }>`
+  display: flex;
+  min-width: ${({ gutterWidth }) => `${gutterWidth}px`};
+`;
+
 const StyledVisibilityToggleContainer = styled.span<{
   isAlwaysShown: boolean;
 }>`
@@ -97,6 +103,7 @@ export const SettingsObjectFieldItemTableRow = ({
   mode,
   status,
   isMostlyEmpty = false,
+  hasDragGripGutter = false,
   showDragGrip = false,
   isVisibleInLayout = true,
   onToggleVisibility,
@@ -215,15 +222,19 @@ export const SettingsObjectFieldItemTableRow = ({
             color={themeCssVariables.font.color.primary}
             gap={themeCssVariables.spacing[2]}
           >
-            {showDragGrip && (
-              <DragDropItemSortableHandle>
-                <StyledGripContainer>
-                  <IconGripVertical
-                    size={theme.icon.size.md}
-                    stroke={theme.icon.stroke.sm}
-                  />
-                </StyledGripContainer>
-              </DragDropItemSortableHandle>
+            {hasDragGripGutter && (
+              <StyledGripGutter gutterWidth={theme.icon.size.md}>
+                {showDragGrip && (
+                  <DragDropItemSortableHandle>
+                    <StyledGripContainer>
+                      <IconGripVertical
+                        size={theme.icon.size.md}
+                        stroke={theme.icon.stroke.sm}
+                      />
+                    </StyledGripContainer>
+                  </DragDropItemSortableHandle>
+                )}
+              </StyledGripGutter>
             )}
             {isDefined(Icon) && (
               <Icon

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/hooks/useDefaultViewFieldsLayout.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/hooks/useDefaultViewFieldsLayout.ts
@@ -2,19 +2,20 @@ import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/Enriche
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { computeFieldMetadataLayoutPositionUpdates } from '@/settings/data-model/object-details/utils/computeFieldMetadataLayoutPositionUpdates';
 import { sortFieldMetadataItemsByViewLayout } from '@/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout';
+import {
+  settingsObjectFieldsPendingLayoutFamilyState,
+  type PendingViewFieldLayout,
+} from '@/settings/data-model/object-details/states/settingsObjectFieldsPendingLayoutFamilyState';
 import { type DraggableListDropResult } from '@/ui/layout/draggable-list/types/DraggableListDropResult';
 import { usePerformViewFieldAPIPersist } from '@/views/hooks/internal/usePerformViewFieldAPIPersist';
 import { useViewOrDefaultView } from '@/views/hooks/useViewOrDefaultView';
-import { useMemo, useState } from 'react';
+import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
+import { useStore } from 'jotai';
+import { useMemo } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 
 const DEFAULT_CREATED_VIEW_FIELD_SIZE = 100;
-
-type PendingViewFieldLayout = {
-  position?: number;
-  isVisible?: boolean;
-};
 
 type ViewFieldLayoutUpdate = {
   fieldMetadataId: string;
@@ -35,8 +36,43 @@ export const useDefaultViewFieldsLayout = ({
   const { performViewFieldAPICreate, performViewFieldAPIUpdate } =
     usePerformViewFieldAPIPersist();
 
-  const [pendingLayoutByFieldMetadataId, setPendingLayoutByFieldMetadataId] =
-    useState<Map<string, PendingViewFieldLayout>>(new Map());
+  const store = useStore();
+  const pendingLayoutFamilyKey = {
+    objectMetadataItemId: objectMetadataItem.id,
+  };
+  const pendingLayoutAtom =
+    settingsObjectFieldsPendingLayoutFamilyState.atomFamily(
+      pendingLayoutFamilyKey,
+    );
+  const settingsObjectFieldsPendingLayout = useAtomFamilyStateValue(
+    settingsObjectFieldsPendingLayoutFamilyState,
+    pendingLayoutFamilyKey,
+  );
+
+  const applyPendingLayoutUpdates = (
+    layoutUpdates: ViewFieldLayoutUpdate[],
+  ) => {
+    const newPending = new Map(store.get(pendingLayoutAtom));
+
+    for (const { fieldMetadataId, layout } of layoutUpdates) {
+      newPending.set(fieldMetadataId, {
+        ...newPending.get(fieldMetadataId),
+        ...layout,
+      });
+    }
+
+    store.set(pendingLayoutAtom, newPending);
+  };
+
+  const clearPendingLayoutUpdates = (fieldMetadataIds: string[]) => {
+    const newPending = new Map(store.get(pendingLayoutAtom));
+
+    for (const fieldMetadataId of fieldMetadataIds) {
+      newPending.delete(fieldMetadataId);
+    }
+
+    store.set(pendingLayoutAtom, newPending);
+  };
 
   const viewFieldByFieldMetadataId = useMemo(
     () =>
@@ -52,7 +88,7 @@ export const useDefaultViewFieldsLayout = ({
   const getEffectiveLayout = (
     fieldMetadataId: string,
   ): { position: number | null; isVisible: boolean } => {
-    const pending = pendingLayoutByFieldMetadataId.get(fieldMetadataId);
+    const pending = settingsObjectFieldsPendingLayout.get(fieldMetadataId);
     const viewField = viewFieldByFieldMetadataId.get(fieldMetadataId);
 
     return {
@@ -65,7 +101,7 @@ export const useDefaultViewFieldsLayout = ({
     const positions = new Map<string, number>();
 
     for (const field of fieldMetadataItems) {
-      const pending = pendingLayoutByFieldMetadataId.get(field.id);
+      const pending = settingsObjectFieldsPendingLayout.get(field.id);
       const viewField = viewFieldByFieldMetadataId.get(field.id);
       const position = pending?.position ?? viewField?.position;
 
@@ -77,7 +113,7 @@ export const useDefaultViewFieldsLayout = ({
     return positions;
   }, [
     fieldMetadataItems,
-    pendingLayoutByFieldMetadataId,
+    settingsObjectFieldsPendingLayout,
     viewFieldByFieldMetadataId,
   ]);
 
@@ -97,18 +133,12 @@ export const useDefaultViewFieldsLayout = ({
       return;
     }
 
-    setPendingLayoutByFieldMetadataId((previousPending) => {
-      const newPending = new Map(previousPending);
+    applyPendingLayoutUpdates(layoutUpdates);
 
-      for (const { fieldMetadataId, layout } of layoutUpdates) {
-        newPending.set(fieldMetadataId, {
-          ...newPending.get(fieldMetadataId),
-          ...layout,
-        });
-      }
-
-      return newPending;
-    });
+    const lastPosition = Math.max(
+      -1,
+      ...Array.from(positionByFieldMetadataId.values()),
+    );
 
     const viewFieldsToCreate = [];
     const viewFieldsToUpdate = [];
@@ -131,11 +161,6 @@ export const useDefaultViewFieldsLayout = ({
           },
         });
       } else {
-        const lastPosition = Math.max(
-          -1,
-          ...Array.from(positionByFieldMetadataId.values()),
-        );
-
         viewFieldsToCreate.push({
           id: v4(),
           viewId: defaultView.id,
@@ -155,23 +180,20 @@ export const useDefaultViewFieldsLayout = ({
         await performViewFieldAPIUpdate(viewFieldsToUpdate);
       }
     } finally {
-      setPendingLayoutByFieldMetadataId((previousPending) => {
-        const newPending = new Map(previousPending);
-
-        for (const { fieldMetadataId } of layoutUpdates) {
-          newPending.delete(fieldMetadataId);
-        }
-
-        return newPending;
-      });
+      clearPendingLayoutUpdates(
+        layoutUpdates.map(({ fieldMetadataId }) => fieldMetadataId),
+      );
     }
   };
 
   const toggleFieldVisibility = async (fieldMetadataId: string) => {
-    const { isVisible } = getEffectiveLayout(fieldMetadataId);
+    const currentIsVisible =
+      store.get(pendingLayoutAtom).get(fieldMetadataId)?.isVisible ??
+      viewFieldByFieldMetadataId.get(fieldMetadataId)?.isVisible ??
+      false;
 
     await persistLayoutUpdates([
-      { fieldMetadataId, layout: { isVisible: !isVisible } },
+      { fieldMetadataId, layout: { isVisible: !currentIsVisible } },
     ]);
   };
 

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/hooks/useDefaultViewFieldsLayout.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/hooks/useDefaultViewFieldsLayout.ts
@@ -21,14 +21,14 @@ type ViewFieldLayoutUpdate = {
   layout: PendingViewFieldLayout;
 };
 
-export const useIndexViewFieldsLayout = ({
+export const useDefaultViewFieldsLayout = ({
   objectMetadataItem,
   fieldMetadataItems,
 }: {
   objectMetadataItem: EnrichedObjectMetadataItem;
   fieldMetadataItems: FieldMetadataItem[];
 }) => {
-  const { view: indexView } = useViewOrDefaultView({
+  const { view: defaultView } = useViewOrDefaultView({
     objectMetadataItemId: objectMetadataItem.id,
   });
 
@@ -41,12 +41,12 @@ export const useIndexViewFieldsLayout = ({
   const viewFieldByFieldMetadataId = useMemo(
     () =>
       new Map(
-        (indexView?.viewFields ?? []).map((viewField) => [
+        (defaultView?.viewFields ?? []).map((viewField) => [
           viewField.fieldMetadataId,
           viewField,
         ]),
       ),
-    [indexView],
+    [defaultView],
   );
 
   const getEffectiveLayout = (
@@ -93,7 +93,7 @@ export const useIndexViewFieldsLayout = ({
   const persistLayoutUpdates = async (
     layoutUpdates: ViewFieldLayoutUpdate[],
   ) => {
-    if (!isDefined(indexView)) {
+    if (!isDefined(defaultView)) {
       return;
     }
 
@@ -138,7 +138,7 @@ export const useIndexViewFieldsLayout = ({
 
         viewFieldsToCreate.push({
           id: v4(),
-          viewId: indexView.id,
+          viewId: defaultView.id,
           fieldMetadataId,
           position: layout.position ?? lastPosition + 1,
           isVisible: layout.isVisible ?? false,
@@ -270,7 +270,7 @@ export const useIndexViewFieldsLayout = ({
   };
 
   return {
-    hasEditableIndexView: isDefined(indexView),
+    hasEditableDefaultView: isDefined(defaultView),
     layoutOrderedFields,
     getEffectiveLayout,
     toggleFieldVisibility,

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/hooks/useIndexViewFieldsLayout.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/hooks/useIndexViewFieldsLayout.ts
@@ -1,0 +1,279 @@
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { computeFieldMetadataLayoutPositionUpdates } from '@/settings/data-model/object-details/utils/computeFieldMetadataLayoutPositionUpdates';
+import { sortFieldMetadataItemsByViewLayout } from '@/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout';
+import { type DraggableListDropResult } from '@/ui/layout/draggable-list/types/DraggableListDropResult';
+import { usePerformViewFieldAPIPersist } from '@/views/hooks/internal/usePerformViewFieldAPIPersist';
+import { useViewOrDefaultView } from '@/views/hooks/useViewOrDefaultView';
+import { useMemo, useState } from 'react';
+import { isDefined } from 'twenty-shared/utils';
+import { v4 } from 'uuid';
+
+const DEFAULT_CREATED_VIEW_FIELD_SIZE = 100;
+
+type PendingViewFieldLayout = {
+  position?: number;
+  isVisible?: boolean;
+};
+
+type ViewFieldLayoutUpdate = {
+  fieldMetadataId: string;
+  layout: PendingViewFieldLayout;
+};
+
+export const useIndexViewFieldsLayout = ({
+  objectMetadataItem,
+  fieldMetadataItems,
+}: {
+  objectMetadataItem: EnrichedObjectMetadataItem;
+  fieldMetadataItems: FieldMetadataItem[];
+}) => {
+  const { view: indexView } = useViewOrDefaultView({
+    objectMetadataItemId: objectMetadataItem.id,
+  });
+
+  const { performViewFieldAPICreate, performViewFieldAPIUpdate } =
+    usePerformViewFieldAPIPersist();
+
+  const [pendingLayoutByFieldMetadataId, setPendingLayoutByFieldMetadataId] =
+    useState<Map<string, PendingViewFieldLayout>>(new Map());
+
+  const viewFieldByFieldMetadataId = useMemo(
+    () =>
+      new Map(
+        (indexView?.viewFields ?? []).map((viewField) => [
+          viewField.fieldMetadataId,
+          viewField,
+        ]),
+      ),
+    [indexView],
+  );
+
+  const getEffectiveLayout = (
+    fieldMetadataId: string,
+  ): { position: number | null; isVisible: boolean } => {
+    const pending = pendingLayoutByFieldMetadataId.get(fieldMetadataId);
+    const viewField = viewFieldByFieldMetadataId.get(fieldMetadataId);
+
+    return {
+      position: pending?.position ?? viewField?.position ?? null,
+      isVisible: pending?.isVisible ?? viewField?.isVisible ?? false,
+    };
+  };
+
+  const positionByFieldMetadataId = useMemo(() => {
+    const positions = new Map<string, number>();
+
+    for (const field of fieldMetadataItems) {
+      const pending = pendingLayoutByFieldMetadataId.get(field.id);
+      const viewField = viewFieldByFieldMetadataId.get(field.id);
+      const position = pending?.position ?? viewField?.position;
+
+      if (isDefined(position)) {
+        positions.set(field.id, position);
+      }
+    }
+
+    return positions;
+  }, [
+    fieldMetadataItems,
+    pendingLayoutByFieldMetadataId,
+    viewFieldByFieldMetadataId,
+  ]);
+
+  const layoutOrderedFields = useMemo(
+    () =>
+      sortFieldMetadataItemsByViewLayout({
+        fieldMetadataItems,
+        positionByFieldMetadataId,
+      }),
+    [fieldMetadataItems, positionByFieldMetadataId],
+  );
+
+  const persistLayoutUpdates = async (
+    layoutUpdates: ViewFieldLayoutUpdate[],
+  ) => {
+    if (!isDefined(indexView)) {
+      return;
+    }
+
+    setPendingLayoutByFieldMetadataId((previousPending) => {
+      const newPending = new Map(previousPending);
+
+      for (const { fieldMetadataId, layout } of layoutUpdates) {
+        newPending.set(fieldMetadataId, {
+          ...newPending.get(fieldMetadataId),
+          ...layout,
+        });
+      }
+
+      return newPending;
+    });
+
+    const viewFieldsToCreate = [];
+    const viewFieldsToUpdate = [];
+
+    for (const { fieldMetadataId, layout } of layoutUpdates) {
+      const existingViewField = viewFieldByFieldMetadataId.get(fieldMetadataId);
+
+      if (isDefined(existingViewField)) {
+        viewFieldsToUpdate.push({
+          input: {
+            id: existingViewField.id,
+            update: {
+              ...(isDefined(layout.position)
+                ? { position: layout.position }
+                : {}),
+              ...(isDefined(layout.isVisible)
+                ? { isVisible: layout.isVisible }
+                : {}),
+            },
+          },
+        });
+      } else {
+        const lastPosition = Math.max(
+          -1,
+          ...Array.from(positionByFieldMetadataId.values()),
+        );
+
+        viewFieldsToCreate.push({
+          id: v4(),
+          viewId: indexView.id,
+          fieldMetadataId,
+          position: layout.position ?? lastPosition + 1,
+          isVisible: layout.isVisible ?? false,
+          size: DEFAULT_CREATED_VIEW_FIELD_SIZE,
+        });
+      }
+    }
+
+    try {
+      if (viewFieldsToCreate.length > 0) {
+        await performViewFieldAPICreate({ inputs: viewFieldsToCreate });
+      }
+      if (viewFieldsToUpdate.length > 0) {
+        await performViewFieldAPIUpdate(viewFieldsToUpdate);
+      }
+    } finally {
+      setPendingLayoutByFieldMetadataId((previousPending) => {
+        const newPending = new Map(previousPending);
+
+        for (const { fieldMetadataId } of layoutUpdates) {
+          newPending.delete(fieldMetadataId);
+        }
+
+        return newPending;
+      });
+    }
+  };
+
+  const toggleFieldVisibility = async (fieldMetadataId: string) => {
+    const { isVisible } = getEffectiveLayout(fieldMetadataId);
+
+    await persistLayoutUpdates([
+      { fieldMetadataId, layout: { isVisible: !isVisible } },
+    ]);
+  };
+
+  const findPrecedingFieldMetadataId = ({
+    movedFieldMetadataId,
+    destinationIndex,
+    visibleFieldMetadataItems,
+  }: {
+    movedFieldMetadataId: string;
+    destinationIndex: number;
+    visibleFieldMetadataItems: FieldMetadataItem[];
+  }): string | null => {
+    const visibleFieldsWithoutMoved = visibleFieldMetadataItems.filter(
+      (field) => field.id !== movedFieldMetadataId,
+    );
+    const layoutOrderedFieldsWithoutMoved = layoutOrderedFields.filter(
+      (field) => field.id !== movedFieldMetadataId,
+    );
+
+    const nextVisibleField = visibleFieldsWithoutMoved[destinationIndex];
+
+    if (!isDefined(nextVisibleField)) {
+      const lastVisibleField =
+        visibleFieldsWithoutMoved[visibleFieldsWithoutMoved.length - 1];
+
+      return lastVisibleField?.id ?? null;
+    }
+
+    const precedingField =
+      layoutOrderedFieldsWithoutMoved[
+        layoutOrderedFieldsWithoutMoved.findIndex(
+          (field) => field.id === nextVisibleField.id,
+        ) - 1
+      ];
+
+    if (isDefined(precedingField)) {
+      return precedingField.id;
+    }
+
+    const firstLayoutField = layoutOrderedFieldsWithoutMoved[0];
+
+    if (
+      isDefined(firstLayoutField) &&
+      firstLayoutField.id === objectMetadataItem.labelIdentifierFieldMetadataId
+    ) {
+      return firstLayoutField.id;
+    }
+
+    return null;
+  };
+
+  const reorderFieldFromDropResult = async ({
+    dropResult,
+    visibleFieldMetadataItems,
+  }: {
+    dropResult: DraggableListDropResult;
+    visibleFieldMetadataItems: FieldMetadataItem[];
+  }) => {
+    if (!isDefined(dropResult.destination)) {
+      return;
+    }
+
+    const movedFieldMetadataId = dropResult.draggableId;
+
+    if (
+      movedFieldMetadataId === objectMetadataItem.labelIdentifierFieldMetadataId
+    ) {
+      return;
+    }
+
+    const precedingFieldMetadataId = findPrecedingFieldMetadataId({
+      movedFieldMetadataId,
+      destinationIndex: dropResult.destination.index,
+      visibleFieldMetadataItems,
+    });
+
+    const positionUpdates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: layoutOrderedFields.map((field) => ({
+        id: field.id,
+        position: positionByFieldMetadataId.get(field.id) ?? null,
+      })),
+      movedFieldMetadataId,
+      precedingFieldMetadataId,
+    });
+
+    if (positionUpdates.length === 0) {
+      return;
+    }
+
+    await persistLayoutUpdates(
+      positionUpdates.map((update) => ({
+        fieldMetadataId: update.fieldMetadataId,
+        layout: { position: update.position },
+      })),
+    );
+  };
+
+  return {
+    hasEditableIndexView: isDefined(indexView),
+    layoutOrderedFields,
+    getEffectiveLayout,
+    toggleFieldVisibility,
+    reorderFieldFromDropResult,
+  };
+};

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/states/settingsObjectFieldsPendingLayoutFamilyState.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/states/settingsObjectFieldsPendingLayoutFamilyState.ts
@@ -1,0 +1,19 @@
+import { createAtomFamilyState } from '@/ui/utilities/state/jotai/utils/createAtomFamilyState';
+
+export type PendingViewFieldLayout = {
+  position?: number;
+  isVisible?: boolean;
+};
+
+export type SettingsObjectFieldsPendingLayoutFamilyStateKey = {
+  objectMetadataItemId: string;
+};
+
+export const settingsObjectFieldsPendingLayoutFamilyState =
+  createAtomFamilyState<
+    Map<string, PendingViewFieldLayout>,
+    SettingsObjectFieldsPendingLayoutFamilyStateKey
+  >({
+    key: 'settingsObjectFieldsPendingLayoutFamilyState',
+    defaultValue: new Map(),
+  });

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/utils/__tests__/computeFieldMetadataLayoutPositionUpdates.test.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/utils/__tests__/computeFieldMetadataLayoutPositionUpdates.test.ts
@@ -1,0 +1,129 @@
+import { computeFieldMetadataLayoutPositionUpdates } from '@/settings/data-model/object-details/utils/computeFieldMetadataLayoutPositionUpdates';
+
+describe('computeFieldMetadataLayoutPositionUpdates', () => {
+  it('writes a single fractional position between two positioned neighbors', () => {
+    const updates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: [
+        { id: 'a', position: 0 },
+        { id: 'b', position: 1 },
+        { id: 'c', position: 2 },
+      ],
+      movedFieldMetadataId: 'c',
+      precedingFieldMetadataId: 'a',
+    });
+
+    expect(updates).toEqual([{ fieldMetadataId: 'c', position: 0.5 }]);
+  });
+
+  it('places the moved field before every positioned one when dropped first', () => {
+    const updates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: [
+        { id: 'a', position: 0 },
+        { id: 'b', position: 1 },
+      ],
+      movedFieldMetadataId: 'b',
+      precedingFieldMetadataId: null,
+    });
+
+    expect(updates).toEqual([{ fieldMetadataId: 'b', position: -1 }]);
+  });
+
+  it('appends after the last positioned field when dropped after it', () => {
+    const updates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: [
+        { id: 'a', position: 0 },
+        { id: 'b', position: 1 },
+      ],
+      movedFieldMetadataId: 'a',
+      precedingFieldMetadataId: 'b',
+    });
+
+    expect(updates).toEqual([{ fieldMetadataId: 'a', position: 2 }]);
+  });
+
+  it('appends after the last positioned field when dropped into the unpositioned tail', () => {
+    const updates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: [
+        { id: 'a', position: 0 },
+        { id: 'b', position: 4 },
+        { id: 'tail-1', position: null },
+        { id: 'tail-2', position: null },
+      ],
+      movedFieldMetadataId: 'a',
+      precedingFieldMetadataId: 'tail-1',
+    });
+
+    expect(updates).toEqual([{ fieldMetadataId: 'a', position: 5 }]);
+  });
+
+  it('positions an unpositioned field dropped between positioned neighbors', () => {
+    const updates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: [
+        { id: 'a', position: 0 },
+        { id: 'b', position: 1 },
+        { id: 'tail-1', position: null },
+      ],
+      movedFieldMetadataId: 'tail-1',
+      precedingFieldMetadataId: 'a',
+    });
+
+    expect(updates).toEqual([{ fieldMetadataId: 'tail-1', position: 0.5 }]);
+  });
+
+  it('never touches unpositioned bystanders', () => {
+    const updates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: [
+        { id: 'a', position: 0 },
+        { id: 'b', position: 1 },
+        { id: 'c', position: 2 },
+        { id: 'tail-1', position: null },
+      ],
+      movedFieldMetadataId: 'c',
+      precedingFieldMetadataId: 'a',
+    });
+
+    expect(updates.map((update) => update.fieldMetadataId)).toEqual(['c']);
+  });
+
+  it('reindexes only the positioned fields when neighbor positions collide', () => {
+    const updates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: [
+        { id: 'a', position: 1 },
+        { id: 'b', position: 1 },
+        { id: 'c', position: 3 },
+        { id: 'tail-1', position: null },
+      ],
+      movedFieldMetadataId: 'c',
+      precedingFieldMetadataId: 'a',
+    });
+
+    expect(updates).toEqual([
+      { fieldMetadataId: 'a', position: 0 },
+      { fieldMetadataId: 'c', position: 1 },
+      { fieldMetadataId: 'b', position: 2 },
+    ]);
+  });
+
+  it('returns no update for an unknown moved field', () => {
+    expect(
+      computeFieldMetadataLayoutPositionUpdates({
+        orderedFieldMetadataItems: [{ id: 'a', position: 0 }],
+        movedFieldMetadataId: 'unknown',
+        precedingFieldMetadataId: null,
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns no update for an unknown preceding field', () => {
+    expect(
+      computeFieldMetadataLayoutPositionUpdates({
+        orderedFieldMetadataItems: [
+          { id: 'a', position: 0 },
+          { id: 'b', position: 1 },
+        ],
+        movedFieldMetadataId: 'a',
+        precedingFieldMetadataId: 'unknown',
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/utils/__tests__/sortFieldMetadataItemsByViewLayout.test.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/utils/__tests__/sortFieldMetadataItemsByViewLayout.test.ts
@@ -1,0 +1,64 @@
+import { sortFieldMetadataItemsByViewLayout } from '@/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout';
+
+describe('sortFieldMetadataItemsByViewLayout', () => {
+  it('orders positioned fields by position before unpositioned ones', () => {
+    const sorted = sortFieldMetadataItemsByViewLayout({
+      fieldMetadataItems: [
+        { id: 'unpositioned', label: 'AAA' },
+        { id: 'second', label: 'ZZZ' },
+        { id: 'first', label: 'MMM' },
+      ],
+      positionByFieldMetadataId: new Map([
+        ['second', 4],
+        ['first', 1],
+      ]),
+    });
+
+    expect(sorted.map((field) => field.id)).toEqual([
+      'first',
+      'second',
+      'unpositioned',
+    ]);
+  });
+
+  it('breaks position ties by label', () => {
+    const sorted = sortFieldMetadataItemsByViewLayout({
+      fieldMetadataItems: [
+        { id: 'b', label: 'Beta' },
+        { id: 'a', label: 'Alpha' },
+      ],
+      positionByFieldMetadataId: new Map([
+        ['a', 2],
+        ['b', 2],
+      ]),
+    });
+
+    expect(sorted.map((field) => field.id)).toEqual(['a', 'b']);
+  });
+
+  it('orders unpositioned fields by label', () => {
+    const sorted = sortFieldMetadataItemsByViewLayout({
+      fieldMetadataItems: [
+        { id: 'b', label: 'Beta' },
+        { id: 'a', label: 'Alpha' },
+      ],
+      positionByFieldMetadataId: new Map(),
+    });
+
+    expect(sorted.map((field) => field.id)).toEqual(['a', 'b']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      { id: 'b', label: 'Beta' },
+      { id: 'a', label: 'Alpha' },
+    ];
+
+    sortFieldMetadataItemsByViewLayout({
+      fieldMetadataItems: input,
+      positionByFieldMetadataId: new Map(),
+    });
+
+    expect(input.map((field) => field.id)).toEqual(['b', 'a']);
+  });
+});

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/utils/computeFieldMetadataLayoutPositionUpdates.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/utils/computeFieldMetadataLayoutPositionUpdates.ts
@@ -1,0 +1,109 @@
+import { isDefined } from 'twenty-shared/utils';
+
+type FieldMetadataLayoutOrderItem = {
+  id: string;
+  position: number | null;
+};
+
+type FieldMetadataLayoutPositionUpdate = {
+  fieldMetadataId: string;
+  position: number;
+};
+
+export const computeFieldMetadataLayoutPositionUpdates = ({
+  orderedFieldMetadataItems,
+  movedFieldMetadataId,
+  precedingFieldMetadataId,
+}: {
+  orderedFieldMetadataItems: FieldMetadataLayoutOrderItem[];
+  movedFieldMetadataId: string;
+  precedingFieldMetadataId: string | null;
+}): FieldMetadataLayoutPositionUpdate[] => {
+  const movedFieldMetadataItem = orderedFieldMetadataItems.find(
+    (item) => item.id === movedFieldMetadataId,
+  );
+
+  if (!isDefined(movedFieldMetadataItem)) {
+    return [];
+  }
+
+  const itemsWithoutMoved = orderedFieldMetadataItems.filter(
+    (item) => item.id !== movedFieldMetadataId,
+  );
+
+  const positionedItems = itemsWithoutMoved.filter(
+    (item): item is { id: string; position: number } =>
+      isDefined(item.position),
+  );
+
+  if (precedingFieldMetadataId === null) {
+    const firstPositionedItem = positionedItems[0];
+
+    return [
+      {
+        fieldMetadataId: movedFieldMetadataId,
+        position: isDefined(firstPositionedItem)
+          ? firstPositionedItem.position - 1
+          : 0,
+      },
+    ];
+  }
+
+  const precedingItem = itemsWithoutMoved.find(
+    (item) => item.id === precedingFieldMetadataId,
+  );
+
+  if (!isDefined(precedingItem)) {
+    return [];
+  }
+
+  const lastPositionedItem = positionedItems[positionedItems.length - 1];
+
+  if (!isDefined(precedingItem.position)) {
+    return [
+      {
+        fieldMetadataId: movedFieldMetadataId,
+        position: isDefined(lastPositionedItem)
+          ? lastPositionedItem.position + 1
+          : 0,
+      },
+    ];
+  }
+
+  const precedingPositionedIndex = positionedItems.findIndex(
+    (item) => item.id === precedingFieldMetadataId,
+  );
+  const nextPositionedItem = positionedItems[precedingPositionedIndex + 1];
+
+  if (!isDefined(nextPositionedItem)) {
+    return [
+      {
+        fieldMetadataId: movedFieldMetadataId,
+        position: precedingItem.position + 1,
+      },
+    ];
+  }
+
+  if (precedingItem.position < nextPositionedItem.position) {
+    return [
+      {
+        fieldMetadataId: movedFieldMetadataId,
+        position: (precedingItem.position + nextPositionedItem.position) / 2,
+      },
+    ];
+  }
+
+  const reorderedPositionedItems = [
+    ...positionedItems.slice(0, precedingPositionedIndex + 1),
+    { id: movedFieldMetadataId, position: movedFieldMetadataItem.position },
+    ...positionedItems.slice(precedingPositionedIndex + 1),
+  ];
+
+  return reorderedPositionedItems
+    .map((item, index) => ({ item, index }))
+    .filter(({ item, index }) => item.position !== index)
+    .map(({ item, index }) => ({
+      fieldMetadataId: item.id,
+      position: index,
+    }));
+};

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout.ts
@@ -1,0 +1,32 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { isDefined } from 'twenty-shared/utils';
+
+export const sortFieldMetadataItemsByViewLayout = ({
+  fieldMetadataItems,
+  positionByFieldMetadataId,
+}: {
+  fieldMetadataItems: FieldMetadataItem[];
+  positionByFieldMetadataId: Map<string, number>;
+}): FieldMetadataItem[] =>
+  [...fieldMetadataItems].sort((fieldA, fieldB) => {
+    const positionA = positionByFieldMetadataId.get(fieldA.id);
+    const positionB = positionByFieldMetadataId.get(fieldB.id);
+
+    if (isDefined(positionA) && isDefined(positionB)) {
+      if (positionA !== positionB) {
+        return positionA - positionB;
+      }
+
+      return fieldA.label.localeCompare(fieldB.label);
+    }
+
+    if (isDefined(positionA)) {
+      return -1;
+    }
+
+    if (isDefined(positionB)) {
+      return 1;
+    }
+
+    return fieldA.label.localeCompare(fieldB.label);
+  });

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout.ts
@@ -1,13 +1,19 @@
-import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 
-export const sortFieldMetadataItemsByViewLayout = ({
+type FieldMetadataLayoutSortable = {
+  id: string;
+  label: string;
+};
+
+export const sortFieldMetadataItemsByViewLayout = <
+  TField extends FieldMetadataLayoutSortable,
+>({
   fieldMetadataItems,
   positionByFieldMetadataId,
 }: {
-  fieldMetadataItems: FieldMetadataItem[];
+  fieldMetadataItems: TField[];
   positionByFieldMetadataId: Map<string, number>;
-}): FieldMetadataItem[] =>
+}): TField[] =>
   [...fieldMetadataItems].sort((fieldA, fieldB) => {
     const positionA = positionByFieldMetadataId.get(fieldA.id);
     const positionB = positionByFieldMetadataId.get(fieldB.id);

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
@@ -130,8 +130,6 @@ export const SettingsObjectFieldTable = ({
   const { performViewFieldAPICreate, performViewFieldAPIUpdate } =
     usePerformViewFieldAPIPersist();
 
-  // Overlay applied while viewField writes are in flight, so rows do not snap
-  // back before the view state carries the persisted values.
   const [pendingLayoutByFieldMetadataId, setPendingLayoutByFieldMetadataId] =
     useState<Map<string, PendingViewFieldLayout>>(new Map());
 
@@ -354,16 +352,24 @@ export const SettingsObjectFieldTable = ({
     );
     const movedField = visibleFields[result.source.index];
 
-    if (!isDefined(movedField)) {
+    if (
+      !isDefined(movedField) ||
+      movedField.id === objectMetadataItem.labelIdentifierFieldMetadataId
+    ) {
       return;
     }
 
     const visibleFieldsWithoutMoved = visibleFields.filter(
       (field) => field.id !== movedField.id,
     );
+    const firstVisibleField = visibleFieldsWithoutMoved[0];
     const precedingField =
       result.destination.index === 0
-        ? null
+        ? isDefined(firstVisibleField) &&
+          firstVisibleField.id ===
+            objectMetadataItem.labelIdentifierFieldMetadataId
+          ? firstVisibleField
+          : null
         : (visibleFieldsWithoutMoved[result.destination.index - 1] ?? null);
 
     const positionUpdates = computeFieldMetadataLayoutPositionUpdates({
@@ -390,6 +396,8 @@ export const SettingsObjectFieldTable = ({
   const fieldTableRows = filteredItems.map(
     (objectSettingsDetailItem, index) => {
       const fieldMetadataId = objectSettingsDetailItem.fieldMetadataItem.id;
+      const isLabelIdentifierField =
+        fieldMetadataId === objectMetadataItem.labelIdentifierFieldMetadataId;
       const status = objectSettingsDetailItem.fieldMetadataItem.isActive
         ? 'active'
         : 'disabled';
@@ -401,10 +409,13 @@ export const SettingsObjectFieldTable = ({
           status={status}
           mode={mode}
           isMostlyEmpty={mostlyEmptyFieldMetadataIds.has(fieldMetadataId)}
-          showDragGrip={isReorderEnabled}
-          isVisibleInLayout={getEffectiveLayout(fieldMetadataId).isVisible}
+          showDragGrip={isReorderEnabled && !isLabelIdentifierField}
+          isVisibleInLayout={
+            isLabelIdentifierField ||
+            getEffectiveLayout(fieldMetadataId).isVisible
+          }
           onToggleVisibility={
-            isLayoutEditable
+            isLayoutEditable && !isLabelIdentifierField
               ? () => handleToggleFieldVisibility(fieldMetadataId)
               : undefined
           }
@@ -420,6 +431,7 @@ export const SettingsObjectFieldTable = ({
           key={fieldMetadataId}
           draggableId={fieldMetadataId}
           index={index}
+          isDragDisabled={isLabelIdentifierField}
           itemComponent={row}
         />
       );

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
@@ -1,5 +1,13 @@
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { isHiddenSystemField } from '@/object-metadata/utils/isHiddenSystemField';
+import { isDDLLockedState } from '@/client-config/states/isDDLLockedState';
+import { isObjectMetadataReadOnly } from '@/object-record/read-only/utils/isObjectMetadataReadOnly';
+import { computeFieldMetadataLayoutPositionUpdates } from '@/settings/data-model/object-details/utils/computeFieldMetadataLayoutPositionUpdates';
+import { sortFieldMetadataItemsByViewLayout } from '@/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout';
+import { DraggableItem } from '@/ui/layout/draggable-list/components/DraggableItem';
+import { DraggableList } from '@/ui/layout/draggable-list/components/DraggableList';
+import { type DraggableListDropResult } from '@/ui/layout/draggable-list/types/DraggableListDropResult';
+import { sortedFieldByTableFamilyState } from '@/ui/layout/table/states/sortedFieldByTableFamilyState';
 import { TableRow } from '@/ui/layout/table/components/TableRow';
 import {
   OBJECT_FIELD_TABLE_ROW_GRID_TEMPLATE_COLUMNS,
@@ -18,6 +26,8 @@ import { useSortedArray } from '@/ui/layout/table/hooks/useSortedArray';
 import { type TableMetadata } from '@/ui/layout/table/types/TableMetadata';
 import { isAdvancedModeEnabledState } from '@/ui/navigation/navigation-drawer/states/isAdvancedModeEnabledState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { usePerformViewFieldAPIPersist } from '@/views/hooks/internal/usePerformViewFieldAPIPersist';
+import { useViewOrDefaultView } from '@/views/hooks/useViewOrDefaultView';
 import { styled } from '@linaria/react';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
@@ -25,10 +35,12 @@ import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAto
 import { useSetAtomFamilyState } from '@/ui/utilities/state/jotai/hooks/useSetAtomFamilyState';
 import { useEffect, useMemo, useState } from 'react';
 import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 import { IconArchive, IconCircleDashed, IconSettings } from 'twenty-ui/icon';
 import { SearchInput } from 'twenty-ui/input';
 import { MenuItemToggle } from 'twenty-ui/navigation';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { v4 } from 'uuid';
 import { useMostlyEmptyFieldMetadataIds } from '@/settings/data-model/object-details/hooks/useMostlyEmptyFieldMetadataIds';
 import { useMapFieldMetadataItemToSettingsObjectDetailTableItem } from '~/pages/settings/data-model/hooks/useMapFieldMetadataItemToSettingsObjectDetailTableItem';
 import { type SettingsObjectDetailTableItem } from '~/pages/settings/data-model/types/SettingsObjectDetailTableItem';
@@ -61,11 +73,12 @@ const SETTINGS_OBJECT_FIELD_TABLE_METADATA: TableMetadata<SettingsObjectDetailTa
         align: 'left',
       },
     ],
-    initialSort: {
-      fieldName: 'label',
-      direction: 'asc',
-    },
   };
+
+type PendingViewFieldLayout = {
+  position?: number;
+  isVisible?: boolean;
+};
 
 export type SettingsObjectFieldTableProps = {
   objectMetadataItem: EnrichedObjectMetadataItem;
@@ -110,28 +123,90 @@ export const SettingsObjectFieldTable = ({
     setSettingsObjectFields(objectMetadataItem.fields);
   }, [objectMetadataItem, setSettingsObjectFields]);
 
+  const { view: indexView } = useViewOrDefaultView({
+    objectMetadataItemId: objectMetadataItem.id,
+  });
+
+  const { performViewFieldAPICreate, performViewFieldAPIUpdate } =
+    usePerformViewFieldAPIPersist();
+
+  // Overlay applied while viewField writes are in flight, so rows do not snap
+  // back before the view state carries the persisted values.
+  const [pendingLayoutByFieldMetadataId, setPendingLayoutByFieldMetadataId] =
+    useState<Map<string, PendingViewFieldLayout>>(new Map());
+
+  const viewFieldByFieldMetadataId = useMemo(
+    () =>
+      new Map(
+        (indexView?.viewFields ?? []).map((viewField) => [
+          viewField.fieldMetadataId,
+          viewField,
+        ]),
+      ),
+    [indexView],
+  );
+
+  const getEffectiveLayout = (
+    fieldMetadataId: string,
+  ): { position: number | null; isVisible: boolean } => {
+    const pending = pendingLayoutByFieldMetadataId.get(fieldMetadataId);
+    const viewField = viewFieldByFieldMetadataId.get(fieldMetadataId);
+
+    return {
+      position: pending?.position ?? viewField?.position ?? null,
+      isVisible: pending?.isVisible ?? viewField?.isVisible ?? false,
+    };
+  };
+
+  const positionByFieldMetadataId = useMemo(() => {
+    const positions = new Map<string, number>();
+
+    for (const field of settingsObjectFields ?? []) {
+      const pending = pendingLayoutByFieldMetadataId.get(field.id);
+      const viewField = viewFieldByFieldMetadataId.get(field.id);
+      const position = pending?.position ?? viewField?.position;
+
+      if (isDefined(position)) {
+        positions.set(field.id, position);
+      }
+    }
+
+    return positions;
+  }, [
+    settingsObjectFields,
+    pendingLayoutByFieldMetadataId,
+    viewFieldByFieldMetadataId,
+  ]);
+
+  const layoutOrderedFields = useMemo(
+    () =>
+      sortFieldMetadataItemsByViewLayout({
+        fieldMetadataItems: settingsObjectFields ?? [],
+        positionByFieldMetadataId,
+      }),
+    [settingsObjectFields, positionByFieldMetadataId],
+  );
+
   const allObjectSettingsDetailItems = useMemo(() => {
     const filteredBySystem = showSystemFields
-      ? settingsObjectFields
-      : settingsObjectFields?.filter(
+      ? layoutOrderedFields
+      : layoutOrderedFields.filter(
           (fieldMetadataItem) => !isHiddenSystemField(fieldMetadataItem),
         );
 
     const fieldsToDisplay = excludeRelations
-      ? filteredBySystem?.filter(
+      ? filteredBySystem.filter(
           (fieldMetadataItem) =>
             fieldMetadataItem.type !== FieldMetadataType.RELATION &&
             fieldMetadataItem.type !== FieldMetadataType.MORPH_RELATION,
         )
       : filteredBySystem;
 
-    return (
-      fieldsToDisplay?.map(
-        mapFieldMetadataItemToSettingsObjectDetailTableItem,
-      ) ?? []
+    return fieldsToDisplay.map(
+      mapFieldMetadataItemToSettingsObjectDetailTableItem,
     );
   }, [
-    settingsObjectFields,
+    layoutOrderedFields,
     mapFieldMetadataItemToSettingsObjectDetailTableItem,
     excludeRelations,
     showSystemFields,
@@ -140,6 +215,18 @@ export const SettingsObjectFieldTable = ({
   const sortedAllObjectSettingsDetailItems = useSortedArray(
     allObjectSettingsDetailItems,
     tableMetadata,
+  );
+
+  const isDDLLocked = useAtomStateValue(isDDLLockedState);
+
+  const readonly =
+    isObjectMetadataReadOnly({
+      objectMetadataItem,
+    }) || isDDLLocked;
+
+  const sortedFieldByTable = useAtomFamilyStateValue(
+    sortedFieldByTableFamilyState,
+    { tableId: tableMetadata.tableId },
   );
 
   const filteredItems = useMemo(() => {
@@ -166,6 +253,178 @@ export const SettingsObjectFieldTable = ({
     showOnlyMostlyEmpty,
     mostlyEmptyFieldMetadataIds,
   ]);
+
+  const isLayoutEditable = mode === 'view' && !readonly && isDefined(indexView);
+
+  const isReorderEnabled =
+    isLayoutEditable && !isDefined(sortedFieldByTable) && searchTerm === '';
+
+  const persistLayoutUpdates = async (
+    layoutUpdates: {
+      fieldMetadataId: string;
+      layout: PendingViewFieldLayout;
+    }[],
+  ) => {
+    if (!isDefined(indexView)) {
+      return;
+    }
+
+    setPendingLayoutByFieldMetadataId((previousPending) => {
+      const newPending = new Map(previousPending);
+
+      for (const { fieldMetadataId, layout } of layoutUpdates) {
+        newPending.set(fieldMetadataId, {
+          ...newPending.get(fieldMetadataId),
+          ...layout,
+        });
+      }
+
+      return newPending;
+    });
+
+    const viewFieldsToCreate = [];
+    const viewFieldsToUpdate = [];
+
+    for (const { fieldMetadataId, layout } of layoutUpdates) {
+      const existingViewField = viewFieldByFieldMetadataId.get(fieldMetadataId);
+
+      if (isDefined(existingViewField)) {
+        viewFieldsToUpdate.push({
+          input: {
+            id: existingViewField.id,
+            update: {
+              ...(isDefined(layout.position)
+                ? { position: layout.position }
+                : {}),
+              ...(isDefined(layout.isVisible)
+                ? { isVisible: layout.isVisible }
+                : {}),
+            },
+          },
+        });
+      } else {
+        viewFieldsToCreate.push({
+          id: v4(),
+          viewId: indexView.id,
+          fieldMetadataId,
+          position:
+            layout.position ??
+            getEffectiveLayout(fieldMetadataId).position ??
+            0,
+          isVisible: layout.isVisible ?? false,
+        });
+      }
+    }
+
+    try {
+      if (viewFieldsToCreate.length > 0) {
+        await performViewFieldAPICreate({ inputs: viewFieldsToCreate });
+      }
+      if (viewFieldsToUpdate.length > 0) {
+        await performViewFieldAPIUpdate(viewFieldsToUpdate);
+      }
+    } finally {
+      setPendingLayoutByFieldMetadataId((previousPending) => {
+        const newPending = new Map(previousPending);
+
+        for (const { fieldMetadataId } of layoutUpdates) {
+          newPending.delete(fieldMetadataId);
+        }
+
+        return newPending;
+      });
+    }
+  };
+
+  const handleToggleFieldVisibility = async (fieldMetadataId: string) => {
+    const { isVisible } = getEffectiveLayout(fieldMetadataId);
+
+    await persistLayoutUpdates([
+      { fieldMetadataId, layout: { isVisible: !isVisible } },
+    ]);
+  };
+
+  const handleReorderDragEnd = async (result: DraggableListDropResult) => {
+    if (!isDefined(result.destination)) {
+      return;
+    }
+
+    const visibleFields = filteredItems.map(
+      (tableItem) => tableItem.fieldMetadataItem,
+    );
+    const movedField = visibleFields[result.source.index];
+
+    if (!isDefined(movedField)) {
+      return;
+    }
+
+    const visibleFieldsWithoutMoved = visibleFields.filter(
+      (field) => field.id !== movedField.id,
+    );
+    const precedingField =
+      result.destination.index === 0
+        ? null
+        : (visibleFieldsWithoutMoved[result.destination.index - 1] ?? null);
+
+    const positionUpdates = computeFieldMetadataLayoutPositionUpdates({
+      orderedFieldMetadataItems: layoutOrderedFields.map((field) => ({
+        id: field.id,
+        position: positionByFieldMetadataId.get(field.id) ?? null,
+      })),
+      movedFieldMetadataId: movedField.id,
+      precedingFieldMetadataId: precedingField?.id ?? null,
+    });
+
+    if (positionUpdates.length === 0) {
+      return;
+    }
+
+    await persistLayoutUpdates(
+      positionUpdates.map((update) => ({
+        fieldMetadataId: update.fieldMetadataId,
+        layout: { position: update.position },
+      })),
+    );
+  };
+
+  const fieldTableRows = filteredItems.map(
+    (objectSettingsDetailItem, index) => {
+      const fieldMetadataId = objectSettingsDetailItem.fieldMetadataItem.id;
+      const status = objectSettingsDetailItem.fieldMetadataItem.isActive
+        ? 'active'
+        : 'disabled';
+
+      const row = (
+        <SettingsObjectFieldItemTableRow
+          key={fieldMetadataId}
+          settingsObjectDetailTableItem={objectSettingsDetailItem}
+          status={status}
+          mode={mode}
+          isMostlyEmpty={mostlyEmptyFieldMetadataIds.has(fieldMetadataId)}
+          showDragGrip={isReorderEnabled}
+          isVisibleInLayout={getEffectiveLayout(fieldMetadataId).isVisible}
+          onToggleVisibility={
+            isLayoutEditable
+              ? () => handleToggleFieldVisibility(fieldMetadataId)
+              : undefined
+          }
+        />
+      );
+
+      if (!isReorderEnabled) {
+        return row;
+      }
+
+      return (
+        <DraggableItem
+          key={fieldMetadataId}
+          draggableId={fieldMetadataId}
+          index={index}
+          itemComponent={row}
+        />
+      );
+    },
+  );
 
   return (
     <>
@@ -237,23 +496,14 @@ export const SettingsObjectFieldTable = ({
         </TableRow>
         <StyledSettingsDataModelTableBodyContainer>
           <TableBody>
-            {filteredItems.map((objectSettingsDetailItem) => {
-              const status = objectSettingsDetailItem.fieldMetadataItem.isActive
-                ? 'active'
-                : 'disabled';
-
-              return (
-                <SettingsObjectFieldItemTableRow
-                  key={objectSettingsDetailItem.fieldMetadataItem.id}
-                  settingsObjectDetailTableItem={objectSettingsDetailItem}
-                  status={status}
-                  mode={mode}
-                  isMostlyEmpty={mostlyEmptyFieldMetadataIds.has(
-                    objectSettingsDetailItem.fieldMetadataItem.id,
-                  )}
-                />
-              );
-            })}
+            {isReorderEnabled ? (
+              <DraggableList
+                onDragEnd={handleReorderDragEnd}
+                draggableItems={<>{fieldTableRows}</>}
+              />
+            ) : (
+              fieldTableRows
+            )}
           </TableBody>
         </StyledSettingsDataModelTableBodyContainer>
       </Table>

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
@@ -75,6 +75,8 @@ const SETTINGS_OBJECT_FIELD_TABLE_METADATA: TableMetadata<SettingsObjectDetailTa
     ],
   };
 
+const DEFAULT_CREATED_VIEW_FIELD_SIZE = 100;
+
 type PendingViewFieldLayout = {
   position?: number;
   isVisible?: boolean;
@@ -226,6 +228,14 @@ export const SettingsObjectFieldTable = ({
     sortedFieldByTableFamilyState,
     { tableId: tableMetadata.tableId },
   );
+  const setSortedFieldByTable = useSetAtomFamilyState(
+    sortedFieldByTableFamilyState,
+    { tableId: tableMetadata.tableId },
+  );
+
+  useEffect(() => {
+    setSortedFieldByTable(null);
+  }, [setSortedFieldByTable]);
 
   const filteredItems = useMemo(() => {
     const searchNormalized = normalizeSearchText(searchTerm);
@@ -301,15 +311,18 @@ export const SettingsObjectFieldTable = ({
           },
         });
       } else {
+        const lastPosition = Math.max(
+          -1,
+          ...Array.from(positionByFieldMetadataId.values()),
+        );
+
         viewFieldsToCreate.push({
           id: v4(),
           viewId: indexView.id,
           fieldMetadataId,
-          position:
-            layout.position ??
-            getEffectiveLayout(fieldMetadataId).position ??
-            0,
+          position: layout.position ?? lastPosition + 1,
           isVisible: layout.isVisible ?? false,
+          size: DEFAULT_CREATED_VIEW_FIELD_SIZE,
         });
       }
     }
@@ -347,38 +360,47 @@ export const SettingsObjectFieldTable = ({
       return;
     }
 
-    const visibleFields = filteredItems.map(
-      (tableItem) => tableItem.fieldMetadataItem,
-    );
-    const movedField = visibleFields[result.source.index];
+    const movedFieldMetadataId = result.draggableId;
 
     if (
-      !isDefined(movedField) ||
-      movedField.id === objectMetadataItem.labelIdentifierFieldMetadataId
+      movedFieldMetadataId === objectMetadataItem.labelIdentifierFieldMetadataId
     ) {
       return;
     }
 
-    const visibleFieldsWithoutMoved = visibleFields.filter(
-      (field) => field.id !== movedField.id,
+    const visibleFieldsWithoutMoved = filteredItems
+      .map((tableItem) => tableItem.fieldMetadataItem)
+      .filter((field) => field.id !== movedFieldMetadataId);
+    const layoutOrderedFieldsWithoutMoved = layoutOrderedFields.filter(
+      (field) => field.id !== movedFieldMetadataId,
     );
-    const firstVisibleField = visibleFieldsWithoutMoved[0];
-    const precedingField =
-      result.destination.index === 0
-        ? isDefined(firstVisibleField) &&
-          firstVisibleField.id ===
-            objectMetadataItem.labelIdentifierFieldMetadataId
-          ? firstVisibleField
-          : null
-        : (visibleFieldsWithoutMoved[result.destination.index - 1] ?? null);
+
+    const nextVisibleField =
+      visibleFieldsWithoutMoved[result.destination.index] ?? null;
+    const precedingField = isDefined(nextVisibleField)
+      ? (layoutOrderedFieldsWithoutMoved[
+          layoutOrderedFieldsWithoutMoved.findIndex(
+            (field) => field.id === nextVisibleField.id,
+          ) - 1
+        ] ?? null)
+      : (visibleFieldsWithoutMoved[visibleFieldsWithoutMoved.length - 1] ??
+        null);
+
+    const labelIdentifierIsFirst =
+      layoutOrderedFieldsWithoutMoved[0]?.id ===
+      objectMetadataItem.labelIdentifierFieldMetadataId;
+    const clampedPrecedingField =
+      !isDefined(precedingField) && labelIdentifierIsFirst
+        ? layoutOrderedFieldsWithoutMoved[0]
+        : precedingField;
 
     const positionUpdates = computeFieldMetadataLayoutPositionUpdates({
       orderedFieldMetadataItems: layoutOrderedFields.map((field) => ({
         id: field.id,
         position: positionByFieldMetadataId.get(field.id) ?? null,
       })),
-      movedFieldMetadataId: movedField.id,
-      precedingFieldMetadataId: precedingField?.id ?? null,
+      movedFieldMetadataId,
+      precedingFieldMetadataId: clampedPrecedingField?.id ?? null,
     });
 
     if (positionUpdates.length === 0) {
@@ -398,6 +420,10 @@ export const SettingsObjectFieldTable = ({
       const fieldMetadataId = objectSettingsDetailItem.fieldMetadataItem.id;
       const isLabelIdentifierField =
         fieldMetadataId === objectMetadataItem.labelIdentifierFieldMetadataId;
+      const isLayoutManageableField =
+        !isLabelIdentifierField &&
+        (objectSettingsDetailItem.fieldMetadataItem.isActive ?? false) &&
+        !isHiddenSystemField(objectSettingsDetailItem.fieldMetadataItem);
       const status = objectSettingsDetailItem.fieldMetadataItem.isActive
         ? 'active'
         : 'disabled';
@@ -409,13 +435,13 @@ export const SettingsObjectFieldTable = ({
           status={status}
           mode={mode}
           isMostlyEmpty={mostlyEmptyFieldMetadataIds.has(fieldMetadataId)}
-          showDragGrip={isReorderEnabled && !isLabelIdentifierField}
+          showDragGrip={isReorderEnabled && isLayoutManageableField}
           isVisibleInLayout={
             isLabelIdentifierField ||
             getEffectiveLayout(fieldMetadataId).isVisible
           }
           onToggleVisibility={
-            isLayoutEditable && !isLabelIdentifierField
+            isLayoutEditable && isLayoutManageableField
               ? () => handleToggleFieldVisibility(fieldMetadataId)
               : undefined
           }
@@ -431,7 +457,7 @@ export const SettingsObjectFieldTable = ({
           key={fieldMetadataId}
           draggableId={fieldMetadataId}
           index={index}
-          isDragDisabled={isLabelIdentifierField}
+          isDragDisabled={!isLayoutManageableField}
           itemComponent={row}
         />
       );

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
@@ -235,6 +235,7 @@ export const SettingsObjectFieldTable = ({
           status={status}
           mode={mode}
           isMostlyEmpty={mostlyEmptyFieldMetadataIds.has(fieldMetadataId)}
+          hasDragGripGutter={isReorderEnabled}
           showDragGrip={isReorderEnabled && isLayoutManageableField}
           isVisibleInLayout={
             isLabelIdentifierField ||

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
@@ -2,8 +2,6 @@ import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/Enriche
 import { isHiddenSystemField } from '@/object-metadata/utils/isHiddenSystemField';
 import { isDDLLockedState } from '@/client-config/states/isDDLLockedState';
 import { isObjectMetadataReadOnly } from '@/object-record/read-only/utils/isObjectMetadataReadOnly';
-import { computeFieldMetadataLayoutPositionUpdates } from '@/settings/data-model/object-details/utils/computeFieldMetadataLayoutPositionUpdates';
-import { sortFieldMetadataItemsByViewLayout } from '@/settings/data-model/object-details/utils/sortFieldMetadataItemsByViewLayout';
 import { DraggableItem } from '@/ui/layout/draggable-list/components/DraggableItem';
 import { DraggableList } from '@/ui/layout/draggable-list/components/DraggableList';
 import { type DraggableListDropResult } from '@/ui/layout/draggable-list/types/DraggableListDropResult';
@@ -26,8 +24,6 @@ import { useSortedArray } from '@/ui/layout/table/hooks/useSortedArray';
 import { type TableMetadata } from '@/ui/layout/table/types/TableMetadata';
 import { isAdvancedModeEnabledState } from '@/ui/navigation/navigation-drawer/states/isAdvancedModeEnabledState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { usePerformViewFieldAPIPersist } from '@/views/hooks/internal/usePerformViewFieldAPIPersist';
-import { useViewOrDefaultView } from '@/views/hooks/useViewOrDefaultView';
 import { styled } from '@linaria/react';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
@@ -40,7 +36,7 @@ import { IconArchive, IconCircleDashed, IconSettings } from 'twenty-ui/icon';
 import { SearchInput } from 'twenty-ui/input';
 import { MenuItemToggle } from 'twenty-ui/navigation';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { v4 } from 'uuid';
+import { useIndexViewFieldsLayout } from '@/settings/data-model/object-details/hooks/useIndexViewFieldsLayout';
 import { useMostlyEmptyFieldMetadataIds } from '@/settings/data-model/object-details/hooks/useMostlyEmptyFieldMetadataIds';
 import { useMapFieldMetadataItemToSettingsObjectDetailTableItem } from '~/pages/settings/data-model/hooks/useMapFieldMetadataItemToSettingsObjectDetailTableItem';
 import { type SettingsObjectDetailTableItem } from '~/pages/settings/data-model/types/SettingsObjectDetailTableItem';
@@ -74,13 +70,6 @@ const SETTINGS_OBJECT_FIELD_TABLE_METADATA: TableMetadata<SettingsObjectDetailTa
       },
     ],
   };
-
-const DEFAULT_CREATED_VIEW_FIELD_SIZE = 100;
-
-type PendingViewFieldLayout = {
-  position?: number;
-  isVisible?: boolean;
-};
 
 export type SettingsObjectFieldTableProps = {
   objectMetadataItem: EnrichedObjectMetadataItem;
@@ -125,67 +114,16 @@ export const SettingsObjectFieldTable = ({
     setSettingsObjectFields(objectMetadataItem.fields);
   }, [objectMetadataItem, setSettingsObjectFields]);
 
-  const { view: indexView } = useViewOrDefaultView({
-    objectMetadataItemId: objectMetadataItem.id,
+  const {
+    hasEditableIndexView,
+    layoutOrderedFields,
+    getEffectiveLayout,
+    toggleFieldVisibility,
+    reorderFieldFromDropResult,
+  } = useIndexViewFieldsLayout({
+    objectMetadataItem,
+    fieldMetadataItems: settingsObjectFields ?? [],
   });
-
-  const { performViewFieldAPICreate, performViewFieldAPIUpdate } =
-    usePerformViewFieldAPIPersist();
-
-  const [pendingLayoutByFieldMetadataId, setPendingLayoutByFieldMetadataId] =
-    useState<Map<string, PendingViewFieldLayout>>(new Map());
-
-  const viewFieldByFieldMetadataId = useMemo(
-    () =>
-      new Map(
-        (indexView?.viewFields ?? []).map((viewField) => [
-          viewField.fieldMetadataId,
-          viewField,
-        ]),
-      ),
-    [indexView],
-  );
-
-  const getEffectiveLayout = (
-    fieldMetadataId: string,
-  ): { position: number | null; isVisible: boolean } => {
-    const pending = pendingLayoutByFieldMetadataId.get(fieldMetadataId);
-    const viewField = viewFieldByFieldMetadataId.get(fieldMetadataId);
-
-    return {
-      position: pending?.position ?? viewField?.position ?? null,
-      isVisible: pending?.isVisible ?? viewField?.isVisible ?? false,
-    };
-  };
-
-  const positionByFieldMetadataId = useMemo(() => {
-    const positions = new Map<string, number>();
-
-    for (const field of settingsObjectFields ?? []) {
-      const pending = pendingLayoutByFieldMetadataId.get(field.id);
-      const viewField = viewFieldByFieldMetadataId.get(field.id);
-      const position = pending?.position ?? viewField?.position;
-
-      if (isDefined(position)) {
-        positions.set(field.id, position);
-      }
-    }
-
-    return positions;
-  }, [
-    settingsObjectFields,
-    pendingLayoutByFieldMetadataId,
-    viewFieldByFieldMetadataId,
-  ]);
-
-  const layoutOrderedFields = useMemo(
-    () =>
-      sortFieldMetadataItemsByViewLayout({
-        fieldMetadataItems: settingsObjectFields ?? [],
-        positionByFieldMetadataId,
-      }),
-    [settingsObjectFields, positionByFieldMetadataId],
-  );
 
   const allObjectSettingsDetailItems = useMemo(() => {
     const filteredBySystem = showSystemFields
@@ -262,157 +200,18 @@ export const SettingsObjectFieldTable = ({
     mostlyEmptyFieldMetadataIds,
   ]);
 
-  const isLayoutEditable = mode === 'view' && !readonly && isDefined(indexView);
+  const isLayoutEditable = mode === 'view' && !readonly && hasEditableIndexView;
 
   const isReorderEnabled =
     isLayoutEditable && !isDefined(sortedFieldByTable) && searchTerm === '';
 
-  const persistLayoutUpdates = async (
-    layoutUpdates: {
-      fieldMetadataId: string;
-      layout: PendingViewFieldLayout;
-    }[],
-  ) => {
-    if (!isDefined(indexView)) {
-      return;
-    }
-
-    setPendingLayoutByFieldMetadataId((previousPending) => {
-      const newPending = new Map(previousPending);
-
-      for (const { fieldMetadataId, layout } of layoutUpdates) {
-        newPending.set(fieldMetadataId, {
-          ...newPending.get(fieldMetadataId),
-          ...layout,
-        });
-      }
-
-      return newPending;
-    });
-
-    const viewFieldsToCreate = [];
-    const viewFieldsToUpdate = [];
-
-    for (const { fieldMetadataId, layout } of layoutUpdates) {
-      const existingViewField = viewFieldByFieldMetadataId.get(fieldMetadataId);
-
-      if (isDefined(existingViewField)) {
-        viewFieldsToUpdate.push({
-          input: {
-            id: existingViewField.id,
-            update: {
-              ...(isDefined(layout.position)
-                ? { position: layout.position }
-                : {}),
-              ...(isDefined(layout.isVisible)
-                ? { isVisible: layout.isVisible }
-                : {}),
-            },
-          },
-        });
-      } else {
-        const lastPosition = Math.max(
-          -1,
-          ...Array.from(positionByFieldMetadataId.values()),
-        );
-
-        viewFieldsToCreate.push({
-          id: v4(),
-          viewId: indexView.id,
-          fieldMetadataId,
-          position: layout.position ?? lastPosition + 1,
-          isVisible: layout.isVisible ?? false,
-          size: DEFAULT_CREATED_VIEW_FIELD_SIZE,
-        });
-      }
-    }
-
-    try {
-      if (viewFieldsToCreate.length > 0) {
-        await performViewFieldAPICreate({ inputs: viewFieldsToCreate });
-      }
-      if (viewFieldsToUpdate.length > 0) {
-        await performViewFieldAPIUpdate(viewFieldsToUpdate);
-      }
-    } finally {
-      setPendingLayoutByFieldMetadataId((previousPending) => {
-        const newPending = new Map(previousPending);
-
-        for (const { fieldMetadataId } of layoutUpdates) {
-          newPending.delete(fieldMetadataId);
-        }
-
-        return newPending;
-      });
-    }
-  };
-
-  const handleToggleFieldVisibility = async (fieldMetadataId: string) => {
-    const { isVisible } = getEffectiveLayout(fieldMetadataId);
-
-    await persistLayoutUpdates([
-      { fieldMetadataId, layout: { isVisible: !isVisible } },
-    ]);
-  };
-
   const handleReorderDragEnd = async (result: DraggableListDropResult) => {
-    if (!isDefined(result.destination)) {
-      return;
-    }
-
-    const movedFieldMetadataId = result.draggableId;
-
-    if (
-      movedFieldMetadataId === objectMetadataItem.labelIdentifierFieldMetadataId
-    ) {
-      return;
-    }
-
-    const visibleFieldsWithoutMoved = filteredItems
-      .map((tableItem) => tableItem.fieldMetadataItem)
-      .filter((field) => field.id !== movedFieldMetadataId);
-    const layoutOrderedFieldsWithoutMoved = layoutOrderedFields.filter(
-      (field) => field.id !== movedFieldMetadataId,
-    );
-
-    const nextVisibleField =
-      visibleFieldsWithoutMoved[result.destination.index] ?? null;
-    const precedingField = isDefined(nextVisibleField)
-      ? (layoutOrderedFieldsWithoutMoved[
-          layoutOrderedFieldsWithoutMoved.findIndex(
-            (field) => field.id === nextVisibleField.id,
-          ) - 1
-        ] ?? null)
-      : (visibleFieldsWithoutMoved[visibleFieldsWithoutMoved.length - 1] ??
-        null);
-
-    const labelIdentifierIsFirst =
-      layoutOrderedFieldsWithoutMoved[0]?.id ===
-      objectMetadataItem.labelIdentifierFieldMetadataId;
-    const clampedPrecedingField =
-      !isDefined(precedingField) && labelIdentifierIsFirst
-        ? layoutOrderedFieldsWithoutMoved[0]
-        : precedingField;
-
-    const positionUpdates = computeFieldMetadataLayoutPositionUpdates({
-      orderedFieldMetadataItems: layoutOrderedFields.map((field) => ({
-        id: field.id,
-        position: positionByFieldMetadataId.get(field.id) ?? null,
-      })),
-      movedFieldMetadataId,
-      precedingFieldMetadataId: clampedPrecedingField?.id ?? null,
+    await reorderFieldFromDropResult({
+      dropResult: result,
+      visibleFieldMetadataItems: filteredItems.map(
+        (tableItem) => tableItem.fieldMetadataItem,
+      ),
     });
-
-    if (positionUpdates.length === 0) {
-      return;
-    }
-
-    await persistLayoutUpdates(
-      positionUpdates.map((update) => ({
-        fieldMetadataId: update.fieldMetadataId,
-        layout: { position: update.position },
-      })),
-    );
   };
 
   const fieldTableRows = filteredItems.map(
@@ -442,7 +241,7 @@ export const SettingsObjectFieldTable = ({
           }
           onToggleVisibility={
             isLayoutEditable && isLayoutManageableField
-              ? () => handleToggleFieldVisibility(fieldMetadataId)
+              ? () => toggleFieldVisibility(fieldMetadataId)
               : undefined
           }
         />

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
@@ -36,7 +36,7 @@ import { IconArchive, IconCircleDashed, IconSettings } from 'twenty-ui/icon';
 import { SearchInput } from 'twenty-ui/input';
 import { MenuItemToggle } from 'twenty-ui/navigation';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { useIndexViewFieldsLayout } from '@/settings/data-model/object-details/hooks/useIndexViewFieldsLayout';
+import { useDefaultViewFieldsLayout } from '@/settings/data-model/object-details/hooks/useDefaultViewFieldsLayout';
 import { useMostlyEmptyFieldMetadataIds } from '@/settings/data-model/object-details/hooks/useMostlyEmptyFieldMetadataIds';
 import { useMapFieldMetadataItemToSettingsObjectDetailTableItem } from '~/pages/settings/data-model/hooks/useMapFieldMetadataItemToSettingsObjectDetailTableItem';
 import { type SettingsObjectDetailTableItem } from '~/pages/settings/data-model/types/SettingsObjectDetailTableItem';
@@ -115,12 +115,12 @@ export const SettingsObjectFieldTable = ({
   }, [objectMetadataItem, setSettingsObjectFields]);
 
   const {
-    hasEditableIndexView,
+    hasEditableDefaultView,
     layoutOrderedFields,
     getEffectiveLayout,
     toggleFieldVisibility,
     reorderFieldFromDropResult,
-  } = useIndexViewFieldsLayout({
+  } = useDefaultViewFieldsLayout({
     objectMetadataItem,
     fieldMetadataItems: settingsObjectFields ?? [],
   });
@@ -200,7 +200,8 @@ export const SettingsObjectFieldTable = ({
     mostlyEmptyFieldMetadataIds,
   ]);
 
-  const isLayoutEditable = mode === 'view' && !readonly && hasEditableIndexView;
+  const isLayoutEditable =
+    mode === 'view' && !readonly && hasEditableDefaultView;
 
   const isReorderEnabled =
     isLayoutEditable && !isDefined(sortedFieldByTable) && searchTerm === '';


### PR DESCRIPTION


https://github.com/user-attachments/assets/65b26544-f476-4c32-b0ba-e5219d7056fc



Architecture pivot (supersedes the closed #24795/#24834 direction): the base view keeps viewFields as its layout storage, and the data-model page is its edit surface. No new columns, no backfill.

## What it does

- The Settings > Data model Fields table renders in the object's index-view order: fields with a viewField by effective position, fields without one after, in label order.
- Drag grip per row. A drop writes a single fractional position on the moved field's viewField through the standard updateViewField mutation; on position collision only the positioned fields are reindexed; fields without viewFields are never touched by someone else's drag. Dropping a field that has no viewField creates exactly one row for it.
- Crossed-eye on row hover toggles the viewField's isVisible (persistent icon when hidden). ViewFields created by a toggle or drag append after the last position with the standard 100px size. Since these are the index view's rows today, hiding a field here hides the table column, which is the intended end state: the index view becomes the base view at retype.
- App-owned views get workspace overrides for free through the existing viewField override machinery, verified live (an override blob carries the edit, the base value stays).
- The label identifier field is pinned (no grip, no toggle, always visible; top drops land below it), and only fields the record table can actually show are manageable: inactive and hidden-system rows get neither grip nor eye. The grip is the actual drag handle, so row clicks and drags no longer compete.
- Reorder disabled while a column sort or search is active, in new-field mode, and for readonly objects; a leftover column sort is cleared on mount since header sorts have no un-click. Drops on a filtered list resolve the preceding field in the full layout order, so they cannot land above rows the filter hides. In-flight writes hold the optimistic order stable.

Rejected alternative: reusing computeNewPositionOfDraggedRecord (record-table column reorder) — its target-item API has no notion of fields without viewFields; the dedicated util handles the null-position tail and collision reindex the settings list needs.

## Not in this PR

- ViewType.BASE, the index retype and the view-UI lock: next step.
- Relations table reordering.

## Tests

| Check | Result |
| --- | --- |
| Position math (fractional, tail drop, collision reindex, bystanders untouched) | 9 unit tests green |
| tsgo front | clean (front-components noise pre-existing) |
| Live on a dev instance | ordering renders the index-view effective layout incl. a pre-existing viewField override; writes land as overrides on app-owned rows; row count stable after drags |
| Mouse drag gesture | works with a real pointer (verified earlier on the same DraggableList); browser automation resolves drops inconsistently, so give it a hand check |