### PR TITLE
Scope calendar orphan cleanup to the events the sync just unlinked

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
@@ -62,6 +62,68 @@ export class CalendarEventCleanerService {
     );
   }
 
+  public async deleteOrphanedCalendarEvents({
+    calendarEventIds,
+    workspaceId,
+  }: {
+    calendarEventIds: string[];
+    workspaceId: string;
+  }) {
+    if (calendarEventIds.length === 0) {
+      return;
+    }
+
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        await this.workspaceOrmManager.runInWorkspaceTransaction(
+          async (transactionScope) => {
+            const calendarEventRepository =
+              transactionScope.getRepository<CalendarEventWorkspaceEntity>(
+                'calendarEvent',
+              );
+            const calendarChannelEventAssociationRepository =
+              transactionScope.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+                'calendarChannelEventAssociation',
+              );
+
+            for (
+              let index = 0;
+              index < calendarEventIds.length;
+              index += CALENDAR_CLEANUP_PAGE_SIZE
+            ) {
+              const pageIds = calendarEventIds.slice(
+                index,
+                index + CALENDAR_CLEANUP_PAGE_SIZE,
+              );
+
+              const associations =
+                await calendarChannelEventAssociationRepository.find({
+                  where: { calendarEventId: In(pageIds) },
+                  select: { calendarEventId: true },
+                });
+
+              const referencedEventIds = new Set(
+                associations.map(({ calendarEventId }) => calendarEventId),
+              );
+
+              const orphanEventIds = pageIds.filter(
+                (eventId) => !referencedEventIds.has(eventId),
+              );
+
+              if (orphanEventIds.length > 0) {
+                await calendarEventRepository.delete(orphanEventIds);
+              }
+            }
+          },
+        );
+      },
+      authContext,
+      { lite: true },
+    );
+  }
+
   public async cleanWorkspaceCalendarEvents(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
@@ -150,19 +150,35 @@ export class CalendarEventsImportService {
               workspaceId,
             );
           }
-          const calendarChannelEventAssociationRepository =
-            this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
-              'calendarChannelEventAssociation',
+          if (cancelledEventExternalIds.length > 0) {
+            const calendarChannelEventAssociationRepository =
+              this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+                'calendarChannelEventAssociation',
+              );
+
+            const associationsToDelete =
+              await calendarChannelEventAssociationRepository.find({
+                where: {
+                  eventExternalId: Any(cancelledEventExternalIds),
+                  calendarChannelId: calendarChannel.id,
+                },
+                select: { calendarEventId: true },
+              });
+
+            await calendarChannelEventAssociationRepository.delete({
+              eventExternalId: Any(cancelledEventExternalIds),
+              calendarChannelId: calendarChannel.id,
+            });
+
+            await this.calendarEventCleanerService.deleteOrphanedCalendarEvents(
+              {
+                calendarEventIds: associationsToDelete.map(
+                  ({ calendarEventId }) => calendarEventId,
+                ),
+                workspaceId,
+              },
             );
-
-          await calendarChannelEventAssociationRepository.delete({
-            eventExternalId: Any(cancelledEventExternalIds),
-            calendarChannelId: calendarChannel.id,
-          });
-
-          await this.calendarEventCleanerService.cleanWorkspaceCalendarEvents(
-            workspaceId,
-          );
+          }
 
           if (eventIdsToFetch.length < CALENDAR_EVENT_IMPORT_BATCH_SIZE) {
             await this.calendarChannelSyncStatusService.markAsCalendarEventSyncCompleted(

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -65,13 +65,27 @@ export class CalendarFetchEventsService {
                 'calendarChannelEventAssociation',
               );
 
+            const associationsToDelete =
+              await calendarChannelEventAssociationRepository.find({
+                where: {
+                  eventExternalId: Any(calendarEventIdsToDelete),
+                  calendarChannelId: calendarChannel.id,
+                },
+                select: { calendarEventId: true },
+              });
+
             await calendarChannelEventAssociationRepository.delete({
               eventExternalId: Any(calendarEventIdsToDelete),
               calendarChannelId: calendarChannel.id,
             });
 
-            await this.calendarEventCleanerService.cleanWorkspaceCalendarEvents(
-              workspaceId,
+            await this.calendarEventCleanerService.deleteOrphanedCalendarEvents(
+              {
+                calendarEventIds: associationsToDelete.map(
+                  ({ calendarEventId }) => calendarEventId,
+                ),
+                workspaceId,
+              },
             );
           }
 

--- a/packages/twenty-server/test/integration/google/calendar/orphan-cleanup.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/calendar/orphan-cleanup.integration-spec.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from 'node:crypto';
+
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+import { googleCalendarEvent } from 'test/integration/google/mocks/google-calendar-event.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { findCalendarEventAssociationChannelIds } from 'test/integration/utils/find-calendar-event-association-channel-ids.util';
+import { findImportedCalendarEventTitles } from 'test/integration/utils/find-imported-records.util';
+import { runCalendarChannelEventsImport } from 'test/integration/utils/run-calendar-channel-events-import.util';
+import { runCalendarChannelListFetch } from 'test/integration/utils/run-calendar-channel-list-fetch.util';
+
+const HANDLE = 'google-calendar-orphan-cleanup@apple.dev';
+const OTHER_HANDLE = 'google-calendar-orphan-cleanup-other@apple.dev';
+
+const syncToken = () => `orphan-cleanup-sync-token-${randomUUID()}`;
+
+const runCalendarSync = async (calendarChannelId: string): Promise<void> => {
+  await runCalendarChannelListFetch(calendarChannelId);
+  await runCalendarChannelEventsImport(calendarChannelId);
+};
+
+describe('Google calendar orphan cleanup (integration)', () => {
+  const google = setupGoogleMock({ handle: HANDLE });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let otherChannel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    google.actAsAccount(OTHER_HANDLE);
+
+    otherChannel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: OTHER_HANDLE,
+    });
+
+    google.actAsAccount(HANDLE);
+  }, 120000);
+
+  afterAll(async () => {
+    await otherChannel?.cleanup().catch(() => undefined);
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('deletes the calendar event once its last association is removed', async () => {
+    const eventExternalId = `google-calendar-event-${randomUUID()}`;
+    const eventTitle = `Orphan probe ${randomUUID()}`;
+
+    google.serveCalendarEvents(
+      [googleCalendarEvent({ id: eventExternalId, summary: eventTitle })],
+      { nextSyncToken: syncToken() },
+    );
+
+    await runCalendarSync(channel.calendarChannelId);
+
+    expect(await findImportedCalendarEventTitles([eventTitle])).toEqual([
+      eventTitle,
+    ]);
+    expect(
+      await findCalendarEventAssociationChannelIds(eventExternalId),
+    ).toEqual([channel.calendarChannelId]);
+
+    google.serveCalendarEvents(
+      [
+        googleCalendarEvent({
+          id: eventExternalId,
+          summary: eventTitle,
+          status: 'cancelled',
+        }),
+      ],
+      { nextSyncToken: syncToken() },
+    );
+
+    await runCalendarSync(channel.calendarChannelId);
+
+    expect(
+      await findCalendarEventAssociationChannelIds(eventExternalId),
+    ).toEqual([]);
+    expect(await findImportedCalendarEventTitles([eventTitle])).toEqual([]);
+  }, 60000);
+
+  it('keeps the events of the same channel that were not cancelled', async () => {
+    const cancelledExternalId = `google-calendar-event-${randomUUID()}`;
+    const cancelledTitle = `Orphan probe cancelled ${randomUUID()}`;
+    const survivingTitle = `Orphan probe surviving ${randomUUID()}`;
+
+    google.serveCalendarEvents(
+      [
+        googleCalendarEvent({
+          id: cancelledExternalId,
+          summary: cancelledTitle,
+        }),
+        googleCalendarEvent({ summary: survivingTitle }),
+      ],
+      { nextSyncToken: syncToken() },
+    );
+
+    await runCalendarSync(channel.calendarChannelId);
+
+    expect(
+      await findImportedCalendarEventTitles([cancelledTitle, survivingTitle]),
+    ).toEqual([cancelledTitle, survivingTitle].sort());
+
+    google.serveCalendarEvents(
+      [
+        googleCalendarEvent({
+          id: cancelledExternalId,
+          summary: cancelledTitle,
+          status: 'cancelled',
+        }),
+      ],
+      { nextSyncToken: syncToken() },
+    );
+
+    await runCalendarSync(channel.calendarChannelId);
+
+    expect(await findImportedCalendarEventTitles([cancelledTitle])).toEqual([]);
+    expect(await findImportedCalendarEventTitles([survivingTitle])).toEqual([
+      survivingTitle,
+    ]);
+  }, 60000);
+
+  it('keeps another channel copy of the same external event', async () => {
+    const sharedExternalId = `google-calendar-event-${randomUUID()}`;
+    const sharedTitle = `Orphan probe shared ${randomUUID()}`;
+
+    google.serveCalendarEvents(
+      [googleCalendarEvent({ id: sharedExternalId, summary: sharedTitle })],
+      { nextSyncToken: syncToken() },
+    );
+
+    await runCalendarSync(channel.calendarChannelId);
+    await runCalendarSync(otherChannel.calendarChannelId);
+
+    expect(
+      await findCalendarEventAssociationChannelIds(sharedExternalId),
+    ).toEqual(
+      [channel.calendarChannelId, otherChannel.calendarChannelId].sort(),
+    );
+
+    google.serveCalendarEvents(
+      [
+        googleCalendarEvent({
+          id: sharedExternalId,
+          summary: sharedTitle,
+          status: 'cancelled',
+        }),
+      ],
+      { nextSyncToken: syncToken() },
+    );
+
+    await runCalendarSync(channel.calendarChannelId);
+
+    expect(
+      await findCalendarEventAssociationChannelIds(sharedExternalId),
+    ).toEqual([otherChannel.calendarChannelId]);
+    expect(await findImportedCalendarEventTitles([sharedTitle])).toEqual([
+      sharedTitle,
+    ]);
+  }, 120000);
+
+  it('keeps previously imported events when the delta has no deletions', async () => {
+    const existingTitle = `Orphan probe existing ${randomUUID()}`;
+    const addedTitle = `Orphan probe added ${randomUUID()}`;
+
+    google.serveCalendarEvents(
+      [googleCalendarEvent({ summary: existingTitle })],
+      { nextSyncToken: syncToken() },
+    );
+
+    await runCalendarSync(channel.calendarChannelId);
+
+    google.serveCalendarEvents([googleCalendarEvent({ summary: addedTitle })], {
+      nextSyncToken: syncToken(),
+    });
+
+    await runCalendarSync(channel.calendarChannelId);
+
+    expect(
+      await findImportedCalendarEventTitles([existingTitle, addedTitle]),
+    ).toEqual([existingTitle, addedTitle].sort());
+  }, 60000);
+});


### PR DESCRIPTION
Every calendar delta swept the whole workspace `calendarEvent` table looking for orphans. That is work sized by the workspace while the delta is a handful of events, and on a large workspace it is a few hundred queries inside one transaction per sync.

`deleteOrphanedCalendarEvents` now checks only the events whose associations were just removed. Same reference-check logic, fed a list instead of walking the table. The call sites resolve the association rows' `calendarEventId` before deleting them.

The full sweep stays for channel deletion, connected account deletion and blocklist removal, where it is proportionate.

History: the sweep arrived in #4442 (2024-03) for **full sync**, where scanning everything matched the work being done. #4822 copied it into the incremental path four weeks later, and it has been carried through six refactors since without being re-examined.

Note this is not gated by a flag - it changes cron-path behaviour for every workspace on merge, which is why it is split out of #24987.