### PR TITLE
perf(server): diff full-sync message deletes via a Set, not Array.includes

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -350,6 +350,10 @@ export class MessagingMessageListFetchService {
 
     const fullSyncMessageChannelMessageAssociationsToDelete = [];
 
+    // Set lookup keeps the per-row diff O(1): mailboxes reach 1M+ associations,
+    // so an Array.includes here is O(existing * total) and blocks the worker loop.
+    const messageExternalIdSet = new Set(messageExternalIds);
+
     const firstMessageChannelMessageAssociation =
       await messageChannelMessageAssociationRepository.findOne({
         where: {
@@ -397,7 +401,7 @@ export class MessagingMessageListFetchService {
             isDefined(
               existingMessageChannelMessageAssociation.messageExternalId,
             ) &&
-            !messageExternalIds.includes(
+            !messageExternalIdSet.has(
               existingMessageChannelMessageAssociation.messageExternalId,
             ),
         );


### PR DESCRIPTION
## Problem

`computeFullSyncMessageChannelMessageAssociationsToDelete` in `MessagingMessageListFetchService` finds associations to delete by scanning the **entire** mailbox id list with `Array.includes` once per existing association:

```ts
existing.filter(a => isDefined(a.messageExternalId) && !messageExternalIds.includes(a.messageExternalId))
```

That makes the full-sync delete pass **O(existing × total)**. The DB reads are batched (`take: 200`) but the diff itself runs in-process against the fully-materialized id list, so the batching does not bound it.

On prod-eu the largest `messageChannelMessageAssociation` table holds **~1.14M rows** (57 workspaces > 100k, 2 > 500k, 1 > 1M). A full re-sync there is ~650B string comparisons and blocks the **worker event loop for minutes**. It shows up as multi-second-to-multi-minute event-loop stalls, with `EventLoopStallMonitorService` naming `messaging-queue/MessagingMessageListFetchJob` as the long in-flight job. Full sync only runs when `syncCursor` is empty (initial connect / reconnect / reset), which is exactly when the mailbox scan is largest.

## Change

Hoist `messageExternalIds` into a `Set` once and test membership with `has()`. The per-row lookup becomes O(1) and the pass O(total). No behavioral change — `Set.has` is equivalent to `Array.includes` for string membership.

## Proof

Microbenchmark at the prod worst case (N = 1,142,447):

| approach | time |
|---|---|
| `Array.includes` (current) | **did not finish in 60s** (~8% scanned → extrapolates to ~12 min) |
| `Set.has` (this PR) | **~1.5s** total |

In situ the Set is built once (O(N)) and the loop yields to the DB between 200-row batches, so the actual event-loop cost per batch is negligible.

## Notes

This fixes the **full-sync** freeze specifically. Steady-state incremental syncs (cursor set) do not hit this path; a separate follow-up will look at the incremental import hotspot. A larger follow-up could push the set-difference into the DB (anti-join) so Node never materializes millions of ids.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

