### PR TITLE
Rebuild timelineActivity searchVector column when dropped at pg level

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
@@ -113,8 +113,8 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
         })
       ];
 
-    // When the field metadata itself is missing, the create path recreates the
-    // column; only probe the schema for a field the metadata claims to have.
+    // Without field metadata there is no column name to probe; the column is
+    // gone with it and the create path recreates both.
     const searchVectorColumnExists = isDefined(searchVectorFlatFieldMetadata)
       ? await this.checkSearchVectorColumnExists({
           dataSource,
@@ -122,7 +122,7 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
           timelineActivityFlatObjectMetadata,
           columnName: searchVectorFlatFieldMetadata.name,
         })
-      : true;
+      : false;
 
     if (
       isDefined(standardFlatSearchFieldMetadata) &&

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
@@ -3,6 +3,7 @@ import { Command } from 'nest-commander';
 import { getSearchFieldUniversalIdentifier } from 'twenty-shared/application';
 import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import { isDefined } from 'twenty-shared/utils';
+import { type DataSource } from 'typeorm';
 
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
@@ -15,6 +16,10 @@ import { buildFlatSearchFieldMetadataForField } from 'src/engine/metadata-module
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+import { type UniversalUpdateFieldAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/types/workspace-migration-field-action';
+import { WORKSPACE_MIGRATION_ACTION_TYPE } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/constants/workspace-migration-action-type.constant';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
 
 const TIMELINE_ACTIVITY = STANDARD_OBJECTS.timelineActivity;
 const LINKED_RECORD_CACHED_NAME_FIELD_UNIVERSAL_IDENTIFIER =
@@ -26,19 +31,21 @@ const SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER =
 @Command({
   name: 'upgrade:2-35:backfill-timeline-activity-search-field-metadata',
   description:
-    'Create the timelineActivity linkedRecordCachedName search field metadata row where it is missing, restoring the searchVector field itself when the workspace lost it. Workspaces upgraded from before the 2.33 search repoint never had this row, and dropping the legacy name field cascades away both their old row and the generated column. Idempotent.',
+    'Create the timelineActivity linkedRecordCachedName search field metadata row where it is missing, restoring the searchVector field itself when the workspace lost it, and rebuild the physical searchVector column when it was dropped at the database level while the metadata survived. Workspaces upgraded from before the 2.33 search repoint never had this row, and dropping the legacy name field cascades away both their old row and the generated column. Idempotent.',
 })
 export class BackfillTimelineActivitySearchFieldMetadataCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
   ) {
     super(workspaceIteratorService);
   }
 
   override async runOnWorkspace({
     workspaceId,
+    dataSource,
     options,
   }: RunOnWorkspaceArgs): Promise<void> {
     const isDryRun = options.dryRun ?? false;
@@ -82,6 +89,14 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
       return;
     }
 
+    if (!isDefined(dataSource)) {
+      this.logger.error(
+        `Cannot verify the timelineActivity searchVector column for workspace ${workspaceId}: no data source. Skipping, rerun once the workspace is reachable.`,
+      );
+
+      return;
+    }
+
     const searchVectorFlatFieldMetadata =
       findFlatEntityByUniversalIdentifier<FlatFieldMetadata>({
         flatEntityMaps: flatFieldMetadataMaps,
@@ -98,9 +113,19 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
         })
       ];
 
+    const isSearchVectorColumnMissing = isDefined(searchVectorFlatFieldMetadata)
+      ? !(await this.searchVectorColumnExists({
+          dataSource,
+          workspaceId,
+          timelineActivityFlatObjectMetadata,
+          columnName: searchVectorFlatFieldMetadata.name,
+        }))
+      : false;
+
     if (
       isDefined(standardFlatSearchFieldMetadata) &&
-      isDefined(searchVectorFlatFieldMetadata)
+      isDefined(searchVectorFlatFieldMetadata) &&
+      !isSearchVectorColumnMissing
     ) {
       this.logger.log(
         `timelineActivity search vector already indexes linkedRecordCachedName for workspace ${workspaceId}, skipping`,
@@ -117,10 +142,43 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
         ...(isDefined(searchVectorFlatFieldMetadata)
           ? []
           : ['searchVector field']),
+        ...(isSearchVectorColumnMissing ? ['searchVector column'] : []),
       ].join(' and ')} for workspace ${workspaceId}`,
     );
 
     if (isDryRun) {
+      return;
+    }
+
+    if (
+      isDefined(standardFlatSearchFieldMetadata) &&
+      isDefined(searchVectorFlatFieldMetadata)
+    ) {
+      // Metadata is already converged and only the physical column is missing.
+      // The builder diffs metadata so it would produce no action here; dispatch
+      // the rebuild directly to the update-field action handler instead, which
+      // drops and recreates the generated column from the search field metadata.
+      const rebuildSearchVectorAction: UniversalUpdateFieldAction = {
+        type: WORKSPACE_MIGRATION_ACTION_TYPE.update,
+        metadataName: 'fieldMetadata',
+        universalIdentifier: SEARCH_VECTOR_FIELD_UNIVERSAL_IDENTIFIER,
+        update: {},
+        rebuildSearchVector: true,
+      };
+
+      await this.workspaceMigrationRunnerService.run({
+        workspaceMigration: {
+          applicationUniversalIdentifier:
+            timelineActivityFlatObjectMetadata.applicationUniversalIdentifier,
+          actions: [rebuildSearchVectorAction],
+        },
+        workspaceId,
+      });
+
+      this.logger.log(
+        `Restored the timelineActivity search vector column for workspace ${workspaceId}`,
+      );
+
       return;
     }
 
@@ -180,6 +238,33 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
     this.logger.log(
       `Restored the timelineActivity search vector for workspace ${workspaceId}`,
     );
+  }
+
+  private async searchVectorColumnExists({
+    dataSource,
+    workspaceId,
+    timelineActivityFlatObjectMetadata,
+    columnName,
+  }: {
+    dataSource: DataSource;
+    workspaceId: string;
+    timelineActivityFlatObjectMetadata: FlatObjectMetadata;
+    columnName: string;
+  }): Promise<boolean> {
+    const { schemaName, tableName } = getWorkspaceSchemaContextForMigration({
+      workspaceId,
+      objectMetadata: timelineActivityFlatObjectMetadata,
+    });
+
+    const rows = await dataSource.query<{ exists: boolean }[]>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema = $1 AND table_name = $2 AND column_name = $3
+       ) AS "exists"`,
+      [schemaName, tableName, columnName],
+    );
+
+    return rows[0]?.exists === true;
   }
 
   private getStandardSearchVectorFlatFieldMetadata({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
@@ -256,12 +256,16 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
       objectMetadata: timelineActivityFlatObjectMetadata,
     });
 
+    // pg_attribute scoped to the single table, not the instance-wide
+    // information_schema.columns view, which is slow on many-tenant instances.
     const rows = await dataSource.query<{ exists: boolean }[]>(
       `SELECT EXISTS (
-         SELECT 1 FROM information_schema.columns
-         WHERE table_schema = $1 AND table_name = $2 AND column_name = $3
+         SELECT 1 FROM pg_attribute
+         WHERE attrelid = to_regclass($1)
+           AND attname = $2
+           AND NOT attisdropped
        ) AS "exists"`,
-      [schemaName, tableName, columnName],
+      [`"${schemaName}"."${tableName}"`, columnName],
     );
 
     return rows[0]?.exists === true;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-35/2-35-workspace-command-1787749300000-backfill-timeline-activity-search-field-metadata.command.ts
@@ -113,19 +113,21 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
         })
       ];
 
-    const isSearchVectorColumnMissing = isDefined(searchVectorFlatFieldMetadata)
-      ? !(await this.searchVectorColumnExists({
+    // When the field metadata itself is missing, the create path recreates the
+    // column; only probe the schema for a field the metadata claims to have.
+    const searchVectorColumnExists = isDefined(searchVectorFlatFieldMetadata)
+      ? await this.checkSearchVectorColumnExists({
           dataSource,
           workspaceId,
           timelineActivityFlatObjectMetadata,
           columnName: searchVectorFlatFieldMetadata.name,
-        }))
-      : false;
+        })
+      : true;
 
     if (
       isDefined(standardFlatSearchFieldMetadata) &&
       isDefined(searchVectorFlatFieldMetadata) &&
-      !isSearchVectorColumnMissing
+      searchVectorColumnExists
     ) {
       this.logger.log(
         `timelineActivity search vector already indexes linkedRecordCachedName for workspace ${workspaceId}, skipping`,
@@ -142,7 +144,7 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
         ...(isDefined(searchVectorFlatFieldMetadata)
           ? []
           : ['searchVector field']),
-        ...(isSearchVectorColumnMissing ? ['searchVector column'] : []),
+        ...(searchVectorColumnExists ? [] : ['searchVector column']),
       ].join(' and ')} for workspace ${workspaceId}`,
     );
 
@@ -240,7 +242,7 @@ export class BackfillTimelineActivitySearchFieldMetadataCommand extends Provisio
     );
   }
 
-  private async searchVectorColumnExists({
+  private async checkSearchVectorColumnExists({
     dataSource,
     workspaceId,
     timelineActivityFlatObjectMetadata,


### PR DESCRIPTION
## Summary

Follow-up to #24846. `upgrade:2-35:backfill-timeline-activity-search-field-metadata` skipped a workspace as healthy when both the `searchFieldMetadata` row and the `searchVector` field metadata exist, without checking that the generated column actually exists in the workspace schema. A workspace where the column was cascade-dropped at the database level but the metadata survived was left broken and skipped on every run.

The v2.35.1 staging run confirmed the gap: every workspace that went through the restore path had its column rebuilt by the injected `rebuildSearchVector` update action, but workspaces hitting the metadata-only skip check were never touched.

## What it does

- Reads `information_schema.columns` through the workspace data source to verify the `searchVector` column physically exists, using the same pattern as `upgrade:2-35:repair-timeline-activity-target-field-names`. When no data source is available, it logs an error and skips so the instance sequence is not aborted.
- The skip condition now requires converged metadata and the physical column.
- When the metadata is already converged and only the column is missing, the migration builder would diff to nothing, so the command dispatches an `update:fieldMetadata` action with `rebuildSearchVector: true` directly to `WorkspaceMigrationRunnerService.run`, the same mechanism as `upgrade:2-18:recompute-search-vectors`. The update-field action handler then drops (`IF EXISTS`) and recreates the generated column from the search field metadata rows, and the runner invalidates the flat-maps caches.
- The missing-metadata path is unchanged: creating the `searchFieldMetadata` row already injects the rebuild action, which recreates the column.

## Notes

- Instances that already ran v2.35.1 have this command recorded in the upgrade cursor, so the fixed logic will not re-run through `upgrade`. Run it directly by name on affected instances: `yarn command:prod upgrade:2-35:backfill-timeline-activity-search-field-metadata` (supports `--dry-run` and `-w <workspace-id>`).
- Still idempotent: a healthy workspace resolves to a single `information_schema` probe and skips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYLKsd4BrAMEc9DxgMdait)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

