### PR TITLE
Bill logic function executions for duration like AWS Lambda

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/logic/logic-functions.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/logic-functions.mdx
@@ -79,6 +79,10 @@ yarn twenty dev:function:logs
 ```
 </Note>
 
+<Note>
+On the cloud, each run consumes workspace credits: a flat charge per invocation plus a per-millisecond charge for the time the function runs, so keeping `timeoutSeconds` tight and code fast keeps costs down. See [Credits](/user-guide/billing/capabilities/credits) for the rates.
+</Note>
+
 #### Route trigger payload
 
 When a route trigger invokes your logic function, it receives a `RoutePayload` object that follows the

--- a/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
+++ b/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
@@ -16,7 +16,7 @@ Cost scales with the work. Everyday automation and quick AI messages cost a tiny
 | What you do | Roughly costs | What that means |
 |-------------|---------------|-----------------|
 | Run a standard workflow step (search, create, or update records) | $0.0001 | **10,000 runs per credit** |
-| Trigger an app's logic function | $0.0001 + $0.00001 per second of runtime | **~9,000 typical runs per credit** |
+| Trigger an app's logic function | $0.0001 + $0.0001 per second of runtime | **Thousands of runs per credit** |
 | Call an external API or run a code node | A small fraction of a credit | Thousands per credit |
 | Send a quick AI chat message or simple AI step | A fraction of a cent | Hundreds per credit |
 | Run a large AI agent task (e.g. "configure 10 workspace objects") | Can run to **~$1 or more** | A few per credit |
@@ -35,9 +35,9 @@ Not every app charges for its runs. Call Recorder and Last Contact react to ever
 Logic function pricing mirrors AWS Lambda: a flat charge per invocation plus a duration charge for the time your code actually runs, billed per millisecond.
 
 - **Per invocation**: $0.0001
-- **Per duration**: $0.00001 per second of runtime ($0.00000001 per millisecond)
+- **Per duration**: $0.0001 per second of runtime ($0.0000001 per millisecond)
 
-A typical function that finishes in under a second costs barely more than the flat invocation charge. Long-running functions pay for the compute they use: a function running for a full minute adds $0.0006, and one hitting the 15-minute timeout adds $0.009. A function that times out is billed for its full elapsed time, just like on AWS.
+A typical function that finishes in under a second costs at most double the flat invocation charge. Long-running functions pay for the compute they use: a function running for a full minute adds $0.006, and one hitting the 15-minute timeout adds $0.09. A function that times out is billed for its full elapsed time, just like on AWS.
 
 ## How AI usage is metered
 

--- a/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
+++ b/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
@@ -15,7 +15,8 @@ Cost scales with the work. Everyday automation and quick AI messages cost a tiny
 
 | What you do | Roughly costs | What that means |
 |-------------|---------------|-----------------|
-| Run a standard workflow step (search, create, or update records) or trigger an app's logic function | $0.0001 | **10,000 runs per credit** |
+| Run a standard workflow step (search, create, or update records) | $0.0001 | **10,000 runs per credit** |
+| Trigger an app's logic function | $0.0001 + $0.00001 per second of runtime | **~9,000 typical runs per credit** |
 | Call an external API or run a code node | A small fraction of a credit | Thousands per credit |
 | Send a quick AI chat message or simple AI step | A fraction of a cent | Hundreds per credit |
 | Run a large AI agent task (e.g. "configure 10 workspace objects") | Can run to **~$1 or more** | A few per credit |
@@ -28,6 +29,15 @@ For most teams, standard automations are effectively free — you'll only make a
 <Note>
 Not every app charges for its runs. Call Recorder and Last Contact react to every email and calendar event imported into your workspace, so their logic function runs are free. You are still charged for the metered work they do, such as recorded call minutes.
 </Note>
+
+## How logic function runs are metered
+
+Logic function pricing mirrors AWS Lambda: a flat charge per invocation plus a duration charge for the time your code actually runs, billed per millisecond.
+
+- **Per invocation**: $0.0001
+- **Per duration**: $0.00001 per second of runtime ($0.00000001 per millisecond)
+
+A typical function that finishes in under a second costs barely more than the flat invocation charge. Long-running functions pay for the compute they use: a function running for a full minute adds $0.0006, and one hitting the 15-minute timeout adds $0.009. A function that times out is billed for its full elapsed time, just like on AWS.
 
 ## How AI usage is metered
 

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -6,8 +6,6 @@ import {
 } from '@aws-sdk/client-lambda';
 import { Logger } from '@nestjs/common';
 
-import { isNonEmptyString } from '@sniptt/guards';
-
 import {
   type LogicFunctionDriver,
   type LogicFunctionExecuteParams,
@@ -204,7 +202,7 @@ export class LambdaDriver implements LogicFunctionDriver {
       const result = await lambdaClient.send(command, {
         abortSignal: AbortSignal.timeout(timeoutMs),
       });
-      const invokeSendMs = Date.now() - invokeStart;
+      const invokeDurationMs = Date.now() - invokeStart;
 
       const parsedResult = result.Payload
         ? JSON.parse(result.Payload.transformToString())
@@ -219,19 +217,16 @@ export class LambdaDriver implements LogicFunctionDriver {
       } = parseLambdaLogResult(result.LogResult);
 
       const duration = Date.now() - invokeFlowStart;
-      const parsedBilledDurationMs = isNonEmptyString(billedDurationMs)
-        ? Number(billedDurationMs)
-        : duration;
 
       this.logger.log(
-        `[lambda-timing] fnId=${flatLogicFunction.id} executionMode=${executionMode} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeSendMs=${invokeSendMs} reportDurationMs=${reportDurationMs ?? 'n/a'} billedMs=${billedDurationMs ?? 'n/a'} initDurationMs=${initDurationMs ?? 'n/a'} coldStart=${coldStart}`,
+        `[lambda-timing] fnId=${flatLogicFunction.id} executionMode=${executionMode} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeDurationMs=${invokeDurationMs} reportDurationMs=${reportDurationMs ?? 'n/a'} billedMs=${billedDurationMs ?? 'n/a'} initDurationMs=${initDurationMs ?? 'n/a'} coldStart=${coldStart}`,
       );
 
       if (result.FunctionError) {
         return {
           data: null,
           duration,
-          billedDurationMs: parsedBilledDurationMs,
+          billedDurationMs: invokeDurationMs,
           status: LogicFunctionExecutionStatus.ERROR,
           error: parsedResult,
           logs,
@@ -242,7 +237,7 @@ export class LambdaDriver implements LogicFunctionDriver {
         data: parsedResult,
         logs,
         duration,
-        billedDurationMs: parsedBilledDurationMs,
+        billedDurationMs: invokeDurationMs,
         status: LogicFunctionExecutionStatus.SUCCESS,
       };
     } catch (error) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -211,7 +211,7 @@ export class LambdaDriver implements LogicFunctionDriver {
       const {
         logs,
         initDurationMs,
-        billedDurationMs,
+        billedDurationMs: awsBilledDurationMs,
         reportDurationMs,
         coldStart,
       } = parseLambdaLogResult(result.LogResult);
@@ -219,7 +219,7 @@ export class LambdaDriver implements LogicFunctionDriver {
       const duration = Date.now() - invokeFlowStart;
 
       this.logger.log(
-        `[lambda-timing] fnId=${flatLogicFunction.id} executionMode=${executionMode} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeDurationMs=${invokeDurationMs} reportDurationMs=${reportDurationMs ?? 'n/a'} billedMs=${billedDurationMs ?? 'n/a'} initDurationMs=${initDurationMs ?? 'n/a'} coldStart=${coldStart}`,
+        `[lambda-timing] fnId=${flatLogicFunction.id} executionMode=${executionMode} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeDurationMs=${invokeDurationMs} reportDurationMs=${reportDurationMs ?? 'n/a'} awsBilledDurationMs=${awsBilledDurationMs ?? 'n/a'} initDurationMs=${initDurationMs ?? 'n/a'} coldStart=${coldStart}`,
       );
 
       if (result.FunctionError) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -6,6 +6,8 @@ import {
 } from '@aws-sdk/client-lambda';
 import { Logger } from '@nestjs/common';
 
+import { isNonEmptyString } from '@sniptt/guards';
+
 import {
   type LogicFunctionDriver,
   type LogicFunctionExecuteParams,
@@ -217,6 +219,9 @@ export class LambdaDriver implements LogicFunctionDriver {
       } = parseLambdaLogResult(result.LogResult);
 
       const duration = Date.now() - invokeFlowStart;
+      const parsedBilledDurationMs = isNonEmptyString(billedDurationMs)
+        ? Number(billedDurationMs)
+        : undefined;
 
       this.logger.log(
         `[lambda-timing] fnId=${flatLogicFunction.id} executionMode=${executionMode} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeSendMs=${invokeSendMs} reportDurationMs=${reportDurationMs ?? 'n/a'} billedMs=${billedDurationMs ?? 'n/a'} initDurationMs=${initDurationMs ?? 'n/a'} coldStart=${coldStart}`,
@@ -226,6 +231,7 @@ export class LambdaDriver implements LogicFunctionDriver {
         return {
           data: null,
           duration,
+          billedDurationMs: parsedBilledDurationMs,
           status: LogicFunctionExecutionStatus.ERROR,
           error: parsedResult,
           logs,
@@ -236,6 +242,7 @@ export class LambdaDriver implements LogicFunctionDriver {
         data: parsedResult,
         logs,
         duration,
+        billedDurationMs: parsedBilledDurationMs,
         status: LogicFunctionExecutionStatus.SUCCESS,
       };
     } catch (error) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -221,7 +221,7 @@ export class LambdaDriver implements LogicFunctionDriver {
       const duration = Date.now() - invokeFlowStart;
       const parsedBilledDurationMs = isNonEmptyString(billedDurationMs)
         ? Number(billedDurationMs)
-        : undefined;
+        : duration;
 
       this.logger.log(
         `[lambda-timing] fnId=${flatLogicFunction.id} executionMode=${executionMode} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeSendMs=${invokeSendMs} reportDurationMs=${reportDurationMs ?? 'n/a'} billedMs=${billedDurationMs ?? 'n/a'} initDurationMs=${initDurationMs ?? 'n/a'} coldStart=${coldStart}`,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/build-logic-function-timeout-result.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/build-logic-function-timeout-result.util.ts
@@ -7,6 +7,7 @@ export const buildLogicFunctionTimeoutResult = (
   data: null,
   logs: '',
   duration: timeoutMs,
+  billedDurationMs: timeoutMs,
   status: LogicFunctionExecutionStatus.ERROR,
   error: {
     errorType: 'TimeoutError',

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
@@ -230,6 +230,7 @@ export class LocalDriver implements LogicFunctionDriver {
             data: (result ?? null) as object | null,
             logs,
             duration,
+            billedDurationMs: duration,
             status: LogicFunctionExecutionStatus.SUCCESS,
           };
         }
@@ -238,6 +239,7 @@ export class LocalDriver implements LogicFunctionDriver {
           data: null,
           logs,
           duration,
+          billedDurationMs: duration,
           error: {
             errorType: errorType ?? 'UnhandledError',
             errorMessage: error || 'Unknown error',

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface.ts
@@ -14,6 +14,9 @@ export type LogicFunctionExecuteError = {
 export type LogicFunctionExecuteResult = {
   data: object | null;
   duration: number;
+  // AWS-billed duration from the lambda execution report; absent for drivers
+  // that have no billing report, in which case duration is the fallback.
+  billedDurationMs?: number;
   logs: string;
   status: LogicFunctionExecutionStatus;
   error?: LogicFunctionExecuteError;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface.ts
@@ -14,9 +14,7 @@ export type LogicFunctionExecuteError = {
 export type LogicFunctionExecuteResult = {
   data: object | null;
   duration: number;
-  // AWS-billed duration from the lambda execution report; absent for drivers
-  // that have no billing report, in which case duration is the fallback.
-  billedDurationMs?: number;
+  billedDurationMs: number;
   logs: string;
   status: LogicFunctionExecutionStatus;
   error?: LogicFunctionExecuteError;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/constants/logic-function-billing.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/constants/logic-function-billing.constant.ts
@@ -1,0 +1,8 @@
+// Flat charge per invocation: $0.0001 (1 micro credit = $0.000001).
+export const LOGIC_FUNCTION_INVOCATION_CREDITS_MICRO = 100;
+
+// Duration is billed like AWS Lambda, which prices $0.0000166667 per GB-second
+// on top of the per-request charge. Executor lambdas run at 512MB, so the raw
+// AWS duration cost is ~8.3 micro credits per second; rounded up to 10 micro
+// credits per second (0.01 per ms) to cover infrastructure overhead.
+export const LOGIC_FUNCTION_DURATION_CREDITS_MICRO_PER_MS = 0.01;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/constants/logic-function-billing.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/constants/logic-function-billing.constant.ts
@@ -1,8 +1,5 @@
 // Flat charge per invocation: $0.0001 (1 micro credit = $0.000001).
 export const LOGIC_FUNCTION_INVOCATION_CREDITS_MICRO = 100;
 
-// Duration is billed like AWS Lambda, which prices $0.0000166667 per GB-second
-// on top of the per-request charge. Executor lambdas run at 512MB, so the raw
-// AWS duration cost is ~8.3 micro credits per second; rounded up to 10 micro
-// credits per second (0.01 per ms) to cover infrastructure overhead.
+// Charge per seconds: $0.00001
 export const LOGIC_FUNCTION_DURATION_CREDITS_MICRO_PER_MS = 0.01;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/constants/logic-function-billing.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/constants/logic-function-billing.constant.ts
@@ -1,5 +1,5 @@
 // Flat charge per invocation: $0.0001 (1 micro credit = $0.000001).
 export const LOGIC_FUNCTION_INVOCATION_CREDITS_MICRO = 100;
 
-// Charge per seconds: $0.00001
-export const LOGIC_FUNCTION_DURATION_CREDITS_MICRO_PER_MS = 0.01;
+// Charge per seconds: $0.0001
+export const LOGIC_FUNCTION_DURATION_CREDITS_MICRO_PER_MS = 0.1;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -604,7 +604,7 @@ export class LogicFunctionExecutorService {
     // and stay untouched.
     const { invocationCreditsMicro, durationCreditsMicro, billedDurationMs } =
       computeLogicFunctionExecutionCreditsMicro({
-        durationMs: result.billedDurationMs ?? result.duration,
+        durationMs: result.billedDurationMs,
         isBillingExempt: isBillingExemptApplication(
           flatApplication.universalIdentifier,
         ),

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -602,7 +602,7 @@ export class LogicFunctionExecutorService {
     // workspace's credits for the execution itself. Explicit chargeCredits
     // calls and AI token usage from within the function are billed separately
     // and stay untouched.
-    const { invocationCreditsMicro, durationCreditsMicro } =
+    const { invocationCreditsMicro, durationCreditsMicro, billedDurationMs } =
       computeLogicFunctionExecutionCreditsMicro({
         durationMs: result.duration,
         isBillingExempt: isBillingExemptApplication(
@@ -632,9 +632,6 @@ export class LogicFunctionExecutorService {
       }
     }
 
-    // Mirrors AWS Lambda's pricing shape: a flat per-request charge plus a
-    // separate duration charge, kept as two events so usage reporting can
-    // attribute each component.
     this.workspaceEventEmitter.emitCustomBatchEvent<UsageEvent>(
       USAGE_RECORDED,
       [
@@ -651,7 +648,7 @@ export class LogicFunctionExecutorService {
           resourceType: UsageResourceType.LOGIC_FUNCTION,
           operationType: UsageOperationType.CODE_EXECUTION,
           creditsUsedMicro: durationCreditsMicro,
-          quantity: Math.max(Math.round(result.duration), 0),
+          quantity: billedDurationMs,
           unit: UsageUnit.MILLISECOND,
           resourceId: flatLogicFunction.id,
           periodStart,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -41,6 +41,7 @@ import { BillingService } from 'src/engine/core-modules/billing/services/billing
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { LogicFunctionDriverFactory } from 'src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory';
+import { computeLogicFunctionExecutionCreditsMicro } from 'src/engine/core-modules/logic-function/logic-function-executor/utils/compute-logic-function-execution-credits-micro.util';
 import { SecretEncryptionService } from 'src/engine/core-modules/secret-encryption/secret-encryption.service';
 import { ThrottlerService } from 'src/engine/core-modules/throttler/throttler.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
@@ -598,14 +599,18 @@ export class LogicFunctionExecutorService {
 
     // Billing-exempt apps (first-party maintenance apps whose per-record
     // triggers fire during mailbox/calendar import) do not consume the
-    // workspace's credits for the invocation itself. Explicit chargeCredits
+    // workspace's credits for the execution itself. Explicit chargeCredits
     // calls and AI token usage from within the function are billed separately
     // and stay untouched.
-    const creditsUsedMicro = isBillingExemptApplication(
-      flatApplication.universalIdentifier,
-    )
-      ? 0
-      : 100;
+    const { invocationCreditsMicro, durationCreditsMicro } =
+      computeLogicFunctionExecutionCreditsMicro({
+        durationMs: result.duration,
+        isBillingExempt: isBillingExemptApplication(
+          flatApplication.universalIdentifier,
+        ),
+      });
+
+    const totalCreditsMicro = invocationCreditsMicro + durationCreditsMicro;
 
     let periodStart: Date | undefined;
 
@@ -618,24 +623,36 @@ export class LogicFunctionExecutorService {
       if (currentBillingSubscription !== NO_BILLING_SUBSCRIPTION) {
         periodStart = currentBillingSubscription.currentPeriodStart;
 
-        if (creditsUsedMicro > 0) {
+        if (totalCreditsMicro > 0) {
           await this.billingUsageService.decrementAvailableCreditsInCache({
             workspaceId,
-            usedCredits: creditsUsedMicro,
+            usedCredits: totalCreditsMicro,
           });
         }
       }
     }
 
+    // Mirrors AWS Lambda's pricing shape: a flat per-request charge plus a
+    // separate duration charge, kept as two events so usage reporting can
+    // attribute each component.
     this.workspaceEventEmitter.emitCustomBatchEvent<UsageEvent>(
       USAGE_RECORDED,
       [
         {
           resourceType: UsageResourceType.LOGIC_FUNCTION,
           operationType: UsageOperationType.CODE_EXECUTION,
-          creditsUsedMicro,
+          creditsUsedMicro: invocationCreditsMicro,
           quantity: 1,
           unit: UsageUnit.INVOCATION,
+          resourceId: flatLogicFunction.id,
+          periodStart,
+        },
+        {
+          resourceType: UsageResourceType.LOGIC_FUNCTION,
+          operationType: UsageOperationType.CODE_EXECUTION,
+          creditsUsedMicro: durationCreditsMicro,
+          quantity: Math.max(Math.round(result.duration), 0),
+          unit: UsageUnit.MILLISECOND,
           resourceId: flatLogicFunction.id,
           periodStart,
         },

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -604,7 +604,7 @@ export class LogicFunctionExecutorService {
     // and stay untouched.
     const { invocationCreditsMicro, durationCreditsMicro, billedDurationMs } =
       computeLogicFunctionExecutionCreditsMicro({
-        durationMs: result.duration,
+        durationMs: result.billedDurationMs ?? result.duration,
         isBillingExempt: isBillingExemptApplication(
           flatApplication.universalIdentifier,
         ),

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/__tests__/compute-logic-function-execution-credits-micro.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/__tests__/compute-logic-function-execution-credits-micro.util.spec.ts
@@ -9,7 +9,7 @@ describe('computeLogicFunctionExecutionCreditsMicro', () => {
       }),
     ).toEqual({
       invocationCreditsMicro: 100,
-      durationCreditsMicro: 10,
+      durationCreditsMicro: 100,
       billedDurationMs: 1_000,
     });
   });
@@ -17,13 +17,13 @@ describe('computeLogicFunctionExecutionCreditsMicro', () => {
   it('rounds duration credits down to the previous micro credit', () => {
     expect(
       computeLogicFunctionExecutionCreditsMicro({
-        durationMs: 99,
+        durationMs: 9,
         isBillingExempt: false,
       }),
     ).toEqual({
       invocationCreditsMicro: 100,
       durationCreditsMicro: 0,
-      billedDurationMs: 99,
+      billedDurationMs: 9,
     });
 
     expect(
@@ -33,7 +33,7 @@ describe('computeLogicFunctionExecutionCreditsMicro', () => {
       }),
     ).toEqual({
       invocationCreditsMicro: 100,
-      durationCreditsMicro: 1,
+      durationCreditsMicro: 15,
       billedDurationMs: 155,
     });
   });
@@ -70,7 +70,7 @@ describe('computeLogicFunctionExecutionCreditsMicro', () => {
       }),
     ).toEqual({
       invocationCreditsMicro: 100,
-      durationCreditsMicro: 9_000,
+      durationCreditsMicro: 90_000,
       billedDurationMs: 900_000,
     });
   });

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/__tests__/compute-logic-function-execution-credits-micro.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/__tests__/compute-logic-function-execution-credits-micro.util.spec.ts
@@ -7,23 +7,35 @@ describe('computeLogicFunctionExecutionCreditsMicro', () => {
         durationMs: 1_000,
         isBillingExempt: false,
       }),
-    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 10 });
+    ).toEqual({
+      invocationCreditsMicro: 100,
+      durationCreditsMicro: 10,
+      billedDurationMs: 1_000,
+    });
   });
 
-  it('rounds duration credits up to the next micro credit', () => {
+  it('rounds duration credits down to the previous micro credit', () => {
     expect(
       computeLogicFunctionExecutionCreditsMicro({
-        durationMs: 1,
+        durationMs: 99,
         isBillingExempt: false,
       }),
-    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 1 });
+    ).toEqual({
+      invocationCreditsMicro: 100,
+      durationCreditsMicro: 0,
+      billedDurationMs: 99,
+    });
 
     expect(
       computeLogicFunctionExecutionCreditsMicro({
-        durationMs: 150,
+        durationMs: 155,
         isBillingExempt: false,
       }),
-    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 2 });
+    ).toEqual({
+      invocationCreditsMicro: 100,
+      durationCreditsMicro: 1,
+      billedDurationMs: 155,
+    });
   });
 
   it('charges no duration credits for a zero or negative duration', () => {
@@ -32,14 +44,22 @@ describe('computeLogicFunctionExecutionCreditsMicro', () => {
         durationMs: 0,
         isBillingExempt: false,
       }),
-    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 0 });
+    ).toEqual({
+      invocationCreditsMicro: 100,
+      durationCreditsMicro: 0,
+      billedDurationMs: 0,
+    });
 
     expect(
       computeLogicFunctionExecutionCreditsMicro({
         durationMs: -5,
         isBillingExempt: false,
       }),
-    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 0 });
+    ).toEqual({
+      invocationCreditsMicro: 100,
+      durationCreditsMicro: 0,
+      billedDurationMs: 0,
+    });
   });
 
   it('bills the full timeout duration of a timed out execution', () => {
@@ -48,7 +68,11 @@ describe('computeLogicFunctionExecutionCreditsMicro', () => {
         durationMs: 900_000,
         isBillingExempt: false,
       }),
-    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 9_000 });
+    ).toEqual({
+      invocationCreditsMicro: 100,
+      durationCreditsMicro: 9_000,
+      billedDurationMs: 900_000,
+    });
   });
 
   it('charges nothing for billing-exempt applications', () => {
@@ -57,6 +81,10 @@ describe('computeLogicFunctionExecutionCreditsMicro', () => {
         durationMs: 5_000,
         isBillingExempt: true,
       }),
-    ).toEqual({ invocationCreditsMicro: 0, durationCreditsMicro: 0 });
+    ).toEqual({
+      invocationCreditsMicro: 0,
+      durationCreditsMicro: 0,
+      billedDurationMs: 0,
+    });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/__tests__/compute-logic-function-execution-credits-micro.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/__tests__/compute-logic-function-execution-credits-micro.util.spec.ts
@@ -1,0 +1,62 @@
+import { computeLogicFunctionExecutionCreditsMicro } from 'src/engine/core-modules/logic-function/logic-function-executor/utils/compute-logic-function-execution-credits-micro.util';
+
+describe('computeLogicFunctionExecutionCreditsMicro', () => {
+  it('charges the flat invocation fee plus duration', () => {
+    expect(
+      computeLogicFunctionExecutionCreditsMicro({
+        durationMs: 1_000,
+        isBillingExempt: false,
+      }),
+    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 10 });
+  });
+
+  it('rounds duration credits up to the next micro credit', () => {
+    expect(
+      computeLogicFunctionExecutionCreditsMicro({
+        durationMs: 1,
+        isBillingExempt: false,
+      }),
+    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 1 });
+
+    expect(
+      computeLogicFunctionExecutionCreditsMicro({
+        durationMs: 150,
+        isBillingExempt: false,
+      }),
+    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 2 });
+  });
+
+  it('charges no duration credits for a zero or negative duration', () => {
+    expect(
+      computeLogicFunctionExecutionCreditsMicro({
+        durationMs: 0,
+        isBillingExempt: false,
+      }),
+    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 0 });
+
+    expect(
+      computeLogicFunctionExecutionCreditsMicro({
+        durationMs: -5,
+        isBillingExempt: false,
+      }),
+    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 0 });
+  });
+
+  it('bills the full timeout duration of a timed out execution', () => {
+    expect(
+      computeLogicFunctionExecutionCreditsMicro({
+        durationMs: 900_000,
+        isBillingExempt: false,
+      }),
+    ).toEqual({ invocationCreditsMicro: 100, durationCreditsMicro: 9_000 });
+  });
+
+  it('charges nothing for billing-exempt applications', () => {
+    expect(
+      computeLogicFunctionExecutionCreditsMicro({
+        durationMs: 5_000,
+        isBillingExempt: true,
+      }),
+    ).toEqual({ invocationCreditsMicro: 0, durationCreditsMicro: 0 });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/compute-logic-function-execution-credits-micro.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/compute-logic-function-execution-credits-micro.util.ts
@@ -9,16 +9,26 @@ export const computeLogicFunctionExecutionCreditsMicro = ({
 }: {
   durationMs: number;
   isBillingExempt: boolean;
-}): { invocationCreditsMicro: number; durationCreditsMicro: number } => {
+}): {
+  invocationCreditsMicro: number;
+  durationCreditsMicro: number;
+  billedDurationMs: number;
+} => {
   if (isBillingExempt) {
-    return { invocationCreditsMicro: 0, durationCreditsMicro: 0 };
+    return {
+      invocationCreditsMicro: 0,
+      durationCreditsMicro: 0,
+      billedDurationMs: 0,
+    };
   }
+
+  const billedDurationMs = Math.max(Math.floor(durationMs), 0);
 
   return {
     invocationCreditsMicro: LOGIC_FUNCTION_INVOCATION_CREDITS_MICRO,
-    // Rounded up like AWS bills per started millisecond.
-    durationCreditsMicro: Math.ceil(
-      Math.max(durationMs, 0) * LOGIC_FUNCTION_DURATION_CREDITS_MICRO_PER_MS,
+    durationCreditsMicro: Math.floor(
+      billedDurationMs * LOGIC_FUNCTION_DURATION_CREDITS_MICRO_PER_MS,
     ),
+    billedDurationMs,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/compute-logic-function-execution-credits-micro.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/utils/compute-logic-function-execution-credits-micro.util.ts
@@ -1,0 +1,24 @@
+import {
+  LOGIC_FUNCTION_DURATION_CREDITS_MICRO_PER_MS,
+  LOGIC_FUNCTION_INVOCATION_CREDITS_MICRO,
+} from 'src/engine/core-modules/logic-function/logic-function-executor/constants/logic-function-billing.constant';
+
+export const computeLogicFunctionExecutionCreditsMicro = ({
+  durationMs,
+  isBillingExempt,
+}: {
+  durationMs: number;
+  isBillingExempt: boolean;
+}): { invocationCreditsMicro: number; durationCreditsMicro: number } => {
+  if (isBillingExempt) {
+    return { invocationCreditsMicro: 0, durationCreditsMicro: 0 };
+  }
+
+  return {
+    invocationCreditsMicro: LOGIC_FUNCTION_INVOCATION_CREDITS_MICRO,
+    // Rounded up like AWS bills per started millisecond.
+    durationCreditsMicro: Math.ceil(
+      Math.max(durationMs, 0) * LOGIC_FUNCTION_DURATION_CREDITS_MICRO_PER_MS,
+    ),
+  };
+};

--- a/packages/twenty-server/src/engine/core-modules/usage/enums/usage-unit.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/usage/enums/usage-unit.enum.ts
@@ -5,6 +5,7 @@ export enum UsageUnit {
   TOKEN = 'TOKEN',
   INVOCATION = 'INVOCATION',
   MINUTE = 'MINUTE',
+  MILLISECOND = 'MILLISECOND',
   BYTE = 'BYTE',
   REQUEST = 'REQUEST',
 }

--- a/packages/twenty-server/test/integration/metadata/suites/application/application-uninstall-retry.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/application-uninstall-retry.integration-spec.ts
@@ -28,6 +28,7 @@ type InstalledApplication = {
 const SUCCESSFUL_EXECUTION_RESULT = {
   data: {},
   duration: 1,
+  billedDurationMs: 1,
   logs: '',
   status: LogicFunctionExecutionStatus.SUCCESS,
 };
@@ -35,6 +36,7 @@ const SUCCESSFUL_EXECUTION_RESULT = {
 const FAILED_EXECUTION_RESULT = {
   data: null,
   duration: 1,
+  billedDurationMs: 1,
   logs: '',
   status: LogicFunctionExecutionStatus.ERROR,
   error: {

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-uninstall-application-logic-function-hook.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-uninstall-application-logic-function-hook.integration-spec.ts
@@ -113,6 +113,7 @@ describe('Uninstall application logic function hook', () => {
       .mockResolvedValue({
         data: {},
         duration: 1,
+        billedDurationMs: 1,
         logs: '',
         status: LogicFunctionExecutionStatus.SUCCESS,
       });
@@ -241,6 +242,7 @@ describe('Uninstall application logic function hook', () => {
     executeSpy.mockResolvedValue({
       data: null,
       duration: 1,
+      billedDurationMs: 1,
       logs: '',
       status: LogicFunctionExecutionStatus.ERROR,
       error: {

--- a/packages/twenty-server/test/integration/metadata/suites/application/workspace-deletion-runs-uninstall-hooks.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/workspace-deletion-runs-uninstall-hooks.integration-spec.ts
@@ -83,6 +83,7 @@ describe('Workspace deletion runs application uninstall hooks', () => {
       .mockResolvedValue({
         data: {},
         duration: 1,
+        billedDurationMs: 1,
         logs: '',
         status: LogicFunctionExecutionStatus.SUCCESS,
       });


### PR DESCRIPTION
## Context

Logic function (lambda) executions were billed a flat 100 micro credits ($0.0001) per invocation, regardless of how long the function ran. AWS Lambda, which runs these executions, charges a per-request fee plus a duration fee per millisecond, so a 15-minute run cost us far more than a 50ms run while both were billed the same.

## Pricing

Duration is billed at **0.1 micro credits per millisecond** ($0.0001 per second), on top of the unchanged flat invocation charge:

| Component | Rate |
|-----------|------|
| Per invocation | 100 micro credits ($0.0001) |
| Per duration | 0.1 micro credits/ms ($0.0001 per second) |

For reference, AWS Lambda duration pricing is $0.0000166667 per GB-second, so raw AWS cost at the 512MB executor size is ~8.3 micro credits per second; the rate covers infrastructure overhead beyond the lambda itself. Examples: a 1s run costs 200 micro credits; a 1-minute run costs 6,100; a run hitting the 900s executor timeout costs 90,100 ($0.09). Timed-out executions are billed for their full elapsed time, like on AWS.

## Changes

- `computeLogicFunctionExecutionCreditsMicro` util computes the invocation and duration components plus the `billedDurationMs`, rounding duration credits down to the whole micro credit and keeping billing-exempt applications free; the constants live in `logic-function-billing.constant.ts`
- `LogicFunctionExecutorService.handleExecutionResult` decrements the credit cache by the combined total and emits two `CODE_EXECUTION` usage events per run: the existing `INVOCATION` event and a new `MILLISECOND` event carrying the billed duration and its credits, mirroring AWS's request + duration line items so usage reporting can attribute each component
- Added `MILLISECOND` to `UsageUnit` (stored as `LowCardinality(String)` in ClickHouse, so no migration needed; usage analytics aggregate `creditsUsedMicro` only, so the extra event doesn't skew existing breakdowns)
- Docs: `user-guide/billing/capabilities/credits.mdx` gets the duration rate and a "How logic function runs are metered" section; `developers/extend/apps/logic/logic-functions.mdx` gets a note that runtime is billed per millisecond

## Testing

- New unit tests for the credit computation (flat + duration, round-down, zero/negative duration, timeout, billing-exempt)
- `nx lint:diff-with-main twenty-server` and `tsgo --noEmit` clean on changed files; usage module test suites pass