### PR TITLE
fix(server): guard rich text field resolution against non-object values

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/resolve-rich-text-fields-in-record.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/resolve-rich-text-fields-in-record.util.spec.ts
@@ -1,0 +1,71 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type ObjectMetadataInfo } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { resolveRichTextFieldsInRecord } from 'src/modules/workflow/workflow-executor/utils/resolve-rich-text-fields-in-record.util';
+
+type TestField = {
+  id: string;
+  name: string;
+  type: FieldMetadataType;
+};
+
+const buildObjectMetadataInfo = (fields: TestField[]): ObjectMetadataInfo => {
+  const byUniversalIdentifier = Object.fromEntries(
+    fields.map((field) => [field.id, field]),
+  );
+  const universalIdentifierById = Object.fromEntries(
+    fields.map((field) => [field.id, field.id]),
+  );
+
+  return {
+    flatObjectMetadata: { fieldIds: fields.map((field) => field.id) },
+    flatFieldMetadataMaps: {
+      byUniversalIdentifier,
+      universalIdentifierById,
+    },
+  } as unknown as ObjectMetadataInfo;
+};
+
+describe('resolveRichTextFieldsInRecord', () => {
+  const objectMetadataInfo = buildObjectMetadataInfo([
+    { id: 'field-1', name: 'body', type: FieldMetadataType.RICH_TEXT },
+  ]);
+
+  it('resolves variables inside a blocknote object value', () => {
+    const blocknote = `[{"type":"paragraph","content":[{"type":"variableTag","attrs":{"variable":"{{trigger.amount}}"}}]}]`;
+
+    const result = resolveRichTextFieldsInRecord(
+      { body: { blocknote } },
+      objectMetadataInfo,
+      { trigger: { amount: 42 } },
+    );
+
+    expect(result.body).toEqual({
+      blocknote: `[{"type":"paragraph","content":[{"type":"text","text":"42"}]}]`,
+    });
+  });
+
+  it('leaves a rich text field holding a raw string template untouched', () => {
+    const objectRecord = { body: 'Latest donation: {{trigger.amount}}' };
+
+    const result = resolveRichTextFieldsInRecord(
+      objectRecord,
+      objectMetadataInfo,
+      {
+        trigger: { amount: 42 },
+      },
+    );
+
+    expect(result.body).toBe('Latest donation: {{trigger.amount}}');
+  });
+
+  it('leaves a null rich text field untouched', () => {
+    const result = resolveRichTextFieldsInRecord(
+      { body: null },
+      objectMetadataInfo,
+      {},
+    );
+
+    expect(result.body).toBeNull();
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/resolve-rich-text-fields-in-record.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/resolve-rich-text-fields-in-record.util.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@sniptt/guards';
 import { isString } from 'class-validator';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined, resolveRichTextVariables } from 'twenty-shared/utils';
@@ -26,7 +27,7 @@ export const resolveRichTextFieldsInRecord = (
     const fieldValue = resolvedRecord[fieldName];
 
     if (
-      isDefined(fieldValue) &&
+      isObject(fieldValue) &&
       'blocknote' in fieldValue &&
       isString(fieldValue.blocknote)
     ) {


### PR DESCRIPTION
## Problem

Two high-volume production Sentry issues (`TWENTY-SERVER-H9K`, `TWENTY-SERVER-HCF`, ~380 events in the last 24h) crash a workflow run with:

```
TypeError: Cannot use 'in' operator to search for 'blocknote' in Latest donation: {{trigger.body.amount}} {{trigger.body.currency}}
```

Both are the same bug in `resolveRichTextFieldsInRecord`, thrown from the record-crud workflow actions (Create / Update / Upsert Record).

## Root cause

`resolveRichTextFieldsInRecord` walks every `RICH_TEXT` field of the target object and tries to resolve variables inside its serialized BlockNote value:

```ts
if (
  isDefined(fieldValue) &&
  'blocknote' in fieldValue &&      // <- throws when fieldValue is a string
  isString(fieldValue.blocknote)
) { ... }
```

`isDefined` only rejects `null`/`undefined`, so a string passes the guard. The `in` operator then runs against a string primitive and throws. The error message is the field value itself, e.g. `"Latest donation: {{trigger.body.amount}} {{trigger.body.currency}}"`.

## Which flow does NOT hit this

The workflow builder UI renders `RICH_TEXT` inputs through `FormRichTextFieldInput`, whose `onChange` always emits the object shape `{ blocknote, markdown }` (see `convertTipTapDocumentToBlockNote`). Records configured through the UI therefore carry an object value, `isObject`/`'blocknote' in` both hold, and variables inside the BlockNote JSON are resolved as intended. These runs were never affected.

## Which flow DOES hit this

When the `RICH_TEXT` field value in `objectRecord` is a plain **string** instead of the `{ blocknote }` object, i.e. a raw text/template string such as `"Latest donation: {{trigger.body.amount}} {{trigger.body.currency}}"`. This happens for records whose action input was not produced by the rich-text editor, e.g. workflows configured via the API/SDK or older/imported workflow definitions that set the field to a string. `isDefined` passes it through, `'blocknote' in "..."` throws, and the whole workflow action fails.

## Fix

Replace `isDefined(fieldValue) && typeof ...` with the existing `isObject` guard (`@sniptt/guards`, the same pattern already used in `evaluate-filter-conditions.util.ts`). `isObject` narrows to a non-null object before the `in` check, so non-object values are simply left untouched:

```ts
if (
  isObject(fieldValue) &&
  'blocknote' in fieldValue &&
  isString(fieldValue.blocknote)
) { ... }
```

A `RICH_TEXT` field holding a raw string now falls through unchanged and is handled by the downstream `resolveInput` call, which already resolves `{{ }}` templates inside strings. Behavior for the object case is unchanged.

## Tests

Added `resolve-rich-text-fields-in-record.util.spec.ts` covering:
- BlockNote object value: variables resolved inside the serialized document (unchanged behavior).
- Raw string template value: passed through untouched, no throw (the regression).
- `null` value: passed through untouched.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

