### PR TITLE
Move call recording widget types to type files and dedupe target lookup

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording/components/CallRecordingWidgetUnavailableDisplay.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording/components/CallRecordingWidgetUnavailableDisplay.tsx
@@ -1,5 +1,5 @@
 import { CallRecordingWidgetEmptyStateDisplay } from '@/page-layout/widgets/call-recording/components/CallRecordingWidgetEmptyStateDisplay';
-import { type CallRecordingWidgetUnavailableReason } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingWidgetUnavailableReason';
+import { type CallRecordingWidgetUnavailableReason } from '@/page-layout/widgets/call-recording/types/CallRecordingWidgetUnavailableReason';
 import { t } from '@lingui/core/macro';
 
 type CallRecordingWidgetUnavailableDisplayProps = {

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording/hooks/useCalendarEventTargetRecordId.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording/hooks/useCalendarEventTargetRecordId.ts
@@ -1,11 +1,9 @@
-import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
-import { CoreObjectNameSingular } from 'twenty-shared/types';
+import { useCallRecordingWidgetTarget } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingWidgetTarget';
 
 export const useCalendarEventTargetRecordId = (): string | undefined => {
-  const { targetRecordIdentifier } = useLayoutRenderingContext();
+  const callRecordingWidgetTarget = useCallRecordingWidgetTarget();
 
-  return targetRecordIdentifier?.targetObjectNameSingular ===
-    CoreObjectNameSingular.CalendarEvent
-    ? targetRecordIdentifier.id
+  return callRecordingWidgetTarget?.targetKind === 'calendarEvent'
+    ? callRecordingWidgetTarget.recordId
     : undefined;
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording/hooks/useCallRecordingWidgetTarget.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording/hooks/useCallRecordingWidgetTarget.ts
@@ -1,10 +1,6 @@
+import { type CallRecordingWidgetTarget } from '@/page-layout/widgets/call-recording/types/CallRecordingWidgetTarget';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
-
-export type CallRecordingWidgetTarget = {
-  targetKind: 'calendarEvent' | 'callRecording';
-  recordId: string;
-};
 
 export const useCallRecordingWidgetTarget = ():
   | CallRecordingWidgetTarget

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording/hooks/useCallRecordingWidgetUnavailableReason.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording/hooks/useCallRecordingWidgetUnavailableReason.ts
@@ -1,11 +1,8 @@
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useCallRecordingWidgetTarget } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingWidgetTarget';
+import { type CallRecordingWidgetUnavailableReason } from '@/page-layout/widgets/call-recording/types/CallRecordingWidgetUnavailableReason';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-
-export type CallRecordingWidgetUnavailableReason =
-  | 'workspaceWithoutCallRecording'
-  | 'recordWithoutCallRecording';
 
 export const useCallRecordingWidgetUnavailableReason = ():
   | CallRecordingWidgetUnavailableReason

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording/types/CallRecordingWidgetTarget.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording/types/CallRecordingWidgetTarget.ts
@@ -1,0 +1,4 @@
+export type CallRecordingWidgetTarget = {
+  targetKind: 'calendarEvent' | 'callRecording';
+  recordId: string;
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording/types/CallRecordingWidgetUnavailableReason.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording/types/CallRecordingWidgetUnavailableReason.ts
@@ -1,0 +1,3 @@
+export type CallRecordingWidgetUnavailableReason =
+  | 'workspaceWithoutCallRecording'
+  | 'recordWithoutCallRecording';


### PR DESCRIPTION
## Summary

Follow-up to #24810 (call recording summary and transcript tabs), aligning it with the PR review conventions:

- Move `CallRecordingWidgetTarget` and `CallRecordingWidgetUnavailableReason` out of their hook files into dedicated files under `page-layout/widgets/call-recording/types/`, matching the exported-types-in-their-own-file convention (the `types/` leaf folder already existed next door with `WidgetCallRecordingCandidate`); `CallRecordingWidgetUnavailableDisplay` now imports the reason type from the type file instead of a hook file
- Rewrite `useCalendarEventTargetRecordId` on top of `useCallRecordingWidgetTarget` so the layout-target-to-widget-target mapping lives in a single place instead of being duplicated across the two hooks

No behavior change.

## Tests

- 98 twenty-front tests under `page-layout/widgets/call-recording*` pass
- `tsgo --noEmit` clean for the touched files (remaining errors are pre-existing unbuilt-package noise in `front-components`)
- oxlint + oxfmt clean on the changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_014Jav6TwkuzT38iby7xsYu7)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

