### PR TITLE
v1.8.1 — Fix partner case-study save rejected by RLS

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-partners",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/mappers/save-my-partner-content.mapper.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/mappers/save-my-partner-content.mapper.ts
@@ -39,8 +39,8 @@ export type CaseStudyRow = {
 };
 
 // Partner self-controls visibility: published → APPROVED (public), draft → WIP (hidden).
-// partnerId and contentType stay out of this mapper (locked fields, trigger-stamped).
-// partnerUserId is stamped on create by the save service, from the authenticated member.
+// partnerId and contentType stay out on purpose: both are locked for the partner role and
+// trigger-stamped, so a partner cannot repoint a case study onto another partner's profile.
 // Create and update share every field mapping; they diverge only on how status is
 // derived, so keep the common fields here and let each add its own status handling.
 const buildContentBaseData = (item: CaseStudyItem) => ({

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/mappers/save-my-partner-content.mapper.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/mappers/save-my-partner-content.mapper.ts
@@ -39,9 +39,9 @@ export type CaseStudyRow = {
 };
 
 // Partner self-controls visibility: published → APPROVED (public), draft → WIP (hidden).
-// Ownership (partnerId/partnerUser) and contentType are stamped server-side by the
-// on-partner-content-created trigger, never written by the caller — so a partner cannot
-// repoint a case study onto another partner's public marketplace profile.
+// partnerId and contentType stay out of this mapper (locked fields, trigger-stamped).
+// partnerUserId is set on create by the save service from the authenticated member,
+// not from the request body, so a partner cannot repoint a case study.
 // Create and update share every field mapping; they diverge only on how status is
 // derived, so keep the common fields here and let each add its own status handling.
 const buildContentBaseData = (item: CaseStudyItem) => ({

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/mappers/save-my-partner-content.mapper.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/mappers/save-my-partner-content.mapper.ts
@@ -40,8 +40,7 @@ export type CaseStudyRow = {
 
 // Partner self-controls visibility: published → APPROVED (public), draft → WIP (hidden).
 // partnerId and contentType stay out of this mapper (locked fields, trigger-stamped).
-// partnerUserId is set on create by the save service from the authenticated member,
-// not from the request body, so a partner cannot repoint a case study.
+// partnerUserId is stamped on create by the save service, from the authenticated member.
 // Create and update share every field mapping; they diverge only on how status is
 // derived, so keep the common fields here and let each add its own status handling.
 const buildContentBaseData = (item: CaseStudyItem) => ({

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.test.ts
@@ -23,36 +23,14 @@ const APP_TOKEN = `header.${Buffer.from(
   JSON.stringify({ userId: USER_ID, userWorkspaceId: USER_WORKSPACE_ID }),
 ).toString('base64url')}.sig`;
 
-type QueryResponses = {
-  workspaceMembers?: unknown;
-  partners?: unknown;
-  partnerContents?: unknown;
-};
-
-const defaultResponses = (): QueryResponses => ({
+const QUERY_RESPONSES: Record<string, unknown> = {
   workspaceMembers: { edges: [{ node: { id: WORKSPACE_MEMBER_ID } }] },
   partners: { edges: [{ node: { id: PARTNER_ID, name: 'Atlas' } }] },
   partnerContents: { edges: [] },
-});
-
-const respondWith = (overrides: QueryResponses = {}) => {
-  const responses = { ...defaultResponses(), ...overrides };
-  queryMock.mockImplementation((selection: Record<string, unknown>) => {
-    const key = Object.keys(selection)[0] as keyof QueryResponses;
-    return Promise.resolve({ [key as string]: responses[key] });
-  });
 };
 
 const routeEvent = (body: unknown): RoutePayload<unknown> =>
-  ({
-    headers: {},
-    queryStringParameters: {},
-    pathParameters: {},
-    body,
-    isBase64Encoded: false,
-    requestContext: { http: { method: 'POST', path: '/save-my-partner-content' } },
-    userWorkspaceId: USER_WORKSPACE_ID,
-  }) as RoutePayload<unknown>;
+  ({ body, userWorkspaceId: USER_WORKSPACE_ID }) as RoutePayload<unknown>;
 
 describe('saveMyPartnerContent', () => {
   const originalToken = process.env.TWENTY_APP_ACCESS_TOKEN;
@@ -69,7 +47,10 @@ describe('saveMyPartnerContent', () => {
     mutationMock.mockResolvedValue({
       createPartnerContent: { id: 'content-1' },
     });
-    respondWith();
+    queryMock.mockImplementation((selection: Record<string, unknown>) => {
+      const key = Object.keys(selection)[0] as string;
+      return Promise.resolve({ [key]: QUERY_RESPONSES[key] });
+    });
   });
 
   it('creates with the authenticated partnerUserId so RLS accepts the insert', async () => {
@@ -80,7 +61,7 @@ describe('saveMyPartnerContent', () => {
             name: 'Atlas rollout',
             clientName: 'Acme',
             headline: 'A migration',
-            bodyMarkdown: 'Used ₹ pricing — “done”.',
+            bodyMarkdown: 'How Acme migrated.',
             caseStudyLink: 'https://example.com/atlas',
             coverImageUrl: 'https://cdn.example.com/cover.png',
             published: false,

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type RoutePayload } from 'twenty-sdk/define';
+
+const { queryMock, mutationMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  mutationMock: vi.fn(),
+}));
+
+vi.mock('twenty-client-sdk/core', () => ({
+  CoreApiClient: vi.fn(function () {
+    return { query: queryMock, mutation: mutationMock };
+  }),
+}));
+
+import { saveMyPartnerContent } from './save-my-partner-content.service';
+
+const USER_ID = 'user-1';
+const USER_WORKSPACE_ID = 'user-workspace-1';
+const WORKSPACE_MEMBER_ID = 'member-1';
+const PARTNER_ID = 'partner-1';
+
+const APP_TOKEN = `header.${Buffer.from(
+  JSON.stringify({ userId: USER_ID, userWorkspaceId: USER_WORKSPACE_ID }),
+).toString('base64url')}.sig`;
+
+type QueryResponses = {
+  workspaceMembers?: unknown;
+  partners?: unknown;
+  partnerContents?: unknown;
+};
+
+const defaultResponses = (): QueryResponses => ({
+  workspaceMembers: { edges: [{ node: { id: WORKSPACE_MEMBER_ID } }] },
+  partners: { edges: [{ node: { id: PARTNER_ID, name: 'Atlas' } }] },
+  partnerContents: { edges: [] },
+});
+
+const respondWith = (overrides: QueryResponses = {}) => {
+  const responses = { ...defaultResponses(), ...overrides };
+  queryMock.mockImplementation((selection: Record<string, unknown>) => {
+    const key = Object.keys(selection)[0] as keyof QueryResponses;
+    return Promise.resolve({ [key as string]: responses[key] });
+  });
+};
+
+const routeEvent = (body: unknown): RoutePayload<unknown> =>
+  ({
+    headers: {},
+    queryStringParameters: {},
+    pathParameters: {},
+    body,
+    isBase64Encoded: false,
+    requestContext: { http: { method: 'POST', path: '/save-my-partner-content' } },
+    userWorkspaceId: USER_WORKSPACE_ID,
+  }) as RoutePayload<unknown>;
+
+describe('saveMyPartnerContent', () => {
+  const originalToken = process.env.TWENTY_APP_ACCESS_TOKEN;
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.TWENTY_APP_ACCESS_TOKEN;
+    else process.env.TWENTY_APP_ACCESS_TOKEN = originalToken;
+  });
+
+  beforeEach(() => {
+    queryMock.mockReset();
+    mutationMock.mockReset();
+    process.env.TWENTY_APP_ACCESS_TOKEN = APP_TOKEN;
+    mutationMock.mockResolvedValue({
+      createPartnerContent: { id: 'content-1' },
+    });
+    respondWith();
+  });
+
+  it('creates with the authenticated partnerUserId so RLS accepts the insert', async () => {
+    const result = await saveMyPartnerContent(
+      routeEvent({
+        caseStudies: [
+          {
+            name: 'Atlas rollout',
+            clientName: 'Acme',
+            headline: 'A migration',
+            bodyMarkdown: 'Used ₹ pricing — “done”.',
+            caseStudyLink: 'https://example.com/atlas',
+            coverImageUrl: 'https://cdn.example.com/cover.png',
+            published: false,
+          },
+        ],
+      }),
+    );
+
+    expect(result).toMatchObject({ ok: true });
+    expect(mutationMock).toHaveBeenCalledWith({
+      createPartnerContent: {
+        __args: {
+          data: expect.objectContaining({
+            name: 'Atlas rollout',
+            partnerUserId: WORKSPACE_MEMBER_ID,
+            status: 'WIP',
+          }),
+        },
+        id: true,
+      },
+    });
+
+    const createData =
+      mutationMock.mock.calls[0][0].createPartnerContent.__args.data;
+    expect(createData).not.toHaveProperty('partnerId');
+    expect(createData).not.toHaveProperty('contentType');
+  });
+
+  it('never reads partnerUserId from the request body', async () => {
+    await saveMyPartnerContent(
+      routeEvent({
+        caseStudies: [{ name: 'Atlas rollout' }],
+        partnerUserId: 'spoofed-member',
+        partnerId: 'spoofed-partner',
+      }),
+    );
+
+    const createData =
+      mutationMock.mock.calls[0][0].createPartnerContent.__args.data;
+    expect(createData.partnerUserId).toBe(WORKSPACE_MEMBER_ID);
+    expect(createData).not.toHaveProperty('partnerId');
+  });
+});

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.test.ts
@@ -74,6 +74,7 @@ describe('saveMyPartnerContent', () => {
       ok: true,
       caseStudies: [{ id: 'content-1', name: 'Atlas rollout', status: 'WIP' }],
     });
+    expect(mutationMock).toHaveBeenCalledTimes(1);
     expect(mutationMock).toHaveBeenCalledWith({
       createPartnerContent: {
         __args: {
@@ -105,6 +106,8 @@ describe('saveMyPartnerContent', () => {
         ],
       }),
     );
+
+    expect(mutationMock).toHaveBeenCalledTimes(1);
 
     const createData =
       mutationMock.mock.calls[0][0].createPartnerContent.__args.data;

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.test.ts
@@ -70,7 +70,10 @@ describe('saveMyPartnerContent', () => {
       }),
     );
 
-    expect(result).toMatchObject({ ok: true });
+    expect(result).toMatchObject({
+      ok: true,
+      caseStudies: [{ id: 'content-1', name: 'Atlas rollout', status: 'WIP' }],
+    });
     expect(mutationMock).toHaveBeenCalledWith({
       createPartnerContent: {
         __args: {
@@ -93,9 +96,13 @@ describe('saveMyPartnerContent', () => {
   it('never reads partnerUserId from the request body', async () => {
     await saveMyPartnerContent(
       routeEvent({
-        caseStudies: [{ name: 'Atlas rollout' }],
-        partnerUserId: 'spoofed-member',
-        partnerId: 'spoofed-partner',
+        caseStudies: [
+          {
+            name: 'Atlas rollout',
+            partnerUserId: 'spoofed-member',
+            partnerId: 'spoofed-partner',
+          },
+        ],
       }),
     );
 

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.ts
@@ -75,13 +75,12 @@ export const saveMyPartnerContent = async (
     const plan = buildReconcilePlan(existingIds, parsed.data.caseStudies);
     if (!plan) return errorResponse('FORBIDDEN');
 
-    // A just-created row isn't owner-stamped by the trigger yet, so the caller's own re-read
-    // (RLS-scoped) can't see it. Return it optimistically from the input + new id.
+    // The re-read filters on partnerId, which the trigger stamps asynchronously, so a
+    // just-created row is usually still absent. Return it optimistically from input + new id.
     const createdRows: CaseStudyRow[] = [];
     for (const item of plan.toCreate) {
-      // RLS on PartnerContent is "partnerUser IS the current member" and checks the
-      // row as submitted. partnerId/contentType stay locked (trigger-stamped);
-      // partnerUser is the RLS field, so insert is allowed to write it.
+      // partnerUser is the RLS predicate field, and the server exempts predicate fields from
+      // the field lock on insert only — so this locked field is writable here and nowhere else.
       const created = await createPartnerContent(client, {
         ...buildContentCreateData(item),
         partnerUserId: resolved.workspaceMemberId,

--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/services/save-my-partner-content.service.ts
@@ -79,10 +79,13 @@ export const saveMyPartnerContent = async (
     // (RLS-scoped) can't see it. Return it optimistically from the input + new id.
     const createdRows: CaseStudyRow[] = [];
     for (const item of plan.toCreate) {
-      const created = await createPartnerContent(
-        client,
-        buildContentCreateData(item),
-      );
+      // RLS on PartnerContent is "partnerUser IS the current member" and checks the
+      // row as submitted. partnerId/contentType stay locked (trigger-stamped);
+      // partnerUser is the RLS field, so insert is allowed to write it.
+      const created = await createPartnerContent(client, {
+        ...buildContentCreateData(item),
+        partnerUserId: resolved.workspaceMemberId,
+      });
       const newId = created.createPartnerContent?.id;
       if (newId !== undefined) {
         createdRows.push({

--- a/packages/twenty-apps/internal/twenty-partners/src/roles/partner.role.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/roles/partner.role.ts
@@ -373,9 +373,11 @@ export default defineRole({
     },
     // Partner Content object — the self-service save route runs with the caller's own
     // permissions, so partners self-publish their own case studies: only status is writable
-    // (the route sets it to APPROVED/WIP; RLS scopes to their own rows). Ownership (partner,
-    // partnerUser) and contentType stay locked and are stamped server-side by the
-    // on-partner-content-created trigger, so a partner cannot repoint content to another partner.
+    // (the route sets it to APPROVED/WIP; RLS scopes to their own rows). partner and contentType
+    // stay locked and are stamped server-side by the on-partner-content-created trigger, so a
+    // partner cannot repoint content to another partner. partnerUser is listed as locked but
+    // stays writable at insert — the server exempts RLS predicate fields there
+    // (permissions.utils.ts, insert case only), which is how the save route stamps ownership.
     {
       objectUniversalIdentifier: PARTNER_CONTENT_OBJECT_UNIVERSAL_IDENTIFIER,
       fieldUniversalIdentifier: PARTNER_CONTENT_TYPE_FIELD_ID,


### PR DESCRIPTION
## Bug

A partner submitting a case study from the partner portal (POST `/save-my-partner-content`) gets the generic `{"ok":false,"reason":"Something went wrong. Please try again."}`. Reported by a partner (AtlasProds) on Aug 1.

## Root cause

The partner role's RLS predicate on `partnerContent` is `partnerUser IS the current member`, and it is checked on the row as submitted. The save route created rows without `partnerUserId` and relied on the async `on-partner-content-created` trigger to stamp ownership afterwards, so the insert was rejected under the partner's role. An API-key create of the same payload succeeds (API keys bypass RLS), which confirmed the data itself was valid.

## Fix

Stamp `partnerUserId` from the authenticated workspace member (`resolved.workspaceMemberId`) at create time in `saveMyPartnerContent`. The value comes from auth resolution, never from the request body, so a partner still cannot repoint content onto another partner. `partnerId` and `contentType` stay locked and trigger-stamped — the server exempts RLS predicate fields from the field lock on insert only, which is what makes `partnerUser` writable here and nowhere else.

## Scope — the create leg only

Review surfaced that the **delete leg of this same route still fails for a partner**, and this PR does not fix it. `partner.role.ts` sets `canSoftDeleteObjectRecords: false` on `PARTNER_CONTENT` while `deleteOne` runs as a soft delete, so a save that removes a case study throws and returns the same generic failure. The original report did not expose this because a first-ever save has no existing rows to delete.

That fix is a permission widening on a security-sensitive role manifest and needs an app republish to take effect, so it belongs in its own PR rather than folded in here. Same class of bug, also unfixed and worth the same follow-up: `saveMyPartnerLinks` and `saveMyPartnerServices` create rows without `partnerUserId`, and `configure-partner-rls.ts` puts `partnerLink` and `partnerService` under the same predicate.

## Testing

- New unit test asserts the create input carries the authenticated member's `partnerUserId`, and that a `partnerUserId`/`partnerId` supplied inside a case-study item never reaches the mutation. Both tests were confirmed to fail with the stamp reverted and pass with it.
- Package unit suite (315 tests) passes; oxlint clean; no typecheck errors attributable to this diff.
- Note: the integration suite runs under the workspace API key, which bypasses RLS, so it cannot reproduce this class of failure. End-to-end verification needs a deployed install with a partner-role user.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->