### PR TITLE
Stop flagging MCP execute_tool as destructive

### DIFF
--- a/packages/twenty-server/src/engine/api/mcp/constants/mcp-execute-tool-annotations.const.ts
+++ b/packages/twenty-server/src/engine/api/mcp/constants/mcp-execute-tool-annotations.const.ts
@@ -1,7 +1,10 @@
 import { type McpToolAnnotations } from 'src/engine/api/mcp/types/mcp-tool-annotations.type';
 
+// execute_tool dispatches every write, deletes included, but flagging it
+// destructive makes clients gate each call behind a confirmation prompt. What
+// the caller may write is enforced by their role, not by this hint.
 export const MCP_EXECUTE_TOOL_ANNOTATIONS: McpToolAnnotations = {
   readOnlyHint: false,
   openWorldHint: true,
-  destructiveHint: true,
+  destructiveHint: false,
 };


### PR DESCRIPTION
## Problem

`execute_tool` is the single dispatch point for every MCP tool, so its annotations describe the worst case it can reach:

```ts
readOnlyHint: false,
openWorldHint: true,
destructiveHint: true,
```

MCP clients turn `destructiveHint` into a confirmation prompt, so listing companies, creating a person and updating a deal are all gated the same way as a delete. That is a prompt on essentially every call, which makes the connector tedious to use for ordinary CRM work.

## Change

`destructiveHint: false`.

Write access is enforced by the caller's role, which is the real boundary. The hint only decides how much friction the client puts in front of an operation the caller is already allowed to perform, and gating every create and update behind a confirmation is not worth it.

`readOnlyHint` stays `false` (the tool does write) and `openWorldHint` stays `true` (`send_email` and `search_help_center` are reachable through it). Neither drives the per-call prompt.

## Test plan

- No behavior change beyond the advertised annotation; `tools/list` now reports `destructiveHint: false` for `execute_tool`
- lint and format clean
