### PR TITLE
Seed message thread and calendar event targets in dev workspaces

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/constants/message-calendar-target-data-seeds.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/constants/message-calendar-target-data-seeds.constant.ts
@@ -151,14 +151,17 @@ const GROUP_PERSON_IDS_BY_PARENT_ID = <Participant>({
   return PERSON_IDS_BY_PARENT_ID;
 };
 
-const BUILD_TARGET_SEEDS = <TargetSeed>(
-  personIdsByParentId: Map<string, Set<string>>,
+const BUILD_TARGET_SEEDS = <TargetSeed>({
+  personIdsByParentId,
+  createTargetSeed,
+}: {
+  personIdsByParentId: Map<string, Set<string>>;
   createTargetSeed: (args: {
     index: number;
     parentId: string;
     targetColumns: TargetColumnsDataSeed;
-  }) => TargetSeed,
-): TargetSeed[] => {
+  }) => TargetSeed;
+}): TargetSeed[] => {
   const TARGET_SEEDS: TargetSeed[] = [];
   let TARGET_INDEX = 1;
 
@@ -178,7 +181,13 @@ const BUILD_TARGET_SEEDS = <TargetSeed>(
   return TARGET_SEEDS;
 };
 
-const BUILD_TARGET_SEED_ID = (index: number, nodeSuffix: string): string => {
+const BUILD_TARGET_SEED_ID = ({
+  index,
+  nodeSuffix,
+}: {
+  index: number;
+  nodeSuffix: string;
+}): string => {
   const HEX_INDEX = index.toString(16).padStart(4, '0');
 
   return `20202020-${HEX_INDEX}-4e7c-8001-${nodeSuffix}`;
@@ -191,36 +200,36 @@ const MESSAGE_THREAD_ID_BY_MESSAGE_ID = new Map(
 export const getMessageThreadTargetDataSeeds = (
   messageParticipantSeeds: MessageParticipantDataSeed[],
 ): MessageThreadTargetDataSeed[] =>
-  BUILD_TARGET_SEEDS(
-    GROUP_PERSON_IDS_BY_PARENT_ID({
+  BUILD_TARGET_SEEDS({
+    personIdsByParentId: GROUP_PERSON_IDS_BY_PARENT_ID({
       participants: messageParticipantSeeds,
       getParentId: (participant) =>
         MESSAGE_THREAD_ID_BY_MESSAGE_ID.get(participant.messageId),
       getPersonId: (participant) => participant.personId,
     }),
-    ({ index, parentId, targetColumns }) => ({
-      id: BUILD_TARGET_SEED_ID(index, 'cafe56789abc'),
+    createTargetSeed: ({ index, parentId, targetColumns }) => ({
+      id: BUILD_TARGET_SEED_ID({ index, nodeSuffix: 'cafe56789abc' }),
       messageThreadId: parentId,
       ...targetColumns,
       isAutomaticallyAssigned: true,
       isManuallyAssigned: false,
     }),
-  );
+  });
 
 export const getCalendarEventTargetDataSeeds = (
   calendarEventParticipantSeeds: CalendarEventParticipantDataSeed[],
 ): CalendarEventTargetDataSeed[] =>
-  BUILD_TARGET_SEEDS(
-    GROUP_PERSON_IDS_BY_PARENT_ID({
+  BUILD_TARGET_SEEDS({
+    personIdsByParentId: GROUP_PERSON_IDS_BY_PARENT_ID({
       participants: calendarEventParticipantSeeds,
       getParentId: (participant) => participant.calendarEventId,
       getPersonId: (participant) => participant.personId,
     }),
-    ({ index, parentId, targetColumns }) => ({
-      id: BUILD_TARGET_SEED_ID(index, 'face56789abc'),
+    createTargetSeed: ({ index, parentId, targetColumns }) => ({
+      id: BUILD_TARGET_SEED_ID({ index, nodeSuffix: 'face56789abc' }),
       calendarEventId: parentId,
       ...targetColumns,
       isAutomaticallyAssigned: true,
       isManuallyAssigned: false,
     }),
-  );
+  });

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/constants/message-calendar-target-data-seeds.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/constants/message-calendar-target-data-seeds.constant.ts
@@ -1,0 +1,207 @@
+import { type CalendarEventParticipantDataSeed } from 'src/engine/workspace-manager/dev-seeder/data/constants/calendar-event-participant-data-seeds.constant';
+import { MESSAGE_DATA_SEEDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/message-data-seeds.constant';
+import { type MessageParticipantDataSeed } from 'src/engine/workspace-manager/dev-seeder/data/constants/message-participant-data-seeds.constant';
+import { OPPORTUNITY_DATA_SEEDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/opportunity-data-seeds.constant';
+import { PERSON_DATA_SEEDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/person-data-seeds.constant';
+
+// Timeline reads resolve through the target junctions once
+// IS_MESSAGE_CALENDAR_TARGET_READ_ENABLED is on, and reconciliation only runs
+// on sync paths, so seeded workspaces must seed the rows reconciliation would
+// have produced: per parent, a Person target for each participant person, a
+// Company target for each of their companies, and an Opportunity target for
+// each opportunity they are the point of contact of.
+
+type TargetColumnsDataSeed = {
+  targetPersonId: string | null;
+  targetCompanyId: string | null;
+  targetOpportunityId: string | null;
+};
+
+export type MessageThreadTargetDataSeed = TargetColumnsDataSeed & {
+  id: string;
+  messageThreadId: string;
+  isAutomaticallyAssigned: boolean;
+  isManuallyAssigned: boolean;
+};
+
+export type CalendarEventTargetDataSeed = TargetColumnsDataSeed & {
+  id: string;
+  calendarEventId: string;
+  isAutomaticallyAssigned: boolean;
+  isManuallyAssigned: boolean;
+};
+
+export const MESSAGE_THREAD_TARGET_DATA_SEED_COLUMNS: (keyof MessageThreadTargetDataSeed)[] =
+  [
+    'id',
+    'messageThreadId',
+    'targetPersonId',
+    'targetCompanyId',
+    'targetOpportunityId',
+    'isAutomaticallyAssigned',
+    'isManuallyAssigned',
+  ];
+
+export const CALENDAR_EVENT_TARGET_DATA_SEED_COLUMNS: (keyof CalendarEventTargetDataSeed)[] =
+  [
+    'id',
+    'calendarEventId',
+    'targetPersonId',
+    'targetCompanyId',
+    'targetOpportunityId',
+    'isAutomaticallyAssigned',
+    'isManuallyAssigned',
+  ];
+
+const COMPANY_ID_BY_PERSON_ID = new Map(
+  PERSON_DATA_SEEDS.map((person) => [person.id, person.companyId]),
+);
+
+const BUILD_OPPORTUNITY_IDS_BY_PERSON_ID = (): Map<string, string[]> => {
+  const OPPORTUNITY_IDS_BY_PERSON_ID = new Map<string, string[]>();
+
+  for (const OPPORTUNITY of OPPORTUNITY_DATA_SEEDS) {
+    const OPPORTUNITY_IDS =
+      OPPORTUNITY_IDS_BY_PERSON_ID.get(OPPORTUNITY.pointOfContactId) ?? [];
+
+    OPPORTUNITY_IDS.push(OPPORTUNITY.id);
+    OPPORTUNITY_IDS_BY_PERSON_ID.set(
+      OPPORTUNITY.pointOfContactId,
+      OPPORTUNITY_IDS,
+    );
+  }
+
+  return OPPORTUNITY_IDS_BY_PERSON_ID;
+};
+
+const OPPORTUNITY_IDS_BY_PERSON_ID = BUILD_OPPORTUNITY_IDS_BY_PERSON_ID();
+
+const BUILD_TARGET_COLUMN_SETS = (
+  personIds: Set<string>,
+): TargetColumnsDataSeed[] => {
+  const TARGET_COLUMN_SETS: TargetColumnsDataSeed[] = [];
+  const COMPANY_IDS = new Set<string>();
+  const OPPORTUNITY_IDS = new Set<string>();
+
+  for (const PERSON_ID of personIds) {
+    TARGET_COLUMN_SETS.push({
+      targetPersonId: PERSON_ID,
+      targetCompanyId: null,
+      targetOpportunityId: null,
+    });
+
+    const COMPANY_ID = COMPANY_ID_BY_PERSON_ID.get(PERSON_ID);
+
+    if (COMPANY_ID) {
+      COMPANY_IDS.add(COMPANY_ID);
+    }
+
+    for (const OPPORTUNITY_ID of OPPORTUNITY_IDS_BY_PERSON_ID.get(PERSON_ID) ??
+      []) {
+      OPPORTUNITY_IDS.add(OPPORTUNITY_ID);
+    }
+  }
+
+  for (const COMPANY_ID of COMPANY_IDS) {
+    TARGET_COLUMN_SETS.push({
+      targetPersonId: null,
+      targetCompanyId: COMPANY_ID,
+      targetOpportunityId: null,
+    });
+  }
+
+  for (const OPPORTUNITY_ID of OPPORTUNITY_IDS) {
+    TARGET_COLUMN_SETS.push({
+      targetPersonId: null,
+      targetCompanyId: null,
+      targetOpportunityId: OPPORTUNITY_ID,
+    });
+  }
+
+  return TARGET_COLUMN_SETS;
+};
+
+const BUILD_TARGET_SEED_ID = (index: number, nodeSuffix: string): string => {
+  const HEX_INDEX = index.toString(16).padStart(4, '0');
+
+  return `20202020-${HEX_INDEX}-4e7c-8001-${nodeSuffix}`;
+};
+
+const MESSAGE_THREAD_ID_BY_MESSAGE_ID = new Map(
+  MESSAGE_DATA_SEEDS.map((message) => [message.id, message.messageThreadId]),
+);
+
+export const getMessageThreadTargetDataSeeds = (
+  messageParticipantSeeds: MessageParticipantDataSeed[],
+): MessageThreadTargetDataSeed[] => {
+  const PERSON_IDS_BY_THREAD_ID = new Map<string, Set<string>>();
+
+  for (const PARTICIPANT of messageParticipantSeeds) {
+    const THREAD_ID = MESSAGE_THREAD_ID_BY_MESSAGE_ID.get(
+      PARTICIPANT.messageId,
+    );
+
+    if (!THREAD_ID || !PARTICIPANT.personId) {
+      continue;
+    }
+
+    const PERSON_IDS = PERSON_IDS_BY_THREAD_ID.get(THREAD_ID) ?? new Set();
+
+    PERSON_IDS.add(PARTICIPANT.personId);
+    PERSON_IDS_BY_THREAD_ID.set(THREAD_ID, PERSON_IDS);
+  }
+
+  const TARGET_SEEDS: MessageThreadTargetDataSeed[] = [];
+  let TARGET_INDEX = 1;
+
+  for (const [THREAD_ID, PERSON_IDS] of PERSON_IDS_BY_THREAD_ID) {
+    for (const TARGET_COLUMNS of BUILD_TARGET_COLUMN_SETS(PERSON_IDS)) {
+      TARGET_SEEDS.push({
+        id: BUILD_TARGET_SEED_ID(TARGET_INDEX, 'cafe56789abc'),
+        messageThreadId: THREAD_ID,
+        ...TARGET_COLUMNS,
+        isAutomaticallyAssigned: true,
+        isManuallyAssigned: false,
+      });
+      TARGET_INDEX++;
+    }
+  }
+
+  return TARGET_SEEDS;
+};
+
+export const getCalendarEventTargetDataSeeds = (
+  calendarEventParticipantSeeds: CalendarEventParticipantDataSeed[],
+): CalendarEventTargetDataSeed[] => {
+  const PERSON_IDS_BY_EVENT_ID = new Map<string, Set<string>>();
+
+  for (const PARTICIPANT of calendarEventParticipantSeeds) {
+    if (!PARTICIPANT.personId) {
+      continue;
+    }
+
+    const PERSON_IDS =
+      PERSON_IDS_BY_EVENT_ID.get(PARTICIPANT.calendarEventId) ?? new Set();
+
+    PERSON_IDS.add(PARTICIPANT.personId);
+    PERSON_IDS_BY_EVENT_ID.set(PARTICIPANT.calendarEventId, PERSON_IDS);
+  }
+
+  const TARGET_SEEDS: CalendarEventTargetDataSeed[] = [];
+  let TARGET_INDEX = 1;
+
+  for (const [CALENDAR_EVENT_ID, PERSON_IDS] of PERSON_IDS_BY_EVENT_ID) {
+    for (const TARGET_COLUMNS of BUILD_TARGET_COLUMN_SETS(PERSON_IDS)) {
+      TARGET_SEEDS.push({
+        id: BUILD_TARGET_SEED_ID(TARGET_INDEX, 'face56789abc'),
+        calendarEventId: CALENDAR_EVENT_ID,
+        ...TARGET_COLUMNS,
+        isAutomaticallyAssigned: true,
+        isManuallyAssigned: false,
+      });
+      TARGET_INDEX++;
+    }
+  }
+
+  return TARGET_SEEDS;
+};

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/constants/message-calendar-target-data-seeds.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/constants/message-calendar-target-data-seeds.constant.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { type CalendarEventParticipantDataSeed } from 'src/engine/workspace-manager/dev-seeder/data/constants/calendar-event-participant-data-seeds.constant';
 import { MESSAGE_DATA_SEEDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/message-data-seeds.constant';
 import { type MessageParticipantDataSeed } from 'src/engine/workspace-manager/dev-seeder/data/constants/message-participant-data-seeds.constant';
@@ -92,7 +94,7 @@ const BUILD_TARGET_COLUMN_SETS = (
 
     const COMPANY_ID = COMPANY_ID_BY_PERSON_ID.get(PERSON_ID);
 
-    if (COMPANY_ID) {
+    if (isDefined(COMPANY_ID)) {
       COMPANY_IDS.add(COMPANY_ID);
     }
 
@@ -121,6 +123,61 @@ const BUILD_TARGET_COLUMN_SETS = (
   return TARGET_COLUMN_SETS;
 };
 
+const GROUP_PERSON_IDS_BY_PARENT_ID = <Participant>({
+  participants,
+  getParentId,
+  getPersonId,
+}: {
+  participants: Participant[];
+  getParentId: (participant: Participant) => string | undefined;
+  getPersonId: (participant: Participant) => string | null;
+}): Map<string, Set<string>> => {
+  const PERSON_IDS_BY_PARENT_ID = new Map<string, Set<string>>();
+
+  for (const PARTICIPANT of participants) {
+    const PARENT_ID = getParentId(PARTICIPANT);
+    const PERSON_ID = getPersonId(PARTICIPANT);
+
+    if (!isDefined(PARENT_ID) || !isDefined(PERSON_ID)) {
+      continue;
+    }
+
+    const PERSON_IDS = PERSON_IDS_BY_PARENT_ID.get(PARENT_ID) ?? new Set();
+
+    PERSON_IDS.add(PERSON_ID);
+    PERSON_IDS_BY_PARENT_ID.set(PARENT_ID, PERSON_IDS);
+  }
+
+  return PERSON_IDS_BY_PARENT_ID;
+};
+
+const BUILD_TARGET_SEEDS = <TargetSeed>(
+  personIdsByParentId: Map<string, Set<string>>,
+  createTargetSeed: (args: {
+    index: number;
+    parentId: string;
+    targetColumns: TargetColumnsDataSeed;
+  }) => TargetSeed,
+): TargetSeed[] => {
+  const TARGET_SEEDS: TargetSeed[] = [];
+  let TARGET_INDEX = 1;
+
+  for (const [PARENT_ID, PERSON_IDS] of personIdsByParentId) {
+    for (const TARGET_COLUMNS of BUILD_TARGET_COLUMN_SETS(PERSON_IDS)) {
+      TARGET_SEEDS.push(
+        createTargetSeed({
+          index: TARGET_INDEX,
+          parentId: PARENT_ID,
+          targetColumns: TARGET_COLUMNS,
+        }),
+      );
+      TARGET_INDEX++;
+    }
+  }
+
+  return TARGET_SEEDS;
+};
+
 const BUILD_TARGET_SEED_ID = (index: number, nodeSuffix: string): string => {
   const HEX_INDEX = index.toString(16).padStart(4, '0');
 
@@ -133,75 +190,37 @@ const MESSAGE_THREAD_ID_BY_MESSAGE_ID = new Map(
 
 export const getMessageThreadTargetDataSeeds = (
   messageParticipantSeeds: MessageParticipantDataSeed[],
-): MessageThreadTargetDataSeed[] => {
-  const PERSON_IDS_BY_THREAD_ID = new Map<string, Set<string>>();
-
-  for (const PARTICIPANT of messageParticipantSeeds) {
-    const THREAD_ID = MESSAGE_THREAD_ID_BY_MESSAGE_ID.get(
-      PARTICIPANT.messageId,
-    );
-
-    if (!THREAD_ID || !PARTICIPANT.personId) {
-      continue;
-    }
-
-    const PERSON_IDS = PERSON_IDS_BY_THREAD_ID.get(THREAD_ID) ?? new Set();
-
-    PERSON_IDS.add(PARTICIPANT.personId);
-    PERSON_IDS_BY_THREAD_ID.set(THREAD_ID, PERSON_IDS);
-  }
-
-  const TARGET_SEEDS: MessageThreadTargetDataSeed[] = [];
-  let TARGET_INDEX = 1;
-
-  for (const [THREAD_ID, PERSON_IDS] of PERSON_IDS_BY_THREAD_ID) {
-    for (const TARGET_COLUMNS of BUILD_TARGET_COLUMN_SETS(PERSON_IDS)) {
-      TARGET_SEEDS.push({
-        id: BUILD_TARGET_SEED_ID(TARGET_INDEX, 'cafe56789abc'),
-        messageThreadId: THREAD_ID,
-        ...TARGET_COLUMNS,
-        isAutomaticallyAssigned: true,
-        isManuallyAssigned: false,
-      });
-      TARGET_INDEX++;
-    }
-  }
-
-  return TARGET_SEEDS;
-};
+): MessageThreadTargetDataSeed[] =>
+  BUILD_TARGET_SEEDS(
+    GROUP_PERSON_IDS_BY_PARENT_ID({
+      participants: messageParticipantSeeds,
+      getParentId: (participant) =>
+        MESSAGE_THREAD_ID_BY_MESSAGE_ID.get(participant.messageId),
+      getPersonId: (participant) => participant.personId,
+    }),
+    ({ index, parentId, targetColumns }) => ({
+      id: BUILD_TARGET_SEED_ID(index, 'cafe56789abc'),
+      messageThreadId: parentId,
+      ...targetColumns,
+      isAutomaticallyAssigned: true,
+      isManuallyAssigned: false,
+    }),
+  );
 
 export const getCalendarEventTargetDataSeeds = (
   calendarEventParticipantSeeds: CalendarEventParticipantDataSeed[],
-): CalendarEventTargetDataSeed[] => {
-  const PERSON_IDS_BY_EVENT_ID = new Map<string, Set<string>>();
-
-  for (const PARTICIPANT of calendarEventParticipantSeeds) {
-    if (!PARTICIPANT.personId) {
-      continue;
-    }
-
-    const PERSON_IDS =
-      PERSON_IDS_BY_EVENT_ID.get(PARTICIPANT.calendarEventId) ?? new Set();
-
-    PERSON_IDS.add(PARTICIPANT.personId);
-    PERSON_IDS_BY_EVENT_ID.set(PARTICIPANT.calendarEventId, PERSON_IDS);
-  }
-
-  const TARGET_SEEDS: CalendarEventTargetDataSeed[] = [];
-  let TARGET_INDEX = 1;
-
-  for (const [CALENDAR_EVENT_ID, PERSON_IDS] of PERSON_IDS_BY_EVENT_ID) {
-    for (const TARGET_COLUMNS of BUILD_TARGET_COLUMN_SETS(PERSON_IDS)) {
-      TARGET_SEEDS.push({
-        id: BUILD_TARGET_SEED_ID(TARGET_INDEX, 'face56789abc'),
-        calendarEventId: CALENDAR_EVENT_ID,
-        ...TARGET_COLUMNS,
-        isAutomaticallyAssigned: true,
-        isManuallyAssigned: false,
-      });
-      TARGET_INDEX++;
-    }
-  }
-
-  return TARGET_SEEDS;
-};
+): CalendarEventTargetDataSeed[] =>
+  BUILD_TARGET_SEEDS(
+    GROUP_PERSON_IDS_BY_PARENT_ID({
+      participants: calendarEventParticipantSeeds,
+      getParentId: (participant) => participant.calendarEventId,
+      getPersonId: (participant) => participant.personId,
+    }),
+    ({ index, parentId, targetColumns }) => ({
+      id: BUILD_TARGET_SEED_ID(index, 'face56789abc'),
+      calendarEventId: parentId,
+      ...targetColumns,
+      isAutomaticallyAssigned: true,
+      isManuallyAssigned: false,
+    }),
+  );

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/services/dev-seeder-data.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/data/services/dev-seeder-data.service.ts
@@ -53,6 +53,12 @@ import {
   MESSAGE_CAMPAIGN_DATA_SEEDS,
 } from 'src/engine/workspace-manager/dev-seeder/data/constants/message-campaign-data-seeds.constant';
 import {
+  CALENDAR_EVENT_TARGET_DATA_SEED_COLUMNS,
+  getCalendarEventTargetDataSeeds,
+  getMessageThreadTargetDataSeeds,
+  MESSAGE_THREAD_TARGET_DATA_SEED_COLUMNS,
+} from 'src/engine/workspace-manager/dev-seeder/data/constants/message-calendar-target-data-seeds.constant';
+import {
   MESSAGE_DATA_SEED_COLUMNS,
   MESSAGE_DATA_SEEDS,
 } from 'src/engine/workspace-manager/dev-seeder/data/constants/message-data-seeds.constant';
@@ -126,6 +132,12 @@ const getRecordSeedsBatches = (
   attachmentSeeds: RecordSeedConfig['recordSeeds'],
   _featureFlags?: Record<FeatureFlagKey, boolean>,
 ): RecordSeedConfig[][] => {
+  // Participants are generated randomly, so they are built once and the
+  // derived target junction seeds are computed from the same arrays.
+  const messageParticipantSeeds = getMessageParticipantDataSeeds(workspaceId);
+  const calendarEventParticipantSeeds =
+    getCalendarEventParticipantDataSeeds(workspaceId);
+
   // Batch 1: No dependencies
   const batch1: RecordSeedConfig[] = [
     {
@@ -237,7 +249,7 @@ const getRecordSeedsBatches = (
     {
       tableName: 'calendarEventParticipant',
       pgColumns: CALENDAR_EVENT_PARTICIPANT_DATA_SEED_COLUMNS,
-      recordSeeds: getCalendarEventParticipantDataSeeds(workspaceId),
+      recordSeeds: calendarEventParticipantSeeds,
     },
     {
       tableName: 'message',
@@ -256,7 +268,19 @@ const getRecordSeedsBatches = (
     {
       tableName: 'messageParticipant',
       pgColumns: MESSAGE_PARTICIPANT_DATA_SEED_COLUMNS,
-      recordSeeds: getMessageParticipantDataSeeds(workspaceId),
+      recordSeeds: messageParticipantSeeds,
+    },
+    {
+      tableName: 'messageThreadTarget',
+      pgColumns: MESSAGE_THREAD_TARGET_DATA_SEED_COLUMNS,
+      recordSeeds: getMessageThreadTargetDataSeeds(messageParticipantSeeds),
+    },
+    {
+      tableName: 'calendarEventTarget',
+      pgColumns: CALENDAR_EVENT_TARGET_DATA_SEED_COLUMNS,
+      recordSeeds: getCalendarEventTargetDataSeeds(
+        calendarEventParticipantSeeds,
+      ),
     },
     {
       tableName: 'attachment',


### PR DESCRIPTION
## Summary

With `IS_MESSAGE_CALENDAR_TARGET_READ_ENABLED` on (dev-seeded on since #24782), record timelines read from the target junctions, but dev seeds never created junction rows: reconciliation only runs on sync paths and the backfill command does not run against seeded workspaces. Result: empty Emails and Calendar tabs on every seeded record.

This seeds `messageThreadTarget` and `calendarEventTarget` rows exactly as reconciliation would have produced them: per thread/event, a Person target for each participant person, a Company target for each of their companies, and an Opportunity target for each opportunity they are point of contact of, all `isAutomaticallyAssigned` and not `isManuallyAssigned`.

Participants are generated randomly at seed time, so the participant arrays are built once in `getRecordSeedsBatches` and the target seeds are derived from the same arrays.

Was stacked on #24782; retargeted to main after its merge.

## Validation

Ran `database:reset` against a dev stack and inspected the seeded workspaces over SQL:

- 3,595 and 4,015 thread targets across the 300 threads; 1,666 and 1,680 event targets across the 800 events (both seeded workspaces)
- 434 companies, 540 persons, and 65 opportunities gain an email timeline; 585 persons gain a calendar timeline
- zero rows without a target column; provenance uniformly automatic true / manual false
- spot check: a thread's 5 distinct participant persons map to exactly 5 person target rows
- server typecheck with tsgo, diff-based lint, and oxfmt clean

---
_Generated by [Claude Code](https://claude.ai/code/session_017nu7UTcjQVDyDSRtBWRhiD)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

