### PR TITLE
docs(slack): correct the run-as permission model in the app README

### DIFF
--- a/packages/twenty-apps/public/slack/README.md
+++ b/packages/twenty-apps/public/slack/README.md
@@ -12,9 +12,9 @@
 
 Mention the bot in a channel or DM it. It replies in the thread with your CRM data, using the recent conversation as context. Answers end with native thumbs up / thumbs down feedback buttons — except very long answers, which fall back to plain text without them — and ratings are stored on the matching Slack Assistant Request record in Twenty.
 
-The bot runs with the **Slack Assistant** role, which by default can read, create, update and soft-delete people, companies, opportunities, notes and tasks. Workspace members stay read-only and hard delete is off. Tighten the role in **Settings → Roles** if you want a narrower bot.
+Out of the box the bot runs with the **Slack Assistant** role, which can read, create, update and soft-delete people, companies, opportunities, notes and tasks. Workspace members stay read-only and hard delete is off. Tighten the role in **Settings → Roles** if you want a narrower bot.
 
-**It acts as whoever tagged it.** The first time someone mentions the bot, their Slack profile email is matched against workspace members and the pair is stored as a **Slack User Link** record. From then on the bot runs with that member's permissions *and* the Slack Assistant role: it can never do more than the person asking, and never more than the role allows. Someone with no link gets the Slack Assistant role on its own, exactly as before.
+**It acts as whoever tagged it.** The first time someone mentions the bot, their Slack profile email is matched against workspace members and the pair is stored as a **Slack User Link** record. From then on the bot runs with that member's own permissions, so it can never do more than the person asking. Someone with no link gets the **Slack Assistant** role instead, exactly as before.
 
 A link matched on email is re-verified on every request: the bot rechecks that the Slack account's current verified email still points at the same member, and follows the live match rather than the stored record if they disagree. The record is an audit trail, not the source of truth.
 


### PR DESCRIPTION
## Why

The app README still describes the old run-as behavior. It says a linked member runs "with that member's permissions *and* the Slack Assistant role: it can never do more than the person asking, and never more than the role allows" — intersection language. Since the server dropped the agent role from the run-as intersection (`build-agent-role-permission-config.util.ts` returns `intersectionOf: [runAsRoleId]`, the member's role alone), a linked member now runs with their own role by itself. The Slack Assistant role is only the fallback for unlinked users. The doc is a security-model description that no longer matches the code.

## What it does

- Rewrites the "acts as whoever tagged it" paragraph: linked member runs with their **own permissions alone**; unlinked users get the Slack Assistant role instead.
- Reframes the opening role paragraph as the out-of-the-box baseline, so it no longer reads as a blanket cap on every request.

Docs-only, no code change.

---
_Generated by [Claude Code](https://claude.ai/code/session_011qV95ZVi9enpBRNZ9jvucg)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

