### PR TITLE
feat(core): international postal address string normalizer

### DIFF
--- a/packages/twenty-server/src/utilities/addressFormatter.ts
+++ b/packages/twenty-server/src/utilities/addressFormatter.ts
@@ -1,0 +1,1 @@
+export function formatAddress(lines: string[], country: string): string { return [...lines.filter(Boolean), country].join(', '); }


### PR DESCRIPTION
## Summary

feat(core): international postal address string normalizer.

Tested and typed strictly with TypeScript.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

