### PR TITLE
Fix e2e on main: disabled sortable cells claim button semantics

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/DragDropItemSortableCell.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/DragDropItemSortableCell.tsx
@@ -124,6 +124,12 @@ export const DragDropItemSortableCell = ({
         $fill={fill}
         $isDragSourceFaded={fadeSourceWhileDragging && isDragSource}
         $isDraggingHighlighted={highlightWhileDragging && isDragging}
+        // dnd-kit's accessibility plugin stamps role="button" and tabindex on
+        // any registered draggable that declares neither, so a disabled cell
+        // would join the tab order and make pointer automation resolve clicks
+        // on its content to a disabled button. Declaring both opts out.
+        role={disabled ? 'none' : undefined}
+        tabIndex={disabled ? -1 : undefined}
         onDragStart={
           disabled && allowNativeDragWhenDisabled
             ? undefined

--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/__tests__/DragDropItemSortableCell.test.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/__tests__/DragDropItemSortableCell.test.tsx
@@ -74,5 +74,6 @@ describe('DragDropItemSortableCell', () => {
       expect(getSortableRoot()).toHaveAttribute('role', 'button');
     });
     expect(getSortableRoot()).toHaveAttribute('tabindex', '0');
+    expect(getSortableRoot()).toHaveAttribute('aria-disabled', 'false');
   });
 });

--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/__tests__/DragDropItemSortableCell.test.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/__tests__/DragDropItemSortableCell.test.tsx
@@ -1,0 +1,52 @@
+import { DragDropItemSortableCell } from '@/ui/utilities/drag-and-drop/components/DragDropItemSortableCell';
+import { DragDropProvider } from '@dnd-kit/react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Playwright resolves a click on a non-interactive element to its closest
+// button-like ancestor before deciding whether the click target is enabled,
+// so a sortable wrapper that advertises itself as a disabled button makes
+// every element inside it unclickable for automation.
+const CLICK_TARGET_ANCESTOR_SELECTOR =
+  'button, [role=button], [role=checkbox], [role=radio]';
+
+const renderSortableCell = ({ disabled }: { disabled: boolean }) =>
+  render(
+    <DragDropProvider>
+      <DragDropItemSortableCell
+        id="widget-id"
+        index={0}
+        group="tab-id"
+        disabled={disabled}
+      >
+        <div data-testid="widget-content">Emails</div>
+      </DragDropItemSortableCell>
+    </DragDropProvider>,
+  );
+
+const getSortableRoot = () =>
+  screen.getByTestId('widget-content').parentElement;
+
+describe('DragDropItemSortableCell', () => {
+  it('keeps content clickable when dragging is disabled', async () => {
+    renderSortableCell({ disabled: true });
+
+    await waitFor(() => {
+      expect(getSortableRoot()).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    expect(
+      screen
+        .getByTestId('widget-content')
+        .closest(CLICK_TARGET_ANCESTOR_SELECTOR),
+    ).toBeNull();
+    expect(getSortableRoot()).not.toHaveAttribute('tabindex', '0');
+  });
+
+  it('exposes the sortable root as a button when dragging is enabled', async () => {
+    renderSortableCell({ disabled: false });
+
+    await waitFor(() => {
+      expect(getSortableRoot()).toHaveAttribute('role', 'button');
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/__tests__/DragDropItemSortableCell.test.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/__tests__/DragDropItemSortableCell.test.tsx
@@ -49,4 +49,30 @@ describe('DragDropItemSortableCell', () => {
       expect(getSortableRoot()).toHaveAttribute('role', 'button');
     });
   });
+
+  it('restores the drag affordances when dragging is enabled again', async () => {
+    const { rerender } = renderSortableCell({ disabled: true });
+
+    await waitFor(() => {
+      expect(getSortableRoot()).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    rerender(
+      <DragDropProvider>
+        <DragDropItemSortableCell
+          id="widget-id"
+          index={0}
+          group="tab-id"
+          disabled={false}
+        >
+          <div data-testid="widget-content">Emails</div>
+        </DragDropItemSortableCell>
+      </DragDropProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getSortableRoot()).toHaveAttribute('role', 'button');
+    });
+    expect(getSortableRoot()).toHaveAttribute('tabindex', '0');
+  });
 });


### PR DESCRIPTION
`CI E2E Main` has been red on every push run on `main` since 2026-08-25, always the same two tests:

- `create-record.spec.ts:51` "Create and update record", timing out clicking the Emails label inside `record-fields-widget`
- `workflow-creation.spec.ts:5` "Create workflow", timing out clicking `.react-flow__renderer`

Both fail with `element is not enabled`, retried ~100 times until the 60s timeout.

## Cause

dnd-kit's accessibility plugin stamps `role="button"`, `tabindex="0"` and `aria-disabled` onto every registered draggable that declares no role of its own. It applies this to sortables registered with `disabled: true` as well, setting `aria-disabled="true"` while still advertising the button role.

Since #24445 every vertical-list widget is wrapped in a `DragDropItemSortableCell` that is disabled outside edit mode (`PageLayoutVerticalListWidgetSlot` passes `disabled={!isInEditMode}`). So in view mode every widget wrapper became a disabled button sitting in the tab order.

Playwright retargets a click on a non-interactive element to `closest("button, [role=button], [role=checkbox], [role=radio]")` before checking whether the target is enabled. Clicking a plain element inside a widget, such as the Emails field label or the react-flow pane, therefore resolved to that disabled wrapper and could never become enabled.

Bisected to the first red run: [32818891251](https://github.com/twentyhq/twenty/actions/runs/32818891251) on d7dcc20b (#24445). The run immediately before it was green, and every `main` push run since has failed the same two tests.

Real users were unaffected, since `aria-disabled` is semantic only. That is why this only ever showed up in automation.

## Fix

Declare `role` and `tabIndex` on the sortable root when dragging is disabled, so the plugin's "stamp only if absent" checks leave both alone. Enabled cells are untouched and keep their `role="button"` and keyboard drag affordances.

This also fixes the accessibility side of the same bug: view-mode widgets no longer sit in the tab order, and screen readers no longer announce each one as a disabled button.

## Verification

`DragDropItemSortableCell.test.tsx` renders the cell inside a real `DragDropProvider` and reproduces Playwright's actionability check with the same ancestor selector. Written against the unfixed component first, where it failed with the exact production markup:

```
<div aria-describedby="dnd-kit-description-1" aria-disabled="true" aria-grabbed="false"
     aria-pressed="false" role="button" tabindex="0">
```

With the fix, content inside a disabled cell resolves to no button ancestor and the root leaves the tab order, while an enabled cell still gets `role="button"`.

Also run: 1430 jest tests across every module that passes `disabled` to this component (record board, record table header, record calendar, page layout, draggable list), plus typecheck, oxlint and oxfmt on `twenty-front`.

The e2e suite itself needs a full stack, so `ci-e2e-main` on this PR is the real confirmation. I am watching it and will follow up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4XeAiKew4hBfJYksvhjy1)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

