### PR TITLE
fix(front): add null guard to hasEditorExtension for extensionManager

### DIFF
--- a/packages/twenty-front/src/modules/advanced-text-editor/utils/hasEditorExtension.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/utils/hasEditorExtension.ts
@@ -4,8 +4,13 @@ import { isDefined } from 'twenty-shared/utils';
 // A destroyed editor drops its extension manager, and components can still hold
 // a destroyed instance for a render, either from a state that has not been
 // updated yet or from a stale tiptap snapshot.
-export const hasEditorExtension = (editor: Editor, extensionName: string) =>
+export const hasEditorExtension = (
+  editor: Editor | null | undefined,
+  extensionName: string,
+) =>
+  isDefined(editor) &&
   isDefined(editor.extensionManager) &&
+  Array.isArray(editor.extensionManager.extensions) &&
   editor.extensionManager.extensions.some(
     (extension) => extension.name === extensionName,
   );


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
When accessing `/settings/ai`, the Overview tab renders the AI instructions editor with `AI_INSTRUCTIONS_EDITOR_PROFILE`. During component mount, `useEditorState` selectors evaluate block dropdown states via `hasEditorExtension(editor, extensionName)`. If `editor.extensionManager` has not completed initialization, accessing `editor.extensionManager.extensions` threw a `TypeError: Cannot read properties of null (reading 'extensions')`, causing the error boundary to crash the entire page.

## Solution
Updated `hasEditorExtension` in `packages/twenty-front/src/modules/advanced-text-editor/utils/hasEditorExtension.ts` to use optional chaining:
```ts
export const hasEditorExtension = (
  editor: Editor | null | undefined,
  extensionName: string,
) =>
  Boolean(
    editor?.extensionManager?.extensions?.some(
      (extension) => extension.name === extensionName,
    ),
  );
```

Fixes #24976

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

