### PR TITLE
Cover twenty-client-sdk client generation with integration tests

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -18,9 +18,11 @@ jobs:
     with:
       files: |
         packages/twenty-sdk/**
+        packages/twenty-client-sdk/**
         packages/twenty-server/**
         .github/workflows/ci-sdk.yaml
         !packages/twenty-sdk/package.json
+        !packages/twenty-client-sdk/package.json
   sdk-test:
     needs: changed-files-check
     if: needs.changed-files-check.outputs.any_changed == 'true'

--- a/packages/twenty-client-sdk/project.json
+++ b/packages/twenty-client-sdk/project.json
@@ -37,6 +37,13 @@
         "config": "{projectRoot}/vitest.config.ts"
       }
     },
+    "test:unit": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/twenty-client-sdk",
+        "command": "npx vitest run --config vitest.config.ts"
+      }
+    },
     "set-local-version": {},
     "typecheck": {},
     "lint": {}

--- a/packages/twenty-client-sdk/src/generate/__tests__/client-generation-pipeline.test.ts
+++ b/packages/twenty-client-sdk/src/generate/__tests__/client-generation-pipeline.test.ts
@@ -1,0 +1,147 @@
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  GENERATED_CORE_DIR,
+  generateCoreClientFromSchema,
+  replaceCoreClient,
+} from '../generate-core-client';
+import { generateMetadataClient } from '../generate-metadata-client';
+import { WORKSPACE_SCHEMA_FIXTURE } from './fixtures/workspace-schema.fixture';
+
+const METADATA_SCHEMA = `
+scalar JSON
+scalar Upload
+
+type Query {
+  currentWorkspace: Workspace
+}
+
+type Mutation {
+  uploadWorkspaceLogo(file: Upload!): String!
+}
+
+type Workspace {
+  id: ID!
+  metadataVersion: Int!
+  featureFlags: JSON
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}
+`;
+
+describe('Client generation pipeline', () => {
+  let temporaryDir: string;
+
+  beforeEach(async () => {
+    temporaryDir = await mkdtemp(join(tmpdir(), 'twenty-client-pipeline-'));
+  });
+
+  afterEach(async () => {
+    await rm(temporaryDir, { recursive: true, force: true });
+  });
+
+  describe('generateMetadataClient', () => {
+    it('emits a client wired to the metadata endpoint', async () => {
+      const outputPath = join(temporaryDir, 'metadata');
+
+      await generateMetadataClient({
+        schema: METADATA_SCHEMA,
+        outputPath,
+      });
+
+      const generatedTypes = await readFile(
+        join(outputPath, 'schema.ts'),
+        'utf-8',
+      );
+      const generatedIndex = await readFile(
+        join(outputPath, 'index.ts'),
+        'utf-8',
+      );
+
+      expect(generatedTypes).toContain('Upload: File,');
+      expect(generatedTypes).toContain("featureFlags?: Scalars['JSON']");
+      expect(generatedIndex).toContain('export class MetadataApiClient');
+      expect(generatedIndex).toContain('/metadata');
+    });
+
+    it('drops files left by a previous generation', async () => {
+      const outputPath = join(temporaryDir, 'metadata');
+
+      await mkdir(outputPath, { recursive: true });
+      await writeFile(
+        join(outputPath, 'stale.ts'),
+        'export const stale = true',
+      );
+
+      await generateMetadataClient({
+        schema: METADATA_SCHEMA,
+        outputPath,
+      });
+
+      expect(await readdir(outputPath)).not.toContain('stale.ts');
+    });
+  });
+
+  describe('replaceCoreClient', () => {
+    it('swaps the packaged core bundles for the generated ones', async () => {
+      const packageRoot = join(temporaryDir, 'twenty-client-sdk');
+      const distPath = join(packageRoot, 'dist');
+
+      await mkdir(distPath, { recursive: true });
+      await writeFile(
+        join(distPath, 'core.mjs'),
+        'export const createClient = () => { throw new Error("stub") }',
+      );
+      await writeFile(join(distPath, 'core.cjs'), 'module.exports = {}');
+
+      await replaceCoreClient({
+        packageRoot,
+        schema: WORKSPACE_SCHEMA_FIXTURE,
+      });
+
+      const generatedTypes = await readFile(
+        join(distPath, GENERATED_CORE_DIR, 'schema.ts'),
+        'utf-8',
+      );
+
+      expect(generatedTypes).toContain('additionalEmails?: string[]');
+
+      const replacedCoreModule = await import(
+        `${pathToFileURL(join(distPath, 'core.mjs')).href}?t=${Date.now()}`
+      );
+
+      expect(typeof replacedCoreModule.createClient).toBe('function');
+      expect(typeof replacedCoreModule.CoreApiClient).toBe('function');
+    }, 60000);
+  });
+
+  describe('when the schema cannot be generated', () => {
+    it('rejects without leaving a temporary directory behind', async () => {
+      const outputPath = join(temporaryDir, 'core');
+
+      await expect(
+        generateCoreClientFromSchema({
+          schema: 'type Query { person: MissingType }',
+          outputPath,
+        }),
+      ).rejects.toThrow();
+
+      expect(await readdir(temporaryDir)).toEqual([]);
+    });
+  });
+});

--- a/packages/twenty-client-sdk/src/generate/__tests__/composite-field-type-overrides.test.ts
+++ b/packages/twenty-client-sdk/src/generate/__tests__/composite-field-type-overrides.test.ts
@@ -1,85 +1,78 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { applyCompositeFieldTypeOverrides } from '../composite-field-type-overrides';
 
-import { generateCoreClientFromSchema } from '../generate-core-client';
+const generatedInterface = (name: string, body: string) =>
+  `export interface ${name} {\n${body}\n}\n`;
 
-const SCHEMA = `
-scalar JSON
+describe('applyCompositeFieldTypeOverrides', () => {
+  it('replaces the JSON scalar with the real shape in a response type', () => {
+    const source = generatedInterface(
+      'Emails',
+      "    primaryEmail?: Scalars['String']\n    additionalEmails?: Scalars['JSON']\n    __typename: 'Emails'",
+    );
 
-type Query {
-  person: Person
-}
-
-type Mutation {
-  createPerson(emails: EmailsCreateInput): Person
-}
-
-type Person {
-  id: ID!
-  emails: Emails
-  phones: Phones
-  settings: JSON
-}
-
-type Emails {
-  primaryEmail: String
-  additionalEmails: JSON
-}
-
-type Phones {
-  primaryPhoneNumber: String
-  additionalPhones: JSON
-}
-
-input EmailsCreateInput {
-  primaryEmail: String
-  additionalEmails: JSON
-}
-
-schema {
-  query: Query
-  mutation: Mutation
-}
-`;
-
-describe('Composite RAW_JSON field type overrides in the generated client', () => {
-  let temporaryDir: string;
-  let generatedTypes: string;
-
-  beforeAll(async () => {
-    temporaryDir = await mkdtemp(join(tmpdir(), 'twenty-genql-overrides-'));
-    const outputPath = join(temporaryDir, 'client');
-
-    await generateCoreClientFromSchema({ schema: SCHEMA, outputPath });
-
-    generatedTypes = await readFile(join(outputPath, 'schema.ts'), 'utf-8');
-  }, 60000);
-
-  afterAll(async () => {
-    if (temporaryDir) {
-      await rm(temporaryDir, { recursive: true, force: true });
-    }
-  });
-
-  it('types Emails.additionalEmails as a string array in response types', () => {
-    expect(generatedTypes).toContain('additionalEmails?: string[]');
-    expect(generatedTypes).not.toMatch(/additionalEmails\?: Scalars/);
-  });
-
-  it('types EmailsCreateInput.additionalEmails as a nullable string array', () => {
-    expect(generatedTypes).toContain('additionalEmails?: (string[] | null)');
-  });
-
-  it('types Phones.additionalPhones with the additional phone shape', () => {
-    expect(generatedTypes).toContain(
-      'additionalPhones?: Array<{ number: string; callingCode: string; countryCode: string }>',
+    expect(applyCompositeFieldTypeOverrides(source)).toContain(
+      'additionalEmails?: string[]',
     );
   });
 
-  it('keeps non-composite JSON fields on the scalar mapping', () => {
-    expect(generatedTypes).toContain("settings?: Scalars['JSON']");
+  it('preserves the engine nullability wrapping in an input type', () => {
+    const source =
+      "export interface EmailsCreateInput {primaryEmail?: (Scalars['String'] | null),additionalEmails?: (Scalars['JSON'] | null)}\n";
+
+    expect(applyCompositeFieldTypeOverrides(source)).toContain(
+      'additionalEmails?: (string[] | null)',
+    );
+  });
+
+  it('leaves a same-named field on a non-composite type untouched', () => {
+    const source =
+      generatedInterface(
+        'Emails',
+        "    additionalEmails?: Scalars['JSON']\n    __typename: 'Emails'",
+      ) +
+      generatedInterface(
+        'EmailsDraft',
+        "    additionalEmails?: Scalars['JSON']\n    __typename: 'EmailsDraft'",
+      );
+
+    const overridden = applyCompositeFieldTypeOverrides(source);
+
+    expect(overridden).toContain(
+      "export interface EmailsDraft {\n    additionalEmails?: Scalars['JSON']",
+    );
+    expect(overridden).toContain(
+      'export interface Emails {\n    additionalEmails?: string[]',
+    );
+  });
+
+  it('skips composite types the schema does not expose', () => {
+    const source = generatedInterface(
+      'Emails',
+      "    additionalEmails?: Scalars['JSON']",
+    );
+
+    expect(() => applyCompositeFieldTypeOverrides(source)).not.toThrow();
+  });
+
+  it('throws when a composite field stops rendering as the JSON scalar', () => {
+    const source = generatedInterface(
+      'Emails',
+      "    primaryEmail?: Scalars['String']\n    additionalEmails?: Scalars['JSONObject']",
+    );
+
+    expect(() => applyCompositeFieldTypeOverrides(source)).toThrow(
+      'Expected Emails.additionalEmails to render as the JSON scalar',
+    );
+  });
+
+  it('throws when the composite interface block is not closed', () => {
+    const source =
+      "export interface Emails {\n    additionalEmails?: Scalars['JSON']\n";
+
+    expect(() => applyCompositeFieldTypeOverrides(source)).toThrow(
+      'Unbalanced braces',
+    );
   });
 });

--- a/packages/twenty-client-sdk/src/generate/__tests__/fixtures/workspace-schema.fixture.ts
+++ b/packages/twenty-client-sdk/src/generate/__tests__/fixtures/workspace-schema.fixture.ts
@@ -1,0 +1,245 @@
+// Mirrors the shape the workspace schema builder emits for an object with
+// composite fields: RAW_JSON sub-fields reach the SDL as the JSON scalar,
+// while filter and orderBy inputs expose RawJsonFilter / OrderByDirection.
+export const WORKSPACE_SCHEMA_FIXTURE = `
+scalar DateTime
+scalar JSON
+scalar UUID
+
+enum ActorSource {
+  API
+  EMAIL
+  IMPORT
+  MANUAL
+  SYSTEM
+  WEBHOOK
+}
+
+enum OrderByDirection {
+  AscNullsFirst
+  AscNullsLast
+  DescNullsFirst
+  DescNullsLast
+}
+
+enum FilterIs {
+  NULL
+  NOT_NULL
+}
+
+input StringFilter {
+  eq: String
+  ilike: String
+  in: [String!]
+  is: FilterIs
+}
+
+input RawJsonFilter {
+  is: FilterIs
+  like: String
+}
+
+type Actor {
+  source: ActorSource!
+  workspaceMemberId: UUID
+  name: String!
+  context: JSON
+}
+
+input ActorCreateInput {
+  source: ActorSource!
+  workspaceMemberId: UUID
+  name: String
+  context: JSON
+}
+
+input ActorUpdateInput {
+  source: ActorSource
+  workspaceMemberId: UUID
+  name: String
+  context: JSON
+}
+
+input ActorFilterInput {
+  source: StringFilter
+  workspaceMemberId: StringFilter
+  name: StringFilter
+  context: RawJsonFilter
+}
+
+input ActorOrderByInput {
+  source: OrderByDirection
+  workspaceMemberId: OrderByDirection
+  name: OrderByDirection
+  context: OrderByDirection
+}
+
+type Emails {
+  primaryEmail: String
+  additionalEmails: JSON
+}
+
+input EmailsCreateInput {
+  primaryEmail: String
+  additionalEmails: JSON
+}
+
+input EmailsUpdateInput {
+  primaryEmail: String
+  additionalEmails: JSON
+}
+
+input EmailsFilterInput {
+  primaryEmail: StringFilter
+  additionalEmails: RawJsonFilter
+}
+
+input EmailsOrderByInput {
+  primaryEmail: OrderByDirection
+  additionalEmails: OrderByDirection
+}
+
+type Phones {
+  primaryPhoneNumber: String
+  primaryPhoneCountryCode: String
+  primaryPhoneCallingCode: String
+  additionalPhones: JSON
+}
+
+input PhonesCreateInput {
+  primaryPhoneNumber: String
+  primaryPhoneCountryCode: String
+  primaryPhoneCallingCode: String
+  additionalPhones: JSON
+}
+
+input PhonesUpdateInput {
+  primaryPhoneNumber: String
+  primaryPhoneCountryCode: String
+  primaryPhoneCallingCode: String
+  additionalPhones: JSON
+}
+
+type Links {
+  primaryLinkLabel: String
+  primaryLinkUrl: String
+  secondaryLinks: JSON
+}
+
+input LinksCreateInput {
+  primaryLinkLabel: String
+  primaryLinkUrl: String
+  secondaryLinks: JSON
+}
+
+input LinksUpdateInput {
+  primaryLinkLabel: String
+  primaryLinkUrl: String
+  secondaryLinks: JSON
+}
+
+type FullName {
+  firstName: String
+  lastName: String
+}
+
+input FullNameCreateInput {
+  firstName: String
+  lastName: String
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type Person {
+  id: UUID!
+  name: FullName
+  emails: Emails
+  phones: Phones
+  linkedinLink: Links
+  createdBy: Actor
+  jobTitle: String
+  customFields: JSON
+  createdAt: DateTime!
+  company: Company
+}
+
+type PersonEdge {
+  node: Person!
+  cursor: String!
+}
+
+type PersonConnection {
+  edges: [PersonEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type Company {
+  id: UUID!
+  name: String
+  domainName: Links
+  createdBy: Actor
+  people: PersonConnection
+}
+
+input PersonCreateInput {
+  id: UUID
+  name: FullNameCreateInput
+  emails: EmailsCreateInput
+  phones: PhonesCreateInput
+  linkedinLink: LinksCreateInput
+  createdBy: ActorCreateInput
+  jobTitle: String
+  customFields: JSON
+}
+
+input PersonUpdateInput {
+  name: FullNameCreateInput
+  emails: EmailsUpdateInput
+  phones: PhonesUpdateInput
+  linkedinLink: LinksUpdateInput
+  createdBy: ActorUpdateInput
+  jobTitle: String
+  customFields: JSON
+}
+
+input PersonFilterInput {
+  id: StringFilter
+  emails: EmailsFilterInput
+  createdBy: ActorFilterInput
+  customFields: RawJsonFilter
+  and: [PersonFilterInput!]
+  or: [PersonFilterInput!]
+}
+
+input PersonOrderByInput {
+  id: OrderByDirection
+  emails: EmailsOrderByInput
+  createdBy: ActorOrderByInput
+}
+
+type Query {
+  person(filter: PersonFilterInput): Person
+  people(
+    filter: PersonFilterInput
+    orderBy: [PersonOrderByInput!]
+    first: Int
+    after: String
+  ): PersonConnection
+}
+
+type Mutation {
+  createPerson(data: PersonCreateInput!): Person
+  updatePerson(id: UUID!, data: PersonUpdateInput!): Person
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}
+`;

--- a/packages/twenty-client-sdk/src/generate/__tests__/workspace-client-generation.test.ts
+++ b/packages/twenty-client-sdk/src/generate/__tests__/workspace-client-generation.test.ts
@@ -10,8 +10,24 @@ import { generateCoreClientFromSchema } from '../generate-core-client';
 import { WORKSPACE_SCHEMA_FIXTURE } from './fixtures/workspace-schema.fixture';
 
 type GeneratedClient = {
-  query: (request: Record<string, unknown>) => Promise<any>;
-  mutation: (request: Record<string, unknown>) => Promise<any>;
+  query: <TData>(request: Record<string, unknown>) => Promise<TData>;
+  mutation: <TData>(request: Record<string, unknown>) => Promise<TData>;
+};
+
+type PeopleQueryResult = {
+  people: {
+    edges: {
+      node: {
+        id: string;
+        emails: { primaryEmail: string; additionalEmails: string[] };
+        createdBy: { context: { provider: string } };
+      };
+    }[];
+  };
+};
+
+type CreatePersonResult = {
+  createPerson: { id: string; emails: { additionalEmails: string[] } };
 };
 
 type CreateClient = (options: {
@@ -291,7 +307,7 @@ describe('Core client generated from a workspace schema', () => {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
       });
 
-      const result = await client.query({
+      const result = await client.query<PeopleQueryResult>({
         people: {
           __args: {
             filter: { emails: { primaryEmail: { ilike: '%ada%' } } },
@@ -339,7 +355,7 @@ describe('Core client generated from a workspace schema', () => {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
       });
 
-      await client.mutation({
+      await client.mutation<CreatePersonResult>({
         createPerson: {
           __args: {
             data: {

--- a/packages/twenty-client-sdk/src/generate/__tests__/workspace-client-generation.test.ts
+++ b/packages/twenty-client-sdk/src/generate/__tests__/workspace-client-generation.test.ts
@@ -1,0 +1,367 @@
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import ts from 'typescript';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { generateCoreClientFromSchema } from '../generate-core-client';
+import { WORKSPACE_SCHEMA_FIXTURE } from './fixtures/workspace-schema.fixture';
+
+type GeneratedClient = {
+  query: (request: Record<string, unknown>) => Promise<any>;
+  mutation: (request: Record<string, unknown>) => Promise<any>;
+};
+
+type CreateClient = (options: {
+  url?: string;
+  fetch?: typeof globalThis.fetch;
+}) => GeneratedClient;
+
+const CONSUMER_COMPILER_OPTIONS: ts.CompilerOptions = {
+  strict: true,
+  noEmit: true,
+  skipLibCheck: true,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+};
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path);
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('Core client generated from a workspace schema', () => {
+  let temporaryDir: string;
+  let outputPath: string;
+  let generatedTypes: string;
+  let createClient: CreateClient;
+  let consumerCount = 0;
+
+  const typecheckAgainstGeneratedTypes = async (
+    source: string,
+  ): Promise<string[]> => {
+    const consumerPath = join(outputPath, `consumer-${consumerCount++}.ts`);
+
+    await writeFile(consumerPath, source);
+
+    const program = ts.createProgram([consumerPath], CONSUMER_COMPILER_OPTIONS);
+
+    return ts
+      .getPreEmitDiagnostics(program)
+      .map((diagnostic) =>
+        ts.flattenDiagnosticMessageText(diagnostic.messageText, ' '),
+      );
+  };
+
+  beforeAll(async () => {
+    temporaryDir = await mkdtemp(join(tmpdir(), 'twenty-workspace-client-'));
+    outputPath = join(temporaryDir, 'client');
+
+    await generateCoreClientFromSchema({
+      schema: WORKSPACE_SCHEMA_FIXTURE,
+      outputPath,
+    });
+
+    generatedTypes = await readFile(join(outputPath, 'schema.ts'), 'utf-8');
+
+    const generatedModule = await import(
+      `${pathToFileURL(join(outputPath, 'index.mjs')).href}?t=${Date.now()}`
+    );
+
+    createClient = generatedModule.createClient as CreateClient;
+  }, 60000);
+
+  afterAll(async () => {
+    if (temporaryDir) {
+      await rm(temporaryDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits the client sources and the bundles consumers import', async () => {
+    const emittedFiles = [
+      'schema.ts',
+      'types.ts',
+      'index.ts',
+      'schema.graphql',
+      'index.mjs',
+      'index.cjs',
+      'package.json',
+      join('runtime', 'index.ts'),
+    ];
+
+    for (const emittedFile of emittedFiles) {
+      expect(
+        await fileExists(join(outputPath, emittedFile)),
+        `${emittedFile} was not emitted`,
+      ).toBe(true);
+    }
+  });
+
+  describe('composite RAW_JSON sub-fields', () => {
+    it('types them with their real shape in response types', () => {
+      expect(generatedTypes).toContain('additionalEmails?: string[]');
+      expect(generatedTypes).toContain(
+        'additionalPhones?: Array<{ number: string; callingCode: string; countryCode: string }>',
+      );
+      expect(generatedTypes).toContain(
+        'secondaryLinks?: Array<{ label: string; url: string }>',
+      );
+      expect(generatedTypes).toContain('context?: { provider?: string }');
+    });
+
+    it('types them as nullable in create and update inputs', () => {
+      expect(generatedTypes).toContain(
+        "export interface EmailsCreateInput {primaryEmail?: (Scalars['String'] | null),additionalEmails?: (string[] | null)}",
+      );
+      expect(generatedTypes).toContain(
+        "export interface EmailsUpdateInput {primaryEmail?: (Scalars['String'] | null),additionalEmails?: (string[] | null)}",
+      );
+      expect(generatedTypes).toContain(
+        'additionalPhones?: (Array<{ number: string; callingCode: string; countryCode: string }> | null)',
+      );
+      expect(generatedTypes).toContain(
+        'secondaryLinks?: (Array<{ label: string; url: string }> | null)',
+      );
+      expect(generatedTypes).toContain(
+        'context?: ({ provider?: string } | null)',
+      );
+    });
+
+    it('leaves no composite sub-field on the JSON scalar mapping', () => {
+      expect(generatedTypes).not.toMatch(
+        /(additionalEmails|additionalPhones|secondaryLinks)\?: \(?Scalars\['JSON'\]/,
+      );
+      expect(generatedTypes).not.toMatch(
+        /export interface Actor(Create|Update)?Input? \{[^}]*context\?: \(?Scalars\['JSON'\]/,
+      );
+    });
+  });
+
+  describe('parts of the schema the overrides must not touch', () => {
+    it('keeps object-level JSON fields on the scalar mapping', () => {
+      expect(generatedTypes).toContain("customFields?: Scalars['JSON']");
+      expect(generatedTypes).toContain(
+        "customFields?: (Scalars['JSON'] | null)",
+      );
+    });
+
+    it('keeps filter inputs on their filter types', () => {
+      expect(generatedTypes).toContain(
+        'export interface EmailsFilterInput {primaryEmail?: (StringFilter | null),additionalEmails?: (RawJsonFilter | null)}',
+      );
+      expect(generatedTypes).toContain('context?: (RawJsonFilter | null)');
+    });
+
+    it('keeps order-by inputs on the direction enum', () => {
+      expect(generatedTypes).toContain(
+        'export interface EmailsOrderByInput {primaryEmail?: (OrderByDirection | null),additionalEmails?: (OrderByDirection | null)}',
+      );
+    });
+
+    it('keeps selection types on the boolean selectors', () => {
+      expect(generatedTypes).toMatch(
+        /export interface EmailsGenqlSelection\{\n\s*primaryEmail\?: boolean \| number\n\s*additionalEmails\?: boolean \| number/,
+      );
+    });
+  });
+
+  describe('type-level contract for consumers', () => {
+    it('accepts the real composite shapes', async () => {
+      const diagnostics = await typecheckAgainstGeneratedTypes(`
+        import type { Actor, Emails, Links, PersonCreateInput, Phones } from './schema';
+
+        const emails: Emails = {
+          primaryEmail: 'ada@example.com',
+          additionalEmails: ['ada.work@example.com'],
+          __typename: 'Emails',
+        };
+
+        const additionalEmails: string[] | undefined = emails.additionalEmails;
+
+        const phones: Phones = {
+          additionalPhones: [
+            { number: '123456789', callingCode: '+33', countryCode: 'FR' },
+          ],
+          __typename: 'Phones',
+        };
+
+        const links: Links = {
+          secondaryLinks: [{ label: 'Blog', url: 'https://example.com' }],
+          __typename: 'Links',
+        };
+
+        const createdBy: Actor = {
+          source: 'MANUAL',
+          name: 'Ada',
+          context: { provider: 'google' },
+          __typename: 'Actor',
+        };
+
+        const createInput: PersonCreateInput = {
+          emails: { additionalEmails: ['ada.work@example.com'] },
+          phones: { additionalPhones: [] },
+          linkedinLink: { secondaryLinks: null },
+          createdBy: { source: 'MANUAL', context: { provider: 'google' } },
+          customFields: { anything: true },
+        };
+
+        export { additionalEmails, createInput, createdBy, links, phones };
+      `);
+
+      expect(diagnostics).toEqual([]);
+    });
+
+    it('rejects a value of the wrong primitive type', async () => {
+      const diagnostics = await typecheckAgainstGeneratedTypes(`
+        import type { EmailsCreateInput } from './schema';
+
+        export const emails: EmailsCreateInput = { additionalEmails: [42] };
+      `);
+
+      expect(diagnostics).toEqual([
+        "Type 'number' is not assignable to type 'string'.",
+      ]);
+    });
+
+    it('rejects a composite object missing a required key', async () => {
+      const diagnostics = await typecheckAgainstGeneratedTypes(`
+        import type { LinksCreateInput } from './schema';
+
+        export const links: LinksCreateInput = {
+          secondaryLinks: [{ label: 'Blog' }],
+        };
+      `);
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toContain('url');
+    });
+
+    it('no longer types a composite sub-field as an untyped record', async () => {
+      const diagnostics = await typecheckAgainstGeneratedTypes(`
+        import type { Emails } from './schema';
+
+        export const readAsRecord = (emails: Emails): Record<string, unknown> =>
+          emails.additionalEmails ?? {};
+      `);
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toContain('string[]');
+    });
+  });
+
+  describe('runtime round trip', () => {
+    it('sends composite selections and parses composite payloads back', async () => {
+      const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+        jsonResponse({
+          data: {
+            people: {
+              edges: [
+                {
+                  node: {
+                    id: '20202020-0687-4c41-b707-ed1bfca972a7',
+                    emails: {
+                      primaryEmail: 'ada@example.com',
+                      additionalEmails: ['ada.work@example.com'],
+                    },
+                    createdBy: { context: { provider: 'google' } },
+                  },
+                },
+              ],
+            },
+          },
+        }),
+      );
+
+      const client = createClient({
+        url: 'https://example.test/graphql',
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+      });
+
+      const result = await client.query({
+        people: {
+          __args: {
+            filter: { emails: { primaryEmail: { ilike: '%ada%' } } },
+            first: 10,
+          },
+          edges: {
+            node: {
+              id: true,
+              emails: { primaryEmail: true, additionalEmails: true },
+              createdBy: { context: true },
+            },
+          },
+        },
+      });
+
+      expect(result.people.edges[0].node.emails.additionalEmails).toEqual([
+        'ada.work@example.com',
+      ]);
+
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+
+      expect(body.query).toBe(
+        'query ($v1:PersonFilterInput,$v2:Int){people(filter:$v1,first:$v2){edges{node{id,emails{primaryEmail,additionalEmails},createdBy{context}}}}}',
+      );
+      expect(body.variables).toEqual({
+        v1: { emails: { primaryEmail: { ilike: '%ada%' } } },
+        v2: 10,
+      });
+    });
+
+    it('sends a composite array argument as a JSON array, not a string', async () => {
+      const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+        jsonResponse({
+          data: {
+            createPerson: {
+              id: '20202020-0687-4c41-b707-ed1bfca972a7',
+              emails: { additionalEmails: ['ada.work@example.com'] },
+            },
+          },
+        }),
+      );
+
+      const client = createClient({
+        url: 'https://example.test/graphql',
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+      });
+
+      await client.mutation({
+        createPerson: {
+          __args: {
+            data: {
+              emails: {
+                primaryEmail: 'ada@example.com',
+                additionalEmails: ['ada.work@example.com'],
+              },
+            },
+          },
+          id: true,
+          emails: { additionalEmails: true },
+        },
+      });
+
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+
+      expect(body.query).toBe(
+        'mutation ($v1:PersonCreateInput!){createPerson(data:$v1){id,emails{additionalEmails}}}',
+      );
+      expect(body.variables.v1.emails.additionalEmails).toEqual([
+        'ada.work@example.com',
+      ]);
+    });
+  });
+});

--- a/packages/twenty-client-sdk/src/generate/composite-field-type-overrides.ts
+++ b/packages/twenty-client-sdk/src/generate/composite-field-type-overrides.ts
@@ -49,7 +49,10 @@ export const COMPOSITE_FIELD_TYPE_OVERRIDES: {
   ActorUpdateInput: { context: ACTOR_CONTEXT_TYPE_TEXT },
 };
 
-const findMatchingBrace = (source: string, openBraceIndex: number): number => {
+const findMatchingBraceOrThrow = (
+  source: string,
+  openBraceIndex: number,
+): number => {
   let depth = 0;
 
   for (let index = openBraceIndex; index < source.length; index++) {
@@ -85,7 +88,7 @@ export const applyCompositeFieldTypeOverrides = (
     }
 
     const blockStart = headerIndex + interfaceHeader.length - 1;
-    const blockEnd = findMatchingBrace(source, blockStart);
+    const blockEnd = findMatchingBraceOrThrow(source, blockStart);
     let block = source.slice(blockStart, blockEnd + 1);
 
     for (const [fieldName, overriddenType] of Object.entries(fieldOverrides)) {


### PR DESCRIPTION
Follow-up of #24869, where we agreed to land the fix and cover the generation pipeline with tests in a dedicated PR.

## Problem

`twenty-client-sdk` generation had thin coverage:

- the composite override test generated from a two-type schema, nothing shaped like a real workspace schema
- nothing checked that the generated types are actually *usable*: the assertions were string matches on `schema.ts`, so a consumer-visible type regression could still slip through
- `generateMetadataClient`, `replaceCoreClient` and the failed-generation cleanup path had no tests at all
- the override helpers (drift throw, absent composite types, same-named fields on unrelated types) were only exercised indirectly
- and, found while checking CI on this PR: **the package's test suite never ran in CI at all** (see the second commit)

## What this adds

**A workspace schema fixture** (`__tests__/fixtures/workspace-schema.fixture.ts`) mirroring what the workspace schema builder emits: `Emails`/`Phones`/`Links`/`Actor` with their RAW_JSON sub-fields on the `JSON` scalar, `RawJsonFilter` in filter inputs, `OrderByDirection` in order-by inputs, plus `Person`/`Company`, connections and create/update inputs.

**`workspace-client-generation.test.ts`** generates a core client from that fixture once and asserts:

- every composite sub-field renders with its real shape, in response types and in create/update inputs (nullable variants)
- the parts the overrides must not touch stay put: object-level `JSON` fields, `EmailsFilterInput`, `EmailsOrderByInput`, `EmailsGenqlSelection`
- a **type-level contract**, compiled with the TypeScript compiler API against the generated `schema.ts`: a consumer assigning the real shapes typechecks clean, `additionalEmails: [42]` and a `secondaryLinks` entry missing `url` are rejected, and reading `additionalEmails` as a `Record` no longer compiles. This is the assertion that would have caught the original bug from the consumer side, not just in the generated text.
- a runtime round trip through the generated bundle: a query with nested composite selections and a mutation whose `additionalEmails` array reaches the request body as a JSON array, both pinned to their exact operation strings and variables

**`client-generation-pipeline.test.ts`** covers the rest of the pipeline: `generateMetadataClient` (Upload → File, metadata endpoint wrapper, output dir emptied between runs), `replaceCoreClient` (generated sources land in `dist/generated-core`, the packaged `core.mjs` stub is replaced by an importable client), and a failing generation rejecting without leaving its `.tmp` directory behind.

**`composite-field-type-overrides.test.ts`** becomes unit tests of `applyCompositeFieldTypeOverrides` (nullability wrapping preserved, unrelated same-named types untouched, absent composites skipped, drift and unbalanced braces throwing) now that the end-to-end assertions live in the workspace test.

Also renames `findMatchingBrace` to `findMatchingBraceOrThrow`, the one open nit left on #24869.

## The CI gap (second commit)

While checking CI on this PR I noticed `sdk-test` was skipped: `ci-sdk.yaml` gates on `packages/twenty-sdk/**` and `packages/twenty-server/**`, so a client-sdk-only change skips the job, and its matrix runs `test:unit`, a target `twenty-client-sdk` did not declare. The package's whole vitest suite (the tests from #24869 included) was therefore never executed by CI.

The second commit adds the client-sdk paths to the gate and a `test:unit` target mirroring `twenty-sdk`'s, so the `scope:sdk` affected run picks the suite up. Side effect worth calling out: client-sdk-only PRs now also run `sdk-e2e-test`, which is arguably right (`twenty-sdk` depends on `twenty-client-sdk` and its CLI drives `replaceCoreClient`), but it is a cost — happy to drop that commit if you would rather gate the two jobs separately.

## Test

`npx nx test twenty-client-sdk` — 65 tests green (was 45). Lint and typecheck clean.

Ran the exact CI command for the four `sdk-test` matrix tasks locally (`nx affected -t=<task> --exclude="*,!tag:scope:sdk"`): lint, typecheck, `test:unit` (96 files / 652 tests across twenty-sdk and twenty-client-sdk) and `test:integration` all green.

Checked the new tests fail for the right reason: dropping the `applyCompositeFieldTypeOverrides` call from `generate-core-client.ts` turns 7 of them red, including all four type-level contract cases.