### PR TITLE
fix(workflow): stop writing workflowRun core ids before every workspace has the fields

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -124,8 +124,6 @@ export class WorkflowRunWorkspaceService {
         workflowVersionId,
         createdBy,
         workflowId: workflow.id,
-        coreWorkflowId: workflow.coreWorkflowId,
-        coreWorkflowVersionId: workflowVersion.coreWorkflowVersionId,
         status,
         position,
         state: initState,


### PR DESCRIPTION
## Prod incident

`TWENTY-SERVER-JVF` — `Field metadata for field "coreWorkflowId" is missing in object metadata workflowRun`. 2807 events, 33 workspaces, v2.36.0, escalating. Workflow run creation fails outright in an affected workspace, so no workflow runs at all.

## Cause

#24842 made `createWorkflowRun` write `coreWorkflowId` / `coreWorkflowVersionId` on every run. The fields are added per workspace by the 2-36 `add-workflow-run-core-id-fields` command, which runs after the deploy and staggered across the fleet. In that window `formatData` throws on a key that has no field metadata — it does not drop unknown keys, which is what #24842 assumed.

## Fix

Remove the two lines that write the ids. They were the only runtime code touching the new fields (nothing reads them yet), so the insert payload goes back to the 2.35 shape and works in migrated and not-yet-migrated workspaces alike.

Deliberately kept: the entity declaration, the standard field definitions, and both 2-36 upgrade commands. A full revert of #24842 was rejected — deleting already-shipped upgrade commands makes the upgrade cursor fall back to 0 (hiding every upgrade-introduced column instance-wide), and removing the standard field metadata can drop the columns on workspaces that already migrated.

## Re-land

Once the fleet has the fields, restore the stamping guarded on the fields being present in the workspace metadata instead of assumed. Rows created in the meantime are covered: the backfill command only fills NULLs and is re-runnable.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

