### PR TITLE
Fix view picker create button width

### DIFF
--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerSaveButtonContainer.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerSaveButtonContainer.tsx
@@ -4,7 +4,7 @@ import { themeCssVariables } from 'twenty-ui/theme-constants';
 const StyledSaveButtonContainer = styled.div`
   display: flex;
   padding: ${themeCssVariables.spacing[1]};
-  width: calc(100% - ${themeCssVariables.spacing[2]});
+  width: 100%;
 `;
 
 export { StyledSaveButtonContainer as ViewPickerSaveButtonContainer };


### PR DESCRIPTION
## Summary

- Restore the Create view button to the full width of the view picker form.
- Keep the footer action aligned with the View type control.

## Before/After


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

