### PR TITLE
feat(ai): let runAgent run as a role, not only a workspace member

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/ai-agent-execution.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/ai-agent-execution.module.ts
@@ -16,6 +16,7 @@ import { AiGraphqlApiExceptionInterceptor } from 'src/engine/metadata-modules/ai
 import { AiModelsModule } from 'src/engine/metadata-modules/ai/ai-models/ai-models.module';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
+import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -61,6 +62,7 @@ import { AgentRunService } from './services/agent-run.service';
     AgentRunResolver,
     AgentRunService,
     provideWorkspaceScopedRepository(RoleTargetEntity),
+    provideWorkspaceScopedRepository(RoleEntity),
     provideWorkspaceScopedRepository(AgentEntity),
   ],
   exports: [

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/dtos/run-agent.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/dtos/run-agent.input.ts
@@ -34,6 +34,11 @@ export class RunAgentInputDTO {
   @Field(() => UUIDScalarType, { nullable: true })
   runAsWorkspaceMemberId?: string;
 
+  @IsUUID()
+  @IsOptional()
+  @Field(() => UUIDScalarType, { nullable: true })
+  runAsRoleId?: string;
+
   @IsOptional()
   @IsArray()
   @ArrayNotEmpty()

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-run.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-run.service.spec.ts
@@ -1,0 +1,140 @@
+import { type AgentActorContextService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service';
+import { type AgentAsyncExecutorService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service';
+import { AgentRunService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-run.service';
+import { AiExceptionCode } from 'src/engine/metadata-modules/ai/ai.exception';
+
+const WORKSPACE = { id: 'workspace-1' } as never;
+const APPLICATION = { id: 'application-1' } as never;
+const AGENT = {
+  id: 'agent-1',
+  applicationId: 'application-1',
+  workspaceId: 'workspace-1',
+} as never;
+
+const buildService = ({
+  role,
+}: {
+  role?: { id: string; label: string; canBeAssignedToAgents: boolean };
+} = {}) => {
+  const executeAgent = jest
+    .fn()
+    .mockResolvedValue({ result: { ok: true }, hasNoMoreAvailableCredits: false });
+
+  const buildRunAsWorkspaceMemberContext = jest.fn().mockResolvedValue({
+    actorContext: {},
+    authContext: { type: 'user', userWorkspaceId: 'user-workspace-1' },
+    roleId: 'member-role-id',
+  });
+
+  const agentRepository = { findOne: jest.fn().mockResolvedValue(AGENT) };
+  const roleRepository = {
+    findOne: jest.fn().mockResolvedValue(role ?? null),
+  };
+  const applicationService = {
+    findById: jest.fn().mockResolvedValue(APPLICATION),
+  };
+
+  const service = new AgentRunService(
+    {
+      buildRunAsWorkspaceMemberContext,
+    } as unknown as AgentActorContextService,
+    { executeAgent } as unknown as AgentAsyncExecutorService,
+    applicationService as never,
+    agentRepository as never,
+    roleRepository as never,
+  );
+
+  return { service, executeAgent, roleRepository };
+};
+
+const runWith = (
+  service: AgentRunService,
+  overrides: {
+    callerApplication?: unknown;
+    runAsRoleId?: string;
+    runAsWorkspaceMemberId?: string;
+    requestUserWorkspaceId?: string | null;
+    requestWorkspaceMemberId?: string | null;
+  },
+) =>
+  service.run({
+    workspace: WORKSPACE,
+    requestUserWorkspaceId: overrides.requestUserWorkspaceId ?? null,
+    requestWorkspaceMemberId: overrides.requestWorkspaceMemberId ?? null,
+    callerApplication:
+      'callerApplication' in overrides
+        ? (overrides.callerApplication as never)
+        : APPLICATION,
+    input: {
+      agentUniversalIdentifier: 'agent-uid',
+      prompt: 'hello',
+      runAsRoleId: overrides.runAsRoleId,
+      runAsWorkspaceMemberId: overrides.runAsWorkspaceMemberId,
+    },
+  });
+
+describe('AgentRunService run-as authorization', () => {
+  const assignableRole = {
+    id: 'channel-role-id',
+    label: 'Read-only CRM',
+    canBeAssignedToAgents: true,
+  };
+
+  it('refuses runAsRoleId without an application token', async () => {
+    const { service } = buildService({ role: assignableRole });
+
+    await expect(
+      runWith(service, {
+        callerApplication: undefined,
+        runAsRoleId: 'channel-role-id',
+      }),
+    ).rejects.toMatchObject({
+      code: AiExceptionCode.RUN_AS_WORKSPACE_MEMBER_NOT_ALLOWED,
+    });
+  });
+
+  it('refuses a role that cannot be assigned to agents', async () => {
+    const { service } = buildService({
+      role: { ...assignableRole, canBeAssignedToAgents: false },
+    });
+
+    await expect(
+      runWith(service, { runAsRoleId: 'channel-role-id' }),
+    ).rejects.toMatchObject({
+      code: AiExceptionCode.ROLE_CANNOT_BE_ASSIGNED_TO_AGENTS,
+    });
+  });
+
+  it('refuses an unknown role', async () => {
+    const { service } = buildService({ role: undefined });
+
+    await expect(
+      runWith(service, { runAsRoleId: 'missing-role-id' }),
+    ).rejects.toMatchObject({ code: AiExceptionCode.ROLE_NOT_FOUND });
+  });
+
+  it('caps a role-only run at that role alone', async () => {
+    const { service, executeAgent } = buildService({ role: assignableRole });
+
+    await runWith(service, { runAsRoleId: 'channel-role-id' });
+
+    expect(executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ runAsRoleIds: ['channel-role-id'] }),
+    );
+  });
+
+  it('intersects the member and channel roles when both are given', async () => {
+    const { service, executeAgent } = buildService({ role: assignableRole });
+
+    await runWith(service, {
+      runAsWorkspaceMemberId: 'member-1',
+      runAsRoleId: 'channel-role-id',
+    });
+
+    expect(executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runAsRoleIds: ['member-role-id', 'channel-role-id'],
+      }),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-run.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-run.service.spec.ts
@@ -18,7 +18,10 @@ const buildService = ({
 } = {}) => {
   const executeAgent = jest
     .fn()
-    .mockResolvedValue({ result: { ok: true }, hasNoMoreAvailableCredits: false });
+    .mockResolvedValue({
+      result: { ok: true },
+      hasNoMoreAvailableCredits: false,
+    });
 
   const buildRunAsWorkspaceMemberContext = jest.fn().mockResolvedValue({
     actorContext: {},

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -145,13 +145,13 @@ export class AgentAsyncExecutorService {
   private async buildPreloadedRegistryTools({
     agent,
     agentRoleId,
-    runAsRoleId,
+    runAsRoleIds,
     authContext,
     actorContext,
   }: {
     agent: AgentEntity;
     agentRoleId: string;
-    runAsRoleId?: string;
+    runAsRoleIds?: string[];
     authContext?: WorkspaceAuthContext;
     actorContext?: ActorMetadata;
   }): Promise<ToolSet> {
@@ -162,7 +162,7 @@ export class AgentAsyncExecutorService {
       roleId: agentRoleId,
       rolePermissionConfig: buildAgentRolePermissionConfig({
         agentRoleId,
-        runAsRoleId,
+        runAsRoleIds,
       }),
       requireExplicitObjectGrants: true,
       authContext,
@@ -185,20 +185,20 @@ export class AgentAsyncExecutorService {
   private async buildLazyRegistryTools({
     agent,
     agentRoleId,
-    runAsRoleId,
+    runAsRoleIds,
     authContext,
     actorContext,
   }: {
     agent: AgentEntity;
     agentRoleId: string;
-    runAsRoleId?: string;
+    runAsRoleIds?: string[];
     authContext?: WorkspaceAuthContext;
     actorContext?: ActorMetadata;
   }): Promise<{ tools: ToolSet; catalogSection: string }> {
     const { userId, userWorkspaceId } = this.resolveUserIdentity(authContext);
 
-    const rolePermissionConfig = isDefined(runAsRoleId)
-      ? buildAgentRolePermissionConfig({ agentRoleId, runAsRoleId })
+    const rolePermissionConfig = isNonEmptyArray(runAsRoleIds)
+      ? buildAgentRolePermissionConfig({ agentRoleId, runAsRoleIds })
       : undefined;
 
     const toolContext: ToolContext = {
@@ -257,7 +257,7 @@ export class AgentAsyncExecutorService {
     authContext,
     workspaceId,
     userWorkspaceId,
-    runAsRoleId,
+    runAsRoleIds,
     operationType = UsageOperationType.AI_WORKFLOW_TOKEN,
     toolLoadingStrategy = 'preload',
   }: {
@@ -268,7 +268,7 @@ export class AgentAsyncExecutorService {
     authContext?: WorkspaceAuthContext;
     workspaceId: string;
     userWorkspaceId?: string | null;
-    runAsRoleId?: string;
+    runAsRoleIds?: string[];
     operationType?: UsageOperationType;
     toolLoadingStrategy?: AgentToolLoadingStrategy;
   }): Promise<AgentExecutionResult> {
@@ -332,7 +332,7 @@ export class AgentAsyncExecutorService {
             const lazyToolset = await this.buildLazyRegistryTools({
               agent,
               agentRoleId,
-              runAsRoleId,
+              runAsRoleIds,
               authContext,
               actorContext,
             });
@@ -343,7 +343,7 @@ export class AgentAsyncExecutorService {
             registryTools = await this.buildPreloadedRegistryTools({
               agent,
               agentRoleId,
-              runAsRoleId,
+              runAsRoleIds,
               authContext,
               actorContext,
             });

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-run.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-run.service.ts
@@ -5,6 +5,7 @@ import {
   type RunAgentMessage,
   type RunAgentResult,
 } from 'twenty-shared/application';
+import { type ActorMetadata } from 'twenty-shared/types';
 import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
@@ -14,7 +15,6 @@ import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-op
 import { type FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
 import { AgentActorContextService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service';
 import { AgentAsyncExecutorService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service';
-import { type RunAsWorkspaceMemberContext } from 'src/engine/metadata-modules/ai/ai-agent-execution/types/run-as-workspace-member-context.type';
 import { AGENT_RUN_BASE_SYSTEM_PROMPT } from 'src/engine/metadata-modules/ai/ai-agent/constants/agent-run-base-system-prompt.const';
 import { AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
 import { withDedicatedAiTrace } from 'src/engine/metadata-modules/ai/ai-models/utils/with-dedicated-ai-trace.util';
@@ -22,6 +22,7 @@ import {
   AiException,
   AiExceptionCode,
 } from 'src/engine/metadata-modules/ai/ai.exception';
+import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 
@@ -30,6 +31,17 @@ type RunAgentServiceInput = {
   prompt?: string | null;
   messages?: RunAgentMessage[] | null;
   runAsWorkspaceMemberId?: string;
+  runAsRoleId?: string;
+};
+
+// The auth context and actor are the member's when running as one (with the
+// application kept as viaApplication), or absent when running as a bare role,
+// which keeps the default application context. roleIds is the intersection the
+// run is capped to: [member], [role], or [member, role].
+type ResolvedRunAsContext = {
+  actorContext?: ActorMetadata;
+  authContext?: WorkspaceAuthContext;
+  roleIds: string[];
 };
 
 @Injectable()
@@ -42,6 +54,8 @@ export class AgentRunService {
     private readonly applicationService: ApplicationService,
     @InjectWorkspaceScopedRepository(AgentEntity)
     private readonly agentRepository: WorkspaceScopedRepository<AgentEntity>,
+    @InjectWorkspaceScopedRepository(RoleEntity)
+    private readonly roleRepository: WorkspaceScopedRepository<RoleEntity>,
   ) {}
 
   async run({
@@ -105,6 +119,7 @@ export class AgentRunService {
 
     const runAsContext = await this.resolveRunAsContext({
       runAsWorkspaceMemberId: input.runAsWorkspaceMemberId,
+      runAsRoleId: input.runAsRoleId,
       callerApplication,
       requestUserWorkspaceId,
       requestWorkspaceMemberId,
@@ -128,8 +143,8 @@ export class AgentRunService {
           authContext,
           workspaceId: workspace.id,
           userWorkspaceId:
-            runAsContext?.authContext.userWorkspaceId ?? requestUserWorkspaceId,
-          runAsRoleId: runAsContext?.roleId,
+            runAsContext?.authContext?.userWorkspaceId ?? requestUserWorkspaceId,
+          runAsRoleIds: runAsContext?.roleIds,
           operationType: UsageOperationType.AI_WORKFLOW_TOKEN,
           toolLoadingStrategy: 'lazy',
         }),
@@ -164,6 +179,7 @@ export class AgentRunService {
 
   private async resolveRunAsContext({
     runAsWorkspaceMemberId,
+    runAsRoleId,
     callerApplication,
     requestUserWorkspaceId,
     requestWorkspaceMemberId,
@@ -171,24 +187,30 @@ export class AgentRunService {
     application,
   }: {
     runAsWorkspaceMemberId?: string;
+    runAsRoleId?: string;
     callerApplication?: FlatApplication;
     requestUserWorkspaceId: string | null;
     requestWorkspaceMemberId: string | null;
     workspaceId: string;
     application: FlatApplication;
-  }): Promise<RunAsWorkspaceMemberContext | undefined> {
-    if (!isDefined(runAsWorkspaceMemberId)) {
+  }): Promise<ResolvedRunAsContext | undefined> {
+    if (!isDefined(runAsWorkspaceMemberId) && !isDefined(runAsRoleId)) {
       return undefined;
     }
 
+    // Both forms of run-as mirror the same trust: only an application, acting as
+    // itself, may narrow a run to a member or a role. Which member or role is
+    // safe to assume is the calling application's responsibility, as it already
+    // is for runAsWorkspaceMemberId.
     if (!isDefined(callerApplication)) {
       throw new AiException(
-        'Running an agent as a workspace member requires an application access token',
+        'Running an agent as a workspace member or role requires an application access token',
         AiExceptionCode.RUN_AS_WORKSPACE_MEMBER_NOT_ALLOWED,
       );
     }
 
     if (
+      isDefined(runAsWorkspaceMemberId) &&
       isDefined(requestUserWorkspaceId) &&
       requestWorkspaceMemberId !== runAsWorkspaceMemberId
     ) {
@@ -198,10 +220,57 @@ export class AgentRunService {
       );
     }
 
-    return this.agentActorContextService.buildRunAsWorkspaceMemberContext({
-      workspaceMemberId: runAsWorkspaceMemberId,
-      workspaceId,
-      viaApplication: application,
+    const runAsRoleIdOrUndefined = isDefined(runAsRoleId)
+      ? await this.resolveRunAsRoleIdOrThrow({ roleId: runAsRoleId, workspaceId })
+      : undefined;
+
+    if (isDefined(runAsWorkspaceMemberId)) {
+      const memberContext =
+        await this.agentActorContextService.buildRunAsWorkspaceMemberContext({
+          workspaceMemberId: runAsWorkspaceMemberId,
+          workspaceId,
+          viaApplication: application,
+        });
+
+      return {
+        actorContext: memberContext.actorContext,
+        authContext: memberContext.authContext,
+        roleIds: isDefined(runAsRoleIdOrUndefined)
+          ? [memberContext.roleId, runAsRoleIdOrUndefined]
+          : [memberContext.roleId],
+      };
+    }
+
+    // Role-only: no member behind the run, so the default application auth
+    // context stands and only the permission ceiling narrows.
+    return { roleIds: [runAsRoleIdOrUndefined as string] };
+  }
+
+  private async resolveRunAsRoleIdOrThrow({
+    roleId,
+    workspaceId,
+  }: {
+    roleId: string;
+    workspaceId: string;
+  }): Promise<string> {
+    const role = await this.roleRepository.findOne(workspaceId, {
+      where: { id: roleId },
     });
+
+    if (!isDefined(role)) {
+      throw new AiException(
+        `Role ${roleId} not found`,
+        AiExceptionCode.ROLE_NOT_FOUND,
+      );
+    }
+
+    if (!role.canBeAssignedToAgents) {
+      throw new AiException(
+        `Role "${role.label}" cannot be assigned to agents`,
+        AiExceptionCode.ROLE_CANNOT_BE_ASSIGNED_TO_AGENTS,
+      );
+    }
+
+    return role.id;
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-run.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-run.service.ts
@@ -10,7 +10,10 @@ import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { type FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
-import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import {
+  type UserWorkspaceAuthContext,
+  type WorkspaceAuthContext,
+} from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-operation-type.enum';
 import { type FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
 import { AgentActorContextService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service';
@@ -40,7 +43,7 @@ type RunAgentServiceInput = {
 // run is capped to: [member], [role], or [member, role].
 type ResolvedRunAsContext = {
   actorContext?: ActorMetadata;
-  authContext?: WorkspaceAuthContext;
+  authContext?: UserWorkspaceAuthContext;
   roleIds: string[];
 };
 
@@ -143,7 +146,8 @@ export class AgentRunService {
           authContext,
           workspaceId: workspace.id,
           userWorkspaceId:
-            runAsContext?.authContext?.userWorkspaceId ?? requestUserWorkspaceId,
+            runAsContext?.authContext?.userWorkspaceId ??
+            requestUserWorkspaceId,
           runAsRoleIds: runAsContext?.roleIds,
           operationType: UsageOperationType.AI_WORKFLOW_TOKEN,
           toolLoadingStrategy: 'lazy',
@@ -221,7 +225,10 @@ export class AgentRunService {
     }
 
     const runAsRoleIdOrUndefined = isDefined(runAsRoleId)
-      ? await this.resolveRunAsRoleIdOrThrow({ roleId: runAsRoleId, workspaceId })
+      ? await this.resolveRunAsRoleIdOrThrow({
+          roleId: runAsRoleId,
+          workspaceId,
+        })
       : undefined;
 
     if (isDefined(runAsWorkspaceMemberId)) {

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/__tests__/build-agent-role-permission-config.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/__tests__/build-agent-role-permission-config.util.spec.ts
@@ -7,20 +7,38 @@ describe('buildAgentRolePermissionConfig', () => {
     ).toEqual({ intersectionOf: ['agent-role-id'] });
   });
 
-  it('uses the member role alone in run-as mode', () => {
+  it('falls back to the agent role when the run-as list is empty', () => {
     expect(
       buildAgentRolePermissionConfig({
         agentRoleId: 'agent-role-id',
-        runAsRoleId: 'run-as-role-id',
+        runAsRoleIds: [],
+      }),
+    ).toEqual({ intersectionOf: ['agent-role-id'] });
+  });
+
+  it('uses the run-as role alone when a single one is given', () => {
+    expect(
+      buildAgentRolePermissionConfig({
+        agentRoleId: 'agent-role-id',
+        runAsRoleIds: ['run-as-role-id'],
       }),
     ).toEqual({ intersectionOf: ['run-as-role-id'] });
   });
 
-  it('does not involve the agent role even when the member holds it', () => {
+  it('intersects the member and channel roles when both are given', () => {
     expect(
       buildAgentRolePermissionConfig({
         agentRoleId: 'agent-role-id',
-        runAsRoleId: 'agent-role-id',
+        runAsRoleIds: ['member-role-id', 'channel-role-id'],
+      }),
+    ).toEqual({ intersectionOf: ['member-role-id', 'channel-role-id'] });
+  });
+
+  it('does not involve the agent role even when the run-as role equals it', () => {
+    expect(
+      buildAgentRolePermissionConfig({
+        agentRoleId: 'agent-role-id',
+        runAsRoleIds: ['agent-role-id'],
       }),
     ).toEqual({ intersectionOf: ['agent-role-id'] });
   });

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/build-agent-role-permission-config.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/build-agent-role-permission-config.util.ts
@@ -1,16 +1,18 @@
-import { isDefined } from 'twenty-shared/utils';
+import { isNonEmptyArray } from 'twenty-shared/utils';
 
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
 
 export const buildAgentRolePermissionConfig = ({
   agentRoleId,
-  runAsRoleId,
+  runAsRoleIds,
 }: {
   agentRoleId: string;
-  runAsRoleId?: string;
+  runAsRoleIds?: string[];
 }): RolePermissionConfig => {
-  if (isDefined(runAsRoleId)) {
-    return { intersectionOf: [runAsRoleId] };
+  // A run-as intersection of one role caps at that role alone; of two
+  // (member plus a channel ceiling) caps at whichever is tighter per operation.
+  if (isNonEmptyArray(runAsRoleIds)) {
+    return { intersectionOf: runAsRoleIds };
   }
 
   return { intersectionOf: [agentRoleId] };

--- a/packages/twenty-shared/src/application/runAgentType.ts
+++ b/packages/twenty-shared/src/application/runAgentType.ts
@@ -8,6 +8,7 @@ export type RunAgentMessage = {
 export type RunAgentInput = {
   agentUniversalIdentifier: string;
   runAsWorkspaceMemberId?: string;
+  runAsRoleId?: string;
 } & (
   | { prompt: string; messages?: never }
   | { messages: RunAgentMessage[]; prompt?: never }


### PR DESCRIPTION
## Why

`runAgent` can run as a workspace member (`runAsWorkspaceMemberId`), capping the run at that member's role. The upcoming Slack channel-permissions work needs a second axis: running under a role an admin has bound to a channel, for callers who are not mapped to a member, and intersecting a member's role with a channel ceiling for those who are. This adds the platform primitive that enables it. It ships on its own and changes no existing behavior.

## What it does

- **`runAsRoleId` on `RunAgentInput`** (shared type + GraphQL DTO, optional UUID), alongside the existing `runAsWorkspaceMemberId`.
- **`resolveRunAsContext`** now handles member-only, role-only, and both:
  - **Role-only**: the default application auth context stands; only the permission ceiling narrows to that role.
  - **Member + role**: returns `[memberRoleId, roleId]` so the run is capped at their intersection.
  - **Member-only**: unchanged.
- **`buildAgentRolePermissionConfig`** generalizes from a single run-as role to a list, emitting `{ intersectionOf: [...] }`. The existing least-privilege intersection reducer already handles multiple roles (it runs `[userRoleId, applicationRoleId]` for application-acting-for-user today), so member-plus-ceiling needs no further change.

## The authorization boundary

`runAsRoleId` mirrors the exact trust already granted to `runAsWorkspaceMemberId`:

- the caller must hold an application access token, and
- the role must be `canBeAssignedToAgents` (else `ROLE_NOT_FOUND` / `ROLE_CANNOT_BE_ASSIGNED_TO_AGENTS`).

*Which* role is safe to assume is the calling application's responsibility, exactly as *which* member already is for the member run-as. There is deliberately no privilege-comparison here because the platform has no role-subset primitive; the consumer (the Slack app) constrains the role to one an admin bound to a channel through an `APPLICATION`-writable, settings-gated config. Flagging the boundary explicitly since it is the one durable decision in this change and worth a close look.

## Tests

- `buildAgentRolePermissionConfig`: agent-role fallback, empty list, single run-as role, two-role (member ∩ ceiling), and run-as role equal to the agent role.
- `AgentRunService` run-as authorization: refuses `runAsRoleId` without an application token, refuses a non-agent-assignable role, refuses an unknown role, caps a role-only run at that role, and intersects member + role when both are given.

## Validation

`tsgo` typecheck clean on the changed files, oxlint + oxfmt clean, and the config-builder spec passes locally. The service spec type-checks and lints; it exercises the DI graph that CI runs in full.


---
_Generated by [Claude Code](https://claude.ai/code/session_011qV95ZVi9enpBRNZ9jvucg)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

