### PR TITLE
refactor(server): extract WorkflowMetadataReadService from the common god-service

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-query-hook.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-query-hook.module.ts
@@ -42,6 +42,7 @@ import { WorkflowVersionRestoreOnePreQueryHook } from 'src/modules/workflow/comm
 import { WorkflowVersionUpdateManyPreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-version-update-many.pre-query.hook';
 import { WorkflowVersionUpdateOnePreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-version-update-one.pre-query.hook';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { WorkflowMetadataReadModule } from 'src/modules/workflow/common/workspace-services/workflow-metadata-read.module';
 import { WorkflowVersionValidationWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service';
 
 @Module({
@@ -54,6 +55,7 @@ import { WorkflowVersionValidationWorkspaceService } from 'src/modules/workflow/
     CommandMenuItemModule,
     FeatureFlagModule,
     WorkflowVersionCoreModule,
+    WorkflowMetadataReadModule,
   ],
   providers: [
     WorkflowCreateOnePreQueryHook,

--- a/packages/twenty-server/src/modules/workflow/common/workflow-common.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workflow-common.module.ts
@@ -7,6 +7,7 @@ import { LogicFunctionModule } from 'src/engine/metadata-modules/logic-function/
 import { WorkflowVersionCoreModule } from 'src/engine/core-modules/workflow/workflow-version-core.module';
 import { WorkflowQueryHookModule } from 'src/modules/workflow/common/query-hooks/workflow-query-hook.module';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { WorkflowMetadataReadModule } from 'src/modules/workflow/common/workspace-services/workflow-metadata-read.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/work
     CommandMenuItemModule,
     FeatureFlagModule,
     WorkflowVersionCoreModule,
+    WorkflowMetadataReadModule,
   ],
   providers: [WorkflowCommonWorkspaceService],
   exports: [WorkflowCommonWorkspaceService],

--- a/packages/twenty-server/src/modules/workflow/common/workflow-common.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workflow-common.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common';
 
 import { CommandMenuItemModule } from 'src/engine/metadata-modules/command-menu-item/command-menu-item.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
-import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
 import { LogicFunctionModule } from 'src/engine/metadata-modules/logic-function/logic-function.module';
 import { WorkflowVersionCoreModule } from 'src/engine/core-modules/workflow/workflow-version-core.module';
 import { WorkflowQueryHookModule } from 'src/modules/workflow/common/query-hooks/workflow-query-hook.module';
@@ -13,7 +12,6 @@ import { WorkflowMetadataReadModule } from 'src/modules/workflow/common/workspac
   imports: [
     WorkflowQueryHookModule,
     LogicFunctionModule,
-    WorkspaceManyOrAllFlatEntityMapsCacheModule,
     CommandMenuItemModule,
     FeatureFlagModule,
     WorkflowVersionCoreModule,

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -6,12 +6,9 @@ import { In } from 'typeorm';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/workflow/services/workflow-version-core-sync.service';
 import { CommandMenuItemService } from 'src/engine/metadata-modules/command-menu-item/command-menu-item.service';
-import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
-import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { buildObjectIdByNameMaps } from 'src/engine/metadata-modules/flat-object-metadata/utils/build-object-id-by-name-maps.util';
 import {
   LogicFunctionException,
   LogicFunctionExceptionCode,
@@ -22,9 +19,9 @@ import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
-  WorkflowCommonException,
-  WorkflowCommonExceptionCode,
-} from 'src/modules/workflow/common/exceptions/workflow-common.exception';
+  type ObjectMetadataInfo,
+  WorkflowMetadataReadService,
+} from 'src/modules/workflow/common/workspace-services/workflow-metadata-read.workspace-service';
 import { type WorkflowAutomatedTriggerWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import { type WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import {
@@ -42,11 +39,7 @@ import {
 import { getWorkflowCommandMenuItemLabel } from 'src/modules/workflow/workflow-trigger/utils/get-workflow-command-menu-item-label.util';
 import { WorkflowActionType } from 'twenty-shared/workflow';
 
-export type ObjectMetadataInfo = {
-  flatObjectMetadata: FlatObjectMetadata;
-  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
-  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
-};
+export type { ObjectMetadataInfo };
 
 @Injectable()
 export class WorkflowCommonWorkspaceService {
@@ -55,7 +48,7 @@ export class WorkflowCommonWorkspaceService {
   constructor(
     private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly logicFunctionFromSourceService: LogicFunctionFromSourceService,
-    private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
+    private readonly workflowMetadataReadService: WorkflowMetadataReadService,
     private readonly commandMenuItemService: CommandMenuItemService,
     private readonly workflowVersionCoreSyncService: WorkflowVersionCoreSyncService,
   ) {}
@@ -212,23 +205,7 @@ export class WorkflowCommonWorkspaceService {
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     objectIdByNameSingular: Record<string, string>;
   }> {
-    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
-      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
-        {
-          workspaceId,
-          flatMapsKeys: ['flatObjectMetadataMaps', 'flatFieldMetadataMaps'],
-        },
-      );
-
-    const { idByNameSingular } = buildObjectIdByNameMaps(
-      flatObjectMetadataMaps,
-    );
-
-    return {
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-      objectIdByNameSingular: idByNameSingular,
-    };
+    return this.workflowMetadataReadService.getFlatEntityMaps(workspaceId);
   }
 
   async getLogicFunctionById({
@@ -238,17 +215,9 @@ export class WorkflowCommonWorkspaceService {
     logicFunctionId: string;
     workspaceId: string;
   }): Promise<FlatLogicFunction | undefined> {
-    const { flatLogicFunctionMaps } =
-      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
-        {
-          workspaceId,
-          flatMapsKeys: ['flatLogicFunctionMaps'],
-        },
-      );
-
-    return findFlatEntityByIdInFlatEntityMaps({
-      flatEntityId: logicFunctionId,
-      flatEntityMaps: flatLogicFunctionMaps,
+    return this.workflowMetadataReadService.getLogicFunctionById({
+      logicFunctionId,
+      workspaceId,
     });
   }
 
@@ -256,38 +225,10 @@ export class WorkflowCommonWorkspaceService {
     objectNameSingular: string,
     workspaceId: string,
   ): Promise<ObjectMetadataInfo> {
-    const {
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-      objectIdByNameSingular,
-    } = await this.getFlatEntityMaps(workspaceId);
-
-    const objectId = objectIdByNameSingular[objectNameSingular];
-
-    if (!isDefined(objectId)) {
-      throw new WorkflowCommonException(
-        `Failed to read: Object ${objectNameSingular} not found`,
-        WorkflowCommonExceptionCode.OBJECT_METADATA_NOT_FOUND,
-      );
-    }
-
-    const flatObjectMetadata = findFlatEntityByIdInFlatEntityMaps({
-      flatEntityId: objectId,
-      flatEntityMaps: flatObjectMetadataMaps,
-    });
-
-    if (!isDefined(flatObjectMetadata)) {
-      throw new WorkflowCommonException(
-        `Failed to read: Object ${objectNameSingular} not found`,
-        WorkflowCommonExceptionCode.OBJECT_METADATA_NOT_FOUND,
-      );
-    }
-
-    return {
-      flatObjectMetadata,
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-    };
+    return this.workflowMetadataReadService.getObjectMetadataInfo(
+      objectNameSingular,
+      workspaceId,
+    );
   }
 
   async handleWorkflowSubEntities({

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-metadata-read.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-metadata-read.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
+import { WorkflowMetadataReadService } from 'src/modules/workflow/common/workspace-services/workflow-metadata-read.workspace-service';
+
+@Module({
+  imports: [WorkspaceManyOrAllFlatEntityMapsCacheModule],
+  providers: [WorkflowMetadataReadService],
+  exports: [WorkflowMetadataReadService],
+})
+export class WorkflowMetadataReadModule {}

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-metadata-read.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-metadata-read.workspace-service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+
+import { isDefined } from 'twenty-shared/utils';
+
+import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { buildObjectIdByNameMaps } from 'src/engine/metadata-modules/flat-object-metadata/utils/build-object-id-by-name-maps.util';
+import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
+import {
+  WorkflowCommonException,
+  WorkflowCommonExceptionCode,
+} from 'src/modules/workflow/common/exceptions/workflow-common.exception';
+
+export type ObjectMetadataInfo = {
+  flatObjectMetadata: FlatObjectMetadata;
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+};
+
+@Injectable()
+export class WorkflowMetadataReadService {
+  constructor(
+    private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
+  ) {}
+
+  async getFlatEntityMaps(workspaceId: string): Promise<{
+    flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+    objectIdByNameSingular: Record<string, string>;
+  }> {
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatObjectMetadataMaps', 'flatFieldMetadataMaps'],
+        },
+      );
+
+    const { idByNameSingular } = buildObjectIdByNameMaps(flatObjectMetadataMaps);
+
+    return {
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      objectIdByNameSingular: idByNameSingular,
+    };
+  }
+
+  async getLogicFunctionById({
+    logicFunctionId,
+    workspaceId,
+  }: {
+    logicFunctionId: string;
+    workspaceId: string;
+  }): Promise<FlatLogicFunction | undefined> {
+    const { flatLogicFunctionMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatLogicFunctionMaps'],
+        },
+      );
+
+    return findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: logicFunctionId,
+      flatEntityMaps: flatLogicFunctionMaps,
+    });
+  }
+
+  async getObjectMetadataInfo(
+    objectNameSingular: string,
+    workspaceId: string,
+  ): Promise<ObjectMetadataInfo> {
+    const {
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      objectIdByNameSingular,
+    } = await this.getFlatEntityMaps(workspaceId);
+
+    const objectId = objectIdByNameSingular[objectNameSingular];
+
+    if (!isDefined(objectId)) {
+      throw new WorkflowCommonException(
+        `Failed to read: Object ${objectNameSingular} not found`,
+        WorkflowCommonExceptionCode.OBJECT_METADATA_NOT_FOUND,
+      );
+    }
+
+    const flatObjectMetadata = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: objectId,
+      flatEntityMaps: flatObjectMetadataMaps,
+    });
+
+    if (!isDefined(flatObjectMetadata)) {
+      throw new WorkflowCommonException(
+        `Failed to read: Object ${objectNameSingular} not found`,
+        WorkflowCommonExceptionCode.OBJECT_METADATA_NOT_FOUND,
+      );
+    }
+
+    return {
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    };
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-metadata-read.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-metadata-read.workspace-service.ts
@@ -39,7 +39,9 @@ export class WorkflowMetadataReadService {
         },
       );
 
-    const { idByNameSingular } = buildObjectIdByNameMaps(flatObjectMetadataMaps);
+    const { idByNameSingular } = buildObjectIdByNameMaps(
+      flatObjectMetadataMaps,
+    );
 
     return {
       flatObjectMetadataMaps,

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.module.ts
@@ -7,7 +7,11 @@ import { WorkflowSchemaModule } from 'src/modules/workflow/workflow-builder/work
 import { WorkflowValidationWorkspaceService } from './workflow-validation.workspace-service';
 
 @Module({
-  imports: [WorkflowCommonModule, WorkflowMetadataReadModule, WorkflowSchemaModule],
+  imports: [
+    WorkflowCommonModule,
+    WorkflowMetadataReadModule,
+    WorkflowSchemaModule,
+  ],
   providers: [WorkflowValidationWorkspaceService],
   exports: [WorkflowValidationWorkspaceService],
 })

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 
 import { WorkflowCommonModule } from 'src/modules/workflow/common/workflow-common.module';
+import { WorkflowMetadataReadModule } from 'src/modules/workflow/common/workspace-services/workflow-metadata-read.module';
 import { WorkflowSchemaModule } from 'src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.module';
 
 import { WorkflowValidationWorkspaceService } from './workflow-validation.workspace-service';
 
 @Module({
-  imports: [WorkflowCommonModule, WorkflowSchemaModule],
+  imports: [WorkflowCommonModule, WorkflowMetadataReadModule, WorkflowSchemaModule],
   providers: [WorkflowValidationWorkspaceService],
   exports: [WorkflowValidationWorkspaceService],
 })

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.workspace-service.ts
@@ -17,6 +17,7 @@ import {
 } from 'twenty-shared/workflow';
 
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { WorkflowMetadataReadService } from 'src/modules/workflow/common/workspace-services/workflow-metadata-read.workspace-service';
 import { WorkflowSchemaWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service';
 import { getPickRecordLoadBalanceConfigError } from 'src/modules/workflow/workflow-builder/workflow-validation/utils/get-pick-record-load-balance-config-error.util';
 import {
@@ -43,6 +44,7 @@ const OBJECT_TARGETING_ACTION_TYPES = new Set<WorkflowActionType>([
 export class WorkflowValidationWorkspaceService {
   constructor(
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
+    private readonly workflowMetadataReadService: WorkflowMetadataReadService,
     private readonly workflowSchemaWorkspaceService: WorkflowSchemaWorkspaceService,
   ) {}
 
@@ -284,7 +286,7 @@ export class WorkflowValidationWorkspaceService {
 
     try {
       const logicFunction =
-        await this.workflowCommonWorkspaceService.getLogicFunctionById({
+        await this.workflowMetadataReadService.getLogicFunctionById({
           logicFunctionId,
           workspaceId,
         });
@@ -325,7 +327,7 @@ export class WorkflowValidationWorkspaceService {
     }
 
     const { objectIdByNameSingular, flatFieldMetadataMaps } =
-      await this.workflowCommonWorkspaceService.getFlatEntityMaps(workspaceId);
+      await this.workflowMetadataReadService.getFlatEntityMaps(workspaceId);
 
     const issues: WorkflowValidationIssue[] = [];
 


### PR DESCRIPTION
First of 3 stacked PRs reworking workflow version validation (refactor → enforcement → upgrade command).

## What

`WorkflowCommonWorkspaceService` conflates two concerns: **metadata reads** (`getFlatEntityMaps`, `getObjectMetadataInfo`, `getLogicFunctionById` — backed only by the flat-maps cache) and **version-sync writes** (which depend on `WorkflowVersionCoreSyncService`). Anything needing just the reads — e.g. workflow validation — transitively inherits the CoreSync dependency.

This extracts the reads into a low-level `WorkflowMetadataReadService` (only dependency: the flat-maps cache):
- `WorkflowCommonWorkspaceService` delegates its three read methods to it (public API unchanged, so all existing consumers are untouched).
- `WorkflowValidationWorkspaceService` now depends on the read service for metadata instead of the common service.

## Why

This is the enabler for the next PR: it lets the a-priori validation gate live at the `writeWorkflowVersionAndMirror` chokepoint (in core-modules) without a circular module dependency (CoreSync → Validation → Common → CoreSync).

## No behavior change

Pure refactor. `ObjectMetadataInfo` is re-exported from the common service for backward compatibility. Typecheck, lint, and the affected listener spec pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

