### PR TITLE
fix(workflow): create a record when a relation variable resolves to null

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
@@ -1,0 +1,100 @@
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { type ObjectMetadataInfo } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { formatWorkflowRecordRelationFields } from 'src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util';
+
+const RELATION_FIELD_NAMES = ['assignee'];
+const TEXT_FIELD_NAMES = ['title'];
+
+const buildObjectMetadataInfo = (): ObjectMetadataInfo => {
+  const fieldNames = [...RELATION_FIELD_NAMES, ...TEXT_FIELD_NAMES];
+
+  const buildField = (name: string) =>
+    RELATION_FIELD_NAMES.includes(name)
+      ? {
+          id: `field-${name}`,
+          universalIdentifier: `field-uid-${name}`,
+          name,
+          type: FieldMetadataType.RELATION,
+          settings: { relationType: RelationType.MANY_TO_ONE },
+          relationTargetObjectMetadataId: 'target-object-id',
+        }
+      : {
+          id: `field-${name}`,
+          universalIdentifier: `field-uid-${name}`,
+          name,
+          type: FieldMetadataType.TEXT,
+          settings: {},
+        };
+
+  return {
+    flatObjectMetadata: {
+      id: 'object-id',
+      universalIdentifier: 'object-uid',
+      nameSingular: 'task',
+      namePlural: 'tasks',
+      fieldIds: fieldNames.map((name) => `field-${name}`),
+    },
+    flatFieldMetadataMaps: {
+      byUniversalIdentifier: Object.fromEntries(
+        fieldNames.map((name) => [`field-uid-${name}`, buildField(name)]),
+      ),
+      universalIdentifierById: Object.fromEntries(
+        fieldNames.map((name) => [`field-${name}`, `field-uid-${name}`]),
+      ),
+      universalIdentifiersByApplicationId: {},
+    },
+    flatObjectMetadataMaps: {
+      byUniversalIdentifier: {},
+      universalIdentifierById: {},
+      universalIdentifiersByApplicationId: {},
+    },
+  } as unknown as ObjectMetadataInfo;
+};
+
+const format = (record: Record<string, unknown>) =>
+  formatWorkflowRecordRelationFields(record, buildObjectMetadataInfo())
+    .formattedRecord;
+
+describe('formatWorkflowRecordRelationFields', () => {
+  it('maps a legacy relation object to its join column', () => {
+    expect(
+      format({ assignee: { id: 'e1c3f8a0-0000-4000-8000-000000000000' } }),
+    ).toEqual({
+      assigneeId: 'e1c3f8a0-0000-4000-8000-000000000000',
+    });
+  });
+
+  it.each([[null], [{ id: null }], [{ id: undefined }], [{ id: '' }]])(
+    'nullifies the join column when the relation resolves to %p',
+    (value) => {
+      expect(format({ title: 'Follow up', assignee: value })).toEqual({
+        title: 'Follow up',
+        assigneeId: null,
+      });
+    },
+  );
+
+  it('keeps an explicitly provided join column over an empty relation', () => {
+    expect(
+      format({
+        assignee: { id: null },
+        assigneeId: 'e1c3f8a0-0000-4000-8000-000000000000',
+      }),
+    ).toEqual({ assigneeId: 'e1c3f8a0-0000-4000-8000-000000000000' });
+  });
+
+  it('leaves nested relation operations untouched', () => {
+    const record = {
+      assignee: {
+        connect: { where: { id: 'e1c3f8a0-0000-4000-8000-000000000000' } },
+      },
+    };
+
+    expect(format(record)).toEqual(record);
+  });
+
+  it('leaves non-relation fields untouched', () => {
+    expect(format({ title: null })).toEqual({ title: null });
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
@@ -1,71 +1,75 @@
 import { FieldMetadataType, RelationType } from 'twenty-shared/types';
 
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type ObjectMetadataInfo } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import { formatWorkflowRecordRelationFields } from 'src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util';
 
-const RELATION_FIELD_NAMES = ['assignee'];
-const TEXT_FIELD_NAMES = ['title'];
+const ASSIGNEE_ID = 'e1c3f8a0-0000-4000-8000-000000000000';
 
-const buildObjectMetadataInfo = (): ObjectMetadataInfo => {
-  const fieldNames = [...RELATION_FIELD_NAMES, ...TEXT_FIELD_NAMES];
+const assigneeFlatFieldMetadata = {
+  id: 'assignee-field-metadata-id',
+  universalIdentifier: 'assignee-field-universal-identifier',
+  name: 'assignee',
+  type: FieldMetadataType.RELATION,
+  settings: { relationType: RelationType.MANY_TO_ONE },
+  relationTargetObjectMetadataId: 'workspace-member-object-metadata-id',
+} satisfies Partial<FlatFieldMetadata<FieldMetadataType.RELATION>>;
 
-  const buildField = (name: string) =>
-    RELATION_FIELD_NAMES.includes(name)
-      ? {
-          id: `field-${name}`,
-          universalIdentifier: `field-uid-${name}`,
-          name,
-          type: FieldMetadataType.RELATION,
-          settings: { relationType: RelationType.MANY_TO_ONE },
-          relationTargetObjectMetadataId: 'target-object-id',
-        }
-      : {
-          id: `field-${name}`,
-          universalIdentifier: `field-uid-${name}`,
-          name,
-          type: FieldMetadataType.TEXT,
-          settings: {},
-        };
+const titleFlatFieldMetadata = {
+  id: 'title-field-metadata-id',
+  universalIdentifier: 'title-field-universal-identifier',
+  name: 'title',
+  type: FieldMetadataType.TEXT,
+} satisfies Partial<FlatFieldMetadata<FieldMetadataType.TEXT>>;
 
-  return {
-    flatObjectMetadata: {
-      id: 'object-id',
-      universalIdentifier: 'object-uid',
-      nameSingular: 'task',
-      namePlural: 'tasks',
-      fieldIds: fieldNames.map((name) => `field-${name}`),
-    },
-    flatFieldMetadataMaps: {
-      byUniversalIdentifier: Object.fromEntries(
-        fieldNames.map((name) => [`field-uid-${name}`, buildField(name)]),
-      ),
-      universalIdentifierById: Object.fromEntries(
-        fieldNames.map((name) => [`field-${name}`, `field-uid-${name}`]),
-      ),
-      universalIdentifiersByApplicationId: {},
-    },
-    flatObjectMetadataMaps: {
-      byUniversalIdentifier: {},
-      universalIdentifierById: {},
-      universalIdentifiersByApplicationId: {},
-    },
-  } as unknown as ObjectMetadataInfo;
-};
+const taskFlatObjectMetadata = {
+  id: 'task-object-metadata-id',
+  universalIdentifier: 'task-object-universal-identifier',
+  nameSingular: 'task',
+  namePlural: 'tasks',
+  fieldIds: [assigneeFlatFieldMetadata.id, titleFlatFieldMetadata.id],
+} satisfies Partial<FlatObjectMetadata>;
+
+const buildFlatEntityMaps = (
+  flatEntities: { id: string; universalIdentifier: string }[],
+) => ({
+  byUniversalIdentifier: Object.fromEntries(
+    flatEntities.map((flatEntity) => [
+      flatEntity.universalIdentifier,
+      flatEntity,
+    ]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    flatEntities.map((flatEntity) => [
+      flatEntity.id,
+      flatEntity.universalIdentifier,
+    ]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+const objectMetadataInfo = {
+  flatObjectMetadata: taskFlatObjectMetadata,
+  flatFieldMetadataMaps: buildFlatEntityMaps([
+    assigneeFlatFieldMetadata,
+    titleFlatFieldMetadata,
+  ]),
+  flatObjectMetadataMaps: buildFlatEntityMaps([taskFlatObjectMetadata]),
+} as unknown as ObjectMetadataInfo;
 
 const format = (record: Record<string, unknown>) =>
-  formatWorkflowRecordRelationFields(record, buildObjectMetadataInfo())
+  formatWorkflowRecordRelationFields(record, objectMetadataInfo)
     .formattedRecord;
 
 describe('formatWorkflowRecordRelationFields', () => {
-  it('maps a legacy relation object to its join column', () => {
-    expect(
-      format({ assignee: { id: 'e1c3f8a0-0000-4000-8000-000000000000' } }),
-    ).toEqual({
-      assigneeId: 'e1c3f8a0-0000-4000-8000-000000000000',
+  it('maps a relation wrapped as an id object to its join column', () => {
+    expect(format({ assignee: { id: ASSIGNEE_ID } })).toEqual({
+      assigneeId: ASSIGNEE_ID,
     });
   });
 
-  it.each([[null], [{ id: null }], [{ id: undefined }], [{ id: '' }]])(
+  it.each([[null], [{ id: null }]])(
     'nullifies the join column when the relation resolves to %p',
     (value) => {
       expect(format({ title: 'Follow up', assignee: value })).toEqual({
@@ -75,21 +79,26 @@ describe('formatWorkflowRecordRelationFields', () => {
     },
   );
 
-  it('keeps an explicitly provided join column over an empty relation', () => {
-    expect(
-      format({
-        assignee: { id: null },
-        assigneeId: 'e1c3f8a0-0000-4000-8000-000000000000',
-      }),
-    ).toEqual({ assigneeId: 'e1c3f8a0-0000-4000-8000-000000000000' });
+  it('keeps an explicitly provided join column over a null relation', () => {
+    expect(format({ assignee: { id: null }, assigneeId: ASSIGNEE_ID })).toEqual(
+      {
+        assigneeId: ASSIGNEE_ID,
+      },
+    );
+  });
+
+  it('writes no join column when the relation id is undefined', () => {
+    expect(Object.keys(format({ assignee: { id: undefined } }))).toEqual([
+      'assignee',
+    ]);
+  });
+
+  it('keeps an empty id so it is rejected downstream', () => {
+    expect(format({ assignee: { id: '' } })).toEqual({ assigneeId: '' });
   });
 
   it('leaves nested relation operations untouched', () => {
-    const record = {
-      assignee: {
-        connect: { where: { id: 'e1c3f8a0-0000-4000-8000-000000000000' } },
-      },
-    };
+    const record = { assignee: { connect: { where: { id: ASSIGNEE_ID } } } };
 
     expect(format(record)).toEqual(record);
   });

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/format-workflow-record-relation-fields.util.spec.ts
@@ -69,7 +69,7 @@ describe('formatWorkflowRecordRelationFields', () => {
     });
   });
 
-  it.each([[null], [{ id: null }]])(
+  it.each([[null], [{ id: null }], [{ id: null, name: 'Unassigned' }]])(
     'nullifies the join column when the relation resolves to %p',
     (value) => {
       expect(format({ title: 'Follow up', assignee: value })).toEqual({

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
@@ -54,6 +54,24 @@ const extractLegacyRelationId = (value: unknown): string | undefined => {
   return record.id;
 };
 
+const isEmptyRelationValue = (value: unknown): boolean => {
+  if (value === null) {
+    return true;
+  }
+
+  if (!isObject(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  if (Object.keys(record).length !== 1 || !('id' in record)) {
+    return false;
+  }
+
+  return !isDefined(record.id) || record.id === '';
+};
+
 const formatWorkflowRecordMorphRelationFields = (
   record: Record<string, unknown>,
   objectMetadataInfo: ObjectMetadataInfo,
@@ -191,16 +209,23 @@ const formatWorkflowRecordSimpleRelationFields = (
       continue;
     }
 
+    const joinColumnName = computeMorphOrRelationFieldJoinColumnName({
+      name: key,
+    });
+
+    if (isEmptyRelationValue(value)) {
+      if (!isDefined(record[joinColumnName])) {
+        formattedRecord[joinColumnName] = null;
+      }
+      continue;
+    }
+
     const legacyId = extractLegacyRelationId(value);
 
     if (!isDefined(legacyId)) {
       formattedRecord[key] = value;
       continue;
     }
-
-    const joinColumnName = computeMorphOrRelationFieldJoinColumnName({
-      name: key,
-    });
 
     if (!isDefined(record[joinColumnName])) {
       formattedRecord[joinColumnName] = legacyId;

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
@@ -1,4 +1,4 @@
-import { isObject, isString } from '@sniptt/guards';
+import { isObject, isString, isUndefined } from '@sniptt/guards';
 import { FieldMetadataType, RelationType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -8,6 +8,7 @@ import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { getMorphNameFromMorphFieldMetadataName } from 'src/engine/metadata-modules/flat-object-metadata/utils/get-morph-name-from-morph-field-metadata-name.util';
 import { type ObjectMetadataInfo } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { isNullRelationValue } from 'src/modules/workflow/workflow-executor/utils/is-null-relation-value.util';
 
 type MorphRelationTargetJoinColumn = {
   joinColumnName: string;
@@ -53,10 +54,6 @@ const extractLegacyRelationId = (value: unknown): string | undefined => {
 
   return record.id;
 };
-
-const isNullRelationValue = (value: unknown): boolean =>
-  value === null ||
-  (isObject(value) && (value as Record<string, unknown>).id === null);
 
 const formatWorkflowRecordMorphRelationFields = (
   record: Record<string, unknown>,
@@ -195,26 +192,21 @@ const formatWorkflowRecordSimpleRelationFields = (
       continue;
     }
 
-    const joinColumnName = computeMorphOrRelationFieldJoinColumnName({
-      name: key,
-    });
+    const joinColumnValue = isNullRelationValue(value)
+      ? null
+      : extractLegacyRelationId(value);
 
-    if (isNullRelationValue(value)) {
-      if (!isDefined(record[joinColumnName])) {
-        formattedRecord[joinColumnName] = null;
-      }
-      continue;
-    }
-
-    const legacyId = extractLegacyRelationId(value);
-
-    if (!isDefined(legacyId)) {
+    if (isUndefined(joinColumnValue)) {
       formattedRecord[key] = value;
       continue;
     }
 
+    const joinColumnName = computeMorphOrRelationFieldJoinColumnName({
+      name: key,
+    });
+
     if (!isDefined(record[joinColumnName])) {
-      formattedRecord[joinColumnName] = legacyId;
+      formattedRecord[joinColumnName] = joinColumnValue;
     }
   }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
@@ -54,19 +54,9 @@ const extractLegacyRelationId = (value: unknown): string | undefined => {
   return record.id;
 };
 
-const isNullRelationValue = (value: unknown): boolean => {
-  if (value === null) {
-    return true;
-  }
-
-  if (!isObject(value)) {
-    return false;
-  }
-
-  const record = value as Record<string, unknown>;
-
-  return Object.keys(record).length === 1 && record.id === null;
-};
+const isNullRelationValue = (value: unknown): boolean =>
+  value === null ||
+  (isObject(value) && (value as Record<string, unknown>).id === null);
 
 const formatWorkflowRecordMorphRelationFields = (
   record: Record<string, unknown>,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/format-workflow-record-relation-fields.util.ts
@@ -54,7 +54,7 @@ const extractLegacyRelationId = (value: unknown): string | undefined => {
   return record.id;
 };
 
-const isEmptyRelationValue = (value: unknown): boolean => {
+const isNullRelationValue = (value: unknown): boolean => {
   if (value === null) {
     return true;
   }
@@ -65,11 +65,7 @@ const isEmptyRelationValue = (value: unknown): boolean => {
 
   const record = value as Record<string, unknown>;
 
-  if (Object.keys(record).length !== 1 || !('id' in record)) {
-    return false;
-  }
-
-  return !isDefined(record.id) || record.id === '';
+  return Object.keys(record).length === 1 && record.id === null;
 };
 
 const formatWorkflowRecordMorphRelationFields = (
@@ -213,7 +209,7 @@ const formatWorkflowRecordSimpleRelationFields = (
       name: key,
     });
 
-    if (isEmptyRelationValue(value)) {
+    if (isNullRelationValue(value)) {
       if (!isDefined(record[joinColumnName])) {
         formattedRecord[joinColumnName] = null;
       }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/is-null-relation-value.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/is-null-relation-value.util.ts
@@ -1,0 +1,5 @@
+import { isObject } from '@sniptt/guards';
+
+export const isNullRelationValue = (value: unknown): boolean =>
+  value === null ||
+  (isObject(value) && (value as Record<string, unknown>).id === null);


### PR DESCRIPTION
Fixes #24849

## Issue

A Create Record step that maps a relation (e.g. Task `assignee`) to a variable fails with `Relation "assignee" requires connect or disconnect operation` whenever that variable resolves to `null`. The expected behaviour is to create the record without the relation.

## Root cause

The create form stores a many-to-one relation wrapped as `{ assignee: { id: "{{trigger.record.assigneeId}}" } }` (`buildUpdatedRecordActionFormData`).

At run time `resolveInput` turns a null source value into `{ id: null }`. `formatWorkflowRecordSimpleRelationFields` only rewrites the relation key into its join column when the id is a string, so the payload kept the `assignee` key, and the data arg processor rejects any relation key that is not a `connect`/`disconnect` operation.

## Fix

A many-to-one value that is `null`, or an object whose `id` is explicitly `null`, is now mapped to a null join column, which the API accepts. This mirrors what the morph relation branch of the same util already does for `null`.

Deliberately left alone, so the fix cannot turn a broken step into a silent one:

- `{ id: undefined }`, what you get when the variable path does not resolve at all, keeps meaning "not provided": it is stripped downstream on create and leaves the relation untouched on upsert. Only a genuine `null` clears the relation.
- `{ id: '' }` still becomes `assigneeId: ''` and fails with `Invalid UUID value ''`.
- Nested `connect`/`disconnect` operations, real ids, and an explicitly provided join column (which still wins over the wrapped relation) are unchanged.

Update Record is unaffected either way: its form writes `assigneeId` directly, so it never went through this branch.

## Alternatives considered

- Accept a `null` relation key in `data-arg-processor` and treat it as a disconnect. That changes the create/update contract for the REST and GraphQL APIs as well, for a bug that only exists in the shape the workflow front-end writes.
- Make the create form store `assigneeId` like the update form does. It does not fix workflows already saved with the wrapped shape, and the server would still reject the payload.

## Test

New unit spec for the util. Four of its nine cases fail against `main`; the cases pinning the untouched behaviours (`{ id: undefined }`, `{ id: '' }`, nested operations, non-relation fields) pass on both sides by design.

## Verified on a dev instance

Manual-trigger workflow with a Create Record step on `task`, field `assignee` bound to `{{trigger.assigneeId}}`, run with payload `{ "assigneeId": null }` — the shape the create form saves. Only the util file was swapped between the two runs.

| Server code | Workflow run | Step | Task created |
| --- | --- | --- | --- |
| `main` | FAILED | `Relation "assignee" requires connect or disconnect operation` | none |
| this branch | COMPLETED | SUCCESS | `assigneeId: null` |