### PR TITLE
remove duplicate dashboard links

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemSectionItems.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemSectionItems.ts
@@ -1,5 +1,4 @@
 import { type NavigationMenuItem } from '~/generated-metadata/graphql';
-
 import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
 import { flattenNavigationMenuItemsWithFolderChildren } from '@/navigation-menu-item/common/utils/flattenNavigationMenuItemsWithFolderChildren';
 import { getWorkspaceSidebarOrphanItemsInDisplayOrder } from '@/navigation-menu-item/display/utils/getWorkspaceSidebarOrphanItemsInDisplayOrder';
@@ -39,8 +38,19 @@ export const useNavigationMenuItemSectionItems = (): NavigationMenuItem[] => {
     includeInaccessibleObjectBackedItems: isLayoutCustomizationModeEnabled,
   });
 
-  return flattenNavigationMenuItemsWithFolderChildren(
+  const flattenedItems = flattenNavigationMenuItemsWithFolderChildren(
     flatItems,
     workspaceNavigationMenuItemsByFolder,
   );
+
+  const seenItemIds = new Set<string>();
+
+  return flattenedItems.filter((item) => {
+    if (seenItemIds.has(item.id)) {
+      return false;
+    }
+
+    seenItemIds.add(item.id);
+    return true;
+  });
 };


### PR DESCRIPTION
Description

When the workspace menu contains duplicate navigation menu items, the same item can be displayed multiple times, resulting in redundant entries such as “Go to Dashboards”.

This change removes duplicate workspace navigation menu items before rendering them.

Testing

git diff --check passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

