### PR TITLE
Read the agent suites' model ids from the recommended list

### DIFF
--- a/packages/twenty-server/test/integration/ai/suites/workflow-agent-role-assignment-persistence.integration-spec.ts
+++ b/packages/twenty-server/test/integration/ai/suites/workflow-agent-role-assignment-persistence.integration-spec.ts
@@ -1,3 +1,4 @@
+import { TEST_AI_MODEL_ID } from 'test/integration/constants/test-ai-model-ids.constants';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { type Repository } from 'typeorm';
@@ -41,7 +42,7 @@ describe('Workflow agent role assignment persistence (integration)', () => {
       input: {
         label: 'Role-Assigned Workflow Agent',
         prompt: 'Test prompt',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
         roleId,
       },
     });
@@ -53,7 +54,7 @@ describe('Workflow agent role assignment persistence (integration)', () => {
       input: {
         label: 'Roleless Workflow Agent',
         prompt: 'Test prompt',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 

--- a/packages/twenty-server/test/integration/constants/test-ai-model-ids.constants.ts
+++ b/packages/twenty-server/test/integration/constants/test-ai-model-ids.constants.ts
@@ -1,0 +1,9 @@
+import { DEFAULT_RECOMMENDED_MODELS } from 'src/engine/metadata-modules/ai/ai-models/utils/load-default-model-preferences.util';
+
+// Workspaces default to useRecommendedModels, so an agent can only be created
+// with a model from this list. Reading the ids from it rather than naming them
+// keeps these suites working when the list is refreshed against the models.dev
+// catalog — that refresh lands on a daily automerge, and the previous
+// hardcoded openai/gpt-4.1 broke every agent suite when it dropped out.
+export const [TEST_AI_MODEL_ID, TEST_AI_OTHER_MODEL_ID] =
+  DEFAULT_RECOMMENDED_MODELS;

--- a/packages/twenty-server/test/integration/constants/test-ai-model-ids.constants.ts
+++ b/packages/twenty-server/test/integration/constants/test-ai-model-ids.constants.ts
@@ -7,3 +7,16 @@ import { DEFAULT_RECOMMENDED_MODELS } from 'src/engine/metadata-modules/ai/ai-mo
 // hardcoded openai/gpt-4.1 broke every agent suite when it dropped out.
 export const [TEST_AI_MODEL_ID, TEST_AI_OTHER_MODEL_ID] =
   DEFAULT_RECOMMENDED_MODELS;
+
+// Two distinct ids are load-bearing: the update suites assert a transition from
+// one model to another, and would pass without testing anything if both were
+// the same. Fail at import rather than let a future list shape silently empty
+// those assertions out.
+if (
+  DEFAULT_RECOMMENDED_MODELS.length < 2 ||
+  TEST_AI_MODEL_ID === TEST_AI_OTHER_MODEL_ID
+) {
+  throw new Error(
+    'The agent integration suites need two distinct recommended models: one to create an agent with and one to update it to. DEFAULT_RECOMMENDED_MODELS no longer provides two different ids.',
+  );
+}

--- a/packages/twenty-server/test/integration/metadata/suites/agent/failing-agent-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/agent/failing-agent-creation.integration-spec.ts
@@ -1,3 +1,4 @@
+import { TEST_AI_MODEL_ID } from 'test/integration/constants/test-ai-model-ids.constants';
 import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
 import { createOneAgent } from 'test/integration/metadata/suites/agent/utils/create-one-agent.util';
 import { deleteOneAgent } from 'test/integration/metadata/suites/agent/utils/delete-one-agent.util';
@@ -32,7 +33,7 @@ describe('Agent creation should fail', () => {
       input: {
         label: globalTestContext.existingAgentLabel,
         prompt: 'Existing agent for testing',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 
@@ -54,7 +55,7 @@ describe('Agent creation should fail', () => {
       context: {
         input: {
           prompt: 'Test prompt',
-          modelId: 'openai/gpt-4.1',
+          modelId: TEST_AI_MODEL_ID,
         } as CreateAgentInput,
       },
     },
@@ -63,7 +64,7 @@ describe('Agent creation should fail', () => {
       context: {
         input: {
           label: 'Test Agent Missing Prompt',
-          modelId: 'openai/gpt-4.1',
+          modelId: TEST_AI_MODEL_ID,
         } as CreateAgentInput,
       },
     },
@@ -82,7 +83,7 @@ describe('Agent creation should fail', () => {
         input: {
           label: '',
           prompt: 'Test prompt',
-          modelId: 'openai/gpt-4.1',
+          modelId: TEST_AI_MODEL_ID,
         },
       },
     },
@@ -92,7 +93,7 @@ describe('Agent creation should fail', () => {
         input: {
           label: 'Empty Prompt Agent',
           prompt: '',
-          modelId: 'openai/gpt-4.1',
+          modelId: TEST_AI_MODEL_ID,
         },
       },
     },
@@ -112,7 +113,7 @@ describe('Agent creation should fail', () => {
         input: {
           label: globalTestContext.existingAgentLabel,
           prompt: 'Duplicate agent',
-          modelId: 'openai/gpt-4.1',
+          modelId: TEST_AI_MODEL_ID,
         },
       },
     },
@@ -122,7 +123,7 @@ describe('Agent creation should fail', () => {
         input: {
           label: 'Invalid Response Format Agent',
           prompt: 'Test prompt',
-          modelId: 'openai/gpt-4.1',
+          modelId: TEST_AI_MODEL_ID,
           responseFormat: {
             type: 'invalid',
           } as any,
@@ -135,7 +136,7 @@ describe('Agent creation should fail', () => {
         input: {
           label: 'JSON Without Schema Agent',
           prompt: 'Test prompt',
-          modelId: 'openai/gpt-4.1',
+          modelId: TEST_AI_MODEL_ID,
           responseFormat: {
             type: 'json',
           } as any,
@@ -148,7 +149,7 @@ describe('Agent creation should fail', () => {
         input: {
           label: 'Text With Schema Agent',
           prompt: 'Test prompt',
-          modelId: 'openai/gpt-4.1',
+          modelId: TEST_AI_MODEL_ID,
           responseFormat: {
             type: 'text',
             schema: { type: 'object' },

--- a/packages/twenty-server/test/integration/metadata/suites/agent/failing-agent-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/agent/failing-agent-update.integration-spec.ts
@@ -1,3 +1,4 @@
+import { TEST_AI_MODEL_ID } from 'test/integration/constants/test-ai-model-ids.constants';
 import { faker } from '@faker-js/faker';
 import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
 import { createOneAgent } from 'test/integration/metadata/suites/agent/utils/create-one-agent.util';
@@ -40,7 +41,7 @@ describe('Agent update should fail', () => {
       input: {
         label: globalTestContext.existingAgentLabelForDuplicate,
         prompt: 'Existing agent for duplicate test',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 
@@ -55,7 +56,7 @@ describe('Agent update should fail', () => {
         description: 'Original description',
         icon: 'IconRobot',
         prompt: 'Original prompt',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 

--- a/packages/twenty-server/test/integration/metadata/suites/agent/successful-agent-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/agent/successful-agent-creation.integration-spec.ts
@@ -1,3 +1,7 @@
+import {
+  TEST_AI_MODEL_ID,
+  TEST_AI_OTHER_MODEL_ID,
+} from 'test/integration/constants/test-ai-model-ids.constants';
 import { createOneAgent } from 'test/integration/metadata/suites/agent/utils/create-one-agent.util';
 import { deleteOneAgent } from 'test/integration/metadata/suites/agent/utils/delete-one-agent.util';
 import { createOneRole } from 'test/integration/metadata/suites/role/utils/create-one-role.util';
@@ -23,7 +27,7 @@ describe('Agent creation should succeed', () => {
       input: {
         label: 'Test Agent',
         prompt: 'You are a helpful test assistant',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 
@@ -36,7 +40,7 @@ describe('Agent creation should succeed', () => {
       icon: null,
       description: null,
       prompt: 'You are a helpful test assistant',
-      modelId: 'openai/gpt-4.1',
+      modelId: TEST_AI_MODEL_ID,
       responseFormat: { type: 'text' },
       roleId: null,
       isCustom: true,
@@ -52,7 +56,7 @@ describe('Agent creation should succeed', () => {
       icon: 'IconRobot',
       description: 'A custom agent with all fields specified',
       prompt: 'You are a specialized assistant for testing',
-      modelId: 'openai/gpt-5.2',
+      modelId: TEST_AI_OTHER_MODEL_ID,
       responseFormat: { type: 'text' },
       modelConfiguration: {
         webSearch: {
@@ -88,7 +92,7 @@ describe('Agent creation should succeed', () => {
       input: {
         label: 'JSON Response Agent',
         prompt: 'Return structured JSON data',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
         responseFormat: {
           type: 'json',
           schema: {
@@ -127,7 +131,7 @@ describe('Agent creation should succeed', () => {
       input: {
         label: 'My Test Agent With Spaces',
         prompt: 'Testing name computation',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 
@@ -149,7 +153,7 @@ describe('Agent creation should succeed', () => {
         icon: '  IconRobot  ',
         description: '  Description with spaces  ',
         prompt: '  Prompt with spaces  ',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 
@@ -190,7 +194,7 @@ describe('Agent creation should succeed', () => {
       input: {
         label: 'Agent With Role',
         prompt: 'Agent with role assignment',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
         roleId: createdRoleId,
       },
     });
@@ -201,7 +205,7 @@ describe('Agent creation should succeed', () => {
       id: expect.any(String),
       label: 'Agent With Role',
       prompt: 'Agent with role assignment',
-      modelId: 'openai/gpt-4.1',
+      modelId: TEST_AI_MODEL_ID,
       roleId: createdRoleId,
       isCustom: true,
     });

--- a/packages/twenty-server/test/integration/metadata/suites/agent/successful-agent-deletion.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/agent/successful-agent-deletion.integration-spec.ts
@@ -1,3 +1,4 @@
+import { TEST_AI_MODEL_ID } from 'test/integration/constants/test-ai-model-ids.constants';
 import { createOneAgent } from 'test/integration/metadata/suites/agent/utils/create-one-agent.util';
 import { deleteOneAgent } from 'test/integration/metadata/suites/agent/utils/delete-one-agent.util';
 import { findOneAgent } from 'test/integration/metadata/suites/agent/utils/find-one-agent.util';
@@ -9,7 +10,7 @@ describe('Agent deletion should succeed', () => {
       input: {
         label: 'Agent To Delete',
         prompt: 'This agent will be deleted',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 

--- a/packages/twenty-server/test/integration/metadata/suites/agent/successful-agent-role-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/agent/successful-agent-role-update.integration-spec.ts
@@ -1,3 +1,4 @@
+import { TEST_AI_MODEL_ID } from 'test/integration/constants/test-ai-model-ids.constants';
 import { createOneAgent } from 'test/integration/metadata/suites/agent/utils/create-one-agent.util';
 import { deleteOneAgent } from 'test/integration/metadata/suites/agent/utils/delete-one-agent.util';
 import { updateOneAgent } from 'test/integration/metadata/suites/agent/utils/update-one-agent.util';
@@ -74,7 +75,7 @@ describe('Agent role update should succeed', () => {
       input: {
         label: 'Agent Without Role',
         prompt: 'Test prompt',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
       },
     });
 
@@ -103,7 +104,7 @@ describe('Agent role update should succeed', () => {
       input: {
         label: 'Agent With Initial Role',
         prompt: 'Test prompt',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
         roleId: testRoleId,
       },
     });
@@ -133,7 +134,7 @@ describe('Agent role update should succeed', () => {
       input: {
         label: 'Agent With Role To Remove',
         prompt: 'Test prompt',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
         roleId: testRoleId,
       },
     });

--- a/packages/twenty-server/test/integration/metadata/suites/agent/successful-agent-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/agent/successful-agent-update.integration-spec.ts
@@ -1,3 +1,7 @@
+import {
+  TEST_AI_MODEL_ID,
+  TEST_AI_OTHER_MODEL_ID,
+} from 'test/integration/constants/test-ai-model-ids.constants';
 import { DEFAULT_TOOL_INPUT_SCHEMA } from 'twenty-shared/logic-function';
 import { type AgentResponseSchema } from 'twenty-shared/ai';
 import { createOneAgent } from 'test/integration/metadata/suites/agent/utils/create-one-agent.util';
@@ -15,7 +19,7 @@ describe('Agent update should succeed', () => {
         description: 'Original description',
         icon: 'IconRobot',
         prompt: 'Original prompt',
-        modelId: 'openai/gpt-4.1',
+        modelId: TEST_AI_MODEL_ID,
         responseFormat: { type: 'text' },
         evaluationInputs: ['input 1'],
       },
@@ -100,13 +104,13 @@ describe('Agent update should succeed', () => {
       expectToFail: false,
       input: {
         id: testAgentId,
-        modelId: 'openai/gpt-5.2',
+        modelId: TEST_AI_OTHER_MODEL_ID,
       },
     });
 
     expect(data.updateOneAgent).toMatchObject({
       id: testAgentId,
-      modelId: 'openai/gpt-5.2',
+      modelId: TEST_AI_OTHER_MODEL_ID,
     });
   });
 
@@ -226,7 +230,7 @@ describe('Agent update should succeed', () => {
         description: 'Updated multiple fields',
         icon: 'IconBrain',
         prompt: 'New comprehensive prompt',
-        modelId: 'openai/gpt-5.2',
+        modelId: TEST_AI_OTHER_MODEL_ID,
         responseFormat: {
           type: 'json',
           schema: DEFAULT_TOOL_INPUT_SCHEMA as AgentResponseSchema,
@@ -241,7 +245,7 @@ describe('Agent update should succeed', () => {
       description: 'Updated multiple fields',
       icon: 'IconBrain',
       prompt: 'New comprehensive prompt',
-      modelId: 'openai/gpt-5.2',
+      modelId: TEST_AI_OTHER_MODEL_ID,
       responseFormat: {
         type: 'json',
         schema: { type: 'object' },


### PR DESCRIPTION
## The problem

`main` is red, and so is every open PR — CI builds `refs/pull/N/merge`, so they all inherit it.

Six `server-integration-test` shards fail with:

```
"message": "The selected model is not available in this workspace.",
"subCode": "AGENT_EXECUTION_FAILED"
```

Workspaces default to `useRecommendedModels` (the column's DB default is `true`), so `isModelAllowedByWorkspace` reduces to `recommendedModelIds.has(modelId)`. The agent suites hardcoded `openai/gpt-4.1` and `openai/gpt-5.2`, and `c77378bb` (#25022) dropped both from `DEFAULT_RECOMMENDED_MODELS` while refreshing the lists against the models.dev catalog. Nothing is wrong with #25022 — the specs were relying on ids it had no reason to preserve.

## The fix

The ids now come from `DEFAULT_RECOMMENDED_MODELS` instead of being named:

```ts
export const [TEST_AI_MODEL_ID, TEST_AI_OTHER_MODEL_ID] =
  DEFAULT_RECOMMENDED_MODELS;
```

Two are exported because the update suites assert a change *from* one model *to* another.

This is deliberately not a swap of one literal for another. `ai-providers.json` is regenerated from models.dev daily and automerged, and the lists that point into it get refreshed to match — so a literal here is a recurring breakage, not a one-off. `load-default-model-preferences.util.ts` already carries a `TODO: derive default model preferences dynamically from the catalog instead of hardcoding model IDs that become stale as models evolve`; this is that idea applied on the test side, where it costs one destructure.

Seven specs updated: the six agent suites under `test/integration/metadata/suites/agent/` and `test/integration/ai/suites/workflow-agent-role-assignment-persistence.integration-spec.ts`. Deliberately-invalid values in the failing-path suites (`''`, `null`) are untouched.

## Scope

I swept for other ids #25022 removed. `xai/grok-4` matches only as a substring of `grok-4.6`/`grok-4.3`. Two unit specs mention old ids but pass their own inputs rather than reading the lists, and `server-test (1-4)` are green on a branch that already merges #25022, which confirms they are unaffected. One genuinely stale id sits in `clickhouse/seeds/fixtures.ts`, but that is seeded analytics data that never has to resolve, so it is left alone rather than widening this PR.

## Testing

`npx nx run twenty-server:test:integration:with-db-reset -- --testPathPattern "agent"` against this branch: **10 suites, 54 tests, all passing.**

For contrast, the same suites fail on any branch merged with current `main`. I also confirmed the inverse earlier: on a branch based on `ef0d7c15` (before #25022) the unmodified specs passed, isolating the cause to that commit.

`tsgo --noEmit`, `oxlint --type-aware` and `oxfmt --check` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jUY5hTR3zArbMkv2BDF3o)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

