### PR TITLE
fix(front): let VIEW navigation menu items use their own color

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/common/utils/__tests__/getNavigationMenuItemColor.test.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/utils/__tests__/getNavigationMenuItemColor.test.ts
@@ -1,0 +1,41 @@
+import { NavigationMenuItemType } from 'twenty-shared/types';
+
+import { getNavigationMenuItemColor } from '@/navigation-menu-item/common/utils/getNavigationMenuItemColor';
+
+describe('getNavigationMenuItemColor', () => {
+  it('returns the folder own color when set', () => {
+    expect(
+      getNavigationMenuItemColor({
+        type: NavigationMenuItemType.FOLDER,
+        color: 'blue',
+      }),
+    ).toBe('blue');
+  });
+
+  it('returns the view own color when set', () => {
+    expect(
+      getNavigationMenuItemColor({
+        type: NavigationMenuItemType.VIEW,
+        color: 'orange',
+      }),
+    ).toBe('orange');
+  });
+
+  it('falls back to the object color for a view without its own color', () => {
+    expect(
+      getNavigationMenuItemColor(
+        { type: NavigationMenuItemType.VIEW, color: null },
+        { nameSingular: 'opportunity', color: 'red', isSystem: false },
+      ),
+    ).toBe('red');
+  });
+
+  it('uses the object color for OBJECT items regardless of any color field', () => {
+    expect(
+      getNavigationMenuItemColor(
+        { type: NavigationMenuItemType.OBJECT, color: 'orange' },
+        { nameSingular: 'opportunity', color: 'red', isSystem: false },
+      ),
+    ).toBe('red');
+  });
+});

--- a/packages/twenty-front/src/modules/navigation-menu-item/common/utils/getNavigationMenuItemColor.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/utils/getNavigationMenuItemColor.ts
@@ -38,6 +38,13 @@ export const getNavigationMenuItemColor = (
     navigationMenuItem.type === NavigationMenuItemType.OBJECT ||
     navigationMenuItem.type === NavigationMenuItemType.VIEW
   ) {
+    if (
+      navigationMenuItem.type === NavigationMenuItemType.VIEW &&
+      isNonEmptyString(navigationMenuItem.color)
+    ) {
+      return navigationMenuItem.color as ThemeColor;
+    }
+
     if (objectMetadataItem) {
       return getObjectColorWithFallback(objectMetadataItem);
     }

--- a/packages/twenty-front/src/modules/navigation-menu-item/common/utils/hasNavigationMenuItemOwnColor.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/utils/hasNavigationMenuItemOwnColor.ts
@@ -1,4 +1,5 @@
 import { NavigationMenuItemType } from 'twenty-shared/types';
 
 export const hasNavigationMenuItemOwnColor = (item: { type?: string | null }) =>
-  item.type === NavigationMenuItemType.FOLDER;
+  item.type === NavigationMenuItemType.FOLDER ||
+  item.type === NavigationMenuItemType.VIEW;


### PR DESCRIPTION
## Problem

Favorite/pinned items of type `VIEW` (e.g. a Kanban board) always render with the color of their underlying object (via `getObjectColorWithFallback`), ignoring their own `color` field entirely. This makes it impossible to give several views on the same object (e.g. multiple Kanban pipelines all built on `Opportunity`) distinct colors in the sidebar, even though the `navigationMenuItem.color` field already exists and is already honored for `FOLDER` and `PAGE_LAYOUT` types.

## Fix

- `getNavigationMenuItemColor`: for `VIEW` items, use `navigationMenuItem.color` when it is a non-empty string, otherwise fall back to the existing object-color behavior (no change for `OBJECT` items, no change when a view has no color set).
- `hasNavigationMenuItemOwnColor`: added `VIEW` alongside `FOLDER` so any UI relying on this helper knows views can carry their own color.
- Added unit tests covering: folder own color (existing), view own color (new), view fallback to object color when unset (new), and object items still ignoring any color field (regression guard).

## Why

Backward compatible — a view without an explicit color keeps today's exact behavior. This only changes rendering for views that already have a `color` value set.

---
*Cette pull request a été écrite par une IA (Claude Code) pour le compte de l'utilisateur.*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

