### PR TITLE
Fix QA Scout turn exhaustion found by the first live audit

### DIFF
--- a/.claude/skills/qa-scout/SKILL.md
+++ b/.claude/skills/qa-scout/SKILL.md
@@ -27,7 +27,7 @@ The invoking prompt gives you concrete paths. In CI they are:
 | Server log (live) | `/tmp/qa-scout/server.log` |
 | Worker log (live) | `/tmp/qa-scout/worker.log` |
 | Run mode | `/tmp/qa-scout/context/mode`: `post-merge` (the change is on main) or `pre-merge` (label-triggered validation of the PR head before merge) |
-| Database (disposable, full access) | `postgres://postgres:postgres@localhost:5432/default` via `psql` |
+| Database (disposable, full access) | `psql -h localhost -U postgres -d default` (PGPASSWORD is set; the URI `postgres://postgres:postgres@localhost:5432/default` also works) |
 
 This environment is ephemeral, so unlike a shared instance you have full
 power here: use `psql` to attest what the UI cannot show. After a write flow,
@@ -80,7 +80,11 @@ own browser observations unreliable.
 
 ## Verdict contract
 
-Always write both files to the output directory, whatever happens:
+Always write both files to the output directory, whatever happens. Write
+first versions right after scoping, before the first scenario (verdict
+INVESTIGATE, headline "run still in progress", scenarios listed as pending),
+then update both after each scenario and finalize at the end: a run that dies
+on turns or time then leaves your last known state instead of silence.
 
 `verdict.json`:
 

--- a/.github/workflows/ci-e2e-main.yaml
+++ b/.github/workflows/ci-e2e-main.yaml
@@ -337,7 +337,7 @@ jobs:
             if [ -f /tmp/qa-scout/output/report.md ]; then
               cat /tmp/qa-scout/output/report.md
             elif [ -f /tmp/qa-scout/output/verdict.json ]; then
-              jq -r '"**\(.verdict)**: \(.headline)\n\n_Full report missing (agent stopped early); details in the qa-scout-report artifact._"' /tmp/qa-scout/output/verdict.json
+              jq -r '"**\(.verdict)**: \(.headline // "no headline recorded")\n\n_Full report missing (agent stopped early); details in the qa-scout-report artifact._"' /tmp/qa-scout/output/verdict.json
             elif [ "$SCOUT_RUN" = "true" ]; then
               echo "No report produced (agent run failed or timed out); see the qa-scout-report artifact and step logs."
             elif [ "$SCOUT_PREP_OUTCOME" = "failure" ]; then
@@ -438,7 +438,7 @@ jobs:
           # report; a synthesized body beats silence on a FAIL.
           if [ -z "$REPORT_FILE" ]; then
             REPORT_FILE=report-fallback.md
-            jq -r '"**\(.verdict)**: \(.headline)\n\n" + ([.scenarios[]? | "- \(.name): \(.result)"] | join("\n")) + "\n\n_Full report missing (agent stopped early); details in the qa-scout-report artifact._"' \
+            jq -r '"**\(.verdict)**: \(.headline // "no headline recorded")\n\n" + ([.scenarios[]? | "- \(.name): \(.result)"] | join("\n")) + "\n\n_Full report missing (agent stopped early); details in the qa-scout-report artifact._"' \
               "$VERDICT_FILE" > "$REPORT_FILE"
           fi
           VERDICT=$(jq -r '.verdict // empty' "$VERDICT_FILE")

--- a/.github/workflows/ci-e2e-main.yaml
+++ b/.github/workflows/ci-e2e-main.yaml
@@ -286,6 +286,7 @@ jobs:
         timeout-minutes: 15
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          PGPASSWORD: postgres
         run: |
           set -euo pipefail
           npm install -g @anthropic-ai/claude-code@2.1.247
@@ -293,8 +294,10 @@ jobs:
           # keeps per-turn detail and permission denials so allowlist tuning
           # reads real data.
           claude -p "Read .claude/skills/qa-scout/SKILL.md and follow it exactly. This is the CI invocation: every path and credential in the skill's Inputs table applies verbatim." \
-            --max-turns 120 \
+            --max-turns 150 \
             --model opus \
+            --add-dir /tmp/qa-scout \
+            --strict-mcp-config \
             --mcp-config /tmp/qa-scout/mcp.json \
             --allowedTools "Read,Grep,Glob,Write,TodoWrite,Bash(cat *),Bash(tail *),Bash(head *),Bash(wc *),Bash(ls *),Bash(grep *),Bash(jq *),Bash(echo *),Bash(diff *),Bash(sort *),Bash(uniq *),Bash(cut *),Bash(tr *),Bash(mkdir *),Bash(sleep *),Bash(date *),Bash(psql *),mcp__playwright" \
             --output-format stream-json --verbose \
@@ -333,6 +336,8 @@ jobs:
             echo "## QA Scout"
             if [ -f /tmp/qa-scout/output/report.md ]; then
               cat /tmp/qa-scout/output/report.md
+            elif [ -f /tmp/qa-scout/output/verdict.json ]; then
+              jq -r '"**\(.verdict)**: \(.headline)\n\n_Full report missing (agent stopped early); details in the qa-scout-report artifact._"' /tmp/qa-scout/output/verdict.json
             elif [ "$SCOUT_RUN" = "true" ]; then
               echo "No report produced (agent run failed or timed out); see the qa-scout-report artifact and step logs."
             elif [ "$SCOUT_PREP_OUTCOME" = "failure" ]; then
@@ -425,9 +430,16 @@ jobs:
           fi
           VERDICT_FILE=$(find qa-scout-report -name verdict.json | head -1 || true)
           REPORT_FILE=$(find qa-scout-report -name report.md | head -1 || true)
-          if [ -z "$VERDICT_FILE" ] || [ -z "$REPORT_FILE" ]; then
-            echo "No verdict or report in the artifact; nothing to post."
+          if [ -z "$VERDICT_FILE" ]; then
+            echo "No verdict in the artifact; nothing to post."
             exit 0
+          fi
+          # A run killed on turns or time can leave the verdict without the
+          # report; a synthesized body beats silence on a FAIL.
+          if [ -z "$REPORT_FILE" ]; then
+            REPORT_FILE=report-fallback.md
+            jq -r '"**\(.verdict)**: \(.headline)\n\n" + ([.scenarios[]? | "- \(.name): \(.result)"] | join("\n")) + "\n\n_Full report missing (agent stopped early); details in the qa-scout-report artifact._"' \
+              "$VERDICT_FILE" > "$REPORT_FILE"
           fi
           VERDICT=$(jq -r '.verdict // empty' "$VERDICT_FILE")
           case "$VERDICT" in


### PR DESCRIPTION
First live audit of the Scout (8 non-superseded push runs since the direct-CLI fix, 11:27Z to 14:00Z today) found one systemic bug; this PR fixes it.

## The numbers

| Run | PR | Outcome |
|---|---|---|
| 11:32 | #24918 (i18n) | skipped by design |
| 11:44 | #24916 (revert) | PASS, 92 turns, 6.2 min, $4.54 |
| 12:16 | #24778 | died at turn 121, no verdict |
| 12:30 | #24708 | PASS, 88 turns, 6.8 min, $4.28 |
| 12:51 | #24780 (upgrade commands) | wrote a PASS verdict on turn 121, then killed before report.md |
| 13:13, 13:47, 14:00 | 3 PRs | died at turn 121, no verdict |

Five of eight runs hit the `--max-turns 120` cap. When they did, the artifact was empty or verdict-only, so the comment job stayed silent and the PR got nothing.

## Root cause

The execution logs (captured since #24907) show every Bash command touching `/tmp/qa-scout` was denied: `wc -l server.log worker.log`, `ls -la /tmp/qa-scout/`, even `tail -n 2 server.log`. The CLI validates Bash file arguments against the session's working directories, and `/tmp/qa-scout` is outside the checkout, so no allowlist prefix rule can permit it. Agents adapted by paging through megabyte log files with the Read tool, which is exactly where the turn budget went. The one modest-PR runs finished under 92 turns; anything meatier blew the cap.

## Fixes

- `--add-dir /tmp/qa-scout`: grants the directory, so one `tail -n +N` replaces dozens of Read pages. Root-cause fix; turn counts should drop well below the old baseline.
- `--max-turns 150`: headroom while the fleet re-baselines (the 15-minute step timeout still bounds cost).
- `--strict-mcp-config`: stops loading the repo's `.mcp.json`, whose postgres server the agent kept reaching for and getting denied.
- `PGPASSWORD` in the step env: bare `psql -h localhost ...` now matches `Bash(psql *)` instead of dying on the `PGPASSWORD=... psql` env-assignment prefix.
- Graceful degradation: the comment job and job summary now synthesize a body from `verdict.json` when `report.md` is missing, so a partial run surfaces its verdict instead of "nothing to post". The 12:51 run on #24780 had a complete PASS verdict that nobody saw.
- Skill: write both output files right after scoping and update them in place, so any death leaves the last known state.

## Validation

Workflow YAML parsed; all three edited run blocks pass `bash -n`; the jq fallback tested against FAIL-with-scenarios, PASS-minimal, and missing-scenarios inputs under pipefail; `--add-dir` and `--strict-mcp-config` verified present in the pinned CLI 2.1.247.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1ML7TTsrqPbPnCtox9rBX)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

