### PR TITLE
fix(server): stop rate-limit throttler exceptions from reaching Sentry

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/application-oauth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/application-oauth.resolver.ts
@@ -13,6 +13,7 @@ import { ApplicationTokenPairDTO } from 'src/engine/core-modules/application/app
 import { AuthGraphqlApiExceptionFilter } from 'src/engine/core-modules/auth/filters/auth-graphql-api-exception.filter';
 import { ApplicationTokenService } from 'src/engine/core-modules/auth/token/services/application-token.service';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
+import { ThrottlerGraphqlApiExceptionFilter } from 'src/engine/core-modules/throttler/filters/throttler-graphql-api-exception.filter';
 import { ThrottlerService } from 'src/engine/core-modules/throttler/throttler.service';
 import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthUserWorkspaceId } from 'src/engine/decorators/auth/auth-user-workspace-id.decorator';
@@ -27,7 +28,11 @@ const APP_TOKEN_RATE_LIMIT_WINDOW_MS = 30_000;
 
 @UsePipes(ResolverValidationPipe)
 @MetadataResolver()
-@UseFilters(ApplicationExceptionFilter, AuthGraphqlApiExceptionFilter)
+@UseFilters(
+  ApplicationExceptionFilter,
+  AuthGraphqlApiExceptionFilter,
+  ThrottlerGraphqlApiExceptionFilter,
+)
 @UseGuards(WorkspaceAuthGuard)
 export class ApplicationOAuthResolver {
   constructor(

--- a/packages/twenty-server/src/engine/core-modules/throttler/throttler.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/throttler/throttler.exception.ts
@@ -1,3 +1,5 @@
+import { HttpStatus } from '@nestjs/common';
+
 import { type MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
 import { assertUnreachable } from 'twenty-shared/utils';
@@ -28,6 +30,7 @@ export class ThrottlerException extends CustomException<ThrottlerExceptionCode> 
     super(message, code, {
       userFriendlyMessage:
         userFriendlyMessage ?? getThrottlerExceptionUserFriendlyMessage(code),
+      statusCode: HttpStatus.TOO_MANY_REQUESTS,
     });
   }
 }

--- a/packages/twenty-server/src/engine/utils/__tests__/global-exception-handler.util.spec.ts
+++ b/packages/twenty-server/src/engine/utils/__tests__/global-exception-handler.util.spec.ts
@@ -1,5 +1,9 @@
 import { RetryableLogicFunctionError } from 'twenty-shared/logic-function';
 
+import {
+  ThrottlerException,
+  ThrottlerExceptionCode,
+} from 'src/engine/core-modules/throttler/throttler.exception';
 import { shouldCaptureException } from 'src/engine/utils/global-exception-handler.util';
 
 describe('shouldCaptureException', () => {
@@ -8,6 +12,17 @@ describe('shouldCaptureException', () => {
       shouldCaptureException(
         new RetryableLogicFunctionError(
           'The remote dependency is temporarily unavailable',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not capture a rate-limit throttler exception', () => {
+    expect(
+      shouldCaptureException(
+        new ThrottlerException(
+          'Limit reached (30 tokens per 30000 ms)',
+          ThrottlerExceptionCode.LIMIT_REACHED,
         ),
       ),
     ).toBe(false);


### PR DESCRIPTION
## Context

Sentry issue [TWENTY-SERVER-GXJ](https://twenty-v7.sentry.io/issues/7495161692/) ("Limit Reached: Limit reached (30 tokens per 30000 ms)") has 17k+ events across 52 users. It is a legitimate rate-limit signal, not a defect, and should not be reported to Sentry.

## Root cause

`ThrottlerException` is thrown by `ThrottlerService.tokenBucketThrottleOrThrow`. In `shouldCaptureException`, a `CustomException` is only skipped when its `statusCode` is defined and `< 500`. `ThrottlerException` never set a `statusCode`, so it fell through and was captured by Sentry.

The specific source of this issue is `ApplicationOAuthResolver.generateApplicationToken` (throttled at 30 requests / 30s). That resolver only declared `ApplicationExceptionFilter` and `AuthGraphqlApiExceptionFilter`, neither of which catches `ThrottlerException`, so the raw exception propagated to the global GraphQL handler and was both captured by Sentry and surfaced to the client as a generic `Internal Server Error`.

## Changes

- Set `statusCode` to `429 (TOO_MANY_REQUESTS)` on `ThrottlerException`. Rate-limiting is a client error, so `shouldCaptureException` now filters it out. This is the central fix and covers every throttle call site (auth password reset, app tokens, logic functions, workflows).
- Wire `ThrottlerGraphqlApiExceptionFilter` into `ApplicationOAuthResolver`, matching the pattern already used by `AuthResolver`, so a throttled app-token request returns a proper rate-limit error instead of `Internal Server Error`.
- Add a unit test asserting `shouldCaptureException` returns `false` for a `ThrottlerException`.

## Test plan

- `npx jest src/engine/utils/__tests__/global-exception-handler.util.spec.ts` passes.
- Typecheck, lint:diff-with-main, and format pass on the changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

