### PR TITLE
Pin Ask AI globally and open new chats in full page

### DIFF
--- a/packages/twenty-front/src/modules/ai/hooks/__tests__/useOpenAiChatPage.test.tsx
+++ b/packages/twenty-front/src/modules/ai/hooks/__tests__/useOpenAiChatPage.test.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook } from '@testing-library/react';
+import { Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { useOpenAiChatPage } from '@/ai/hooks/useOpenAiChatPage';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+
+const navigateMock = jest.fn();
+const closeSidePanelMenuMock = jest.fn();
+
+let location = { pathname: '/objects/people', search: '', hash: '' };
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => navigateMock,
+  useLocation: () => location,
+}));
+
+jest.mock('@/side-panel/hooks/useSidePanelMenu', () => ({
+  useSidePanelMenu: () => ({ closeSidePanelMenu: closeSidePanelMenuMock }),
+}));
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <JotaiProvider store={jotaiStore}>{children}</JotaiProvider>
+);
+
+describe('useOpenAiChatPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    location = { pathname: '/objects/people', search: '', hash: '' };
+    window.history.pushState({}, '', '/objects/people');
+  });
+
+  it('should open a new chat and remember where to collapse back to', () => {
+    const { result } = renderHook(() => useOpenAiChatPage(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.openAiChatPage();
+    });
+
+    expect(closeSidePanelMenuMock).toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/chat', {
+      state: { returnLocation: '/objects/people' },
+    });
+  });
+
+  it('should keep the current view and query in the return location', () => {
+    location = { pathname: '/objects/people', search: '?viewId=42', hash: '' };
+
+    const { result } = renderHook(() => useOpenAiChatPage(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.openAiChatPage();
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith('/chat', {
+      state: { returnLocation: '/objects/people?viewId=42' },
+    });
+  });
+
+  it('should open an existing thread', () => {
+    const { result } = renderHook(() => useOpenAiChatPage(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.openAiChatPage({
+        threadId: '20202020-0000-4000-8000-000000000001',
+      });
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/chat/20202020-0000-4000-8000-000000000001',
+      expect.anything(),
+    );
+  });
+
+  it('should ignore a draft thread that has no thread id yet', () => {
+    const { result } = renderHook(() => useOpenAiChatPage(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.openAiChatPage({ threadId: 'new-thread-draft' });
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith('/chat', expect.anything());
+  });
+
+  it('should not navigate while already on the AI chat page', () => {
+    window.history.pushState({}, '', '/chat');
+
+    const { result } = renderHook(() => useOpenAiChatPage(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.openAiChatPage();
+    });
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(closeSidePanelMenuMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front/src/modules/ai/hooks/__tests__/useOpenAiChatPage.test.tsx
+++ b/packages/twenty-front/src/modules/ai/hooks/__tests__/useOpenAiChatPage.test.tsx
@@ -8,12 +8,9 @@ import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 const navigateMock = jest.fn();
 const closeSidePanelMenuMock = jest.fn();
 
-let location = { pathname: '/objects/people', search: '', hash: '' };
-
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => navigateMock,
-  useLocation: () => location,
 }));
 
 jest.mock('@/side-panel/hooks/useSidePanelMenu', () => ({
@@ -27,7 +24,6 @@ const Wrapper = ({ children }: { children: ReactNode }) => (
 describe('useOpenAiChatPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    location = { pathname: '/objects/people', search: '', hash: '' };
     window.history.pushState({}, '', '/objects/people');
   });
 
@@ -47,7 +43,7 @@ describe('useOpenAiChatPage', () => {
   });
 
   it('should keep the current view and query in the return location', () => {
-    location = { pathname: '/objects/people', search: '?viewId=42', hash: '' };
+    window.history.pushState({}, '', '/objects/people?viewId=42');
 
     const { result } = renderHook(() => useOpenAiChatPage(), {
       wrapper: Wrapper,

--- a/packages/twenty-front/src/modules/ai/hooks/useOpenAiChatPage.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useOpenAiChatPage.ts
@@ -1,0 +1,41 @@
+import { useLocation } from 'react-router-dom';
+import { AppPath } from 'twenty-shared/types';
+import { isDefined, isValidUuid } from 'twenty-shared/utils';
+
+import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
+import { useNavigateApp } from '~/hooks/useNavigateApp';
+import { isCurrentPathAiChatPage } from '~/utils/isCurrentPathAiChatPage';
+
+export const useOpenAiChatPage = () => {
+  const navigate = useNavigateApp();
+  const location = useLocation();
+  const { closeSidePanelMenu } = useSidePanelMenu();
+
+  const openAiChatPage = ({
+    threadId,
+  }: {
+    threadId?: string | null;
+  } = {}) => {
+    if (isCurrentPathAiChatPage()) {
+      return;
+    }
+
+    void closeSidePanelMenu();
+
+    navigate(
+      AppPath.AiChat,
+      {
+        threadId:
+          isDefined(threadId) && isValidUuid(threadId) ? threadId : null,
+      },
+      undefined,
+      {
+        state: {
+          returnLocation: `${location.pathname}${location.search}${location.hash}`,
+        },
+      },
+    );
+  };
+
+  return { openAiChatPage };
+};

--- a/packages/twenty-front/src/modules/ai/hooks/useOpenAiChatPage.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useOpenAiChatPage.ts
@@ -1,4 +1,3 @@
-import { useLocation } from 'react-router-dom';
 import { AppPath } from 'twenty-shared/types';
 import { isDefined, isValidUuid } from 'twenty-shared/utils';
 
@@ -8,7 +7,6 @@ import { isCurrentPathAiChatPage } from '~/utils/isCurrentPathAiChatPage';
 
 export const useOpenAiChatPage = () => {
   const navigate = useNavigateApp();
-  const location = useLocation();
   const { closeSidePanelMenu } = useSidePanelMenu();
 
   const openAiChatPage = ({
@@ -31,7 +29,10 @@ export const useOpenAiChatPage = () => {
       undefined,
       {
         state: {
-          returnLocation: `${location.pathname}${location.search}${location.hash}`,
+          // Read from the window rather than useLocation so that opening a new
+          // chat does not require a router context from every caller of
+          // useSwitchToNewAiChat, front components included.
+          returnLocation: `${window.location.pathname}${window.location.search}${window.location.hash}`,
         },
       },
     );

--- a/packages/twenty-front/src/modules/ai/hooks/useSwitchToNewAiChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useSwitchToNewAiChat.ts
@@ -1,5 +1,6 @@
 import { useStore } from 'jotai';
 
+import { useOpenAiChatPage } from '@/ai/hooks/useOpenAiChatPage';
 import { useSelectAiChatThread } from '@/ai/hooks/useSelectAiChatThread';
 import { AGENT_CHAT_NEW_THREAD_DRAFT_KEY } from '@/ai/states/agentChatDraftsByThreadIdState';
 import { shouldFocusChatEditorState } from '@/ai/states/shouldFocusChatEditorState';
@@ -8,19 +9,32 @@ import { threadIdCreatedFromDraftState } from '@/ai/states/threadIdCreatedFromDr
 import { useOpenAskAiPageInSidePanel } from '@/side-panel/hooks/useOpenAskAiPageInSidePanel';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 
-export const useSwitchToNewAiChat = () => {
+type UseSwitchToNewAiChatParams = {
+  shouldOpenInFullPage?: boolean;
+};
+
+export const useSwitchToNewAiChat = ({
+  shouldOpenInFullPage = false,
+}: UseSwitchToNewAiChatParams = {}) => {
   const setThreadIdCreatedFromDraft = useSetAtomState(
     threadIdCreatedFromDraftState,
   );
   const { selectAiChatThread } = useSelectAiChatThread();
   const store = useStore();
   const { openAskAiPage } = useOpenAskAiPageInSidePanel();
+  const { openAiChatPage } = useOpenAiChatPage();
 
   const switchToNewChat = () => {
     setThreadIdCreatedFromDraft(null);
     store.set(hasTriggeredCreateForDraftState.atom, false);
     selectAiChatThread(AGENT_CHAT_NEW_THREAD_DRAFT_KEY);
-    openAskAiPage();
+
+    if (shouldOpenInFullPage) {
+      openAiChatPage();
+    } else {
+      openAskAiPage();
+    }
+
     store.set(shouldFocusChatEditorState.atom, true);
   };
 

--- a/packages/twenty-front/src/modules/navigation/components/MainNavigationDrawerTabsRow.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/MainNavigationDrawerTabsRow.tsx
@@ -149,7 +149,9 @@ export const MainNavigationDrawerTabsRow = ({
   const { theme } = useContext(ThemeContext);
   const [navigationDrawerActiveTab, setNavigationDrawerActiveTab] =
     useAtomState(navigationDrawerActiveTabState);
-  const { switchToNewChat } = useSwitchToNewAiChat();
+  const { switchToNewChat } = useSwitchToNewAiChat({
+    shouldOpenInFullPage: true,
+  });
   const hasAiPermission = useHasPermissionFlag(PermissionFlagType.AI);
 
   const isExpanded = useIsNavigationDrawerContentExpanded();
@@ -171,6 +173,7 @@ export const MainNavigationDrawerTabsRow = ({
     };
 
   const handleNewChatClick = () => {
+    setNavigationDrawerActiveTab(NAVIGATION_DRAWER_TABS.AI_CHAT_HISTORY);
     switchToNewChat();
   };
 

--- a/packages/twenty-front/src/modules/side-panel/pages/ask-ai/hooks/useExpandAskAiSidePanelPage.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/ask-ai/hooks/useExpandAskAiSidePanelPage.ts
@@ -1,42 +1,20 @@
 import { useLingui } from '@lingui/react/macro';
-import { useLocation } from 'react-router-dom';
-import { AppPath } from 'twenty-shared/types';
-import { isDefined, isValidUuid } from 'twenty-shared/utils';
 
+import { useOpenAiChatPage } from '@/ai/hooks/useOpenAiChatPage';
 import { currentAiChatThreadState } from '@/ai/states/currentAiChatThreadState';
-import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
 import { type SidePanelExpandTarget } from '@/side-panel/types/SidePanelExpandTarget';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { useNavigateApp } from '~/hooks/useNavigateApp';
 
 export const useExpandAskAiSidePanelPage = (): SidePanelExpandTarget => {
   const { t } = useLingui();
-  const navigate = useNavigateApp();
-  const location = useLocation();
   const currentAiChatThread = useAtomStateValue(currentAiChatThreadState);
-  const { closeSidePanelMenu } = useSidePanelMenu();
+  const { openAiChatPage } = useOpenAiChatPage();
 
   return {
     label: t`Expand chat`,
     hasExpandShortcut: false,
     expand: () => {
-      void closeSidePanelMenu();
-
-      navigate(
-        AppPath.AiChat,
-        {
-          threadId:
-            isDefined(currentAiChatThread) && isValidUuid(currentAiChatThread)
-              ? currentAiChatThread
-              : null,
-        },
-        undefined,
-        {
-          state: {
-            returnLocation: `${location.pathname}${location.search}${location.hash}`,
-          },
-        },
-      );
+      openAiChatPage({ threadId: currentAiChatThread });
     },
   };
 };

--- a/packages/twenty-front/src/testing/mock-data/generated/metadata/command-menu-items/mock-command-menu-items-data.ts
+++ b/packages/twenty-front/src/testing/mock-data/generated/metadata/command-menu-items/mock-command-menu-items-data.ts
@@ -901,7 +901,7 @@ export const mockedCommandMenuItems: CommandMenuItemFieldsFragment[] =
     "frontComponentId": null,
     "engineComponentKey": "ASK_AI",
     "position": 43,
-    "isPinned": false,
+    "isPinned": true,
     "payload": null,
     "hotKeys": [
       "@"
@@ -914,7 +914,7 @@ export const mockedCommandMenuItems: CommandMenuItemFieldsFragment[] =
     "frontComponent": null,
     "label": "Ask AI",
     "icon": "IconSparkles",
-    "shortLabel": "Ask AI"
+    "shortLabel": null
   },
   {
     "__typename": "CommandMenuItem",

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-upgrade-version-command.module.ts
@@ -5,6 +5,7 @@ import { AddBlocklistScopeFieldCommand } from 'src/database/commands/upgrade-ver
 import { EnableEditLayoutAcrossAppCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1787906715270-enable-edit-layout-across-app.command';
 import { BackfillLinkedTimelineActivityHappensAtCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1787914663665-backfill-linked-timeline-activity-happens-at.command';
 import { ConfigureTimelineActivityHappensAtCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1787918663365-configure-timeline-activity-happens-at.command';
+import { PinAskAiCommandMenuItemCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1787938100000-pin-ask-ai-command-menu-item.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -25,6 +26,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     EnableEditLayoutAcrossAppCommand,
     BackfillLinkedTimelineActivityHappensAtCommand,
     ConfigureTimelineActivityHappensAtCommand,
+    PinAskAiCommandMenuItemCommand,
   ],
 })
 export class V2_38_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1787938100000-pin-ask-ai-command-menu-item.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1787938100000-pin-ask-ai-command-menu-item.command.ts
@@ -1,0 +1,78 @@
+import { Command } from 'nest-commander';
+import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { buildPinAskAiCommandMenuItemUpdate } from 'src/database/commands/upgrade-version-command/2-38/utils/build-pin-ask-ai-command-menu-item-update.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+import { WorkspaceMigrationBuilderException } from 'src/engine/workspace-manager/workspace-migration/exceptions/workspace-migration-builder-exception';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+@RegisteredWorkspaceCommand('2.38.0', 1787938100000)
+@Command({
+  name: 'upgrade:2-38:pin-ask-ai-command-menu-item',
+  description:
+    'Pin the Ask AI command to page headers as an icon-only action across the app',
+})
+export class PinAskAiCommandMenuItemCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const { flatCommandMenuItemMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatCommandMenuItemMaps',
+      ]);
+
+    const commandMenuItemToUpdate = buildPinAskAiCommandMenuItemUpdate({
+      existingCommandMenuItem:
+        flatCommandMenuItemMaps.byUniversalIdentifier[
+          STANDARD_COMMAND_MENU_ITEMS.askAi.universalIdentifier
+        ],
+      now: new Date().toISOString(),
+    });
+
+    if (!isDefined(commandMenuItemToUpdate)) {
+      return;
+    }
+
+    if (options.dryRun) {
+      this.logger.log(`Would pin the Ask AI command for workspace ${workspaceId}`);
+
+      return;
+    }
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            commandMenuItem: {
+              flatEntityToCreate: [],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [commandMenuItemToUpdate],
+            },
+          },
+          workspaceId,
+          isSystemBuild: true,
+          applicationUniversalIdentifier:
+            TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      throw new WorkspaceMigrationBuilderException(validateAndBuildResult);
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-pin-ask-ai-command-menu-item-update.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-pin-ask-ai-command-menu-item-update.util.spec.ts
@@ -1,0 +1,87 @@
+import { buildPinAskAiCommandMenuItemUpdate } from 'src/database/commands/upgrade-version-command/2-38/utils/build-pin-ask-ai-command-menu-item-update.util';
+import { type FlatCommandMenuItem } from 'src/engine/metadata-modules/flat-command-menu-item/types/flat-command-menu-item.type';
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { createStandardCommandMenuItemFlatMetadata } from 'src/engine/workspace-manager/twenty-standard-application/utils/command-menu-item/create-standard-command-menu-item-flat-metadata.util';
+
+const NOW = '2026-08-28T14:00:00.000Z';
+const LEGACY_COMMAND_MENU_ITEM: FlatCommandMenuItem = Object.freeze({
+  ...createStandardCommandMenuItemFlatMetadata({
+    commandMenuItemName: 'askAi',
+    commandMenuItemId: 'ask-ai-command-id',
+    workspaceId: 'workspace-id',
+    twentyStandardApplicationId: 'application-id',
+    dependencyFlatEntityMaps: {
+      flatObjectMetadataMaps: createEmptyFlatEntityMaps(),
+    },
+    now: '2026-08-01T00:00:00.000Z',
+  }),
+  isPinned: false,
+  shortLabel: 'Ask AI',
+});
+
+describe('buildPinAskAiCommandMenuItemUpdate', () => {
+  it('pins the command and drops its short label without changing other fields', () => {
+    expect(
+      buildPinAskAiCommandMenuItemUpdate({
+        existingCommandMenuItem: LEGACY_COMMAND_MENU_ITEM,
+        now: NOW,
+      }),
+    ).toEqual({
+      ...LEGACY_COMMAND_MENU_ITEM,
+      isPinned: true,
+      shortLabel: null,
+      updatedAt: NOW,
+    });
+  });
+
+  it.each([
+    { name: 'missing command', existingCommandMenuItem: undefined },
+    {
+      name: 'command already pinned',
+      existingCommandMenuItem: {
+        ...LEGACY_COMMAND_MENU_ITEM,
+        isPinned: true,
+      },
+    },
+    {
+      name: 'custom short label',
+      existingCommandMenuItem: {
+        ...LEGACY_COMMAND_MENU_ITEM,
+        shortLabel: 'Ask Twenty',
+      },
+    },
+    {
+      name: 'workspace pinning override',
+      existingCommandMenuItem: {
+        ...LEGACY_COMMAND_MENU_ITEM,
+        overrides: { isPinned: false },
+      },
+    },
+    {
+      name: 'workspace short label override',
+      existingCommandMenuItem: {
+        ...LEGACY_COMMAND_MENU_ITEM,
+        overrides: { shortLabel: 'Ask AI' },
+      },
+    },
+  ])('skips $name', ({ existingCommandMenuItem }) => {
+    expect(
+      buildPinAskAiCommandMenuItemUpdate({ existingCommandMenuItem, now: NOW }),
+    ).toBeUndefined();
+  });
+
+  it('does not update an already migrated command', () => {
+    const updatedCommandMenuItem = buildPinAskAiCommandMenuItemUpdate({
+      existingCommandMenuItem: LEGACY_COMMAND_MENU_ITEM,
+      now: NOW,
+    });
+
+    expect(updatedCommandMenuItem).toBeDefined();
+    expect(
+      buildPinAskAiCommandMenuItemUpdate({
+        existingCommandMenuItem: updatedCommandMenuItem,
+        now: '2026-08-29T14:00:00.000Z',
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-pin-ask-ai-command-menu-item-update.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-pin-ask-ai-command-menu-item-update.util.ts
@@ -1,0 +1,39 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type FlatCommandMenuItem } from 'src/engine/metadata-modules/flat-command-menu-item/types/flat-command-menu-item.type';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+
+const LEGACY_ASK_AI_SHORT_LABEL = 'Ask AI';
+
+export const buildPinAskAiCommandMenuItemUpdate = ({
+  existingCommandMenuItem,
+  now,
+}: {
+  existingCommandMenuItem: FlatCommandMenuItem | undefined;
+  now: string;
+}): FlatCommandMenuItem | undefined => {
+  if (!isDefined(existingCommandMenuItem)) {
+    return undefined;
+  }
+
+  // Pinning and short labels are workspace-editable, so an override means the
+  // workspace already made its own choice for this command.
+  const hasWorkspaceOverride =
+    isDefined(existingCommandMenuItem.overrides?.isPinned) ||
+    isDefined(existingCommandMenuItem.overrides?.shortLabel);
+
+  if (
+    hasWorkspaceOverride ||
+    existingCommandMenuItem.isPinned !== false ||
+    existingCommandMenuItem.shortLabel !== LEGACY_ASK_AI_SHORT_LABEL
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...existingCommandMenuItem,
+    isPinned: STANDARD_COMMAND_MENU_ITEMS.askAi.isPinned,
+    shortLabel: STANDARD_COMMAND_MENU_ITEMS.askAi.shortLabel,
+    updatedAt: now,
+  };
+};

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
@@ -873,11 +873,9 @@ export const STANDARD_COMMAND_MENU_ITEMS = {
       msg({ message: `Ask AI`, context: 'commandMenuItem.label' }),
     ),
     icon: 'IconSparkles',
-    isPinned: false,
+    isPinned: true,
     position: 43,
-    shortLabel: i18nLabel(
-      msg({ message: `Ask AI`, context: 'commandMenuItem.shortLabel' }),
-    ),
+    shortLabel: null,
     availabilityType: CommandMenuItemAvailabilityType.GLOBAL,
     conditionalAvailabilityExpression: 'permissionFlags.AI',
     availabilityObjectMetadataUniversalIdentifier: null,


### PR DESCRIPTION
## Summary

- Pin the standard Ask AI command and drop its short label, so it renders as an icon-only sparkles button in every page header (index, record, standalone) next to the primary action, with the label kept as a tooltip.
- Migrate existing workspaces with a 2.38 workspace command, skipping any workspace that already pinned or relabelled the command itself.
- Point the sidebar New chat button at the full page chat instead of the side panel, and switch the drawer to the chat list at the same time.

## Details

`shortLabel: null` is the existing opt-out for a pinned button showing text, so the change is `isPinned: true` + `shortLabel: null` on the standard definition. Since the button carries no label it never takes the single labelled slot in the side panel footer, and because the header row is reversed it lands to the right of the primary action.

The upgrade command only touches a workspace whose Ask AI command still has the shipped defaults and no `isPinned` / `shortLabel` override, so a workspace that unpinned it on purpose keeps its choice.

For the New chat button, `useOpenAiChatPage` now holds the navigation to the full page chat (close the panel, navigate, remember where to collapse back to). `useExpandAskAiSidePanelPage` was rewritten on top of it rather than duplicating it, and `useSwitchToNewAiChat` takes a `shouldOpenInFullPage` flag so the side panel callers (the preprompt flow, the mobile bar, the page header) are unchanged.

## Before/After

Before: Ask AI was reachable only through the command menu or the `@` hotkey. The sidebar New chat button opened a new conversation in the side panel and left the drawer on the navigation tab.

After: every page header carries the Ask AI sparkles button. New chat opens the conversation full page and flips the drawer to the chat list.

## Test plan

- `npx jest src/modules/side-panel src/modules/ai src/modules/navigation src/modules/command-menu-item` in twenty-front (135 suites, 820 tests) and the new upgrade util spec in twenty-server.
- New `useOpenAiChatPage` tests cover the return location, an existing thread, a draft thread and the no-op while already on the chat page.
- Typecheck and diff lint on both packages.


---
_Generated by [Claude Code](https://claude.ai/code/session_011dJv3FHwb7oVtWhZ6VzQDU)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

