### PR TITLE
Stop caching the partners API response

### DIFF
--- a/packages/twenty-website/src/partners-marketplace/fetch-live-partner-profile.ts
+++ b/packages/twenty-website/src/partners-marketplace/fetch-live-partner-profile.ts
@@ -78,7 +78,6 @@ export async function fetchLivePartnerProfile(
   try {
     const data = (await partnersApiFetch(
       `/s/partner-by-slug?slug=${encodeURIComponent(slug)}`,
-      { cache: 'no-store' },
     )) as ApiProfileResponse;
 
     if (!data.ok || !('partner' in data)) {

--- a/packages/twenty-website/src/partners-marketplace/partners-api-fetch.ts
+++ b/packages/twenty-website/src/partners-marketplace/partners-api-fetch.ts
@@ -1,17 +1,9 @@
-// Authed GET against the Twenty partners API, cached at the fetch layer (the
-// house pattern — no unstable_cache wrapper). Env-gated: throws when the env is
+// Authed GET against the Twenty partners API. Env-gated: throws when the env is
 // missing so the seam's catch can fall back to [] cleanly.
-const REVALIDATE_SECONDS = 300;
-
-type PartnersApiFetchOptions = {
-  /** Profile pages are force-dynamic; skip the Data Cache so edits show immediately. */
-  cache?: RequestCache;
-};
-
-export async function partnersApiFetch(
-  path: string,
-  options: PartnersApiFetchOptions = {},
-): Promise<unknown> {
+//
+// Never cached. Every payload embeds file URLs signed with a token that expires
+// in 24h, so a Data Cache entry outliving its tokens serves a page of 403s.
+export async function partnersApiFetch(path: string): Promise<unknown> {
   const baseUrl = process.env.TWENTY_PARTNERS_API_URL;
   const apiKey = process.env.TWENTY_PARTNERS_API_KEY;
   if (baseUrl === undefined || apiKey === undefined) {
@@ -23,9 +15,7 @@ export async function partnersApiFetch(
       Accept: 'application/json',
       Authorization: `Bearer ${apiKey}`,
     },
-    ...(options.cache === 'no-store'
-      ? { cache: 'no-store' as const }
-      : { next: { revalidate: REVALIDATE_SECONDS } }),
+    cache: 'no-store',
   });
 
   if (!response.ok) {


### PR DESCRIPTION
The partners API embeds file URLs signed with a token that expires in 24h. The directory list went through the Next Data Cache, and its entry on prod had been frozen since 2026-08-27 07:49 UTC, so every partner logo on /partners was returning a 403 from FileByIdGuard.

Profile pages already opted out with cache: 'no-store'. Drop the caching branch entirely instead of adding a second opt-out: no partners payload can safely outlive its tokens, so there is no case left where the Data Cache is correct.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

