### PR TITLE
[DO NOT REVIEW] Revert "chore: bump version to 2.37.0"

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
@@ -7,4 +7,4 @@
  *                              |___/
  */
 
-export const TWENTY_CURRENT_VERSION = '2.37.0' as const;
+export const TWENTY_CURRENT_VERSION = '2.36.0' as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
@@ -8,5 +8,5 @@
  */
 
 export const TWENTY_NEXT_VERSIONS = [
-  '2.38.0',
+  '2.37.0',
 ] as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
@@ -47,5 +47,4 @@ export const TWENTY_PREVIOUS_VERSIONS = [
   '2.33.0',
   '2.34.0',
   '2.35.0',
-  '2.36.0',
 ] as const;


### PR DESCRIPTION
Reverts #24894.

Restores `TWENTY_CURRENT_VERSION` to 2.36.0, removes 2.36.0 from `TWENTY_PREVIOUS_VERSIONS`, and sets `TWENTY_NEXT_VERSIONS` back to 2.37.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_016de2VwRB5DMcu2z6jBtVdR)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

