### PR TITLE
fix(twenty-shared): normalizeLocale ignores inherited Object prototype keys

### DIFF
--- a/packages/twenty-shared/src/utils/validation/__tests__/normalizeLocale.test.ts
+++ b/packages/twenty-shared/src/utils/validation/__tests__/normalizeLocale.test.ts
@@ -39,6 +39,13 @@ describe('normalizeLocale', () => {
     expect(normalizeLocale('')).toBe(SOURCE_LOCALE);
   });
 
+  it('should not treat inherited Object prototype keys as valid locales', () => {
+    expect(normalizeLocale('toString')).toBe(SOURCE_LOCALE);
+    expect(normalizeLocale('constructor')).toBe(SOURCE_LOCALE);
+    expect(normalizeLocale('valueOf')).toBe(SOURCE_LOCALE);
+    expect(normalizeLocale('hasOwnProperty')).toBe(SOURCE_LOCALE);
+  });
+
   it('should handle SOURCE_LOCALE and its variants correctly', () => {
     expect(normalizeLocale(SOURCE_LOCALE)).toBe(SOURCE_LOCALE);
     // If SOURCE_LOCALE is 'en', test 'en-US', 'en-GB', etc.

--- a/packages/twenty-shared/src/utils/validation/normalizeLocale.ts
+++ b/packages/twenty-shared/src/utils/validation/normalizeLocale.ts
@@ -6,27 +6,34 @@ import { SOURCE_LOCALE } from '@/translations/constants/SourceLocale';
 
 // Maps language codes to full locale keys in APP_LOCALES
 // Example: 'fr' -> 'fr-FR', 'en' -> 'en'
+// Null-prototype dict: it is keyed by untrusted input below, so a normal object
+// would resolve inherited keys like 'constructor' to Object.prototype members.
 const languageToLocaleMap = Object.keys(APP_LOCALES).reduce<
   Record<string, string>
->((map, locale) => {
-  const language = locale.split('-')[0].toLowerCase();
+>(
+  (map, locale) => {
+    const language = locale.split('-')[0].toLowerCase();
 
-  // Only add to the map if not already added or if the current locale is the source locale
-  // This ensures language codes map to their full locale version (e.g., 'es' -> 'es-ES')
-  // but preserves 'en' -> 'en' since it's the source locale
-  if (!map[language] || locale === SOURCE_LOCALE) {
-    map[language] = locale;
-  }
+    // Only add to the map if not already added or if the current locale is the source locale
+    // This ensures language codes map to their full locale version (e.g., 'es' -> 'es-ES')
+    // but preserves 'en' -> 'en' since it's the source locale
+    if (!map[language] || locale === SOURCE_LOCALE) {
+      map[language] = locale;
+    }
 
-  return map;
-}, {});
+    return map;
+  },
+  Object.create(null) as Record<string, string>,
+);
 
 export const normalizeLocale = (value: string | null): AppLocale => {
   if (value === null) {
     return SOURCE_LOCALE;
   }
 
-  if (value in APP_LOCALES) {
+  // `in` walks the prototype chain, so inherited Object keys like 'toString' or
+  // 'constructor' would be treated as valid locales; check own keys only.
+  if (Object.keys(APP_LOCALES).includes(value)) {
     return value as AppLocale;
   }
 


### PR DESCRIPTION
## What
`normalizeLocale` could return values that are not valid locales when given input that matches an inherited `Object.prototype` member.

Two lookups walked the prototype chain:

1. `if (value in APP_LOCALES)` — the `in` operator checks the prototype chain, so `normalizeLocale('toString')` returned `'toString'`.
2. `languageToLocaleMap[languageCode]` on a plain object — so `normalizeLocale('constructor')` returned the `Object` constructor function instead of falling back to `SOURCE_LOCALE`.

Both should have returned `SOURCE_LOCALE`.

## Fix
- Use an own-key check (`Object.keys(APP_LOCALES).includes(value)`) for the direct match.
- Build `languageToLocaleMap` with `Object.create(null)` so inherited keys resolve to `undefined`.

Both are small, behavior-preserving for every real locale.

## Tested
- Added a regression test in `normalizeLocale.test.ts` covering `toString`, `constructor`, `valueOf`, `hasOwnProperty` (all now return `SOURCE_LOCALE`).
- `npx nx test twenty-shared` — 1835 tests pass.
- `npx nx lint twenty-shared` and `npx nx typecheck twenty-shared` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

