### PR TITLE
Fix front component translation message IDs

### DIFF
--- a/packages/twenty-shared/src/i18n/__tests__/generate-message-id.spec.ts
+++ b/packages/twenty-shared/src/i18n/__tests__/generate-message-id.spec.ts
@@ -10,8 +10,31 @@ describe('generateMessageId', () => {
     ['A company', 'kZR6+h'],
     ['12HRS', '0eYXBl'],
     ['{fieldType} fields cannot be unique.', 'ZkHTHm'],
+    ['This week', 'yByRxz'],
   ])('matches the Lingui-generated id for %p', (message, expectedId) => {
     expect(generateMessageId(message)).toBe(expectedId);
+  });
+
+  it('does not depend on a Buffer global provided by the worker host', () => {
+    const originalBuffer = globalThis.Buffer;
+
+    Object.defineProperty(globalThis, 'Buffer', {
+      configurable: true,
+      value: {
+        from: () => ({ toString: () => 'wrong-message-id' }),
+      },
+    });
+
+    try {
+      expect(generateMessageId('Front component host Buffer isolation')).toBe(
+        't1LltP',
+      );
+    } finally {
+      Object.defineProperty(globalThis, 'Buffer', {
+        configurable: true,
+        value: originalBuffer,
+      });
+    }
   });
 
   it('returns a six-character id', () => {

--- a/packages/twenty-shared/src/i18n/generate-message-id.ts
+++ b/packages/twenty-shared/src/i18n/generate-message-id.ts
@@ -15,10 +15,37 @@ const MAX_CACHED_MESSAGE_IDS = 50_000;
 
 const messageIdByCacheKey = new Map<string, string>();
 
-const toBase64 = (bytes: Uint8Array): string =>
-  typeof Buffer !== 'undefined'
-    ? Buffer.from(bytes).toString('base64')
-    : btoa(String.fromCharCode(...bytes));
+const BASE64_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+// Front-component libraries can define Node-like globals in the worker. Keep
+// message ids independent from those mutable globals so build and runtime agree.
+const toBase64 = (bytes: Uint8Array): string => {
+  let encoded = '';
+
+  for (let offset = 0; offset < bytes.length; offset += 3) {
+    const firstByte = bytes[offset];
+    const secondByte = bytes[offset + 1];
+    const thirdByte = bytes[offset + 2];
+
+    encoded += BASE64_ALPHABET.charAt(firstByte >> 2);
+    encoded += BASE64_ALPHABET.charAt(
+      ((firstByte & 0b00000011) << 4) | ((secondByte ?? 0) >> 4),
+    );
+    encoded +=
+      secondByte === undefined
+        ? '='
+        : BASE64_ALPHABET.charAt(
+            ((secondByte & 0b00001111) << 2) | ((thirdByte ?? 0) >> 6),
+          );
+    encoded +=
+      thirdByte === undefined
+        ? '='
+        : BASE64_ALPHABET.charAt(thirdByte & 0b00111111);
+  }
+
+  return encoded;
+};
 
 export const generateMessageId = (message: string, context = ''): string => {
   const cacheKey = message + UNIT_SEPARATOR + (context || '');


### PR DESCRIPTION
Fixes #24890

## What changed

- encode Lingui message IDs without reading mutable worker `Buffer` or `btoa` globals
- pin the reported `This week` → `yByRxz` mapping
- cover lookup when the worker exposes an incompatible `Buffer`

This keeps catalog compilation and front-component runtime lookup byte-identical across realms.

## Verification

- twenty-shared message ID spec (8 tests)
- twenty-sdk translation specs (8 tests)
- twenty-shared and twenty-sdk typechecks
- Prettier and Oxlint on changed files
- rebuilt front-component artifact resolves `Esta semana` with a poisoned `Buffer` global
- 10,000 generated IDs matched Node SHA-256/Base64 output

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

