### PR TITLE
Improve record page layout editing experience

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutContent.tsx
@@ -5,7 +5,6 @@ import { useCurrentPageLayoutOrThrow } from '@/page-layout/hooks/useCurrentPageL
 import { useIsPageLayoutInEditMode } from '@/page-layout/hooks/useIsPageLayoutInEditMode';
 import { usePageLayoutTabWithVisibleWidgetsOrThrow } from '@/page-layout/hooks/usePageLayoutTabWithVisibleWidgetsOrThrow';
 import { StandaloneWidgetPlaceholder } from '@/page-layout/widgets/components/StandaloneWidgetPlaceholder';
-import { RecordPageAddWidgetSection } from '@/page-layout/widgets/components/RecordPageAddWidgetSection';
 import { styled } from '@linaria/react';
 import {
   PageLayoutTabLayoutMode,
@@ -47,15 +46,10 @@ export const PageLayoutContent = () => {
     return <PageLayoutGridLayout tabId={tabId} />;
   }
 
-  const isVerticalListInEditMode = isPageLayoutInEditMode && isRecordPageLayout;
-
   return (
     <PageLayoutVerticalList
-      isInEditMode={isVerticalListInEditMode}
+      isInEditMode={isPageLayoutInEditMode && isRecordPageLayout}
       widgets={activeTab.widgets}
-      trailingElement={
-        isVerticalListInEditMode ? <RecordPageAddWidgetSection /> : undefined
-      }
     />
   );
 };

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
@@ -40,12 +40,12 @@ import { type PageLayoutTab } from '@/page-layout/types/PageLayoutTab';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { type PageLayoutWidgetDndData } from '@/page-layout/types/PageLayoutWidgetDndData';
 import { shouldEnableTabEditingFeatures } from '@/page-layout/utils/shouldEnableTabEditingFeatures';
+import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { TabListDropdown } from '@/ui/layout/tab-list/components/TabListDropdown';
 import { TabListFromUrlOptionalEffect } from '@/ui/layout/tab-list/components/TabListFromUrlOptionalEffect';
 import { type SingleTabProps } from '@/ui/layout/tab-list/types/SingleTabProps';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { isDefined } from 'twenty-shared/utils';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import {
@@ -267,11 +267,13 @@ export const PageLayoutTabList = ({
   });
 
   const isPageLayoutInEditMode = useIsPageLayoutInEditMode();
-  const pageLayoutTabSettingsOpenTabId = useAtomComponentStateValue(
-    pageLayoutTabSettingsOpenTabIdComponentState,
-    pageLayoutId,
-  );
+  const [pageLayoutTabSettingsOpenTabId, setPageLayoutTabSettingsOpenTabId] =
+    useAtomComponentState(
+      pageLayoutTabSettingsOpenTabIdComponentState,
+      pageLayoutId,
+    );
   const { openTabSettings } = useOpenPageLayoutTabSettings(pageLayoutId);
+  const { closeSidePanelMenu } = useSidePanelMenu();
 
   const isTabSettingsOpen = isDefined(pageLayoutTabSettingsOpenTabId);
 
@@ -295,7 +297,7 @@ export const PageLayoutTabList = ({
   );
 
   const handleSelectTab = useCallback(
-    (tabId: string) => {
+    (tabId: string, select = selectTab) => {
       const shouldOpenSettings =
         isPageLayoutInEditMode &&
         shouldEnableTabEditingFeatures(pageLayoutType);
@@ -306,16 +308,23 @@ export const PageLayoutTabList = ({
       }
 
       if (shouldOpenSettings && isTabSettingsOpen) {
-        openTabSettings(tabId);
+        if (pageLayoutType === PageLayoutType.RECORD_PAGE) {
+          closeSidePanelMenu();
+          setPageLayoutTabSettingsOpenTabId(null);
+        } else {
+          openTabSettings(tabId);
+        }
       }
 
-      selectTab(tabId);
+      select(tabId);
     },
     [
       isPageLayoutInEditMode,
       pageLayoutType,
       activeTabId,
       isTabSettingsOpen,
+      closeSidePanelMenu,
+      setPageLayoutTabSettingsOpenTabId,
       openTabSettings,
       selectTab,
     ],
@@ -323,31 +332,10 @@ export const PageLayoutTabList = ({
 
   const handleSelectTabFromDropdown = useCallback(
     (tabId: string) => {
-      const shouldOpenSettings =
-        isPageLayoutInEditMode &&
-        shouldEnableTabEditingFeatures(pageLayoutType);
-
-      if (shouldOpenSettings && activeTabId === tabId) {
-        openTabSettings(tabId);
-        closeOverflowDropdown();
-        return;
-      }
-
-      if (shouldOpenSettings && isTabSettingsOpen) {
-        openTabSettings(tabId);
-      }
-
-      selectTabFromDropdown(tabId);
+      handleSelectTab(tabId, selectTabFromDropdown);
+      closeOverflowDropdown();
     },
-    [
-      isPageLayoutInEditMode,
-      pageLayoutType,
-      activeTabId,
-      isTabSettingsOpen,
-      openTabSettings,
-      closeOverflowDropdown,
-      selectTabFromDropdown,
-    ],
+    [handleSelectTab, closeOverflowDropdown, selectTabFromDropdown],
   );
 
   if (tabsWithIcons.length === 0) {

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabList.tsx
@@ -297,7 +297,13 @@ export const PageLayoutTabList = ({
   );
 
   const handleSelectTab = useCallback(
-    (tabId: string, select = selectTab) => {
+    ({
+      tabId,
+      select = selectTab,
+    }: {
+      tabId: string;
+      select?: (tabId: string) => void;
+    }) => {
       const shouldOpenSettings =
         isPageLayoutInEditMode &&
         shouldEnableTabEditingFeatures(pageLayoutType);
@@ -332,7 +338,7 @@ export const PageLayoutTabList = ({
 
   const handleSelectTabFromDropdown = useCallback(
     (tabId: string) => {
-      handleSelectTab(tabId, selectTabFromDropdown);
+      handleSelectTab({ tabId, select: selectTabFromDropdown });
       closeOverflowDropdown();
     },
     [handleSelectTab, closeOverflowDropdown, selectTabFromDropdown],
@@ -423,7 +429,7 @@ export const PageLayoutTabList = ({
             behaveAsLinks={behaveAsLinks}
             loading={loading}
             onChangeTab={onChangeTab}
-            onSelectTab={handleSelectTab}
+            onSelectTab={(tabId) => handleSelectTab({ tabId })}
             canReorder={canReorderTabs}
             widgetDropTargetWidgetsByTabId={widgetDropTargetWidgetsByTabId}
             firstHiddenTabId={

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListNewTabDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListNewTabDropdownContent.tsx
@@ -54,11 +54,11 @@ export const PageLayoutTabListNewTabDropdownContent = ({
     (tabId: string) => {
       updatePageLayoutTab(tabId, { isActive: true });
       setActiveTabId(tabId);
-      setPageLayoutTabSettingsOpenTabId(tabId);
       navigatePageLayoutSidePanel({
         sidePanelPage: SidePanelPages.PageLayoutTabSettings,
         resetNavigationStack: true,
       });
+      setPageLayoutTabSettingsOpenTabId(tabId);
       closeDropdown(dropdownId);
     },
     [

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListReorderableOverflowDropdown.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListReorderableOverflowDropdown.tsx
@@ -103,10 +103,10 @@ export const PageLayoutTabListReorderableOverflowDropdown = ({
   };
 
   const handleEditClick = (tabId: string) => {
-    setPageLayoutTabSettingsOpenTabId(tabId);
     navigatePageLayoutSidePanel({
       sidePanelPage: SidePanelPages.PageLayoutTabSettings,
     });
+    setPageLayoutTabSettingsOpenTabId(tabId);
     onClose();
   };
 

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListReorderableTab.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabListReorderableTab.tsx
@@ -3,6 +3,7 @@ import { PAGE_LAYOUT_TAB_DND_TYPE } from '@/page-layout/constants/PageLayoutTabD
 import { pageLayoutTabSettingsOpenTabIdComponentState } from '@/page-layout/states/pageLayoutTabSettingsOpenTabIdComponentState';
 import { type PageLayoutTabDragData } from '@/page-layout/types/PageLayoutTabDragData';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
+import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { type SingleTabProps } from '@/ui/layout/tab-list/types/SingleTabProps';
 import { DragDropItemSortableCell } from '@/ui/utilities/drag-and-drop/components/DragDropItemSortableCell';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
@@ -10,6 +11,7 @@ import { styled } from '@linaria/react';
 import { isDefined } from 'twenty-shared/utils';
 import { StyledTabContainer, TabContent } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { PageLayoutType } from '~/generated-metadata/graphql';
 
 type PageLayoutTabListReorderableTabProps = {
   tab: SingleTabProps;
@@ -22,10 +24,10 @@ type PageLayoutTabListReorderableTabProps = {
   onSelect: () => void;
 };
 
-const StyledTabContentWrapper = styled.div<{ isBeingEdited: boolean }>`
+const StyledTabContentWrapper = styled.div<{ isHighlighted: boolean }>`
   border-radius: ${themeCssVariables.border.radius.sm};
-  outline: ${({ isBeingEdited }) =>
-    isBeingEdited ? `1px solid ${themeCssVariables.color.blue}` : 'none'};
+  outline: ${({ isHighlighted }) =>
+    isHighlighted ? `1px solid ${themeCssVariables.color.blue}` : 'none'};
   outline-offset: -1px;
 `;
 
@@ -39,11 +41,15 @@ export const PageLayoutTabListReorderableTab = ({
   widgetDropTargetWidgets,
   onSelect,
 }: PageLayoutTabListReorderableTabProps) => {
+  const { layoutType } = useLayoutRenderingContext();
   const pageLayoutTabSettingsOpenTabId = useAtomComponentStateValue(
     pageLayoutTabSettingsOpenTabIdComponentState,
   );
 
-  const isSettingsOpenForThisTab = pageLayoutTabSettingsOpenTabId === tab.id;
+  const isHighlighted =
+    layoutType === PageLayoutType.RECORD_PAGE
+      ? isActive
+      : pageLayoutTabSettingsOpenTabId === tab.id;
 
   const tabDragData: PageLayoutTabDragData = {
     type: 'tab',
@@ -69,7 +75,7 @@ export const PageLayoutTabListReorderableTab = ({
         active={isActive}
         disabled={disabled}
       >
-        <StyledTabContentWrapper isBeingEdited={isSettingsOpenForThisTab}>
+        <StyledTabContentWrapper isHighlighted={isHighlighted}>
           <TabContent
             id={tab.id}
             active={isActive}

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabMenuItemSelectAvatar.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabMenuItemSelectAvatar.tsx
@@ -80,7 +80,10 @@ export const PageLayoutTabMenuItemSelectAvatar = ({
               Icon={IconPencil}
               size="small"
               accent="tertiary"
-              onClick={() => onEditClick?.(tab.id)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onEditClick?.(tab.id);
+              }}
             />
           </div>
         )}

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutVerticalList.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutVerticalList.tsx
@@ -5,13 +5,16 @@ import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { type PageLayoutWidgetListDropData } from '@/page-layout/types/PageLayoutWidgetListDropData';
 import { canVerticalListAcceptWidgetDrag } from '@/page-layout/utils/canVerticalListAcceptWidgetDrag';
 import { getIsSingleWidgetTab } from '@/page-layout/utils/getIsSingleWidgetTab';
+import { RecordPageAddWidgetSection } from '@/page-layout/widgets/components/RecordPageAddWidgetSection';
+import { RecordPageWidgetInsertionSeparator } from '@/page-layout/widgets/components/RecordPageWidgetInsertionSeparator';
+import { isViewportFillingWidgetType } from '@/page-layout/widgets/utils/isViewportFillingWidgetType';
 import { DragDropItemDropTarget } from '@/ui/utilities/drag-and-drop/components/DragDropItemDropTarget';
 import { WorkflowDiagramAllowPageScrollContext } from '@/workflow/workflow-diagram/contexts/WorkflowDiagramAllowPageScrollContext';
 import { type Draggable } from '@dnd-kit/abstract';
 import { pointerIntersection } from '@dnd-kit/collision';
 import { useDroppable } from '@dnd-kit/react';
 import { styled } from '@linaria/react';
-import { type ReactNode, useCallback } from 'react';
+import { Fragment, useCallback } from 'react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { PageLayoutTabLayoutMode } from '~/generated-metadata/graphql';
 
@@ -41,8 +44,6 @@ const StyledVerticalListContainer = styled.div<{
   background: var(--record-card-background-color);
   display: flex;
   flex-direction: column;
-  gap: ${({ isInEditMode }) =>
-    isInEditMode ? themeCssVariables.spacing[4] : '0'};
   min-height: ${({ isInEditMode }) => (isInEditMode ? '0' : '100%')};
   // The pinned tab sits next to the main tab area, so while editing it takes
   // that area's vertical padding to line their widgets up, and keeps the
@@ -58,25 +59,31 @@ const StyledVerticalListContainer = styled.div<{
       : '0'};
 `;
 
+const StyledHeader = styled.div`
+  flex-shrink: 0;
+  margin-bottom: ${themeCssVariables.spacing[4]};
+`;
+
 const StyledDropTarget = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: ${themeCssVariables.spacing[4]};
   min-height: ${themeCssVariables.spacing[6]};
   position: relative;
+
+  &:not(:first-child) {
+    margin-top: ${themeCssVariables.spacing[4]};
+  }
 `;
 
 type PageLayoutVerticalListProps = {
   isInEditMode: boolean;
   widgets: PageLayoutWidget[];
-  trailingElement?: ReactNode;
 };
 
 export const PageLayoutVerticalList = ({
   isInEditMode,
   widgets,
-  trailingElement,
 }: PageLayoutVerticalListProps) => {
   const { layoutMode, tabId } = usePageLayoutContentContext();
 
@@ -99,6 +106,11 @@ export const PageLayoutVerticalList = ({
   // (workflow canvases) must keep it when there is no page scroll to reach.
   const hasPageScroll = isInEditMode || widgets.length > 1;
 
+  const firstViewportFillingWidgetIndex = widgets.findIndex((widget) =>
+    isViewportFillingWidgetType(widget.type),
+  );
+  const hasViewportFillingWidget = firstViewportFillingWidgetIndex !== -1;
+
   const endDropData: PageLayoutWidgetListDropData = {
     type: 'widget-list',
     tabId,
@@ -119,7 +131,7 @@ export const PageLayoutVerticalList = ({
     accept: canAcceptWidgetDrag,
     collisionDetector: pointerIntersection,
     data: endDropData,
-    disabled: !isInEditMode,
+    disabled: !isInEditMode || hasViewportFillingWidget,
   });
 
   return (
@@ -130,20 +142,37 @@ export const PageLayoutVerticalList = ({
       shouldUseWhiteBackground={!isInPinnedTab || isMobile}
     >
       <WorkflowDiagramAllowPageScrollContext.Provider value={hasPageScroll}>
+        {isInEditMode && firstViewportFillingWidgetIndex === 0 && (
+          <StyledHeader>
+            <RecordPageAddWidgetSection
+              insertionContext={{
+                targetWidgetId: widgets[0].id,
+                direction: 'above',
+              }}
+            />
+          </StyledHeader>
+        )}
         {widgets.map((widget, index) => (
-          <PageLayoutVerticalListWidgetSlot
-            canAcceptWidgetDrag={canAcceptWidgetDrag}
-            index={index}
-            isInEditMode={isInEditMode}
-            isSoloCanvasPresentation={shouldUseSoloCanvasPresentation}
-            key={widget.id}
-            layoutMode={layoutMode}
-            shouldShowDivider={isSideColumnContext}
-            tabId={tabId}
-            widget={widget}
-          />
+          <Fragment key={widget.id}>
+            {isInEditMode &&
+              index > 0 &&
+              (!hasViewportFillingWidget ||
+                index <= firstViewportFillingWidgetIndex) && (
+                <RecordPageWidgetInsertionSeparator widget={widget} />
+              )}
+            <PageLayoutVerticalListWidgetSlot
+              canAcceptWidgetDrag={canAcceptWidgetDrag}
+              index={index}
+              isInEditMode={isInEditMode}
+              isSoloCanvasPresentation={shouldUseSoloCanvasPresentation}
+              layoutMode={layoutMode}
+              shouldShowDivider={isSideColumnContext}
+              tabId={tabId}
+              widget={widget}
+            />
+          </Fragment>
         ))}
-        {isInEditMode && (
+        {isInEditMode && !hasViewportFillingWidget && (
           <StyledDropTarget ref={endDropZoneRef}>
             <DragDropItemDropTarget
               index={widgets.length}
@@ -151,7 +180,7 @@ export const PageLayoutVerticalList = ({
               orientation="horizontal"
               compact
             />
-            {trailingElement}
+            <RecordPageAddWidgetSection />
           </StyledDropTarget>
         )}
       </WorkflowDiagramAllowPageScrollContext.Provider>

--- a/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutContent.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutContent.test.tsx
@@ -1,7 +1,9 @@
 import { PageLayoutContent } from '@/page-layout/components/PageLayoutContent';
+import { type WidgetInsertionContext } from '@/page-layout/states/widgetInsertionContextComponentState';
 import { makeTab } from '@/page-layout/testing/pageLayoutDraftFixtures';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type * as React from 'react';
 import {
   PageLayoutTabLayoutMode,
@@ -10,6 +12,13 @@ import {
 } from '~/generated-metadata/graphql';
 
 let mockIsInEditMode = false;
+const mockNavigateToMoreWidgets = jest.fn();
+
+jest.mock('@/page-layout/hooks/useNavigateToMoreWidgets', () => ({
+  useNavigateToMoreWidgets: () => ({
+    navigateToMoreWidgets: mockNavigateToMoreWidgets,
+  }),
+}));
 
 const mockWidget = {
   __typename: 'PageLayoutWidget',
@@ -85,13 +94,14 @@ jest.mock('@/page-layout/widgets/components/WidgetRenderer', () => {
   const { useState } = jest.requireActual('react') as typeof React;
 
   return {
-    WidgetRenderer: () => {
+    WidgetRenderer: ({ widget }: { widget: PageLayoutWidget }) => {
       const [isExpanded, setIsExpanded] = useState(false);
 
       return (
         <button
           type="button"
           aria-expanded={isExpanded}
+          aria-label={widget.title}
           onClick={() => setIsExpanded((current: boolean) => !current)}
         >
           Toggle widget expansion
@@ -104,7 +114,18 @@ jest.mock('@/page-layout/widgets/components/WidgetRenderer', () => {
 jest.mock(
   '@/page-layout/widgets/components/RecordPageAddWidgetSection',
   () => ({
-    RecordPageAddWidgetSection: () => <div>Add widget</div>,
+    RecordPageAddWidgetSection: ({
+      insertionContext = null,
+    }: {
+      insertionContext?: WidgetInsertionContext;
+    }) => (
+      <div>
+        <span>Add widget</span>
+        <button onClick={() => mockNavigateToMoreWidgets(insertionContext)}>
+          More widgets
+        </button>
+      </div>
+    ),
   }),
 );
 
@@ -133,25 +154,285 @@ jest.mock('twenty-ui/utilities', () => ({
 
 describe('PageLayoutContent', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockIsInEditMode = false;
+    mockTab.widgets = [mockWidget];
   });
 
-  it('keeps widget-local state when edit mode changes', () => {
+  it('keeps widget-local state when edit mode changes', async () => {
     const { rerender } = render(<PageLayoutContent />);
     const expansionButton = screen.getByRole('button', {
-      name: 'Toggle widget expansion',
+      name: 'Fields',
     });
 
-    fireEvent.click(expansionButton);
+    await userEvent.setup().click(expansionButton);
 
     expect(expansionButton).toHaveAttribute('aria-expanded', 'true');
 
     mockIsInEditMode = true;
     rerender(<PageLayoutContent />);
 
+    expect(screen.getByRole('button', { name: 'Fields' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getAllByText('Add widget')).toHaveLength(1);
+  });
+
+  it('shows only the bottom chooser when the tab has no full-height widget', () => {
+    mockIsInEditMode = true;
+    render(<PageLayoutContent />);
+    const bottomChooser = screen.getByText('Add widget');
+    const widget = screen.getByRole('button', { name: 'Fields' });
     expect(
-      screen.getByRole('button', { name: 'Toggle widget expansion' }),
-    ).toHaveAttribute('aria-expanded', 'true');
+      widget.compareDocumentPosition(bottomChooser) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: 'Add widget above Fields' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the bottom chooser appending widgets', async () => {
+    mockIsInEditMode = true;
+    render(<PageLayoutContent />);
+    const user = userEvent.setup();
+    const bottomPicker = screen.getByRole('button', {
+      name: 'More widgets',
+    });
+
+    await user.click(bottomPicker);
+    expect(mockNavigateToMoreWidgets).toHaveBeenLastCalledWith(null);
+  });
+
+  it.each([
+    WidgetType.TASKS,
+    WidgetType.TIMELINE,
+    WidgetType.FILES,
+    WidgetType.EMAILS,
+    WidgetType.NOTES,
+    WidgetType.CALENDAR,
+    WidgetType.WORKFLOW,
+    WidgetType.CALL_RECORDING_SUMMARY,
+  ])(
+    'keeps only the between-widget plus when a field precedes a full-height %s widget',
+    (type) => {
+      mockIsInEditMode = true;
+      mockTab.widgets.push({
+        ...mockWidget,
+        id: 'full-height',
+        title: 'Full-height widget',
+        type,
+      });
+
+      render(<PageLayoutContent />);
+
+      expect(screen.queryByText('Add widget')).not.toBeInTheDocument();
+      expect(screen.queryByText('More widgets')).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {
+          name: 'Add widget above Full-height widget',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getAllByRole('button', { name: /^Add widget above / }),
+      ).toHaveLength(1);
+    },
+  );
+
+  it('opens the picker at the gap before a full-height widget', async () => {
+    mockIsInEditMode = true;
+    mockTab.widgets.push({
+      ...mockWidget,
+      id: 'tasks',
+      title: 'Tasks',
+      type: WidgetType.TASKS,
+    });
+    render(<PageLayoutContent />);
+
+    const insertionButton = screen.getByRole('button', {
+      name: 'Add widget above Tasks',
+    });
+    expect(
+      screen
+        .getByRole('button', { name: 'Fields' })
+        .compareDocumentPosition(insertionButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      insertionButton.compareDocumentPosition(
+        screen.getByRole('button', { name: 'Tasks' }),
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    await userEvent.setup().click(insertionButton);
+    expect(mockNavigateToMoreWidgets).toHaveBeenCalledWith({
+      targetWidgetId: 'tasks',
+      direction: 'above',
+    });
+  });
+
+  it.each([
+    WidgetType.TASKS,
+    WidgetType.TIMELINE,
+    WidgetType.FILES,
+    WidgetType.EMAILS,
+    WidgetType.EMAIL_THREAD,
+    WidgetType.NOTES,
+    WidgetType.CALENDAR,
+    WidgetType.WORKFLOW,
+    WidgetType.WORKFLOW_RUN,
+    WidgetType.WORKFLOW_VERSION,
+    WidgetType.CALL_RECORDING_SUMMARY,
+    WidgetType.CALL_RECORDING_TRANSCRIPT,
+  ])(
+    'shows the expanded chooser above a lone full-height %s widget',
+    (type) => {
+      mockIsInEditMode = true;
+      mockTab.widgets = [
+        { ...mockWidget, id: 'full-height', title: 'Full-height widget', type },
+      ];
+
+      render(<PageLayoutContent />);
+
+      expect(
+        screen
+          .getByText('Add widget')
+          .compareDocumentPosition(
+            screen.getByRole('button', { name: 'Full-height widget' }),
+          ) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(screen.getByText('More widgets')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /^Add widget above / }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it('opens the expanded chooser above a lone full-height widget with the keyboard', async () => {
+    mockIsInEditMode = true;
+    mockTab.widgets = [
+      { ...mockWidget, id: 'tasks', title: 'Tasks', type: WidgetType.TASKS },
+    ];
+
+    render(<PageLayoutContent />);
+    expect(
+      screen
+        .getByText('Add widget')
+        .compareDocumentPosition(
+          screen.getByRole('button', { name: 'Tasks' }),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: /^Add widget above / }),
+    ).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'More widgets' })).toHaveFocus();
+    await user.keyboard('{Enter}');
+    expect(mockNavigateToMoreWidgets).toHaveBeenCalledWith({
+      targetWidgetId: 'tasks',
+      direction: 'above',
+    });
+  });
+
+  it('replaces the top chooser with a between-widget plus after inserting a widget', () => {
+    mockIsInEditMode = true;
+    const fullHeightWidget = {
+      ...mockWidget,
+      id: 'tasks',
+      title: 'Tasks',
+      type: WidgetType.TASKS,
+    };
+    mockTab.widgets = [fullHeightWidget];
+
+    const { rerender } = render(<PageLayoutContent />);
     expect(screen.getByText('Add widget')).toBeInTheDocument();
+
+    mockTab.widgets = [mockWidget, fullHeightWidget];
+    rerender(<PageLayoutContent />);
+
+    expect(screen.queryByText('Add widget')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Add widget above Tasks' }),
+    ).toBeInTheDocument();
+
+    mockTab.widgets = [fullHeightWidget];
+    rerender(<PageLayoutContent />);
+
+    expect(screen.getByText('Add widget')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Add widget above Tasks' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the between-widget insertion point keyboard accessible', async () => {
+    mockIsInEditMode = true;
+    mockTab.widgets.push({
+      ...mockWidget,
+      id: 'tasks',
+      title: 'Tasks',
+      type: WidgetType.TASKS,
+    });
+    render(<PageLayoutContent />);
+    const user = userEvent.setup();
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Fields' })).toHaveFocus();
+    await user.tab();
+    expect(
+      screen.getByRole('button', { name: 'Add widget above Tasks' }),
+    ).toHaveFocus();
+    await user.keyboard('{Enter}');
+    expect(mockNavigateToMoreWidgets).toHaveBeenCalledWith({
+      targetWidgetId: 'tasks',
+      direction: 'above',
+    });
+  });
+
+  it('removes insertion controls when leaving edit mode', () => {
+    mockIsInEditMode = true;
+    mockTab.widgets.push({
+      ...mockWidget,
+      id: 'tasks',
+      title: 'Tasks',
+      type: WidgetType.TASKS,
+    });
+    const { rerender } = render(<PageLayoutContent />);
+    expect(
+      screen.getByRole('button', { name: 'Add widget above Tasks' }),
+    ).toBeInTheDocument();
+    mockIsInEditMode = false;
+    rerender(<PageLayoutContent />);
+    expect(
+      screen.queryByRole('button', { name: /^Add widget above / }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Add widget')).not.toBeInTheDocument();
+  });
+
+  it('keeps the expanded chooser on empty tabs', () => {
+    mockIsInEditMode = true;
+    mockTab.widgets = [];
+    render(<PageLayoutContent />);
+    expect(screen.getByText('Add widget')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^Add widget above / }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the top chooser outside edit mode for a lone full-height widget', () => {
+    mockTab.widgets = [
+      { ...mockWidget, id: 'tasks', title: 'Tasks', type: WidgetType.TASKS },
+    ];
+
+    render(<PageLayoutContent />);
+
+    expect(screen.queryByText('Add widget')).not.toBeInTheDocument();
+    expect(screen.queryByText('More widgets')).not.toBeInTheDocument();
+  });
+
+  it('hides the insertion row outside edit mode', () => {
+    render(<PageLayoutContent />);
+    expect(screen.queryByText('Add widget')).not.toBeInTheDocument();
   });
 });

--- a/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabList.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabList.test.tsx
@@ -1,0 +1,355 @@
+import { PageLayoutTabList } from '@/page-layout/components/PageLayoutTabList';
+import { PageLayoutComponentInstanceContext } from '@/page-layout/states/contexts/PageLayoutComponentInstanceContext';
+import { pageLayoutTabSettingsOpenTabIdComponentState } from '@/page-layout/states/pageLayoutTabSettingsOpenTabIdComponentState';
+import { makeTab } from '@/page-layout/testing/pageLayoutDraftFixtures';
+import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
+import { type SingleTabProps } from '@/ui/layout/tab-list/types/SingleTabProps';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createStore, Provider } from 'jotai';
+import { type ReactNode } from 'react';
+import { PageLayoutType } from '~/generated-metadata/graphql';
+
+const PAGE_LAYOUT_ID = 'page-layout';
+const TAB_LIST_ID = 'tab-list';
+const TABS = ['Tasks', 'Notes', 'Files'].map((title, index) =>
+  makeTab(title, [], index),
+);
+const mockNavigate = jest.fn();
+const mockOpenTabSettings = jest.fn();
+const mockCloseSidePanelMenu = jest.fn();
+const mockCloseDropdown = jest.fn();
+let mockIsInEditMode = true;
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@dnd-kit/react', () => ({ useDragDropMonitor: jest.fn() }));
+
+jest.mock('@/page-layout/hooks/useIsPageLayoutInEditMode', () => ({
+  useIsPageLayoutInEditMode: () => mockIsInEditMode,
+}));
+
+jest.mock('@/page-layout/hooks/useOpenPageLayoutTabSettings', () => ({
+  useOpenPageLayoutTabSettings: () => ({
+    openTabSettings: mockOpenTabSettings,
+  }),
+}));
+
+jest.mock('@/side-panel/hooks/useSidePanelMenu', () => ({
+  useSidePanelMenu: () => ({ closeSidePanelMenu: mockCloseSidePanelMenu }),
+}));
+
+jest.mock('@/ui/layout/dropdown/hooks/useCloseDropdown', () => ({
+  useCloseDropdown: () => ({ closeDropdown: mockCloseDropdown }),
+}));
+
+jest.mock('@/ui/layout/dropdown/hooks/useOpenDropdown', () => ({
+  useOpenDropdown: () => ({ openDropdown: jest.fn() }),
+}));
+
+jest.mock('@/ui/utilities/pointer-event/hooks/useClickOutsideListener', () => ({
+  useClickOutsideListener: () => ({ toggleClickOutside: jest.fn() }),
+}));
+
+jest.mock('@/ui/utilities/responsive/hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}));
+
+jest.mock('@/ui/layout/tab-list/hooks/useTabListMeasurements', () => ({
+  useTabListMeasurements: ({
+    visibleTabs,
+  }: {
+    visibleTabs: SingleTabProps[];
+  }) => ({
+    visibleTabCount: 2,
+    hiddenTabs: visibleTabs.slice(2),
+    hiddenTabsCount: 1,
+    hasHiddenTabs: true,
+    onTabWidthChange: jest.fn(),
+    onContainerWidthChange: jest.fn(),
+    onMoreButtonWidthChange: jest.fn(),
+    onAddButtonWidthChange: jest.fn(),
+  }),
+}));
+
+jest.mock('@/ui/utilities/dimensions/components/NodeDimension', () => ({
+  NodeDimension: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/ui/layout/tab-list/components/TabListHiddenMeasurements', () => ({
+  TabListHiddenMeasurements: () => null,
+}));
+
+jest.mock(
+  '@/ui/layout/tab-list/components/TabListFromUrlOptionalEffect',
+  () => ({
+    TabListFromUrlOptionalEffect: () => null,
+  }),
+);
+
+jest.mock('@/page-layout/components/PageLayoutTabListVisibleTabs', () => ({
+  PageLayoutTabListVisibleTabs: ({
+    visibleTabs,
+    visibleTabCount,
+    activeTabId,
+    onSelectTab,
+  }: {
+    visibleTabs: SingleTabProps[];
+    visibleTabCount: number;
+    activeTabId: string | null;
+    onSelectTab: (tabId: string) => void;
+  }) => (
+    <>
+      {visibleTabs.slice(0, visibleTabCount).map((tab) => (
+        <button
+          key={tab.id}
+          aria-pressed={activeTabId === tab.id}
+          onClick={() => onSelectTab(tab.id)}
+        >
+          {tab.title}
+        </button>
+      ))}
+    </>
+  ),
+}));
+
+jest.mock(
+  '@/page-layout/components/PageLayoutTabListReorderableOverflowDropdown',
+  () => ({
+    PageLayoutTabListReorderableOverflowDropdown: ({
+      hiddenTabs,
+      activeTabId,
+      onSelect,
+    }: {
+      hiddenTabs: SingleTabProps[];
+      activeTabId: string | null;
+      onSelect: (tabId: string) => void;
+    }) => (
+      <div aria-label="More tabs">
+        {hiddenTabs.map((tab) => (
+          <button
+            key={tab.id}
+            aria-pressed={activeTabId === tab.id}
+            onClick={() => onSelect(tab.id)}
+          >
+            {tab.title}
+          </button>
+        ))}
+      </div>
+    ),
+  }),
+);
+
+const renderTabList = ({
+  pageLayoutType = PageLayoutType.RECORD_PAGE,
+  settingsTabId = null,
+  isInSidePanel = false,
+  behaveAsLinks = false,
+}: {
+  pageLayoutType?: PageLayoutType;
+  settingsTabId?: string | null;
+  isInSidePanel?: boolean;
+  behaveAsLinks?: boolean;
+} = {}) => {
+  const store = createStore();
+  const settingsTabAtom =
+    pageLayoutTabSettingsOpenTabIdComponentState.atomFamily({
+      instanceId: PAGE_LAYOUT_ID,
+    });
+  store.set(
+    activeTabIdComponentState.atomFamily({ instanceId: TAB_LIST_ID }),
+    'Tasks',
+  );
+  store.set(settingsTabAtom, settingsTabId);
+  mockOpenTabSettings.mockImplementation((tabId: string) => {
+    store.set(settingsTabAtom, tabId);
+  });
+
+  render(
+    <Provider store={store}>
+      <I18nProvider i18n={i18n}>
+        <PageLayoutComponentInstanceContext.Provider
+          value={{ instanceId: PAGE_LAYOUT_ID }}
+        >
+          <PageLayoutTabList
+            tabs={TABS}
+            componentInstanceId={TAB_LIST_ID}
+            pageLayoutType={pageLayoutType}
+            behaveAsLinks={behaveAsLinks}
+            isReorderEnabled
+            isInSidePanel={isInSidePanel}
+          />
+        </PageLayoutComponentInstanceContext.Provider>
+      </I18nProvider>
+    </Provider>,
+  );
+
+  return { store, settingsTabAtom };
+};
+
+describe('PageLayoutTabList selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsInEditMode = true;
+  });
+
+  it.each(['Notes', 'Files'])(
+    'navigates to %s first and opens settings on a second click',
+    async (title) => {
+      renderTabList();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole('button', { name: title }));
+
+      expect(screen.getByRole('button', { name: title })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(`#${title}`);
+      expect(mockOpenTabSettings).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: title }));
+
+      expect(mockOpenTabSettings).toHaveBeenCalledTimes(1);
+      expect(mockOpenTabSettings).toHaveBeenCalledWith(title);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(['Notes', 'Files'])(
+    'closes previous tab settings when navigating to %s',
+    async (title) => {
+      const { store, settingsTabAtom } = renderTabList({
+        settingsTabId: 'Tasks',
+      });
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole('button', { name: title }));
+
+      expect(screen.getByRole('button', { name: title })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      expect(mockOpenTabSettings).not.toHaveBeenCalled();
+      expect(mockCloseSidePanelMenu).toHaveBeenCalledTimes(1);
+      expect(store.get(settingsTabAtom)).toBeNull();
+
+      await user.click(screen.getByRole('button', { name: title }));
+
+      expect(mockOpenTabSettings).toHaveBeenCalledWith(title);
+      expect(store.get(settingsTabAtom)).toBe(title);
+    },
+  );
+
+  it('opens settings immediately when clicking the current tab', async () => {
+    renderTabList();
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'Tasks' }));
+
+    expect(mockOpenTabSettings).toHaveBeenCalledWith('Tasks');
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockCloseSidePanelMenu).not.toHaveBeenCalled();
+  });
+
+  it('opens settings once when double-clicking another tab', async () => {
+    const { store, settingsTabAtom } = renderTabList();
+
+    await userEvent
+      .setup()
+      .dblClick(screen.getByRole('button', { name: 'Notes' }));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('#Notes');
+    expect(mockOpenTabSettings).toHaveBeenCalledTimes(1);
+    expect(store.get(settingsTabAtom)).toBe('Notes');
+  });
+
+  it('clears the previous settings selection without waiting for the panel to close', async () => {
+    const { store, settingsTabAtom } = renderTabList({
+      settingsTabId: 'Tasks',
+    });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Notes' }));
+    await user.click(screen.getByRole('button', { name: 'Files' }));
+
+    expect(mockCloseSidePanelMenu).toHaveBeenCalledTimes(1);
+    expect(mockOpenTabSettings).not.toHaveBeenCalled();
+    expect(store.get(settingsTabAtom)).toBeNull();
+    expect(screen.getByRole('button', { name: 'Files' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it.each([PageLayoutType.DASHBOARD, PageLayoutType.STANDALONE_PAGE])(
+    'preserves settings-follow-selection behavior for %s layouts',
+    async (pageLayoutType) => {
+      renderTabList({ pageLayoutType, settingsTabId: 'Tasks' });
+
+      await userEvent
+        .setup()
+        .click(screen.getByRole('button', { name: 'Notes' }));
+
+      expect(mockOpenTabSettings).toHaveBeenCalledWith('Notes');
+      expect(mockCloseSidePanelMenu).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['Notes', 'Files'])(
+    'does not open or close settings for %s outside edit mode',
+    async (title) => {
+      mockIsInEditMode = false;
+      renderTabList({ settingsTabId: 'Tasks' });
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole('button', { name: title }));
+      await user.click(screen.getByRole('button', { name: title }));
+
+      expect(mockOpenTabSettings).not.toHaveBeenCalled();
+      expect(mockCloseSidePanelMenu).not.toHaveBeenCalled();
+    },
+  );
+
+  it('switches an embedded record tab without changing the page URL', async () => {
+    renderTabList({ isInSidePanel: true });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Notes' }));
+    expect(screen.getByRole('button', { name: 'Notes' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockOpenTabSettings).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Notes' }));
+    expect(mockOpenTabSettings).toHaveBeenCalledWith('Notes');
+  });
+
+  it('preserves URL-driven navigation for overflow tabs in read mode', async () => {
+    mockIsInEditMode = false;
+    renderTabList({ behaveAsLinks: true });
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'Files' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('#Files');
+    expect(screen.getByRole('button', { name: 'Tasks' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(mockOpenTabSettings).not.toHaveBeenCalled();
+    expect(mockCloseDropdown).toHaveBeenCalledWith(
+      `tab-overflow-${TAB_LIST_ID}`,
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabSettingsNavigation.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabSettingsNavigation.test.tsx
@@ -1,0 +1,188 @@
+import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
+import { PageLayoutTabListNewTabDropdownContent } from '@/page-layout/components/PageLayoutTabListNewTabDropdownContent';
+import { PageLayoutTabListReorderableOverflowDropdown } from '@/page-layout/components/PageLayoutTabListReorderableOverflowDropdown';
+import {
+  PAGE_LAYOUT_TEST_INSTANCE_ID,
+  PageLayoutTestWrapper,
+} from '@/page-layout/hooks/__tests__/PageLayoutTestWrapper';
+import { usePageLayoutAddTabStrategy } from '@/page-layout/hooks/usePageLayoutAddTabStrategy';
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
+import { pageLayoutTabSettingsOpenTabIdComponentState } from '@/page-layout/states/pageLayoutTabSettingsOpenTabIdComponentState';
+import {
+  makeDraft,
+  makeTab,
+} from '@/page-layout/testing/pageLayoutDraftFixtures';
+import { getTabListInstanceIdFromPageLayoutId } from '@/page-layout/utils/getTabListInstanceIdFromPageLayoutId';
+import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createStore } from 'jotai';
+import { type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { SidePanelPages } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { PageLayoutType } from '~/generated-metadata/graphql';
+
+const TAB_LIST_ID = getTabListInstanceIdFromPageLayoutId(
+  PAGE_LAYOUT_TEST_INSTANCE_ID,
+);
+const mockNavigatePageLayoutSidePanel = jest.fn();
+const mockCloseDropdown = jest.fn();
+const mockSelectTab = jest.fn();
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/useNavigatePageLayoutSidePanel',
+  () => ({
+    useNavigatePageLayoutSidePanel: () => ({
+      navigatePageLayoutSidePanel: mockNavigatePageLayoutSidePanel,
+    }),
+  }),
+);
+
+jest.mock('@/ui/layout/dropdown/hooks/useCloseDropdown', () => ({
+  useCloseDropdown: () => ({ closeDropdown: mockCloseDropdown }),
+}));
+
+jest.mock('@/ui/layout/dropdown/components/Dropdown', () => ({
+  Dropdown: ({ dropdownComponents }: { dropdownComponents: ReactNode }) => (
+    <>{dropdownComponents}</>
+  ),
+}));
+
+jest.mock(
+  '@/ui/utilities/drag-and-drop/components/DragDropItemSortableCell',
+  () => ({
+    DragDropItemSortableCell: ({ children }: { children: ReactNode }) => (
+      <>{children}</>
+    ),
+  }),
+);
+
+jest.mock(
+  '@/ui/utilities/drag-and-drop/components/DragDropItemDropTarget',
+  () => ({
+    DragDropItemDropTarget: () => null,
+  }),
+);
+
+const TabSettingsControls = () => {
+  const addTabStrategy = usePageLayoutAddTabStrategy({
+    pageLayoutId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+    tabListInstanceId: TAB_LIST_ID,
+  });
+
+  if (!isDefined(addTabStrategy)) {
+    return null;
+  }
+
+  return (
+    <>
+      <PageLayoutTabListNewTabDropdownContent
+        onCreate={addTabStrategy.onCreate}
+        dropdownId="new-tab"
+      />
+      <PageLayoutTabListReorderableOverflowDropdown
+        dropdownId="more-tabs"
+        hiddenTabs={[{ id: 'hidden-tab', title: 'Hidden tab' }]}
+        hiddenTabsCount={1}
+        isActiveTabHidden={false}
+        activeTabId="active-tab"
+        onSelect={mockSelectTab}
+        visibleTabCount={1}
+        onClose={mockCloseDropdown}
+        pageLayoutType={PageLayoutType.RECORD_PAGE}
+      />
+    </>
+  );
+};
+
+describe('tab settings navigation during a closing panel', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it.each(['create', 'reactivate', 'overflow'])(
+    'keeps the selected tab when opening settings through %s',
+    async (action) => {
+      const store = createStore();
+      const draftAtom = pageLayoutDraftComponentState.atomFamily({
+        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+      });
+      const settingsTabAtom =
+        pageLayoutTabSettingsOpenTabIdComponentState.atomFamily({
+          instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+        });
+      const activeTabAtom = activeTabIdComponentState.atomFamily({
+        instanceId: TAB_LIST_ID,
+      });
+      store.set(isLayoutCustomizationModeEnabledState.atom, true);
+      store.set(activeTabAtom, 'active-tab');
+      store.set(settingsTabAtom, 'active-tab');
+      store.set(
+        draftAtom,
+        makeDraft([
+          makeTab('active-tab', []),
+          makeTab('disabled-tab', [], 1, undefined, {
+            title: 'Disabled tab',
+            isActive: false,
+          }),
+          makeTab('hidden-tab', [], 2),
+        ]),
+      );
+      mockNavigatePageLayoutSidePanel.mockImplementationOnce(() => {
+        store.set(settingsTabAtom, null);
+      });
+
+      render(
+        <PageLayoutTestWrapper
+          store={store}
+          layoutType={PageLayoutType.RECORD_PAGE}
+        >
+          <I18nProvider i18n={i18n}>
+            <MemoryRouter>
+              <TabSettingsControls />
+            </MemoryRouter>
+          </I18nProvider>
+        </PageLayoutTestWrapper>,
+      );
+
+      const user = userEvent.setup({ skipHover: true });
+
+      if (action === 'overflow') {
+        const tab = screen.getByRole('option', { name: 'Hidden tab' });
+        await user.hover(tab);
+        await user.click(within(tab).getByRole('button'));
+      } else {
+        await user.click(
+          screen.getByText(action === 'create' ? 'Empty tab' : 'Disabled tab'),
+        );
+      }
+
+      const tabs = store.get(draftAtom).tabs;
+      const expectedTabId =
+        action === 'create'
+          ? tabs.find((tab) => tab.title === 'Untitled')?.id
+          : action === 'reactivate'
+            ? 'disabled-tab'
+            : 'hidden-tab';
+      expect(expectedTabId).toEqual(expect.any(String));
+      expect(store.get(settingsTabAtom)).toBe(expectedTabId);
+      expect(tabs.find((tab) => tab.id === expectedTabId)?.isActive).toBe(true);
+      expect(store.get(activeTabAtom)).toBe(
+        action === 'overflow' ? 'active-tab' : expectedTabId,
+      );
+      expect(mockNavigatePageLayoutSidePanel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sidePanelPage: SidePanelPages.PageLayoutTabSettings,
+        }),
+      );
+      expect(mockCloseDropdown).toHaveBeenCalledTimes(1);
+      expect(mockSelectTab).not.toHaveBeenCalled();
+      if (action === 'create') {
+        expect(mockNavigatePageLayoutSidePanel).toHaveBeenCalledWith(
+          expect.objectContaining({ focusTitleInput: true }),
+        );
+      }
+    },
+  );
+});

--- a/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutVerticalList.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutVerticalList.test.tsx
@@ -13,6 +13,17 @@ let mockLayoutMode = PageLayoutTabLayoutMode.VERTICAL_LIST;
 let mockIsSideColumnContext = false;
 let mockIsInPinnedTab = false;
 
+jest.mock('@/page-layout/hooks/useNavigateToMoreWidgets', () => ({
+  useNavigateToMoreWidgets: () => ({ navigateToMoreWidgets: jest.fn() }),
+}));
+
+jest.mock(
+  '@/page-layout/widgets/components/RecordPageAddWidgetSection',
+  () => ({
+    RecordPageAddWidgetSection: () => <div>Add widget</div>,
+  }),
+);
+
 jest.mock('@/page-layout/contexts/PageLayoutContentContext', () => ({
   usePageLayoutContentContext: () => ({
     layoutMode: mockLayoutMode,

--- a/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useCreateRecordPageFieldWidgets.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useCreateRecordPageFieldWidgets.test.tsx
@@ -1,0 +1,126 @@
+import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
+import { PageLayoutContentProvider } from '@/page-layout/contexts/PageLayoutContentContext';
+import {
+  PAGE_LAYOUT_TEST_INSTANCE_ID,
+  PageLayoutTestWrapper,
+} from '@/page-layout/hooks/__tests__/PageLayoutTestWrapper';
+import { useCreateRecordPageFieldWidget } from '@/page-layout/hooks/useCreateRecordPageFieldWidget';
+import { useCreateRecordPageFieldsWidget } from '@/page-layout/hooks/useCreateRecordPageFieldsWidget';
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
+import { pageLayoutEditingWidgetIdComponentState } from '@/page-layout/states/pageLayoutEditingWidgetIdComponentState';
+import {
+  makeDraft,
+  makeTab,
+} from '@/page-layout/testing/pageLayoutDraftFixtures';
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'jotai';
+import { type ReactNode } from 'react';
+import { SidePanelPages } from 'twenty-shared/types';
+import {
+  PageLayoutTabLayoutMode,
+  PageLayoutType,
+  WidgetType,
+} from '~/generated-metadata/graphql';
+
+const mockNavigatePageLayoutSidePanel = jest.fn();
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/useNavigatePageLayoutSidePanel',
+  () => ({
+    useNavigatePageLayoutSidePanel: () => ({
+      navigatePageLayoutSidePanel: mockNavigatePageLayoutSidePanel,
+    }),
+  }),
+);
+
+jest.mock('@/ui/layout/contexts/useTargetRecord', () => ({
+  useTargetRecord: () => ({ targetObjectNameSingular: 'company' }),
+}));
+
+jest.mock('@/object-metadata/hooks/useObjectMetadataItem', () => ({
+  useObjectMetadataItem: () => ({
+    objectMetadataItem: { id: 'company-metadata' },
+  }),
+}));
+
+jest.mock(
+  '@/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields',
+  () => ({
+    useFieldWidgetEligibleFields: () => [],
+  }),
+);
+
+describe('record-page field widget creation', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it.each([
+    {
+      widgetType: WidgetType.FIELD,
+      sidePanelPage: SidePanelPages.RecordPageFieldSettings,
+    },
+    {
+      widgetType: WidgetType.FIELDS,
+      sidePanelPage: SidePanelPages.RecordPageFieldsSettings,
+    },
+  ])(
+    'keeps $widgetType selected when creation reopens a closing panel',
+    ({ widgetType, sidePanelPage }) => {
+      const store = createStore();
+      const draftAtom = pageLayoutDraftComponentState.atomFamily({
+        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+      });
+      const editingWidgetAtom =
+        pageLayoutEditingWidgetIdComponentState.atomFamily({
+          instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+        });
+      store.set(isLayoutCustomizationModeEnabledState.atom, true);
+      store.set(draftAtom, makeDraft([makeTab('tab-1', [])]));
+      mockNavigatePageLayoutSidePanel.mockImplementationOnce(() => {
+        store.set(editingWidgetAtom, null);
+      });
+
+      const { result } = renderHook(
+        () => {
+          const { createRecordPageFieldWidget } =
+            useCreateRecordPageFieldWidget();
+          const { createRecordPageFieldsWidget } =
+            useCreateRecordPageFieldsWidget();
+          return widgetType === WidgetType.FIELD
+            ? createRecordPageFieldWidget
+            : createRecordPageFieldsWidget;
+        },
+        {
+          wrapper: ({ children }: { children: ReactNode }) => (
+            <PageLayoutTestWrapper
+              store={store}
+              layoutType={PageLayoutType.RECORD_PAGE}
+            >
+              <PageLayoutContentProvider
+                value={{
+                  tabId: 'tab-1',
+                  layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+                  presentation: 'stack',
+                }}
+              >
+                {children}
+              </PageLayoutContentProvider>
+            </PageLayoutTestWrapper>
+          ),
+        },
+      );
+
+      act(() => {
+        result.current();
+      });
+
+      const widget = store.get(draftAtom).tabs[0].widgets[0];
+      expect(widget.type).toBe(widgetType);
+      expect(store.get(editingWidgetAtom)).toBe(widget.id);
+      expect(mockNavigatePageLayoutSidePanel).toHaveBeenCalledWith({
+        sidePanelPage,
+        focusTitleInput: true,
+        resetNavigationStack: true,
+      });
+    },
+  );
+});

--- a/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useInsertCreatedWidgetAtContext.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useInsertCreatedWidgetAtContext.test.tsx
@@ -63,7 +63,7 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('widget-c');
+      result.current.insertCreatedWidgetAtContext({ newWidgetId: 'widget-c' });
     });
 
     const draft = store.get(getDraftAtom());
@@ -95,7 +95,7 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('widget-c');
+      result.current.insertCreatedWidgetAtContext({ newWidgetId: 'widget-c' });
     });
 
     const draft = store.get(getDraftAtom());
@@ -130,7 +130,9 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('new-widget');
+      result.current.insertCreatedWidgetAtContext({
+        newWidgetId: 'new-widget',
+      });
     });
 
     const draft = store.get(getDraftAtom());
@@ -165,7 +167,7 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('widget-c');
+      result.current.insertCreatedWidgetAtContext({ newWidgetId: 'widget-c' });
     });
 
     const draft = store.get(getDraftAtom());
@@ -196,7 +198,7 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('widget-b');
+      result.current.insertCreatedWidgetAtContext({ newWidgetId: 'widget-b' });
     });
 
     const draft = store.get(getDraftAtom());
@@ -226,9 +228,12 @@ describe('useInsertCreatedWidgetAtContext', () => {
     });
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('new-widget', {
-        targetWidgetId: 'first',
-        direction: 'above',
+      result.current.insertCreatedWidgetAtContext({
+        newWidgetId: 'new-widget',
+        insertionContext: {
+          targetWidgetId: 'first',
+          direction: 'above',
+        },
       });
     });
 
@@ -254,7 +259,10 @@ describe('useInsertCreatedWidgetAtContext', () => {
     });
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('new-widget', null);
+      result.current.insertCreatedWidgetAtContext({
+        newWidgetId: 'new-widget',
+        insertionContext: null,
+      });
     });
 
     expect(store.get(getDraftAtom())).toBe(initialDraft);
@@ -281,7 +289,7 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('widget-b');
+      result.current.insertCreatedWidgetAtContext({ newWidgetId: 'widget-b' });
     });
 
     const draft = store.get(getDraftAtom());
@@ -309,7 +317,9 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('non-existent-widget');
+      result.current.insertCreatedWidgetAtContext({
+        newWidgetId: 'non-existent-widget',
+      });
     });
 
     const draft = store.get(getDraftAtom());
@@ -340,7 +350,7 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('widget-b');
+      result.current.insertCreatedWidgetAtContext({ newWidgetId: 'widget-b' });
     });
 
     const insertionContext = store.get(getInsertionContextAtom());
@@ -377,7 +387,7 @@ describe('useInsertCreatedWidgetAtContext', () => {
     );
 
     act(() => {
-      result.current.insertCreatedWidgetAtContext('widget-c');
+      result.current.insertCreatedWidgetAtContext({ newWidgetId: 'widget-c' });
     });
 
     const draft = store.get(getDraftAtom());

--- a/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useInsertCreatedWidgetAtContext.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useInsertCreatedWidgetAtContext.test.tsx
@@ -204,6 +204,63 @@ describe('useInsertCreatedWidgetAtContext', () => {
     expect(draft).toBe(initialDraft);
   });
 
+  it('uses an explicit top insertion point instead of a stale picker context', () => {
+    const store = createStore();
+    store.set(
+      getDraftAtom(),
+      makeDraft([
+        makeTab('tab-1', [
+          makeWidget('first', 0),
+          makeWidget('second', 1),
+          makeWidget('new-widget', 2),
+        ]),
+      ]),
+    );
+    store.set(getInsertionContextAtom(), {
+      targetWidgetId: 'second',
+      direction: 'below',
+    });
+
+    const { result } = renderHook(() => useInsertCreatedWidgetAtContext(), {
+      wrapper: getWrapper(store),
+    });
+
+    act(() => {
+      result.current.insertCreatedWidgetAtContext('new-widget', {
+        targetWidgetId: 'first',
+        direction: 'above',
+      });
+    });
+
+    expect(
+      store.get(getDraftAtom()).tabs[0].widgets.map(({ id }) => id),
+    ).toEqual(['new-widget', 'first', 'second']);
+    expect(store.get(getInsertionContextAtom())).toBeNull();
+  });
+
+  it('keeps a bottom insertion appended and clears a stale picker context', () => {
+    const store = createStore();
+    const initialDraft = makeDraft([
+      makeTab('tab-1', [makeWidget('first', 0), makeWidget('new-widget', 1)]),
+    ]);
+    store.set(getDraftAtom(), initialDraft);
+    store.set(getInsertionContextAtom(), {
+      targetWidgetId: 'first',
+      direction: 'above',
+    });
+
+    const { result } = renderHook(() => useInsertCreatedWidgetAtContext(), {
+      wrapper: getWrapper(store),
+    });
+
+    act(() => {
+      result.current.insertCreatedWidgetAtContext('new-widget', null);
+    });
+
+    expect(store.get(getDraftAtom())).toBe(initialDraft);
+    expect(store.get(getInsertionContextAtom())).toBeNull();
+  });
+
   it('should no-op when target widget is not found', () => {
     const store = createStore();
     const wrapper = getWrapper(store);

--- a/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useNavigateToMoreWidgets.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useNavigateToMoreWidgets.test.tsx
@@ -1,0 +1,115 @@
+import { useNavigateToMoreWidgets } from '@/page-layout/hooks/useNavigateToMoreWidgets';
+import { pageLayoutEditingWidgetIdComponentState } from '@/page-layout/states/pageLayoutEditingWidgetIdComponentState';
+import { widgetCreationTargetTabIdComponentState } from '@/page-layout/states/widgetCreationTargetTabIdComponentState';
+import { widgetInsertionContextComponentState } from '@/page-layout/states/widgetInsertionContextComponentState';
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'jotai';
+import { type ReactNode } from 'react';
+import { SidePanelPages } from 'twenty-shared/types';
+import {
+  PAGE_LAYOUT_TEST_INSTANCE_ID,
+  PageLayoutTestWrapper,
+} from './PageLayoutTestWrapper';
+
+const mockNavigatePageLayoutSidePanel = jest.fn();
+let mockTabId = 'main-tab';
+
+jest.mock('@/page-layout/contexts/PageLayoutContentContext', () => ({
+  usePageLayoutContentContext: () => ({ tabId: mockTabId }),
+}));
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/useNavigatePageLayoutSidePanel',
+  () => ({
+    useNavigatePageLayoutSidePanel: () => ({
+      navigatePageLayoutSidePanel: mockNavigatePageLayoutSidePanel,
+    }),
+  }),
+);
+
+describe('useNavigateToMoreWidgets', () => {
+  const instanceId = PAGE_LAYOUT_TEST_INSTANCE_ID;
+  const editingWidgetAtom = pageLayoutEditingWidgetIdComponentState.atomFamily({
+    instanceId,
+  });
+  const targetTabAtom = widgetCreationTargetTabIdComponentState.atomFamily({
+    instanceId,
+  });
+  const insertionContextAtom = widgetInsertionContextComponentState.atomFamily({
+    instanceId,
+  });
+
+  const setup = () => {
+    const store = createStore();
+    store.set(editingWidgetAtom, 'previous-widget');
+    store.set(targetTabAtom, 'previous-tab');
+    store.set(insertionContextAtom, {
+      targetWidgetId: 'previous-widget',
+      direction: 'below',
+    });
+
+    const { result } = renderHook(() => useNavigateToMoreWidgets(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <PageLayoutTestWrapper store={store}>{children}</PageLayoutTestWrapper>
+      ),
+    });
+    return { store, result };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTabId = 'main-tab';
+  });
+
+  it.each(['main-tab', 'pinned-tab'])(
+    'opens the picker at the requested insertion point in %s without replacing a widget',
+    (tabId) => {
+      mockTabId = tabId;
+      const { store, result } = setup();
+
+      act(() =>
+        result.current.navigateToMoreWidgets({
+          targetWidgetId: 'next-widget',
+          direction: 'above',
+        }),
+      );
+
+      expect(store.get(editingWidgetAtom)).toBeNull();
+      expect(store.get(targetTabAtom)).toBe(tabId);
+      expect(store.get(insertionContextAtom)).toEqual({
+        targetWidgetId: 'next-widget',
+        direction: 'above',
+      });
+      expect(mockNavigatePageLayoutSidePanel).toHaveBeenCalledWith({
+        sidePanelPage: SidePanelPages.PageLayoutRecordPageWidgetTypeSelect,
+      });
+    },
+  );
+
+  it('clears a previous insertion point when opening the bottom picker', () => {
+    const { store, result } = setup();
+    act(() => result.current.navigateToMoreWidgets());
+
+    expect(store.get(insertionContextAtom)).toBeNull();
+    expect(store.get(editingWidgetAtom)).toBeNull();
+    expect(store.get(targetTabAtom)).toBe('main-tab');
+  });
+
+  it('preserves the insertion point when reopening a closing panel', () => {
+    const { store, result } = setup();
+    const insertionContext = {
+      targetWidgetId: 'next-widget',
+      direction: 'above',
+    } as const;
+    mockNavigatePageLayoutSidePanel.mockImplementationOnce(() => {
+      store.set(editingWidgetAtom, null);
+      store.set(insertionContextAtom, null);
+    });
+
+    act(() => result.current.navigateToMoreWidgets(insertionContext));
+
+    expect(store.get(insertionContextAtom)).toEqual(insertionContext);
+    expect(store.get(editingWidgetAtom)).toBeNull();
+    expect(store.get(targetTabAtom)).toBe('main-tab');
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useOpenPageLayoutTabSettings.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useOpenPageLayoutTabSettings.test.tsx
@@ -1,0 +1,61 @@
+import { useOpenPageLayoutTabSettings } from '@/page-layout/hooks/useOpenPageLayoutTabSettings';
+import { pageLayoutTabSettingsOpenTabIdComponentState } from '@/page-layout/states/pageLayoutTabSettingsOpenTabIdComponentState';
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'jotai';
+import { type ReactNode } from 'react';
+import { SidePanelPages } from 'twenty-shared/types';
+import {
+  PAGE_LAYOUT_TEST_INSTANCE_ID,
+  PageLayoutTestWrapper,
+} from './PageLayoutTestWrapper';
+
+const mockNavigatePageLayoutSidePanel = jest.fn();
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/useNavigatePageLayoutSidePanel',
+  () => ({
+    useNavigatePageLayoutSidePanel: () => ({
+      navigatePageLayoutSidePanel: mockNavigatePageLayoutSidePanel,
+    }),
+  }),
+);
+
+describe('useOpenPageLayoutTabSettings', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it.each([false, true])(
+    'opens the requested tab settings when interrupting a closing panel: %s',
+    (isPanelClosing) => {
+      const store = createStore();
+      const settingsTabAtom =
+        pageLayoutTabSettingsOpenTabIdComponentState.atomFamily({
+          instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+        });
+      store.set(settingsTabAtom, isPanelClosing ? 'previous-tab' : null);
+
+      if (isPanelClosing) {
+        mockNavigatePageLayoutSidePanel.mockImplementation(() => {
+          store.set(settingsTabAtom, null);
+        });
+      }
+
+      const { result } = renderHook(() => useOpenPageLayoutTabSettings(), {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <PageLayoutTestWrapper store={store}>
+            {children}
+          </PageLayoutTestWrapper>
+        ),
+      });
+
+      act(() => result.current.openTabSettings('selected-tab'));
+
+      expect(store.get(settingsTabAtom)).toBe('selected-tab');
+      expect(mockNavigatePageLayoutSidePanel).toHaveBeenCalledWith({
+        sidePanelPage: SidePanelPages.PageLayoutTabSettings,
+        resetNavigationStack: true,
+      });
+    },
+  );
+});

--- a/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldWidget.ts
@@ -92,13 +92,12 @@ export const useCreateRecordPageFieldWidget = () => {
       tabs: addWidgetToTab(prev.tabs, tabId, newWidget),
     }));
 
-    store.set(pageLayoutEditingWidgetIdState, widgetId);
-
     navigatePageLayoutSidePanel({
       sidePanelPage: SidePanelPages.RecordPageFieldSettings,
       focusTitleInput: true,
       resetNavigationStack: true,
     });
+    store.set(pageLayoutEditingWidgetIdState, widgetId);
 
     return newWidget;
   }, [

--- a/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldWidget.ts
@@ -99,6 +99,8 @@ export const useCreateRecordPageFieldWidget = () => {
       focusTitleInput: true,
       resetNavigationStack: true,
     });
+
+    return newWidget;
   }, [
     allFieldWidgetFields,
     currentPageLayout.tabs,

--- a/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldsWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldsWidget.ts
@@ -57,13 +57,12 @@ export const useCreateRecordPageFieldsWidget = () => {
       tabs: addWidgetToTab(prev.tabs, tabId, newWidget),
     }));
 
-    store.set(pageLayoutEditingWidgetIdState, widgetId);
-
     navigatePageLayoutSidePanel({
       sidePanelPage: SidePanelPages.RecordPageFieldsSettings,
       focusTitleInput: true,
       resetNavigationStack: true,
     });
+    store.set(pageLayoutEditingWidgetIdState, widgetId);
 
     return newWidget;
   }, [

--- a/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldsWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldsWidget.ts
@@ -64,6 +64,8 @@ export const useCreateRecordPageFieldsWidget = () => {
       focusTitleInput: true,
       resetNavigationStack: true,
     });
+
+    return newWidget;
   }, [
     currentPageLayout.tabs,
     navigatePageLayoutSidePanel,

--- a/packages/twenty-front/src/modules/page-layout/hooks/useInsertCreatedWidgetAtContext.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useInsertCreatedWidgetAtContext.ts
@@ -1,6 +1,9 @@
 import { PageLayoutComponentInstanceContext } from '@/page-layout/states/contexts/PageLayoutComponentInstanceContext';
 import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
-import { widgetInsertionContextComponentState } from '@/page-layout/states/widgetInsertionContextComponentState';
+import {
+  type WidgetInsertionContext,
+  widgetInsertionContextComponentState,
+} from '@/page-layout/states/widgetInsertionContextComponentState';
 import { reindexWidgetsToVerticalListPositions } from '@/page-layout/utils/reindexWidgetsToVerticalListPositions';
 import { sortWidgetsByVerticalListPosition } from '@/page-layout/utils/sortWidgetsByVerticalListPosition';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
@@ -29,8 +32,13 @@ export const useInsertCreatedWidgetAtContext = (
   const store = useStore();
 
   const insertCreatedWidgetAtContext = useCallback(
-    (newWidgetId: string) => {
-      const insertionContext = store.get(widgetInsertionContextState);
+    (
+      newWidgetId: string,
+      insertionContext: WidgetInsertionContext = store.get(
+        widgetInsertionContextState,
+      ),
+    ) => {
+      store.set(widgetInsertionContextState, null);
 
       if (insertionContext === null) {
         return;
@@ -92,8 +100,6 @@ export const useInsertCreatedWidgetAtContext = (
           }),
         };
       });
-
-      store.set(widgetInsertionContextState, null);
     },
     [pageLayoutDraftState, store, widgetInsertionContextState],
   );

--- a/packages/twenty-front/src/modules/page-layout/hooks/useInsertCreatedWidgetAtContext.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useInsertCreatedWidgetAtContext.ts
@@ -32,12 +32,13 @@ export const useInsertCreatedWidgetAtContext = (
   const store = useStore();
 
   const insertCreatedWidgetAtContext = useCallback(
-    (
-      newWidgetId: string,
-      insertionContext: WidgetInsertionContext = store.get(
-        widgetInsertionContextState,
-      ),
-    ) => {
+    ({
+      newWidgetId,
+      insertionContext = store.get(widgetInsertionContextState),
+    }: {
+      newWidgetId: string;
+      insertionContext?: WidgetInsertionContext;
+    }) => {
       store.set(widgetInsertionContextState, null);
 
       if (insertionContext === null) {

--- a/packages/twenty-front/src/modules/page-layout/hooks/useNavigateToMoreWidgets.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useNavigateToMoreWidgets.ts
@@ -1,7 +1,10 @@
 import { usePageLayoutContentContext } from '@/page-layout/contexts/PageLayoutContentContext';
 import { pageLayoutEditingWidgetIdComponentState } from '@/page-layout/states/pageLayoutEditingWidgetIdComponentState';
 import { widgetCreationTargetTabIdComponentState } from '@/page-layout/states/widgetCreationTargetTabIdComponentState';
-import { widgetInsertionContextComponentState } from '@/page-layout/states/widgetInsertionContextComponentState';
+import {
+  type WidgetInsertionContext,
+  widgetInsertionContextComponentState,
+} from '@/page-layout/states/widgetInsertionContextComponentState';
 import { useNavigatePageLayoutSidePanel } from '@/side-panel/pages/page-layout/hooks/useNavigatePageLayoutSidePanel';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { useStore } from 'jotai';
@@ -27,22 +30,24 @@ export const useNavigateToMoreWidgets = () => {
 
   const store = useStore();
 
-  const navigateToMoreWidgets = useCallback(() => {
-    store.set(pageLayoutEditingWidgetIdState, null);
-    store.set(widgetInsertionContextState, null);
-    store.set(widgetCreationTargetTabIdState, tabId);
-
-    navigatePageLayoutSidePanel({
-      sidePanelPage: SidePanelPages.PageLayoutRecordPageWidgetTypeSelect,
-    });
-  }, [
-    navigatePageLayoutSidePanel,
-    pageLayoutEditingWidgetIdState,
-    store,
-    tabId,
-    widgetCreationTargetTabIdState,
-    widgetInsertionContextState,
-  ]);
+  const navigateToMoreWidgets = useCallback(
+    (insertionContext: WidgetInsertionContext = null) => {
+      navigatePageLayoutSidePanel({
+        sidePanelPage: SidePanelPages.PageLayoutRecordPageWidgetTypeSelect,
+      });
+      store.set(pageLayoutEditingWidgetIdState, null);
+      store.set(widgetInsertionContextState, insertionContext);
+      store.set(widgetCreationTargetTabIdState, tabId);
+    },
+    [
+      navigatePageLayoutSidePanel,
+      pageLayoutEditingWidgetIdState,
+      store,
+      tabId,
+      widgetCreationTargetTabIdState,
+      widgetInsertionContextState,
+    ],
+  );
 
   return { navigateToMoreWidgets };
 };

--- a/packages/twenty-front/src/modules/page-layout/hooks/useOpenPageLayoutTabSettings.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useOpenPageLayoutTabSettings.ts
@@ -16,11 +16,12 @@ export const useOpenPageLayoutTabSettings = (
 
   const openTabSettings = useCallback(
     (tabId: string) => {
-      setPageLayoutTabSettingsOpenTabId(tabId);
+      // Opening during the close animation clears the previous tab selection.
       navigatePageLayoutSidePanel({
         sidePanelPage: SidePanelPages.PageLayoutTabSettings,
         resetNavigationStack: true,
       });
+      setPageLayoutTabSettingsOpenTabId(tabId);
     },
     [setPageLayoutTabSettingsOpenTabId, navigatePageLayoutSidePanel],
   );

--- a/packages/twenty-front/src/modules/page-layout/hooks/usePageLayoutAddTabStrategy.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/usePageLayoutAddTabStrategy.ts
@@ -46,11 +46,11 @@ export const usePageLayoutAddTabStrategy = ({
       navigate(`#${newTabId}`);
     }
 
-    setPageLayoutTabSettingsOpenTabId(newTabId);
     navigatePageLayoutSidePanel({
       sidePanelPage: SidePanelPages.PageLayoutTabSettings,
       focusTitleInput: true,
     });
+    setPageLayoutTabSettingsOpenTabId(newTabId);
   }, [
     createPageLayoutTab,
     isInSidePanel,

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageAddWidgetSection.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageAddWidgetSection.tsx
@@ -1,19 +1,21 @@
 import { usePageLayoutContentContext } from '@/page-layout/contexts/PageLayoutContentContext';
-import { useCreateRecordPageNoteWidget } from '@/page-layout/hooks/useCreateRecordPageNoteWidget';
 import { useCreateRecordPageFieldWidget } from '@/page-layout/hooks/useCreateRecordPageFieldWidget';
 import { useCreateRecordPageFieldsWidget } from '@/page-layout/hooks/useCreateRecordPageFieldsWidget';
+import { useCreateRecordPageNoteWidget } from '@/page-layout/hooks/useCreateRecordPageNoteWidget';
+import { useInsertCreatedWidgetAtContext } from '@/page-layout/hooks/useInsertCreatedWidgetAtContext';
 import { useNavigateToMoreWidgets } from '@/page-layout/hooks/useNavigateToMoreWidgets';
+import { type WidgetInsertionContext } from '@/page-layout/states/widgetInsertionContextComponentState';
+import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
-import { useContext } from 'react';
 import {
   IconListDetails,
+  IconListSearch,
   IconNotes,
   IconPlus,
-  IconSquarePlus,
 } from 'twenty-ui/icon';
 import { MenuItem } from 'twenty-ui/navigation';
-import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledContainer = styled.div`
   border: 1px solid transparent;
@@ -32,7 +34,6 @@ const StyledHeader = styled.div`
   flex-shrink: 0;
   font-size: ${themeCssVariables.font.size.md};
   font-weight: ${themeCssVariables.font.weight.medium};
-  gap: ${themeCssVariables.spacing[1]};
   height: ${themeCssVariables.spacing[6]};
   padding-inline: ${themeCssVariables.spacing[1]};
 `;
@@ -46,55 +47,63 @@ const StyledMenuItemList = styled.div`
   padding: ${themeCssVariables.spacing[2]};
 `;
 
-export const RecordPageAddWidgetSection = () => {
-  const { theme } = useContext(ThemeContext);
+type RecordPageAddWidgetSectionProps = {
+  insertionContext?: WidgetInsertionContext;
+};
+
+export const RecordPageAddWidgetSection = ({
+  insertionContext = null,
+}: RecordPageAddWidgetSectionProps) => {
   const { tabId } = usePageLayoutContentContext();
-  const { createRecordPageNoteWidget } = useCreateRecordPageNoteWidget();
 
   const { createRecordPageFieldsWidget } = useCreateRecordPageFieldsWidget();
 
   const { createRecordPageFieldWidget } = useCreateRecordPageFieldWidget();
 
+  const { createRecordPageNoteWidget } = useCreateRecordPageNoteWidget();
+
   const { navigateToMoreWidgets } = useNavigateToMoreWidgets();
+
+  const { insertCreatedWidgetAtContext } = useInsertCreatedWidgetAtContext();
+
+  const handleCreateWidget = (createWidget: () => PageLayoutWidget) => {
+    const widget = createWidget();
+    insertCreatedWidgetAtContext(widget.id, insertionContext);
+  };
 
   return (
     <StyledContainer>
-      <StyledHeader>
-        <IconSquarePlus
-          size={theme.icon.size.md}
-          stroke={theme.icon.stroke.md}
-          color={theme.font.color.extraLight}
-        />
-        {t`Add widget`}
-      </StyledHeader>
+      <StyledHeader>{t`Add widget`}</StyledHeader>
       <StyledMenuItemList>
         <MenuItem
           LeftIcon={IconListDetails}
           withIconContainer
           text={t`Fields group`}
           contextualText={t`Group multiple fields from this record`}
-          onClick={createRecordPageFieldsWidget}
+          onClick={() => handleCreateWidget(createRecordPageFieldsWidget)}
         />
         <MenuItem
-          LeftIcon={IconListDetails}
+          LeftIcon={IconListSearch}
           withIconContainer
           text={t`Field`}
           contextualText={t`Single field with smart formats`}
-          onClick={createRecordPageFieldWidget}
+          onClick={() => handleCreateWidget(createRecordPageFieldWidget)}
         />
         <MenuItem
           LeftIcon={IconNotes}
           withIconContainer
           text={t`Note`}
           contextualText={t`Static text shared across all record pages`}
-          onClick={() => createRecordPageNoteWidget({ tabId })}
+          onClick={() =>
+            handleCreateWidget(() => createRecordPageNoteWidget({ tabId }))
+          }
         />
         <MenuItem
           LeftIcon={IconPlus}
           withIconContainer
           text={t`More widgets`}
           hasSubMenu
-          onClick={navigateToMoreWidgets}
+          onClick={() => navigateToMoreWidgets(insertionContext)}
         />
       </StyledMenuItemList>
     </StyledContainer>

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageAddWidgetSection.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageAddWidgetSection.tsx
@@ -68,7 +68,7 @@ export const RecordPageAddWidgetSection = ({
 
   const handleCreateWidget = (createWidget: () => PageLayoutWidget) => {
     const widget = createWidget();
-    insertCreatedWidgetAtContext(widget.id, insertionContext);
+    insertCreatedWidgetAtContext({ newWidgetId: widget.id, insertionContext });
   };
 
   return (

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageWidgetInsertionSeparator.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageWidgetInsertionSeparator.tsx
@@ -1,0 +1,88 @@
+import { useNavigateToMoreWidgets } from '@/page-layout/hooks/useNavigateToMoreWidgets';
+import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
+import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
+import { IconPlus } from 'twenty-ui/icon';
+import { FloatingIconButton } from 'twenty-ui/input';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledInsertButton = styled(FloatingIconButton)`
+  background: ${themeCssVariables.background.transparent.primary};
+  border-color: ${themeCssVariables.background.transparent.light};
+  flex-shrink: 0;
+  opacity: 0;
+  pointer-events: none;
+`;
+
+const StyledSeparator = styled.div`
+  align-items: center;
+  box-sizing: border-box;
+  display: flex;
+  flex-shrink: 0;
+  height: ${themeCssVariables.spacing[4]};
+  overflow: visible;
+  padding-inline: ${themeCssVariables.spacing[4]};
+  position: relative;
+  z-index: 4;
+
+  &::before,
+  &::after {
+    background: ${themeCssVariables.border.color.strong};
+    border-radius: ${themeCssVariables.border.radius.pill};
+    content: '';
+    flex: 1;
+    height: 1px;
+    opacity: 0;
+  }
+
+  &:hover,
+  &:focus-within {
+    &::before,
+    &::after,
+    ${StyledInsertButton} {
+      opacity: 1;
+    }
+
+    ${StyledInsertButton} {
+      pointer-events: auto;
+    }
+  }
+
+  @media (hover: none) {
+    &::before,
+    &::after,
+    ${StyledInsertButton} {
+      opacity: 1;
+    }
+
+    ${StyledInsertButton} {
+      pointer-events: auto;
+    }
+  }
+`;
+
+type RecordPageWidgetInsertionSeparatorProps = {
+  widget: Pick<PageLayoutWidget, 'id' | 'title'>;
+};
+
+export const RecordPageWidgetInsertionSeparator = ({
+  widget,
+}: RecordPageWidgetInsertionSeparatorProps) => {
+  const { navigateToMoreWidgets } = useNavigateToMoreWidgets();
+
+  return (
+    <StyledSeparator>
+      <StyledInsertButton
+        Icon={IconPlus}
+        ariaLabel={t`Add widget above ${widget.title}`}
+        size="small"
+        onClick={() =>
+          navigateToMoreWidgets({
+            targetWidgetId: widget.id,
+            direction: 'above',
+          })
+        }
+      />
+    </StyledSeparator>
+  );
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/__tests__/RecordPageAddNoteWidgetSection.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/__tests__/RecordPageAddNoteWidgetSection.test.tsx
@@ -3,8 +3,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type * as TwentyIcons from 'twenty-ui/icon';
 
-const mockCreateRecordPageNoteWidget = jest.fn();
+const mockCreateRecordPageNoteWidget = jest.fn(() => ({ id: 'new-note' }));
 const mockNavigateToMoreWidgets = jest.fn();
+
+jest.mock('@/page-layout/hooks/useInsertCreatedWidgetAtContext', () => ({
+  useInsertCreatedWidgetAtContext: () => ({
+    insertCreatedWidgetAtContext: jest.fn(),
+  }),
+}));
 
 jest.mock('twenty-ui/icon', () => ({
   ...jest.requireActual<typeof TwentyIcons>('twenty-ui/icon'),

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/__tests__/RecordPageAddWidgetSection.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/__tests__/RecordPageAddWidgetSection.test.tsx
@@ -1,0 +1,121 @@
+import { RecordPageAddWidgetSection } from '@/page-layout/widgets/components/RecordPageAddWidgetSection';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type * as TwentyIcons from 'twenty-ui/icon';
+
+const mockNavigateToMoreWidgets = jest.fn();
+const mockCreateRecordPageNoteWidget = jest.fn(() => ({ id: 'new-note' }));
+const mockCreateRecordPageFieldWidget = jest.fn(() => ({ id: 'new-field' }));
+const mockCreateRecordPageFieldsWidget = jest.fn(() => ({ id: 'new-fields' }));
+const mockInsertCreatedWidgetAtContext = jest.fn();
+
+jest.mock('twenty-ui/icon', () => ({
+  ...jest.requireActual<typeof TwentyIcons>('twenty-ui/icon'),
+  IconListDetails: () => <svg role="img" aria-label="Fields group icon" />,
+  IconListSearch: () => <svg role="img" aria-label="Field icon" />,
+  IconNotes: () => <svg role="img" aria-label="Note icon" />,
+}));
+
+jest.mock('@/page-layout/contexts/PageLayoutContentContext', () => ({
+  usePageLayoutContentContext: () => ({ tabId: 'tab-1' }),
+}));
+
+jest.mock('@/page-layout/hooks/useNavigateToMoreWidgets', () => ({
+  useNavigateToMoreWidgets: () => ({
+    navigateToMoreWidgets: mockNavigateToMoreWidgets,
+  }),
+}));
+jest.mock('@/page-layout/hooks/useCreateRecordPageFieldWidget', () => ({
+  useCreateRecordPageFieldWidget: () => ({
+    createRecordPageFieldWidget: mockCreateRecordPageFieldWidget,
+  }),
+}));
+jest.mock('@/page-layout/hooks/useCreateRecordPageFieldsWidget', () => ({
+  useCreateRecordPageFieldsWidget: () => ({
+    createRecordPageFieldsWidget: mockCreateRecordPageFieldsWidget,
+  }),
+}));
+
+jest.mock('@/page-layout/hooks/useInsertCreatedWidgetAtContext', () => ({
+  useInsertCreatedWidgetAtContext: () => ({
+    insertCreatedWidgetAtContext: mockInsertCreatedWidgetAtContext,
+  }),
+}));
+jest.mock('@/page-layout/hooks/useCreateRecordPageNoteWidget', () => ({
+  useCreateRecordPageNoteWidget: () => ({
+    createRecordPageNoteWidget: mockCreateRecordPageNoteWidget,
+  }),
+}));
+
+describe('RecordPageAddWidgetSection', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('opens the existing picker from More widgets', async () => {
+    render(<RecordPageAddWidgetSection />);
+    await userEvent.setup().click(screen.getByText('More widgets'));
+    expect(mockNavigateToMoreWidgets).toHaveBeenCalledTimes(1);
+    expect(mockNavigateToMoreWidgets).toHaveBeenCalledWith(null);
+  });
+
+  it('shows the expanded chooser', () => {
+    render(<RecordPageAddWidgetSection />);
+    expect(screen.getByText('Add widget')).toBeInTheDocument();
+    expect(screen.getByText('Fields group')).toBeInTheDocument();
+    expect(screen.getByText('Field')).toBeInTheDocument();
+    expect(screen.getByText('Note')).toBeInTheDocument();
+    expect(screen.getByText('More widgets')).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: 'Fields group icon' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Field icon' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Note icon' })).toBeInTheDocument();
+  });
+
+  it('creates a Note in the current tab through the shared creator', async () => {
+    render(<RecordPageAddWidgetSection />);
+    await userEvent.setup().click(screen.getByText('Note'));
+    expect(mockCreateRecordPageNoteWidget).toHaveBeenCalledWith({
+      tabId: 'tab-1',
+    });
+    expect(mockInsertCreatedWidgetAtContext).toHaveBeenCalledWith(
+      'new-note',
+      null,
+    );
+  });
+
+  it.each([
+    ['Fields group', 'new-fields'],
+    ['Field', 'new-field'],
+    ['Note', 'new-note'],
+  ])(
+    'inserts %s at the expanded chooser insertion point',
+    async (label, widgetId) => {
+      const insertionContext = {
+        targetWidgetId: 'first-widget',
+        direction: 'above',
+      } as const;
+      render(
+        <RecordPageAddWidgetSection insertionContext={insertionContext} />,
+      );
+
+      await userEvent.setup().click(screen.getByText(label, { exact: true }));
+
+      expect(mockInsertCreatedWidgetAtContext).toHaveBeenCalledWith(
+        widgetId,
+        insertionContext,
+      );
+    },
+  );
+
+  it('preserves the insertion point when opening More widgets', async () => {
+    const insertionContext = {
+      targetWidgetId: 'first-widget',
+      direction: 'above',
+    } as const;
+    render(<RecordPageAddWidgetSection insertionContext={insertionContext} />);
+
+    await userEvent.setup().click(screen.getByText('More widgets'));
+
+    expect(mockNavigateToMoreWidgets).toHaveBeenCalledWith(insertionContext);
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/__tests__/RecordPageAddWidgetSection.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/__tests__/RecordPageAddWidgetSection.test.tsx
@@ -77,10 +77,10 @@ describe('RecordPageAddWidgetSection', () => {
     expect(mockCreateRecordPageNoteWidget).toHaveBeenCalledWith({
       tabId: 'tab-1',
     });
-    expect(mockInsertCreatedWidgetAtContext).toHaveBeenCalledWith(
-      'new-note',
-      null,
-    );
+    expect(mockInsertCreatedWidgetAtContext).toHaveBeenCalledWith({
+      newWidgetId: 'new-note',
+      insertionContext: null,
+    });
   });
 
   it.each([
@@ -100,10 +100,10 @@ describe('RecordPageAddWidgetSection', () => {
 
       await userEvent.setup().click(screen.getByText(label, { exact: true }));
 
-      expect(mockInsertCreatedWidgetAtContext).toHaveBeenCalledWith(
-        widgetId,
+      expect(mockInsertCreatedWidgetAtContext).toHaveBeenCalledWith({
+        newWidgetId: widgetId,
         insertionContext,
-      );
+      });
     },
   );
 

--- a/packages/twenty-front/src/modules/side-panel/hooks/__tests__/useOpenWidgetSettingsInSidePanel.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/hooks/__tests__/useOpenWidgetSettingsInSidePanel.test.tsx
@@ -4,6 +4,7 @@ import {
 } from '@/page-layout/hooks/__tests__/PageLayoutTestWrapper';
 import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
 import { pageLayoutEditingWidgetIdComponentState } from '@/page-layout/states/pageLayoutEditingWidgetIdComponentState';
+import { pageLayoutTabSettingsOpenTabIdComponentState } from '@/page-layout/states/pageLayoutTabSettingsOpenTabIdComponentState';
 import {
   makeDraft,
   makeTab,
@@ -222,6 +223,50 @@ describe('useOpenWidgetSettingsInSidePanel', () => {
 
     expect(store.get(getEditingWidgetIdAtom())).toBe(widget.id);
   });
+
+  it.each([
+    {
+      widgetType: WidgetType.TIMELINE,
+      sidePanelPage: SidePanelPages.PageLayoutWidgetSettings,
+    },
+    {
+      widgetType: WidgetType.FRONT_COMPONENT,
+      sidePanelPage: SidePanelPages.PageLayoutTabSettings,
+    },
+  ])(
+    'keeps $widgetType settings selected when interrupting a closing panel',
+    ({ widgetType, sidePanelPage }) => {
+      const store = createStore();
+      const settingsTabAtom =
+        pageLayoutTabSettingsOpenTabIdComponentState.atomFamily({
+          instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+        });
+      const widget = { ...makeWidget('widget', 0), type: widgetType };
+      store.set(getDraftAtom(), makeDraft([makeTab('tab-1', [widget])]));
+      mockNavigatePageLayoutSidePanel.mockImplementationOnce(() => {
+        store.set(getEditingWidgetIdAtom(), null);
+        store.set(settingsTabAtom, null);
+      });
+
+      const { result } = renderOpenWidgetSettingsHook(store);
+      act(() =>
+        result.current.openWidgetSettingsInSidePanel({
+          widgetId: widget.id,
+          widgetType,
+        }),
+      );
+
+      expect(mockNavigatePageLayoutSidePanel).toHaveBeenCalledWith({
+        sidePanelPage,
+        resetNavigationStack: true,
+      });
+      if (sidePanelPage === SidePanelPages.PageLayoutTabSettings) {
+        expect(store.get(settingsTabAtom)).toBe('tab-1');
+      } else {
+        expect(store.get(getEditingWidgetIdAtom())).toBe(widget.id);
+      }
+    },
+  );
 
   it.each([WidgetType.IFRAME, WidgetType.GRAPH, WidgetType.RECORD_TABLE])(
     'opens generic widget settings for a %s widget on a record page',

--- a/packages/twenty-front/src/modules/side-panel/hooks/useOpenWidgetSettingsInSidePanel.ts
+++ b/packages/twenty-front/src/modules/side-panel/hooks/useOpenWidgetSettingsInSidePanel.ts
@@ -141,19 +141,19 @@ export const useOpenWidgetSettingsInSidePanel = (
         isContainingTabSingleWidget &&
         !isViewportFillingWidgetInVerticalList
       ) {
-        setPageLayoutTabSettingsOpenTabId(containingTab.id);
         navigatePageLayoutSidePanel({
           sidePanelPage: SidePanelPages.PageLayoutTabSettings,
           resetNavigationStack: true,
         });
+        setPageLayoutTabSettingsOpenTabId(containingTab.id);
         return;
       }
 
-      setPageLayoutEditingWidgetId(widgetId);
       navigatePageLayoutSidePanel({
         sidePanelPage: SidePanelPages.PageLayoutWidgetSettings,
         resetNavigationStack: true,
       });
+      setPageLayoutEditingWidgetId(widgetId);
     },
     [
       isDashboardPageLayout,

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutDashboardWidgetTypeSelect.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutDashboardWidgetTypeSelect.tsx
@@ -247,7 +247,7 @@ export const SidePanelPageLayoutDashboardWidgetTypeSelect = () => {
 
   return (
     <SidePanelList selectableItemIds={selectableItemIds}>
-      <SidePanelGroup heading={t`Widget type`}>
+      <SidePanelGroup heading={t`Standard widgets`}>
         <SelectableListItem
           itemId="chart"
           onEnter={handleNavigateToGraphTypeSelect}

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
@@ -32,7 +32,12 @@ import { useStore } from 'jotai';
 import { useCallback } from 'react';
 import { SidePanelPages } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { IconApps, IconListDetails, IconNotes } from 'twenty-ui/icon';
+import {
+  IconApps,
+  IconListDetails,
+  IconListSearch,
+  IconNotes,
+} from 'twenty-ui/icon';
 import { v4 as uuidv4 } from 'uuid';
 import {
   type FrontComponent,
@@ -344,18 +349,18 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
 
   return (
     <SidePanelList selectableItemIds={selectableItemIds}>
-      <SidePanelGroup heading={t`Widget type`}>
+      <SidePanelGroup heading={t`Standard widgets`}>
         <SelectableListItem itemId="fields" onEnter={handleCreateFieldsWidget}>
           <CommandMenuItem
             Icon={IconListDetails}
-            label={t`Fields`}
+            label={t`Fields group`}
             id="fields"
             onClick={handleCreateFieldsWidget}
           />
         </SelectableListItem>
         <SelectableListItem itemId="field" onEnter={handleCreateFieldWidget}>
           <CommandMenuItem
-            Icon={IconListDetails}
+            Icon={IconListSearch}
             label={t`Field`}
             id="field"
             onClick={handleCreateFieldWidget}

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
@@ -181,7 +181,7 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
     }));
 
     setPageLayoutEditingWidgetId(widgetId);
-    insertCreatedWidgetAtContext(widgetId);
+    insertCreatedWidgetAtContext({ newWidgetId: widgetId });
 
     navigatePageLayoutSidePanel({
       sidePanelPage: SidePanelPages.RecordPageFieldsSettings,
@@ -252,7 +252,7 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
     }));
 
     setPageLayoutEditingWidgetId(widgetId);
-    insertCreatedWidgetAtContext(widgetId);
+    insertCreatedWidgetAtContext({ newWidgetId: widgetId });
 
     navigatePageLayoutSidePanel({
       sidePanelPage: SidePanelPages.RecordPageFieldSettings,
@@ -278,7 +278,7 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
       widgetToReplace: existingWidget,
     });
 
-    insertCreatedWidgetAtContext(newWidget.id);
+    insertCreatedWidgetAtContext({ newWidgetId: newWidget.id });
   };
 
   const handleCreateFrontComponentWidget = useCallback(
@@ -324,7 +324,7 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
       }));
 
       setPageLayoutEditingWidgetId(widgetId);
-      insertCreatedWidgetAtContext(widgetId);
+      insertCreatedWidgetAtContext({ newWidgetId: widgetId });
 
       closeSidePanelMenu();
     },

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/__tests__/SidePanelPageLayoutRecordPageWidgetTypeSelect.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/__tests__/SidePanelPageLayoutRecordPageWidgetTypeSelect.test.tsx
@@ -1,0 +1,143 @@
+import {
+  PAGE_LAYOUT_TEST_INSTANCE_ID,
+  PageLayoutTestWrapper,
+} from '@/page-layout/hooks/__tests__/PageLayoutTestWrapper';
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
+import { widgetCreationTargetTabIdComponentState } from '@/page-layout/states/widgetCreationTargetTabIdComponentState';
+import {
+  makeDraft,
+  makeTab,
+} from '@/page-layout/testing/pageLayoutDraftFixtures';
+import { SidePanelPageLayoutRecordPageWidgetTypeSelect } from '@/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect';
+import { render, screen } from '@testing-library/react';
+import { createStore } from 'jotai';
+import { type ReactNode } from 'react';
+import { type IconComponent } from 'twenty-ui/icon';
+import type * as TwentyIcons from 'twenty-ui/icon';
+
+const mockNavigatePageLayoutSidePanel = jest.fn();
+
+jest.mock('twenty-ui/icon', () => ({
+  ...jest.requireActual<typeof TwentyIcons>('twenty-ui/icon'),
+  IconListDetails: () => <svg role="img" aria-label="Fields group icon" />,
+  IconListSearch: () => <svg role="img" aria-label="Field icon" />,
+}));
+
+jest.mock('@apollo/client/react', () => ({
+  useQuery: () => ({ data: { frontComponents: [] } }),
+}));
+
+jest.mock('@/object-metadata/hooks/useObjectMetadataItem', () => ({
+  useObjectMetadataItem: () => ({ objectMetadataItem: { id: 'company' } }),
+}));
+
+jest.mock(
+  '@/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields',
+  () => ({
+    useFieldWidgetEligibleFields: () => [],
+  }),
+);
+
+jest.mock('@/side-panel/hooks/useSidePanelMenu', () => ({
+  useSidePanelMenu: () => ({ closeSidePanelMenu: jest.fn() }),
+}));
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/useNavigatePageLayoutSidePanel',
+  () => ({
+    useNavigatePageLayoutSidePanel: () => ({
+      navigatePageLayoutSidePanel: mockNavigatePageLayoutSidePanel,
+    }),
+  }),
+);
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/usePageLayoutIdFromContextStore',
+  () => ({
+    usePageLayoutIdFromContextStore: () => ({
+      pageLayoutId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+      objectNameSingular: 'company',
+    }),
+  }),
+);
+
+jest.mock('@/side-panel/components/SidePanelList', () => ({
+  SidePanelList: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/side-panel/components/SidePanelGroup', () => ({
+  SidePanelGroup: ({
+    heading,
+    children,
+  }: {
+    heading: string;
+    children: ReactNode;
+  }) => (
+    <section>
+      <h2>{heading}</h2>
+      {children}
+    </section>
+  ),
+}));
+
+jest.mock('@/ui/layout/selectable-list/components/SelectableListItem', () => ({
+  SelectableListItem: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('@/command-menu/components/CommandMenuItem', () => ({
+  CommandMenuItem: ({
+    label,
+    onClick,
+    Icon,
+  }: {
+    label: string;
+    onClick: () => void;
+    Icon: IconComponent;
+  }) => (
+    <button aria-label={label} onClick={onClick}>
+      <Icon />
+      {label}
+    </button>
+  ),
+}));
+
+describe('SidePanelPageLayoutRecordPageWidgetTypeSelect', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('labels standard widgets and distinguishes a fields group from a single field', () => {
+    const store = createStore();
+    store.set(
+      pageLayoutDraftComponentState.atomFamily({
+        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+      }),
+      makeDraft([makeTab('tab-1', [])]),
+    );
+    store.set(
+      widgetCreationTargetTabIdComponentState.atomFamily({
+        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
+      }),
+      'tab-1',
+    );
+
+    render(
+      <PageLayoutTestWrapper store={store}>
+        <SidePanelPageLayoutRecordPageWidgetTypeSelect />
+      </PageLayoutTestWrapper>,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Standard widgets' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Widget type')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Fields group' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Field' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: 'Fields group icon' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Field icon' })).toBeInTheDocument();
+  });
+});

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/utils/__tests__/getPageLayoutIcon.test.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/utils/__tests__/getPageLayoutIcon.test.ts
@@ -6,6 +6,7 @@ import {
   IconFrame,
   IconLayoutDashboard,
   IconListDetails,
+  IconListSearch,
   IconPerspective,
   IconPlus,
   IconTable,
@@ -19,7 +20,7 @@ describe('getPageLayoutIcon', () => {
     [SidePanelPages.PageLayoutTabSettings, IconPerspective],
     [SidePanelPages.PageLayoutWidgetSettings, IconLayoutDashboard],
     [SidePanelPages.RecordPageFieldsSettings, IconListDetails],
-    [SidePanelPages.RecordPageFieldSettings, IconListDetails],
+    [SidePanelPages.RecordPageFieldSettings, IconListSearch],
     [SidePanelPages.DashboardRecordTableSettings, IconTable],
     [SidePanelPages.PageLayoutRecordPageWidgetTypeSelect, IconPlus],
   ] as const)('returns the expected icon for %s', (page, expectedIcon) => {

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/utils/getPageLayoutIcon.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/utils/getPageLayoutIcon.ts
@@ -7,6 +7,7 @@ import {
   IconFrame,
   IconLayoutDashboard,
   IconListDetails,
+  IconListSearch,
   IconPerspective,
   IconPlus,
   IconTable,
@@ -27,7 +28,7 @@ export const getPageLayoutIcon = (page: PageLayoutSidePanelPage) => {
     case SidePanelPages.RecordPageFieldsSettings:
       return IconListDetails;
     case SidePanelPages.RecordPageFieldSettings:
-      return IconListDetails;
+      return IconListSearch;
     case SidePanelPages.DashboardRecordTableSettings:
       return IconTable;
     case SidePanelPages.PageLayoutRecordPageWidgetTypeSelect:


### PR DESCRIPTION
## Summary

Split the record-page layout editing improvements out of #24992 so they can be reviewed separately from the Note widget.

- Add hover insertion controls between widgets, using the existing widget picker and inserting at the selected position.
- Keep the expanded Add widget chooser at the bottom when the tab can accept another widget there, or above a lone full-height widget for discoverability.
- Use distinct Fields group / Field icons and clearer picker labels.
- In layout edit mode, click a different tab to navigate; click the current tab again to open its settings. Preserve the existing blue outline on the selected tab.
- Preserve the selected widget/tab when reopening settings during the side-panel close animation, and clear stale insertion positions.

## Stack / review scope

**Base: #24992 (Note widget). Merge #24992 first, then retarget this PR to `main`.**

The diff against this base contains the layout-editing experience only. The Note implementation and rich-text fixes remain in #24992. Keeping this layer stacked also keeps the shared widget picker changes out of the Note review.

## Validation

- Full page-layout / side-panel regression run passes: **266 suites, 1,781 tests**, including new regressions for New Tab, reactivation, overflow-menu editing, and full-height widget settings during panel closure.
- Direct frontend typecheck passes (`tsgo --noEmit`, without Nx cache).
- Changed-file type-aware lint and formatting pass.
- Merge check against the Note base is clean. Follow-up review fixes preserve widget/tab selection when reopening a closing panel, stop overflow edit clicks from also navigating, and use named arguments for insertion and tab selection.
- Fresh isolated-browser verification was blocked by the existing local server's older metadata schema (`isFirstTabPinned` is unavailable). No new visual or save verification is claimed for the split.

GitHub status is intentionally open / ready for review while retaining the `-PR: draft` label.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

