### PR TITLE
fix(ai): refresh the default model lists for self-hosted instances

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/load-default-model-preferences.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/load-default-model-preferences.util.ts
@@ -1,30 +1,34 @@
-// TODO: derive default model preferences dynamically from the catalog
-// instead of hardcoding model IDs that become stale as models evolve
+// These lists are resolved by taking the first model that is actually
+// available, meaning the one whose provider the instance holds a key for. They
+// are therefore a preference chain across providers, not a shortlist: every
+// supported provider needs an entry, or an instance configured with only that
+// provider resolves to nothing and shows an empty model picker.
 import { type AiModelPreferences } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-preferences.type';
 
 export const DEFAULT_FAST_MODELS = [
-  'openai/gpt-5-mini',
-  'anthropic/claude-haiku-4-5-20251001',
-  'google/gemini-3-flash-preview',
-  'xai/grok-4-1-fast',
+  'openai/gpt-5.6-luna',
+  'anthropic/claude-sonnet-5',
+  'google/gemini-3.7-flash',
+  'xai/grok-4.3',
   'mistral/mistral-large-latest',
 ];
 
 export const DEFAULT_SMART_MODELS = [
-  'openai/gpt-5.2',
-  'anthropic/claude-sonnet-4-6',
+  'openai/gpt-5.6-sol',
+  'anthropic/claude-opus-5',
   'google/gemini-3.1-pro-preview',
-  'xai/grok-4',
+  'xai/grok-4.6',
   'mistral/mistral-large-latest',
 ];
 
 export const DEFAULT_RECOMMENDED_MODELS = [
-  'openai/gpt-5.2',
-  'openai/gpt-4.1',
-  'anthropic/claude-opus-4-6',
-  'anthropic/claude-sonnet-4-6',
+  'openai/gpt-5.6-luna',
+  'openai/gpt-5.6-sol',
+  'anthropic/claude-sonnet-5',
+  'anthropic/claude-opus-5',
   'google/gemini-3.1-pro-preview',
-  'xai/grok-4',
+  'xai/grok-4.6',
+  'mistral/mistral-large-latest',
 ];
 
 export const DEFAULT_DISABLED_MODELS: string[] = [];

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/load-default-model-preferences.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/load-default-model-preferences.util.ts
@@ -1,3 +1,6 @@
+// TODO: derive default model preferences dynamically from the catalog
+// instead of hardcoding model IDs that become stale as models evolve
+//
 // These lists are resolved by taking the first model that is actually
 // available, meaning the one whose provider the instance holds a key for. They
 // are therefore a preference chain across providers, not a shortlist: every


### PR DESCRIPTION
## The problem

`ai-providers.json` is regenerated from models.dev daily and automerged, so a self-hosted instance's **catalog** stays current. The lists pointing into it are hardcoded in `load-default-model-preferences.util.ts`, so they don't — and they've drifted.

**Two entries no longer resolve at all.** `xai/grok-4` and `xai/grok-4-1-fast` are absent from the generated catalog. An instance holding only an xAI key falls through them.

**The rest are behind.** An instance with an OpenAI key resolves:

| role | resolves to today | available in the same catalog |
| --- | --- | --- |
| fast | `gpt-5-mini` — $0.25/$2 | `gpt-5.6-luna` — **$0.2/$1.2** |
| smart | `gpt-5.2` | `gpt-5.6-sol` |

Luna is newer, cheaper on both axes, and better. Self-hosters are getting a worse *and* more expensive default than what already sits in their catalog.

## The change

Every entry is now the current model from its provider — cheapest that can hold a tool-calling conversation for `fast`, the provider's frontier for `smart`:

| | fast | smart |
| --- | --- | --- |
| openai | `gpt-5.6-luna` | `gpt-5.6-sol` |
| anthropic | `claude-sonnet-5` | `claude-opus-5` |
| google | `gemini-3.7-flash` | `gemini-3.1-pro-preview` |
| xai | `grok-4.3` | `grok-4.6` |
| mistral | `mistral-large-latest` | `mistral-large-latest` |

Anthropic's fast entry moves from Haiku to Sonnet 5. Haiku is cheaper but doesn't reliably hold the agent's tool-calling turns — and picking on price alone is what these lists exist to prevent.

## Why the recommended list got longer, not shorter

It now spans all five providers (7 entries). That's deliberate and worth understanding before trimming it:

`useWorkspaceAiModelAvailability` filters the recommended list to models the instance can actually reach. An instance with a single provider key therefore sees an **empty picker** unless that provider appears in the list. A hosted picker can be a tight shortlist because every key is present; a self-hosted one cannot.

Dropped: `gpt-4.1`, `claude-opus-4-6`, `claude-sonnet-4-6` — all superseded by entries already in the list.

## Note

The resolution order is unchanged: `getFirstAvailableModelFromList` takes the first entry whose provider is configured, so this only changes *which* model each provider contributes.

`fast` and `smart` are kept as distinct tiers here. Twenty Cloud recently collapsed them (both resolve to Luna) on the grounds that a Luna-class model is good enough for the chat; the same argument would apply here, but that's a product call rather than a staleness fix, so it's left alone.

## Test plan

- [x] Every id verified present and not deprecated in `ai-providers.json`
- [x] All five providers represented in fast, smart and recommended
- [x] `tsgo --noEmit` clean, Prettier clean
- [ ] Confirm on a single-provider instance that the picker is non-empty and the default resolves as expected

https://claude.ai/code/session_01Qr97dXdyZGXsMVMMPzB8oH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qr97dXdyZGXsMVMMPzB8oH)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

