### PR TITLE
Repair missing timeline activity search vectors after 2.35 upgrade

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-upgrade-version-command.module.ts
@@ -1,11 +1,20 @@
 import { Module } from '@nestjs/common';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { RepairTimelineActivitySearchVectorCommand } from 'src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787747735000-repair-timeline-activity-search-vector.command';
 import { RewriteIsNotNullWorkflowFilterOperandsCommand } from 'src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787700000000-rewrite-is-not-null-workflow-filter-operands.command';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
 
 @Module({
-  imports: [WorkspaceIteratorModule, WorkspaceCacheModule],
-  providers: [RewriteIsNotNullWorkflowFilterOperandsCommand],
+  imports: [
+    WorkspaceIteratorModule,
+    WorkspaceCacheModule,
+    WorkspaceMigrationRunnerModule,
+  ],
+  providers: [
+    RewriteIsNotNullWorkflowFilterOperandsCommand,
+    RepairTimelineActivitySearchVectorCommand,
+  ],
 })
 export class V2_36_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787747735000-repair-timeline-activity-search-vector.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787747735000-repair-timeline-activity-search-vector.command.ts
@@ -1,0 +1,117 @@
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
+import { type UniversalUpdateFieldAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/types/workspace-migration-field-action';
+import { WORKSPACE_MIGRATION_ACTION_TYPE } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/constants/workspace-migration-action-type.constant';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
+
+@RegisteredWorkspaceCommand('2.36.0', 1787747735000)
+@Command({
+  name: 'upgrade:2-36:repair-timeline-activity-search-vector',
+  description:
+    'Recreate timelineActivity.searchVector when the legacy name column contraction removed it through a generated-column dependency',
+})
+export class RepairTimelineActivitySearchVectorCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    dataSource,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+        'flatFieldMetadataMaps',
+      ]);
+
+    const timelineActivityObject =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier:
+          STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+      });
+    const searchVectorField =
+      findFlatEntityByUniversalIdentifier<FlatFieldMetadata>({
+        flatEntityMaps: flatFieldMetadataMaps,
+        universalIdentifier:
+          STANDARD_OBJECTS.timelineActivity.fields.searchVector
+            .universalIdentifier,
+      });
+
+    if (!isDefined(timelineActivityObject) || !isDefined(searchVectorField)) {
+      return;
+    }
+
+    if (!isDefined(dataSource)) {
+      throw new Error(
+        `Cannot inspect timelineActivity.searchVector for workspace ${workspaceId} without a data source`,
+      );
+    }
+
+    const { schemaName, tableName } = getWorkspaceSchemaContextForMigration({
+      workspaceId,
+      objectMetadata: timelineActivityObject,
+    });
+    const [searchVectorColumn] = await dataSource.query<
+      Array<{ exists: boolean }>
+    >(
+      `SELECT EXISTS (
+  SELECT 1
+  FROM information_schema.columns
+  WHERE table_schema = $1
+    AND table_name = $2
+    AND column_name = $3
+) AS "exists"`,
+      [schemaName, tableName, searchVectorField.name],
+    );
+
+    if (searchVectorColumn?.exists === true) {
+      return;
+    }
+
+    const isDryRun = options.dryRun ?? false;
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Repairing missing timelineActivity.searchVector for workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    const rebuildSearchVectorAction: UniversalUpdateFieldAction = {
+      type: WORKSPACE_MIGRATION_ACTION_TYPE.update,
+      metadataName: 'fieldMetadata',
+      universalIdentifier: searchVectorField.universalIdentifier,
+      update: {},
+      rebuildSearchVector: true,
+    };
+
+    await this.workspaceMigrationRunnerService.run({
+      workspaceMigration: {
+        applicationUniversalIdentifier:
+          TWENTY_STANDARD_APPLICATION.universalIdentifier,
+        actions: [rebuildSearchVectorAction],
+      },
+      workspaceId,
+    });
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/__tests__/2-36-workspace-command-1787747735000-repair-timeline-activity-search-vector.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-36/__tests__/2-36-workspace-command-1787747735000-repair-timeline-activity-search-vector.command.spec.ts
@@ -1,0 +1,111 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+
+import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { RepairTimelineActivitySearchVectorCommand } from 'src/database/commands/upgrade-version-command/2-36/2-36-workspace-command-1787747735000-repair-timeline-activity-search-vector.command';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
+import { type WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+const WORKSPACE_ID = '00000000-0000-4000-8000-000000000001';
+const TIMELINE_ACTIVITY_OBJECT_ID = '00000000-0000-4000-8000-000000000002';
+const SEARCH_VECTOR_FIELD_ID = '00000000-0000-4000-8000-000000000003';
+
+const buildCommand = ({
+  hasSearchVectorColumn,
+}: {
+  hasSearchVectorColumn: boolean;
+}) => {
+  const query = jest
+    .fn()
+    .mockResolvedValue([{ exists: hasSearchVectorColumn }]);
+  const run = jest.fn().mockResolvedValue(undefined);
+  const command = new RepairTimelineActivitySearchVectorCommand(
+    {} as WorkspaceIteratorService,
+    {
+      getOrRecompute: jest.fn().mockResolvedValue({
+        flatObjectMetadataMaps: {
+          byUniversalIdentifier: {
+            [STANDARD_OBJECTS.timelineActivity.universalIdentifier]: {
+              id: TIMELINE_ACTIVITY_OBJECT_ID,
+              universalIdentifier:
+                STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+              nameSingular: 'timelineActivity',
+              isCustom: false,
+            },
+          },
+        },
+        flatFieldMetadataMaps: {
+          byUniversalIdentifier: {
+            [STANDARD_OBJECTS.timelineActivity.fields.searchVector
+              .universalIdentifier]: {
+              id: SEARCH_VECTOR_FIELD_ID,
+              universalIdentifier:
+                STANDARD_OBJECTS.timelineActivity.fields.searchVector
+                  .universalIdentifier,
+              name: 'searchVector',
+            },
+          },
+        },
+      }),
+    } as unknown as WorkspaceCacheService,
+    { run } as unknown as WorkspaceMigrationRunnerService,
+  );
+
+  return { command, dataSource: { query }, query, run };
+};
+
+const runCommand = (
+  context: ReturnType<typeof buildCommand>,
+  { dryRun = false }: { dryRun?: boolean } = {},
+) =>
+  context.command.runOnWorkspace({
+    workspaceId: WORKSPACE_ID,
+    dataSource: context.dataSource as never,
+    options: { dryRun },
+    index: 0,
+    total: 1,
+  });
+
+describe('RepairTimelineActivitySearchVectorCommand', () => {
+  it('rebuilds a missing timeline activity search vector', async () => {
+    const context = buildCommand({ hasSearchVectorColumn: false });
+
+    await runCommand(context);
+
+    expect(context.run).toHaveBeenCalledWith({
+      workspaceMigration: {
+        applicationUniversalIdentifier:
+          TWENTY_STANDARD_APPLICATION.universalIdentifier,
+        actions: [
+          {
+            type: 'update',
+            metadataName: 'fieldMetadata',
+            universalIdentifier:
+              STANDARD_OBJECTS.timelineActivity.fields.searchVector
+                .universalIdentifier,
+            update: {},
+            rebuildSearchVector: true,
+          },
+        ],
+      },
+      workspaceId: WORKSPACE_ID,
+    });
+  });
+
+  it('does nothing when the search vector column exists', async () => {
+    const context = buildCommand({ hasSearchVectorColumn: true });
+
+    await runCommand(context);
+
+    expect(context.run).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing column without rebuilding during a dry run', async () => {
+    const context = buildCommand({ hasSearchVectorColumn: false });
+
+    await runCommand(context, { dryRun: true });
+
+    expect(context.query).toHaveBeenCalled();
+    expect(context.run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add an idempotent 2.36 workspace upgrade that detects a missing physical `timelineActivity.searchVector` column
- rebuild the generated column and its GIN index through the standard workspace migration runner
- cover missing, healthy, and dry-run paths

## Root cause

The 2.35 timeline compatibility contraction removed the legacy `timelineActivity.name` field through the legacy workspace migration path. The generated search vector could still depend on `name`, so PostgreSQL's `DROP COLUMN ... CASCADE` also removed `searchVector` and its index. Core metadata still retained the search-vector field.

Timeline materialization reads recent activities before merging them. The v2 repository projects the metadata-declared columns, so affected upgraded workspaces fail that read with an undefined-column error wrapped as `Data validation error`. Internal events are still emitted and audit jobs still succeed; the failure is scoped to timeline materialization jobs that enter this merge path.

This also explains why the existing timeline write integration suite stayed green: it provisions a fresh, internally consistent schema rather than upgrading a schema through the 2.35 contraction.

Supersedes #24822, which addressed the repository symptom rather than the schema drift.

## Verification

- reproduced in an affected upgraded workspace and narrowed the failing projection to `timelineActivity.searchVector`
- reproduced PostgreSQL dropping a generated `searchVector` when its legacy source column is dropped with `CASCADE`
- `RepairTimelineActivitySearchVectorCommand`: 3 tests passed
- timeline write path plus search-vector rebuild integration: 14 tests passed
- direct `twenty-server` typecheck passed
- changed-file oxlint passed with zero warnings or errors


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

