### PR TITLE
fix(front-component): stop Node.contains from hanging the sandbox worker

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
@@ -808,7 +808,7 @@ A `ref` gives you a sandbox element, not an `HTMLElement`.
 |----------------|--------------|-------------|
 | `ref.current.focus()`, `.click()`, `.select()`, `.setSelectionRange()`, `.scrollIntoView()`, `video.play()` | Throws | Controlled components; read values from `event.target` |
 | `element.classList.add(...)` | Throws (`classList` is `undefined`) | Build the `className` string yourself |
-| `document.createTreeWalker()` | Throws | `querySelector()` / `querySelectorAll()` and `getElementById()` work; `getElementsByClassName()` works too, but returns a static collection, not a live `HTMLCollection` |
+| `document.createTreeWalker()` | Throws | `querySelector()` / `querySelectorAll()`, `getElementById()` and `node.contains()` work; `getElementsByClassName()` works too, but returns a static collection, not a live `HTMLCollection` |
 | `document.activeElement` | Always `undefined` | Track focus with `onFocus` / `onBlur` |
 | `canvas` | Renders nothing, no error | SVG, or draw offscreen and show the result in an `img` element |
 | `createPortal(node, document.body)` | Renders nothing, while `isConnected` reports success | Overlays inline with `position: absolute`, or pass the library your own container element |

--- a/packages/twenty-front-component-renderer/src/__stories__/TwentyUiGallery.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/TwentyUiGallery.stories.tsx
@@ -162,18 +162,6 @@ export const SurfacesPreact: Story = createGalleryStory(
   'preact',
 );
 
-// KNOWN ISSUE (TDD) golden test: an open Modal (base-ui Dialog portal) hangs
-// the React-runtime render — the gallery status must never mount. Works under
-// Preact (see ModalOpenPreact). When fixed, flip this story to the strict
-// zero-failure play used by ModalOpenPreact.
-const modalOpenHangTest: Story['play'] = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-
-  await expect(
-    canvas.findByTestId('gallery-status', {}, { timeout: 10000 }),
-  ).rejects.toThrow();
-};
-
 const modalOpenTest: Story['play'] = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
 
@@ -193,7 +181,7 @@ const modalOpenTest: Story['play'] = async ({ canvasElement }) => {
 
 export const ModalOpenReact: Story = {
   ...createGalleryStory('twenty-ui-modal-open-gallery'),
-  play: modalOpenHangTest,
+  play: modalOpenTest,
 };
 export const ModalOpenPreact: Story = {
   ...createGalleryStory('twenty-ui-modal-open-gallery', 'preact'),

--- a/packages/twenty-front-component-renderer/src/polyfills/dom/utils/__tests__/installNodeContains.test.ts
+++ b/packages/twenty-front-component-renderer/src/polyfills/dom/utils/__tests__/installNodeContains.test.ts
@@ -1,0 +1,96 @@
+import { installNodeContains } from '../installNodeContains';
+
+class FakeNode {
+  parentNode: FakeNode | null = null;
+
+  appendChild(child: FakeNode): FakeNode {
+    child.parentNode = this;
+
+    return child;
+  }
+}
+
+installNodeContains(FakeNode.prototype);
+
+type NodeWithContains = FakeNode & {
+  contains: (otherNode: unknown) => boolean;
+};
+
+const asInstalled = (node: FakeNode) => node as NodeWithContains;
+
+describe('installNodeContains', () => {
+  it('should report a node as containing itself', () => {
+    const node = new FakeNode();
+
+    expect(asInstalled(node).contains(node)).toBe(true);
+  });
+
+  it('should report a direct child as contained', () => {
+    const parent = new FakeNode();
+    const child = parent.appendChild(new FakeNode());
+
+    expect(asInstalled(parent).contains(child)).toBe(true);
+  });
+
+  it('should report a deep descendant as contained', () => {
+    const root = new FakeNode();
+    const intermediate = root.appendChild(new FakeNode());
+    const leaf = intermediate.appendChild(new FakeNode());
+
+    expect(asInstalled(root).contains(leaf)).toBe(true);
+  });
+
+  it('should not report an ancestor as contained by its descendant', () => {
+    const root = new FakeNode();
+    const child = root.appendChild(new FakeNode());
+
+    expect(asInstalled(child).contains(root)).toBe(false);
+  });
+
+  it('should not report a node from a detached tree as contained', () => {
+    const root = new FakeNode();
+    root.appendChild(new FakeNode());
+
+    const otherRoot = new FakeNode();
+    const otherLeaf = otherRoot.appendChild(new FakeNode());
+
+    expect(asInstalled(root).contains(otherLeaf)).toBe(false);
+  });
+
+  it('should return false for a nullish argument', () => {
+    const node = new FakeNode();
+
+    expect(asInstalled(node).contains(null)).toBe(false);
+    expect(asInstalled(node).contains(undefined)).toBe(false);
+  });
+
+  it('should read each ancestor once instead of re-reading the argument', () => {
+    const root = new FakeNode();
+    const intermediate = root.appendChild(new FakeNode());
+    const leaf = intermediate.appendChild(new FakeNode());
+    const ancestorChain = [leaf, intermediate, root];
+
+    // A cursor that never advances re-reads the same parentNode forever, which
+    // hangs rather than fails; the read budget turns that into an assertion.
+    let parentNodeReads = 0;
+
+    for (const node of ancestorChain) {
+      const resolvedParentNode = node.parentNode;
+
+      Object.defineProperty(node, 'parentNode', {
+        get: () => {
+          parentNodeReads += 1;
+
+          if (parentNodeReads > ancestorChain.length) {
+            throw new Error('contains() did not advance past the argument');
+          }
+
+          return resolvedParentNode;
+        },
+      });
+    }
+
+    expect(asInstalled(new FakeNode()).contains(leaf)).toBe(false);
+    expect(parentNodeReads).toBe(ancestorChain.length);
+  });
+});

--- a/packages/twenty-front-component-renderer/src/polyfills/dom/utils/installNodeContains.ts
+++ b/packages/twenty-front-component-renderer/src/polyfills/dom/utils/installNodeContains.ts
@@ -1,0 +1,31 @@
+import { isObject } from '@sniptt/guards';
+import { isDefined } from 'twenty-shared/utils';
+
+type NodeLike = { parentNode?: unknown };
+
+// @remote-dom/polyfill 1.5.1 ships Node.contains with a cursor that never
+// advances: it re-reads the argument's own parentNode on every pass instead of
+// the current node's. Any node whose parent is neither the receiver nor null
+// therefore loops forever, wedging the worker's event loop with no exception
+// thrown, so timers and the remote-dom bridge stop with no visible error.
+export const installNodeContains = (installTarget: object): void => {
+  Object.defineProperty(installTarget, 'contains', {
+    value: function (this: object, otherNode: unknown): boolean {
+      let currentNode: object | null = isObject(otherNode) ? otherNode : null;
+
+      while (isDefined(currentNode)) {
+        if (currentNode === this) {
+          return true;
+        }
+
+        const parentNode: unknown = (currentNode as NodeLike).parentNode;
+
+        currentNode = isObject(parentNode) ? parentNode : null;
+      }
+
+      return false;
+    },
+    configurable: true,
+    writable: true,
+  });
+};

--- a/packages/twenty-front-component-renderer/src/remote/worker/remote-worker.ts
+++ b/packages/twenty-front-component-renderer/src/remote/worker/remote-worker.ts
@@ -15,6 +15,7 @@ import { installGetComputedStyle } from '@/polyfills/dom/utils/installGetCompute
 import { installGetElementsByClassName } from '@/polyfills/dom/utils/installGetElementsByClassName';
 import { installLocalStyleOnBaseElements } from '@/polyfills/dom/utils/installLocalStyleOnBaseElements';
 import { installMutationObserver } from '@/polyfills/dom/utils/installMutationObserver';
+import { installNodeContains } from '@/polyfills/dom/utils/installNodeContains';
 import { workerGeometryStore } from '@/polyfills/geometry/states/workerGeometryStore';
 import { installElementGeometryPolyfill } from '@/polyfills/geometry/utils/installElementGeometryPolyfill';
 import { installWindowGeometryPolyfill } from '@/polyfills/geometry/utils/installWindowGeometryPolyfill';
@@ -44,6 +45,7 @@ installDocumentGetElementById(document);
 installGetElementsByClassName(Element.prototype);
 installGetElementsByClassName(document);
 installLocalStyleOnBaseElements(Element.prototype);
+installNodeContains(Node.prototype);
 
 installGetComputedStyle(toGlobalScopeRecord(globalThis));
 


### PR DESCRIPTION
Closes #24573

## Problem

`@remote-dom/polyfill` implements `Node.contains` with a cursor that never advances:

```js
// node_modules/@remote-dom/polyfill/build/esm/Node.mjs:106
contains(node) {
  let currentNode = node;
  while (true) {
    if (currentNode == null) return false;
    if (currentNode === this) return true;
    currentNode = node.parentNode;   // re-reads the argument, not the cursor
  }
}
```

`currentNode` is assigned `node.parentNode` on every pass, so after the first step it is a constant. Only three inputs terminate:

- the receiver itself (`currentNode === this` before any parent read),
- a **direct** child, whose `parentNode` happens to be the receiver on that first read,
- a parentless node (`null` ends the loop).

Every other input loops forever: a deeper descendant, or any unrelated node that has a parent. `typeof element.contains === 'function'` is `true` and nothing throws, so the worker's event loop simply stops. Timers stop firing, remote-dom mutations stop, and the mirrored UI freezes with no console output, recoverable only by reloading the page.

That accidental direct-child case is why this went unnoticed: the shape you reach for first in a repro works. Hit-testing between arbitrary elements, as in the drag-and-drop editor from the issue, hits the non-terminating branch almost immediately, so it presents as "the widget randomly freezes on drop".

## Fix

`installNodeContains` installs a spec-correct `contains()` that walks the ancestor chain of the *argument*, advancing the cursor each step. It follows the existing `install*` polyfill pattern in this package and reuses the same traversal `isElementUnderRemoteRoot` already does (`parentNode` via `isObject`, terminating on a non-object).

It is installed on `Node.prototype`. The polyfill's hierarchy is `Element extends ParentNode extends ChildNode extends Node`, so one install covers every sandbox element, and `Window.setGlobal` copies `Node` onto the worker's `globalThis`, so `Node.prototype` is reachable at the existing install site.

`1.5.1` is the latest published `@remote-dom/polyfill`, so there is no upstream release to bump to. The bug is present in both its `esm` and `cjs` builds.

## Scope

Only `contains()` is corrected. The polyfill assumes an acyclic tree throughout (`textContent`, `selfAndDescendants`, the `MutationObserver` ancestor walks), and insertion has no hierarchy-request guard, so a deliberately constructed parent cycle would still hang. That is a separate, latent concern and not what this issue hit; guarding it only here would cost an allocation per `contains()` call on a hit-testing path while leaving the rest of the polyfill exposed.

## Tests

`installNodeContains.test.ts` covers the identity case, a direct child, a deep descendant, the reverse direction (descendant does not contain its ancestor), a node from a detached tree, and nullish arguments.

The last test pins the non-termination directly. A synchronous infinite loop cannot be caught by Jest's timeout, so a naive regression test would hang CI instead of failing. Instead it wraps each ancestor's `parentNode` in a counting getter that throws once reads exceed the chain length, then asserts the walk reads exactly one parent per ancestor. Replaying the upstream implementation against that fixture throws on the 4th read, so the test fails fast rather than hanging if the fix regresses.

I also checked the fix against the real polyfill rather than only the test double: with `Window.setGlobal` applied, `globalThis.Node` is a function, `Element.prototype` inherits from `Node.prototype`, the upstream `contains` is confirmed non-terminating for a deeper walk, and after the install all of `contains(self)`, `contains(grandchild)`, `contains(unrelated)`, `contains(ancestor)` and `contains(null)` return the spec answers.

```
Test Suites: 108 passed, 108 total
Tests:       650 passed, 650 total
```

`oxlint --type-aware` and `oxfmt --check` clean on the changed files. `tsgo --noEmit` on `twenty-front-component-renderer` reports the same 332 pre-existing errors before and after this change (unbuilt `twenty-sdk` subpath imports plus existing `Window`/`Storage` typings); none are in the touched files.

## Docs

The "DOM access" limitations table listed the traversal APIs that work; `node.contains()` now joins them.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

