### PR TITLE
Allow configuring the SMTP EHLO hostname

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/email/email-driver.factory.ts
+++ b/packages/twenty-server/src/engine/core-modules/email/email-driver.factory.ts
@@ -50,6 +50,7 @@ export class EmailDriverFactory extends DriverFactoryBase<EmailDriverInterface> 
         const user = this.twentyConfigService.get('EMAIL_SMTP_USER');
         const pass = this.twentyConfigService.get('EMAIL_SMTP_PASSWORD');
         const noTLS = this.twentyConfigService.get('EMAIL_SMTP_NO_TLS');
+        const name = this.twentyConfigService.get('EMAIL_SMTP_NAME');
 
         if (!host || !port) {
           throw new Error('SMTP driver requires host and port to be defined');
@@ -62,7 +63,14 @@ export class EmailDriverFactory extends DriverFactoryBase<EmailDriverInterface> 
           secure?: boolean;
           ignoreTLS?: boolean;
           requireTLS?: boolean;
+          name?: string;
         } = { host, port };
+
+        // Nodemailer greets with the machine hostname, and a relay that wants a
+        // fully qualified name rejects a short one before any mail is sent.
+        if (name) {
+          options.name = name;
+        }
 
         if (user && pass) {
           options.auth = { user, pass };

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -514,6 +514,15 @@ export class ConfigVariables {
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.EMAIL_SETTINGS,
+    description:
+      'Hostname announced in the SMTP EHLO greeting, when the machine hostname is not fully qualified',
+    type: ConfigVariableType.STRING,
+  })
+  @IsOptional()
+  EMAIL_SMTP_NAME: string;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.EMAIL_SETTINGS,
     description: 'SMTP port for sending emails',
     type: ConfigVariableType.NUMBER,
   })


### PR DESCRIPTION
### Problem

Nodemailer greets the SMTP server with the machine's hostname. When that hostname is not fully qualified - common on self-hosted boxes named `crm`, `mail`, `twenty` and so on - strict relays reject the connection before any mail is exchanged.

Against Google's SMTP relay this surfaces as:

```
[SmtpDriver] sending email to 'user@example.com':
421-4.7.0 Try again later, closing connection. (EHLO)
```

The error is actively misleading. "Try again later" implies a transient fault, and the obvious suspects look guilty instead: missing SMTP credentials, or an IP that is not allowlisted. Neither is the cause, and there is currently no way to configure the greeting.

### Diagnosis

Sending by hand with Python's `smtplib` succeeded every time, unauthenticated, over both IPv4 and IPv6, because `smtplib` lets you pass the EHLO name explicitly. Driving nodemailer with the exact options `EmailDriverFactory` builds reproduced the failure, and adding `name` alone fixed it: same host, same port, same absent credentials.

### Change

Adds an optional `EMAIL_SMTP_NAME` config variable, declared alongside the other email settings and passed through to nodemailer's `name` option. Default behaviour is unchanged when unset.

### Testing

Verified on a self-hosted instance whose hostname is not fully qualified. Before, every invitation and password reset failed with the 421 above. After setting `EMAIL_SMTP_NAME`, through Twenty's own driver:

```
[SmtpDriver] Email to 'user@example.com' successfully sent
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

