### PR TITLE
Fix spacing between profile name fields

### DIFF
--- a/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
@@ -15,9 +15,7 @@ import { logError } from '~/utils/logError';
 const StyledComboInputContainer = styled.div`
   display: flex;
   flex-direction: row;
-  > * + * {
-    margin-left: ${themeCssVariables.spacing[4]};
-  }
+  gap: ${themeCssVariables.spacing[4]};
 `;
 
 type NameFieldsProps = {

--- a/packages/twenty-front/src/pages/settings/__stories__/SettingsProfile.stories.tsx
+++ b/packages/twenty-front/src/pages/settings/__stories__/SettingsProfile.stories.tsx
@@ -35,8 +35,9 @@ export const Default: Story = {
     });
     const lastName = await canvas.findByRole('textbox', { name: 'Last Name' });
 
-    expect(lastName.getBoundingClientRect().left).toBeGreaterThan(
-      firstName.getBoundingClientRect().right,
-    );
+    expect(
+      lastName.getBoundingClientRect().left -
+        firstName.getBoundingClientRect().right,
+    ).toBe(16);
   },
 };

--- a/packages/twenty-front/src/pages/settings/__stories__/SettingsProfile.stories.tsx
+++ b/packages/twenty-front/src/pages/settings/__stories__/SettingsProfile.stories.tsx
@@ -1,11 +1,14 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
 
+import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import {
   PageDecorator,
   type PageDecoratorArgs,
 } from '~/testing/decorators/PageDecorator';
 import { graphqlMocks } from '~/testing/graphqlMocks';
+import { mockedWorkspaceMemberData } from '~/testing/mock-data/users';
 
 import { SettingsProfile } from '~/pages/settings/profile/SettingsProfile';
 
@@ -16,6 +19,13 @@ const meta: Meta<PageDecoratorArgs> = {
   args: {
     routePath: '/settings/profile',
     additionalRoutes: ['/welcome'],
+  },
+  beforeEach: () => {
+    jotaiStore.set(currentWorkspaceMemberState.atom, mockedWorkspaceMemberData);
+
+    return () => {
+      jotaiStore.set(currentWorkspaceMemberState.atom, null);
+    };
   },
   parameters: {
     msw: graphqlMocks,

--- a/packages/twenty-front/src/pages/settings/__stories__/SettingsProfile.stories.tsx
+++ b/packages/twenty-front/src/pages/settings/__stories__/SettingsProfile.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
 
 import {
   PageDecorator,
@@ -25,4 +26,17 @@ export default meta;
 
 export type Story = StoryObj<typeof SettingsProfile>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const firstName = await canvas.findByRole('textbox', {
+      name: 'First Name',
+    });
+    const lastName = await canvas.findByRole('textbox', { name: 'Last Name' });
+
+    expect(lastName.getBoundingClientRect().left).toBeGreaterThan(
+      firstName.getBoundingClientRect().right,
+    );
+  },
+};


### PR DESCRIPTION
## Summary

- Restore the 16px gap between First Name and Last Name in profile settings using flex gap, which works with the input's `display: contents` wrapper.
- Add a regression check to the existing profile Storybook story.

## Before/After

Before — reported spacing regression:

<img width="791" height="172" alt="Before: missing spacing between profile name fields" src="https://github.com/user-attachments/assets/192f8c02-146c-479d-8b2d-d79bd8fa44dd" />
