### PR TITLE
Restore settings navigation command menu item labels corrupted by 2-33 upgrade

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-37/2-37-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-37/2-37-upgrade-version-command.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { BackfillMessageCalendarTargetsCommand } from 'src/database/commands/upgrade-version-command/2-37/2-37-workspace-command-1787832413051-backfill-message-calendar-targets.command';
 import { SyncMessageCalendarTargetMetadataCommand } from 'src/database/commands/upgrade-version-command/2-37/2-37-workspace-command-1787832412051-sync-message-calendar-target-metadata.command';
+import { RestoreSettingsNavigationCommandMenuItemLabelsCommand } from 'src/database/commands/upgrade-version-command/2-37/2-37-workspace-command-1787840804000-restore-settings-navigation-command-menu-item-labels.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
@@ -17,6 +18,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
   providers: [
     SyncMessageCalendarTargetMetadataCommand,
     BackfillMessageCalendarTargetsCommand,
+    RestoreSettingsNavigationCommandMenuItemLabelsCommand,
   ],
 })
 export class V2_37_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-37/2-37-workspace-command-1787840804000-restore-settings-navigation-command-menu-item-labels.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-37/2-37-workspace-command-1787840804000-restore-settings-navigation-command-menu-item-labels.command.ts
@@ -1,0 +1,96 @@
+import { Command } from 'nest-commander';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { computeSettingsNavigationDisplayFieldRestore } from 'src/database/commands/upgrade-version-command/2-37/utils/compute-settings-navigation-display-field-restore.util';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+@RegisteredWorkspaceCommand('2.37.0', 1787840804000)
+@Command({
+  name: 'upgrade:2-37:restore-settings-navigation-command-menu-item-labels',
+  description:
+    'Restore the standard label, shortLabel and icon on the path-based settings navigation command menu items that upgrade:2-33 overwrote with object placeholder templates',
+})
+export class RestoreSettingsNavigationCommandMenuItemLabelsCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const { flatCommandMenuItemMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatCommandMenuItemMaps',
+      ]);
+
+    const flatCommandMenuItemsToUpdate =
+      computeSettingsNavigationDisplayFieldRestore({
+        flatCommandMenuItemMaps,
+        now: new Date().toISOString(),
+      });
+
+    if (flatCommandMenuItemsToUpdate.length === 0) {
+      this.logger.log(
+        `Settings navigation command menu item labels already match the standard definition for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] Would restore' : 'Restoring'} ${flatCommandMenuItemsToUpdate.length} settings navigation command menu item label(s) for workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            commandMenuItem: {
+              flatEntityToCreate: [],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: flatCommandMenuItemsToUpdate,
+            },
+          },
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      this.logger.error(
+        `Failed to restore settings navigation command menu item labels:\n${JSON.stringify(validateAndBuildResult, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to restore settings navigation command menu item labels for workspace ${workspaceId}`,
+      );
+    }
+
+    this.logger.log(
+      `Successfully restored ${flatCommandMenuItemsToUpdate.length} settings navigation command menu item label(s) for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-37/utils/__tests__/compute-settings-navigation-display-field-restore.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-37/utils/__tests__/compute-settings-navigation-display-field-restore.util.spec.ts
@@ -1,0 +1,120 @@
+import { computeSettingsNavigationDisplayFieldRestore } from 'src/database/commands/upgrade-version-command/2-37/utils/compute-settings-navigation-display-field-restore.util';
+import { EngineComponentKey } from 'src/engine/metadata-modules/command-menu-item/enums/engine-component-key.enum';
+import {
+  NAVIGATION_INTERPOLATED_ICON,
+  NAVIGATION_INTERPOLATED_LABEL,
+  NAVIGATION_INTERPOLATED_SHORT_LABEL,
+} from 'src/engine/metadata-modules/flat-command-menu-item/utils/build-navigation-flat-command-menu-item.util';
+import { type FlatCommandMenuItem } from 'src/engine/metadata-modules/flat-command-menu-item/types/flat-command-menu-item.type';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+
+const NOW = '2026-08-27T00:00:00.000Z';
+
+const GO_TO_SETTINGS = STANDARD_COMMAND_MENU_ITEMS.goToSettings;
+
+const buildFlatCommandMenuItem = (
+  overrides: Partial<FlatCommandMenuItem> & Pick<FlatCommandMenuItem, 'id'>,
+): FlatCommandMenuItem =>
+  ({
+    universalIdentifier: overrides.id,
+    engineComponentKey: EngineComponentKey.NAVIGATION,
+    payload: { path: '/settings/profile' },
+    label: NAVIGATION_INTERPOLATED_LABEL,
+    shortLabel: NAVIGATION_INTERPOLATED_SHORT_LABEL,
+    icon: NAVIGATION_INTERPOLATED_ICON,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }) as FlatCommandMenuItem;
+
+const buildFlatCommandMenuItemMaps = (
+  flatCommandMenuItems: FlatCommandMenuItem[],
+): FlatEntityMaps<FlatCommandMenuItem> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    flatCommandMenuItems.map((item) => [item.universalIdentifier, item]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    flatCommandMenuItems.map((item) => [item.id, item.universalIdentifier]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+describe('computeSettingsNavigationDisplayFieldRestore', () => {
+  it('restores the standard display fields on a corrupted settings navigation item', () => {
+    const itemsToUpdate = computeSettingsNavigationDisplayFieldRestore({
+      flatCommandMenuItemMaps: buildFlatCommandMenuItemMaps([
+        buildFlatCommandMenuItem({
+          id: 'command-1',
+          universalIdentifier: GO_TO_SETTINGS.universalIdentifier,
+        }),
+      ]),
+      now: NOW,
+    });
+
+    expect(itemsToUpdate).toHaveLength(1);
+    expect(itemsToUpdate[0]).toMatchObject({
+      id: 'command-1',
+      label: GO_TO_SETTINGS.label,
+      shortLabel: GO_TO_SETTINGS.shortLabel,
+      icon: GO_TO_SETTINGS.icon,
+      updatedAt: NOW,
+    });
+  });
+
+  it('is idempotent once the display fields match the standard definition', () => {
+    const itemsToUpdate = computeSettingsNavigationDisplayFieldRestore({
+      flatCommandMenuItemMaps: buildFlatCommandMenuItemMaps([
+        buildFlatCommandMenuItem({
+          id: 'command-1',
+          universalIdentifier: GO_TO_SETTINGS.universalIdentifier,
+          label: GO_TO_SETTINGS.label,
+          shortLabel: GO_TO_SETTINGS.shortLabel,
+          icon: GO_TO_SETTINGS.icon,
+        }),
+      ]),
+      now: NOW,
+    });
+
+    expect(itemsToUpdate).toEqual([]);
+  });
+
+  it('leaves an object navigation item on its placeholder templates', () => {
+    const itemsToUpdate = computeSettingsNavigationDisplayFieldRestore({
+      flatCommandMenuItemMaps: buildFlatCommandMenuItemMaps([
+        buildFlatCommandMenuItem({
+          id: 'command-1',
+          payload: { objectMetadataItemId: 'object-1' },
+        }),
+      ]),
+      now: NOW,
+    });
+
+    expect(itemsToUpdate).toEqual([]);
+  });
+
+  it('leaves a path navigation item that is not in the standard definition untouched', () => {
+    const itemsToUpdate = computeSettingsNavigationDisplayFieldRestore({
+      flatCommandMenuItemMaps: buildFlatCommandMenuItemMaps([
+        buildFlatCommandMenuItem({ id: 'command-1' }),
+      ]),
+      now: NOW,
+    });
+
+    expect(itemsToUpdate).toEqual([]);
+  });
+
+  it('leaves a non navigation item untouched even when its label differs from the definition', () => {
+    const itemsToUpdate = computeSettingsNavigationDisplayFieldRestore({
+      flatCommandMenuItemMaps: buildFlatCommandMenuItemMaps([
+        buildFlatCommandMenuItem({
+          id: 'command-1',
+          universalIdentifier: GO_TO_SETTINGS.universalIdentifier,
+          engineComponentKey: EngineComponentKey.FRONT_COMPONENT_RENDERER,
+        }),
+      ]),
+      now: NOW,
+    });
+
+    expect(itemsToUpdate).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-37/utils/compute-settings-navigation-display-field-restore.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-37/utils/compute-settings-navigation-display-field-restore.util.ts
@@ -1,0 +1,69 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { EngineComponentKey } from 'src/engine/metadata-modules/command-menu-item/enums/engine-component-key.enum';
+import { isObjectMetadataCommandMenuItemPayload } from 'src/engine/metadata-modules/command-menu-item/utils/is-object-metadata-command-menu-item-payload.util';
+import { type FlatCommandMenuItem } from 'src/engine/metadata-modules/flat-command-menu-item/types/flat-command-menu-item.type';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+
+type DisplayFields = Pick<FlatCommandMenuItem, 'label' | 'shortLabel' | 'icon'>;
+
+const DISPLAY_FIELDS = ['label', 'shortLabel', 'icon'] as const;
+
+const STANDARD_DISPLAY_FIELDS_BY_UNIVERSAL_IDENTIFIER: Record<
+  string,
+  DisplayFields
+> = Object.fromEntries(
+  Object.values(STANDARD_COMMAND_MENU_ITEMS).map((item) => [
+    item.universalIdentifier,
+    { label: item.label, shortLabel: item.shortLabel, icon: item.icon },
+  ]),
+);
+
+// upgrade:2-33:migrate-command-menu-item-labels-to-placeholders keyed its
+// expected display fields on the NAVIGATION engine key alone, so the path-based
+// settings commands — which share that key with the per-object navigation items
+// but live in the standard definition — had their label, shortLabel and icon
+// overwritten with the object placeholder templates. Only object payloads get
+// those placeholders filled at read time, so the templates leaked to the client
+// and every settings command rendered as "Go to <current object>".
+export const computeSettingsNavigationDisplayFieldRestore = ({
+  flatCommandMenuItemMaps,
+  now,
+}: {
+  flatCommandMenuItemMaps: FlatEntityMaps<FlatCommandMenuItem>;
+  now: string;
+}): FlatCommandMenuItem[] => {
+  return Object.values(flatCommandMenuItemMaps.byUniversalIdentifier)
+    .filter(isDefined)
+    .filter(
+      (flatCommandMenuItem) =>
+        flatCommandMenuItem.engineComponentKey ===
+          EngineComponentKey.NAVIGATION &&
+        !isObjectMetadataCommandMenuItemPayload(flatCommandMenuItem.payload),
+    )
+    .flatMap((flatCommandMenuItem) => {
+      const standardDisplayFields =
+        STANDARD_DISPLAY_FIELDS_BY_UNIVERSAL_IDENTIFIER[
+          flatCommandMenuItem.universalIdentifier
+        ];
+
+      if (
+        !isDefined(standardDisplayFields) ||
+        DISPLAY_FIELDS.every(
+          (field) =>
+            flatCommandMenuItem[field] === standardDisplayFields[field],
+        )
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          ...flatCommandMenuItem,
+          ...standardDisplayFields,
+          updatedAt: now,
+        },
+      ];
+    });
+};


### PR DESCRIPTION
## Context
closes https://github.com/twentyhq/twenty/issues/24825
<img width="1257" height="794" alt="image" src="https://github.com/user-attachments/assets/5f68fbbc-c09e-419f-b0c0-47f3bd288249" />

On any workspace upgraded through 2.33, the command menu shows 17 seemingly duplicated "Go to <current object>" entries (reported on engineering.twenty.com, where they all read "Go to Contributors").

These are not duplicated rows: they are the 17 path-based settings navigation commands (goToSettings, goToSettingsExperience, ...). `upgrade:2-33:migrate-command-menu-item-labels-to-placeholders` (introduced in #24326) keyed its expected display fields on the NAVIGATION engine key alone, without checking the payload type, so it overwrote their label, shortLabel and icon with the per-object placeholder templates (`Go to {objectLabelPlural}`, `{objectLabelPlural}`, `{objectIcon}`).

The server only interpolates those placeholders for object payloads (`interpolate-navigation-command-menu-item-field.util.ts`), so the raw templates reach the client, and the client fills leftover placeholders with the current page's object (`getCommandMenuItemPlaceholderValues`). Every settings command then renders with the current object's label and icon.

## Fix

New `upgrade:2-37:restore-settings-navigation-command-menu-item-labels` workspace command. A pure util selects NAVIGATION items with a path payload (guarded by `isObjectMetadataCommandMenuItemPayload`, the check 2-33 missed) whose universalIdentifier is in `STANDARD_COMMAND_MENU_ITEMS` and whose display fields differ from the standard definition, and restores label, shortLabel and icon from it.

Notes:
- Restores on any mismatch with the standard definition rather than only the exact template strings, so it is idempotent and self-healing.
- Object navigation items keep their placeholder templates, which are correct for them.
- The 2-33 command is left untouched: this command runs after it in any upgrade sequence, so a workspace upgrading from pre-2.33 gets corrupted and repaired within the same run.

## Test

- Unit spec covers: restoring a corrupted settings item, idempotency, leaving object navigation items on their templates, leaving non-standard path items untouched, leaving non-navigation items untouched.
- tsgo typecheck, oxlint and oxfmt clean.
