### PR TITLE
docs: explain Ask AI sidebar navigation

### DIFF
--- a/packages/twenty-docs/user-guide/layout/capabilities/navigation.mdx
+++ b/packages/twenty-docs/user-guide/layout/capabilities/navigation.mdx
@@ -11,6 +11,14 @@ On desktop, click the collapse button at the top of the sidebar to make more roo
 
 You can also open the command menu with `Cmd+K` (Mac) or `Ctrl+K` (Windows), search for **sidebar**, and choose **Collapse sidebar** or **Expand sidebar**. The command reflects the sidebar's current state and closes the command menu after you select it.
 
+## Ask AI
+
+<!-- AI chat navigation from MainNavigationDrawerTabsRow.tsx and useOpenAiChatPage.ts -->
+
+If you have AI permission, the top of the sidebar lets you switch between
+workspace navigation and chat history. Choose **New chat** to open Ask AI as a
+full page.
+
 ## Reordering items
 
 The order of items in the **Workspace** section is shared across the workspace. With the **Layouts** permission, hover over **Workspace** and click the wrench icon to enter sidebar customization mode. Drag and drop items to change their positions, then save your changes.
@@ -43,4 +51,7 @@ Press `Cmd+K` (or `Ctrl+K`) to open the command menu — a quick-access search b
 
 To customize the sidebar, hover over the "Workspace" section in the sidebar and click the wrench icon.
 
-<img src="/images/user-guide/layout/navigation-edit-icon.png" alt="Sidebar customization icon" />
+<img
+  src="/images/user-guide/layout/navigation-edit-icon.png"
+  alt="Sidebar customization icon"
+/>


### PR DESCRIPTION
## Summary

- document the AI-permission-gated sidebar chat controls
- clarify that **New chat** opens Ask AI as a full page
- add a symbolic source reference for future documentation audits

## Validation

- `npx prettier@3.6.2 --check packages/twenty-docs/user-guide/layout/capabilities/navigation.mdx`
- verified the documented controls against `MainNavigationDrawerTabsRow.tsx` and `useOpenAiChatPage.ts`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

