### PR TITLE
Remove pre-2-32 uiScale and pre-2-27 openRecordIn fallbacks

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-member-transpiler.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-member-transpiler.service.ts
@@ -100,9 +100,7 @@ export class WorkspaceMemberTranspiler {
       avatarUrl,
       userWorkspaceId: userWorkspace.id,
       colorScheme,
-      // Workspaces upgrade after the code rolls out, so this field is
-      // absent until the 2-27 workspace command reaches them.
-      openRecordIn: (openRecordIn as OpenRecordIn) ?? OpenRecordIn.SIDE_PANEL,
+      openRecordIn: openRecordIn as OpenRecordIn,
       uiScale,
       dateFormat: dateFormat as WorkspaceMemberDateFormatEnum,
       locale,

--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-member-transpiler.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-member-transpiler.service.ts
@@ -100,10 +100,10 @@ export class WorkspaceMemberTranspiler {
       avatarUrl,
       userWorkspaceId: userWorkspace.id,
       colorScheme,
-      // Workspaces upgrade after the code rolls out, so these fields are
-      // absent until their workspace commands (2-27, 2-32) reach them.
+      // Workspaces upgrade after the code rolls out, so this field is
+      // absent until the 2-27 workspace command reaches them.
       openRecordIn: (openRecordIn as OpenRecordIn) ?? OpenRecordIn.SIDE_PANEL,
-      uiScale: uiScale ?? 'Default',
+      uiScale,
       dateFormat: dateFormat as WorkspaceMemberDateFormatEnum,
       locale,
       timeFormat: timeFormat as WorkspaceMemberTimeFormatEnum,

--- a/packages/twenty-server/src/engine/metadata-modules/role/role.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/role/role.resolver.ts
@@ -127,8 +127,6 @@ export class RoleResolver {
 
     return {
       ...workspaceMember,
-      // pre-2-32 workspaces lack the column until the upgrade command runs
-      uiScale: workspaceMember.uiScale ?? 'Default',
       userWorkspaceId,
       roles,
     } as WorkspaceMemberDTO;
@@ -319,17 +317,10 @@ export class RoleResolver {
     @Parent() role: RoleDTO,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<WorkspaceMemberWorkspaceEntity[]> {
-    const workspaceMembers =
-      await this.userRoleService.getWorkspaceMembersAssignedToRole(
-        role.id,
-        workspace.id,
-      );
-
-    // pre-2-32 workspaces lack the column until the upgrade command runs
-    return workspaceMembers.map((workspaceMember) => ({
-      ...workspaceMember,
-      uiScale: workspaceMember.uiScale ?? 'Default',
-    }));
+    return await this.userRoleService.getWorkspaceMembersAssignedToRole(
+      role.id,
+      workspace.id,
+    );
   }
 
   @ResolveField('agents', () => [AgentDTO])


### PR DESCRIPTION
Closes twentyhq/core-team-issues#2774

`workspaceMember.uiScale` is a non-nullable GraphQL field, but workspaces that had not yet run the 2-32 upgrade command lacked the column. Three server sites defaulted the value to `'Default'` to hold the non-null contract during that rollout.

`TWENTY_CURRENT_VERSION` is now `2.38.0`, six versions past 2-32, so the column exists with a default everywhere and the fallbacks are dead weight. Removed all three:

- `role.resolver.ts` — `updateWorkspaceMemberRole` return value
- `role.resolver.ts` — `workspaceMembers` field resolution (the `.map()` now collapses to returning the service result directly)
- `workspace-member-transpiler.service.ts` — the `uiScale ?? 'Default'` fallback

## Also removing the openRecordIn (2-27) fallback

The first round kept the sibling `openRecordIn ?? SIDE_PANEL` fallback in the transpiler, since 2-27 is a separate rollout. Removing it too, because the guard was never actually load-bearing:

`openRecordIn` is also `nullable: false` on `WorkspaceMemberDTO`, and both role resolver paths returned it through a `...workspaceMember` spread with no fallback at all. So two of the three paths serving that field were already unguarded. A fallback on the third does not close the upgrade window it named, it just hides that the window was never closed.

2-27 is also older than 2-32, so if the 2-32 window has closed, so has 2-27's.

## Not touched

`uiScale: 'Default'` / `openRecordIn: SIDE_PANEL` in `user-workspace.service.ts` are creation defaults for new workspace members, not rollout fallbacks. The `?? USER_CHOICE` / `?? SIDE_PANEL` defaults in the application- and view-manifest converters are manifest defaults on `objectMetadata`/`view`, unrelated to workspace members.

Both fields are typed non-nullable on `WorkspaceMemberWorkspaceEntity`, so no types change and the GraphQL schema is unchanged (both DTO fields were already `nullable: false`).

## Test

- `npx tsgo -p tsconfig.json --noEmit` in `twenty-server`: clean, exit 0
- `npx nx lint:diff-with-main twenty-server`: 0 warnings, 0 errors, formatting clean
- Unit tests under `core-modules/user/` and `metadata-modules/role/`: 5 suites, 31 tests passing

No test referenced the removed fallbacks.