### PR TITLE
Add upgrade-mode QA Scout to the cross-version upgrade gate

### DIFF
--- a/.claude/skills/qa-scout/SKILL.md
+++ b/.claude/skills/qa-scout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-scout
-description: Browser QA of a PR against a running Twenty app, post-merge on main or pre-merge via the qa-scout label. Derives user-visible scenarios from the PR diff, executes them with the Playwright MCP browser, attests database effects over SQL, watches server and worker logs for swallowed errors, and writes a structured verdict plus a report. Invoked by ci-e2e-main.yaml after the deterministic e2e suite; also runnable locally against a dev stack.
+description: Browser QA of a PR against a running Twenty app, post-merge on main or pre-merge via the qa-scout label. Derives user-visible scenarios from the PR diff, executes them with the Playwright MCP browser, attests database effects over SQL, watches server and worker logs for swallowed errors, and writes a structured verdict plus a report. Invoked by ci-e2e-main.yaml after the deterministic e2e suite; also runs in upgrade mode inside ci-cross-version-upgrade.yaml, attesting upgrade-command effects over SQL and GraphQL with no browser; also runnable locally against a dev stack.
 ---
 
 # QA Scout
@@ -26,7 +26,7 @@ The invoking prompt gives you concrete paths. In CI they are:
 | Credentials | `tim@apple.dev` / `tim@apple.dev`, workspace `Apple` |
 | Server log (live) | `/tmp/qa-scout/server.log` |
 | Worker log (live) | `/tmp/qa-scout/worker.log` |
-| Run mode | `/tmp/qa-scout/context/mode`: `post-merge` (the change is on main) or `pre-merge` (label-triggered validation of the PR head before merge) |
+| Run mode | `/tmp/qa-scout/context/mode`: `post-merge` (the change is on main), `pre-merge` (label-triggered validation of the PR head before merge), or `upgrade` (see Upgrade mode below) |
 | Database (disposable, full access) | `postgres://postgres:postgres@localhost:5432/default` via `psql` |
 
 This environment is ephemeral, so unlike a shared instance you have full
@@ -78,6 +78,53 @@ own browser observations unreliable.
 6. **Collect evidence.** Take a screenshot at each scenario's end state and at
    every failure, with descriptive filenames (`03-note-timeline-missing.png`).
 
+## Upgrade mode
+
+`mode` = `upgrade` means you are inside ci-cross-version-upgrade.yaml: the PR
+changes an upgrade command, and the app you are probing was seeded on the
+oldest supported release and upgraded to the PR head by running `upgrade` for
+real, so the database carries the full upgrade history. There is no browser
+and no frontend here; the deterministic steps before you already asserted
+that `upgrade` ran twice cleanly. Your question narrows to: did this PR's
+upgrade command leave the database and the app in the state the current code
+expects?
+
+Input deltas from the table above:
+
+| What | Path |
+|---|---|
+| GraphQL (core / metadata), authenticated | `/tmp/qa-scout/bin/gql core < query.json` (Write the query JSON to a file first; `cat query.json \| /tmp/qa-scout/bin/gql metadata` also works) |
+| Database | same URL via `psql`; workspace tables live in `workspace_*` schemas |
+| Server log (live) | `/tmp/qa-scout/server.log` |
+| Worker log (live) | `/tmp/qa-scout/worker.log` |
+
+The procedure replaces browser scenarios with:
+
+1. Mark both log offsets first, as always.
+2. Read the upgrade command(s) this PR adds or changes under
+   `packages/twenty-server/src/database/commands/upgrade-version-command/`.
+   List every table and column they touch, directly or through builders.
+3. **Schema attestation.** For each touched table, compare the physical
+   schema (`information_schema.columns` in a `workspace_*` schema) against
+   the entity definition in the source tree
+   (`packages/twenty-server/src/modules/**`). The source is what the running
+   code expects; an entity-declared column missing from the database is a
+   FAIL even when every query you ran looked fine. Give special attention to
+   generated columns (search vectors) and to columns the command never named:
+   a CASCADE drop takes dependents silently, and `pg_depend` tells you what
+   depended on what.
+4. **Write path.** Create a record of an affected object over `gql`, wait a
+   few seconds for the worker, then confirm over `psql` that the timeline
+   activity row (and any other side-effect row the diff implies) landed.
+5. Read both log windows after each step. A new exception in the worker log
+   is a FAIL exactly as in browser mode; the incident this mode exists for
+   threw only there.
+
+The verdict contract below is unchanged. On FAIL or INVESTIGATE the stakes
+line is: this upgrade command, run against a database carrying the full
+upgrade history, left drift behind, and merging ships that drift to every
+instance at the next release.
+
 ## Verdict contract
 
 Always write both files to the output directory, whatever happens:
@@ -102,7 +149,8 @@ Always write both files to the output directory, whatever happens:
 - **PASS**: scenarios green and no new errors attributable to them. Never PASS
   with unexplained new exceptions in your log window.
 
-`report.md` (GitHub-flavored, posted verbatim as a PR comment on non-PASS):
+`report.md` (GitHub-flavored; in browser modes posted verbatim as a PR
+comment on non-PASS, in upgrade mode surfaced in the job summary):
 
 - On FAIL or INVESTIGATE, open with a `> [!CAUTION]` admonition of 3 to 6
   lines: the user action that breaks, one quoted log line, the suspect files,

--- a/.github/workflows/ci-cross-version-upgrade.yaml
+++ b/.github/workflows/ci-cross-version-upgrade.yaml
@@ -13,6 +13,10 @@ on:
         type: string
         required: false
         description: 'Old Twenty version to upgrade from (defaults to oldest supported: v1.22)'
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: false
+        description: 'Inference credential for the QA Scout step; absent on fork runs, in which case the Scout skips'
   workflow_dispatch:
     inputs:
       from_version:

--- a/.github/workflows/ci-cross-version-upgrade.yaml
+++ b/.github/workflows/ci-cross-version-upgrade.yaml
@@ -47,7 +47,9 @@ jobs:
 
   cross-version-upgrade:
     if: format('{0}', inputs.skip) != 'true'
-    timeout-minutes: 45
+    # 60 so the deterministic phases plus the QA Scout's 15-minute step cap
+    # fit without the job ceiling killing a step mid-flight.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Compute run config
@@ -246,6 +248,13 @@ jobs:
           tail -100 upgrade-logs/twenty-new.log || true
           exit 1
 
+      - name: Server / Start worker
+        # Async side effects (timeline writes among them) only exist with a
+        # worker running; the 2.35 searchVector incident lived exactly there.
+        run: |
+          npx nx run twenty-server:worker > upgrade-logs/twenty-worker.log 2>&1 &
+          echo "Worker started"
+
       # ================================================================
       # Phase 3 — Smoke tests on upgraded instance
       # ================================================================
@@ -277,6 +286,20 @@ jobs:
             || { echo "FAIL: Instance is not up to date"; exit 1; }
           echo "$OUTPUT" | grep -q "0 behind, 0 failed" \
             || { echo "FAIL: Some workspaces are behind or failed"; exit 1; }
+
+      - name: Smoke / Upgrade idempotency re-run
+        # UPGRADE_COMMANDS.md mandates idempotent commands but nothing tested
+        # it until now; the moment a command ever executes twice for real, this
+        # property is load-bearing. A second run must succeed and stay clean.
+        run: |
+          npx nx run twenty-server:command-no-deps -- upgrade --verbose
+          RAW=$(FORCE_COLOR=0 NO_COLOR=1 npx nx run twenty-server:command-no-deps -- upgrade:status 2>&1)
+          OUTPUT=$(printf '%s\n' "$RAW" | sed -E 's/\x1b\[[0-9;]*m//g')
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -q "Instance: Up to date" \
+            || { echo "FAIL: Instance not up to date after idempotency re-run"; exit 1; }
+          echo "$OUTPUT" | grep -q "0 behind, 0 failed" \
+            || { echo "FAIL: Workspaces behind or failed after idempotency re-run"; exit 1; }
 
       - name: Smoke / Query companies
         run: |
@@ -319,6 +342,145 @@ jobs:
           fi
           jq -e '.data.objects.edges | length > 0' /tmp/response.json \
             || { echo "FAIL: expected metadata objects"; exit 1; }
+
+      # ================================================================
+      # Phase 3.5 — QA Scout (upgrade mode)
+      # ================================================================
+      # Agent QA of the PR's upgrade command against the v1.22-upgraded
+      # database (.claude/skills/qa-scout/SKILL.md, upgrade mode): schema
+      # attested over psql against the entity sources, write flows over
+      # GraphQL, worker log window diffed. No browser here: this is a blocking
+      # pre-merge gate and the bug class is backend; browser coverage lives in
+      # the post-merge e2e habitat. Shadow-safe: continue-on-error everywhere,
+      # so only the deterministic phases above can redden this check. Runs
+      # after the phases succeeded (a red gate is already the signal).
+
+      - name: QA Scout / Prepare upgrade context
+        id: qa-scout-prep
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # secrets are unavailable to fork runs and to callers that do not
+          # inherit them; the Scout skips loudly instead of failing the action.
+          HAS_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+        run: |
+          mkdir -p /tmp/qa-scout/context /tmp/qa-scout/output /tmp/qa-scout/bin
+          if [ "$HAS_OAUTH_TOKEN" != "true" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No CLAUDE_CODE_OAUTH_TOKEN available (fork PR or secrets not inherited); skipping the Scout."
+            exit 0
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '{number, title, body, url: .html_url, author: .user.login, headSha: .head.sha}' \
+            > /tmp/qa-scout/context/pr.json
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[] | {path: .filename, additions, deletions, status}' | jq -s '.' \
+            > /tmp/qa-scout/context/files.json
+          gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > /tmp/qa-scout/context/pr.diff.full
+          head -c 400000 /tmp/qa-scout/context/pr.diff.full > /tmp/qa-scout/context/pr.diff
+          if [ "$(stat -c%s /tmp/qa-scout/context/pr.diff.full)" -gt 400000 ]; then
+            printf '\n\n[TRUNCATED: diff exceeds 400000 bytes; the complete file list is in files.json]\n' >> /tmp/qa-scout/context/pr.diff
+          fi
+          rm -f /tmp/qa-scout/context/pr.diff.full
+          echo "upgrade" > /tmp/qa-scout/context/mode
+          # Disposable app credential (minted by the smoke phase, dead with the
+          # run); handed to the agent through the gql wrapper, deleted before
+          # any artifact upload.
+          printf '%s' "$API_KEY" > /tmp/qa-scout/context/api_token
+          chmod 600 /tmp/qa-scout/context/api_token
+          cat > /tmp/qa-scout/bin/gql <<'SCRIPT'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          ENDPOINT="${1:-core}"
+          case "$ENDPOINT" in
+            core) URL="http://localhost:3000/graphql" ;;
+            metadata) URL="http://localhost:3000/metadata" ;;
+            *) echo "usage: gql [core|metadata] < query.json" >&2; exit 2 ;;
+          esac
+          curl -s "$URL" \
+            -H "Authorization: Bearer $(cat /tmp/qa-scout/context/api_token)" \
+            -H "Content-Type: application/json" \
+            -d @-
+          SCRIPT
+          chmod +x /tmp/qa-scout/bin/gql
+          ln -sf "$GITHUB_WORKSPACE/upgrade-logs/twenty-new.log" /tmp/qa-scout/server.log
+          ln -sf "$GITHUB_WORKSPACE/upgrade-logs/twenty-worker.log" /tmp/qa-scout/worker.log
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      # Same privilege model as the e2e Scout: read-only GitHub token, no
+      # write capability anywhere. The allowlist scopes rather than contains
+      # (psql is deliberately full power against the disposable database);
+      # gql is the prepare-authored wrapper pinned to the local GraphQL
+      # endpoints, so the agent has a write path into the app without an
+      # open curl.
+      - name: QA Scout / Run
+        id: qa-scout-run
+        if: ${{ steps.qa-scout-prep.outputs.run == 'true' }}
+        continue-on-error: true
+        timeout-minutes: 15
+        uses: anthropics/claude-code-action@ac7e24bf2938964b8ab203e417a2773802392ddd # v1.0.146
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The action needs a GitHub token to bootstrap; the workflow token
+          # is contents:read only, so the agent still holds no write
+          # capability.
+          github_token: ${{ github.token }}
+          prompt: |
+            Read .claude/skills/qa-scout/SKILL.md and follow it exactly, in
+            upgrade mode. This is the cross-version CI invocation: the paths
+            in the skill's Upgrade mode section apply verbatim.
+          claude_args: '--max-turns 80 --model opus --allowedTools "Read,Grep,Glob,Write,Bash(cat *),Bash(tail *),Bash(head *),Bash(wc *),Bash(ls *),Bash(grep *),Bash(jq *),Bash(mkdir *),Bash(sleep *),Bash(date *),Bash(psql *),Bash(/tmp/qa-scout/bin/gql *)"'
+
+      # The agent process necessarily holds the inference credential; redact
+      # its token shape from everything both artifacts ship, in the trusted
+      # lane, and drop the app credential entirely.
+      - name: QA Scout / Scrub outputs
+        if: ${{ steps.qa-scout-prep.outputs.run == 'true' }}
+        continue-on-error: true
+        run: |
+          rm -f /tmp/qa-scout/context/api_token
+          if grep -rq 'sk-ant-' /tmp/qa-scout upgrade-logs 2>/dev/null; then
+            echo "Redacting Anthropic token shapes from Scout files:"
+            grep -rl 'sk-ant-' /tmp/qa-scout upgrade-logs 2>/dev/null
+            grep -rlZ 'sk-ant-' /tmp/qa-scout upgrade-logs 2>/dev/null \
+              | xargs -0 sed -i -E 's/sk-ant-[A-Za-z0-9_-]+/[REDACTED]/g'
+          fi
+
+      - name: QA Scout / Job summary
+        if: ${{ steps.qa-scout-prep.outcome != 'skipped' }}
+        continue-on-error: true
+        env:
+          SCOUT_RUN: ${{ steps.qa-scout-prep.outputs.run }}
+          SCOUT_PREP_OUTCOME: ${{ steps.qa-scout-prep.outcome }}
+        run: |
+          {
+            echo "## QA Scout (upgrade mode)"
+            if [ -f /tmp/qa-scout/output/report.md ]; then
+              cat /tmp/qa-scout/output/report.md
+            elif [ "$SCOUT_RUN" = "true" ]; then
+              echo "No report produced (agent run failed or timed out); see the qa-scout-upgrade-report artifact and step logs."
+            elif [ "$SCOUT_PREP_OUTCOME" = "failure" ]; then
+              echo "Did not run: the prepare step failed; see its logs."
+            else
+              echo "Did not run: no OAuth token available (fork PR or secrets not inherited)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: QA Scout / Upload report
+        if: ${{ steps.qa-scout-prep.outputs.run == 'true' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: qa-scout-upgrade-report
+          path: |
+            /tmp/qa-scout/context/
+            /tmp/qa-scout/output/
+          if-no-files-found: ignore
+          retention-days: 14
 
       # ================================================================
       # Phase 4 — Collect logs & cleanup

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -354,6 +354,8 @@ jobs:
   cross-version-upgrade:
     needs: [upgrade-changed-files-check, server-build]
     uses: ./.github/workflows/ci-cross-version-upgrade.yaml
+    # For the QA Scout step; fork runs inherit nothing and the Scout skips.
+    secrets: inherit
     with:
       skip: ${{ needs.upgrade-changed-files-check.outputs.any_changed != 'true' }}
 

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -354,8 +354,10 @@ jobs:
   cross-version-upgrade:
     needs: [upgrade-changed-files-check, server-build]
     uses: ./.github/workflows/ci-cross-version-upgrade.yaml
-    # For the QA Scout step; fork runs inherit nothing and the Scout skips.
-    secrets: inherit
+    # Only the Scout's credential crosses into the reusable workflow; fork
+    # runs pass nothing and the Scout skips.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:
       skip: ${{ needs.upgrade-changed-files-check.outputs.any_changed != 'true' }}
 


### PR DESCRIPTION
Follow-up to #24856, targeting the upgrade-command bug class directly.

## Why here

The cross-version job already reproduces the preconditions of the 2.35 searchVector incident: it seeds a database on the oldest supported release (v1.22) and upgrades it to the PR head by running `upgrade` for real, so the schema carries the full upgrade history the fresh-seeded e2e env structurally cannot have. But its verification was three read-only GraphQL queries plus `upgrade:status`, with no worker running. A CASCADE-dropped column on a write path was invisible: the habitat reproduced the bug and had no eyes where it showed.

## What this adds

Deterministic, blocking:
- `Smoke / Upgrade idempotency re-run`: runs `upgrade` a second time and asserts `upgrade:status` still reports clean. UPGRADE_COMMANDS.md mandates idempotency; nothing tested it until now, and it becomes load-bearing the moment a command ever executes twice for real.
- `Server / Start worker`: async side effects (timeline writes among them) only exist with a worker; its log is captured to `upgrade-logs/twenty-worker.log`.

Agent, shadow-safe (`continue-on-error` everywhere, runs only after the deterministic phases succeeded):
- QA Scout in a new `upgrade` mode (`.claude/skills/qa-scout/SKILL.md`): attests the physical schema against the entity sources over `psql` (generated columns and CASCADE losses specifically, via `information_schema` and `pg_depend`), exercises a write flow over GraphQL, confirms the timeline side-effect row landed, and diffs both log windows for new exceptions. Verdict lands in the job summary and a `qa-scout-upgrade-report` artifact; no PR comment job, since this workflow is already a blocking pre-merge gate.

No browser and no frontend build: the gate is blocking and latency matters, the bug class is backend, and browser coverage already lives in the post-merge e2e habitat. GraphQL access goes through a prepare-authored `gql` wrapper pinned to the local endpoints, so the agent gets a write path into the disposable app without an open `curl` rule (same reasoning that removed `curl` from the e2e allowlist).

## Privilege model

Identical to #24856: the agent step holds a read-only GitHub token and no write capability; the app API key is disposable (per-run APP_SECRET, deleted before artifact upload); token shapes are scrubbed from both artifacts in the trusted lane. `secrets: inherit` is added at the ci-server call site; fork runs inherit nothing and the Scout skips with a breadcrumb in the job summary.

## Cost and frequency

Fires only on PRs touching `upgrade-version-command/**` or `core-modules/upgrade/**` (the existing changed-files gate), a handful per week. Job timeout raised 45 to 60 so the 15-minute Scout cap fits without the job ceiling killing steps mid-flight.

## Validation

Workflow YAML parsed, every new run block passes `bash -n`, and the `gql` heredoc was executed standalone: the generated wrapper is syntactically valid and its endpoint guard rejects anything but `core`/`metadata`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1ML7TTsrqPbPnCtox9rBX)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

