### PR TITLE
fix(billing): rebuild creditBalanceMicro from the ledger on rollback

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-instance-command-fast-1787906740818-drop-billing-customer-credit-balance-micro.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-instance-command-fast-1787906740818-drop-billing-customer-credit-balance-micro.ts
@@ -30,5 +30,25 @@ export class DropBillingCustomerCreditBalanceMicroFastInstanceCommand
     await queryRunner.query(
       `ALTER TABLE "core"."billingCustomer" ADD COLUMN IF NOT EXISTS "creditBalanceMicro" bigint NOT NULL DEFAULT 0`,
     );
+
+    if (!(await isCoreTablePresent(queryRunner, 'billingCreditGrant'))) {
+      return;
+    }
+
+    // Recreating the column at its default would hand every workspace a zero
+    // balance, and a rollback that continues past 2.31 reaches code that reads
+    // this column as the authority rather than the ledger. Rebuild it from the
+    // grants that are spendable now, matching getActiveCreditsMicro.
+    await queryRunner.query(
+      `UPDATE "core"."billingCustomer"
+       SET "creditBalanceMicro" = COALESCE((
+         SELECT SUM("billingCreditGrant"."amountMicro")
+         FROM "core"."billingCreditGrant"
+         WHERE "billingCreditGrant"."workspaceId" = "billingCustomer"."workspaceId"
+           AND "billingCreditGrant"."revokedAt" IS NULL
+           AND "billingCreditGrant"."effectiveAt" <= now()
+           AND "billingCreditGrant"."expiresAt" > now()
+       ), 0)`,
+    );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/__tests__/2-38-instance-command-fast-1787906740818-drop-billing-customer-credit-balance-micro.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/__tests__/2-38-instance-command-fast-1787906740818-drop-billing-customer-credit-balance-micro.spec.ts
@@ -1,0 +1,93 @@
+import { type QueryRunner } from 'typeorm';
+
+import { DropBillingCustomerCreditBalanceMicroFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-instance-command-fast-1787906740818-drop-billing-customer-credit-balance-micro';
+
+const collapseWhitespace = (statement: string): string =>
+  statement.replace(/\s+/g, ' ').trim();
+
+describe('DropBillingCustomerCreditBalanceMicroFastInstanceCommand', () => {
+  const query = jest.fn();
+  const queryRunner = { query } as unknown as QueryRunner;
+  const command = new DropBillingCustomerCreditBalanceMicroFastInstanceCommand();
+
+  const presentTables = (...tableNames: string[]) => {
+    query.mockImplementation((statement: string, parameters?: unknown[]) => {
+      if (!statement.includes('pg_tables')) {
+        return Promise.resolve(undefined);
+      }
+
+      return Promise.resolve(
+        tableNames.includes(String(parameters?.[0])) ? [{ '?column?': 1 }] : [],
+      );
+    });
+  };
+
+  const statements = (): string[] =>
+    query.mock.calls
+      .map(([statement]) => collapseWhitespace(statement))
+      .filter((statement) => !statement.includes('pg_tables'));
+
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  it('drops the mirror column', async () => {
+    presentTables('billingCustomer', 'billingCreditGrant');
+
+    await command.up(queryRunner);
+
+    expect(statements()).toEqual([
+      'ALTER TABLE "core"."billingCustomer" DROP COLUMN IF EXISTS "creditBalanceMicro"',
+    ]);
+  });
+
+  it('leaves an instance without billing alone', async () => {
+    presentTables();
+
+    await command.up(queryRunner);
+    await command.down(queryRunner);
+
+    expect(statements()).toEqual([]);
+  });
+
+  it('restores the column and rebuilds it from the ledger', async () => {
+    presentTables('billingCustomer', 'billingCreditGrant');
+
+    await command.down(queryRunner);
+
+    const [addColumn, rebuild] = statements();
+
+    expect(addColumn).toBe(
+      'ALTER TABLE "core"."billingCustomer" ADD COLUMN IF NOT EXISTS "creditBalanceMicro" bigint NOT NULL DEFAULT 0',
+    );
+    expect(rebuild).toContain('UPDATE "core"."billingCustomer"');
+    expect(rebuild).toContain('SUM("billingCreditGrant"."amountMicro")');
+  });
+
+  // The rebuild has to keep counting exactly what getActiveCreditsMicro counts,
+  // or a rollback hands out credits that were revoked or already expired.
+  it('rebuilds from the same grants getActiveCreditsMicro reads', async () => {
+    presentTables('billingCustomer', 'billingCreditGrant');
+
+    await command.down(queryRunner);
+
+    const [, rebuild] = statements();
+
+    expect(rebuild).toContain('"billingCreditGrant"."revokedAt" IS NULL');
+    expect(rebuild).toContain('"billingCreditGrant"."effectiveAt" <= now()');
+    expect(rebuild).toContain('"billingCreditGrant"."expiresAt" > now()');
+    expect(rebuild).toContain('COALESCE(');
+  });
+
+  // Restoring the column is still right without a ledger to rebuild from; only
+  // the backfill has to be skipped.
+  it('restores the column without rebuilding when the ledger is absent', async () => {
+    presentTables('billingCustomer');
+
+    await command.down(queryRunner);
+
+    expect(statements()).toEqual([
+      'ALTER TABLE "core"."billingCustomer" ADD COLUMN IF NOT EXISTS "creditBalanceMicro" bigint NOT NULL DEFAULT 0',
+    ]);
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/__tests__/2-38-instance-command-fast-1787906740818-drop-billing-customer-credit-balance-micro.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/__tests__/2-38-instance-command-fast-1787906740818-drop-billing-customer-credit-balance-micro.spec.ts
@@ -79,8 +79,6 @@ describe('DropBillingCustomerCreditBalanceMicroFastInstanceCommand', () => {
     expect(rebuild).toContain('COALESCE(');
   });
 
-  // Restoring the column is still right without a ledger to rebuild from; only
-  // the backfill has to be skipped.
   it('restores the column without rebuilding when the ledger is absent', async () => {
     presentTables('billingCustomer');
 


### PR DESCRIPTION
Follow-up to #24969. The review finding on that PR ([discussion](https://github.com/twentyhq/twenty/pull/24969#discussion_r3880019045)) was raised while the PR was in flight, and #24969 was squash-merged about two minutes before the fix was pushed, so the fix did not make it into `53e284ca`. This carries it over on its own.

# The problem

`DropBillingCustomerCreditBalanceMicroFastInstanceCommand.down` recreates `billingCustomer.creditBalanceMicro` at its `bigint NOT NULL DEFAULT 0` and stops there, so every workspace comes back with a zero balance.

That is fine as long as a rollback stops between 2.32 and 2.37, where the ledger is the authority and `syncMirrorBalance` rewrites the column on the next credit state refresh. It is not fine for the case the two-phase drop exists to support: a rollback continuing past 2.31 reaches code that reads `creditBalanceMicro` as the authority rather than the ledger, so a workspace holding active grants silently loses its visible and spendable balance.

# The fix

`down` now rebuilds the column from the grants that are spendable at that moment, using the same predicate as `getActiveCreditsMicro` — not revoked, `effectiveAt` in the past, `expiresAt` in the future. It is skipped when the ledger table is absent, matching the guard the 2.31 backfill's own `down` uses, and the write is idempotent.

`up` is unchanged.

# Not part of this

`hasReachedCurrentPeriodCap` still restores to its original `DEFAULT false`, deliberately. It is a derived banner hint rather than a stored value, and reconstructing it truthfully needs the live ClickHouse usage and Redis counter reads that a SQL `down` cannot make. The worst case there is a missing banner on an exhausted workspace, which is the pre-#24175 status quo rather than lost money.

# Testing

Reproduced first, then fixed. Driving the command class directly against a database seeded with two active grants (700k + 250k), one revoked grant and one expired grant:

| | before | after |
|---|---|---|
| workspace with active grants | `0` | `950000` |
| workspace with no grants | `0` | `0` |
| second consecutive `down` | — | `950000`, no double count |

Revoked and expired grants are correctly excluded from the total. Also re-ran a full `database:reset` with billing enabled (`1-22 AddCreditBalance` → `2-31 Backfill` → the two `2-38` drops, all successful), and `tsgo --noEmit` plus oxlint `--type-aware` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0181YCS2ezTpvx6VM192thz9)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

