### PR TITLE
fix: allow deletion of default relation fields on custom objects

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldDisabledActionDropdown.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldDisabledActionDropdown.tsx
@@ -18,6 +18,7 @@ import { type FieldMetadataType } from '~/generated-metadata/graphql';
 type SettingsObjectFieldInactiveActionDropdownProps = {
   isCustomField?: boolean;
   isSystemField?: boolean;
+  isDeletableSystemRelation?: boolean;
   fieldType?: FieldMetadataType;
   onActivate: () => void;
   onEdit: () => void;
@@ -34,6 +35,7 @@ export const SettingsObjectFieldInactiveActionDropdown = ({
   onEdit,
   isCustomField,
   isSystemField,
+  isDeletableSystemRelation = false,
 }: SettingsObjectFieldInactiveActionDropdownProps) => {
   const dropdownId = `${fieldMetadataItemId}-settings-field-disabled-action-dropdown`;
 
@@ -54,7 +56,9 @@ export const SettingsObjectFieldInactiveActionDropdown = ({
     closeDropdown(dropdownId);
   };
 
-  const isDeletable = isCustomField && !isSystemField;
+  const isDeletable =
+    (isCustomField === true && isSystemField === false) ||
+    isDeletableSystemRelation;
 
   return (
     <Dropdown

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectRelationItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectRelationItemTableRow.tsx
@@ -17,7 +17,11 @@ import { styled } from '@linaria/react';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useLingui } from '@lingui/react/macro';
 import { type MouseEvent, useContext, useMemo } from 'react';
-import { FieldMetadataType, SettingsPath } from 'twenty-shared/types';
+import {
+  CoreObjectNameSingular,
+  FieldMetadataType,
+  SettingsPath,
+} from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import {
   IconChevronRight,
@@ -35,6 +39,13 @@ type SettingsObjectRelationItemTableRowProps = {
 
 export const OBJECT_RELATION_TABLE_ROW_GRID_TEMPLATE_COLUMNS =
   'minmax(0, 1fr) 148px 148px 36px';
+
+const DELETABLE_DEFAULT_RELATION_TARGET_NAMES: readonly CoreObjectNameSingular[] =
+  [
+    CoreObjectNameSingular.Attachment,
+    CoreObjectNameSingular.NoteTarget,
+    CoreObjectNameSingular.TaskTarget,
+  ];
 
 const StyledNameContainer = styled.div`
   align-items: center;
@@ -146,6 +157,15 @@ export const SettingsObjectRelationItemTableRow = ({
   const shouldDisplayFieldLabelAsSubtitle =
     isMorphRelation || isDefined(relationObjectMetadataItem);
 
+  const isObjectCustom = getIsMetadataItemCustom(objectMetadataItem);
+
+  const isDeletableDefaultRelation =
+    isObjectCustom &&
+    isDefined(fieldMetadataItem.relation?.targetObjectMetadata?.nameSingular) &&
+    (DELETABLE_DEFAULT_RELATION_TARGET_NAMES as readonly string[]).includes(
+      fieldMetadataItem.relation.targetObjectMetadata.nameSingular,
+    );
+
   return (
     <TableRow
       gridTemplateColumns={OBJECT_RELATION_TABLE_ROW_GRID_TEMPLATE_COLUMNS}
@@ -243,6 +263,8 @@ export const SettingsObjectRelationItemTableRow = ({
         ) : (
           <SettingsObjectFieldInactiveActionDropdown
             isCustomField={getIsMetadataItemCustom(fieldMetadataItem)}
+            isSystemField={fieldMetadataItem.isSystem === true}
+            isDeletableSystemRelation={isDeletableDefaultRelation}
             readonly={readonly}
             fieldMetadataItemId={fieldMetadataItem.id}
             onEdit={navigateToFieldEdit}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/from-delete-field-input-to-flat-field-metadatas-to-delete.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/from-delete-field-input-to-flat-field-metadatas-to-delete.spec.ts
@@ -1,5 +1,7 @@
+import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
 import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
 import { FieldMetadataType } from 'twenty-shared/types';
+
 
 import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
 import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
@@ -153,6 +155,169 @@ describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
       fromDeleteFieldInputToFlatFieldMetadatasToDelete({
         deleteOneFieldInput: { id: standardAppField.id },
         flatFieldMetadataMaps: buildFlatFieldMetadataMaps([standardAppField]),
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+        flatIndexMaps: createEmptyFlatEntityMaps(),
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+      }),
+    );
+  });
+
+  it('should allow deletion of attachment default relation field', () => {
+    const objectId = 'obj-1';
+    const companionMorphFieldId = '00000000-0000-0000-0000-000000000001';
+    const attachmentRelationField = getFlatFieldMetadataMock({
+      universalIdentifier: 'attachment-relation-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.RELATION,
+      name: 'attachments',
+      isSystemSideEffect: true,
+      relationTargetFieldMetadataId: companionMorphFieldId,
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.attachment,
+    });
+    const companionMorphField = getFlatFieldMetadataMock({
+      id: companionMorphFieldId,
+      universalIdentifier: 'companion-morph-attachment-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.MORPH_RELATION,
+      name: 'attachmentTargets',
+      isSystemSideEffect: true,
+    });
+
+    const result = fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+      deleteOneFieldInput: { id: attachmentRelationField.id },
+      flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+        attachmentRelationField,
+        companionMorphField,
+      ]),
+      flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+      flatIndexMaps: createEmptyFlatEntityMaps(),
+    });
+
+    expect(result.flatFieldMetadatasToDelete).toContainEqual(
+      expect.objectContaining({ id: attachmentRelationField.id }),
+    );
+  });
+
+  it('should allow deletion of noteTarget default relation field', () => {
+    const objectId = 'obj-1';
+    const companionMorphFieldId = '00000000-0000-0000-0000-000000000002';
+    const noteTargetRelationField = getFlatFieldMetadataMock({
+      universalIdentifier: 'note-target-relation-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.RELATION,
+      name: 'noteTargets',
+      isSystemSideEffect: true,
+      relationTargetFieldMetadataId: companionMorphFieldId,
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.noteTarget,
+    });
+    const companionMorphField = getFlatFieldMetadataMock({
+      id: companionMorphFieldId,
+      universalIdentifier: 'companion-morph-note-target-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.MORPH_RELATION,
+      name: 'noteTargetMorphs',
+      isSystemSideEffect: true,
+    });
+
+    const result = fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+      deleteOneFieldInput: { id: noteTargetRelationField.id },
+      flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+        noteTargetRelationField,
+        companionMorphField,
+      ]),
+      flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+      flatIndexMaps: createEmptyFlatEntityMaps(),
+    });
+
+    expect(result.flatFieldMetadatasToDelete).toContainEqual(
+      expect.objectContaining({ id: noteTargetRelationField.id }),
+    );
+  });
+
+  it('should allow deletion of taskTarget default relation field', () => {
+    const objectId = 'obj-1';
+    const companionMorphFieldId = '00000000-0000-0000-0000-000000000003';
+    const taskTargetRelationField = getFlatFieldMetadataMock({
+      universalIdentifier: 'task-target-relation-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.RELATION,
+      name: 'taskTargets',
+      isSystemSideEffect: true,
+      relationTargetFieldMetadataId: companionMorphFieldId,
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.taskTarget,
+    });
+    const companionMorphField = getFlatFieldMetadataMock({
+      id: companionMorphFieldId,
+      universalIdentifier: 'companion-morph-task-target-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.MORPH_RELATION,
+      name: 'taskTargetMorphs',
+      isSystemSideEffect: true,
+    });
+
+    const result = fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+      deleteOneFieldInput: { id: taskTargetRelationField.id },
+      flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+        taskTargetRelationField,
+        companionMorphField,
+      ]),
+      flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+      flatIndexMaps: createEmptyFlatEntityMaps(),
+    });
+
+    expect(result.flatFieldMetadatasToDelete).toContainEqual(
+      expect.objectContaining({ id: taskTargetRelationField.id }),
+    );
+  });
+
+  it('should throw FIELD_MUTATION_NOT_ALLOWED when deleting timelineActivity relation', () => {
+    const objectId = 'obj-1';
+    const timelineActivityRelationField = getFlatFieldMetadataMock({
+      universalIdentifier: 'timeline-activity-relation-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.RELATION,
+      name: 'timelineActivities',
+      isSystemSideEffect: true,
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.timelineActivity,
+    });
+
+    expect(() =>
+      fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+        deleteOneFieldInput: { id: timelineActivityRelationField.id },
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+          timelineActivityRelationField,
+        ]),
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+        flatIndexMaps: createEmptyFlatEntityMaps(),
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+      }),
+    );
+  });
+
+  it('should throw FIELD_MUTATION_NOT_ALLOWED when deleting system-managed non-relation field', () => {
+    const objectId = 'obj-1';
+    const systemTextField = getFlatFieldMetadataMock({
+      universalIdentifier: 'system-text-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.TEXT,
+      name: 'systemManagedField',
+      isSystemSideEffect: true,
+    });
+
+    expect(() =>
+      fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+        deleteOneFieldInput: { id: systemTextField.id },
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([systemTextField]),
         flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
         flatIndexMaps: createEmptyFlatEntityMaps(),
       }),

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/is-deletable-default-relation-flat-field-metadata.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/is-deletable-default-relation-flat-field-metadata.spec.ts
@@ -1,0 +1,94 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
+
+import { isDeletableDefaultRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-deletable-default-relation-flat-field-metadata.util';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+
+const buildRelationField = (
+  overrides: Partial<UniversalFlatFieldMetadata> = {},
+): UniversalFlatFieldMetadata =>
+  ({
+    type: FieldMetadataType.RELATION,
+    isSystemSideEffect: true,
+    relationTargetObjectMetadataUniversalIdentifier: '',
+    objectMetadataUniversalIdentifier: '',
+    ...overrides,
+  }) as unknown as UniversalFlatFieldMetadata;
+
+describe('isDeletableDefaultRelationFlatFieldMetadata', () => {
+  it('should return true for attachment relation targeting attachment object', () => {
+    const field = buildRelationField({
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.attachment,
+    });
+
+    expect(isDeletableDefaultRelationFlatFieldMetadata(field)).toBe(true);
+  });
+
+  it('should return true for noteTarget relation targeting noteTarget object', () => {
+    const field = buildRelationField({
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.noteTarget,
+    });
+
+    expect(isDeletableDefaultRelationFlatFieldMetadata(field)).toBe(true);
+  });
+
+  it('should return true for taskTarget relation targeting taskTarget object', () => {
+    const field = buildRelationField({
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.taskTarget,
+    });
+
+    expect(isDeletableDefaultRelationFlatFieldMetadata(field)).toBe(true);
+  });
+
+  it('should return false for timelineActivity relation', () => {
+    const field = buildRelationField({
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.timelineActivity,
+    });
+
+    expect(isDeletableDefaultRelationFlatFieldMetadata(field)).toBe(false);
+  });
+
+  it('should return false when field is not a system side effect', () => {
+    const field = buildRelationField({
+      isSystemSideEffect: false,
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.attachment,
+    });
+
+    expect(isDeletableDefaultRelationFlatFieldMetadata(field)).toBe(false);
+  });
+
+  it('should return false when field is not a relation type', () => {
+    const field = {
+      type: FieldMetadataType.TEXT,
+      isSystemSideEffect: true,
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.attachment,
+    } as unknown as UniversalFlatFieldMetadata;
+
+    expect(isDeletableDefaultRelationFlatFieldMetadata(field)).toBe(false);
+  });
+
+  it('should return false for non-default-relation target', () => {
+    const field = buildRelationField({
+      relationTargetObjectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person,
+    });
+
+    expect(isDeletableDefaultRelationFlatFieldMetadata(field)).toBe(false);
+  });
+
+  it('should return true when object itself is a deletable default relation (reverse direction)', () => {
+    const field = buildRelationField({
+      objectMetadataUniversalIdentifier:
+        STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.attachment,
+      relationTargetObjectMetadataUniversalIdentifier: 'some-custom-object',
+    });
+
+    expect(isDeletableDefaultRelationFlatFieldMetadata(field)).toBe(true);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
@@ -18,6 +18,7 @@ import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-m
 import { isSystemUniqueFlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/utils/is-system-unique-flat-index-metadata.util';
 import { generateFlatIndexMetadataWithNameOrThrow } from 'src/engine/metadata-modules/index-metadata/utils/generate-flat-index.util';
 import { belongsToTwentyStandardApp } from 'src/engine/metadata-modules/utils/belongs-to-twenty-standard-app.util';
+import { isDeletableDefaultRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-deletable-default-relation-flat-field-metadata.util';
 import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
 import { type UniversalFlatIndexMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-index-metadata.type';
 
@@ -66,7 +67,10 @@ export const fromDeleteFieldInputToFlatFieldMetadatasToDelete = ({
     );
   }
 
-  if (flatFieldMetadataToDelete.isSystemSideEffect === true) {
+  if (
+    flatFieldMetadataToDelete.isSystemSideEffect === true &&
+    !isDeletableDefaultRelationFlatFieldMetadata(flatFieldMetadataToDelete)
+  ) {
     throw new FieldMetadataException(
       `Cannot delete system-managed field "${flatFieldMetadataToDelete.name}"`,
       FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/is-deletable-default-relation-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/is-deletable-default-relation-flat-field-metadata.util.ts
@@ -1,0 +1,31 @@
+import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
+
+import { isMorphOrRelationUniversalFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+
+const DELETABLE_DEFAULT_RELATION_TARGET_UNIVERSAL_IDENTIFIERS: ReadonlySet<string> =
+  new Set([
+    STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.attachment,
+    STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.noteTarget,
+    STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.taskTarget,
+  ]);
+
+export const isDeletableDefaultRelationFlatFieldMetadata = (
+  flatFieldMetadata: UniversalFlatFieldMetadata,
+): boolean => {
+  if (
+    flatFieldMetadata.isSystemSideEffect !== true ||
+    !isMorphOrRelationUniversalFlatFieldMetadata(flatFieldMetadata)
+  ) {
+    return false;
+  }
+
+  return (
+    DELETABLE_DEFAULT_RELATION_TARGET_UNIVERSAL_IDENTIFIERS.has(
+      flatFieldMetadata.relationTargetObjectMetadataUniversalIdentifier,
+    ) ||
+    DELETABLE_DEFAULT_RELATION_TARGET_UNIVERSAL_IDENTIFIERS.has(
+      flatFieldMetadata.objectMetadataUniversalIdentifier,
+    )
+  );
+};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
@@ -14,6 +14,7 @@ import { FlatFieldMetadataRelationPropertiesToCompare } from 'src/engine/metadat
 import { isFlatFieldMetadataNameSyncedWithLabel } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-name-synced-with-label.util';
 import { isMorphOrRelationUniversalFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { validateFlatFieldMetadataNameAvailability } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util';
+import { isDeletableDefaultRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-deletable-default-relation-flat-field-metadata.util';
 import { validateFlatFieldMetadataName } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name.util';
 import { UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
 import { FailedFlatEntityValidation } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
@@ -285,6 +286,19 @@ export class FlatFieldMetadataValidatorService {
         code: FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
         message: 'System fields cannot be deleted',
         userFriendlyMessage: msg`System fields cannot be deleted`,
+      });
+    }
+
+    if (
+      !buildOptions.isSystemBuild &&
+      flatFieldMetadataToDelete.isSystemSideEffect === true &&
+      !isDeletableDefaultRelationFlatFieldMetadata(flatFieldMetadataToDelete) &&
+      !parentObjectMetadataHasBeenDeleted
+    ) {
+      validationResult.errors.push({
+        code: FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+        message: 'System-managed fields cannot be deleted',
+        userFriendlyMessage: msg`System-managed fields cannot be deleted`,
       });
     }
 


### PR DESCRIPTION
Closes #24245

## Problem

When creating a custom object, Twenty automatically adds default relations (Attachments, Notes, Tasks, Timeline Activities). Users could only deactivate these relations, not delete them. This left unnecessary fields in the system, especially problematic for junction objects.

## Solution

Allow users to delete default relation fields (Attachments, Notes, Tasks) from custom objects. Timeline Activities remain protected.

## Changes

### Backend

- `from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts`:
  Added `isDeletableDefaultRelation()` helper to identify deletable default relations (attachment, noteTarget, taskTarget). Modified system side-effect guard to allow deletion of these fields.

- `flat-field-metadata-validator.service.ts`:
  Added same validation check to allow system-managed default relations to be deleted at migration level.

### Frontend

- `SettingsObjectFieldDisabledActionDropdown.tsx`:
  Added `isDeletableSystemRelation` prop to show delete button for deletable system relations.

- `SettingsObjectRelationItemTableRow.tsx`:
  Added logic to detect if a relation targets attachment, noteTarget, or taskTarget, and pass `isDeletableSystemRelation` to dropdown.

## What users can now delete

- Attachments relation
- Notes relation
- Tasks relation
- Timeline Activities (protected, cannot delete)

---

@ManasMadrecha @martmull

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

