### PR TITLE
Rework the /partners hero away from the match pitch

### DIFF
--- a/packages/twenty-website/src/client-brief/GetMatchedButton.tsx
+++ b/packages/twenty-website/src/client-brief/GetMatchedButton.tsx
@@ -3,13 +3,25 @@
 import { type MessageDescriptor } from '@lingui/core';
 import { useLingui } from '@lingui/react';
 
-import { Button } from '@/ui';
+import { Button, type ButtonVariant } from '@/ui';
 
 import { useClientBriefModal } from './use-client-brief-modal';
 
-export function GetMatchedButton({ label }: { label: MessageDescriptor }) {
+export function GetMatchedButton({
+  label,
+  variant,
+}: {
+  label: MessageDescriptor;
+  variant?: ButtonVariant;
+}) {
   const { i18n } = useLingui();
   const { openClientBriefModal } = useClientBriefModal();
 
-  return <Button label={i18n._(label)} onClick={openClientBriefModal} />;
+  return (
+    <Button
+      label={i18n._(label)}
+      onClick={openClientBriefModal}
+      variant={variant}
+    />
+  );
 }

--- a/packages/twenty-website/src/sections/partner-hero/BrowseDirectoryButton.tsx
+++ b/packages/twenty-website/src/sections/partner-hero/BrowseDirectoryButton.tsx
@@ -32,7 +32,6 @@ export function BrowseDirectoryButton() {
       href={`#${PARTNER_DIRECTORY_ANCHOR_ID}`}
       label={i18n._(msg`Browse partners`)}
       onClick={scrollToDirectory}
-      variant="outlined"
     />
   );
 }

--- a/packages/twenty-website/src/sections/partner-hero/PartnerLeadHero.tsx
+++ b/packages/twenty-website/src/sections/partner-hero/PartnerLeadHero.tsx
@@ -78,20 +78,20 @@ export function PartnerLeadHero() {
         <HeadingPair>
           <HeadingMeasure>
             <Heading as="h1" size="lg" weight="light">
-              {i18n._(msg`Tell us what you need, we match you in *48 hours*`)}
+              {i18n._(msg`Hire the people who *build on Twenty*`)}
             </Heading>
           </HeadingMeasure>
           <BodyMeasure>
             <Body muted size="sm">
               {i18n._(
-                msg`Skip the browsing. Describe your project and we connect you with a certified Twenty partner who fits it.`,
+                msg`Certified partners who set up your CRM to match how your company works, from the migration to the custom apps.`,
               )}
             </Body>
           </BodyMeasure>
         </HeadingPair>
         <CtaRow>
-          <GetMatchedButton label={msg`Get matched`} />
           <BrowseDirectoryButton />
+          <GetMatchedButton label={msg`Get matched`} variant="outlined" />
         </CtaRow>
       </IntroStack>
       <VisualStage>


### PR DESCRIPTION
## Why

The `/partners` hero was selling the concierge brief twice.

- The H1 was a service promise ("we match you in *48 hours*"), not a statement of what the page is for.
- "Skip the browsing" argued against the partner directory, which is the page's own main content directly below it.
- `MarketplaceBriefPrompt` further down already catches visitors who do not find anyone ("Didn't find the right partner?").

## What changed

**Before**
> Tell us what you need, we match you in *48 hours*
> Skip the browsing. Describe your project and we connect you with a certified Twenty partner who fits it.
>
> `[Get matched]` `[Browse partners]`

**After**
> Hire the people who *build on Twenty*
> Certified partners who set up your CRM to match how your company works, from the migration to the custom apps.
>
> `[Browse partners]` `[Get matched]`

The body deliberately ends the range on custom apps rather than self-hosting, so the hero does not push self-host over cloud.

`Browse partners` becomes the filled primary and `Get matched` the outlined secondary, so the hero points at the directory it sits above. The brief keeps its own band lower on the page, so no path is lost.

`GetMatchedButton` gains an optional `variant` prop to allow that swap.

The 48-hour figure stays in the two FAQ answers, which is where a service detail belongs.

## Checks

`tsgo --noEmit`, `check-conventions`, `oxlint` and `oxfmt` all pass. Rendered locally at `/partners` and reviewed full page.
