### PR TITLE
Skip timeline activity payloads targeting destroyed records

### DIFF
--- a/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
+++ b/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
@@ -4,6 +4,7 @@ import { type ObjectRecord } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { In, MoreThan, type ObjectLiteral } from 'typeorm';
 
+import { POSTGRESQL_ERROR_CODES } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-codes.constants';
 import { objectRecordDiffMerge } from 'src/engine/core-modules/event-emitter/utils/object-record-diff-merge';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
@@ -28,15 +29,42 @@ const ACQUIRE_TIMELINE_ACTIVITY_MERGE_LOCK = `SELECT pg_advisory_xact_lock(hasht
    FROM unnest($1::text[]) WITH ORDINALITY AS "locks"("lockName", "ordinality")
    ORDER BY "ordinality"`;
 
+const isForeignKeyViolation = (error: unknown): boolean =>
+  (error as Error & { cause?: { code?: unknown } }).cause?.code ===
+  POSTGRESQL_ERROR_CODES.FOREIGN_KEY_VIOLATION;
+
 @Injectable()
 export class TimelineActivityRepository {
   constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
-  async upsertTimelineActivities({
+  async upsertTimelineActivities(
+    args: TimelineActivityPayloadWorkspaceIdAndObjectSingularName,
+  ) {
+    try {
+      await this.upsertTimelineActivitiesOnce({
+        ...args,
+        shouldFilterMissingTargets: false,
+      });
+    } catch (error) {
+      if (!isForeignKeyViolation(error)) {
+        throw error;
+      }
+
+      await this.upsertTimelineActivitiesOnce({
+        ...args,
+        shouldFilterMissingTargets: true,
+      });
+    }
+  }
+
+  private async upsertTimelineActivitiesOnce({
     objectSingularName,
     workspaceId,
     payloads,
-  }: TimelineActivityPayloadWorkspaceIdAndObjectSingularName) {
+    shouldFilterMissingTargets,
+  }: TimelineActivityPayloadWorkspaceIdAndObjectSingularName & {
+    shouldFilterMissingTargets: boolean;
+  }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
@@ -139,6 +167,14 @@ export class TimelineActivityRepository {
             }
           }
 
+          const insertablePayloads = shouldFilterMissingTargets
+            ? await this.filterPayloadsWithExistingTarget({
+                transactionScope,
+                objectSingularName,
+                payloads: payloadsToInsert,
+              })
+            : payloadsToInsert;
+
           await Promise.all([
             this.updateTimelineActivities({
               timelineActivityRepository,
@@ -147,12 +183,45 @@ export class TimelineActivityRepository {
             this.insertTimelineActivities({
               timelineActivityRepository,
               objectSingularName,
-              payloads: payloadsToInsert,
+              payloads: insertablePayloads,
             }),
           ]);
         },
       );
     }, authContext);
+  }
+
+  private async filterPayloadsWithExistingTarget({
+    transactionScope,
+    objectSingularName,
+    payloads,
+  }: {
+    transactionScope: WorkspaceTransactionScope;
+    objectSingularName: string;
+    payloads: TimelineActivityPayloadWorkspaceIdAndObjectSingularName['payloads'];
+  }) {
+    if (payloads.length === 0) {
+      return payloads;
+    }
+
+    const targetRepository = transactionScope.getRepository<ObjectLiteral>(
+      objectSingularName,
+      { shouldBypassPermissionChecks: true },
+    );
+
+    const existingRecords = await targetRepository.find({
+      select: ['id'],
+      where: { id: In(payloads.map((payload) => payload.recordId)) },
+      withDeleted: true,
+    });
+
+    const existingRecordIds = new Set(
+      existingRecords.map((record) => record.id),
+    );
+
+    return payloads.filter((payload) =>
+      existingRecordIds.has(payload.recordId),
+    );
   }
 
   private async acquireMergeLocks({


### PR DESCRIPTION
## Context

[TWENTY-SERVER-5SG](https://twenty-v7.sentry.io/issues/6605857826): `insert or update on table "timelineActivity" violates foreign key constraint` — 13k events across 466 workspaces since May 2025, ~60/day currently, dominated by `FK_7460f3992bc8d73165b3b2874e6` (`targetCompanyId`).

## Root cause

Timeline activities are written asynchronously: a record event is queued on `entityEventsToDbQueue` and inserted later by the worker. If the record is hard-destroyed before the job runs, the insert references a row that no longer exists and violates the target FK. `destroyed` events are not timeline-routed, so nothing cancels the already-queued job.

The window is not exotic: REST `DELETE` is a hard destroy by default, the UI exposes delete-then-destroy, and the queue runs at concurrency 1 per worker, so any backlog widens it from milliseconds to seconds.

**Reproduced locally** against this branch, with the worker paused to make the queue window explicit: create a company, soft-delete it, destroy it, then let the worker drain. Result: 8 violations of `FK_7460f3992bc8d73165b3b2874e6`, the exact constraint from Sentry. With the fix, the same script yields 0 violations and the timeline jobs succeed.

Record merge was also tested and is **not** a producer: it re-points related records (including existing `timelineActivity` rows) to the winner before hard-deleting the losers, and the resulting junction event produces a `taskLinked` payload targeting the winner, not a dangling one.

A payload pointing at a destroyed record is one whose activity would be cascade-deleted with that record (`ON DELETE CASCADE`), so there is nothing to write.

## Fix

On a foreign key violation, retry the upsert once with the insert payloads filtered by target-record existence (`withDeleted: true`, so soft-deleted targets keep their activities). The happy path is untouched — no extra query — and only the payloads whose target is gone are dropped.

The retry matters because the batch is one transaction: without it, a single dangling payload takes every other timeline entry in the batch down with it.

No error swallowing: a residual foreign key violation (a destroy landing between the filter and the insert, or a dangling `workspaceMemberId`) still surfaces in Sentry, which is intended — after this fix those should be near zero, and any remaining occurrence points at a different producer.

Fixes TWENTY-SERVER-5SG
