### PR TITLE
Add page link and theme commands to command menu

### DIFF
--- a/packages/twenty-docs/user-guide/layout/capabilities/navigation.mdx
+++ b/packages/twenty-docs/user-guide/layout/capabilities/navigation.mdx
@@ -39,6 +39,9 @@ Add links to external tools directly in the sidebar. Useful for linking to your 
 
 Press `Cmd+K` (or `Ctrl+K`) to open the command menu — a quick-access search bar for jumping to any record, view, or action without navigating the sidebar.
 
+- Choose **Copy link to page** to copy the current page URL, including its view and tab, to your clipboard.
+- Search for **theme** to switch to light, dark, or system appearance. The menu offers the themes you aren't currently using, and your choice is saved to your profile.
+
 ## Customizing the sidebar
 
 To customize the sidebar, hover over the "Workspace" section in the sidebar and click the wrench icon.

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
@@ -1,56 +1,32 @@
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
 import { CommandMenuItemRenderer } from '@/command-menu-item/display/components/CommandMenuItemRenderer';
 import { PINNED_COMMAND_MENU_ITEMS_GAP } from '@/command-menu-item/display/constants/PinnedCommandMenuItemsGap';
+import { useCommandMenuUtilityItems } from '@/command-menu-item/display/hooks/useCommandMenuUtilityItems';
 import { commandMenuPinnedInlineLayoutFamilyState } from '@/command-menu-item/display/states/commandMenuPinnedInlineLayoutFamilyState';
 import { getVisibleCommandMenuItemCountForContainerWidth } from '@/command-menu-item/display/utils/getVisibleCommandMenuItemCountForContainerWidth';
 import { groupCommandMenuItems } from '@/command-menu-item/utils/groupCommandMenuItems';
 import { CommandMenuItem } from '@/command-menu/components/CommandMenuItem';
-import { useIsSettingsDrawer } from '@/navigation/hooks/useIsSettingsDrawer';
-import { useNavigationDrawerTogglePresentation } from '@/navigation/hooks/useNavigationDrawerTogglePresentation';
-import { useToggleNavigationDrawer } from '@/navigation/hooks/useToggleNavigationDrawer';
 import { SidePanelGroup } from '@/side-panel/components/SidePanelGroup';
 import { SidePanelList } from '@/side-panel/components/SidePanelList';
 import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
 import { useFilterCommandMenuItemsWithSidePanelSearch } from '@/side-panel/pages/root/hooks/useFilterCommandMenuItemsWithSidePanelSearch';
 import { sidePanelSearchState } from '@/side-panel/states/sidePanelSearchState';
 import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
-import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useLingui } from '@lingui/react/macro';
 import { isNonEmptyString, isNumber } from '@sniptt/guards';
 import { useContext, useMemo } from 'react';
 import { CommandMenuItemAvailabilityType } from '~/generated-metadata/graphql';
-import { normalizeSearchText } from '~/utils/normalizeSearchText';
-
-const TOGGLE_NAVIGATION_DRAWER_COMMAND_ID = 'toggle-navigation-drawer';
 
 export const SidePanelCommandMenuItemDisplayPage = () => {
   const { t } = useLingui();
-  const isMobile = useIsMobile();
-  const isSettingsDrawer = useIsSettingsDrawer();
-  const { isNavigationDrawerExpanded, toggleNavigationDrawer } =
-    useToggleNavigationDrawer();
+  const { utilityItems } = useCommandMenuUtilityItems();
   const { closeSidePanelMenu } = useSidePanelMenu();
 
   const sidePanelSearch = useAtomStateValue(sidePanelSearchState);
-  const { commandMenuItems, commandMenuContextApi, isInPreviewMode } =
+  const { commandMenuItems, commandMenuContextApi } =
     useContext(CommandMenuContext);
-
-  const { label: navigationDrawerCommandLabel, Icon: NavigationDrawerIcon } =
-    useNavigationDrawerTogglePresentation(isNavigationDrawerExpanded);
-  const shouldDisplayNavigationDrawerCommand =
-    !isMobile &&
-    !isSettingsDrawer &&
-    !isInPreviewMode &&
-    normalizeSearchText(navigationDrawerCommandLabel).includes(
-      normalizeSearchText(sidePanelSearch.trim()),
-    );
-
-  const handleToggleNavigationDrawer = () => {
-    toggleNavigationDrawer();
-    closeSidePanelMenu();
-  };
 
   // The command menu list surfaces whatever overflowed out of the page header.
   const commandMenuPinnedInlineLayout = useAtomFamilyStateValue(
@@ -127,7 +103,7 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
   const hasNoMatchingItems =
     !matchingPinnedItems.length &&
     !matchingOtherItems.length &&
-    !shouldDisplayNavigationDrawerCommand;
+    utilityItems.length === 0;
 
   const shouldDisplayFallbackItems =
     hasNoMatchingItems && fallbackCommandMenuItems.length > 0;
@@ -138,9 +114,7 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
   const selectableItemIds = [
     ...matchingPinnedItems.map((item) => item.id),
     ...matchingOtherItems.map((item) => item.id),
-    ...(shouldDisplayNavigationDrawerCommand
-      ? [TOGGLE_NAVIGATION_DRAWER_COMMAND_ID]
-      : []),
+    ...utilityItems.map((item) => item.id),
     ...(shouldDisplayFallbackItems
       ? fallbackCommandMenuItems.map((item) => item.id)
       : []),
@@ -158,25 +132,32 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
           ))}
         </SidePanelGroup>
       )}
-      {(matchingOtherItems.length > 0 ||
-        shouldDisplayNavigationDrawerCommand) && (
+      {(matchingOtherItems.length > 0 || utilityItems.length > 0) && (
         <SidePanelGroup heading={t`Other`}>
           {matchingOtherItems.map((item) => (
             <CommandMenuItemRenderer item={item} key={item.id} />
           ))}
-          {shouldDisplayNavigationDrawerCommand && (
-            <SelectableListItem
-              itemId={TOGGLE_NAVIGATION_DRAWER_COMMAND_ID}
-              onEnter={handleToggleNavigationDrawer}
-            >
-              <CommandMenuItem
-                id={TOGGLE_NAVIGATION_DRAWER_COMMAND_ID}
-                label={navigationDrawerCommandLabel}
-                Icon={NavigationDrawerIcon}
-                onClick={handleToggleNavigationDrawer}
-              />
-            </SelectableListItem>
-          )}
+          {utilityItems.map((item) => {
+            const handleClick = () => {
+              item.onClick();
+              closeSidePanelMenu();
+            };
+
+            return (
+              <SelectableListItem
+                key={item.id}
+                itemId={item.id}
+                onEnter={handleClick}
+              >
+                <CommandMenuItem
+                  id={item.id}
+                  label={item.label}
+                  Icon={item.Icon}
+                  onClick={handleClick}
+                />
+              </SelectableListItem>
+            );
+          })}
         </SidePanelGroup>
       )}
       {shouldDisplayFallbackItems && (

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
@@ -1,7 +1,7 @@
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
 import { CommandMenuItemRenderer } from '@/command-menu-item/display/components/CommandMenuItemRenderer';
 import { PINNED_COMMAND_MENU_ITEMS_GAP } from '@/command-menu-item/display/constants/PinnedCommandMenuItemsGap';
-import { useCommandMenuUtilityItems } from '@/command-menu-item/display/hooks/useCommandMenuUtilityItems';
+import { useCommandMenuAppActions } from '@/command-menu-item/display/hooks/useCommandMenuAppActions';
 import { commandMenuPinnedInlineLayoutFamilyState } from '@/command-menu-item/display/states/commandMenuPinnedInlineLayoutFamilyState';
 import { getVisibleCommandMenuItemCountForContainerWidth } from '@/command-menu-item/display/utils/getVisibleCommandMenuItemCountForContainerWidth';
 import { groupCommandMenuItems } from '@/command-menu-item/utils/groupCommandMenuItems';
@@ -21,7 +21,7 @@ import { CommandMenuItemAvailabilityType } from '~/generated-metadata/graphql';
 
 export const SidePanelCommandMenuItemDisplayPage = () => {
   const { t } = useLingui();
-  const { utilityItems } = useCommandMenuUtilityItems();
+  const { appActions } = useCommandMenuAppActions();
   const { closeSidePanelMenu } = useSidePanelMenu();
 
   const sidePanelSearch = useAtomStateValue(sidePanelSearchState);
@@ -103,7 +103,7 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
   const hasNoMatchingItems =
     !matchingPinnedItems.length &&
     !matchingOtherItems.length &&
-    utilityItems.length === 0;
+    appActions.length === 0;
 
   const shouldDisplayFallbackItems =
     hasNoMatchingItems && fallbackCommandMenuItems.length > 0;
@@ -114,7 +114,7 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
   const selectableItemIds = [
     ...matchingPinnedItems.map((item) => item.id),
     ...matchingOtherItems.map((item) => item.id),
-    ...utilityItems.map((item) => item.id),
+    ...appActions.map((item) => item.id),
     ...(shouldDisplayFallbackItems
       ? fallbackCommandMenuItems.map((item) => item.id)
       : []),
@@ -132,12 +132,12 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
           ))}
         </SidePanelGroup>
       )}
-      {(matchingOtherItems.length > 0 || utilityItems.length > 0) && (
+      {(matchingOtherItems.length > 0 || appActions.length > 0) && (
         <SidePanelGroup heading={t`Other`}>
           {matchingOtherItems.map((item) => (
             <CommandMenuItemRenderer item={item} key={item.id} />
           ))}
-          {utilityItems.map((item) => {
+          {appActions.map((item) => {
             const handleClick = () => {
               item.onClick();
               closeSidePanelMenu();

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -5,24 +5,34 @@ import {
   type StoryObj,
 } from '@storybook/react-vite';
 import { Provider as JotaiProvider } from 'jotai';
+import { graphql, HttpResponse } from 'msw';
 import { Context as ResponsiveContext } from 'react-responsive';
 import { MemoryRouter } from 'react-router-dom';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, spyOn, userEvent, waitFor, within } from 'storybook/test';
 
+import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
 import { EMPTY_COMMAND_MENU_CONTEXT_API } from '@/command-menu-item/constants/EmptyCommandMenuContextApi';
 import { SidePanelCommandMenuItemDisplayPage } from '@/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage';
 import { commandMenuPinnedInlineLayoutFamilyState } from '@/command-menu-item/display/states/commandMenuPinnedInlineLayoutFamilyState';
 import { CommandMenuComponentInstanceContext } from '@/command-menu/states/contexts/CommandMenuComponentInstanceContext';
+import { SIDE_PANEL_FOCUS_ID } from '@/side-panel/constants/SidePanelFocusId';
 import { isSidePanelOpenedState } from '@/side-panel/states/isSidePanelOpenedState';
 import { sidePanelSearchState } from '@/side-panel/states/sidePanelSearchState';
+import { SnackBarProvider } from '@/ui/feedback/snack-bar-manager/components/SnackBarProvider';
 import { isNavigationDrawerExpandedState } from '@/ui/navigation/states/isNavigationDrawerExpanded';
 import { navigationDrawerActiveTabState } from '@/ui/navigation/states/navigationDrawerActiveTabState';
 import { NAVIGATION_DRAWER_TABS } from '@/ui/navigation/states/navigationDrawerTabs';
+import { BaseThemeProvider } from '@/ui/theme/components/BaseThemeProvider';
+import { persistedColorSchemeState } from '@/ui/theme/states/persistedColorSchemeState';
+import { focusStackState } from '@/ui/utilities/focus/states/focusStackState';
+import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
 import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
 import { ContextStoreDecorator } from '~/testing/decorators/ContextStoreDecorator';
 import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
 import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
+import { mockedWorkspaceMemberData } from '~/testing/mock-data/users';
 import {
   CommandMenuItemAvailabilityType,
   EngineComponentKey,
@@ -91,6 +101,7 @@ type CreateDecoratorParams = {
   isInPreviewMode?: boolean;
   pathname?: string;
   viewportWidth?: number;
+  colorScheme?: ColorScheme;
 };
 
 const createDecorator =
@@ -102,10 +113,29 @@ const createDecorator =
     isInPreviewMode = false,
     pathname = '/objects/companies',
     viewportWidth = 1280,
+    colorScheme = 'System',
   }: CreateDecoratorParams): Decorator =>
   (Story) => {
     jotaiStore.set(sidePanelSearchState.atom, sidePanelSearch);
     jotaiStore.set(isSidePanelOpenedState.atom, true);
+    jotaiStore.set(currentWorkspaceMemberState.atom, {
+      ...mockedWorkspaceMemberData,
+      colorScheme,
+    });
+    jotaiStore.set(persistedColorSchemeState.atom, colorScheme);
+    jotaiStore.set(focusStackState.atom, [
+      {
+        focusId: SIDE_PANEL_FOCUS_ID,
+        componentInstance: {
+          componentType: FocusComponentType.SIDE_PANEL,
+          componentInstanceId: SIDE_PANEL_FOCUS_ID,
+        },
+        globalHotkeysConfig: {
+          enableGlobalHotkeysWithModifiers: true,
+          enableGlobalHotkeysConflictingWithKeyboard: true,
+        },
+      },
+    ]);
     jotaiStore.set(
       isNavigationDrawerExpandedState.atom,
       isNavigationDrawerExpanded,
@@ -140,7 +170,11 @@ const createDecorator =
                   isInPreviewMode,
                 }}
               >
-                <Story />
+                <BaseThemeProvider>
+                  <SnackBarProvider>
+                    <Story />
+                  </SnackBarProvider>
+                </BaseThemeProvider>
               </CommandMenuContext.Provider>
             </CommandMenuComponentInstanceContext.Provider>
           </MemoryRouter>
@@ -371,4 +405,139 @@ export const HiddenInLayoutPreview: Story = {
     }),
   ],
   play: HiddenOnMobile.play,
+};
+
+export const CopyLinkToPage: Story = {
+  decorators: [
+    createDecorator({
+      commandMenuItems: [FALLBACK_ITEM],
+      sidePanelSearch: ' COPY LINK ',
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const writeText = spyOn(
+      navigator.clipboard,
+      'writeText',
+    ).mockResolvedValue();
+
+    try {
+      expect(canvas.queryByText('Search records')).not.toBeInTheDocument();
+      await userEvent.click(await canvas.findByText('Copy link to page'));
+
+      expect(writeText).toHaveBeenCalledWith(window.location.href);
+      expect(await canvas.findByText('Link copied to clipboard')).toBeVisible();
+      expect(jotaiStore.get(isSidePanelOpenedState.atom)).toBe(false);
+    } finally {
+      writeText.mockRestore();
+    }
+  },
+};
+
+export const CopyLinkToPageWithKeyboard: Story = {
+  decorators: CopyLinkToPage.decorators,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const writeText = spyOn(
+      navigator.clipboard,
+      'writeText',
+    ).mockResolvedValue();
+
+    try {
+      expect(await canvas.findByText('Copy link to page')).toBeVisible();
+      await userEvent.keyboard('{Enter}');
+
+      expect(writeText).toHaveBeenCalledWith(window.location.href);
+      expect(jotaiStore.get(isSidePanelOpenedState.atom)).toBe(false);
+    } finally {
+      writeText.mockRestore();
+    }
+  },
+};
+
+const createThemeStory = (colorScheme: ColorScheme, label: string): Story => {
+  const updateWorkspaceMemberSettings = fn();
+
+  return {
+    decorators: [
+      createDecorator({
+        commandMenuItems: [FALLBACK_ITEM],
+        sidePanelSearch: ' THEME ',
+        colorScheme: colorScheme === 'System' ? 'Dark' : 'System',
+      }),
+    ],
+    parameters: {
+      msw: {
+        handlers: [
+          graphql.mutation('UpdateWorkspaceMemberSettings', ({ variables }) => {
+            updateWorkspaceMemberSettings(variables.input);
+
+            return HttpResponse.json({
+              data: { updateWorkspaceMemberSettings: true },
+            });
+          }),
+        ],
+      },
+    },
+    beforeEach: () => {
+      updateWorkspaceMemberSettings.mockClear();
+    },
+    play: async ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+
+      expect(canvas.queryByText('Search records')).not.toBeInTheDocument();
+      await userEvent.click(await canvas.findByText(label));
+
+      await waitFor(() => {
+        expect(updateWorkspaceMemberSettings).toHaveBeenCalledWith({
+          workspaceMemberId: mockedWorkspaceMemberData.id,
+          update: { colorScheme },
+        });
+      });
+      expect(
+        jotaiStore.get(currentWorkspaceMemberState.atom)?.colorScheme,
+      ).toBe(colorScheme);
+      expect(jotaiStore.get(persistedColorSchemeState.atom)).toBe(colorScheme);
+      const isDarkTheme =
+        colorScheme === 'Dark' ||
+        (colorScheme === 'System' &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+      expect(canvasElement.ownerDocument.documentElement).toHaveClass(
+        isDarkTheme ? 'dark' : 'light',
+      );
+      expect(jotaiStore.get(isSidePanelOpenedState.atom)).toBe(false);
+      expect(canvas.queryByText(label)).not.toBeInTheDocument();
+    },
+  };
+};
+
+export const ChangeThemeToLight = createThemeStory(
+  'Light',
+  'Change theme to light',
+);
+export const ChangeThemeToDark = createThemeStory(
+  'Dark',
+  'Change theme to dark',
+);
+export const ChangeThemeToSystem = createThemeStory(
+  'System',
+  'Change theme to system',
+);
+
+export const UtilitiesHiddenInLayoutPreview: Story = {
+  decorators: [
+    createDecorator({
+      commandMenuItems: [],
+      sidePanelSearch: '',
+      isInPreviewMode: true,
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.queryByText('Copy link to page')).not.toBeInTheDocument();
+    expect(canvas.queryByText(/Change theme to/)).not.toBeInTheDocument();
+    expect(canvas.queryByText('Collapse sidebar')).not.toBeInTheDocument();
+  },
 };

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -1,4 +1,5 @@
 import { CommandMenuItemContainerType } from '@/command-menu-item/types/CommandMenuItemContainerType';
+import { styled } from '@linaria/react';
 import {
   type Decorator,
   type Meta,
@@ -40,6 +41,13 @@ import {
 } from '~/generated-metadata/graphql';
 
 const PINNED_ITEM_WIDTH = 100;
+
+// CI zeroes animation durations, which would immediately dismiss snackbars.
+const StyledStoryContainer = styled.div`
+  [role='status'] * {
+    animation: none !important;
+  }
+`;
 
 const createCommandMenuItem = (
   overrides: Partial<CommandMenuItemFieldsFragment> &
@@ -171,9 +179,11 @@ const createDecorator =
                 }}
               >
                 <BaseThemeProvider>
-                  <SnackBarProvider>
-                    <Story />
-                  </SnackBarProvider>
+                  <StyledStoryContainer>
+                    <SnackBarProvider>
+                      <Story />
+                    </SnackBarProvider>
+                  </StyledStoryContainer>
                 </BaseThemeProvider>
               </CommandMenuContext.Provider>
             </CommandMenuComponentInstanceContext.Provider>

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -499,10 +499,10 @@ const createThemeStory = (colorScheme: ColorScheme, label: string): Story => {
 
       await waitFor(() => {
         expect(canvas.queryByText(label)).not.toBeInTheDocument();
-      });
-      expect(updateWorkspaceMemberSettings).toHaveBeenCalledWith({
-        workspaceMemberId: mockedWorkspaceMemberData.id,
-        update: { colorScheme },
+        expect(updateWorkspaceMemberSettings).toHaveBeenCalledWith({
+          workspaceMemberId: mockedWorkspaceMemberData.id,
+          update: { colorScheme },
+        });
       });
       expect(
         jotaiStore.get(currentWorkspaceMemberState.atom)?.colorScheme,
@@ -540,7 +540,17 @@ export const ChangeThemeFailure: Story = {
     msw: {
       handlers: [
         graphql.mutation('UpdateWorkspaceMemberSettings', () =>
-          HttpResponse.json({ errors: [{ message: 'Profile update failed' }] }),
+          HttpResponse.json({
+            errors: [
+              {
+                message: 'Permission denied',
+                extensions: {
+                  userFriendlyMessage:
+                    'You do not have permission to update this workspace member.',
+                },
+              },
+            ],
+          }),
         ),
       ],
     },
@@ -551,7 +561,11 @@ export const ChangeThemeFailure: Story = {
     await userEvent.click(await canvas.findByText('Change theme to dark'));
 
     await waitFor(() => {
-      expect(canvas.getByText('Failed to update theme')).toBeVisible();
+      expect(
+        canvas.getByText(
+          'You do not have permission to update this workspace member.',
+        ),
+      ).toBeVisible();
     });
     expect(jotaiStore.get(currentWorkspaceMemberState.atom)?.colorScheme).toBe(
       'System',
@@ -561,7 +575,7 @@ export const ChangeThemeFailure: Story = {
   },
 };
 
-export const UtilitiesHiddenInLayoutPreview: Story = {
+export const AppActionsHiddenInLayoutPreview: Story = {
   decorators: [
     createDecorator({
       commandMenuItems: [],

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -426,7 +426,9 @@ export const CopyLinkToPage: Story = {
       await userEvent.click(await canvas.findByText('Copy link to page'));
 
       expect(writeText).toHaveBeenCalledWith(window.location.href);
-      expect(await canvas.findByText('Link copied to clipboard')).toBeVisible();
+      await waitFor(() => {
+        expect(canvas.getByText('Link copied to clipboard')).toBeVisible();
+      });
       expect(jotaiStore.get(isSidePanelOpenedState.atom)).toBe(false);
     } finally {
       writeText.mockRestore();
@@ -538,7 +540,9 @@ export const ChangeThemeFailure: Story = {
 
     await userEvent.click(await canvas.findByText('Change theme to dark'));
 
-    expect(await canvas.findByText('Failed to update theme')).toBeVisible();
+    await waitFor(() => {
+      expect(canvas.getByText('Failed to update theme')).toBeVisible();
+    });
     expect(jotaiStore.get(currentWorkspaceMemberState.atom)?.colorScheme).toBe(
       'System',
     );

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -479,9 +479,6 @@ const createThemeStory = (colorScheme: ColorScheme, label: string): Story => {
         ],
       },
     },
-    beforeEach: () => {
-      updateWorkspaceMemberSettings.mockClear();
-    },
     play: async ({ canvasElement }) => {
       const canvas = within(canvasElement);
 
@@ -489,10 +486,11 @@ const createThemeStory = (colorScheme: ColorScheme, label: string): Story => {
       await userEvent.click(await canvas.findByText(label));
 
       await waitFor(() => {
-        expect(updateWorkspaceMemberSettings).toHaveBeenCalledWith({
-          workspaceMemberId: mockedWorkspaceMemberData.id,
-          update: { colorScheme },
-        });
+        expect(canvas.queryByText(label)).not.toBeInTheDocument();
+      });
+      expect(updateWorkspaceMemberSettings).toHaveBeenCalledWith({
+        workspaceMemberId: mockedWorkspaceMemberData.id,
+        update: { colorScheme },
       });
       expect(
         jotaiStore.get(currentWorkspaceMemberState.atom)?.colorScheme,
@@ -507,7 +505,6 @@ const createThemeStory = (colorScheme: ColorScheme, label: string): Story => {
         isDarkTheme ? 'dark' : 'light',
       );
       expect(jotaiStore.get(isSidePanelOpenedState.atom)).toBe(false);
-      expect(canvas.queryByText(label)).not.toBeInTheDocument();
     },
   };
 };
@@ -524,6 +521,31 @@ export const ChangeThemeToSystem = createThemeStory(
   'System',
   'Change theme to system',
 );
+
+export const ChangeThemeFailure: Story = {
+  decorators: ChangeThemeToDark.decorators,
+  parameters: {
+    msw: {
+      handlers: [
+        graphql.mutation('UpdateWorkspaceMemberSettings', () =>
+          HttpResponse.json({ errors: [{ message: 'Profile update failed' }] }),
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(await canvas.findByText('Change theme to dark'));
+
+    expect(await canvas.findByText('Failed to update theme')).toBeVisible();
+    expect(jotaiStore.get(currentWorkspaceMemberState.atom)?.colorScheme).toBe(
+      'System',
+    );
+    expect(jotaiStore.get(persistedColorSchemeState.atom)).toBe('System');
+    expect(jotaiStore.get(isSidePanelOpenedState.atom)).toBe(false);
+  },
+};
 
 export const UtilitiesHiddenInLayoutPreview: Story = {
   decorators: [

--- a/packages/twenty-front/src/modules/command-menu-item/display/hooks/useCommandMenuAppActions.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/hooks/useCommandMenuAppActions.ts
@@ -13,7 +13,7 @@ import { IconCopy } from 'twenty-ui/icon';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 import { normalizeSearchText } from '~/utils/normalizeSearchText';
 
-export const useCommandMenuUtilityItems = () => {
+export const useCommandMenuAppActions = () => {
   const { t } = useLingui();
   const isMobile = useIsMobile();
   const isSettingsDrawer = useIsSettingsDrawer();
@@ -33,7 +33,7 @@ export const useCommandMenuUtilityItems = () => {
     System: t`Change theme to system`,
   };
 
-  const utilityItems = [
+  const appActions = [
     {
       id: 'toggle-navigation-drawer',
       ...navigationDrawerPresentation,
@@ -60,7 +60,7 @@ export const useCommandMenuUtilityItems = () => {
   const normalizedSearch = normalizeSearchText(sidePanelSearch.trim());
 
   return {
-    utilityItems: utilityItems.filter(
+    appActions: appActions.filter(
       (item) =>
         !isInPreviewMode &&
         item.isAvailable &&

--- a/packages/twenty-front/src/modules/command-menu-item/display/hooks/useCommandMenuUtilityItems.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/hooks/useCommandMenuUtilityItems.ts
@@ -1,0 +1,70 @@
+import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
+import { useIsSettingsDrawer } from '@/navigation/hooks/useIsSettingsDrawer';
+import { useNavigationDrawerTogglePresentation } from '@/navigation/hooks/useNavigationDrawerTogglePresentation';
+import { useToggleNavigationDrawer } from '@/navigation/hooks/useToggleNavigationDrawer';
+import { sidePanelSearchState } from '@/side-panel/states/sidePanelSearchState';
+import { useColorScheme } from '@/ui/theme/hooks/useColorScheme';
+import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
+import { useLingui } from '@lingui/react/macro';
+import { useContext } from 'react';
+import { IconLink } from 'twenty-ui/icon';
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
+import { normalizeSearchText } from '~/utils/normalizeSearchText';
+
+export const useCommandMenuUtilityItems = () => {
+  const { t } = useLingui();
+  const isMobile = useIsMobile();
+  const isSettingsDrawer = useIsSettingsDrawer();
+  const { isInPreviewMode } = useContext(CommandMenuContext);
+  const sidePanelSearch = useAtomStateValue(sidePanelSearchState);
+  const { isNavigationDrawerExpanded, toggleNavigationDrawer } =
+    useToggleNavigationDrawer();
+  const navigationDrawerPresentation = useNavigationDrawerTogglePresentation(
+    isNavigationDrawerExpanded,
+  );
+  const { copyToClipboard } = useCopyToClipboard();
+  const { colorScheme, setColorScheme, colorSchemeList } = useColorScheme();
+
+  const themeLabels: Record<ColorScheme, string> = {
+    Light: t`Change theme to light`,
+    Dark: t`Change theme to dark`,
+    System: t`Change theme to system`,
+  };
+
+  const utilityItems = [
+    {
+      id: 'toggle-navigation-drawer',
+      ...navigationDrawerPresentation,
+      onClick: toggleNavigationDrawer,
+      isAvailable: !isMobile && !isSettingsDrawer,
+    },
+    {
+      id: 'copy-page-link',
+      label: t`Copy link to page`,
+      Icon: IconLink,
+      onClick: () =>
+        copyToClipboard(window.location.href, t`Link copied to clipboard`),
+      isAvailable: true,
+    },
+    ...colorSchemeList.map((theme) => ({
+      id: `change-theme-${theme.id.toLowerCase()}`,
+      label: themeLabels[theme.id],
+      Icon: theme.icon,
+      onClick: () => setColorScheme(theme.id),
+      isAvailable: theme.id !== colorScheme,
+    })),
+  ];
+
+  const normalizedSearch = normalizeSearchText(sidePanelSearch.trim());
+
+  return {
+    utilityItems: utilityItems.filter(
+      (item) =>
+        !isInPreviewMode &&
+        item.isAvailable &&
+        normalizeSearchText(item.label).includes(normalizedSearch),
+    ),
+  };
+};

--- a/packages/twenty-front/src/modules/command-menu-item/display/hooks/useCommandMenuUtilityItems.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/display/hooks/useCommandMenuUtilityItems.ts
@@ -9,7 +9,7 @@ import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomState
 import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
 import { useLingui } from '@lingui/react/macro';
 import { useContext } from 'react';
-import { IconLink } from 'twenty-ui/icon';
+import { IconCopy } from 'twenty-ui/icon';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 import { normalizeSearchText } from '~/utils/normalizeSearchText';
 
@@ -43,7 +43,7 @@ export const useCommandMenuUtilityItems = () => {
     {
       id: 'copy-page-link',
       label: t`Copy link to page`,
-      Icon: IconLink,
+      Icon: IconCopy,
       onClick: () =>
         copyToClipboard(window.location.href, t`Link copied to clipboard`),
       isAvailable: true,

--- a/packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx
@@ -5,13 +5,19 @@ import {
   type CurrentWorkspaceMember,
 } from '@/auth/states/currentWorkspaceMemberState';
 import { useColorScheme } from '@/ui/theme/hooks/useColorScheme';
+import { persistedColorSchemeState } from '@/ui/theme/states/persistedColorSchemeState';
 import { resetJotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 
 const mockUpdateWorkspaceMemberSettings = jest.fn();
+const mockEnqueueErrorSnackBar = jest.fn();
 
-jest.mock('@/settings/profile/hooks/useUpdateWorkspaceMemberSettings', () => ({
-  useUpdateWorkspaceMemberSettings: () => ({
-    updateWorkspaceMemberSettings: mockUpdateWorkspaceMemberSettings,
+jest.mock('@apollo/client/react', () => ({
+  useMutation: () => [mockUpdateWorkspaceMemberSettings],
+}));
+
+jest.mock('@/ui/feedback/snack-bar-manager/hooks/useSnackBar', () => ({
+  useSnackBar: () => ({
+    enqueueErrorSnackBar: mockEnqueueErrorSnackBar,
   }),
 }));
 
@@ -26,31 +32,92 @@ const workspaceMember: CurrentWorkspaceMember = {
   userEmail: 'userEmail',
 };
 
+const renderColorSchemeHook = () => {
+  const store = resetJotaiStore();
+  store.set(currentWorkspaceMemberState.atom, workspaceMember);
+  store.set(persistedColorSchemeState.atom, 'System');
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <JotaiProvider store={store}>{children}</JotaiProvider>
+  );
+
+  return { store, ...renderHook(useColorScheme, { wrapper: Wrapper }) };
+};
+
 describe('useColorScheme', () => {
-  it('should update color scheme', async () => {
-    const store = resetJotaiStore();
-    store.set(currentWorkspaceMemberState.atom, workspaceMember);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateWorkspaceMemberSettings.mockResolvedValue({
+      data: { updateWorkspaceMemberSettings: true },
+    });
+  });
 
-    const Wrapper = ({ children }: { children: React.ReactNode }) => (
-      <JotaiProvider store={store}>{children}</JotaiProvider>
-    );
+  it('should update both color scheme preferences only after saving', async () => {
+    const { result, store } = renderColorSchemeHook();
 
-    const { result } = renderHook(
-      () => {
-        const colorScheme = useColorScheme();
-        return colorScheme;
+    await act(async () => {
+      const update = result.current.setColorScheme('Dark');
+
+      expect(store.get(currentWorkspaceMemberState.atom)?.colorScheme).toBe(
+        'System',
+      );
+      expect(store.get(persistedColorSchemeState.atom)).toBe('System');
+
+      await update;
+    });
+
+    expect(result.current.colorScheme).toBe('Dark');
+    expect(store.get(persistedColorSchemeState.atom)).toBe('Dark');
+    expect(mockUpdateWorkspaceMemberSettings).toHaveBeenCalledWith({
+      variables: {
+        input: {
+          workspaceMemberId: workspaceMember.id,
+          update: { colorScheme: 'Dark' },
+        },
       },
-      {
-        wrapper: Wrapper,
-      },
-    );
+    });
+    expect(mockEnqueueErrorSnackBar).not.toHaveBeenCalled();
+  });
 
-    expect(result.current.colorScheme).toBe('System');
+  it.each([false, true])(
+    'should keep the saved theme and report a failure (unmounted: %s)',
+    async (shouldUnmount) => {
+      mockUpdateWorkspaceMemberSettings.mockRejectedValueOnce(
+        new Error('Profile update failed'),
+      );
+      const { result, store, unmount } = renderColorSchemeHook();
 
+      await act(async () => {
+        const update = result.current.setColorScheme('Dark');
+
+        if (shouldUnmount) {
+          unmount();
+        }
+
+        await expect(update).resolves.toBeUndefined();
+      });
+
+      expect(store.get(currentWorkspaceMemberState.atom)?.colorScheme).toBe(
+        'System',
+      );
+      expect(store.get(persistedColorSchemeState.atom)).toBe('System');
+      expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({
+        message: 'Failed to update theme',
+      });
+    },
+  );
+
+  it('should not save a theme without a workspace member', async () => {
+    const { result, store } = renderColorSchemeHook();
+
+    act(() => {
+      store.set(currentWorkspaceMemberState.atom, null);
+    });
     await act(async () => {
       await result.current.setColorScheme('Dark');
     });
 
-    expect(result.current.colorScheme).toEqual('Dark');
+    expect(mockUpdateWorkspaceMemberSettings).not.toHaveBeenCalled();
+    expect(store.get(persistedColorSchemeState.atom)).toBe('System');
   });
 });

--- a/packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx
@@ -1,3 +1,4 @@
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { act, renderHook } from '@testing-library/react';
 import { Provider as JotaiProvider } from 'jotai';
 import {
@@ -52,16 +53,16 @@ describe('useColorScheme', () => {
     });
   });
 
-  it('should update both color scheme preferences only after saving', async () => {
+  it('should update both color scheme preferences before saving completes', async () => {
     const { result, store } = renderColorSchemeHook();
 
     await act(async () => {
       const update = result.current.setColorScheme('Dark');
 
       expect(store.get(currentWorkspaceMemberState.atom)?.colorScheme).toBe(
-        'System',
+        'Dark',
       );
-      expect(store.get(persistedColorSchemeState.atom)).toBe('System');
+      expect(store.get(persistedColorSchemeState.atom)).toBe('Dark');
 
       await update;
     });
@@ -80,15 +81,31 @@ describe('useColorScheme', () => {
   });
 
   it.each([false, true])(
-    'should keep the saved theme and report a failure (unmounted: %s)',
+    'should restore the previous preferences and report a failure (unmounted: %s)',
     async (shouldUnmount) => {
-      mockUpdateWorkspaceMemberSettings.mockRejectedValueOnce(
-        new Error('Profile update failed'),
-      );
+      const error = new CombinedGraphQLErrors({
+        errors: [
+          {
+            message: 'Permission denied',
+            extensions: {
+              userFriendlyMessage:
+                'You do not have permission to update this workspace member.',
+            },
+          },
+        ],
+      });
+
+      mockUpdateWorkspaceMemberSettings.mockRejectedValueOnce(error);
       const { result, store, unmount } = renderColorSchemeHook();
+      store.set(persistedColorSchemeState.atom, 'Light');
 
       await act(async () => {
         const update = result.current.setColorScheme('Dark');
+
+        expect(store.get(currentWorkspaceMemberState.atom)?.colorScheme).toBe(
+          'Dark',
+        );
+        expect(store.get(persistedColorSchemeState.atom)).toBe('Dark');
 
         if (shouldUnmount) {
           unmount();
@@ -100,12 +117,79 @@ describe('useColorScheme', () => {
       expect(store.get(currentWorkspaceMemberState.atom)?.colorScheme).toBe(
         'System',
       );
-      expect(store.get(persistedColorSchemeState.atom)).toBe('System');
+      expect(store.get(persistedColorSchemeState.atom)).toBe('Light');
       expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({
-        message: 'Failed to update theme',
+        apolloError: error,
       });
     },
   );
+
+  it('should preserve unrelated profile changes when rolling back', async () => {
+    mockUpdateWorkspaceMemberSettings.mockRejectedValueOnce(
+      new Error('Profile update failed'),
+    );
+    const { result, store } = renderColorSchemeHook();
+
+    await act(async () => {
+      const update = result.current.setColorScheme('Dark');
+
+      store.set(currentWorkspaceMemberState.atom, {
+        ...workspaceMember,
+        colorScheme: 'Dark',
+        locale: 'fr',
+      });
+
+      await update;
+    });
+
+    expect(store.get(currentWorkspaceMemberState.atom)).toEqual({
+      ...workspaceMember,
+      locale: 'fr',
+    });
+  });
+
+  it.each([
+    { ...workspaceMember, id: 'another-member', colorScheme: 'Dark' as const },
+    { ...workspaceMember, colorScheme: 'Light' as const },
+    null,
+  ])(
+    'should not roll back a changed workspace member or theme: %s',
+    async (member) => {
+      mockUpdateWorkspaceMemberSettings.mockRejectedValueOnce(
+        new Error('Profile update failed'),
+      );
+      const { result, store } = renderColorSchemeHook();
+
+      await act(async () => {
+        const update = result.current.setColorScheme('Dark');
+
+        store.set(currentWorkspaceMemberState.atom, member);
+        store.set(
+          persistedColorSchemeState.atom,
+          member?.colorScheme ?? 'System',
+        );
+
+        await update;
+      });
+
+      expect(store.get(currentWorkspaceMemberState.atom)).toEqual(member);
+      expect(store.get(persistedColorSchemeState.atom)).toBe(
+        member?.colorScheme ?? 'System',
+      );
+    },
+  );
+
+  it('should use the default error message for a non-error rejection', async () => {
+    mockUpdateWorkspaceMemberSettings.mockRejectedValueOnce(undefined);
+    const { result } = renderColorSchemeHook();
+
+    await act(async () => {
+      await result.current.setColorScheme('Dark');
+    });
+
+    expect(result.current.colorScheme).toBe('System');
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({});
+  });
 
   it('should not save a theme without a workspace member', async () => {
     const { result, store } = renderColorSchemeHook();

--- a/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
@@ -3,9 +3,9 @@ import { useUpdateWorkspaceMemberSettings } from '@/settings/profile/hooks/useUp
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { persistedColorSchemeState } from '@/ui/theme/states/persistedColorSchemeState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
-import { t } from '@lingui/core/macro';
+import { isErrorLike } from '@apollo/client/errors';
+import { useStore } from 'jotai';
 import { useCallback } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import {
@@ -17,37 +17,61 @@ import {
 
 export const useColorScheme = () => {
   const currentWorkspaceMember = useAtomStateValue(currentWorkspaceMemberState);
+  const store = useStore();
 
   const { updateWorkspaceMemberSettings } = useUpdateWorkspaceMemberSettings();
-  const setPersistedColorScheme = useSetAtomState(persistedColorSchemeState);
   const { enqueueErrorSnackBar } = useSnackBar();
 
   const colorScheme = currentWorkspaceMember?.colorScheme ?? 'System';
 
   const setColorScheme = useCallback(
     async (value: ColorScheme) => {
-      if (!isDefined(currentWorkspaceMember)) {
+      const workspaceMember = store.get(currentWorkspaceMemberState.atom);
+
+      if (!isDefined(workspaceMember)) {
         return;
       }
 
+      const previousPersistedColorScheme = store.get(
+        persistedColorSchemeState.atom,
+      );
+
+      store.set(currentWorkspaceMemberState.atom, {
+        ...workspaceMember,
+        colorScheme: value,
+      });
+      store.set(persistedColorSchemeState.atom, value);
+
       try {
         await updateWorkspaceMemberSettings({
-          workspaceMemberId: currentWorkspaceMember.id,
+          workspaceMemberId: workspaceMember.id,
           update: {
             colorScheme: value,
           },
         });
-        setPersistedColorScheme(value);
-      } catch {
-        enqueueErrorSnackBar({ message: t`Failed to update theme` });
+      } catch (error) {
+        const latestWorkspaceMember = store.get(
+          currentWorkspaceMemberState.atom,
+        );
+
+        if (
+          latestWorkspaceMember?.id === workspaceMember.id &&
+          latestWorkspaceMember.colorScheme === value
+        ) {
+          store.set(currentWorkspaceMemberState.atom, {
+            ...latestWorkspaceMember,
+            colorScheme: workspaceMember.colorScheme,
+          });
+          store.set(
+            persistedColorSchemeState.atom,
+            previousPersistedColorScheme,
+          );
+        }
+
+        enqueueErrorSnackBar(isErrorLike(error) ? { apolloError: error } : {});
       }
     },
-    [
-      currentWorkspaceMember,
-      setPersistedColorScheme,
-      updateWorkspaceMemberSettings,
-      enqueueErrorSnackBar,
-    ],
+    [store, updateWorkspaceMemberSettings, enqueueErrorSnackBar],
   );
 
   const colorSchemeList: Array<{

--- a/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
@@ -1,10 +1,13 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { useUpdateWorkspaceMemberSettings } from '@/settings/profile/hooks/useUpdateWorkspaceMemberSettings';
-import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
-import { useCallback } from 'react';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { persistedColorSchemeState } from '@/ui/theme/states/persistedColorSchemeState';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
+import { t } from '@lingui/core/macro';
+import { useCallback } from 'react';
+import { isDefined } from 'twenty-shared/utils';
 import {
   type IconComponent,
   IconMoon,
@@ -13,42 +16,37 @@ import {
 } from 'twenty-ui/icon';
 
 export const useColorScheme = () => {
-  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useAtomState(
-    currentWorkspaceMemberState,
-  );
+  const currentWorkspaceMember = useAtomStateValue(currentWorkspaceMemberState);
 
   const { updateWorkspaceMemberSettings } = useUpdateWorkspaceMemberSettings();
   const setPersistedColorScheme = useSetAtomState(persistedColorSchemeState);
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const colorScheme = currentWorkspaceMember?.colorScheme ?? 'System';
 
   const setColorScheme = useCallback(
     async (value: ColorScheme) => {
-      if (!currentWorkspaceMember) {
+      if (!isDefined(currentWorkspaceMember)) {
         return;
       }
-      setPersistedColorScheme(value);
-      setCurrentWorkspaceMember((current) => {
-        if (!current) {
-          return current;
-        }
-        return {
-          ...current,
-          colorScheme: value,
-        };
-      });
-      await updateWorkspaceMemberSettings({
-        workspaceMemberId: currentWorkspaceMember.id,
-        update: {
-          colorScheme: value,
-        },
-      });
+
+      try {
+        await updateWorkspaceMemberSettings({
+          workspaceMemberId: currentWorkspaceMember.id,
+          update: {
+            colorScheme: value,
+          },
+        });
+        setPersistedColorScheme(value);
+      } catch {
+        enqueueErrorSnackBar({ message: t`Failed to update theme` });
+      }
     },
     [
       currentWorkspaceMember,
-      setCurrentWorkspaceMember,
       setPersistedColorScheme,
       updateWorkspaceMemberSettings,
+      enqueueErrorSnackBar,
     ],
   );
 


### PR DESCRIPTION
## Summary

- Add **Copy link to page** with the existing clipboard confirmation and error handling.
- Add **Change theme to light/dark/system**, reusing the saved profile preference and hiding the current choice.
- Share search, keyboard selection, and menu closing with the sidebar command; keep utilities out of layout previews.
- Document the commands and add interaction stories.

## Before/After

Before: copying the current page link and changing appearance require leaving the command menu.

After: both actions are available from the command menu. Page links retain the current URL, and theme choices persist to the profile.


https://github.com/user-attachments/assets/2769e430-7247-4711-81af-ab29f97eb3f8
