### PR TITLE
Hide the group header when the fields widget has a single group

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsWidget.tsx
@@ -97,6 +97,9 @@ export const FieldsWidget = ({ widget }: FieldsWidgetProps) => {
 
   const hasFieldsToDisplay = groups.length > 0;
 
+  const shouldDisplayGroupHeaders =
+    displayMode === 'grouped' && groups.length > 1;
+
   if (!hasFieldsToDisplay) {
     return (
       <SidePanelProvider value={{ isInSidePanel }}>
@@ -125,16 +128,7 @@ export const FieldsWidget = ({ widget }: FieldsWidgetProps) => {
             instanceId,
           }}
         >
-          {displayMode === 'inline' ? (
-            <StyledInlineFieldsPropertyBox
-              hasMoreGroup={shouldShowHiddenFields}
-            >
-              <FieldsWidgetFieldList
-                fields={groups.flatMap((group) => group.fields)}
-                instanceId={instanceId}
-              />
-            </StyledInlineFieldsPropertyBox>
-          ) : (
+          {shouldDisplayGroupHeaders ? (
             groups.map((group) => (
               <FieldsWidgetGroupContainer key={group.id} title={group.name}>
                 <StyledPropertyBox>
@@ -145,6 +139,15 @@ export const FieldsWidget = ({ widget }: FieldsWidgetProps) => {
                 </StyledPropertyBox>
               </FieldsWidgetGroupContainer>
             ))
+          ) : (
+            <StyledInlineFieldsPropertyBox
+              hasMoreGroup={shouldShowHiddenFields}
+            >
+              <FieldsWidgetFieldList
+                fields={visibleFields}
+                instanceId={instanceId}
+              />
+            </StyledInlineFieldsPropertyBox>
           )}
 
           {shouldShowHiddenFields && (

--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/__stories__/FieldsWidget.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/__stories__/FieldsWidget.stories.tsx
@@ -246,6 +246,71 @@ const createViewFieldGroup = (
   viewFields,
 });
 
+const FieldsWidgetStoryRenderer = ({ view }: { view: ViewWithRelations }) => {
+  const widget = createFieldsWidget(FIELDS_VIEW_ID);
+
+  const pageLayoutData = createPageLayoutWithWidget(
+    widget,
+    companyObjectMetadataItem.id,
+  );
+
+  setTestObjectMetadataItemsInMetadataStore(
+    jotaiStore,
+    getTestEnrichedObjectMetadataItemsMock(),
+  );
+  jotaiStore.set(isMinimalMetadataReadyState.atom, true);
+  setTestViewsInMetadataStore(jotaiStore, [view]);
+  jotaiStore.set(
+    pageLayoutPersistedComponentState.atomFamily({
+      instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+    }),
+    pageLayoutData,
+  );
+  jotaiStore.set(
+    pageLayoutDraftComponentState.atomFamily({
+      instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+    }),
+    pageLayoutData,
+  );
+  setRecordInStore(TEST_RECORD_ID, mockCompanyRecord);
+
+  return (
+    <div style={{ width: '400px', padding: '20px' }}>
+      <JestMetadataAndApolloMocksWrapper>
+        <CoreClientProviderWrapper>
+          <PageLayoutTestWrapper store={jotaiStore}>
+            <LayoutRenderingProvider
+              value={{
+                isInSidePanel: false,
+                layoutType: PageLayoutType.RECORD_PAGE,
+                targetRecordIdentifier: {
+                  id: TEST_RECORD_ID,
+                  targetObjectNameSingular:
+                    companyObjectMetadataItem.nameSingular,
+                },
+              }}
+            >
+              <PageLayoutContentProvider
+                value={{
+                  layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+                  presentation: 'stack',
+                  tabId: TAB_ID_OVERVIEW,
+                }}
+              >
+                <WidgetComponentInstanceContext.Provider
+                  value={{ instanceId: widget.id }}
+                >
+                  <FieldsWidget widget={widget} />
+                </WidgetComponentInstanceContext.Provider>
+              </PageLayoutContentProvider>
+            </LayoutRenderingProvider>
+          </PageLayoutTestWrapper>
+        </CoreClientProviderWrapper>
+      </JestMetadataAndApolloMocksWrapper>
+    </div>
+  );
+};
+
 const meta: Meta<typeof FieldsWidget> = {
   title: 'Modules/PageLayout/Widgets/FieldsWidget',
   component: FieldsWidget,
@@ -304,68 +369,7 @@ export const WithViewFieldGroups: Story = {
       ],
     });
 
-    const widget = createFieldsWidget(FIELDS_VIEW_ID);
-
-    const pageLayoutData = createPageLayoutWithWidget(
-      widget,
-      companyObjectMetadataItem.id,
-    );
-
-    setTestObjectMetadataItemsInMetadataStore(
-      jotaiStore,
-      getTestEnrichedObjectMetadataItemsMock(),
-    );
-    jotaiStore.set(isMinimalMetadataReadyState.atom, true);
-    setTestViewsInMetadataStore(jotaiStore, [view]);
-    jotaiStore.set(
-      pageLayoutPersistedComponentState.atomFamily({
-        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
-      }),
-      pageLayoutData,
-    );
-    jotaiStore.set(
-      pageLayoutDraftComponentState.atomFamily({
-        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
-      }),
-      pageLayoutData,
-    );
-    setRecordInStore(TEST_RECORD_ID, mockCompanyRecord);
-
-    return (
-      <div style={{ width: '400px', padding: '20px' }}>
-        <JestMetadataAndApolloMocksWrapper>
-          <CoreClientProviderWrapper>
-            <PageLayoutTestWrapper store={jotaiStore}>
-              <LayoutRenderingProvider
-                value={{
-                  isInSidePanel: false,
-                  layoutType: PageLayoutType.RECORD_PAGE,
-                  targetRecordIdentifier: {
-                    id: TEST_RECORD_ID,
-                    targetObjectNameSingular:
-                      companyObjectMetadataItem.nameSingular,
-                  },
-                }}
-              >
-                <PageLayoutContentProvider
-                  value={{
-                    layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
-                    presentation: 'stack',
-                    tabId: TAB_ID_OVERVIEW,
-                  }}
-                >
-                  <WidgetComponentInstanceContext.Provider
-                    value={{ instanceId: widget.id }}
-                  >
-                    <FieldsWidget widget={widget} />
-                  </WidgetComponentInstanceContext.Provider>
-                </PageLayoutContentProvider>
-              </LayoutRenderingProvider>
-            </PageLayoutTestWrapper>
-          </CoreClientProviderWrapper>
-        </JestMetadataAndApolloMocksWrapper>
-      </div>
-    );
+    return <FieldsWidgetStoryRenderer view={view} />;
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -381,82 +385,52 @@ export const WithViewFieldGroups: Story = {
   },
 };
 
-export const WithDefaultGroups: Story = {
+export const WithSingleViewFieldGroup: Story = {
   render: () => {
-    const view = createView();
+    const contactInfoFields = [
+      createViewField('vf-name', nameField.id, 0, 'group-contact-info'),
+      createViewField('vf-address', addressField.id, 1, 'group-contact-info'),
+      createViewField('vf-linkedin', linkedinField.id, 2, 'group-contact-info'),
+    ];
 
-    const widget = createFieldsWidget(FIELDS_VIEW_ID);
+    const view = createView({
+      viewFields: contactInfoFields,
+      viewFieldGroups: [
+        createViewFieldGroup(
+          'group-contact-info',
+          'Contact Info',
+          0,
+          contactInfoFields,
+        ),
+      ],
+    });
 
-    const pageLayoutData = createPageLayoutWithWidget(
-      widget,
-      companyObjectMetadataItem.id,
-    );
-
-    setTestObjectMetadataItemsInMetadataStore(
-      jotaiStore,
-      getTestEnrichedObjectMetadataItemsMock(),
-    );
-    jotaiStore.set(isMinimalMetadataReadyState.atom, true);
-    setTestViewsInMetadataStore(jotaiStore, [view]);
-    jotaiStore.set(
-      pageLayoutPersistedComponentState.atomFamily({
-        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
-      }),
-      pageLayoutData,
-    );
-    jotaiStore.set(
-      pageLayoutDraftComponentState.atomFamily({
-        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
-      }),
-      pageLayoutData,
-    );
-    setRecordInStore(TEST_RECORD_ID, mockCompanyRecord);
-
-    return (
-      <div style={{ width: '400px', padding: '20px' }}>
-        <JestMetadataAndApolloMocksWrapper>
-          <CoreClientProviderWrapper>
-            <PageLayoutTestWrapper store={jotaiStore}>
-              <LayoutRenderingProvider
-                value={{
-                  isInSidePanel: false,
-                  layoutType: PageLayoutType.RECORD_PAGE,
-                  targetRecordIdentifier: {
-                    id: TEST_RECORD_ID,
-                    targetObjectNameSingular:
-                      companyObjectMetadataItem.nameSingular,
-                  },
-                }}
-              >
-                <PageLayoutContentProvider
-                  value={{
-                    layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
-                    presentation: 'stack',
-                    tabId: TAB_ID_OVERVIEW,
-                  }}
-                >
-                  <WidgetComponentInstanceContext.Provider
-                    value={{ instanceId: widget.id }}
-                  >
-                    <FieldsWidget widget={widget} />
-                  </WidgetComponentInstanceContext.Provider>
-                </PageLayoutContentProvider>
-              </LayoutRenderingProvider>
-            </PageLayoutTestWrapper>
-          </CoreClientProviderWrapper>
-        </JestMetadataAndApolloMocksWrapper>
-      </div>
-    );
+    return <FieldsWidgetStoryRenderer view={view} />;
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const generalHeader = await canvas.findByText('General');
-    expect(generalHeader).toBeVisible();
+    const companyName = await canvas.findByText('Acme Corporation');
+    expect(companyName).toBeVisible();
+
+    expect(canvas.queryByText('Contact Info')).not.toBeInTheDocument();
+  },
+};
+
+export const WithDefaultGroups: Story = {
+  render: () => {
+    const view = createView();
+
+    return <FieldsWidgetStoryRenderer view={view} />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
 
     const creationDateElements = await canvas.findAllByText('Creation date');
     expect(creationDateElements.length).toBeGreaterThan(0);
     expect(creationDateElements[0]).toBeVisible();
+
+    expect(canvas.queryByText('General')).not.toBeInTheDocument();
   },
 };
 
@@ -468,68 +442,7 @@ export const Empty: Story = {
       ],
     });
 
-    const widget = createFieldsWidget(FIELDS_VIEW_ID);
-
-    const pageLayoutData = createPageLayoutWithWidget(
-      widget,
-      companyObjectMetadataItem.id,
-    );
-
-    setTestObjectMetadataItemsInMetadataStore(
-      jotaiStore,
-      getTestEnrichedObjectMetadataItemsMock(),
-    );
-    jotaiStore.set(isMinimalMetadataReadyState.atom, true);
-    setTestViewsInMetadataStore(jotaiStore, [view]);
-    jotaiStore.set(
-      pageLayoutPersistedComponentState.atomFamily({
-        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
-      }),
-      pageLayoutData,
-    );
-    jotaiStore.set(
-      pageLayoutDraftComponentState.atomFamily({
-        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
-      }),
-      pageLayoutData,
-    );
-    setRecordInStore(TEST_RECORD_ID, mockCompanyRecord);
-
-    return (
-      <div style={{ width: '400px', padding: '20px' }}>
-        <JestMetadataAndApolloMocksWrapper>
-          <CoreClientProviderWrapper>
-            <PageLayoutTestWrapper store={jotaiStore}>
-              <LayoutRenderingProvider
-                value={{
-                  isInSidePanel: false,
-                  layoutType: PageLayoutType.RECORD_PAGE,
-                  targetRecordIdentifier: {
-                    id: TEST_RECORD_ID,
-                    targetObjectNameSingular:
-                      companyObjectMetadataItem.nameSingular,
-                  },
-                }}
-              >
-                <PageLayoutContentProvider
-                  value={{
-                    layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
-                    presentation: 'stack',
-                    tabId: TAB_ID_OVERVIEW,
-                  }}
-                >
-                  <WidgetComponentInstanceContext.Provider
-                    value={{ instanceId: widget.id }}
-                  >
-                    <FieldsWidget widget={widget} />
-                  </WidgetComponentInstanceContext.Provider>
-                </PageLayoutContentProvider>
-              </LayoutRenderingProvider>
-            </PageLayoutTestWrapper>
-          </CoreClientProviderWrapper>
-        </JestMetadataAndApolloMocksWrapper>
-      </div>
-    );
+    return <FieldsWidgetStoryRenderer view={view} />;
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);


### PR DESCRIPTION
A fields widget with a single group ("General", "Other", or a custom name) showed that group's collapsible header above the fields, which adds a line of chrome without telling the reader anything: there is nothing to distinguish it from.

Group headers now render only when the widget is in grouped mode **and** has more than one visible group. With a single group the fields render inline, using the same layout as the ungrouped display path. The hidden-fields "More (N)" section is unchanged and still renders its own collapsible header.

## Test plan

`FieldsWidget.stories.tsx`:
- new `WithSingleViewFieldGroup` story: one view field group, asserts its name is not rendered while its fields are
- `WithDefaultGroups`: the standard-object mock produces only "General", so it now asserts that header is gone
- `WithViewFieldGroups` (two groups) and `Empty` unchanged

The three stories duplicated the same ~60-line render wrapper; it is now a single `FieldsWidgetStoryRenderer` that takes the view.

All four stories pass locally (`vitest run --project=storybook`), and `tsgo --noEmit`, `oxlint --type-aware` and `oxfmt --check` are clean on the changed files.

<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24997?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>