### PR TITLE
Add copy and see-all actions to the call recording summary widget header

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/CallRecordingSummaryBody.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/CallRecordingSummaryBody.tsx
@@ -2,6 +2,7 @@ import { LazyMarkdownRenderer } from '@/ai/components/LazyMarkdownRenderer';
 import { CallRecordingWidgetEmptyStateDisplay } from '@/page-layout/widgets/call-recording/components/CallRecordingWidgetEmptyStateDisplay';
 import { CallRecordingWidgetForbiddenDisplay } from '@/page-layout/widgets/call-recording/components/CallRecordingWidgetForbiddenDisplay';
 import { type WidgetCallRecordingCandidate } from '@/page-layout/widgets/call-recording/types/WidgetCallRecordingCandidate';
+import { getCallRecordingSummaryMarkdown } from '@/page-layout/widgets/call-recording-summary/utils/getCallRecordingSummaryMarkdown';
 import { isCallRecordingSummaryFailed } from '@/page-layout/widgets/call-recording-summary/utils/isCallRecordingSummaryFailed';
 import { isCallRecordingSummaryPending } from '@/page-layout/widgets/call-recording-summary/utils/isCallRecordingSummaryPending';
 import { PageLayoutWidgetErrorDisplay } from '@/page-layout/widgets/components/PageLayoutWidgetErrorDisplay';
@@ -10,14 +11,17 @@ import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
 import { type WidgetAccessDenialInfo } from '@/page-layout/widgets/types/WidgetAccessDenialInfo';
 import { t } from '@lingui/core/macro';
 import { styled } from '@linaria/react';
-import { isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledSummaryContainer = styled.div`
   display: flex;
   flex-direction: column;
-  padding: ${themeCssVariables.spacing[2]};
+
+  // The markdown renderer spaces blocks for chat bubbles, pushing the summary below where the transcript starts.
+  & > *:first-child,
+  & > *:first-child > *:first-child {
+    margin-top: 0;
+  }
 `;
 
 type CallRecordingSummaryBodyProps = {
@@ -57,12 +61,12 @@ export const CallRecordingSummaryBody = ({
     );
   }
 
-  const trimmedSummaryMarkdown = callRecording.summary?.markdown?.trim();
+  const summaryMarkdown = getCallRecordingSummaryMarkdown(callRecording);
 
-  if (isNonEmptyString(trimmedSummaryMarkdown)) {
+  if (isDefined(summaryMarkdown)) {
     return (
       <StyledSummaryContainer>
-        <LazyMarkdownRenderer text={trimmedSummaryMarkdown} />
+        <LazyMarkdownRenderer text={summaryMarkdown} />
       </StyledSummaryContainer>
     );
   }

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/WidgetActionCallRecordingSummary.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/WidgetActionCallRecordingSummary.tsx
@@ -1,0 +1,52 @@
+import { useCallRecordingsSeeAllHref } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingsSeeAllHref';
+import { useCallRecordingForSummary } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingForSummary';
+import { getCallRecordingSummaryMarkdown } from '@/page-layout/widgets/call-recording-summary/utils/getCallRecordingSummaryMarkdown';
+import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
+import { widgetHeaderCountComponentFamilyState } from '@/page-layout/widgets/states/widgetHeaderCountComponentFamilyState';
+import { WidgetCardHeaderActionButton } from '@/page-layout/widgets/widget-card/components/WidgetCardHeaderActionButton';
+import { WidgetCardHeaderActionLink } from '@/page-layout/widgets/widget-card/components/WidgetCardHeaderActionLink';
+import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
+import { t } from '@lingui/core/macro';
+import { isDefined } from 'twenty-shared/utils';
+import { IconArrowUpRight, IconCopy } from 'twenty-ui/icon';
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
+
+export const WidgetActionCallRecordingSummary = () => {
+  const widget = useCurrentWidget();
+  const { callRecording, loading, error, restriction } =
+    useCallRecordingForSummary();
+  const widgetHeaderCount = useAtomComponentFamilyStateValue(
+    widgetHeaderCountComponentFamilyState,
+    widget.id,
+  );
+  const callRecordingsSeeAllHref = useCallRecordingsSeeAllHref();
+  const { copyToClipboard } = useCopyToClipboard();
+
+  const summaryMarkdown =
+    !loading && !isDefined(error) && !isDefined(restriction)
+      ? getCallRecordingSummaryMarkdown(callRecording)
+      : undefined;
+
+  return (
+    <>
+      {isDefined(summaryMarkdown) && (
+        <WidgetCardHeaderActionButton
+          Icon={IconCopy}
+          label={t`Copy summary`}
+          onClick={() =>
+            copyToClipboard(summaryMarkdown, t`Summary copied to clipboard`)
+          }
+        />
+      )}
+      {isDefined(callRecordingsSeeAllHref) &&
+        isDefined(widgetHeaderCount) &&
+        widgetHeaderCount > 0 && (
+          <WidgetCardHeaderActionLink
+            Icon={IconArrowUpRight}
+            label={t`See all call recordings linked to this calendar event`}
+            to={callRecordingsSeeAllHref}
+          />
+        )}
+    </>
+  );
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/WidgetActionCallRecordingSummary.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/WidgetActionCallRecordingSummary.tsx
@@ -1,25 +1,15 @@
-import { useCallRecordingsSeeAllHref } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingsSeeAllHref';
+import { WidgetActionCallRecordingSeeAll } from '@/page-layout/widgets/call-recording/components/WidgetActionCallRecordingSeeAll';
 import { useCallRecordingForSummary } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingForSummary';
 import { getCallRecordingSummaryMarkdown } from '@/page-layout/widgets/call-recording-summary/utils/getCallRecordingSummaryMarkdown';
-import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
-import { widgetHeaderCountComponentFamilyState } from '@/page-layout/widgets/states/widgetHeaderCountComponentFamilyState';
 import { WidgetCardHeaderActionButton } from '@/page-layout/widgets/widget-card/components/WidgetCardHeaderActionButton';
-import { WidgetCardHeaderActionLink } from '@/page-layout/widgets/widget-card/components/WidgetCardHeaderActionLink';
-import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
 import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
-import { IconArrowUpRight, IconCopy } from 'twenty-ui/icon';
+import { IconCopy } from 'twenty-ui/icon';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 export const WidgetActionCallRecordingSummary = () => {
-  const widget = useCurrentWidget();
   const { callRecording, loading, error, restriction } =
     useCallRecordingForSummary();
-  const widgetHeaderCount = useAtomComponentFamilyStateValue(
-    widgetHeaderCountComponentFamilyState,
-    widget.id,
-  );
-  const callRecordingsSeeAllHref = useCallRecordingsSeeAllHref();
   const { copyToClipboard } = useCopyToClipboard();
 
   const summaryMarkdown =
@@ -38,15 +28,7 @@ export const WidgetActionCallRecordingSummary = () => {
           }
         />
       )}
-      {isDefined(callRecordingsSeeAllHref) &&
-        isDefined(widgetHeaderCount) &&
-        widgetHeaderCount > 0 && (
-          <WidgetCardHeaderActionLink
-            Icon={IconArrowUpRight}
-            label={t`See all call recordings linked to this calendar event`}
-            to={callRecordingsSeeAllHref}
-          />
-        )}
+      <WidgetActionCallRecordingSeeAll />
     </>
   );
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/__stories__/CallRecordingSummaryBody.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/components/__stories__/CallRecordingSummaryBody.stories.tsx
@@ -14,6 +14,8 @@ import {
   WidgetType,
 } from '~/generated-metadata/graphql';
 import { CallRecordingStatus } from '~/generated/graphql';
+import { MemoryRouterDecorator } from '~/testing/decorators/MemoryRouterDecorator';
+import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
 
 const SUMMARY_WIDGET_ID = 'summary-widget';
 const SUMMARY_TAB_ID = 'summary-tab';
@@ -127,6 +129,8 @@ const meta: Meta<typeof CallRecordingSummaryBody> = {
       tabId: SUMMARY_TAB_ID,
       widgetId: SUMMARY_WIDGET_ID,
     }),
+    MemoryRouterDecorator,
+    SnackBarDecorator,
     ComponentDecorator,
   ],
   parameters: {

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/utils/__tests__/getCallRecordingSummaryMarkdown.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/utils/__tests__/getCallRecordingSummaryMarkdown.test.ts
@@ -1,0 +1,40 @@
+import { type WidgetCallRecordingCandidate } from '@/page-layout/widgets/call-recording/types/WidgetCallRecordingCandidate';
+import { getCallRecordingSummaryMarkdown } from '@/page-layout/widgets/call-recording-summary/utils/getCallRecordingSummaryMarkdown';
+import { CallRecordingStatus } from '~/generated/graphql';
+
+const makeCallRecording = (
+  summary: WidgetCallRecordingCandidate['summary'],
+): WidgetCallRecordingCandidate => ({
+  __typename: 'CallRecording',
+  id: 'call-recording-id',
+  status: CallRecordingStatus.COMPLETED,
+  transcript: null,
+  summary,
+  video: null,
+  createdAt: '2026-01-01T00:00:00Z',
+});
+
+describe('getCallRecordingSummaryMarkdown', () => {
+  it('returns the trimmed summary markdown', () => {
+    expect(
+      getCallRecordingSummaryMarkdown(
+        makeCallRecording({
+          markdown: '\n## Recap\n\nWe agreed on pricing.\n',
+        }),
+      ),
+    ).toBe('## Recap\n\nWe agreed on pricing.');
+  });
+
+  it('returns undefined without summary markdown', () => {
+    expect(getCallRecordingSummaryMarkdown(undefined)).toBe(undefined);
+    expect(getCallRecordingSummaryMarkdown(makeCallRecording(null))).toBe(
+      undefined,
+    );
+    expect(
+      getCallRecordingSummaryMarkdown(makeCallRecording({ markdown: null })),
+    ).toBe(undefined);
+    expect(
+      getCallRecordingSummaryMarkdown(makeCallRecording({ markdown: '   \n' })),
+    ).toBe(undefined);
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/utils/getCallRecordingSummaryMarkdown.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-summary/utils/getCallRecordingSummaryMarkdown.ts
@@ -1,0 +1,12 @@
+import { type WidgetCallRecordingCandidate } from '@/page-layout/widgets/call-recording/types/WidgetCallRecordingCandidate';
+import { isNonEmptyString } from '@sniptt/guards';
+
+export const getCallRecordingSummaryMarkdown = (
+  callRecording: Pick<WidgetCallRecordingCandidate, 'summary'> | undefined,
+): string | undefined => {
+  const trimmedSummaryMarkdown = callRecording?.summary?.markdown?.trim();
+
+  return isNonEmptyString(trimmedSummaryMarkdown)
+    ? trimmedSummaryMarkdown
+    : undefined;
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/WidgetActionCallRecordingTranscript.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording-transcript/components/WidgetActionCallRecordingTranscript.tsx
@@ -1,12 +1,8 @@
-import { useCallRecordingsSeeAllHref } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingsSeeAllHref';
+import { WidgetActionCallRecordingSeeAll } from '@/page-layout/widgets/call-recording/components/WidgetActionCallRecordingSeeAll';
 import { useCallRecordingForTranscript } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingForTranscript';
 import { getCallRecordingVideoFileUrl } from '@/page-layout/widgets/call-recording/utils/getCallRecordingVideoFileUrl';
-import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
 import { buildCallRecordingTranscriptPlainText } from '@/page-layout/widgets/call-recording-transcript/utils/buildCallRecordingTranscriptPlainText';
-import { widgetHeaderCountComponentFamilyState } from '@/page-layout/widgets/states/widgetHeaderCountComponentFamilyState';
 import { WidgetCardHeaderActionButton } from '@/page-layout/widgets/widget-card/components/WidgetCardHeaderActionButton';
-import { WidgetCardHeaderActionLink } from '@/page-layout/widgets/widget-card/components/WidgetCardHeaderActionLink';
-import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
 import { t } from '@lingui/core/macro';
 import { useMemo } from 'react';
 import {
@@ -14,18 +10,12 @@ import {
   isNonEmptyArray,
   parseCallRecordingTranscriptEntries,
 } from 'twenty-shared/utils';
-import { IconArrowUpRight, IconCopy, IconLink } from 'twenty-ui/icon';
+import { IconCopy, IconLink } from 'twenty-ui/icon';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 export const WidgetActionCallRecordingTranscript = () => {
-  const widget = useCurrentWidget();
   const { callRecording, loading, error, restriction } =
     useCallRecordingForTranscript();
-  const widgetHeaderCount = useAtomComponentFamilyStateValue(
-    widgetHeaderCountComponentFamilyState,
-    widget.id,
-  );
-  const callRecordingsSeeAllHref = useCallRecordingsSeeAllHref();
   const { copyToClipboard } = useCopyToClipboard();
 
   const canExposeCallRecording =
@@ -70,15 +60,7 @@ export const WidgetActionCallRecordingTranscript = () => {
           }
         />
       )}
-      {isDefined(callRecordingsSeeAllHref) &&
-        isDefined(widgetHeaderCount) &&
-        widgetHeaderCount > 0 && (
-          <WidgetCardHeaderActionLink
-            Icon={IconArrowUpRight}
-            label={t`See all call recordings linked to this calendar event`}
-            to={callRecordingsSeeAllHref}
-          />
-        )}
+      <WidgetActionCallRecordingSeeAll />
     </>
   );
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/call-recording/components/WidgetActionCallRecordingSeeAll.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/call-recording/components/WidgetActionCallRecordingSeeAll.tsx
@@ -1,0 +1,33 @@
+import { useCallRecordingsSeeAllHref } from '@/page-layout/widgets/call-recording/hooks/useCallRecordingsSeeAllHref';
+import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
+import { widgetHeaderCountComponentFamilyState } from '@/page-layout/widgets/states/widgetHeaderCountComponentFamilyState';
+import { WidgetCardHeaderActionLink } from '@/page-layout/widgets/widget-card/components/WidgetCardHeaderActionLink';
+import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
+import { t } from '@lingui/core/macro';
+import { isDefined } from 'twenty-shared/utils';
+import { IconArrowUpRight } from 'twenty-ui/icon';
+
+export const WidgetActionCallRecordingSeeAll = () => {
+  const widget = useCurrentWidget();
+  const widgetHeaderCount = useAtomComponentFamilyStateValue(
+    widgetHeaderCountComponentFamilyState,
+    widget.id,
+  );
+  const callRecordingsSeeAllHref = useCallRecordingsSeeAllHref();
+
+  if (
+    !isDefined(callRecordingsSeeAllHref) ||
+    !isDefined(widgetHeaderCount) ||
+    widgetHeaderCount <= 0
+  ) {
+    return null;
+  }
+
+  return (
+    <WidgetCardHeaderActionLink
+      Icon={IconArrowUpRight}
+      label={t`See all call recordings linked to this calendar event`}
+      to={callRecordingsSeeAllHref}
+    />
+  );
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/utils/__tests__/getWidgetHeaderActionDefinition.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/utils/__tests__/getWidgetHeaderActionDefinition.test.ts
@@ -57,10 +57,11 @@ describe('getWidgetHeaderActionDefinition', () => {
 
   it('returns no action for an actionless widget', () => {
     const definition = getWidgetHeaderActionDefinition({
-      type: WidgetType.CALL_RECORDING_SUMMARY,
+      type: WidgetType.IFRAME,
       configuration: {
-        __typename: 'CallRecordingSummaryConfiguration',
-        configurationType: WidgetConfigurationType.CALL_RECORDING_SUMMARY,
+        __typename: 'IframeConfiguration',
+        configurationType: WidgetConfigurationType.IFRAME,
+        url: 'https://example.com',
       },
     });
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/utils/getWidgetHeaderActionDefinition.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/utils/getWidgetHeaderActionDefinition.ts
@@ -1,4 +1,5 @@
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
+import { WidgetActionCallRecordingSummary } from '@/page-layout/widgets/call-recording-summary/components/WidgetActionCallRecordingSummary';
 import { WidgetActionCallRecordingTranscript } from '@/page-layout/widgets/call-recording-transcript/components/WidgetActionCallRecordingTranscript';
 import { WidgetFieldActions } from '@/page-layout/widgets/components/WidgetFieldActions';
 import { WidgetActionCalendarEventCreate } from '@/page-layout/widgets/calendar/components/WidgetActionCalendarEventCreate';
@@ -36,6 +37,7 @@ const widgetHeaderActionComponentByWidgetType: Partial<
   [WidgetType.NOTES]: WidgetActionNoteCreate,
   [WidgetType.FILES]: WidgetActionFileAttach,
   [WidgetType.TIMELINE]: WidgetActionTimeline,
+  [WidgetType.CALL_RECORDING_SUMMARY]: WidgetActionCallRecordingSummary,
   [WidgetType.CALL_RECORDING_TRANSCRIPT]: WidgetActionCallRecordingTranscript,
 };
 


### PR DESCRIPTION
Stacked on #24945.

## Summary

- add copy and see-all actions to the call recording summary widget header
- align the summary body spacing with the transcript widget