### PR TITLE
Fix double-composited translucency on tooltips

### DIFF
--- a/packages/twenty-ui/src/surfaces/AppTooltip/AppTooltip.module.scss
+++ b/packages/twenty-ui/src/surfaces/AppTooltip/AppTooltip.module.scss
@@ -18,8 +18,6 @@
   word-break: break-word;
   width: max-content;
   max-width: 100%;
-  // react-tooltip showed tooltips at 0.9 opacity with 0.15s fades
-  opacity: 0.9;
   will-change: opacity;
   transition: opacity 0.15s ease-out;
 
@@ -37,26 +35,43 @@
   pointer-events: auto;
 }
 
+// the background is translucent, so the arrow has to sit flush outside the
+// popup: any overlap composites the two layers and shows up as a darker shape
 .arrow {
+  --tooltip-arrow-size: 6px;
+
   position: absolute;
-  width: 8px;
-  height: 8px;
   background: inherit;
-  transform: rotate(45deg);
+
+  &[data-side='top'],
+  &[data-side='bottom'] {
+    width: calc(2 * var(--tooltip-arrow-size));
+    height: var(--tooltip-arrow-size);
+  }
+
+  &[data-side='left'],
+  &[data-side='right'] {
+    width: var(--tooltip-arrow-size);
+    height: calc(2 * var(--tooltip-arrow-size));
+  }
 
   &[data-side='top'] {
-    bottom: -4px;
+    bottom: calc(-1 * var(--tooltip-arrow-size));
+    clip-path: polygon(0 0, 100% 0, 50% 100%);
   }
 
   &[data-side='bottom'] {
-    top: -4px;
+    top: calc(-1 * var(--tooltip-arrow-size));
+    clip-path: polygon(50% 0, 100% 100%, 0 100%);
   }
 
   &[data-side='left'] {
-    right: -4px;
+    right: calc(-1 * var(--tooltip-arrow-size));
+    clip-path: polygon(0 0, 100% 50%, 0 100%);
   }
 
   &[data-side='right'] {
-    left: -4px;
+    left: calc(-1 * var(--tooltip-arrow-size));
+    clip-path: polygon(100% 0, 100% 100%, 0 50%);
   }
 }


### PR DESCRIPTION
Tooltips render a small dark triangle poking into the body, most visible on the arrow side.

## Cause

Two independent stacks of alpha in `AppTooltip.module.scss`:

1. **The triangle.** The arrow was an 8x8 square rotated 45 degrees, offset by `-4px`. At that offset the diamond's centre lands exactly on the popup's edge, so half of it sits on top of the popup body. Both use `--t-color-transparent-gray11` (0.722 alpha in light), so the overlap composites to `1 - (1 - 0.722)^2 = 0.92` instead of `0.72`. That darker inner half is the triangle.

2. **The wash.** `opacity: 0.9` on the popup, a leftover from the react-tooltip migration (the comment said as much), multiplied on top of the already-translucent token. Effective alpha was 0.65, not the 0.722 the token specifies.

## Change

- Draw the arrow as a `clip-path` triangle sitting flush outside the popup instead of a rotated square straddling the edge, so the translucent background is never composited twice.
- Drop the redundant `opacity: 0.9`. The fade transition still runs 0 -> 1, and the tooltip now renders at the weight its token specifies.
- Arrow size moved to a local `--tooltip-arrow-size` so the offset cannot drift out of sync with the size.

Only `AppTooltip.module.scss` changes. No DOM or component API change, and the exported class names are unchanged.

## Verification

Rendered the actual shipped stylesheet in Chromium against the real Base UI component, with Twenty's typography (Inter, `html` 13px, tooltip `0.92rem`, `padding: 8px`):

- All four sides (`top` / `bottom` / `left` / `right`), light and dark themes, over saturated backgrounds: no darker triangle, uniform surface.
- Sampled pixel luminance across the arrow-to-body joint at 1x, 2x and 3x device pixel ratios, 10 placements each: 0 defects. Body reads 71 on white throughout, matching `0.722` alpha exactly.

One note for reviewers, since it came up while checking this. Two separately composited translucent shapes that share an edge can conflate on that edge if it lands mid-device-pixel, which shows as a hairline. It does not happen here: Floating UI snaps the positioner to device pixels, and the tooltip box resolves to whole pixels (31px for one line, 46 / 61 for two / three, 35 with an icon). It is reachable if the popup height ever becomes fractional; forcing `line-height: 19.3px` (height 35.296875) reproduces it in 9 of 10 placements. The bulletproof alternative is to paint body and arrow opaque inside one wrapper and apply the token's alpha once to the flattened group, but that needs an extra DOM node and `mask-clip: no-clip`, whose unsupported fallback hides the arrow entirely. Not worth it for a defect that does not currently fire, so it is left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_016vjThgf2QNqXq3mNoH82sf)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

