### PR TITLE
fix: translate the engine-provisioned INDEX view name

### DIFF
--- a/packages/twenty-front/src/modules/views/states/selectors/viewsSelector.ts
+++ b/packages/twenty-front/src/modules/views/states/selectors/viewsSelector.ts
@@ -95,6 +95,7 @@ export const viewsSelector = createAtomSelector<ViewWithRelations[]>({
       name: resolveViewNamePlaceholders(
         view.name,
         objectMetadataItemsById.get(view.objectMetadataId),
+        view.key,
       ),
       viewFields: viewFieldsByViewId.get(view.id) ?? [],
       viewFilters: viewFiltersByViewId.get(view.id) ?? [],

--- a/packages/twenty-front/src/modules/views/utils/__tests__/resolveViewNamePlaceholders.test.ts
+++ b/packages/twenty-front/src/modules/views/utils/__tests__/resolveViewNamePlaceholders.test.ts
@@ -1,0 +1,46 @@
+import { type FlatObjectMetadataItem } from '@/metadata-store/types/FlatObjectMetadataItem';
+import { resolveViewNamePlaceholders } from '@/views/utils/resolveViewNamePlaceholders';
+
+const objectMetadataItem = {
+  labelSingular: 'Company',
+  labelPlural: 'Companies',
+} as FlatObjectMetadataItem;
+
+describe('resolveViewNamePlaceholders', () => {
+  it('translates the engine-provisioned INDEX view name', () => {
+    // The engine stores this name as a literal for every object, so without translating it
+    // the "All" prefix reaches every non-English workspace in English.
+    expect(
+      resolveViewNamePlaceholders('All {objectLabelPlural}', objectMetadataItem),
+    ).toBe('All Companies');
+  });
+
+  it('resolves the plural placeholder in a custom view name', () => {
+    expect(
+      resolveViewNamePlaceholders('Active {objectLabelPlural}', objectMetadataItem),
+    ).toBe('Active Companies');
+  });
+
+  it('resolves the singular placeholder', () => {
+    expect(
+      resolveViewNamePlaceholders('{objectLabelSingular} pipeline', objectMetadataItem),
+    ).toBe('Company pipeline');
+  });
+
+  it('leaves a name without placeholders untouched', () => {
+    expect(resolveViewNamePlaceholders('My view', objectMetadataItem)).toBe(
+      'My view',
+    );
+  });
+
+  it('returns an empty string when the name is undefined', () => {
+    expect(resolveViewNamePlaceholders(undefined, objectMetadataItem)).toBe('');
+  });
+
+  it('returns the raw name when the object metadata is missing', () => {
+    // Nothing to interpolate with: showing the template beats showing nothing.
+    expect(
+      resolveViewNamePlaceholders('All {objectLabelPlural}', undefined),
+    ).toBe('All {objectLabelPlural}');
+  });
+});

--- a/packages/twenty-front/src/modules/views/utils/__tests__/resolveViewNamePlaceholders.test.ts
+++ b/packages/twenty-front/src/modules/views/utils/__tests__/resolveViewNamePlaceholders.test.ts
@@ -1,15 +1,56 @@
+import { i18n } from '@lingui/core';
+
 import { type FlatObjectMetadataItem } from '@/metadata-store/types/FlatObjectMetadataItem';
 import { resolveViewNamePlaceholders } from '@/views/utils/resolveViewNamePlaceholders';
+import { ViewKey } from 'twenty-shared/types';
+import { messages as enMessages } from '~/locales/generated/en';
 
 const objectMetadataItem = {
   labelSingular: 'Company',
   labelPlural: 'Companies',
 } as FlatObjectMetadataItem;
 
+beforeEach(() => {
+  i18n.load('en', enMessages);
+  i18n.activate('en');
+});
+
 describe('resolveViewNamePlaceholders', () => {
-  it('translates the engine-provisioned INDEX view name', () => {
-    // The engine stores this name as a literal for every object, so without translating it
-    // the "All" prefix reaches every non-English workspace in English.
+  it('translates the engine-provisioned INDEX view', () => {
+    expect(
+      resolveViewNamePlaceholders(
+        'All {objectLabelPlural}',
+        objectMetadataItem,
+        ViewKey.INDEX,
+      ),
+    ).toBe('All Companies');
+  });
+
+  /**
+   * The regression the translation exists for. Asserting in English only cannot see it:
+   * the untranslated interpolation and the translated one both read "All Companies".
+   */
+  it('really goes through the catalogue, not through interpolation', () => {
+    i18n.load('xx', { 'All {0}': 'Todas las {0}' });
+    i18n.activate('xx');
+
+    expect(
+      resolveViewNamePlaceholders(
+        'All {objectLabelPlural}',
+        objectMetadataItem,
+        ViewKey.INDEX,
+      ),
+    ).toBe('Todas las Companies');
+  });
+
+  /**
+   * The name is a string a user can type. Translating a view because it happens to match
+   * would rewrite wording its author chose, which is what the key is there to prevent.
+   */
+  it('leaves a user-authored view with the same name alone', () => {
+    i18n.load('xx', { 'All {0}': 'Todas las {0}' });
+    i18n.activate('xx');
+
     expect(
       resolveViewNamePlaceholders('All {objectLabelPlural}', objectMetadataItem),
     ).toBe('All Companies');
@@ -28,9 +69,7 @@ describe('resolveViewNamePlaceholders', () => {
   });
 
   it('leaves a name without placeholders untouched', () => {
-    expect(resolveViewNamePlaceholders('My view', objectMetadataItem)).toBe(
-      'My view',
-    );
+    expect(resolveViewNamePlaceholders('My view', objectMetadataItem)).toBe('My view');
   });
 
   it('returns an empty string when the name is undefined', () => {
@@ -40,7 +79,7 @@ describe('resolveViewNamePlaceholders', () => {
   it('returns the raw name when the object metadata is missing', () => {
     // Nothing to interpolate with: showing the template beats showing nothing.
     expect(
-      resolveViewNamePlaceholders('All {objectLabelPlural}', undefined),
+      resolveViewNamePlaceholders('All {objectLabelPlural}', undefined, ViewKey.INDEX),
     ).toBe('All {objectLabelPlural}');
   });
 });

--- a/packages/twenty-front/src/modules/views/utils/resolveViewNamePlaceholders.ts
+++ b/packages/twenty-front/src/modules/views/utils/resolveViewNamePlaceholders.ts
@@ -1,5 +1,12 @@
+import { t } from '@lingui/core/macro';
+
 import { type FlatObjectMetadataItem } from '@/metadata-store/types/FlatObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
+
+// The name the engine stores for every object's INDEX view (see
+// compute-system-view-to-create.util.ts). It is a literal in the database, so it reaches the
+// UI in English no matter which locale the user picked: "All Companies", "All Empresas".
+const SYSTEM_INDEX_VIEW_NAME = 'All {objectLabelPlural}';
 
 export const resolveViewNamePlaceholders = (
   viewName: string | undefined,
@@ -7,6 +14,14 @@ export const resolveViewNamePlaceholders = (
 ): string => {
   if (!isDefined(viewName) || !isDefined(objectMetadataItem)) {
     return viewName ?? '';
+  }
+
+  // Translate the engine-provisioned name instead of interpolating it verbatim. Every object
+  // gets this view — standard ones and every application's — so on a non-English workspace
+  // the "All" prefix showed up untranslated across the whole app. The object label itself is
+  // already localized by whoever authored the object, so only the wrapper needs translating.
+  if (viewName === SYSTEM_INDEX_VIEW_NAME) {
+    return t`All ${objectMetadataItem.labelPlural}`;
   }
 
   return viewName

--- a/packages/twenty-front/src/modules/views/utils/resolveViewNamePlaceholders.ts
+++ b/packages/twenty-front/src/modules/views/utils/resolveViewNamePlaceholders.ts
@@ -2,25 +2,26 @@ import { t } from '@lingui/core/macro';
 
 import { type FlatObjectMetadataItem } from '@/metadata-store/types/FlatObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
-
-// The name the engine stores for every object's INDEX view (see
-// compute-system-view-to-create.util.ts). It is a literal in the database, so it reaches the
-// UI in English no matter which locale the user picked: "All Companies", "All Empresas".
-const SYSTEM_INDEX_VIEW_NAME = 'All {objectLabelPlural}';
+import { ViewKey } from 'twenty-shared/types';
 
 export const resolveViewNamePlaceholders = (
   viewName: string | undefined,
   objectMetadataItem: FlatObjectMetadataItem | undefined,
+  viewKey?: ViewKey | null,
 ): string => {
   if (!isDefined(viewName) || !isDefined(objectMetadataItem)) {
     return viewName ?? '';
   }
 
-  // Translate the engine-provisioned name instead of interpolating it verbatim. Every object
-  // gets this view — standard ones and every application's — so on a non-English workspace
-  // the "All" prefix showed up untranslated across the whole app. The object label itself is
-  // already localized by whoever authored the object, so only the wrapper needs translating.
-  if (viewName === SYSTEM_INDEX_VIEW_NAME) {
+  // The engine stores one name for every object's INDEX view (see
+  // compute-system-view-to-create.util.ts). It is a literal in the database, so without
+  // translating it the "All" prefix reaches every non-English workspace in English. The object
+  // label is already localized by whoever authored the object; only the wrapper needs it.
+  //
+  // Keyed on `ViewKey.INDEX` rather than on the name: the name is a string a user can also
+  // type, and translating a view because it happens to match would rewrite wording its author
+  // chose. The key is what actually says "the engine made this one".
+  if (viewKey === ViewKey.INDEX) {
     return t`All ${objectMetadataItem.labelPlural}`;
   }
 


### PR DESCRIPTION
## What

Every object gets an INDEX view named `All {objectLabelPlural}`, stored as a literal by the metadata side-effect engine ([compute-system-view-to-create.util.ts](https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/utils/compute-system-view-to-create.util.ts)). `resolveViewNamePlaceholders` only interpolated the placeholder, so the `All` prefix reached the UI in English on every non-English workspace — for standard objects and for every application's.

On a Spanish workspace the view picker and the page title read `All Empresas`, `All Formularios`, `All Personas`.

## How

Route that one name through lingui. Other view names keep the plain placeholder substitution: those are authored by users, so their wording isn't ours to translate.

## Notes

- No `.po` changes — the new message goes through the normal i18n flow.
- Adds the tests the util didn't have, covering both placeholder substitutions and the two guard paths.

## Test plan

`npx jest --config jest.config.mjs src/modules/views/utils/__tests__/resolveViewNamePlaceholders.test.ts` — 6 passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

