### PR TITLE
Type applyManuallyAssignedDefault generically to keep hook payload types

### DIFF
--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event-target/calendar-event-target-create-many.pre-query-hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event-target/calendar-event-target-create-many.pre-query-hook.ts
@@ -2,18 +2,15 @@ import { type WorkspacePreQueryHookInstance } from 'src/engine/api/graphql/works
 import { type CreateManyResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
-import {
-  applyManuallyAssignedDefault,
-  type TargetJunctionRecordInput,
-} from 'src/modules/match-participant/utils/apply-manually-assigned-default.util';
+import { applyManuallyAssignedDefault } from 'src/modules/match-participant/utils/apply-manually-assigned-default.util';
 
 @WorkspaceQueryHook('calendarEventTarget.createMany')
 export class CalendarEventTargetCreateManyPreQueryHook implements WorkspacePreQueryHookInstance {
   async execute(
     _authContext: WorkspaceAuthContext,
     _objectName: string,
-    payload: CreateManyResolverArgs<TargetJunctionRecordInput>,
-  ): Promise<CreateManyResolverArgs<TargetJunctionRecordInput>> {
+    payload: CreateManyResolverArgs,
+  ): Promise<CreateManyResolverArgs> {
     return {
       ...payload,
       data: payload.data.map(applyManuallyAssignedDefault),

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event-target/calendar-event-target-create-one.pre-query-hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event-target/calendar-event-target-create-one.pre-query-hook.ts
@@ -2,18 +2,15 @@ import { type WorkspacePreQueryHookInstance } from 'src/engine/api/graphql/works
 import { type CreateOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
-import {
-  applyManuallyAssignedDefault,
-  type TargetJunctionRecordInput,
-} from 'src/modules/match-participant/utils/apply-manually-assigned-default.util';
+import { applyManuallyAssignedDefault } from 'src/modules/match-participant/utils/apply-manually-assigned-default.util';
 
 @WorkspaceQueryHook('calendarEventTarget.createOne')
 export class CalendarEventTargetCreateOnePreQueryHook implements WorkspacePreQueryHookInstance {
   async execute(
     _authContext: WorkspaceAuthContext,
     _objectName: string,
-    payload: CreateOneResolverArgs<TargetJunctionRecordInput>,
-  ): Promise<CreateOneResolverArgs<TargetJunctionRecordInput>> {
+    payload: CreateOneResolverArgs,
+  ): Promise<CreateOneResolverArgs> {
     return {
       ...payload,
       data: applyManuallyAssignedDefault(payload.data),

--- a/packages/twenty-server/src/modules/match-participant/utils/apply-manually-assigned-default.util.ts
+++ b/packages/twenty-server/src/modules/match-participant/utils/apply-manually-assigned-default.util.ts
@@ -1,15 +1,13 @@
-export type TargetJunctionRecordInput = Record<string, unknown> & {
-  isManuallyAssigned?: boolean;
-};
-
 // API writes to target junctions are user attachments. The field default
 // covers plain inserts, but an upsert that matches an existing row (an
 // automatic row, or an exclusion tombstone being restored) only applies the
 // caller's input, so the manual provenance has to ride the input itself or
 // reconciliation will reap the row as obsolete automatic state.
-export const applyManuallyAssignedDefault = (
-  record: TargetJunctionRecordInput,
-): TargetJunctionRecordInput => ({
+export const applyManuallyAssignedDefault = <
+  TRecord extends { isManuallyAssigned?: boolean; [key: string]: unknown },
+>(
+  record: TRecord,
+): TRecord & { isManuallyAssigned: boolean } => ({
   ...record,
   isManuallyAssigned: record.isManuallyAssigned ?? true,
 });

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message-thread-target/message-thread-target-create-many.pre-query-hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message-thread-target/message-thread-target-create-many.pre-query-hook.ts
@@ -2,18 +2,15 @@ import { type WorkspacePreQueryHookInstance } from 'src/engine/api/graphql/works
 import { type CreateManyResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
-import {
-  applyManuallyAssignedDefault,
-  type TargetJunctionRecordInput,
-} from 'src/modules/match-participant/utils/apply-manually-assigned-default.util';
+import { applyManuallyAssignedDefault } from 'src/modules/match-participant/utils/apply-manually-assigned-default.util';
 
 @WorkspaceQueryHook('messageThreadTarget.createMany')
 export class MessageThreadTargetCreateManyPreQueryHook implements WorkspacePreQueryHookInstance {
   async execute(
     _authContext: WorkspaceAuthContext,
     _objectName: string,
-    payload: CreateManyResolverArgs<TargetJunctionRecordInput>,
-  ): Promise<CreateManyResolverArgs<TargetJunctionRecordInput>> {
+    payload: CreateManyResolverArgs,
+  ): Promise<CreateManyResolverArgs> {
     return {
       ...payload,
       data: payload.data.map(applyManuallyAssignedDefault),

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message-thread-target/message-thread-target-create-one.pre-query-hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message-thread-target/message-thread-target-create-one.pre-query-hook.ts
@@ -2,18 +2,15 @@ import { type WorkspacePreQueryHookInstance } from 'src/engine/api/graphql/works
 import { type CreateOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
-import {
-  applyManuallyAssignedDefault,
-  type TargetJunctionRecordInput,
-} from 'src/modules/match-participant/utils/apply-manually-assigned-default.util';
+import { applyManuallyAssignedDefault } from 'src/modules/match-participant/utils/apply-manually-assigned-default.util';
 
 @WorkspaceQueryHook('messageThreadTarget.createOne')
 export class MessageThreadTargetCreateOnePreQueryHook implements WorkspacePreQueryHookInstance {
   async execute(
     _authContext: WorkspaceAuthContext,
     _objectName: string,
-    payload: CreateOneResolverArgs<TargetJunctionRecordInput>,
-  ): Promise<CreateOneResolverArgs<TargetJunctionRecordInput>> {
+    payload: CreateOneResolverArgs,
+  ): Promise<CreateOneResolverArgs> {
     return {
       ...payload,
       data: applyManuallyAssignedDefault(payload.data),


### PR DESCRIPTION
## Summary

Follow-up to the review note on #24778 (r3871293277): `applyManuallyAssignedDefault` typed its input as `Record<string, unknown> & { isManuallyAssigned?: boolean }`, erasing the create payload's field types at the four calendar and message thread target pre-query hooks.

- make the util generic: `<TRecord extends { isManuallyAssigned?: boolean; [key: string]: unknown }>(record: TRecord): TRecord & { isManuallyAssigned: boolean }`
- the four hooks now use the resolver args' own `Partial<ObjectRecord>` payload type instead of the widened alias
- delete `TargetJunctionRecordInput`

Net minus 14 lines, behavior unchanged.

## Validation

- server typecheck with tsgo, no errors
- apply-manually-assigned-default.util.spec.ts passes
- diff-based lint passes

---
_Generated by [Claude Code](https://claude.ai/code/session_017nu7UTcjQVDyDSRtBWRhiD)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

