### PR TITLE
fix(engine): allow null relation names in data-arg-processor by normalizing to disconnect (#24849)

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { msg } from '@lingui/core/macro';
 import { isNull, isObject, isUndefined } from '@sniptt/guards';
+import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
 import {
   FieldMetadataSettingsMapping,
   FieldMetadataType,
@@ -254,6 +255,15 @@ export class DataArgProcessorService {
         }
 
         if (isDefined(joinColumnName) && !isRelationNestedOperation(value)) {
+          // A null relation-name value (as opposed to a null on the join
+          // column, which validateUUIDFieldOrThrow already accepts) means
+          // "clear this relation" - normalize it to the disconnect shape
+          // extractNestedRelationFieldsByEntityIndex already knows how to
+          // handle, instead of rejecting it.
+          if (isNull(value)) {
+            return { [RELATION_NESTED_QUERY_KEYWORDS.DISCONNECT]: true };
+          }
+
           throw new CommonQueryRunnerException(
             `Relation "${key}" requires connect or disconnect operation`,
             CommonQueryRunnerExceptionCode.INVALID_ARGS_DATA,


### PR DESCRIPTION
## Description

Closes #24849.

When setting a relation field to `null` via its **logical relation name** (e.g. `assignee: null`), the API rejected the request with `Relation "assignee" requires connect or disconnect operation`. This happened even though the equivalent **join-column** path (e.g. `assigneeId: null`) already worked fine, since `validateUUIDFieldOrThrow` explicitly tolerates `null` there.

### Root cause

In `data-arg-processor.service.ts`, the relation-name branch only accepted a nested operation object (`{ connect: { where: {...} } }` or `{ disconnect: true }`). Any other value - including `null` - fell through to a thrown `CommonQueryRunnerException`. The join-column branch had no such restriction, so the two paths for referring to the same relation behaved inconsistently.

### Fix

When the incoming value for a relation-name field is `null` (and not already a nested connect/disconnect operation), it is now normalized to `{ disconnect: true }` before being handed off, reusing the exact shape `extractNestedRelationFieldsByEntityIndex` already understands. This aligns the relation-name path with the join-column path, letting API consumers clear a relation without needing to know its underlying join-column name.

The change is scoped to this one normalization branch and does not touch the `connect`/`disconnect` handling itself.

### Testing

- `npx tsgo -p tsconfig.json --noEmit` on `twenty-server`: no new errors introduced (13 pre-existing errors remain, all unrelated missing-module errors in sibling packages that need their own build step, none in the touched file).
- `oxlint --type-aware` on the touched file: 0 warnings, 0 errors.
- `oxfmt --check` on the touched file: correctly formatted.
- No dedicated unit test exists for `data-arg-processor.service.ts` itself (only its smaller utility functions have `.spec.ts` files), so verification here relied on typecheck/lint plus manual trace-through of the existing guards (`isRelationNestedOperation`, `validateUUIDFieldOrThrow`, `extractNestedRelationFieldsByEntityIndex`).

Opening as a draft for maintainer feedback on the approach before marking ready for review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

