### PR TITLE
chore: bump version to 2.37.0

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
@@ -7,4 +7,4 @@
  *                              |___/
  */
 
-export const TWENTY_CURRENT_VERSION = '2.36.0' as const;
+export const TWENTY_CURRENT_VERSION = '2.37.0' as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
@@ -8,5 +8,5 @@
  */
 
 export const TWENTY_NEXT_VERSIONS = [
-  '2.37.0',
+  '2.38.0',
 ] as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
@@ -47,4 +47,5 @@ export const TWENTY_PREVIOUS_VERSIONS = [
   '2.33.0',
   '2.34.0',
   '2.35.0',
+  '2.36.0',
 ] as const;


### PR DESCRIPTION
Bumps `TWENTY_CURRENT_VERSION` from 2.36.0 to 2.37.0 as part of the v2.36 release.

- `TWENTY_CURRENT_VERSION`: 2.36.0 → 2.37.0
- `TWENTY_PREVIOUS_VERSIONS`: += 2.36.0
- `TWENTY_NEXT_VERSIONS`: 2.37.0 → 2.38.0

Merge only after the `twenty/v2.36.0` tag has been cut, so the release build captures `TWENTY_CURRENT_VERSION = 2.36.0`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

