### PR TITLE
perf(server): reuse the html-to-text converter across imported messages

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-message-body-text.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-message-body-text.util.ts
@@ -5,6 +5,18 @@ import { extractTextWithoutReplyQuotations } from 'src/modules/messaging/message
 import { normalizeMessageText } from 'src/modules/messaging/message-import-manager/utils/normalize-message-text.util';
 import { sanitizeString } from 'src/modules/messaging/message-import-manager/utils/sanitize-string.util';
 
+// createHtmlToTextConverter builds a JSDOM + DOMPurify instance, which is
+// expensive. extractMessageBodyText runs once per message, so an import batch
+// (hundreds of emails) would build hundreds of JSDOMs on the worker event loop.
+// The converter is stateless across calls, so build it once and reuse it.
+let htmlToTextConverter: ((html: string) => string) | undefined;
+
+const getHtmlToTextConverter = (): ((html: string) => string) => {
+  htmlToTextConverter ??= createHtmlToTextConverter();
+
+  return htmlToTextConverter;
+};
+
 export const extractMessageBodyText = ({
   text,
   html,
@@ -15,7 +27,7 @@ export const extractMessageBodyText = ({
   const candidate = isNonEmptyString(text)
     ? text
     : isNonEmptyString(html)
-      ? createHtmlToTextConverter()(html)
+      ? getHtmlToTextConverter()(html)
       : '';
 
   const textWithoutReplyQuotations =


### PR DESCRIPTION
## Problem

`extractMessageBodyText` (message import) converts each HTML email body to text by calling `createHtmlToTextConverter()` **per message**:

```ts
// extract-message-body-text.util.ts
? createHtmlToTextConverter()(html)   // called once per email
```

and that factory builds a **fresh JSDOM + DOMPurify every call**:

```ts
// create-html-to-text-converter.util.ts
const jsdom = new JSDOM('');
const purify = createDOMPurify(jsdom.window);
```

An import batch is hundreds of messages (`MESSAGING_MESSAGES_GET_BATCH_SIZE = 400`), so a single `MessagingMessagesImportJob` spins up **hundreds of JSDOMs synchronously on the worker event loop**.

### Evidence (prod-eu)

A live V8 CPU profile of a worker that was actively stalling attributes **~29% of all worker CPU to `jsdom`** (and ~35% to HTML/email parsing overall: jsdom + parse5 + css-tree + symbol-tree + email-reply-parser + planer). This is the dominant driver of the multi-second-to-multi-minute worker event-loop stalls that `EventLoopStallMonitorService` reports with `messaging-queue/MessagingMessagesImportJob` (and `MessagingMessageListFetchJob`, which runs the first import batch inline) as the in-flight job.

## Change

Memoize a single converter and reuse it across messages. This is safe because the converter carries no per-message state:
- **DOMPurify** is designed to be created once per window and `sanitize()`d many times.
- **planer.extractFromHtml(html, document)** only uses the window's `implementation.createHTMLDocument()` to build its own throwaway documents; it never mutates the shared document, so there is no cross-message accumulation.

The 13 existing tests for `extract-message-body-text` and `create-html-to-text-converter` pass unchanged.

## Benchmark

400 messages through sanitize + convert:

| | event-loop time |
|---|---|
| per-message construction (current) | ~4.1 s |
| reused converter (this PR) | ~2.6 s |

**1.6x**, removing the fixed per-message JSDOM construction cost.

## Follow-up

The remaining per-message cost is jsdom parsing the body itself (DOMPurify sanitize + planer). A larger follow-up could drop jsdom entirely — `html-to-text` parses HTML on its own; jsdom is only there for DOMPurify and planer — which would shed most of the remaining ~29%.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

