### PR TITLE
fix(front): share the scroll overlay button between AI chat and transcript

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AiChatScrollToBottomButton.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatScrollToBottomButton.tsx
@@ -1,40 +1,11 @@
 import { agentChatIsScrolledToBottomComponentSelector } from '@/ai/states/selectors/agentChatIsScrolledToBottomComponentSelector';
 import { scrollAiChatToBottom } from '@/ai/utils/scrollAiChatToBottom';
+import { ScrollOverlayButton } from '@/ui/utilities/scroll/components/ScrollOverlayButton';
 import { useScrollWrapperHTMLElement } from '@/ui/utilities/scroll/hooks/useScrollWrapperHTMLElement';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
-import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import { IconArrowDown } from 'twenty-ui/icon';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
-
-const StyledScrollToBottomButton = styled.button<{ isVisible: boolean }>`
-  align-items: center;
-  background: ${themeCssVariables.background.primary};
-  border: 1px solid ${themeCssVariables.border.color.medium};
-  border-radius: ${themeCssVariables.border.radius.rounded};
-  bottom: ${themeCssVariables.spacing[3]};
-  box-shadow: ${themeCssVariables.boxShadow.light};
-  color: ${themeCssVariables.font.color.secondary};
-  corner-shape: round;
-  cursor: pointer;
-  display: flex;
-  height: 32px;
-  justify-content: center;
-  left: 50%;
-  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
-  pointer-events: ${({ isVisible }) => (isVisible ? 'auto' : 'none')};
-  position: absolute;
-  transform: translateX(-50%);
-  transition:
-    opacity calc(${themeCssVariables.animation.duration.normal} * 1s) ease,
-    background calc(${themeCssVariables.animation.duration.fast} * 1s) ease;
-  width: 32px;
-  z-index: 1;
-
-  &:hover {
-    background: ${themeCssVariables.background.tertiary};
-  }
-`;
 
 export const AiChatScrollToBottomButton = () => {
   const agentChatIsScrolledToBottom = useAtomComponentSelectorValue(
@@ -52,11 +23,11 @@ export const AiChatScrollToBottomButton = () => {
   };
 
   return (
-    <StyledScrollToBottomButton
+    <ScrollOverlayButton
+      Icon={IconArrowDown}
+      ariaLabel={t`Scroll to bottom`}
       isVisible={!agentChatIsScrolledToBottom}
       onClick={handleClick}
-    >
-      <IconArrowDown size={16} />
-    </StyledScrollToBottomButton>
+    />
   );
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptEntryList.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptEntryList.tsx
@@ -2,6 +2,7 @@ import { CallRecordingTranscriptEntryListItem } from '@/page-layout/widgets/call
 import { CallRecordingTranscriptFollowScrollEffect } from '@/page-layout/widgets/call-recording-transcript/components/CallRecordingTranscriptFollowScrollEffect';
 import { type CallRecordingTranscriptPlayback } from '@/page-layout/widgets/call-recording-transcript/types/CallRecordingTranscriptPlayback';
 import { getCallRecordingTranscriptEntryPlaybackPhase } from '@/page-layout/widgets/call-recording-transcript/utils/getCallRecordingTranscriptEntryPlaybackPhase';
+import { ScrollOverlayButton } from '@/ui/utilities/scroll/components/ScrollOverlayButton';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import {
@@ -13,7 +14,6 @@ import {
 } from 'react';
 import { type CallRecordingParsedTranscriptEntry } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { Button } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledTranscriptContainer = styled.div`
@@ -38,13 +38,6 @@ const StyledEntryList = styled.ul<{ hasPlaybackControls: boolean }>`
     hasPlaybackControls
       ? `${themeCssVariables.spacing[4]} 0 ${themeCssVariables.spacing[10]}`
       : '0'};
-`;
-
-const StyledResumeFollowButton = styled.div`
-  bottom: ${themeCssVariables.spacing[3]};
-  left: 50%;
-  position: absolute;
-  transform: translateX(-50%);
 `;
 
 const MANUAL_SCROLL_KEYS = [
@@ -141,16 +134,13 @@ export const CallRecordingTranscriptEntryList = ({
           })}
         </StyledEntryList>
       </StyledTranscriptScrollContainer>
-      {hasPlayback && !isFollowingPlayback && (
-        <StyledResumeFollowButton>
-          <Button
-            ariaLabel={t`Jump to current`}
-            size="small"
-            title={t`Jump to current`}
-            variant="secondary"
-            onClick={resumeFollowingPlayback}
-          />
-        </StyledResumeFollowButton>
+      {hasPlayback && (
+        <ScrollOverlayButton
+          ariaLabel={t`Jump to current`}
+          isVisible={!isFollowingPlayback}
+          title={t`Jump to current`}
+          onClick={resumeFollowingPlayback}
+        />
       )}
     </StyledTranscriptContainer>
   );

--- a/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollOverlayButton.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollOverlayButton.tsx
@@ -14,8 +14,6 @@ const StyledScrollOverlayButton = styled.button<{
   bottom: ${themeCssVariables.spacing[3]};
   box-shadow: ${themeCssVariables.boxShadow.light};
   color: ${themeCssVariables.font.color.secondary};
-  // The pill radius is never doubled for squircles, so it needs round corners
-  // to read as a capsule rather than a superellipse.
   corner-shape: round;
   cursor: pointer;
   display: flex;

--- a/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollOverlayButton.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollOverlayButton.tsx
@@ -1,0 +1,77 @@
+import { styled } from '@linaria/react';
+import { isDefined } from 'twenty-shared/utils';
+import { type IconComponent } from 'twenty-ui/icon';
+import { themeCssVariables, useTheme } from 'twenty-ui/theme-constants';
+
+const StyledScrollOverlayButton = styled.button<{
+  hasTitle: boolean;
+  isVisible: boolean;
+}>`
+  align-items: center;
+  background: ${themeCssVariables.background.primary};
+  border: 1px solid ${themeCssVariables.border.color.medium};
+  border-radius: ${themeCssVariables.border.radius.pill};
+  bottom: ${themeCssVariables.spacing[3]};
+  box-shadow: ${themeCssVariables.boxShadow.light};
+  color: ${themeCssVariables.font.color.secondary};
+  // The pill radius is never doubled for squircles, so it needs round corners
+  // to read as a capsule rather than a superellipse.
+  corner-shape: round;
+  cursor: pointer;
+  display: flex;
+  font-family: ${themeCssVariables.font.family};
+  font-size: ${themeCssVariables.font.size.md};
+  font-weight: ${themeCssVariables.font.weight.regular};
+  gap: ${themeCssVariables.spacing[1]};
+  height: 32px;
+  justify-content: center;
+  left: 50%;
+  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+  padding: ${({ hasTitle }) =>
+    hasTitle ? `0 ${themeCssVariables.spacing[3]}` : '0'};
+  pointer-events: ${({ isVisible }) => (isVisible ? 'auto' : 'none')};
+  position: absolute;
+  transform: translateX(-50%);
+  transition:
+    opacity calc(${themeCssVariables.animation.duration.normal} * 1s) ease,
+    background calc(${themeCssVariables.animation.duration.fast} * 1s) ease;
+  width: ${({ hasTitle }) => (hasTitle ? 'auto' : '32px')};
+  z-index: 1;
+
+  &:hover {
+    background: ${themeCssVariables.background.tertiary};
+  }
+`;
+
+type ScrollOverlayButtonProps = {
+  ariaLabel: string;
+  isVisible: boolean;
+  onClick: () => void;
+  Icon?: IconComponent;
+  title?: string;
+};
+
+export const ScrollOverlayButton = ({
+  ariaLabel,
+  isVisible,
+  onClick,
+  Icon,
+  title,
+}: ScrollOverlayButtonProps) => {
+  const theme = useTheme();
+
+  return (
+    <StyledScrollOverlayButton
+      aria-hidden={!isVisible}
+      aria-label={ariaLabel}
+      hasTitle={isDefined(title)}
+      isVisible={isVisible}
+      tabIndex={isVisible ? 0 : -1}
+      type="button"
+      onClick={onClick}
+    >
+      {isDefined(Icon) && <Icon size={theme.icon.size.md} />}
+      {title}
+    </StyledScrollOverlayButton>
+  );
+};

--- a/packages/twenty-front/src/modules/ui/utilities/scroll/components/__stories__/ScrollOverlayButton.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/components/__stories__/ScrollOverlayButton.stories.tsx
@@ -1,0 +1,85 @@
+import { ScrollOverlayButton } from '@/ui/utilities/scroll/components/ScrollOverlayButton';
+import { styled } from '@linaria/react';
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { IconArrowDown } from 'twenty-ui/icon';
+import { ComponentDecorator } from 'twenty-ui/testing';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledScrollAreaMock = styled.div`
+  background: ${themeCssVariables.background.secondary};
+  height: 120px;
+  position: relative;
+  width: 320px;
+`;
+
+const meta: Meta<typeof ScrollOverlayButton> = {
+  title: 'UI/Utilities/Scroll/ScrollOverlayButton',
+  component: ScrollOverlayButton,
+  decorators: [
+    (Story) => (
+      <StyledScrollAreaMock>
+        <Story />
+      </StyledScrollAreaMock>
+    ),
+    ComponentDecorator,
+  ],
+  args: {
+    isVisible: true,
+    onClick: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ScrollOverlayButton>;
+
+export const IconOnly: Story = {
+  args: {
+    Icon: IconArrowDown,
+    ariaLabel: 'Scroll to bottom',
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Scroll to bottom' }),
+    );
+
+    expect(args.onClick).toHaveBeenCalled();
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    ariaLabel: 'Jump to current',
+    title: 'Jump to current',
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = await canvas.findByRole('button', {
+      name: 'Jump to current',
+    });
+
+    expect(button).toBeVisible();
+
+    await userEvent.click(button);
+
+    expect(args.onClick).toHaveBeenCalled();
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ariaLabel: 'Jump to current',
+    isVisible: false,
+    title: 'Jump to current',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(
+      canvas.queryByRole('button', { name: 'Jump to current' }),
+    ).not.toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## What

The "Jump to current" overlay in the call recording transcript widget had a transparent background, so transcript lines scrolled visibly through it and collided with its label.

## Before / After

The same widget at the same scroll position, playback paused at 0:31. Before, the line "Perfect, let's gather final feedback and wrap up." reads straight through the button and tangles with its label. After, the overlay occludes it cleanly.

| Before | After |
| --- | --- |
| ![Before: transcript text reads through the transparent overlay button](https://raw.githubusercontent.com/twentyhq/twenty/refs/heads/claude/transcript-jump-button-assets/transcript-overlay-before.png) | ![After: the opaque capsule cleanly occludes the transcript line behind it](https://raw.githubusercontent.com/twentyhq/twenty/refs/heads/claude/transcript-jump-button-assets/transcript-overlay-after.png) |

## Why

`Button variant="secondary"` is unfilled by design. `Button.module.scss` sets `background: var(--btn-bg, transparent)` and only the `primary` branch ever assigns `--btn-bg`. The secondary/tertiary block says so explicitly:

> Background stays transparent (the .button fallback). The two variants only differ in their resting border: secondary uses border-secondary, tertiary is borderless.

That is correct for a button in normal flow on a solid surface, but this one is absolutely positioned over the scrolling transcript. `variant="primary"` would not have fixed it either, since the default accent's fill is `--t-background-transparent-lighter`, which composites onto what is behind rather than occluding it.

AI chat already solved this exact affordance. `AiChatScrollToBottomButton` is an opaque capsule pinned to the bottom of its scroll container that fades in once you scroll away from the live position, and its positioning block was already character-for-character the same as the transcript's. Two components, same job, one of them correct.

## Changes

- Add `ScrollOverlayButton` in `ui/utilities/scroll/components/`, carrying the surface, positioning and fade behaviour from `AiChatScrollToBottomButton` unchanged.
- Use it in both places: icon-only for AI chat, labelled for the transcript.
- Delete the transcript's `StyledResumeFollowButton` wrapper, since the shared component owns positioning.

The transcript keeps its text label rather than adopting AI chat's down arrow: its target can be above or below the viewport depending on where you scrolled, so a fixed arrow direction would be wrong about half the time. AI chat's is always downwards.

Visibility moved from conditional mount to `isVisible` plus `aria-hidden`, matching AI chat. The button stays mounted while playback exists, so it fades instead of popping, and it stays out of the accessibility tree and the tab order while hidden.

The AI chat button renders identically, verified by measuring both against each other (32x32, same padding, border and background; `border-radius: pill` at that size resolves to the same circle as `rounded`). It also gains an accessible name it was previously missing, since it was an icon-only button with no label.

## Testing

- `CallRecordingTranscriptBody`, `CallRecordingTranscriptEntryList` and `CallRecordingTranscriptEntryListItem` stories: 19 passed, unchanged. Includes "With Video Interactions", which asserts the overlay appears after a wheel scroll and disappears after a seek.
- `ai/components` jest suites: 67 passed across 13 suites.
- Typecheck clean on `twenty-front`; oxlint and oxfmt clean on all three files.

## Notes for reviewers

`corner-shape: round` on the shared component is load-bearing, not copied noise. The theme applies `corner-shape: squircle` globally under `@supports`, and the `pill` and `rounded` radius tokens are deliberately not doubled there because they are meant for elements that opt back out. Without it the button renders as a superellipse rather than a capsule.

The screenshots above are served from `claude/transcript-jump-button-assets`, a parentless branch holding only those two PNGs, so they stay out of this diff. It can be deleted once the images are no longer needed.