### PR TITLE
Preserve hash and query in OAuth connect redirect locations

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/connection-provider-oauth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/connection-provider-oauth.controller.ts
@@ -15,6 +15,7 @@ import {
   AuthExceptionCode,
 } from 'src/engine/core-modules/auth/auth.exception';
 import { TransientTokenService } from 'src/engine/core-modules/auth/token/services/transient-token.service';
+import { parseRelativeUrl } from 'src/engine/core-modules/domain/domain-server-config/utils/parse-relative-url.util';
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { GuardRedirectService } from 'src/engine/core-modules/guard-redirect/services/guard-redirect.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
@@ -203,13 +204,16 @@ export class ConnectionProviderOAuthController {
         );
       }
 
-      const pathname =
+      const { pathname, searchParams, hash } = parseRelativeUrl(
         redirectLocation ||
-        getSettingsPath(SettingsPath.ApplicationDetail, { applicationId });
+          getSettingsPath(SettingsPath.ApplicationDetail, { applicationId }),
+      );
 
       const url = this.workspaceDomainsService.buildWorkspaceURL({
         workspace,
         pathname,
+        searchParams,
+        hash,
       });
 
       // Frontend tab list reads the URL hash to pick the active tab.

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/google-apis-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/google-apis-auth.controller.ts
@@ -23,6 +23,7 @@ import { GoogleAPIsOauthRequestCodeGuard } from 'src/engine/core-modules/auth/gu
 import { GoogleAPIsService } from 'src/engine/core-modules/auth/services/google-apis.service';
 import { TransientTokenService } from 'src/engine/core-modules/auth/token/services/transient-token.service';
 import { APIsOAuthRequest } from 'src/engine/core-modules/auth/types/apis-oauth-request.type';
+import { parseRelativeUrl } from 'src/engine/core-modules/domain/domain-server-config/utils/parse-relative-url.util';
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { GuardRedirectService } from 'src/engine/core-modules/guard-redirect/services/guard-redirect.service';
 import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
@@ -125,15 +126,18 @@ export class GoogleAPIsAuthController {
         );
       }
 
-      const pathname =
+      const { pathname, searchParams, hash } = parseRelativeUrl(
         redirectLocation ||
-        getSettingsPath(SettingsPath.AccountsConfiguration, {
-          connectedAccountId,
-        });
+          getSettingsPath(SettingsPath.AccountsConfiguration, {
+            connectedAccountId,
+          }),
+      );
 
       const url = this.workspaceDomainsService.buildWorkspaceURL({
         workspace,
         pathname,
+        searchParams,
+        hash,
       });
 
       return res.redirect(url.toString());

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/microsoft-apis-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/microsoft-apis-auth.controller.ts
@@ -23,6 +23,7 @@ import { MicrosoftAPIsOauthRequestCodeGuard } from 'src/engine/core-modules/auth
 import { MicrosoftAPIsService } from 'src/engine/core-modules/auth/services/microsoft-apis.service';
 import { TransientTokenService } from 'src/engine/core-modules/auth/token/services/transient-token.service';
 import { APIsOAuthRequest } from 'src/engine/core-modules/auth/types/apis-oauth-request.type';
+import { parseRelativeUrl } from 'src/engine/core-modules/domain/domain-server-config/utils/parse-relative-url.util';
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { GuardRedirectService } from 'src/engine/core-modules/guard-redirect/services/guard-redirect.service';
 import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
@@ -132,15 +133,18 @@ export class MicrosoftAPIsAuthController {
         );
       }
 
-      const pathname =
+      const { pathname, searchParams, hash } = parseRelativeUrl(
         redirectLocation ||
-        getSettingsPath(SettingsPath.AccountsConfiguration, {
-          connectedAccountId,
-        });
+          getSettingsPath(SettingsPath.AccountsConfiguration, {
+            connectedAccountId,
+          }),
+      );
 
       const url = this.workspaceDomainsService.buildWorkspaceURL({
         workspace,
         pathname,
+        searchParams,
+        hash,
       });
 
       return res.redirect(url.toString());

--- a/packages/twenty-server/src/engine/core-modules/domain/domain-server-config/utils/__tests__/parse-relative-url.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/domain-server-config/utils/__tests__/parse-relative-url.util.spec.ts
@@ -1,0 +1,63 @@
+import { buildUrlWithPathnameAndSearchParams } from 'src/engine/core-modules/domain/domain-server-config/utils/build-url-with-pathname-and-search-params.util';
+import { parseRelativeUrl } from 'src/engine/core-modules/domain/domain-server-config/utils/parse-relative-url.util';
+
+describe('parseRelativeUrl', () => {
+  it('parses a plain pathname', () => {
+    expect(parseRelativeUrl('/settings/accounts')).toEqual({
+      pathname: '/settings/accounts',
+      searchParams: {},
+      hash: '',
+    });
+  });
+
+  it('splits a tab anchor out of the pathname', () => {
+    expect(
+      parseRelativeUrl(
+        '/object/company/46d9f704-ee56-4063-835b-ffb3aea3c544#630fec80-dc2d-400b-b760-f8d9b7402cac',
+      ),
+    ).toEqual({
+      pathname: '/object/company/46d9f704-ee56-4063-835b-ffb3aea3c544',
+      searchParams: {},
+      hash: '#630fec80-dc2d-400b-b760-f8d9b7402cac',
+    });
+  });
+
+  it('splits a query string and a hash out of the pathname', () => {
+    expect(
+      parseRelativeUrl('/objects/companies?viewId=view-1&page=2#tab-1'),
+    ).toEqual({
+      pathname: '/objects/companies',
+      searchParams: { viewId: 'view-1', page: '2' },
+      hash: '#tab-1',
+    });
+  });
+
+  it('keeps only the path, query and hash of an absolute url', () => {
+    expect(parseRelativeUrl('https://evil.com/phishing?a=1#target')).toEqual({
+      pathname: '/phishing',
+      searchParams: { a: '1' },
+      hash: '#target',
+    });
+  });
+
+  it('keeps only the path of a protocol-relative url', () => {
+    expect(parseRelativeUrl('//evil.com/phishing')).toEqual({
+      pathname: '/phishing',
+      searchParams: {},
+      hash: '',
+    });
+  });
+
+  it('rebuilds into a url without percent-encoding the separators', () => {
+    const url = buildUrlWithPathnameAndSearchParams({
+      baseUrl: new URL('https://acme.twenty.com'),
+      ...parseRelativeUrl(
+        '/object/company/46d9f704-ee56-4063-835b-ffb3aea3c544#630fec80-dc2d-400b-b760-f8d9b7402cac',
+      ),
+    });
+
+    expect(url.toString()).toBe(
+      'https://acme.twenty.com/object/company/46d9f704-ee56-4063-835b-ffb3aea3c544#630fec80-dc2d-400b-b760-f8d9b7402cac',
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/domain/domain-server-config/utils/parse-relative-url.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/domain-server-config/utils/parse-relative-url.util.ts
@@ -1,0 +1,17 @@
+// A redirect location coming from the front can carry a query string and a
+// tab anchor (e.g. /object/company/<recordId>#<tabId>). Assigning the whole
+// string to URL.pathname percent-encodes '?' and '#' into the path, so split
+// it into parts the URL API can reassemble. Parsing against a fixed base also
+// drops any host smuggled into the value, keeping redirects on our domain.
+export const parseRelativeUrl = (relativeUrl: string) => {
+  const { pathname, searchParams, hash } = new URL(
+    relativeUrl,
+    'http://relative-url.invalid',
+  );
+
+  return {
+    pathname,
+    searchParams: Object.fromEntries(searchParams.entries()),
+    hash,
+  };
+};


### PR DESCRIPTION
## Problem

In prod, a company page can end up at a URL whose record id is two UUIDs joined by `#`, and every record-scoped query on the page then fails GraphQL UUID validation:

```
Invalid UUID value '46d9f704-ee56-4063-835b-ffb3aea3c544#630fec80-dc2d-400b-b760-f8d9b7402cac' for field "id"
```

Root cause chain:

1. Record pages store the active page-layout tab in the URL hash (`navigate(`#${tabId}`)` in `PageLayoutTabList`), so a record page URL looks like `/object/company/<recordId>#<pageLayoutTabId>`.
2. The calendar composer side panel sends that full location (`pathname + search + hash`) as `redirectLocation` when the user reauthorizes their Google/Microsoft account (`SidePanelComposeCalendarEventPage`).
3. After the OAuth round trip, `GoogleAPIsAuthController` / `MicrosoftAPIsAuthController` rebuild the return URL with `buildWorkspaceURL({ workspace, pathname: redirectLocation })`, which bottoms out in `url.pathname = redirectLocation`. The WHATWG URL pathname setter cannot represent `#` (or `?`) in a path and percent-encodes it, so the browser is redirected to `/object/company/<recordId>%23<tabId>`.
4. React Router decodes the path segment back, `useParams().objectRecordId` becomes `<recordId>#<tabId>`, and the company/people/timelineActivities/timeline queries all 400. The broken URL then persists in browser history.

History: the mangling has been latent since #8656 (Dec 2024) replaced plain string concatenation (`${FRONT_BASE_URL}${redirectLocation}`, which kept `#` a real fragment) with the `url.pathname` assignment. It became reachable with #24667 (Aug 24, 2026), the first flow to send a `redirectLocation` that carries a hash. #22845 already added `hash` support to the URL builder for email deep links, but the OAuth controllers never used it.

## Fix

Add a `parseRelativeUrl` util that splits a front-provided location into `pathname`, `searchParams` and `hash`, and use it in the three OAuth callbacks that replay a `redirectLocation`:

- `google-apis-auth.controller.ts`
- `microsoft-apis-auth.controller.ts`
- `connection-provider-oauth.controller.ts`

`buildWorkspaceURL` already forwards all three parts, so the tab anchor now survives as a real fragment and the user lands back on the record page with the right tab active. Parsing against a fixed base URL also strips any host smuggled into the value, so an absolute or protocol-relative `redirectLocation` cannot redirect off the workspace domain.

## Validation

- New unit spec `parse-relative-url.util.spec.ts` (6 tests) covering plain paths, tab anchors, query + hash, absolute and protocol-relative inputs, and a rebuild test locking the exact prod URL shape without `%23`
- `tsgo -p tsconfig.json --noEmit` clean on twenty-server
- oxlint (type-aware) and oxfmt clean on the five changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_011PWYa6qYLqUhgqKq2pKLDV)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

