### PR TITLE
Audit runner egress on the QA Scout job

### DIFF
--- a/.github/workflows/ci-e2e-main.yaml
+++ b/.github/workflows/ci-e2e-main.yaml
@@ -66,6 +66,9 @@ jobs:
       # weeks of audit data, egress-policy block with that allowlist makes
       # real-time exfiltration impossible rather than merely unscoped.
       - name: Harden runner (egress audit)
+        # Fail-open while auditing: an observer must never redden the status
+        # check. The eventual block-mode flip drops this so it fails closed.
+        continue-on-error: true
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit

--- a/.github/workflows/ci-e2e-main.yaml
+++ b/.github/workflows/ci-e2e-main.yaml
@@ -58,6 +58,18 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      # Audit only: records every outbound endpoint this job touches in the
+      # StepSecurity insights, blocks nothing, changes no behavior. This is
+      # the observation phase for the QA Scout containment follow-up: the
+      # agent step's allowlist scopes what it does, not where the runner can
+      # reach, so once the job's endpoint set is known and stable from a few
+      # weeks of audit data, egress-policy block with that allowlist makes
+      # real-time exfiltration impossible rather than merely unscoped.
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10


### PR DESCRIPTION
Follow-up to #24856, first step of the containment hardening discussed in its security review.

## The gap this works toward closing

The Scout's `--allowedTools` list scopes what the agent does, not where the runner can reach. The accepted residual in #24856 is that a prompt-injected agent could exfiltrate the inference token in real time over the runner's open egress (`psql` alone is arbitrarily powerful in the disposable env, so pure allowlisting cannot close this). The real fix is a runner-level egress block with an endpoint allowlist. Writing that allowlist blind would break the job on the first missing endpoint.

## What this PR does

Adds `step-security/harden-runner` (sha-pinned to v2.21.0) as the first step of the `e2e-test` job with `egress-policy: audit`:

- records every outbound endpoint the job actually uses (yarn install, Playwright, the Anthropic API, GitHub) in the StepSecurity insights for the run,
- blocks nothing and changes no behavior; a failure of the action itself fails nothing downstream since it only observes.

## What comes after

Once a few weeks of audit data show a stable endpoint set, a follow-up flips to `egress-policy: block` with that allowlist. At that point real-time exfiltration from the agent step becomes impossible rather than merely out of scope, and the same pattern can extend to the other agent-running workflows (`claude.yml`, and the cross-version Scout of #24906).

## Supply-chain note

This adds a third-party action to the job. It is pinned by commit sha, runs in audit (observe-only) mode, and is the de facto standard for exactly this purpose; calling it out explicitly since the tradeoff (new dependency vs egress visibility) is a real one for reviewers to weigh.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1ML7TTsrqPbPnCtox9rBX)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

