### PR TITLE
Show Stripe Link in the onboarding payment step

### DIFF
--- a/packages/twenty-front/src/pages/onboarding/UpgradeFreeTrial.tsx
+++ b/packages/twenty-front/src/pages/onboarding/UpgradeFreeTrial.tsx
@@ -321,7 +321,10 @@ export const UpgradeFreeTrial = ({
             mode: 'subscription',
             amount: baseProductPrice.unitAmount,
             currency: 'usd',
-            paymentMethodTypes: ['card'],
+            // Listing paymentMethodTypes overrides the Dashboard's dynamic payment
+            // methods, and 'card' only implies the Apple Pay / Google Pay wallets:
+            // Link has to be named explicitly or it never renders.
+            paymentMethodTypes: ['card', 'link'],
             appearance,
           }}
         >

--- a/packages/twenty-front/src/pages/onboarding/UpgradeFreeTrial.tsx
+++ b/packages/twenty-front/src/pages/onboarding/UpgradeFreeTrial.tsx
@@ -321,9 +321,6 @@ export const UpgradeFreeTrial = ({
             mode: 'subscription',
             amount: baseProductPrice.unitAmount,
             currency: 'usd',
-            // Listing paymentMethodTypes overrides the Dashboard's dynamic payment
-            // methods, and 'card' only implies the Apple Pay / Google Pay wallets:
-            // Link has to be named explicitly or it never renders.
             paymentMethodTypes: ['card', 'link'],
             appearance,
           }}


### PR DESCRIPTION
The "Upgrade your free trial" onboarding step never offered Stripe Link, while every other payment surface does.

## Cause

`UpgradeFreeTrial.tsx` mounted `Elements` with `paymentMethodTypes: ['card']`. Per Stripe's own typings that option means "instead of using automatic payment methods, declare specific payment methods to enable", so it overrides the payment method configuration managed in the Stripe Dashboard.

Two consequences, both visible in the step today:

- Google Pay and Apple Pay still render, because the `card` type implicitly enables those wallets.
- Link does not, because Link is its own payment method type. Stripe's docs are explicit that an explicit list has to name both `link` and `card`.

Nothing on the server was restricting it. The subscription is created without `payment_settings.payment_method_types` and the setup intent uses `automatic_payment_methods: { enabled: true }`, so the intent already accepted whatever the Dashboard has enabled.

## Change

`paymentMethodTypes: ['card', 'link']`.

Kept as an explicit list rather than dropping the option, so the step does not silently pick up every other method enabled in the Dashboard (SEPA, iDEAL, Bancontact) in the middle of signup. That is a product decision rather than a Link fix.

## Audit of the other card-entry surfaces

Checked each one; none needed a change.

| Surface | Link | Email for Link auth |
| --- | --- | --- |
| Onboarding step (`UpgradeFreeTrial.tsx`) | fixed here | `defaultValues.billingDetails.email` from `currentUserState` |
| Settings modal (`AddPaymentMethodForm.tsx`) | already OK, omits `paymentMethodTypes` so the Dashboard config applies | same |
| Hosted Checkout (`stripe-checkout.service.ts:61`) | already OK, no `payment_method_types` | Stripe Customer created with `email: userEmail` |
| Billing Portal (`stripe-billing-portal.service.ts`) | already OK, Stripe-hosted, driven by the Portal configuration | from the Customer |

Both `PaymentElement` call sites already pass `defaultValues.billingDetails.email`, which is what Stripe requires to start Link authentication or enrollment. `name` and `phone` are optional and not passed anywhere; that only means returning Link users type a little more during enrollment.

Redirect handling is payment-method agnostic on both return paths, so a Link redirect lands correctly: `EndTrialAfterPaymentMethodEffect` for the settings modal, and `PaymentSuccess` (which polls subscription status) for onboarding.

## Prerequisite

Link has to be enabled in the Stripe Dashboard payment method configuration. If it is not, the server-created intent will not include `link` and confirmation would fail for anyone selecting it. Quickest check: Link showing up in Settings > Billing > add a card means the Dashboard is already configured and this line was the only thing in the way.

## Testing

Not able to typecheck or lint locally (no `node_modules` in the session container). The change is a string array literal against a `string[]`-typed option, so CI is the real check. Worth a manual pass through onboarding to confirm the Link tab renders and a Link payment confirms.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GXa3dsXVZw7sv94aaiWqPp)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

