### PR TITLE
Scope two-hop relation widgets through the right morph branch

### DIFF
--- a/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.test.ts
@@ -4,7 +4,10 @@ import {
   ViewFilterOperand as RecordFilterOperand,
 } from '@/types';
 import { type RecordFilter } from '@/utils';
-import { turnRecordFilterIntoRecordGqlOperationFilter } from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
+import {
+  type FieldShared,
+  turnRecordFilterIntoRecordGqlOperationFilter,
+} from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
 
 const fields = [
   { id: 'f-text', name: 'name', type: FieldMetadataType.TEXT, label: 'Name' },
@@ -65,6 +68,7 @@ const fields = [
       {
         type: RelationType.MANY_TO_ONE,
         targetObjectMetadata: {
+          id: 'o-person',
           nameSingular: 'person',
           namePlural: 'people',
         },
@@ -72,6 +76,7 @@ const fields = [
       {
         type: RelationType.MANY_TO_ONE,
         targetObjectMetadata: {
+          id: 'o-company',
           nameSingular: 'company',
           namePlural: 'companies',
         },
@@ -1181,5 +1186,126 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
         },
       });
     });
+  });
+});
+
+describe('turnRecordFilterIntoRecordGqlOperationFilter - traversed morph relations', () => {
+  const CURRENT_CLIENT_ID = '11111111-1111-4111-8111-111111111111';
+
+  const morphFrom = {
+    id: 'f-from-morph',
+    name: 'from',
+    type: FieldMetadataType.MORPH_RELATION,
+    label: 'From',
+    relation: { sourceObjectMetadata: { id: 'o-transaction' } },
+    morphRelations: [
+      {
+        type: RelationType.MANY_TO_ONE,
+        targetObjectMetadata: {
+          id: 'o-wallet',
+          nameSingular: 'wallet',
+          namePlural: 'wallets',
+        },
+      },
+      {
+        type: RelationType.MANY_TO_ONE,
+        targetObjectMetadata: {
+          id: 'o-trading-account',
+          nameSingular: 'tradingAccount',
+          namePlural: 'tradingAccounts',
+        },
+      },
+    ],
+  };
+
+  const plainFrom = {
+    id: 'f-from-plain',
+    name: 'from',
+    type: FieldMetadataType.RELATION,
+    label: 'From',
+    relation: { sourceObjectMetadata: { id: 'o-transaction' } },
+  };
+
+  const tradingAccountClient = {
+    id: 'f-trading-account-client',
+    name: 'client',
+    type: FieldMetadataType.RELATION,
+    label: 'Client',
+    relation: { sourceObjectMetadata: { id: 'o-trading-account' } },
+  };
+
+  const traversedFieldMetadataItemById = new Map<string, FieldShared>([
+    [morphFrom.id, morphFrom],
+    [plainFrom.id, plainFrom],
+    [tradingAccountClient.id, tradingAccountClient],
+  ]);
+
+  const makeTraversedFilter = (fieldMetadataId: string) =>
+    ({
+      id: 'test-filter',
+      fieldMetadataId,
+      value: JSON.stringify({
+        selectedRecordIds: [],
+        isCurrentRecordSelected: true,
+      }),
+      type: 'RELATION',
+      operand: RecordFilterOperand.IS,
+      relationTargetFieldMetadataId: tradingAccountClient.id,
+    }) as RecordFilter;
+
+  const clientPageDependencies = {
+    timeZone: 'UTC',
+    currentRecord: {
+      id: CURRENT_CLIENT_ID,
+      objectMetadataNameSingular: 'client',
+    },
+  };
+
+  it('should scope a traversed filter through a plain relation', () => {
+    const result = turnRecordFilterIntoRecordGqlOperationFilter({
+      filterValueDependencies: clientPageDependencies,
+      recordFilter: makeTraversedFilter(plainFrom.id),
+      fieldMetadataItemById: traversedFieldMetadataItemById,
+    });
+
+    expect(result).toEqual({
+      from: { clientId: { in: [CURRENT_CLIENT_ID] } },
+    });
+  });
+
+  it('should scope a traversed filter through the morph branch the traversal continues from', () => {
+    const result = turnRecordFilterIntoRecordGqlOperationFilter({
+      filterValueDependencies: clientPageDependencies,
+      recordFilter: makeTraversedFilter(morphFrom.id),
+      fieldMetadataItemById: traversedFieldMetadataItemById,
+    });
+
+    expect(result).toEqual({
+      fromTradingAccount: { clientId: { in: [CURRENT_CLIENT_ID] } },
+    });
+  });
+
+  it('should throw when no morph branch targets the traversed object', () => {
+    const unrelatedTargetField = {
+      id: 'f-unrelated',
+      name: 'owner',
+      type: FieldMetadataType.RELATION,
+      label: 'Owner',
+      relation: { sourceObjectMetadata: { id: 'o-invoice' } },
+    };
+
+    expect(() =>
+      turnRecordFilterIntoRecordGqlOperationFilter({
+        filterValueDependencies: clientPageDependencies,
+        recordFilter: {
+          ...makeTraversedFilter(morphFrom.id),
+          relationTargetFieldMetadataId: unrelatedTargetField.id,
+        } as RecordFilter,
+        fieldMetadataItemById: new Map<string, FieldShared>([
+          ...traversedFieldMetadataItemById,
+          [unrelatedTargetField.id, unrelatedTargetField],
+        ]),
+      }),
+    ).toThrow('No morph relation on field from targets the traversed object');
   });
 });

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -62,6 +62,7 @@ import {
 } from '@/utils/filter/utils/validation-schemas/filterValueScalarSchemas';
 import { arrayOfUuidOrVariableSchema } from '@/utils/filter/utils/validation-schemas/arrayOfUuidsOrVariablesSchema';
 import { jsonRelationFilterValueSchema } from '@/utils/filter/utils/validation-schemas/jsonRelationFilterValueSchema';
+import { computeMorphRelationGqlFieldName } from '@/utils/fieldMetadata/compute-morph-relation-gql-field-name';
 import {
   computeMorphRelationGqlFieldJoinColumnName,
   computeRelationGqlFieldJoinColumnName,
@@ -88,6 +89,7 @@ const parseActorSourceFilterValue = (value: string): string[] => {
 type FieldSharedMorphRelation = {
   type: RelationType;
   targetObjectMetadata: {
+    id: string;
     nameSingular: string;
     namePlural: string;
   };
@@ -98,6 +100,7 @@ export type FieldShared = {
   name: string;
   type: FieldMetadataType;
   label: string;
+  relation?: { sourceObjectMetadata: { id: string } } | null;
   morphRelations?: FieldSharedMorphRelation[] | null;
 };
 
@@ -105,6 +108,42 @@ type TurnRecordFilterIntoRecordGqlOperationFilterParams = {
   filterValueDependencies: RecordFilterValueDependencies;
   recordFilter: Omit<RecordFilter, 'id'>;
   fieldMetadataItemById: Map<string, FieldShared>;
+};
+
+const getTraversalFieldName = ({
+  sourceFieldMetadataItem,
+  targetFieldMetadataItem,
+}: {
+  sourceFieldMetadataItem: FieldShared;
+  targetFieldMetadataItem: FieldShared;
+}): string => {
+  if (sourceFieldMetadataItem.type !== FieldMetadataType.MORPH_RELATION) {
+    return sourceFieldMetadataItem.name;
+  }
+
+  const traversedObjectMetadataId =
+    targetFieldMetadataItem.relation?.sourceObjectMetadata.id;
+
+  const matchingMorphRelation = sourceFieldMetadataItem.morphRelations?.find(
+    (morphRelation) =>
+      morphRelation.targetObjectMetadata.id === traversedObjectMetadataId,
+  );
+
+  if (!isDefined(matchingMorphRelation)) {
+    throw new CustomError(
+      `No morph relation on field ${sourceFieldMetadataItem.name} targets the traversed object ${traversedObjectMetadataId}`,
+      'UNRESOLVED_MORPH_RELATION_TRAVERSAL',
+    );
+  }
+
+  return computeMorphRelationGqlFieldName({
+    fieldName: sourceFieldMetadataItem.name,
+    relationType: matchingMorphRelation.type,
+    targetObjectMetadataNameSingular:
+      matchingMorphRelation.targetObjectMetadata.nameSingular,
+    targetObjectMetadataNamePlural:
+      matchingMorphRelation.targetObjectMetadata.namePlural,
+  });
 };
 
 export const turnRecordFilterIntoRecordGqlOperationFilter = ({
@@ -127,7 +166,8 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
   }
 
   if (
-    sourceFieldMetadataItem.type === FieldMetadataType.RELATION &&
+    (sourceFieldMetadataItem.type === FieldMetadataType.RELATION ||
+      sourceFieldMetadataItem.type === FieldMetadataType.MORPH_RELATION) &&
     isDefined(recordFilter.relationTargetFieldMetadataId)
   ) {
     const targetFieldMetadataItem = fieldMetadataItemById.get(
@@ -137,6 +177,11 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
     if (!isDefined(targetFieldMetadataItem)) {
       return;
     }
+
+    const traversalFieldName = getTraversalFieldName({
+      sourceFieldMetadataItem,
+      targetFieldMetadataItem,
+    });
 
     const innerFilter = buildDirectFieldGqlOperationFilter({
       recordFilter: {
@@ -153,7 +198,7 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
     }
 
     return {
-      [sourceFieldMetadataItem.name]: innerFilter,
+      [traversalFieldName]: innerFilter,
     } as RecordGqlOperationFilter;
   }
 


### PR DESCRIPTION
## Context

Reported by a user. On a Client record page, a nested relation widget titled `Trading Accounts → Incoming transactions` listed **every** transaction in the workspace instead of the ones belonging to that client's trading accounts. It even listed transactions with no trading account at all, only a wallet.

Their schema is `Client --has many--> Trading Account --has many--> Transaction`, where the transaction's `from` field is a **morph relation** pointing at either a Wallet or a Trading Account.

A repro with a plain single-target relation scopes correctly, which is why this was not caught: the bug needs the morph branch to exist.

## Root cause

A nested relation widget seeds its embedded view with a filter carrying `relationTargetFieldMetadataId`, expressing the extra hop. Two things went wrong when the last hop lands on a morph relation field.

1. The traversal branch was gated on `sourceFieldMetadataItem.type === FieldMetadataType.RELATION`, so a `MORPH_RELATION` source skipped nesting entirely and fell through to the direct-filter path.

2. That path resolves the morph branch by matching the morph's targets against `filterValueDependencies.currentRecord`. In a two-hop widget the current record is the **Client**, one relation further out than the morph's targets (Wallet, Trading Account), so nothing ever matched.

No match returned `undefined`, and an undefined filter means *no filter applied* rather than an error, so the view returned the whole table. That is why wallet-only transactions appeared too.

## Changes

**`turnRecordFilterIntoGqlOperationFilter.ts`**
- The traversal branch now accepts `MORPH_RELATION` alongside `RELATION`.
- New `getTraversalFieldName` resolves the nesting key. For a plain relation it is the field name, unchanged. For a morph relation it selects the branch whose target is the object that **owns the traversal target field**, then builds the branch field name via `computeMorphRelationGqlFieldName`.
- If no morph branch targets the traversed object the compiler throws. Returning `undefined` was not a safe fallback: `computeRecordGqlOperationFilter` drops undefined results and returns `{}` when none survive, which means *no filter*, i.e. the whole table. That is the reported symptom, so failing loudly is the only honest option. Throwing matches the existing style of this file.

- The traversed object is read off the target field's `relation.sourceObjectMetadata.id`, which the metadata fragment already selects. The traversal target is always a relation field, so this is always present, and matching by id means renaming an object cannot break the scoping.

The change is contained to one file plus its spec: no front change, no query change, no codegen.

For the reported case the filter now compiles to:

```
{ fromTradingAccount: { clientId: { in: [<clientId>] } } }
```

instead of nothing.

## Tests

Three cases added to the existing spec:
- plain relation traversal still scopes correctly (control)
- morph relation traversal nests under the branch the traversal continues from
- morph traversal with no matching branch throws

Reverting the source change fails the second and third cases; the first is a control that holds either way. 147 tests pass across the filter directory.

Not covered: a morph source whose branch happens to match the record being viewed previously produced a direct join-column filter that ignored the hop, and now produces the nested form. That is the better answer but it does change what such an existing widget returns.

## Rejected alternatives

Enriching `flattenedFieldMetadataItemsSelector` to attach the owning object to every field. It worked, but that selector has around twenty consumers and spreading each field into a new object gives the app two copies of every field metadata item that are not referentially equal.

Adding `objectMetadataId` to the metadata fragment's `fieldsList`. Also correct, but it widens a query fetched on every app load and forces regenerating the typed documents. `relation.sourceObjectMetadata` carries the same identity and is already requested.

## Out of scope

Server-side paths that recompute view filters from flat metadata still cannot traverse a morph relation. Flat metadata does carry `objectMetadataId`, but it has no `morphRelations` array — a morph is stored as one row per branch sharing a `morphId` — so branch resolution finds nothing. Unchanged behaviour, not a regression.

That leaves a gap worth a follow-up: the same saved widget view can resolve scoped in the browser and unscoped through a server path that recomputes it by `viewId`. Not reproduced, flagged for review.