### PR TITLE
fix(advanced-text-editor): handle null extensionManager in hasEditorExtension

### DIFF
--- a/packages/twenty-front/src/modules/advanced-text-editor/utils/__tests__/hasEditorExtension.test.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/utils/__tests__/hasEditorExtension.test.ts
@@ -23,4 +23,11 @@ describe('hasEditorExtension', () => {
     expect(hasEditorExtension(editor, 'italic')).toBe(false);
     expect(hasEditorExtension(editor, 'heading')).toBe(false);
   });
+
+  it('should return false safely when editor or extensionManager is null or undefined', () => {
+    expect(hasEditorExtension(null, 'heading')).toBe(false);
+    expect(hasEditorExtension(undefined, 'heading')).toBe(false);
+    expect(hasEditorExtension({ extensionManager: null } as any, 'heading')).toBe(false);
+    expect(hasEditorExtension({ extensionManager: { extensions: null } } as any, 'heading')).toBe(false);
+  });
 });

--- a/packages/twenty-front/src/modules/advanced-text-editor/utils/hasEditorExtension.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/utils/hasEditorExtension.ts
@@ -1,6 +1,9 @@
 import { type Editor } from '@tiptap/core';
 
-export const hasEditorExtension = (editor: Editor, extensionName: string) =>
-  editor.extensionManager.extensions.some(
+export const hasEditorExtension = (
+  editor: Editor | null | undefined,
+  extensionName: string,
+) =>
+  editor?.extensionManager?.extensions?.some(
     (extension) => extension.name === extensionName,
-  );
+  ) ?? false;


### PR DESCRIPTION
## Summary
Fixes #24976

Adds optional chaining and null-safe guards to \hasEditorExtension\ to prevent TypeError crashes during editor initialization before \extensionManager\ is loaded.

### Changes
- **\packages/twenty-front/src/modules/advanced-text-editor/utils/hasEditorExtension.ts\**: Uses optional chaining on \editor?.extensionManager?.extensions?.some(...)\ with a fallback to \alse\ for null or uninitialized editor instances.
- **\packages/twenty-front/src/modules/advanced-text-editor/utils/__tests__/hasEditorExtension.test.ts\**: Added unit test assertions covering null, undefined, and uninitialized editor states.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

