### PR TITLE
Align timeline event icons with their row text

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/EventRow.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/EventRow.tsx
@@ -4,6 +4,7 @@ import { useContext } from 'react';
 
 import { TimelineActivityContext } from '@/activities/timeline-activities/contexts/TimelineActivityContext';
 
+import { TIMELINE_ICON_SLOT_SIZE } from '@/activities/timeline-activities/constants/TimelineIconSlotSize';
 import { EventIconDynamicComponent } from '@/activities/timeline-activities/rows/components/EventIconDynamicComponent';
 import { EventRowDynamicComponent } from '@/activities/timeline-activities/rows/components/EventRowDynamicComponent';
 import { getStandardTimelineActivityRenderer } from '@/activities/timeline-activities/rows/components/StandardTimelineActivityRenderer';
@@ -30,42 +31,36 @@ const StyledTimelineItemContainer = styled.div`
   color: ${themeCssVariables.font.color.primary};
   display: flex;
   gap: ${themeCssVariables.spacing[4]};
-  height: 'auto';
   justify-content: space-between;
   overflow: hidden;
   white-space: nowrap;
 `;
 
 const StyledLeftContainer = styled.div`
+  align-items: center;
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
+  width: ${TIMELINE_ICON_SLOT_SIZE}px;
 `;
 
 const StyledIconContainer = styled.div`
   align-items: center;
   color: ${themeCssVariables.font.color.tertiary};
   display: flex;
-  height: 16px;
-  justify-content: center;
-  margin: 5px;
-  text-decoration-line: underline;
-  user-select: none;
-  width: 16px;
-  z-index: 2;
-`;
-
-const StyledVerticalLineContainer = styled.div`
-  display: flex;
   flex-shrink: 0;
-  height: 100%;
+  height: ${TIMELINE_ICON_SLOT_SIZE}px;
   justify-content: center;
+  user-select: none;
+  width: 100%;
   z-index: 2;
 `;
 
 const StyledVerticalLine = styled.div`
   background: ${themeCssVariables.border.color.light};
-  height: 100%;
+  flex: 1;
   width: 2px;
+  z-index: 2;
 `;
 
 const StyledItemContainer = styled.div<{ isMarginBottom?: boolean }>`
@@ -76,7 +71,8 @@ const StyledItemContainer = styled.div<{ isMarginBottom?: boolean }>`
   gap: ${themeCssVariables.spacing[1]};
   margin-bottom: ${({ isMarginBottom }) =>
     isMarginBottom ? themeCssVariables.spacing[3] : '0'};
-  min-height: 26px;
+  min-height: ${TIMELINE_ICON_SLOT_SIZE}px;
+  min-width: 0;
   overflow: hidden;
 `;
 
@@ -189,11 +185,7 @@ export const EventRow = ({
               linkedObjectMetadataItem={linkedObjectMetadataItem}
             />
           </StyledIconContainer>
-          {!isLastEvent && (
-            <StyledVerticalLineContainer>
-              <StyledVerticalLine />
-            </StyledVerticalLineContainer>
-          )}
+          {!isLastEvent && <StyledVerticalLine />}
         </StyledLeftContainer>
         <StyledItemContainer isMarginBottom={!isLastEvent}>
           <EventRowDynamicComponent

--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/EventsGroup.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/EventsGroup.tsx
@@ -1,6 +1,7 @@
 import { styled } from '@linaria/react';
 
 import { EventRow } from '@/activities/timeline-activities/components/EventRow';
+import { TIMELINE_ICON_SLOT_SIZE } from '@/activities/timeline-activities/constants/TimelineIconSlotSize';
 import { type EventGroup } from '@/activities/timeline-activities/utils/groupEventsByMonth';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
@@ -27,17 +28,14 @@ const StyledActivityGroupContainer = styled.div`
 `;
 
 const StyledActivityGroupBar = styled.div`
-  align-items: center;
   background: ${themeCssVariables.background.secondary};
   border: 1px solid ${themeCssVariables.border.color.light};
   border-radius: ${themeCssVariables.border.radius.md};
-  display: flex;
-  flex-direction: column;
   height: 100%;
-  justify-content: center;
+  left: 0;
   position: absolute;
   top: 0;
-  width: 24px;
+  width: ${TIMELINE_ICON_SLOT_SIZE}px;
 `;
 
 const StyledMonthSeperator = styled.div`

--- a/packages/twenty-front/src/modules/activities/timeline-activities/constants/TimelineIconSlotSize.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/constants/TimelineIconSlotSize.ts
@@ -1,3 +1,2 @@
-// The icon square drives the rail width and the height of an event row's first
-// line, so icons, rail and row text all resolve to the same center.
+// One shared value is what keeps icon, rail and row text on the same center.
 export const TIMELINE_ICON_SLOT_SIZE = 26;

--- a/packages/twenty-front/src/modules/activities/timeline-activities/constants/TimelineIconSlotSize.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/constants/TimelineIconSlotSize.ts
@@ -1,0 +1,3 @@
+// The icon square drives the rail width and the height of an event row's first
+// line, so icons, rail and row text all resolve to the same center.
+export const TIMELINE_ICON_SLOT_SIZE = 26;

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventCardToggleButton.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventCardToggleButton.tsx
@@ -1,3 +1,4 @@
+import { TIMELINE_ICON_SLOT_SIZE } from '@/activities/timeline-activities/constants/TimelineIconSlotSize';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
 import { IconButton } from 'twenty-ui/input';
@@ -10,7 +11,11 @@ type EventCardToggleButtonProps = {
 };
 
 const StyledButtonContainer = styled.div`
+  align-items: center;
   border-radius: ${themeCssVariables.border.radius.sm};
+  display: flex;
+  flex-shrink: 0;
+  height: ${TIMELINE_ICON_SLOT_SIZE}px;
 `;
 
 export const EventCardToggleButton = ({

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventIconDynamicComponent.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventIconDynamicComponent.tsx
@@ -2,6 +2,7 @@ import { ObjectMetadataIcon } from '@/object-metadata/components/ObjectMetadataI
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 import { useIcons } from 'twenty-ui/icon';
+import { useTheme } from 'twenty-ui/theme-constants';
 
 export const EventIconDynamicComponent = ({
   eventIcon,
@@ -11,6 +12,7 @@ export const EventIconDynamicComponent = ({
   linkedObjectMetadataItem: EnrichedObjectMetadataItem | null;
 }) => {
   const { getIcon } = useIcons();
+  const theme = useTheme();
 
   if (!isDefined(eventIcon)) {
     return <ObjectMetadataIcon objectMetadataItem={linkedObjectMetadataItem} />;
@@ -18,5 +20,5 @@ export const EventIconDynamicComponent = ({
 
   const EventIcon = getIcon(eventIcon);
 
-  return <EventIcon />;
+  return <EventIcon size={theme.icon.size.md} />;
 };

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowStyles.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventRowStyles.tsx
@@ -1,18 +1,28 @@
 import { styled } from '@linaria/react';
 
+import { TIMELINE_ICON_SLOT_SIZE } from '@/activities/timeline-activities/constants/TimelineIconSlotSize';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+export const StyledEventRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[1]};
+  width: 100%;
+`;
 
 export const StyledEventRowContainer = styled.div`
   align-items: center;
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
   justify-content: space-between;
+  min-height: ${TIMELINE_ICON_SLOT_SIZE}px;
 `;
 
 export const StyledEventRowContent = styled.div`
   align-items: center;
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
+  min-width: 0;
   overflow: hidden;
 `;
 

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/generic/components/EventRowGenericLinked.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/generic/components/EventRowGenericLinked.tsx
@@ -8,6 +8,7 @@ import { type EventRowNativeComponentProps } from '@/activities/timeline-activit
 import { EventRowItem } from '@/activities/timeline-activities/rows/components/EventRowItem';
 import { getAuthorizedLinkedRecordName } from '@/activities/timeline-activities/rows/generic/utils/getAuthorizedLinkedRecordName';
 import {
+  StyledEventRow,
   StyledEventRowContainer,
   StyledEventRowContent,
   StyledEventRowLinkedRecord,
@@ -20,17 +21,8 @@ import { allowRequestsToTwentyIconsState } from '@/client-config/states/allowReq
 import { recordStoreIdentifierFamilySelector } from '@/object-record/record-store/states/selectors/recordStoreIdentifierFamilySelector';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { styled } from '@linaria/react';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 type EventRowGenericLinkedProps = EventRowNativeComponentProps;
-
-const StyledGenericLinkedContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${themeCssVariables.spacing[1]};
-  width: 100%;
-`;
 
 export const EventRowGenericLinked = ({
   event,
@@ -94,7 +86,7 @@ export const EventRowGenericLinked = ({
   };
 
   return (
-    <StyledGenericLinkedContainer>
+    <StyledEventRow>
       <StyledEventRowContainer>
         <StyledEventRowContent>
           <EventRowItem>{authorFullName}</EventRowItem>
@@ -126,6 +118,6 @@ export const EventRowGenericLinked = ({
           />
         </EventCard>
       )}
-    </StyledGenericLinkedContainer>
+    </StyledEventRow>
   );
 };

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
@@ -1,34 +1,16 @@
 import { EventRowDate } from '@/activities/timeline-activities/rows/components/EventRowDate';
 import { type EventRowNativeComponentProps } from '@/activities/timeline-activities/rows/components/EventRowDynamicComponent.types';
 import { EventRowItem } from '@/activities/timeline-activities/rows/components/EventRowItem';
+import {
+  StyledEventRow,
+  StyledEventRowContainer,
+  StyledEventRowContent,
+} from '@/activities/timeline-activities/rows/components/EventRowStyles';
 import { EventRowMainObjectUpdated } from '@/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated';
-import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 type EventRowMainObjectProps = EventRowNativeComponentProps;
-
-const StyledMainContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${themeCssVariables.spacing[1]};
-  width: 100%;
-`;
-
-const StyledRowContainer = styled.div`
-  align-items: center;
-  display: flex;
-  gap: ${themeCssVariables.spacing[1]};
-  justify-content: space-between;
-`;
-
-const StyledRow = styled.div`
-  align-items: center;
-  display: flex;
-  gap: ${themeCssVariables.spacing[1]};
-  overflow: hidden;
-`;
 
 export const EventRowMainObject = ({
   authorFullName,
@@ -43,18 +25,18 @@ export const EventRowMainObject = ({
   switch (eventAction) {
     case 'created': {
       return (
-        <StyledMainContainer>
-          <StyledRowContainer>
-            <StyledRow>
+        <StyledEventRow>
+          <StyledEventRowContainer>
+            <StyledEventRowContent>
               <EventRowItem>{labelIdentifierValue}</EventRowItem>
               <EventRowItem variant="action">
                 {eventTypeLabel ?? t`was created by`}
               </EventRowItem>
               <EventRowItem>{authorFullName}</EventRowItem>
-            </StyledRow>
+            </StyledEventRowContent>
             <EventRowDate happensAt={happensAt} />
-          </StyledRowContainer>
-        </StyledMainContainer>
+          </StyledEventRowContainer>
+        </StyledEventRow>
       );
     }
     case 'updated': {
@@ -72,34 +54,34 @@ export const EventRowMainObject = ({
     }
     case 'deleted': {
       return (
-        <StyledMainContainer>
-          <StyledRowContainer>
-            <StyledRow>
+        <StyledEventRow>
+          <StyledEventRowContainer>
+            <StyledEventRowContent>
               <EventRowItem>{labelIdentifierValue}</EventRowItem>
               <EventRowItem variant="action">
                 {eventTypeLabel ?? t`was deleted by`}
               </EventRowItem>
               <EventRowItem>{authorFullName}</EventRowItem>
-            </StyledRow>
+            </StyledEventRowContent>
             <EventRowDate happensAt={happensAt} />
-          </StyledRowContainer>
-        </StyledMainContainer>
+          </StyledEventRowContainer>
+        </StyledEventRow>
       );
     }
     case 'restored': {
       return (
-        <StyledMainContainer>
-          <StyledRowContainer>
-            <StyledRow>
+        <StyledEventRow>
+          <StyledEventRowContainer>
+            <StyledEventRowContent>
               <EventRowItem>{labelIdentifierValue}</EventRowItem>
               <EventRowItem variant="action">
                 {eventTypeLabel ?? t`was restored by`}
               </EventRowItem>
               <EventRowItem>{authorFullName}</EventRowItem>
-            </StyledRow>
+            </StyledEventRowContent>
             <EventRowDate happensAt={happensAt} />
-          </StyledRowContainer>
-        </StyledMainContainer>
+          </StyledEventRowContainer>
+        </StyledEventRow>
       );
     }
     default: {
@@ -108,16 +90,16 @@ export const EventRowMainObject = ({
       }
 
       return (
-        <StyledMainContainer>
-          <StyledRowContainer>
-            <StyledRow>
+        <StyledEventRow>
+          <StyledEventRowContainer>
+            <StyledEventRowContent>
               <EventRowItem>{authorFullName}</EventRowItem>
               <EventRowItem variant="action">{eventTypeLabel}</EventRowItem>
               <EventRowItem>{labelIdentifierValue}</EventRowItem>
-            </StyledRow>
+            </StyledEventRowContent>
             <EventRowDate happensAt={happensAt} />
-          </StyledRowContainer>
-        </StyledMainContainer>
+          </StyledEventRowContainer>
+        </StyledEventRow>
       );
     }
   }

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated.tsx
@@ -1,4 +1,3 @@
-import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
 import { useState } from 'react';
 
@@ -6,10 +5,14 @@ import { EventCard } from '@/activities/timeline-activities/rows/components/Even
 import { EventCardToggleButton } from '@/activities/timeline-activities/rows/components/EventCardToggleButton';
 import { EventRowDate } from '@/activities/timeline-activities/rows/components/EventRowDate';
 import { EventRowItem } from '@/activities/timeline-activities/rows/components/EventRowItem';
+import {
+  StyledEventRow,
+  StyledEventRowContainer,
+  StyledEventRowContent,
+} from '@/activities/timeline-activities/rows/components/EventRowStyles';
 import { EventFieldDiffContainer } from '@/activities/timeline-activities/rows/main-object/components/EventFieldDiffContainer';
 import { type TimelineActivity } from '@/activities/timeline-activities/types/TimelineActivity';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 type EventRowMainObjectUpdatedProps = {
   mainObjectMetadataItem: EnrichedObjectMetadataItem;
@@ -20,27 +23,6 @@ type EventRowMainObjectUpdatedProps = {
   happensAt?: string;
   hasRenderer?: boolean;
 };
-
-const StyledRowContainer = styled.div`
-  align-items: center;
-  display: flex;
-  gap: ${themeCssVariables.spacing[1]};
-  justify-content: space-between;
-`;
-
-const StyledRow = styled.div`
-  align-items: center;
-  display: flex;
-  gap: ${themeCssVariables.spacing[1]};
-  overflow: hidden;
-`;
-
-const StyledEventRowMainObjectUpdatedContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${themeCssVariables.spacing[1]};
-  width: 100%;
-`;
 
 export const EventRowMainObjectUpdated = ({
   authorFullName,
@@ -59,18 +41,18 @@ export const EventRowMainObjectUpdated = ({
   const diffEntries = Object.entries(diff);
   if (diffEntries.length === 0) {
     return (
-      <StyledEventRowMainObjectUpdatedContainer>
-        <StyledRowContainer>
-          <StyledRow>
+      <StyledEventRow>
+        <StyledEventRowContainer>
+          <StyledEventRowContent>
             <EventRowItem>{authorFullName}</EventRowItem>
             <EventRowItem variant="action">
               {eventTypeLabel ?? t`updated`}
             </EventRowItem>
             <EventRowItem>{labelIdentifierValue}</EventRowItem>
-          </StyledRow>
+          </StyledEventRowContent>
           <EventRowDate happensAt={happensAt} />
-        </StyledRowContainer>
-      </StyledEventRowMainObjectUpdatedContainer>
+        </StyledEventRowContainer>
+      </StyledEventRow>
     );
   }
 
@@ -78,9 +60,9 @@ export const EventRowMainObjectUpdated = ({
   const recordLabel = labelIdentifierValue;
 
   return (
-    <StyledEventRowMainObjectUpdatedContainer>
-      <StyledRowContainer>
-        <StyledRow>
+    <StyledEventRow>
+      <StyledEventRowContainer>
+        <StyledEventRowContent>
           <EventRowItem>{authorFullName}</EventRowItem>
           <EventRowItem variant="action">
             {eventTypeLabel ?? t`updated`}
@@ -101,9 +83,9 @@ export const EventRowMainObjectUpdated = ({
               )}
             </>
           )}
-        </StyledRow>
+        </StyledEventRowContent>
         <EventRowDate happensAt={happensAt} />
-      </StyledRowContainer>
+      </StyledEventRowContainer>
       {diffEntries.length > 1 && !hasRenderer && (
         <EventCard isOpen={isOpen}>
           {diffEntries.map(([diffKey, diffValue]) => (
@@ -117,6 +99,6 @@ export const EventRowMainObjectUpdated = ({
           ))}
         </EventCard>
       )}
-    </StyledEventRowMainObjectUpdatedContainer>
+    </StyledEventRow>
   );
 };


### PR DESCRIPTION
Timeline event icons sat lower than the text they belong to, and the offset changed depending on the row type.

### What was wrong

Measured on the rendered components (`getBoundingClientRect`, icon glyph center vs. row first-line center):

| | before | after |
|---|---|---|
| plain text row (created / deleted / restored) | icon **5px** low | 0px |
| row with an inline field diff (24px tall) | icon **1px** low | 0px |
| rail center vs. icon column center | **1px** off | 0px |

Causes:

- `StyledIconContainer` was a 16px box with a 5px margin, putting the glyph center 13px from the row top. A plain text row's first line is ~15px tall and centers around 7.5px, while a row carrying an inline `EventFieldDiff` is 24px tall and centers at 12px. Nothing tied the two together, so the offset drifted with the row's content.
- `StyledActivityGroupBar` (the rail behind the icons) was 24px wide while the icon column measured 26px, so the icons and the connector line sat 1px right of the rail's center.
- `StyledTimelineItemContainer` carried `height: 'auto'` — a quoted value, so it was never valid CSS.

### What changed

Everything is keyed to one `TIMELINE_ICON_SLOT_SIZE`: the icon square, the rail width, and the minimum height of an event row's first line. The icon, the connector line, the rail, the toggle button and the row text now resolve to the same center regardless of what the row contains.

- `EventRow` — icon slot is a `TIMELINE_ICON_SLOT_SIZE` square in a fixed-width column; the connector line is a `flex: 1` child instead of a `height: 100%` wrapper that overflowed and relied on the parent's `overflow: hidden` to be clipped.
- `EventsGroup` — rail width matches the icon column; dropped the flex properties it carried with no children.
- `EventRowStyles` — the row container now sets the first-line band; `EventRowMainObject`, `EventRowMainObjectUpdated` and `EventRowGenericLinked` each declared a byte-identical copy of these styles, so they now import the shared ones and cannot drift apart again.
- `EventCardToggleButton` — centers in the same band, so the chevron lines up with the row text.
- `EventIconDynamicComponent` — sizes the icon explicitly. The old 16px slot was doubling as a size clamp: `getIcon` returns a raw Tabler component and this rendered it with no `size` prop, so the SVG carried Tabler's default 24px and flexbox squeezed it down. Widening the slot removed that clamp and icons jumped to 24px; `size={theme.icon.size.md}` pins them at 16px independently of the slot.

### Verification

Measured on the real components, over the `getIcon` path that production actually uses (an earlier pass only exercised the `ObjectMetadataIcon` fallback, whose `TintedIconTile` is a hard-coded 16px box and so hid the size regression above):

| | icon slot | SVG box | glyph |
|---|---|---|---|
| `main` | 16x16 | 16x24 | 16px |
| mid-PR (regressed) | 26x26 | 24x24 | 24px |
| head | 26x26 | 16x16 | 16px |

Rows covered: created / updated-with-one-field / updated-with-several-fields / linked-record / deleted / restored, plus the single-event case from the report, at desktop and mobile widths. Every icon center, date column position and toggle button center matches its row to 0.00px, and the rail's top and bottom land exactly on the first and last icon slots.

`npx jest packages/twenty-front/src/modules/activities/timeline-activities` — 58 tests pass. Typecheck, oxlint and oxfmt clean.

Note for reviewers: the `Visual Regression Review` check reported *"Visual review could not run — manual check recommended"*, so no automated screenshot comparison covered this. Given the PR is entirely visual, a look at the preview environment is worth it.

### Not addressed

A long record label still hard-clips without an ellipsis (`EventRowItem` children don't shrink), which on the "N fields on \<record\>" row pushes the toggle button out of view. That's a truncation bug rather than an alignment one and predates this change, so I left it out — happy to take it in a follow-up.