### PR TITLE
Fix timeline activity search vector deletion + support ts_vector creation through create field actions handler

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-upgrade-version-command.module.ts
@@ -6,6 +6,7 @@ import { BackfillCommandMenuItemTargetObjectMetadataCommand } from 'src/database
 import { RestoreStandardDefaultRelationFieldsCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787582101000-restore-standard-default-relation-fields.command';
 import { RepairTimelineActivityTargetFieldNamesCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787641226000-repair-timeline-activity-target-field-names.command';
 import { ContractTimelineActivityCompatibilityCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787648000000-contract-timeline-activity-compatibility.command';
+import { BackfillTimelineActivitySearchFieldMetadataCommand } from 'src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
@@ -25,6 +26,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     RestoreStandardDefaultRelationFieldsCommand,
     RepairTimelineActivityTargetFieldNamesCommand,
     ContractTimelineActivityCompatibilityCommand,
+    BackfillTimelineActivitySearchFieldMetadataCommand,
   ],
 })
 export class V2_35_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
@@ -1,25 +1,20 @@
 import { Command } from 'nest-commander';
 
+import { getSearchFieldUniversalIdentifier } from 'twenty-shared/application';
 import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import { isDefined } from 'twenty-shared/utils';
 
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
-import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { type FlatSearchFieldMetadata } from 'src/engine/metadata-modules/flat-search-field-metadata/types/flat-search-field-metadata.type';
 import { buildFlatSearchFieldMetadataForField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/build-flat-search-field-metadata-for-field.util';
-import { getTargetSearchFieldMetadatasForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/get-target-search-field-metadatas-for-ts-vector-field.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
-import { type UniversalUpdateFieldAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/types/workspace-migration-field-action';
-import { WORKSPACE_MIGRATION_ACTION_TYPE } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/constants/workspace-migration-action-type.constant';
-import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
 
 const TIMELINE_ACTIVITY = STANDARD_OBJECTS.timelineActivity;
 const LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER =
@@ -31,15 +26,13 @@ const SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER =
 @Command({
   name: 'upgrade:2-35:backfill-timeline-activity-search-field-metadata',
   description:
-    'Converge the timelineActivity search field metadata to the standard declaration (linkedRecordCachedName), restoring the searchVector field when it is missing and dropping the rows that still index another field, then rebuild the generated column. Repairs workspaces whose search vector was derived from the legacy name field. Idempotent.',
+    'Create the timelineActivity linkedRecordCachedName search field metadata row where it is missing, restoring the searchVector field itself when the workspace lost it. Workspaces upgraded from before the 2.33 search repoint never had this row, and dropping the legacy name field cascades away both their old row and the generated column. Idempotent.',
 })
 export class BackfillTimelineActivitySearchFieldMetadataCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
-    private readonly applicationService: ApplicationService,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
-    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
   ) {
     super(workspaceIteratorService);
   }
@@ -95,20 +88,19 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
         universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
       });
 
-    // timelineActivity declares linkedRecordCachedName as its only search field, so the
-    // search vector indexes at most this one row.
-    const [indexedFlatSearchFieldMetadata] = isDefined(
-      searchVectorFlatFieldMetadata,
-    )
-      ? getTargetSearchFieldMetadatasForTsVectorField({
-          tsVectorFieldMetadataId: searchVectorFlatFieldMetadata.id,
-          flatSearchFieldMetadataMaps,
+    const standardFlatSearchFieldMetadata =
+      flatSearchFieldMetadataMaps.byUniversalIdentifier[
+        getSearchFieldUniversalIdentifier({
+          applicationUniversalIdentifier:
+            timelineActivityFlatObjectMetadata.applicationUniversalIdentifier,
+          fieldMetadataUniversalIdentifier:
+            LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER,
         })
-      : [];
+      ];
 
     if (
-      indexedFlatSearchFieldMetadata?.fieldMetadataUniversalIdentifier ===
-      LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER
+      isDefined(standardFlatSearchFieldMetadata) &&
+      isDefined(searchVectorFlatFieldMetadata)
     ) {
       this.logger.log(
         `timelineActivity search vector already indexes linkedRecordCachedName for workspace ${workspaceId}, skipping`,
@@ -118,58 +110,75 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
     }
 
     this.logger.log(
-      `${isDryRun ? '[DRY RUN] ' : ''}Repointing the timelineActivity search vector to linkedRecordCachedName for workspace ${workspaceId}, currently indexing ${
-        indexedFlatSearchFieldMetadata?.fieldMetadataUniversalIdentifier ??
-        'nothing'
-      }`,
+      `${isDryRun ? '[DRY RUN] ' : ''}Restoring the timelineActivity ${[
+        ...(isDefined(standardFlatSearchFieldMetadata)
+          ? []
+          : ['search field metadata']),
+        ...(isDefined(searchVectorFlatFieldMetadata)
+          ? []
+          : ['searchVector field']),
+      ].join(' and ')} for workspace ${workspaceId}`,
     );
 
     if (isDryRun) {
       return;
     }
 
-    const { twentyStandardFlatApplication } =
-      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
-        { workspaceId },
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          workspaceId,
+          applicationUniversalIdentifier:
+            timelineActivityFlatObjectMetadata.applicationUniversalIdentifier,
+          allFlatEntityOperationByMetadataName: {
+            fieldMetadata: {
+              flatEntityToCreate: isDefined(searchVectorFlatFieldMetadata)
+                ? []
+                : [
+                    this.getStandardSearchVectorFlatFieldMetadata({
+                      workspaceId,
+                      twentyStandardApplicationId:
+                        timelineActivityFlatObjectMetadata.applicationId,
+                    }),
+                  ],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+            searchFieldMetadata: {
+              flatEntityToCreate: isDefined(standardFlatSearchFieldMetadata)
+                ? []
+                : [
+                    buildFlatSearchFieldMetadataForField({
+                      flatObjectMetadata: timelineActivityFlatObjectMetadata,
+                      flatFieldMetadata:
+                        linkedRecordCachedNameFlatFieldMetadata,
+                      tsVectorFlatFieldMetadata: {
+                        universalIdentifier:
+                          SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
+                      },
+                      position: 0,
+                    }),
+                  ],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+        },
       );
 
-    await this.applyConvergence({
-      workspaceId,
-      applicationUniversalIdentifier:
-        twentyStandardFlatApplication.universalIdentifier,
-      flatFieldMetadatasToCreate: isDefined(searchVectorFlatFieldMetadata)
-        ? []
-        : [
-            this.getStandardSearchVectorFlatFieldMetadata({
-              workspaceId,
-              twentyStandardApplicationId: twentyStandardFlatApplication.id,
-            }),
-          ],
-      flatSearchFieldMetadatasToCreate: [
-        buildFlatSearchFieldMetadataForField({
-          flatObjectMetadata: timelineActivityFlatObjectMetadata,
-          flatFieldMetadata: linkedRecordCachedNameFlatFieldMetadata,
-          tsVectorFlatFieldMetadata: {
-            universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
-          },
-          position: 0,
-        }),
-      ],
-      flatSearchFieldMetadatasToDelete: isDefined(
-        indexedFlatSearchFieldMetadata,
-      )
-        ? [indexedFlatSearchFieldMetadata]
-        : [],
-    });
-
-    await this.rebuildSearchVector({
-      workspaceId,
-      applicationUniversalIdentifier:
-        twentyStandardFlatApplication.universalIdentifier,
-    });
+    if (validateAndBuildResult.status === 'fail') {
+      throw new Error(
+        `Failed to restore the timelineActivity search field metadata for workspace ${workspaceId}:\n${JSON.stringify(
+          validateAndBuildResult,
+          null,
+          2,
+        )}`,
+      );
+    }
 
     this.logger.log(
-      `Converged the timelineActivity search vector for workspace ${workspaceId}`,
+      `Restored the timelineActivity search vector for workspace ${workspaceId}`,
     );
   }
 
@@ -204,86 +213,5 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
       viewFieldIds: [],
       viewFieldUniversalIdentifiers: [],
     };
-  }
-
-  // Repointing a row is not expressible as an update: the engine treats a search field
-  // metadata's indexed field as immutable (it is not part of its compared properties),
-  // so the divergent rows are dropped and the standard one recreated in the same matrix.
-  // Legacy path so the system searchVector field is restored exactly as declared,
-  // without the record-page companions the side-effect engine injects for a new field.
-  private async applyConvergence({
-    workspaceId,
-    applicationUniversalIdentifier,
-    flatFieldMetadatasToCreate,
-    flatSearchFieldMetadatasToCreate,
-    flatSearchFieldMetadatasToDelete,
-  }: {
-    workspaceId: string;
-    applicationUniversalIdentifier: string;
-    flatFieldMetadatasToCreate: FlatFieldMetadata[];
-    flatSearchFieldMetadatasToCreate: ReturnType<
-      typeof buildFlatSearchFieldMetadataForField
-    >[];
-    flatSearchFieldMetadatasToDelete: FlatSearchFieldMetadata[];
-  }): Promise<void> {
-    const validateAndBuildResult =
-      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
-        {
-          isSystemBuild: true,
-          workspaceId,
-          applicationUniversalIdentifier,
-          allFlatEntityOperationByMetadataName: {
-            fieldMetadata: {
-              flatEntityToCreate: flatFieldMetadatasToCreate,
-              flatEntityToDelete: [],
-              flatEntityToUpdate: [],
-            },
-            searchFieldMetadata: {
-              flatEntityToCreate: flatSearchFieldMetadatasToCreate,
-              flatEntityToDelete: flatSearchFieldMetadatasToDelete,
-              flatEntityToUpdate: [],
-            },
-          },
-        },
-      );
-
-    if (validateAndBuildResult.status === 'fail') {
-      throw new Error(
-        `Failed to converge the timelineActivity search field metadata for workspace ${workspaceId}:\n${JSON.stringify(
-          validateAndBuildResult,
-          null,
-          2,
-        )}`,
-      );
-    }
-  }
-
-  // Search field metadata operations never touch the workspace schema, so the generated
-  // column keeps the expression it was built with (the dropped name column, or nothing
-  // at all once its cascade took the column down with it).
-  private async rebuildSearchVector({
-    workspaceId,
-    applicationUniversalIdentifier,
-  }: {
-    workspaceId: string;
-    applicationUniversalIdentifier: string;
-  }): Promise<void> {
-    const actions: UniversalUpdateFieldAction[] = [
-      {
-        type: WORKSPACE_MIGRATION_ACTION_TYPE.update,
-        metadataName: 'fieldMetadata',
-        universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
-        update: {},
-        rebuildSearchVector: true,
-      },
-    ];
-
-    await this.workspaceMigrationRunnerService.run({
-      workspaceMigration: {
-        applicationUniversalIdentifier,
-        actions,
-      },
-      workspaceId,
-    });
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
@@ -13,6 +13,7 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type FlatSearchFieldMetadata } from 'src/engine/metadata-modules/flat-search-field-metadata/types/flat-search-field-metadata.type';
 import { buildFlatSearchFieldMetadataForField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/build-flat-search-field-metadata-for-field.util';
+import { getTargetSearchFieldMetadatasForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/get-target-search-field-metadatas-for-ts-vector-field.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
@@ -94,54 +95,33 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
         universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
       });
 
-    const existingFlatSearchFieldMetadatas =
-      timelineActivityFlatObjectMetadata.searchFieldMetadataUniversalIdentifiers
-        .map(
-          (searchFieldMetadataUniversalIdentifier) =>
-            flatSearchFieldMetadataMaps.byUniversalIdentifier[
-              searchFieldMetadataUniversalIdentifier
-            ],
-        )
-        .filter(isDefined);
-
-    const alignedFlatSearchFieldMetadata =
-      existingFlatSearchFieldMetadatas.find(
-        (flatSearchFieldMetadata) =>
-          flatSearchFieldMetadata.fieldMetadataUniversalIdentifier ===
-          LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER,
-      );
-
-    // timelineActivity declares linkedRecordCachedName as its only search field, so any
-    // other row indexes a field the standard definition no longer declares.
-    const divergentFlatSearchFieldMetadatas =
-      existingFlatSearchFieldMetadatas.filter(
-        (flatSearchFieldMetadata) =>
-          flatSearchFieldMetadata.fieldMetadataUniversalIdentifier !==
-          LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER,
-      );
+    // timelineActivity declares linkedRecordCachedName as its only search field, so the
+    // search vector indexes at most this one row.
+    const [indexedFlatSearchFieldMetadata] = isDefined(
+      searchVectorFlatFieldMetadata,
+    )
+      ? getTargetSearchFieldMetadatasForTsVectorField({
+          tsVectorFieldMetadataId: searchVectorFlatFieldMetadata.id,
+          flatSearchFieldMetadataMaps,
+        })
+      : [];
 
     if (
-      isDefined(searchVectorFlatFieldMetadata) &&
-      isDefined(alignedFlatSearchFieldMetadata) &&
-      divergentFlatSearchFieldMetadatas.length === 0
+      indexedFlatSearchFieldMetadata?.fieldMetadataUniversalIdentifier ===
+      LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER
     ) {
       this.logger.log(
-        `timelineActivity search vector already indexes linkedRecordCachedName only for workspace ${workspaceId}, skipping`,
+        `timelineActivity search vector already indexes linkedRecordCachedName for workspace ${workspaceId}, skipping`,
       );
 
       return;
     }
 
     this.logger.log(
-      `${isDryRun ? '[DRY RUN] ' : ''}Converging the timelineActivity search vector for workspace ${workspaceId}: ${
-        isDefined(searchVectorFlatFieldMetadata)
-          ? 'searchVector present'
-          : 'searchVector missing'
-      }, ${
-        isDefined(alignedFlatSearchFieldMetadata)
-          ? 'linkedRecordCachedName indexed'
-          : 'linkedRecordCachedName not indexed'
-      }, ${divergentFlatSearchFieldMetadatas.length} divergent row(s)`,
+      `${isDryRun ? '[DRY RUN] ' : ''}Repointing the timelineActivity search vector to linkedRecordCachedName for workspace ${workspaceId}, currently indexing ${
+        indexedFlatSearchFieldMetadata?.fieldMetadataUniversalIdentifier ??
+        'nothing'
+      }`,
     );
 
     if (isDryRun) {
@@ -165,21 +145,21 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
               twentyStandardApplicationId: twentyStandardFlatApplication.id,
             }),
           ],
-      flatSearchFieldMetadatasToCreate: isDefined(
-        alignedFlatSearchFieldMetadata,
+      flatSearchFieldMetadatasToCreate: [
+        buildFlatSearchFieldMetadataForField({
+          flatObjectMetadata: timelineActivityFlatObjectMetadata,
+          flatFieldMetadata: linkedRecordCachedNameFlatFieldMetadata,
+          tsVectorFlatFieldMetadata: {
+            universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
+          },
+          position: 0,
+        }),
+      ],
+      flatSearchFieldMetadatasToDelete: isDefined(
+        indexedFlatSearchFieldMetadata,
       )
-        ? []
-        : [
-            buildFlatSearchFieldMetadataForField({
-              flatObjectMetadata: timelineActivityFlatObjectMetadata,
-              flatFieldMetadata: linkedRecordCachedNameFlatFieldMetadata,
-              tsVectorFlatFieldMetadata: {
-                universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
-              },
-              position: 0,
-            }),
-          ],
-      flatSearchFieldMetadatasToDelete: divergentFlatSearchFieldMetadatas,
+        ? [indexedFlatSearchFieldMetadata]
+        : [],
     });
 
     await this.rebuildSearchVector({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
@@ -1,0 +1,309 @@
+import { Command } from 'nest-commander';
+
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type FlatSearchFieldMetadata } from 'src/engine/metadata-modules/flat-search-field-metadata/types/flat-search-field-metadata.type';
+import { buildFlatSearchFieldMetadataForField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/build-flat-search-field-metadata-for-field.util';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+import { type UniversalUpdateFieldAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/types/workspace-migration-field-action';
+import { WORKSPACE_MIGRATION_ACTION_TYPE } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/constants/workspace-migration-action-type.constant';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+const TIMELINE_ACTIVITY = STANDARD_OBJECTS.timelineActivity;
+const LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER =
+  TIMELINE_ACTIVITY.fields.linkedRecordCachedName.universalIdentifier;
+const SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER =
+  TIMELINE_ACTIVITY.fields.searchVector.universalIdentifier;
+
+@RegisteredWorkspaceCommand('2.35.0', 1787749300000)
+@Command({
+  name: 'upgrade:2-35:backfill-timeline-activity-search-field-metadata',
+  description:
+    'Converge the timelineActivity search field metadata to the standard declaration (linkedRecordCachedName), restoring the searchVector field when it is missing and dropping the rows that still index another field, then rebuild the generated column. Repairs workspaces whose search vector was derived from the legacy name field. Idempotent.',
+})
+export class BackfillTimelineActivitySearchFieldMetadataCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const {
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      flatSearchFieldMetadataMaps,
+    } = await this.workspaceCacheService.getOrRecompute(workspaceId, [
+      'flatObjectMetadataMaps',
+      'flatFieldMetadataMaps',
+      'flatSearchFieldMetadataMaps',
+    ]);
+
+    const timelineActivityFlatObjectMetadata =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier: TIMELINE_ACTIVITY.universalIdentifier,
+      });
+
+    if (!isDefined(timelineActivityFlatObjectMetadata)) {
+      this.logger.log(
+        `timelineActivity object does not exist for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    const linkedRecordCachedNameFlatFieldMetadata =
+      findFlatEntityByUniversalIdentifier<FlatFieldMetadata>({
+        flatEntityMaps: flatFieldMetadataMaps,
+        universalIdentifier:
+          LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER,
+      });
+
+    if (!isDefined(linkedRecordCachedNameFlatFieldMetadata)) {
+      this.logger.log(
+        `timelineActivity.linkedRecordCachedName does not exist for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    const searchVectorFlatFieldMetadata =
+      findFlatEntityByUniversalIdentifier<FlatFieldMetadata>({
+        flatEntityMaps: flatFieldMetadataMaps,
+        universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
+      });
+
+    const existingFlatSearchFieldMetadatas =
+      timelineActivityFlatObjectMetadata.searchFieldMetadataUniversalIdentifiers
+        .map(
+          (searchFieldMetadataUniversalIdentifier) =>
+            flatSearchFieldMetadataMaps.byUniversalIdentifier[
+              searchFieldMetadataUniversalIdentifier
+            ],
+        )
+        .filter(isDefined);
+
+    const alignedFlatSearchFieldMetadata =
+      existingFlatSearchFieldMetadatas.find(
+        (flatSearchFieldMetadata) =>
+          flatSearchFieldMetadata.fieldMetadataUniversalIdentifier ===
+          LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER,
+      );
+
+    // timelineActivity declares linkedRecordCachedName as its only search field, so any
+    // other row indexes a field the standard definition no longer declares.
+    const divergentFlatSearchFieldMetadatas =
+      existingFlatSearchFieldMetadatas.filter(
+        (flatSearchFieldMetadata) =>
+          flatSearchFieldMetadata.fieldMetadataUniversalIdentifier !==
+          LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER,
+      );
+
+    if (
+      isDefined(searchVectorFlatFieldMetadata) &&
+      isDefined(alignedFlatSearchFieldMetadata) &&
+      divergentFlatSearchFieldMetadatas.length === 0
+    ) {
+      this.logger.log(
+        `timelineActivity search vector already indexes linkedRecordCachedName only for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Converging the timelineActivity search vector for workspace ${workspaceId}: ${
+        isDefined(searchVectorFlatFieldMetadata)
+          ? 'searchVector present'
+          : 'searchVector missing'
+      }, ${
+        isDefined(alignedFlatSearchFieldMetadata)
+          ? 'linkedRecordCachedName indexed'
+          : 'linkedRecordCachedName not indexed'
+      }, ${divergentFlatSearchFieldMetadatas.length} divergent row(s)`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    await this.applyConvergence({
+      workspaceId,
+      applicationUniversalIdentifier:
+        twentyStandardFlatApplication.universalIdentifier,
+      flatFieldMetadatasToCreate: isDefined(searchVectorFlatFieldMetadata)
+        ? []
+        : [
+            this.getStandardSearchVectorFlatFieldMetadata({
+              workspaceId,
+              twentyStandardApplicationId: twentyStandardFlatApplication.id,
+            }),
+          ],
+      flatSearchFieldMetadatasToCreate: isDefined(
+        alignedFlatSearchFieldMetadata,
+      )
+        ? []
+        : [
+            buildFlatSearchFieldMetadataForField({
+              flatObjectMetadata: timelineActivityFlatObjectMetadata,
+              flatFieldMetadata: linkedRecordCachedNameFlatFieldMetadata,
+              tsVectorFlatFieldMetadata: {
+                universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
+              },
+              position: 0,
+            }),
+          ],
+      flatSearchFieldMetadatasToDelete: divergentFlatSearchFieldMetadatas,
+    });
+
+    await this.rebuildSearchVector({
+      workspaceId,
+      applicationUniversalIdentifier:
+        twentyStandardFlatApplication.universalIdentifier,
+    });
+
+    this.logger.log(
+      `Converged the timelineActivity search vector for workspace ${workspaceId}`,
+    );
+  }
+
+  private getStandardSearchVectorFlatFieldMetadata({
+    workspaceId,
+    twentyStandardApplicationId,
+  }: {
+    workspaceId: string;
+    twentyStandardApplicationId: string;
+  }): FlatFieldMetadata {
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        now: new Date().toISOString(),
+        workspaceId,
+        twentyStandardApplicationId,
+      });
+
+    const standardSearchVectorFlatFieldMetadata =
+      findFlatEntityByUniversalIdentifier<FlatFieldMetadata>({
+        flatEntityMaps: standardAllFlatEntityMaps.flatFieldMetadataMaps,
+        universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
+      });
+
+    if (!isDefined(standardSearchVectorFlatFieldMetadata)) {
+      throw new Error(
+        'Standard application is missing timelineActivity.searchVector',
+      );
+    }
+
+    return {
+      ...standardSearchVectorFlatFieldMetadata,
+      viewFieldIds: [],
+      viewFieldUniversalIdentifiers: [],
+    };
+  }
+
+  // Repointing a row is not expressible as an update: the engine treats a search field
+  // metadata's indexed field as immutable (it is not part of its compared properties),
+  // so the divergent rows are dropped and the standard one recreated in the same matrix.
+  // Legacy path so the system searchVector field is restored exactly as declared,
+  // without the record-page companions the side-effect engine injects for a new field.
+  private async applyConvergence({
+    workspaceId,
+    applicationUniversalIdentifier,
+    flatFieldMetadatasToCreate,
+    flatSearchFieldMetadatasToCreate,
+    flatSearchFieldMetadatasToDelete,
+  }: {
+    workspaceId: string;
+    applicationUniversalIdentifier: string;
+    flatFieldMetadatasToCreate: FlatFieldMetadata[];
+    flatSearchFieldMetadatasToCreate: ReturnType<
+      typeof buildFlatSearchFieldMetadataForField
+    >[];
+    flatSearchFieldMetadatasToDelete: FlatSearchFieldMetadata[];
+  }): Promise<void> {
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          workspaceId,
+          applicationUniversalIdentifier,
+          allFlatEntityOperationByMetadataName: {
+            fieldMetadata: {
+              flatEntityToCreate: flatFieldMetadatasToCreate,
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+            searchFieldMetadata: {
+              flatEntityToCreate: flatSearchFieldMetadatasToCreate,
+              flatEntityToDelete: flatSearchFieldMetadatasToDelete,
+              flatEntityToUpdate: [],
+            },
+          },
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      throw new Error(
+        `Failed to converge the timelineActivity search field metadata for workspace ${workspaceId}:\n${JSON.stringify(
+          validateAndBuildResult,
+          null,
+          2,
+        )}`,
+      );
+    }
+  }
+
+  // Search field metadata operations never touch the workspace schema, so the generated
+  // column keeps the expression it was built with (the dropped name column, or nothing
+  // at all once its cascade took the column down with it).
+  private async rebuildSearchVector({
+    workspaceId,
+    applicationUniversalIdentifier,
+  }: {
+    workspaceId: string;
+    applicationUniversalIdentifier: string;
+  }): Promise<void> {
+    const actions: UniversalUpdateFieldAction[] = [
+      {
+        type: WORKSPACE_MIGRATION_ACTION_TYPE.update,
+        metadataName: 'fieldMetadata',
+        universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
+        update: {},
+        rebuildSearchVector: true,
+      },
+    ];
+
+    await this.workspaceMigrationRunnerService.run({
+      workspaceMigration: {
+        applicationUniversalIdentifier,
+        actions,
+      },
+      workspaceId,
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-search-field-metadata/utils/resolve-search-vector-as-expression-for-ts-vector-field.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-search-field-metadata/utils/resolve-search-vector-as-expression-for-ts-vector-field.util.ts
@@ -1,0 +1,43 @@
+import { type FieldMetadataType } from 'twenty-shared/types';
+
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatSearchFieldMetadata } from 'src/engine/metadata-modules/flat-search-field-metadata/types/flat-search-field-metadata.type';
+import { deriveSearchVectorAsExpressionForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/derive-search-vector-as-expression-for-ts-vector-field.util';
+import { getTargetSearchFieldMetadatasForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/get-target-search-field-metadatas-for-ts-vector-field.util';
+
+type ResolvableFlatFieldMetadata = {
+  id: string;
+  name: string;
+  type: FieldMetadataType;
+};
+
+export const resolveSearchVectorAsExpressionForTsVectorField = ({
+  tsVectorFieldMetadataId,
+  objectFlatFieldMetadatas,
+  flatSearchFieldMetadataMaps,
+  getSearchFieldMetadatasByTsVectorFieldId,
+}: {
+  tsVectorFieldMetadataId: string;
+  objectFlatFieldMetadatas: ResolvableFlatFieldMetadata[];
+  flatSearchFieldMetadataMaps: FlatEntityMaps<FlatSearchFieldMetadata>;
+  getSearchFieldMetadatasByTsVectorFieldId?: (
+    tsVectorFieldMetadataId: string,
+  ) => FlatSearchFieldMetadata[];
+}): string =>
+  deriveSearchVectorAsExpressionForTsVectorField({
+    targetSearchFieldMetadatas:
+      getSearchFieldMetadatasByTsVectorFieldId?.(tsVectorFieldMetadataId) ??
+      getTargetSearchFieldMetadatasForTsVectorField({
+        tsVectorFieldMetadataId,
+        flatSearchFieldMetadataMaps,
+      }),
+    indexedFieldById: new Map(
+      objectFlatFieldMetadatas.map((objectFlatFieldMetadata) => [
+        objectFlatFieldMetadata.id,
+        {
+          name: objectFlatFieldMetadata.name,
+          type: objectFlatFieldMetadata.type,
+        },
+      ]),
+    ),
+  });

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/aggregate-orchestrator-actions-report-deprioritize-ts-vector-create-field-actions.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/aggregate-orchestrator-actions-report-deprioritize-ts-vector-create-field-actions.util.ts
@@ -1,0 +1,33 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type AggregateOrchestratorActionsReportArgs } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-aggregate-orchestrator-actions-report-args.type';
+import { type OrchestratorActionsReport } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-orchestrator.type';
+
+export const aggregateOrchestratorActionsReportDeprioritizeTsVectorCreateFieldActions =
+  ({
+    orchestratorActionsReport,
+  }: AggregateOrchestratorActionsReportArgs): OrchestratorActionsReport => {
+    const createFieldActions = orchestratorActionsReport.fieldMetadata.create;
+
+    const tsVectorCreateFieldActions = createFieldActions.filter(
+      (createFieldAction) =>
+        createFieldAction.flatEntity.type === FieldMetadataType.TS_VECTOR,
+    );
+
+    if (tsVectorCreateFieldActions.length === 0) {
+      return orchestratorActionsReport;
+    }
+
+    const otherCreateFieldActions = createFieldActions.filter(
+      (createFieldAction) =>
+        createFieldAction.flatEntity.type !== FieldMetadataType.TS_VECTOR,
+    );
+
+    return {
+      ...orchestratorActionsReport,
+      fieldMetadata: {
+        ...orchestratorActionsReport.fieldMetadata,
+        create: [...otherCreateFieldActions, ...tsVectorCreateFieldActions],
+      },
+    };
+  };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/aggregate-orchestrator-actions-report.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/aggregate-orchestrator-actions-report.util.ts
@@ -1,6 +1,7 @@
 import { type AggregateOrchestratorActionsReportArgs } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-aggregate-orchestrator-actions-report-args.type';
 import { aggregateNonRelationFieldsIntoObjectActions } from 'src/engine/workspace-manager/workspace-migration/utils/aggregate-non-relation-fields-into-object-actions.util';
 import { aggregateOrchestratorActionsReportDeprioritizeSearchVectorUpdateFieldActions } from 'src/engine/workspace-manager/workspace-migration/utils/aggregate-orchestrator-actions-report-deprioritize-search-vector-update-field-actions.util';
+import { aggregateOrchestratorActionsReportDeprioritizeTsVectorCreateFieldActions } from 'src/engine/workspace-manager/workspace-migration/utils/aggregate-orchestrator-actions-report-deprioritize-ts-vector-create-field-actions.util';
 import { aggregateRelationFieldPairs } from 'src/engine/workspace-manager/workspace-migration/utils/aggregate-relation-field-pairs.util';
 
 export const aggregateOrchestratorActionsReport = ({
@@ -11,6 +12,7 @@ export const aggregateOrchestratorActionsReport = ({
   const aggregatedOrchestratorActionsReport = [
     aggregateNonRelationFieldsIntoObjectActions,
     aggregateRelationFieldPairs,
+    aggregateOrchestratorActionsReportDeprioritizeTsVectorCreateFieldActions,
     aggregateOrchestratorActionsReportDeprioritizeSearchVectorUpdateFieldActions,
   ].reduce(
     (currentOrchestratorActionsReport, aggregator) =>

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/create-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/create-field-action-handler.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { RelationType } from 'twenty-shared/types';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { type QueryRunner } from 'typeorm';
 import { v4 } from 'uuid';
@@ -8,11 +8,15 @@ import { v4 } from 'uuid';
 import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type FlatSearchFieldMetadata } from 'src/engine/metadata-modules/flat-search-field-metadata/types/flat-search-field-metadata.type';
+import { resolveSearchVectorAsExpressionForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/resolve-search-vector-as-expression-for-ts-vector-field.util';
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
 import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
 import { convertOnDeleteActionToOnDelete } from 'src/engine/workspace-manager/workspace-migration/utils/convert-on-delete-action-to-on-delete.util';
@@ -119,7 +123,12 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
     const {
       flatAction,
       queryRunner,
-      allFlatEntityMaps: { flatObjectMetadataMaps },
+      allFlatEntityMaps: {
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        flatSearchFieldMetadataMaps,
+      },
+      getSearchFieldMetadatasByTsVectorFieldId,
       workspaceId,
     } = context;
     const { flatEntity, relatedFlatFieldMetadata } = flatAction;
@@ -162,6 +171,9 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
           flatFieldMetadata,
           flatObjectMetadata,
           flatObjectMetadataMaps,
+          objectFlatFieldMetadatas,
+          flatSearchFieldMetadataMaps,
+          getSearchFieldMetadatasByTsVectorFieldId,
           queryRunner,
           schemaName,
           tableName,
@@ -175,6 +187,9 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
     flatFieldMetadata,
     flatObjectMetadata,
     flatObjectMetadataMaps,
+    objectFlatFieldMetadatas,
+    flatSearchFieldMetadataMaps,
+    getSearchFieldMetadatasByTsVectorFieldId,
     queryRunner,
     schemaName,
     tableName,
@@ -183,6 +198,11 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
     flatFieldMetadata: FlatFieldMetadata;
     flatObjectMetadata: FlatObjectMetadata;
     flatObjectMetadataMaps: MetadataFlatEntityMaps<'objectMetadata'>;
+    objectFlatFieldMetadatas: FlatFieldMetadata[];
+    flatSearchFieldMetadataMaps: FlatEntityMaps<FlatSearchFieldMetadata>;
+    getSearchFieldMetadatasByTsVectorFieldId?: (
+      tsVectorFieldMetadataId: string,
+    ) => FlatSearchFieldMetadata[];
     queryRunner: QueryRunner;
     schemaName: string;
     tableName: string;
@@ -198,6 +218,17 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
       flatFieldMetadata,
       flatObjectMetadata,
       workspaceId,
+      searchVectorAsExpression: isFlatFieldMetadataOfType(
+        flatFieldMetadata,
+        FieldMetadataType.TS_VECTOR,
+      )
+        ? resolveSearchVectorAsExpressionForTsVectorField({
+            tsVectorFieldMetadataId: flatFieldMetadata.id,
+            objectFlatFieldMetadatas,
+            flatSearchFieldMetadataMaps,
+            getSearchFieldMetadatasByTsVectorFieldId,
+          })
+        : undefined,
     });
 
     await executeBatchEnumOperations({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/create-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/create-field-action-handler.service.ts
@@ -11,6 +11,7 @@ import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-mana
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
+import { findManyFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-many-flat-entity-by-id-in-flat-entity-maps.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
@@ -154,7 +155,7 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
 
     for (const [
       objectMetadataId,
-      objectFlatFieldMetadatas,
+      createdFlatFieldMetadatas,
     ] of fieldsByObjectMetadataId) {
       const flatObjectMetadata = findFlatEntityByIdInFlatEntityMapsOrThrow({
         flatEntityMaps: flatObjectMetadataMaps,
@@ -166,7 +167,15 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
         objectMetadata: flatObjectMetadata,
       });
 
-      for (const flatFieldMetadata of objectFlatFieldMetadatas) {
+      const objectFlatFieldMetadatas = [
+        ...findManyFlatEntityByIdInFlatEntityMaps({
+          flatEntityMaps: flatFieldMetadataMaps,
+          flatEntityIds: flatObjectMetadata.fieldIds,
+        }),
+        ...createdFlatFieldMetadatas,
+      ];
+
+      for (const flatFieldMetadata of createdFlatFieldMetadatas) {
         await this.executeSingleFieldMetadataWorkspaceSchema({
           flatFieldMetadata,
           flatObjectMetadata,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/update-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/update-field-action-handler.service.ts
@@ -24,8 +24,7 @@ import { isCompositeFlatFieldMetadata } from 'src/engine/metadata-modules/flat-f
 import { isEnumFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-enum-flat-field-metadata.util';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
-import { deriveSearchVectorAsExpressionForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/derive-search-vector-as-expression-for-ts-vector-field.util';
-import { getTargetSearchFieldMetadatasForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/get-target-search-field-metadatas-for-ts-vector-field.util';
+import { resolveSearchVectorAsExpressionForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/resolve-search-vector-as-expression-for-ts-vector-field.util';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
 import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
@@ -354,30 +353,15 @@ export class UpdateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
         FieldMetadataType.TS_VECTOR,
       )
     ) {
-      const indexedFieldById = new Map(
-        findManyFlatEntityByIdInFlatEntityMaps({
-          flatEntityMaps: flatFieldMetadataMaps,
-          flatEntityIds: flatObjectMetadata.fieldIds,
-        }).map((indexedFlatFieldMetadata) => [
-          indexedFlatFieldMetadata.id,
-          {
-            name: indexedFlatFieldMetadata.name,
-            type: indexedFlatFieldMetadata.type,
-          },
-        ]),
-      );
-
       const searchVectorAsExpression =
-        deriveSearchVectorAsExpressionForTsVectorField({
-          targetSearchFieldMetadatas:
-            getSearchFieldMetadatasByTsVectorFieldId?.(
-              optimisticFlatFieldMetadata.id,
-            ) ??
-            getTargetSearchFieldMetadatasForTsVectorField({
-              tsVectorFieldMetadataId: optimisticFlatFieldMetadata.id,
-              flatSearchFieldMetadataMaps,
-            }),
-          indexedFieldById,
+        resolveSearchVectorAsExpressionForTsVectorField({
+          tsVectorFieldMetadataId: optimisticFlatFieldMetadata.id,
+          objectFlatFieldMetadatas: findManyFlatEntityByIdInFlatEntityMaps({
+            flatEntityMaps: flatFieldMetadataMaps,
+            flatEntityIds: flatObjectMetadata.fieldIds,
+          }),
+          flatSearchFieldMetadataMaps,
+          getSearchFieldMetadatasByTsVectorFieldId,
         });
 
       const columnDefinitions = generateColumnDefinitions({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/create-object-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/create-object-action-handler.service.ts
@@ -9,8 +9,7 @@ import { ALL_METADATA_ENTITY_BY_METADATA_NAME } from 'src/engine/metadata-module
 import { isCompositeFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-composite-flat-field-metadata.util';
 import { isEnumFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-enum-flat-field-metadata.util';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
-import { deriveSearchVectorAsExpressionForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/derive-search-vector-as-expression-for-ts-vector-field.util';
-import { getTargetSearchFieldMetadatasForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/get-target-search-field-metadatas-for-ts-vector-field.util';
+import { resolveSearchVectorAsExpressionForTsVectorField } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/resolve-search-vector-as-expression-for-ts-vector-field.util';
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
 import {
   FlatCreateObjectAction,
@@ -135,13 +134,6 @@ export class CreateObjectActionHandlerService extends WorkspaceMigrationRunnerAc
       objectMetadata: flatObjectMetadata,
     });
 
-    const indexedFieldById = new Map(
-      flatFieldMetadatas.map((flatFieldMetadata) => [
-        flatFieldMetadata.id,
-        { name: flatFieldMetadata.name, type: flatFieldMetadata.type },
-      ]),
-    );
-
     const columnDefinitions = flatFieldMetadatas.flatMap((flatFieldMetadata) =>
       generateColumnDefinitions({
         flatFieldMetadata,
@@ -151,17 +143,12 @@ export class CreateObjectActionHandlerService extends WorkspaceMigrationRunnerAc
           flatFieldMetadata,
           FieldMetadataType.TS_VECTOR,
         )
-          ? deriveSearchVectorAsExpressionForTsVectorField({
-              targetSearchFieldMetadatas:
-                getSearchFieldMetadatasByTsVectorFieldId?.(
-                  flatFieldMetadata.id,
-                ) ??
-                getTargetSearchFieldMetadatasForTsVectorField({
-                  tsVectorFieldMetadataId: flatFieldMetadata.id,
-                  flatSearchFieldMetadataMaps:
-                    allFlatEntityMaps.flatSearchFieldMetadataMaps,
-                }),
-              indexedFieldById,
+          ? resolveSearchVectorAsExpressionForTsVectorField({
+              tsVectorFieldMetadataId: flatFieldMetadata.id,
+              objectFlatFieldMetadatas: flatFieldMetadatas,
+              flatSearchFieldMetadataMaps:
+                allFlatEntityMaps.flatSearchFieldMetadataMaps,
+              getSearchFieldMetadatasByTsVectorFieldId,
             })
           : undefined,
       }),


### PR DESCRIPTION
## Summary

Adds `upgrade:2-35:backfill-timeline-activity-search-field-metadata`, which converges the `timelineActivity` search field metadata to the standard declaration and rebuilds its `searchVector` generated column.

## Why

2.33 repointed the `timelineActivity` search field from `name` to `linkedRecordCachedName` in the standard definition, but the standard application sync does not run during upgrades and `upgrade:2-33:replace-timeline-activity-name-with-type` only repointed the label identifier. Workspaces upgraded from before that change therefore still carry a `searchFieldMetadata` row indexing `name`, and a `searchVector` expression built from it.

`upgrade:2-35:contract-timeline-activity-compatibility` then deletes the `name` field. Its column drop is issued with `CASCADE`, so on those workspaces the drop also takes down the `searchVector` generated column that depends on it, while the FK cascade in core removes the `searchFieldMetadata` row. The object is left with a `searchVector` field whose physical column no longer exists.

## What it does

Everything is resolved from the `STANDARD_OBJECTS.timelineActivity` universal identifiers, and the whole command no-ops on a healthy workspace.

- Invalidates and recomputes the object, field and search field metadata maps. The contraction deletes the `name` field through the legacy path, so the row removal happens as a database cascade the migration runner never sees and never invalidates.
- Skips the workspace when the `timelineActivity` object or `linkedRecordCachedName` is absent.
- Recreates the standard `searchVector` field when it is missing.
- Deletes the rows still indexing another field, and creates the standard `linkedRecordCachedName` row at position 0.
- Rebuilds the generated column with a `rebuildSearchVector: true` field update, the same mechanism as `upgrade:2-18:recompute-search-vectors`.

## Notes for review

- **Divergent rows are deleted and the standard one recreated, rather than repointed.** `fieldMetadataId` is `toCompare: false` in `ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME`, so the engine treats a search field metadata's indexed field as immutable and only `position` is diffable. Delete plus create is the only way to express the change in a migration. `timelineActivity` is a system object declaring a single search field, so no user-authored searchable field is at risk here.
- **Legacy migration path** rather than the side-effect one the docs prefer for 2.19 and later: restoring the system `searchVector` field through the engine would inject a record-page view field for it. The sibling 2-35 commands that restore standard metadata use the legacy path for the same reason.
- `timelineActivity` still has no `searchVectorGinIndex` in its static definition, the same gap tracked for `callRecording` in twentyhq/core-team-issues#2672. The rebuild recreates the column without an index, so this is neither a regression nor a fix for that.

## Test plan

- Typecheck and lint pass.
- Cross-version upgrade CI exercises the command, which is a no-op on a freshly provisioned workspace.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

