### PR TITLE
fix: prevent concurrent twenty-sdk output writes

### DIFF
--- a/packages/twenty-front-component-renderer/project.json
+++ b/packages/twenty-front-component-renderer/project.json
@@ -54,7 +54,7 @@
       "dependsOn": [
         "generate-remote-dom-elements",
         {
-          "target": "build:sdk",
+          "target": "build",
           "projects": "twenty-sdk"
         },
         {
@@ -89,10 +89,6 @@
       "dependsOn": [
         "generate-remote-dom-elements",
         "sandbox:prebuild",
-        {
-          "target": "build:sdk",
-          "projects": "twenty-sdk"
-        },
         {
           "target": "build:individual",
           "projects": "twenty-ui"


### PR DESCRIPTION
## Summary

- make the front-component sandbox depend on the canonical `twenty-sdk:build` target
- remove the redundant partial SDK dependency from the renderer Storybook prebuild
- ensure normal frontend and Storybook task graphs have a single writer for `packages/twenty-sdk/dist`

## Why

`twenty-front:build` scheduled both `twenty-sdk:build` and `twenty-sdk:build:sdk`. Both targets write the same `dist` tree, while the full build starts with `rimraf dist`. Depending on Nx scheduling, the delete could overlap the partial build and fail with:

```text
ENOTEMPTY: directory not empty, rmdir '/app/packages/twenty-sdk/dist'
```

This caused preview environments to fail during the Docker compose build, for example https://github.com/twentyhq/ci-public/actions/runs/32968581430.

Using the canonical build as the sandbox dependency lets Nx deduplicate the SDK task. This preserves parallelism for unrelated tasks instead of serializing the whole frontend build or retrying a racy graph.

## Validation

- confirmed `twenty-front:build` task graph contains only `twenty-sdk:build`
- confirmed renderer `storybook:build` task graph contains only `twenty-sdk:build`
- `twenty-shared:build` passes on Node 24.18
- `twenty-client-sdk:build` passes on Node 24.18
- `twenty-sdk:build` passes on Node 24.18
- `twenty-front-component-renderer:sandbox:prebuild` passes on Node 24.18
- `twenty-front-component-renderer:build` passes on Node 24.18
- Prettier check passes


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

