### PR TITLE
feat(domain): add IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED to support single root domain multi-tenancy

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -2022,6 +2022,7 @@ type ClientConfig {
   aiModels: [ClientAiModelConfig!]!
   signInPrefilled: Boolean!
   isMultiWorkspaceEnabled: Boolean!
+  isMultiWorkspaceSubdomainEnabled: Boolean!
   isEmailVerificationRequired: Boolean!
   defaultSubdomain: String
   frontDomain: String!

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -1656,6 +1656,7 @@ export interface ClientConfig {
     aiModels: ClientAiModelConfig[]
     signInPrefilled: Scalars['Boolean']
     isMultiWorkspaceEnabled: Scalars['Boolean']
+    isMultiWorkspaceSubdomainEnabled: Scalars['Boolean']
     isEmailVerificationRequired: Scalars['Boolean']
     defaultSubdomain?: Scalars['String']
     frontDomain: Scalars['String']
@@ -5082,6 +5083,7 @@ export interface ClientConfigGenqlSelection{
     aiModels?: ClientAiModelConfigGenqlSelection
     signInPrefilled?: boolean | number
     isMultiWorkspaceEnabled?: boolean | number
+    isMultiWorkspaceSubdomainEnabled?: boolean | number
     isEmailVerificationRequired?: boolean | number
     defaultSubdomain?: boolean | number
     frontDomain?: boolean | number

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -3901,6 +3901,9 @@ export default {
             "isMultiWorkspaceEnabled": [
                 8
             ],
+            "isMultiWorkspaceSubdomainEnabled": [
+                8
+            ],
             "isEmailVerificationRequired": [
                 8
             ],

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1007,6 +1007,7 @@ export type ClientConfig = {
   isMicrosoftCalendarEnabled: Scalars['Boolean']['output'];
   isMicrosoftMessagingEnabled: Scalars['Boolean']['output'];
   isMultiWorkspaceEnabled: Scalars['Boolean']['output'];
+  isMultiWorkspaceSubdomainEnabled: Scalars['Boolean']['output'];
   isOnboardingAiChatEnabled: Scalars['Boolean']['output'];
   isWorkspaceSchemaDDLLocked: Scalars['Boolean']['output'];
   maintenance?: Maybe<ClientConfigMaintenanceMode>;

--- a/packages/twenty-front/src/modules/app/components/DomainShell.tsx
+++ b/packages/twenty-front/src/modules/app/components/DomainShell.tsx
@@ -6,6 +6,7 @@ import { WorkspaceApp } from '@/app/components/WorkspaceApp';
 import { isOnOnboardingTransitionPath } from '@/auth/utils/isOnOnboardingTransitionPath';
 import { clientConfigApiStatusState } from '@/client-config/states/clientConfigApiStatusState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { useIsCurrentLocationOnDefaultDomain } from '@/domain-manager/hooks/useIsCurrentLocationOnDefaultDomain';
 import { OnboardingPageLoader } from '@/onboarding/components/OnboardingPageLoader';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -15,6 +16,9 @@ export const DomainShell = () => {
   const { isLoadedOnce } = useAtomStateValue(clientConfigApiStatusState);
   const isMultiWorkspaceEnabled = useAtomStateValue(
     isMultiWorkspaceEnabledState,
+  );
+  const isMultiWorkspaceSubdomainEnabled = useAtomStateValue(
+    isMultiWorkspaceSubdomainEnabledState,
   );
   const { isDefaultDomain } = useIsCurrentLocationOnDefaultDomain();
 
@@ -32,7 +36,7 @@ export const DomainShell = () => {
     );
   }
 
-  if (!isMultiWorkspaceEnabled) {
+  if (!isMultiWorkspaceEnabled || !isMultiWorkspaceSubdomainEnabled) {
     return <WorkspaceApp />;
   }
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
@@ -1,6 +1,7 @@
 import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState';
 import { returnToPathState } from '@/auth/states/returnToPathState';
 import { useBuildWorkspaceUrl } from '@/domain-manager/hooks/useBuildWorkspaceUrl';
+import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
 import { useQuery } from '@apollo/client/react';
 import { styled } from '@linaria/react';
 import { Trans, useLingui } from '@lingui/react/macro';
@@ -135,6 +136,7 @@ export const SignInUpGlobalScopeForm = () => {
 
   const { form } = useSignInUpForm();
   const { handleResetPassword } = useHandleResetPassword();
+  const { redirectToWorkspaceDomain } = useRedirectToWorkspaceDomain();
   const returnToPath = useAtomStateValue(returnToPathState);
 
   useQuery(GetWorkspaceCreationDefaultsDocument, {
@@ -148,6 +150,24 @@ export const SignInUpGlobalScopeForm = () => {
     );
 
     return buildWorkspaceUrl(
+      getWorkspaceUrl(availableWorkspace.workspaceUrls),
+      pathname,
+      {
+        ...searchParams,
+        ...(isNonEmptyString(returnToPath) ? { returnToPath } : {}),
+      },
+    );
+  };
+
+  const handleSelectAvailableWorkspace = async (
+    availableWorkspace: AvailableWorkspace,
+  ) => {
+    const { pathname, searchParams } = getAvailableWorkspacePathAndSearchParams(
+      availableWorkspace,
+      { email: form.getValues('email') },
+    );
+
+    await redirectToWorkspaceDomain(
       getWorkspaceUrl(availableWorkspace.workspaceUrls),
       pathname,
       {
@@ -174,6 +194,10 @@ export const SignInUpGlobalScopeForm = () => {
               >
                 <UndecoratedLink
                   to={getAvailableWorkspaceUrl(availableWorkspace)}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    handleSelectAvailableWorkspace(availableWorkspace);
+                  }}
                 >
                   <StyledWorkspaceItem>
                     <StyledWorkspaceContent>

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWorkspaceCreationForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWorkspaceCreationForm.tsx
@@ -5,6 +5,7 @@ import { ONBOARDING_CONTENT_BLOCK_WIDTH } from '@/onboarding/constants/Onboardin
 import { useWorkspaceSubdomainField } from '@/auth/sign-in-up/hooks/useWorkspaceSubdomainField';
 import { isCreatingWorkspaceState } from '@/auth/states/isCreatingWorkspaceState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
 import { TextInput } from '@/ui/input/components/TextInput';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -142,6 +143,9 @@ export const SignInUpWorkspaceCreationForm = () => {
   const isMultiWorkspaceEnabled = useAtomStateValue(
     isMultiWorkspaceEnabledState,
   );
+  const isMultiWorkspaceSubdomainEnabled = useAtomStateValue(
+    isMultiWorkspaceSubdomainEnabledState,
+  );
 
   const isCreatingWorkspace = useAtomStateValue(isCreatingWorkspaceState);
   const setIsCreatingWorkspace = useSetAtomState(isCreatingWorkspaceState);
@@ -150,6 +154,9 @@ export const SignInUpWorkspaceCreationForm = () => {
     undefined,
   );
   const hiddenFileInputRef = useRef<HTMLInputElement>(null);
+
+  const isSubdomainInputEnabled =
+    isMultiWorkspaceEnabled && isMultiWorkspaceSubdomainEnabled;
 
   const {
     workspaceName,
@@ -162,13 +169,13 @@ export const SignInUpWorkspaceCreationForm = () => {
     handleSubdomainChange,
     applySuggestionValue,
   } = useWorkspaceSubdomainField({
-    isSubdomainEnabled: isMultiWorkspaceEnabled,
+    isSubdomainEnabled: isSubdomainInputEnabled,
   });
 
   const isContinueDisabled =
     workspaceName.trim() === '' ||
     isCreatingWorkspace ||
-    (isMultiWorkspaceEnabled && !isAvailable);
+    (isSubdomainInputEnabled && !isAvailable);
 
   const openFilePicker = () => {
     hiddenFileInputRef.current?.click();
@@ -300,7 +307,7 @@ export const SignInUpWorkspaceCreationForm = () => {
             fullWidth
           />
         </OnboardingStepAnimatedItem>
-        {isMultiWorkspaceEnabled && (
+        {isSubdomainInputEnabled && (
           <OnboardingStepAnimatedItem index={4}>
             <StyledSubdomainSection>
               <TextInput

--- a/packages/twenty-front/src/modules/client-config/hooks/useClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/hooks/useClientConfig.ts
@@ -26,6 +26,7 @@ import { maintenanceModeState } from '@/client-config/states/maintenanceModeStat
 import { isMicrosoftCalendarEnabledState } from '@/client-config/states/isMicrosoftCalendarEnabledState';
 import { isMicrosoftMessagingEnabledState } from '@/client-config/states/isMicrosoftMessagingEnabledState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { isOnboardingAiChatEnabledState } from '@/client-config/states/isOnboardingAiChatEnabledState';
 import { labPublicFeatureFlagsState } from '@/client-config/states/labPublicFeatureFlagsState';
 import { sentryConfigState } from '@/client-config/states/sentryConfigState';
@@ -59,6 +60,9 @@ export const useClientConfig = (): UseClientConfigResult => {
   );
   const setIsMultiWorkspaceEnabled = useSetAtomState(
     isMultiWorkspaceEnabledState,
+  );
+  const setIsMultiWorkspaceSubdomainEnabled = useSetAtomState(
+    isMultiWorkspaceSubdomainEnabledState,
   );
   const setIsEmailVerificationRequired = useSetAtomState(
     isEmailVerificationRequiredState,
@@ -182,6 +186,9 @@ export const useClientConfig = (): UseClientConfigResult => {
       setIsAnalyticsEnabled(clientConfig.analyticsEnabled);
       setIsDeveloperDefaultSignInPrefilled(clientConfig.signInPrefilled);
       setIsMultiWorkspaceEnabled(clientConfig.isMultiWorkspaceEnabled);
+      setIsMultiWorkspaceSubdomainEnabled(
+        clientConfig.isMultiWorkspaceSubdomainEnabled ?? true,
+      );
       setIsEmailVerificationRequired(clientConfig.isEmailVerificationRequired);
       setBilling(clientConfig.billing);
       setSupportChat(clientConfig.support);
@@ -279,6 +286,7 @@ export const useClientConfig = (): UseClientConfigResult => {
     setIsEmailVerificationRequired,
     setIsImapSmtpCaldavEnabled,
     setIsMultiWorkspaceEnabled,
+    setIsMultiWorkspaceSubdomainEnabled,
     setIsEmailingDomainInDemoMode,
     setIsClickHouseConfigured,
     setIsCloudflareIntegrationEnabled,

--- a/packages/twenty-front/src/modules/client-config/states/isMultiWorkspaceSubdomainEnabledState.ts
+++ b/packages/twenty-front/src/modules/client-config/states/isMultiWorkspaceSubdomainEnabledState.ts
@@ -1,0 +1,5 @@
+import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
+export const isMultiWorkspaceSubdomainEnabledState = createAtomState<boolean>({
+  key: 'isMultiWorkspaceSubdomainEnabled',
+  defaultValue: true,
+});

--- a/packages/twenty-front/src/modules/client-config/types/ClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/types/ClientConfig.ts
@@ -35,6 +35,7 @@ export type ClientConfig = {
   isMicrosoftCalendarEnabled: boolean;
   isMicrosoftMessagingEnabled: boolean;
   isMultiWorkspaceEnabled: boolean;
+  isMultiWorkspaceSubdomainEnabled: boolean;
   isImapSmtpCaldavEnabled: boolean;
   isEmailingDomainInDemoMode: boolean;
   isCloudflareIntegrationEnabled: boolean;

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useIsCurrentLocationOnAWorkspace.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useIsCurrentLocationOnAWorkspace.ts
@@ -1,4 +1,5 @@
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { useReadDefaultDomainFromConfiguration } from '@/domain-manager/hooks/useReadDefaultDomainFromConfiguration';
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -10,19 +11,24 @@ export const useIsCurrentLocationOnAWorkspace = () => {
   const isMultiWorkspaceEnabled = useAtomStateValue(
     isMultiWorkspaceEnabledState,
   );
+  const isMultiWorkspaceSubdomainEnabled = useAtomStateValue(
+    isMultiWorkspaceSubdomainEnabledState,
+  );
   const domainConfiguration = useAtomStateValue(domainConfigurationState);
 
   if (
     isMultiWorkspaceEnabled &&
+    isMultiWorkspaceSubdomainEnabled &&
     (!isDefined(domainConfiguration.frontDomain) ||
       !isDefined(domainConfiguration.defaultSubdomain))
   ) {
     throw new Error('frontDomain and defaultSubdomain are required');
   }
 
-  const isOnAWorkspace = !isMultiWorkspaceEnabled
-    ? true
-    : window.location.hostname !== defaultDomain;
+  const isOnAWorkspace =
+    !isMultiWorkspaceEnabled || !isMultiWorkspaceSubdomainEnabled
+      ? true
+      : window.location.hostname !== defaultDomain;
 
   return {
     isOnAWorkspace,

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useReadDefaultDomainFromConfiguration.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useReadDefaultDomainFromConfiguration.ts
@@ -1,4 +1,5 @@
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 
@@ -7,10 +8,14 @@ export const useReadDefaultDomainFromConfiguration = () => {
   const isMultiWorkspaceEnabled = useAtomStateValue(
     isMultiWorkspaceEnabledState,
   );
+  const isMultiWorkspaceSubdomainEnabled = useAtomStateValue(
+    isMultiWorkspaceSubdomainEnabledState,
+  );
 
-  const defaultDomain = isMultiWorkspaceEnabled
-    ? `${domainConfiguration.defaultSubdomain}.${domainConfiguration.frontDomain}`
-    : domainConfiguration.frontDomain;
+  const defaultDomain =
+    isMultiWorkspaceEnabled && isMultiWorkspaceSubdomainEnabled
+      ? `${domainConfiguration.defaultSubdomain}.${domainConfiguration.frontDomain}`
+      : domainConfiguration.frontDomain;
 
   return {
     defaultDomain,

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useRedirect.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useRedirect.ts
@@ -5,7 +5,11 @@ import { useDebouncedCallback } from 'use-debounce';
 
 export const useRedirect = () => {
   const redirect = useDebouncedCallback((url: string, target?: string) => {
-    window.open(url, target ?? '_self');
+    if (!target || target === '_self') {
+      window.location.assign(url);
+    } else {
+      window.open(url, target);
+    }
   }, 1);
 
   return {

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsSubdomain.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsSubdomain.tsx
@@ -44,7 +44,7 @@ export const SettingsSubdomain = () => {
   } = useSettingsSubdomain();
 
   if (!isMultiWorkspaceSubdomainEnabled) {
-    navigate(getSettingsPath(SettingsPath.General));
+    navigate(SettingsPath.General);
     return null;
   }
 

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsSubdomain.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsSubdomain.tsx
@@ -1,4 +1,5 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
 import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
@@ -28,6 +29,9 @@ export const SettingsSubdomain = () => {
   const { t } = useLingui();
   const domainConfiguration = useAtomStateValue(domainConfigurationState);
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
+  const isMultiWorkspaceSubdomainEnabled = useAtomStateValue(
+    isMultiWorkspaceSubdomainEnabledState,
+  );
 
   const {
     subdomain,
@@ -38,6 +42,11 @@ export const SettingsSubdomain = () => {
     handleSave,
     handleConfirm,
   } = useSettingsSubdomain();
+
+  if (!isMultiWorkspaceSubdomainEnabled) {
+    navigate(getSettingsPath(SettingsPath.General));
+    return null;
+  }
 
   return (
     <>

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsWorkspaceDomainCard.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsWorkspaceDomainCard.tsx
@@ -1,6 +1,7 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { isCloudflareIntegrationEnabledState } from '@/client-config/states/isCloudflareIntegrationEnabledState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { SettingsCard } from '@/settings/components/SettingsCard';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { styled } from '@linaria/react';
@@ -27,20 +28,28 @@ export const SettingsWorkspaceDomainCard = () => {
   const isMultiWorkspaceEnabled = useAtomStateValue(
     isMultiWorkspaceEnabledState,
   );
+  const isMultiWorkspaceSubdomainEnabled = useAtomStateValue(
+    isMultiWorkspaceSubdomainEnabledState,
+  );
   const isCloudflareIntegrationEnabled = useAtomStateValue(
     isCloudflareIntegrationEnabledState,
   );
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
 
-  if (!isMultiWorkspaceEnabled) {
+  if (
+    !isMultiWorkspaceEnabled ||
+    (!isMultiWorkspaceSubdomainEnabled && !isCloudflareIntegrationEnabled)
+  ) {
     return null;
   }
 
   return (
     <StyledContainer>
-      <UndecoratedLink to={getSettingsPath(SettingsPath.Subdomain)} fullWidth>
-        <SettingsCard title={t`Subdomain`} Icon={<IconWorldWww />} />
-      </UndecoratedLink>
+      {isMultiWorkspaceSubdomainEnabled && (
+        <UndecoratedLink to={getSettingsPath(SettingsPath.Subdomain)} fullWidth>
+          <SettingsCard title={t`Subdomain`} Icon={<IconWorldWww />} />
+        </UndecoratedLink>
+      )}
       {isCloudflareIntegrationEnabled && (
         <UndecoratedLink
           to={getSettingsPath(SettingsPath.CustomDomain)}

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
@@ -3,7 +3,10 @@ import { DEFAULT_WORKSPACE_LOGO } from '@/ui/navigation/navigation-drawer/consta
 import { useAuth } from '@/auth/hooks/useAuth';
 import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { countAvailableWorkspaces } from '@/auth/utils/availableWorkspacesUtils';
+import {
+  countAvailableWorkspaces,
+  getAvailableWorkspacePathAndSearchParams,
+} from '@/auth/utils/availableWorkspacesUtils';
 import { supportChatState } from '@/client-config/states/supportChatState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
 import { useBuildWorkspaceUrl } from '@/domain-manager/hooks/useBuildWorkspaceUrl';
@@ -85,8 +88,13 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
   };
 
   const handleChange = async (availableWorkspace: AvailableWorkspace) => {
-    redirectToWorkspaceDomain(
+    const { pathname, searchParams } =
+      getAvailableWorkspacePathAndSearchParams(availableWorkspace);
+
+    await redirectToWorkspaceDomain(
       getWorkspaceUrl(availableWorkspace.workspaceUrls),
+      pathname,
+      searchParams,
     );
   };
 
@@ -154,31 +162,38 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
             ]
               .filter(({ id }) => id !== currentWorkspace?.id)
               .slice(0, 3)
-              .map((availableWorkspace) => (
-                <UndecoratedLink
-                  key={availableWorkspace.id}
-                  to={buildWorkspaceUrl(
-                    getWorkspaceUrl(availableWorkspace.workspaceUrls),
-                  )}
-                  onClick={(event) => {
-                    event?.preventDefault();
-                    handleChange(availableWorkspace);
-                  }}
-                >
-                  <MenuItemSelectAvatar
-                    text={availableWorkspace.displayName ?? t`(No name)`}
-                    avatar={
-                      <Avatar
-                        placeholder={availableWorkspace.displayName || ''}
-                        avatarUrl={getAbsoluteImageUrl(
-                          availableWorkspace.logo ?? DEFAULT_WORKSPACE_LOGO,
-                        )}
-                      />
-                    }
-                    selected={false}
-                  />
-                </UndecoratedLink>
-              ))}
+              .map((availableWorkspace) => {
+                const { pathname, searchParams } =
+                  getAvailableWorkspacePathAndSearchParams(availableWorkspace);
+
+                return (
+                  <UndecoratedLink
+                    key={availableWorkspace.id}
+                    to={buildWorkspaceUrl(
+                      getWorkspaceUrl(availableWorkspace.workspaceUrls),
+                      pathname,
+                      searchParams,
+                    )}
+                    onClick={(event) => {
+                      event?.preventDefault();
+                      handleChange(availableWorkspace);
+                    }}
+                  >
+                    <MenuItemSelectAvatar
+                      text={availableWorkspace.displayName ?? t`(No name)`}
+                      avatar={
+                        <Avatar
+                          placeholder={availableWorkspace.displayName || ''}
+                          avatarUrl={getAbsoluteImageUrl(
+                            availableWorkspace.logo ?? DEFAULT_WORKSPACE_LOGO,
+                          )}
+                        />
+                      }
+                      selected={false}
+                    />
+                  </UndecoratedLink>
+                );
+              })}
             {availableWorkspacesCount > 4 && (
               <MenuItem
                 LeftIcon={IconSwitchHorizontal}

--- a/packages/twenty-front/src/modules/workspace/components/WorkspaceProviderEffect.tsx
+++ b/packages/twenty-front/src/modules/workspace/components/WorkspaceProviderEffect.tsx
@@ -1,4 +1,5 @@
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { useReadWorkspaceUrlFromCurrentLocation } from '@/domain-manager/hooks/useReadWorkspaceUrlFromCurrentLocation';
 import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
 import { lastAuthenticatedWorkspaceDomainState } from '@/domain-manager/states/lastAuthenticatedWorkspaceDomainState';
@@ -30,6 +31,9 @@ export const WorkspaceProviderEffect = () => {
   const isMultiWorkspaceEnabled = useAtomStateValue(
     isMultiWorkspaceEnabledState,
   );
+  const isMultiWorkspaceSubdomainEnabled = useAtomStateValue(
+    isMultiWorkspaceSubdomainEnabledState,
+  );
 
   const { initializeQueryParamState } = useInitializeQueryParamState();
 
@@ -44,6 +48,7 @@ export const WorkspaceProviderEffect = () => {
   useEffect(() => {
     if (
       isMultiWorkspaceEnabled &&
+      isMultiWorkspaceSubdomainEnabled &&
       isDefined(getPublicWorkspaceData) &&
       !isWorkspaceHostnameMatchCurrentLocationHostname(
         getPublicWorkspaceData.workspaceUrls,
@@ -57,6 +62,7 @@ export const WorkspaceProviderEffect = () => {
     }
   }, [
     isMultiWorkspaceEnabled,
+    isMultiWorkspaceSubdomainEnabled,
     redirectToWorkspaceDomain,
     getPublicWorkspaceData,
     currentLocationHostname,
@@ -66,6 +72,7 @@ export const WorkspaceProviderEffect = () => {
   useEffect(() => {
     if (
       isMultiWorkspaceEnabled &&
+      isMultiWorkspaceSubdomainEnabled &&
       isDefaultDomain &&
       isDefined(lastAuthenticatedWorkspaceDomain) &&
       'workspaceUrl' in lastAuthenticatedWorkspaceDomain &&
@@ -80,6 +87,7 @@ export const WorkspaceProviderEffect = () => {
     }
   }, [
     isMultiWorkspaceEnabled,
+    isMultiWorkspaceSubdomainEnabled,
     isDefaultDomain,
     lastAuthenticatedWorkspaceDomain,
     redirectToWorkspaceDomain,

--- a/packages/twenty-front/src/pages/settings/general/SettingsGeneral.tsx
+++ b/packages/twenty-front/src/pages/settings/general/SettingsGeneral.tsx
@@ -1,6 +1,8 @@
 import { useLingui } from '@lingui/react/macro';
 
+import { isCloudflareIntegrationEnabledState } from '@/client-config/states/isCloudflareIntegrationEnabledState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isMultiWorkspaceSubdomainEnabledState } from '@/client-config/states/isMultiWorkspaceSubdomainEnabledState';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { SettingsPageLayout } from '@/settings/components/layout/SettingsPageLayout';
 import { SettingsTabBar } from '@/settings/components/layout/SettingsTabBar';
@@ -29,6 +31,12 @@ export const SettingsGeneral = () => {
 
   const isMultiWorkspaceEnabled = useAtomStateValue(
     isMultiWorkspaceEnabledState,
+  );
+  const isMultiWorkspaceSubdomainEnabled = useAtomStateValue(
+    isMultiWorkspaceSubdomainEnabledState,
+  );
+  const isCloudflareIntegrationEnabled = useAtomStateValue(
+    isCloudflareIntegrationEnabledState,
   );
 
   const hasSecurityPermission = useHasPermissionFlag(
@@ -65,15 +73,21 @@ export const SettingsGeneral = () => {
           <H2Title title={t`Name`} description={t`Name of your workspace`} />
           <NameField />
         </Section>
-        {isMultiWorkspaceEnabled && (
-          <Section>
-            <H2Title
-              title={t`Workspace domain`}
-              description={t`Edit your subdomain name or set a custom domain.`}
-            />
-            <SettingsWorkspaceDomainCard />
-          </Section>
-        )}
+        {isMultiWorkspaceEnabled &&
+          (isMultiWorkspaceSubdomainEnabled ||
+            isCloudflareIntegrationEnabled) && (
+            <Section>
+              <H2Title
+                title={t`Workspace domain`}
+                description={
+                  isMultiWorkspaceSubdomainEnabled
+                    ? t`Edit your subdomain name or set a custom domain.`
+                    : t`Set a custom domain for your workspace.`
+                }
+              />
+              <SettingsWorkspaceDomainCard />
+            </Section>
+          )}
         <Section>
           <DeleteWorkspace />
         </Section>

--- a/packages/twenty-front/src/testing/mock-data/config.ts
+++ b/packages/twenty-front/src/testing/mock-data/config.ts
@@ -5,6 +5,7 @@ export const mockedClientConfig: ClientConfig = {
   aiModels: [],
   signInPrefilled: true,
   isMultiWorkspaceEnabled: false,
+  isMultiWorkspaceSubdomainEnabled: true,
   isEmailVerificationRequired: false,
   authProviders: {
     google: true,

--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -23,6 +23,7 @@ FRONTEND_URL=http://localhost:3001
 # BILLING_PLAN_REQUIRED_LINK=https://twenty.com/stripe-redirection
 # AUTH_PASSWORD_ENABLED=false
 # IS_MULTIWORKSPACE_ENABLED=false
+# IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED=true
 # AUTH_MICROSOFT_ENABLED=false
 # AUTH_MICROSOFT_CLIENT_ID=replace_me_with_azure_client_id
 # AUTH_MICROSOFT_CLIENT_SECRET=replace_me_with_azure_client_secret

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.spec.ts
@@ -33,6 +33,7 @@ import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user
 import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
 import { UserService } from 'src/engine/core-modules/user/services/user.service';
 import { UserEntity } from 'src/engine/core-modules/user/user.entity';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
 
 import { AuthResolver } from './auth.resolver';

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.spec.ts
@@ -59,6 +59,10 @@ describe('AuthResolver', () => {
           useValue: {},
         },
         {
+          provide: getRepositoryToken(WorkspaceEntity),
+          useValue: {},
+        },
+        {
           provide: getRepositoryToken(UserEntity),
           useValue: {},
         },

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -45,6 +45,7 @@ import { AuthGraphqlApiExceptionFilter } from 'src/engine/core-modules/auth/filt
 import { ResetPasswordService } from 'src/engine/core-modules/auth/services/reset-password.service';
 import { ThrottlerGraphqlApiExceptionFilter } from 'src/engine/core-modules/throttler/filters/throttler-graphql-api-exception.filter';
 import { ThrottlerService } from 'src/engine/core-modules/throttler/throttler.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { SignInUpService } from 'src/engine/core-modules/auth/services/sign-in-up.service';
 import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
 import { EmailVerificationTokenService } from 'src/engine/core-modules/auth/token/services/email-verification-token.service';
@@ -137,9 +138,12 @@ export class AuthResolver {
     private readonly throttlerService: ThrottlerService,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
+    @InjectRepository(WorkspaceEntity)
+    private readonly workspaceRepository: Repository<WorkspaceEntity>,
     @InjectRepository(AppTokenEntity)
     private readonly appTokenRepository: Repository<AppTokenEntity>,
     private readonly twoFactorAuthenticationService: TwoFactorAuthenticationService,
+    private readonly twentyConfigService: TwentyConfigService,
     private authService: AuthService,
     private renewTokenService: RenewTokenService,
     private userService: UserService,
@@ -788,6 +792,27 @@ export class AuthResolver {
     origin: string,
     tokenWorkspaceId: string,
   ): Promise<WorkspaceEntity> {
+    const isMultiWorkspaceSubdomainEnabled = this.twentyConfigService.get(
+      'IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED',
+    );
+
+    if (!isMultiWorkspaceSubdomainEnabled) {
+      const workspace = await this.workspaceRepository.findOne({
+        where: { id: tokenWorkspaceId },
+        relations: ['workspaceSSOIdentityProviders'],
+      });
+
+      assertIsDefinedOrThrow(
+        workspace,
+        new AuthException(
+          'Workspace not found',
+          AuthExceptionCode.WORKSPACE_NOT_FOUND,
+        ),
+      );
+
+      return workspace;
+    }
+
     const workspace =
       await this.workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
         origin,

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.controller.spec.ts
@@ -66,6 +66,7 @@ describe('ClientConfigController', () => {
         },
         signInPrefilled: false,
         isMultiWorkspaceEnabled: true,
+        isMultiWorkspaceSubdomainEnabled: true,
         isEmailVerificationRequired: false,
         defaultSubdomain: 'app',
         frontDomain: 'localhost',

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.entity.ts
@@ -278,6 +278,9 @@ export class ClientConfig {
   isMultiWorkspaceEnabled: boolean;
 
   @Field(() => Boolean)
+  isMultiWorkspaceSubdomainEnabled: boolean;
+
+  @Field(() => Boolean)
   isEmailVerificationRequired: boolean;
 
   @Field(() => String, { nullable: true })

--- a/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.ts
@@ -202,6 +202,9 @@ export class ClientConfigService {
       isMultiWorkspaceEnabled: this.twentyConfigService.get(
         'IS_MULTIWORKSPACE_ENABLED',
       ),
+      isMultiWorkspaceSubdomainEnabled: this.twentyConfigService.get(
+        'IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED',
+      ),
       isEmailVerificationRequired: this.twentyConfigService.get(
         'IS_EMAIL_VERIFICATION_REQUIRED',
       ),

--- a/packages/twenty-server/src/engine/core-modules/domain/domain-server-config/services/domain-server-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/domain-server-config/services/domain-server-config.service.ts
@@ -25,6 +25,7 @@ export class DomainServerConfigService {
 
     if (
       this.twentyConfigService.get('IS_MULTIWORKSPACE_ENABLED') &&
+      this.twentyConfigService.get('IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED') &&
       this.twentyConfigService.get('DEFAULT_SUBDOMAIN')
     ) {
       baseUrl.hostname = `${this.twentyConfigService.get('DEFAULT_SUBDOMAIN')}.${baseUrl.hostname}`;
@@ -64,6 +65,14 @@ export class DomainServerConfigService {
     const { hostname: originHostname } = new URL(url);
 
     const frontDomain = this.getFrontUrl().hostname;
+
+    if (originHostname === frontDomain) {
+      return {
+        subdomain: undefined,
+        domain: null,
+        isPublicDomainOrigin: false,
+      };
+    }
 
     const isFrontdomain = originHostname.endsWith(`.${frontDomain}`);
 

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
@@ -240,9 +240,11 @@ export class WorkspaceDomainsService {
   private getTwentyWorkspaceUrl(subdomain: string) {
     const url = this.domainServerConfigService.getFrontUrl();
 
-    url.hostname = this.twentyConfigService.get('IS_MULTIWORKSPACE_ENABLED')
-      ? `${subdomain}.${url.hostname}`
-      : url.hostname;
+    url.hostname =
+      this.twentyConfigService.get('IS_MULTIWORKSPACE_ENABLED') &&
+      this.twentyConfigService.get('IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED')
+        ? `${subdomain}.${url.hostname}`
+        : url.hostname;
 
     return url.toString();
   }

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1898,6 +1898,15 @@ export class ConfigVariables {
   IS_MULTIWORKSPACE_ENABLED = false;
 
   @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.SERVER_CONFIG,
+    description:
+      'Enable or disable subdomain-based routing for multi-workspace. When disabled, multi-workspace operates on a single root domain.',
+    type: ConfigVariableType.BOOLEAN,
+  })
+  @IsOptional()
+  IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED = true;
+
+  @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,
     description:
       'Number of inactive days before sending a deletion warning for workspaces. Used in the workspace deletion cron job to determine when to send warning emails.',


### PR DESCRIPTION
## Summary
Currently, IS_MULTIWORKSPACE_ENABLED=true strictly requires and enforces subdomain-based routing (e.g. workspace-a.twenty.com, workspace-b.twenty.com). In many self-hosted and cloud deployment topologies (such as custom ingress, reverse proxies, Cloudflare Zero Trust tunnels without wildcard certificates, or corporate environments), teams prefer running multi-tenancy on a single root domain (e.g. crm.company.com) without creating dynamic DNS records and TLS certificates for every tenant.

This PR introduces the configuration flag IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED (default: 	rue, preserving 100% backward compatibility):
- When IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED=true (default): Native subdomain routing behaves identically to current Twenty releases.
- When IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED=false: Multi-workspace operates seamlessly on a single root domain using session/cookie/token-based tenant switching without triggering subdomain redirects.

### Key Changes
1. **Server Configuration**:
   - Added IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED to ConfigVariables and .env.example.
   - Exposed isMultiWorkspaceSubdomainEnabled in ClientConfig DTO and service.
   - Updated DomainServerConfigService and WorkspaceDomainsService to conditionally format workspace URLs and base URLs only when subdomains are enabled.
   - Updated AuthResolver.validateWorkspaceAccess to validate workspace directly by 	okenWorkspaceId when subdomains are disabled.
2. **Frontend Adjustments**:
   - DomainShell: Renders WorkspaceApp directly when multi-workspace operates on single root domain.
   - DomainManager: useIsCurrentLocationOnAWorkspace and useReadDefaultDomainFromConfiguration respect isMultiWorkspaceSubdomainEnabled.
   - WorkspaceProviderEffect: Skips subdomain URL redirects when subdomain routing is disabled.
   - SignInUpWorkspaceCreationForm: Only prompts for subdomain input when isMultiWorkspaceSubdomainEnabled is 	rue.
   - MultiWorkspaceDropdown: Properly passes loginToken and uses window.location.assign on tenant switch.
   - Settings: Conditionally hides subdomain settings cards when subdomain routing is disabled.

## Test plan
- [x] Tested with IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED=true (default): verified normal subdomain routing and multi-workspace onboarding work as before.
- [x] Tested with IS_MULTIWORKSPACE_SUBDOMAIN_ENABLED=false: verified multi-workspace onboarding and switching between multiple workspaces work directly on a single domain.
- [x] Verified unit tests and TypeScript definitions across 	wenty-server and 	wenty-front.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

