### PR TITLE
feat(core): workspace SSO allowed email domain wildcard matcher

### DIFF
--- a/packages/twenty-server/src/utilities/domainMatcher.ts
+++ b/packages/twenty-server/src/utilities/domainMatcher.ts
@@ -1,0 +1,1 @@
+export function isDomainAllowed(email: string, domains: string[]): boolean { const domain = email.split('@')[1] || ''; return domains.some(d => d === '*' || d === domain || (d.startsWith('*.') && domain.endsWith(d.slice(2)))); }


### PR DESCRIPTION
## Summary

feat(core): workspace SSO allowed email domain wildcard matcher.

Tested and typed strictly with TypeScript.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

