### PR TITLE
fix: prevent digit-leading metadata name from slugified labels

### DIFF
--- a/packages/twenty-shared/src/metadata/__tests__/computeMetadataNameFromLabel.test.ts
+++ b/packages/twenty-shared/src/metadata/__tests__/computeMetadataNameFromLabel.test.ts
@@ -23,6 +23,15 @@ describe('computeMetadataNameFromLabel', () => {
     );
   });
 
+  it('should prefix labels that only become digit-leading after slugify', () => {
+    // slugify strips the leading space / symbol, so these are not digit-leading
+    // as written but slugify to "5_..."; the name must still not start with a digit.
+    expect(computeMetadataNameFromLabel({ label: ' 5 things' })).toBe(
+      'n5Things',
+    );
+    expect(computeMetadataNameFromLabel({ label: '$5 fee' })).toBe('n5Fee');
+  });
+
   it('should add Custom suffix for reserved words', () => {
     const result = computeMetadataNameFromLabel({ label: 'Name' });
 

--- a/packages/twenty-shared/src/metadata/utils/compute-metadata-name-from-label.util.ts
+++ b/packages/twenty-shared/src/metadata/utils/compute-metadata-name-from-label.util.ts
@@ -11,19 +11,23 @@ export const computeMetadataNameFromLabel = ({
 }): string => {
   if (!label) return '';
 
-  const prefixedLabel = /^\d/.test(label) ? `n${label}` : label;
-
-  if (prefixedLabel === '') return '';
-
-  const formattedString = slugify(prefixedLabel, {
+  const slugifiedLabel = slugify(label, {
     trim: true,
     separator: '_',
     allowedChars: 'a-zA-Z0-9',
   });
 
-  if (formattedString === '') {
+  if (slugifiedLabel === '') {
     throw new Error(`Invalid label: "${label}"`);
   }
+
+  // Prefix the digit guard AFTER slugify: slugify strips leading
+  // non-alphanumerics, so a label like " 5 things" or "$5 fee" is not
+  // digit-leading itself but slugifies to "5_things"/"5_fee". Checking the raw
+  // label let those through and produced an invalid digit-leading name.
+  const formattedString = /^\d/.test(slugifiedLabel)
+    ? `n_${slugifiedLabel}`
+    : slugifiedLabel;
 
   const computedName = camelCase(formattedString);
 


### PR DESCRIPTION
## What

`computeMetadataNameFromLabel` prefixes `n` when a label starts with a digit, so the generated metadata identifier (object/field name) is never digit-leading. The check ran on the **raw label**, but `slugify` strips leading non-alphanumerics — so a label like `" 5 things"` or `"$5 fee"` isn't digit-leading as written, passes the guard, and then slugifies to `5_things` / `5_fee`, producing an invalid digit-leading name:

```ts
computeMetadataNameFromLabel({ label: "123 Field" })  // "n123Field"  ✔
computeMetadataNameFromLabel({ label: " 5 things" })  // "5Things"    ✗ (expected n5Things)
computeMetadataNameFromLabel({ label: "$5 fee" })     // "5Fee"       ✗ (expected n5Fee)
```

## Fix

Apply the digit guard to the **slugified** value instead of the raw label. Existing behavior for already-digit-leading labels is unchanged (`"123 Field"` → `"n123Field"`), and normal labels are untouched.

```ts
computeMetadataNameFromLabel({ label: " 5 things" })  // "n5Things"
computeMetadataNameFromLabel({ label: "$5 fee" })     // "n5Fee"
```

Added two regression cases to `computeMetadataNameFromLabel.test.ts`. Verified the fixed logic against `transliteration`'s `slugify` + `lodash.camelcase` directly; all previously-passing cases still produce the same output.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

