### PR TITLE
fix(workflow): clear the join column when a record relation resolves to empty

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
@@ -2,6 +2,7 @@ import { FieldMetadataType, RelationType } from 'twenty-shared/types';
 
 import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
 import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
@@ -41,21 +42,15 @@ const taskObject = getFlatObjectMetadataMock({
 
 const buildFlatFieldMetadataMaps = (
   fields: FlatFieldMetadata[],
-): FlatEntityMaps<FlatFieldMetadata> => {
-  const byUniversalIdentifier: Record<string, FlatFieldMetadata> = {};
-  const universalIdentifierById: Record<string, string> = {};
-
-  for (const field of fields) {
-    byUniversalIdentifier[field.universalIdentifier] = field;
-    universalIdentifierById[field.id] = field.universalIdentifier;
-  }
-
-  return {
-    byUniversalIdentifier,
-    universalIdentifierById,
-    universalIdentifiersByApplicationId: {},
-  };
-};
+): FlatEntityMaps<FlatFieldMetadata> =>
+  fields.reduce(
+    (flatEntityMaps, flatEntity) =>
+      addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity,
+        flatEntityMaps,
+      }),
+    createEmptyFlatEntityMaps() as FlatEntityMaps<FlatFieldMetadata>,
+  );
 
 const objectMetadataInfo: ObjectMetadataInfo = {
   flatObjectMetadata: taskObject,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
@@ -1,0 +1,110 @@
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type ObjectMetadataInfo } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { formatWorkflowRecordRelationFields } from 'src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util';
+
+const TITLE_FIELD_ID = '20202020-0000-4000-8000-000000000001';
+const ASSIGNEE_FIELD_ID = '20202020-0000-4000-8000-000000000002';
+const TASK_OBJECT_ID = '20202020-0000-4000-8000-000000000003';
+const WORKSPACE_MEMBER_ID = '20202020-0000-4000-8000-000000000004';
+
+const titleField = getFlatFieldMetadataMock({
+  universalIdentifier: 'task-title',
+  objectMetadataId: TASK_OBJECT_ID,
+  id: TITLE_FIELD_ID,
+  name: 'title',
+  type: FieldMetadataType.TEXT,
+});
+
+const assigneeField = getFlatFieldMetadataMock<FieldMetadataType.RELATION>({
+  universalIdentifier: 'task-assignee',
+  objectMetadataId: TASK_OBJECT_ID,
+  id: ASSIGNEE_FIELD_ID,
+  name: 'assignee',
+  type: FieldMetadataType.RELATION,
+  settings: { relationType: RelationType.MANY_TO_ONE },
+});
+
+const taskObject = getFlatObjectMetadataMock({
+  universalIdentifier: 'task',
+  id: TASK_OBJECT_ID,
+  nameSingular: 'task',
+  namePlural: 'tasks',
+  fieldIds: [TITLE_FIELD_ID, ASSIGNEE_FIELD_ID],
+});
+
+const buildFlatFieldMetadataMaps = (
+  fields: FlatFieldMetadata[],
+): FlatEntityMaps<FlatFieldMetadata> => {
+  const byUniversalIdentifier: Record<string, FlatFieldMetadata> = {};
+  const universalIdentifierById: Record<string, string> = {};
+
+  for (const field of fields) {
+    byUniversalIdentifier[field.universalIdentifier] = field;
+    universalIdentifierById[field.id] = field.universalIdentifier;
+  }
+
+  return {
+    byUniversalIdentifier,
+    universalIdentifierById,
+    universalIdentifiersByApplicationId: {},
+  };
+};
+
+const objectMetadataInfo: ObjectMetadataInfo = {
+  flatObjectMetadata: taskObject,
+  flatObjectMetadataMaps:
+    createEmptyFlatEntityMaps() as FlatEntityMaps<FlatObjectMetadata>,
+  flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+    titleField,
+    assigneeField,
+  ]),
+};
+
+const format = (record: Record<string, unknown>) =>
+  formatWorkflowRecordRelationFields(record, objectMetadataInfo)
+    .formattedRecord;
+
+describe('formatWorkflowRecordRelationFields', () => {
+  it('maps a relation wrapper to its join column', () => {
+    expect(
+      format({ title: 'Follow up', assignee: { id: WORKSPACE_MEMBER_ID } }),
+    ).toEqual({
+      title: 'Follow up',
+      assigneeId: WORKSPACE_MEMBER_ID,
+    });
+  });
+
+  it.each([
+    ['a null relation', null],
+    ['a wrapper whose variable resolved to null', { id: null }],
+    ['a wrapper whose variable resolved to nothing', { id: undefined }],
+  ])('clears the join column for %s', (_, assignee) => {
+    expect(format({ title: 'Follow up', assignee })).toEqual({
+      title: 'Follow up',
+      assigneeId: null,
+    });
+  });
+
+  it('keeps an explicit join column over an empty relation wrapper', () => {
+    expect(
+      format({ assignee: { id: null }, assigneeId: WORKSPACE_MEMBER_ID }),
+    ).toEqual({ assigneeId: WORKSPACE_MEMBER_ID });
+  });
+
+  it('leaves a value that is not a relation wrapper untouched', () => {
+    expect(format({ assignee: { connect: { where: { id: '1' } } } })).toEqual({
+      assignee: { connect: { where: { id: '1' } } },
+    });
+  });
+
+  it('leaves a non-relation field holding null untouched', () => {
+    expect(format({ title: null })).toEqual({ title: null });
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
@@ -1,4 +1,4 @@
-import { isObject, isString } from '@sniptt/guards';
+import { isObject, isString, isUndefined } from '@sniptt/guards';
 import { FieldMetadataType, RelationType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -40,18 +40,29 @@ const extractMorphValue = (value: unknown): ExtractedMorphValue | null => {
   return null;
 };
 
-const extractLegacyRelationId = (value: unknown): string | undefined => {
+const extractLegacyRelationJoinColumnValue = (
+  value: unknown,
+): string | null | undefined => {
+  if (value === null) {
+    return null;
+  }
+
   if (!isObject(value)) {
     return undefined;
   }
 
   const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
 
-  if (Object.keys(record).length !== 1 || !isString(record.id)) {
+  if (keys.length !== 1 || keys[0] !== 'id') {
     return undefined;
   }
 
-  return record.id;
+  if (!isDefined(record.id)) {
+    return null;
+  }
+
+  return isString(record.id) ? record.id : undefined;
 };
 
 const formatWorkflowRecordMorphRelationFields = (
@@ -191,9 +202,9 @@ const formatWorkflowRecordSimpleRelationFields = (
       continue;
     }
 
-    const legacyId = extractLegacyRelationId(value);
+    const joinColumnValue = extractLegacyRelationJoinColumnValue(value);
 
-    if (!isDefined(legacyId)) {
+    if (isUndefined(joinColumnValue)) {
       formattedRecord[key] = value;
       continue;
     }
@@ -203,7 +214,7 @@ const formatWorkflowRecordSimpleRelationFields = (
     });
 
     if (!isDefined(record[joinColumnName])) {
-      formattedRecord[joinColumnName] = legacyId;
+      formattedRecord[joinColumnName] = joinColumnValue;
     }
   }
 


### PR DESCRIPTION
Fixes #24849

## Problem

A Create Record step that binds a workflow variable to a relation fails the whole run when that variable resolves to empty:

> Relation "assignee" requires connect or disconnect operation

The form stores a MANY_TO_ONE relation as a wrapper around the variable ([`buildUpdatedRecordActionFormData.ts:38`](https://github.com/twentyhq/twenty/blob/main/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/utils/buildUpdatedRecordActionFormData.ts#L38)):

```json
{ "objectName": "task", "objectRecord": { "assignee": { "id": "{{trigger.record.assigneeId}}" } } }
```

`resolveInput` walks into that object, so when the source record has no assignee the step input becomes `{ assignee: { id: null } }`.

`formatWorkflowRecordSimpleRelationFields` is what translates that wrapper into the join column, but `extractLegacyRelationId` only recognised `{ id: string }`:

```ts
if (Object.keys(record).length !== 1 || !isString(record.id)) {
  return undefined;
}
```

With a null id it returned `undefined`, which the caller reads as "not a relation wrapper", so `assignee` was copied through verbatim and `assigneeId` was never written. `DataArgProcessorService` then sees a relation field addressed by its own name rather than its join column and throws, since `null` is neither a `connect` nor a `disconnect` ([`data-arg-processor.service.ts:256`](https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts#L256)).

The morph relation branch in the same file already handles this correctly: `value === null` nulls every target join column. The plain relation branch was missing the equivalent.

## Fix

`extractLegacyRelationJoinColumnValue` now returns the join column value rather than only an id, so an empty relation maps to `null` instead of falling through:

- `assignee: null` and `assignee: { id: null }` (or `{ id: undefined }`) produce `assigneeId: null`
- `assignee: { id: "<uuid>" }` still produces `assigneeId: "<uuid>"`
- anything that is not the `{ id }` wrapper (a `connect` operation, a full record object, `{ id: 42 }`) is still passed through untouched, so no shape that worked before changes

`assigneeId: null` is the shape the join column path already accepts (`validateUUIDFieldOrThrow` allows null) and it survives `removeUndefinedFromRecord`, so the record is created with the relation empty. Where a relation is genuinely not nullable, the processor's own nullability check now reports "A required field is missing" instead of the misleading connect/disconnect error.

The `{ id }` wrapper comes from `buildUpdatedRecordActionFormData`, which only the Create Record and Upsert Record forms use, so both steps get the fix. The Update Record form keys many-to-one fields by their join column and writes the resolved value straight to `assigneeId` ([`WorkflowEditActionUpdateRecord.tsx:220`](https://github.com/twentyhq/twenty/blob/main/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionUpdateRecord.tsx#L220)), so it never produced this shape and is unaffected either way.

## Verification

`packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts` is new; the util had no coverage. Against the pre-fix formatter 4 of its 7 cases fail, the 3 covering existing behavior pass.

Also ran the whole `src/modules/workflow` suite: 529 passed, 0 failed. Six suites fail to load in my environment both with and without this change (an unrelated `IsEnum` decorator error while importing `command-menu-item.dto.ts`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


