### PR TITLE
Grant credits to enrichment-qualified workspaces

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/company-enrichment/resolvers/__tests__/company-enrichment.resolver.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/company-enrichment/resolvers/__tests__/company-enrichment.resolver.spec.ts
@@ -13,6 +13,7 @@ describe('CompanyEnrichmentResolver', () => {
   let personEnrichmentService: { enrichPersonForWorkspaceCreator: jest.Mock };
   let onboardingService: {
     setOnboardingBookCallPendingIfQualified: jest.Mock;
+    creditEnrichmentQualificationReward: jest.Mock;
     isOnboardingBookCallPending: jest.Mock;
   };
 
@@ -30,6 +31,7 @@ describe('CompanyEnrichmentResolver', () => {
     };
     onboardingService = {
       setOnboardingBookCallPendingIfQualified: jest.fn(),
+      creditEnrichmentQualificationReward: jest.fn(),
       isOnboardingBookCallPending: jest.fn().mockResolvedValue(false),
     };
 
@@ -78,6 +80,27 @@ describe('CompanyEnrichmentResolver', () => {
     });
   });
 
+  it('should hand the enriched employee count to the credit reward on a match', async () => {
+    companyEnrichmentService.enrichCompanyForWorkspaceCreator.mockResolvedValue(
+      {
+        outcome: 'matched',
+        enrichment: { domain: 'acme.com', employeeCount: 320 },
+      },
+    );
+
+    await resolver.enrichWorkspaceCompany(user, workspace);
+
+    expect(
+      onboardingService.creditEnrichmentQualificationReward,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      onboardingService.creditEnrichmentQualificationReward,
+    ).toHaveBeenCalledWith({
+      workspaceId: workspace.id,
+      employeeCount: 320,
+    });
+  });
+
   it.each(['unavailable', 'transientError'])(
     'should not qualify for the book-call step on outcome %s',
     async (outcome) => {
@@ -89,6 +112,9 @@ describe('CompanyEnrichmentResolver', () => {
 
       expect(
         onboardingService.setOnboardingBookCallPendingIfQualified,
+      ).not.toHaveBeenCalled();
+      expect(
+        onboardingService.creditEnrichmentQualificationReward,
       ).not.toHaveBeenCalled();
     },
   );

--- a/packages/twenty-server/src/engine/core-modules/company-enrichment/resolvers/company-enrichment.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/company-enrichment/resolvers/company-enrichment.resolver.ts
@@ -49,8 +49,15 @@ export class CompanyEnrichmentResolver {
     ]);
 
     if (enrichmentResult.outcome === 'matched') {
+      // Two independent bars on the same enrichment: a company worth a demo and
+      // a company worth credits are not necessarily the same company.
       await this.onboardingService.setOnboardingBookCallPendingIfQualified({
         userId: user.id,
+        workspaceId: workspace.id,
+        employeeCount: enrichmentResult.enrichment.employeeCount,
+      });
+
+      await this.onboardingService.creditEnrichmentQualificationReward({
         workspaceId: workspace.id,
         employeeCount: enrichmentResult.enrichment.employeeCount,
       });

--- a/packages/twenty-server/src/engine/core-modules/onboarding/__tests__/onboarding.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/__tests__/onboarding.service.spec.ts
@@ -19,24 +19,27 @@ describe('OnboardingService', () => {
 
   const userId = 'user-id';
   const workspaceId = 'workspace-id';
-  const minEmployeeCount = 20;
-  const creditsReward = 5_000_000;
+  const creditTiers = {
+    midMarket: { minEmployeeCount: 20, amountMicro: 5_000_000 },
+  };
+
+  // The book-call step deliberately asks for a far bigger company than the
+  // credit reward, so the two bars cannot be confused for one another.
+  const bookCallMinEmployeeCount = 200;
 
   const configValues: Record<string, unknown> = {
     CALENDAR_BOOKING_PAGE_ID: 'team/twenty/talk-to-us',
-    ONBOARDING_BOOK_CALL_MIN_EMPLOYEE_COUNT: minEmployeeCount,
-    ONBOARDING_BOOK_CALL_QUALIFICATION_CREDITS_REWARD: creditsReward,
+    ONBOARDING_BOOK_CALL_MIN_EMPLOYEE_COUNT: bookCallMinEmployeeCount,
+    ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS: creditTiers,
   };
 
   const grantCredits = jest.fn();
   const setIfNotExists = jest.fn();
-  const setUserVar = jest.fn();
   const getConfig = jest.fn();
 
   beforeEach(async () => {
     grantCredits.mockResolvedValue(null);
     setIfNotExists.mockResolvedValue(true);
-    setUserVar.mockResolvedValue(undefined);
     getConfig.mockImplementation((key: string) => configValues[key]);
 
     const dataSource = {
@@ -54,7 +57,7 @@ describe('OnboardingService', () => {
           provide: UserVarsService,
           useValue: {
             get: jest.fn(),
-            set: setUserVar,
+            set: jest.fn(),
             delete: jest.fn(),
             setIfNotExists,
           },
@@ -77,80 +80,108 @@ describe('OnboardingService', () => {
     jest.resetAllMocks();
   });
 
-  describe('setOnboardingBookCallPendingIfQualified', () => {
-    it('grants the qualification reward once the workspace clears the employee-count bar', async () => {
-      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
-        { userId, workspaceId, employeeCount: minEmployeeCount },
-      );
+  describe('creditEnrichmentQualificationReward', () => {
+    it('grants the amount of the tier the enriched company lands in', async () => {
+      await service.creditEnrichmentQualificationReward({
+        workspaceId,
+        employeeCount: 20,
+      });
 
-      expect(hasQualified).toBe(true);
       expect(grantCredits).toHaveBeenCalledWith(
         expect.objectContaining({
           workspaceId,
-          amountMicro: creditsReward,
+          amountMicro: 5_000_000,
           type: BillingCreditGrantType.ONBOARDING_REWARD,
-          idempotencyKey: `onboarding-book-call-qualified:${workspaceId}`,
+          idempotencyKey: `onboarding-enrichment-qualified:${workspaceId}`,
         }),
       );
     });
 
-    it('grants nothing to a workspace below the employee-count bar', async () => {
-      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
-        { userId, workspaceId, employeeCount: minEmployeeCount - 1 },
-      );
+    it('grants nothing to a company below every tier', async () => {
+      await service.creditEnrichmentQualificationReward({
+        workspaceId,
+        employeeCount: 19,
+      });
 
-      expect(hasQualified).toBe(false);
       expect(grantCredits).not.toHaveBeenCalled();
     });
 
     it('grants nothing to a workspace enrichment could not match', async () => {
-      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
-        { userId, workspaceId, employeeCount: null },
-      );
+      await service.creditEnrichmentQualificationReward({
+        workspaceId,
+        employeeCount: null,
+      });
 
-      expect(hasQualified).toBe(false);
       expect(grantCredits).not.toHaveBeenCalled();
     });
 
-    it('grants nothing while the book-call step is unconfigured', async () => {
+    it('grants nothing while no tier is configured', async () => {
       getConfig.mockImplementation((key: string) =>
-        key === 'CALENDAR_BOOKING_PAGE_ID' ? undefined : configValues[key],
+        key === 'ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS'
+          ? {}
+          : configValues[key],
       );
 
-      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
-        { userId, workspaceId, employeeCount: minEmployeeCount },
-      );
+      await service.creditEnrichmentQualificationReward({
+        workspaceId,
+        employeeCount: 5000,
+      });
 
-      expect(hasQualified).toBe(false);
       expect(grantCredits).not.toHaveBeenCalled();
     });
 
-    it('grants nothing when another qualification already claimed the offer', async () => {
-      setIfNotExists.mockResolvedValue(false);
-
-      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
-        { userId, workspaceId, employeeCount: minEmployeeCount },
-      );
-
-      expect(hasQualified).toBe(false);
-      expect(grantCredits).not.toHaveBeenCalled();
-    });
-
-    it('still offers the call when granting the credits fails', async () => {
+    it('swallows a billing failure so enrichment still completes', async () => {
       grantCredits.mockRejectedValue(new Error('billing is down'));
 
-      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
-        { userId, workspaceId, employeeCount: minEmployeeCount },
+      await expect(
+        service.creditEnrichmentQualificationReward({
+          workspaceId,
+          employeeCount: 5000,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('grants credits even when the book-a-call step is switched off', async () => {
+      getConfig.mockImplementation((key: string) =>
+        key === 'CALENDAR_BOOKING_PAGE_ID' ||
+        key === 'ONBOARDING_BOOK_CALL_MIN_EMPLOYEE_COUNT'
+          ? undefined
+          : configValues[key],
       );
 
-      expect(hasQualified).toBe(true);
-      expect(setUserVar).toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: 'ONBOARDING_BOOK_CALL_PENDING',
-          value: true,
-        }),
-        expect.anything(),
+      await service.creditEnrichmentQualificationReward({
+        workspaceId,
+        employeeCount: 20,
+      });
+
+      expect(grantCredits).toHaveBeenCalledWith(
+        expect.objectContaining({ amountMicro: 5_000_000 }),
       );
+    });
+  });
+
+  describe('setOnboardingBookCallPendingIfQualified', () => {
+    it('offers the call without granting credits', async () => {
+      const hasQualified =
+        await service.setOnboardingBookCallPendingIfQualified({
+          userId,
+          workspaceId,
+          employeeCount: bookCallMinEmployeeCount,
+        });
+
+      expect(hasQualified).toBe(true);
+      expect(grantCredits).not.toHaveBeenCalled();
+    });
+
+    it('withholds the call from a company that only clears the credit tier', async () => {
+      const hasQualified =
+        await service.setOnboardingBookCallPendingIfQualified({
+          userId,
+          workspaceId,
+          employeeCount: 20,
+        });
+
+      expect(hasQualified).toBe(false);
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/onboarding/__tests__/onboarding.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/__tests__/onboarding.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
+
+import { type DataSource } from 'typeorm';
+
+import { BillingCreditGrantType } from 'src/engine/core-modules/billing/enums/billing-credit-grant-type.enum';
+import { BillingCreditService } from 'src/engine/core-modules/billing/services/billing-credit.service';
+import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { getQueueToken } from 'src/engine/core-modules/message-queue/utils/get-queue-token.util';
+import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { UserVarsService } from 'src/engine/core-modules/user/user-vars/services/user-vars.service';
+import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+
+describe('OnboardingService', () => {
+  let service: OnboardingService;
+
+  const userId = 'user-id';
+  const workspaceId = 'workspace-id';
+  const minEmployeeCount = 20;
+  const creditsReward = 5_000_000;
+
+  const configValues: Record<string, unknown> = {
+    CALENDAR_BOOKING_PAGE_ID: 'team/twenty/talk-to-us',
+    ONBOARDING_BOOK_CALL_MIN_EMPLOYEE_COUNT: minEmployeeCount,
+    ONBOARDING_BOOK_CALL_QUALIFICATION_CREDITS_REWARD: creditsReward,
+  };
+
+  const grantCredits = jest.fn();
+  const setIfNotExists = jest.fn();
+  const setUserVar = jest.fn();
+  const getConfig = jest.fn();
+
+  beforeEach(async () => {
+    grantCredits.mockResolvedValue(null);
+    setIfNotExists.mockResolvedValue(true);
+    setUserVar.mockResolvedValue(undefined);
+    getConfig.mockImplementation((key: string) => configValues[key]);
+
+    const dataSource = {
+      transaction: jest.fn((runInTransaction) =>
+        runInTransaction({ queryRunner: {} }),
+      ),
+    } as unknown as DataSource;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OnboardingService,
+        { provide: BillingService, useValue: { isBillingEnabled: jest.fn() } },
+        { provide: BillingCreditService, useValue: { grantCredits } },
+        {
+          provide: UserVarsService,
+          useValue: {
+            get: jest.fn(),
+            set: setUserVar,
+            delete: jest.fn(),
+            setIfNotExists,
+          },
+        },
+        { provide: TwentyConfigService, useValue: { get: getConfig } },
+        { provide: getRepositoryToken(WorkspaceEntity), useValue: {} },
+        { provide: getRepositoryToken(UserWorkspaceEntity), useValue: {} },
+        {
+          provide: getQueueToken(MessageQueue.workspaceQueue),
+          useValue: { add: jest.fn() },
+        },
+        { provide: getDataSourceToken(), useValue: dataSource },
+      ],
+    }).compile();
+
+    service = module.get<OnboardingService>(OnboardingService);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('setOnboardingBookCallPendingIfQualified', () => {
+    it('grants the qualification reward once the workspace clears the employee-count bar', async () => {
+      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
+        { userId, workspaceId, employeeCount: minEmployeeCount },
+      );
+
+      expect(hasQualified).toBe(true);
+      expect(grantCredits).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId,
+          amountMicro: creditsReward,
+          type: BillingCreditGrantType.ONBOARDING_REWARD,
+          idempotencyKey: `onboarding-book-call-qualified:${workspaceId}`,
+        }),
+      );
+    });
+
+    it('grants nothing to a workspace below the employee-count bar', async () => {
+      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
+        { userId, workspaceId, employeeCount: minEmployeeCount - 1 },
+      );
+
+      expect(hasQualified).toBe(false);
+      expect(grantCredits).not.toHaveBeenCalled();
+    });
+
+    it('grants nothing to a workspace enrichment could not match', async () => {
+      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
+        { userId, workspaceId, employeeCount: null },
+      );
+
+      expect(hasQualified).toBe(false);
+      expect(grantCredits).not.toHaveBeenCalled();
+    });
+
+    it('grants nothing while the book-call step is unconfigured', async () => {
+      getConfig.mockImplementation((key: string) =>
+        key === 'CALENDAR_BOOKING_PAGE_ID' ? undefined : configValues[key],
+      );
+
+      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
+        { userId, workspaceId, employeeCount: minEmployeeCount },
+      );
+
+      expect(hasQualified).toBe(false);
+      expect(grantCredits).not.toHaveBeenCalled();
+    });
+
+    it('grants nothing when another qualification already claimed the offer', async () => {
+      setIfNotExists.mockResolvedValue(false);
+
+      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
+        { userId, workspaceId, employeeCount: minEmployeeCount },
+      );
+
+      expect(hasQualified).toBe(false);
+      expect(grantCredits).not.toHaveBeenCalled();
+    });
+
+    it('still offers the call when granting the credits fails', async () => {
+      grantCredits.mockRejectedValue(new Error('billing is down'));
+
+      const hasQualified = await service.setOnboardingBookCallPendingIfQualified(
+        { userId, workspaceId, employeeCount: minEmployeeCount },
+      );
+
+      expect(hasQualified).toBe(true);
+      expect(setUserVar).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'ONBOARDING_BOOK_CALL_PENDING',
+          value: true,
+        }),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/onboarding/__tests__/onboarding.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/__tests__/onboarding.service.spec.ts
@@ -6,6 +6,7 @@ import { type DataSource } from 'typeorm';
 import { BillingCreditGrantType } from 'src/engine/core-modules/billing/enums/billing-credit-grant-type.enum';
 import { BillingCreditService } from 'src/engine/core-modules/billing/services/billing-credit.service';
 import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { getQueueToken } from 'src/engine/core-modules/message-queue/utils/get-queue-token.util';
 import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
@@ -34,6 +35,7 @@ describe('OnboardingService', () => {
   };
 
   const grantCredits = jest.fn();
+  const captureExceptions = jest.fn();
   const setIfNotExists = jest.fn();
   const getConfig = jest.fn();
 
@@ -53,6 +55,10 @@ describe('OnboardingService', () => {
         OnboardingService,
         { provide: BillingService, useValue: { isBillingEnabled: jest.fn() } },
         { provide: BillingCreditService, useValue: { grantCredits } },
+        {
+          provide: ExceptionHandlerService,
+          useValue: { captureExceptions },
+        },
         {
           provide: UserVarsService,
           useValue: {
@@ -87,6 +93,7 @@ describe('OnboardingService', () => {
         employeeCount: 20,
       });
 
+      expect(grantCredits).toHaveBeenCalledTimes(1);
       expect(grantCredits).toHaveBeenCalledWith(
         expect.objectContaining({
           workspaceId,
@@ -139,6 +146,47 @@ describe('OnboardingService', () => {
           employeeCount: 5000,
         }),
       ).resolves.toBeUndefined();
+    });
+
+    it('reports malformed tiers to Sentry and pays the well-formed ones', async () => {
+      getConfig.mockImplementation((key: string) =>
+        key === 'ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS'
+          ? { broken: { minEmployeeCount: 'twenty' }, ...creditTiers }
+          : configValues[key],
+      );
+
+      await service.creditEnrichmentQualificationReward({
+        workspaceId,
+        employeeCount: 20,
+      });
+
+      expect(captureExceptions).toHaveBeenCalledTimes(1);
+      expect(captureExceptions.mock.calls[0][0][0].message).toContain('broken');
+      expect(grantCredits).toHaveBeenCalledWith(
+        expect.objectContaining({ amountMicro: 5_000_000 }),
+      );
+    });
+
+    it('survives a tier config too malformed to even read, and reports it', async () => {
+      // The JSON config transformer throws rather than returning a value when
+      // the configured tiers are not a parseable object.
+      getConfig.mockImplementation((key: string) => {
+        if (key === 'ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS') {
+          throw new Error('Failed to parse JSON string');
+        }
+
+        return configValues[key];
+      });
+
+      await expect(
+        service.creditEnrichmentQualificationReward({
+          workspaceId,
+          employeeCount: 20,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(grantCredits).not.toHaveBeenCalled();
+      expect(captureExceptions).toHaveBeenCalledTimes(1);
     });
 
     it('grants credits even when the book-a-call step is switched off', async () => {

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -9,6 +9,7 @@ import { type DataSource, type QueryRunner, Repository } from 'typeorm';
 import { BillingCreditGrantType } from 'src/engine/core-modules/billing/enums/billing-credit-grant-type.enum';
 import { BillingCreditService } from 'src/engine/core-modules/billing/services/billing-credit.service';
 import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
@@ -59,6 +60,7 @@ export class OnboardingService {
   constructor(
     private readonly billingService: BillingService,
     private readonly billingCreditService: BillingCreditService,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
     private readonly userVarsService: UserVarsService<OnboardingKeyValueTypeMap>,
     private readonly twentyConfigService: TwentyConfigService,
     @InjectRepository(WorkspaceEntity)
@@ -863,18 +865,33 @@ export class OnboardingService {
     workspaceId: string;
     employeeCount: number | null;
   }) {
-    const amountMicro = getOnboardingEnrichmentCreditRewardMicro({
-      employeeCount,
-      tiers: this.twentyConfigService.get(
-        'ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS',
-      ),
-    });
-
-    if (!isDefined(amountMicro)) {
-      return;
-    }
-
+    // Reading the tiers throws on its own when the configured value is not a
+    // parseable JSON object, so it sits inside the guard with the grant: a
+    // reward nobody has configured correctly must not cost anyone their
+    // onboarding.
     try {
+      const { amountMicro, malformedTierKeys } =
+        getOnboardingEnrichmentCreditRewardMicro({
+          employeeCount,
+          tiers: this.twentyConfigService.get(
+            'ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS',
+          ),
+        });
+
+      if (malformedTierKeys.length > 0) {
+        // Dropping a malformed tier silently would under-pay every workspace
+        // that should have matched it, with nothing to notice it by.
+        this.exceptionHandlerService.captureExceptions([
+          new Error(
+            `Ignored malformed ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS entries: ${malformedTierKeys.join(', ')}`,
+          ),
+        ]);
+      }
+
+      if (!isDefined(amountMicro)) {
+        return;
+      }
+
       await this.billingCreditService.grantCredits({
         workspaceId,
         amountMicro,
@@ -891,6 +908,10 @@ export class OnboardingService {
         `Failed to credit onboarding enrichment qualification reward for workspace ${workspaceId}`,
         error,
       );
+
+      this.exceptionHandlerService.captureExceptions([error], {
+        workspace: { id: workspaceId },
+      });
     }
   }
 

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -25,6 +25,7 @@ import {
   OnboardingExceptionCode,
 } from 'src/engine/core-modules/onboarding/onboarding.exception';
 import { type ReversibleOnboardingStep } from 'src/engine/core-modules/onboarding/types/reversible-onboarding-step.type';
+import { getOnboardingEnrichmentCreditRewardMicro } from 'src/engine/core-modules/onboarding/utils/get-onboarding-enrichment-credit-reward-micro.util';
 import { readBookCallStepMinEmployeeCount } from 'src/engine/core-modules/onboarding/utils/read-book-call-step-min-employee-count.util';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { UserVarsService } from 'src/engine/core-modules/user/user-vars/services/user-vars.service';
@@ -855,6 +856,44 @@ export class OnboardingService {
     );
   }
 
+  async creditEnrichmentQualificationReward({
+    workspaceId,
+    employeeCount,
+  }: {
+    workspaceId: string;
+    employeeCount: number | null;
+  }) {
+    const amountMicro = getOnboardingEnrichmentCreditRewardMicro({
+      employeeCount,
+      tiers: this.twentyConfigService.get(
+        'ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS',
+      ),
+    });
+
+    if (!isDefined(amountMicro)) {
+      return;
+    }
+
+    try {
+      await this.billingCreditService.grantCredits({
+        workspaceId,
+        amountMicro,
+        type: BillingCreditGrantType.ONBOARDING_REWARD,
+        reason: 'Onboarding reward: enrichment-qualified workspace',
+        // The only gate on the reward, deliberately: it is keyed on the
+        // workspace rather than the enriching user so that a re-run of the
+        // enrichment, or a second member qualifying later, replays instead of
+        // topping up a balance the workspace already received.
+        idempotencyKey: `onboarding-enrichment-qualified:${workspaceId}`,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to credit onboarding enrichment qualification reward for workspace ${workspaceId}`,
+        error,
+      );
+    }
+  }
+
   async isOnboardingBookCallPending({
     userId,
     workspaceId,
@@ -1000,30 +1039,6 @@ export class OnboardingService {
       return false;
     }
 
-    const hasClaimedBookCallOffer = await this.claimBookCallOffer({
-      userId,
-      workspaceId,
-    });
-
-    if (!hasClaimedBookCallOffer) {
-      return false;
-    }
-
-    // Granted outside the claim transaction: grantCredits takes a Redis lock and
-    // writes on its own connection, so keeping it inside would hold the row lock
-    // across the lock wait without buying any rollback guarantee.
-    await this.creditBookCallQualificationReward({ workspaceId });
-
-    return true;
-  }
-
-  private async claimBookCallOffer({
-    userId,
-    workspaceId,
-  }: {
-    userId: string;
-    workspaceId: string;
-  }): Promise<boolean> {
     try {
       return await this.dataSource.transaction(async (entityManager) => {
         const { queryRunner } = entityManager;
@@ -1067,32 +1082,6 @@ export class OnboardingService {
       );
 
       return false;
-    }
-  }
-
-  private async creditBookCallQualificationReward({
-    workspaceId,
-  }: {
-    workspaceId: string;
-  }) {
-    try {
-      await this.billingCreditService.grantCredits({
-        workspaceId,
-        amountMicro: this.twentyConfigService.get(
-          'ONBOARDING_BOOK_CALL_QUALIFICATION_CREDITS_REWARD',
-        ),
-        type: BillingCreditGrantType.ONBOARDING_REWARD,
-        reason: 'Onboarding reward: enrichment-qualified workspace',
-        // Keyed on the workspace while the offer is claimed per user: credits are
-        // a workspace balance, so a second member qualifying later must not add
-        // another grant.
-        idempotencyKey: `onboarding-book-call-qualified:${workspaceId}`,
-      });
-    } catch (error) {
-      this.logger.error(
-        `Failed to credit onboarding book-call qualification reward for workspace ${workspaceId}`,
-        error,
-      );
     }
   }
 

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -1000,6 +1000,30 @@ export class OnboardingService {
       return false;
     }
 
+    const hasClaimedBookCallOffer = await this.claimBookCallOffer({
+      userId,
+      workspaceId,
+    });
+
+    if (!hasClaimedBookCallOffer) {
+      return false;
+    }
+
+    // Granted outside the claim transaction: grantCredits takes a Redis lock and
+    // writes on its own connection, so keeping it inside would hold the row lock
+    // across the lock wait without buying any rollback guarantee.
+    await this.creditBookCallQualificationReward({ workspaceId });
+
+    return true;
+  }
+
+  private async claimBookCallOffer({
+    userId,
+    workspaceId,
+  }: {
+    userId: string;
+    workspaceId: string;
+  }): Promise<boolean> {
     try {
       return await this.dataSource.transaction(async (entityManager) => {
         const { queryRunner } = entityManager;
@@ -1043,6 +1067,32 @@ export class OnboardingService {
       );
 
       return false;
+    }
+  }
+
+  private async creditBookCallQualificationReward({
+    workspaceId,
+  }: {
+    workspaceId: string;
+  }) {
+    try {
+      await this.billingCreditService.grantCredits({
+        workspaceId,
+        amountMicro: this.twentyConfigService.get(
+          'ONBOARDING_BOOK_CALL_QUALIFICATION_CREDITS_REWARD',
+        ),
+        type: BillingCreditGrantType.ONBOARDING_REWARD,
+        reason: 'Onboarding reward: enrichment-qualified workspace',
+        // Keyed on the workspace while the offer is claimed per user: credits are
+        // a workspace balance, so a second member qualifying later must not add
+        // another grant.
+        idempotencyKey: `onboarding-book-call-qualified:${workspaceId}`,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to credit onboarding book-call qualification reward for workspace ${workspaceId}`,
+        error,
+      );
     }
   }
 

--- a/packages/twenty-server/src/engine/core-modules/onboarding/types/onboarding-enrichment-credit-reward-tier.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/types/onboarding-enrichment-credit-reward-tier.type.ts
@@ -1,0 +1,8 @@
+// A band of enriched company data and what a workspace landing in it is worth.
+// Conditions are additive over time: a qualification score will join
+// minEmployeeCount here, and a tier missing the newer field keeps matching on
+// the conditions it does carry.
+export type OnboardingEnrichmentCreditRewardTier = {
+  minEmployeeCount: number;
+  amountMicro: number;
+};

--- a/packages/twenty-server/src/engine/core-modules/onboarding/utils/__tests__/get-onboarding-enrichment-credit-reward-micro.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/utils/__tests__/get-onboarding-enrichment-credit-reward-micro.util.spec.ts
@@ -1,0 +1,70 @@
+import { getOnboardingEnrichmentCreditRewardMicro } from 'src/engine/core-modules/onboarding/utils/get-onboarding-enrichment-credit-reward-micro.util';
+
+describe('getOnboardingEnrichmentCreditRewardMicro', () => {
+  const tiers = {
+    midMarket: { minEmployeeCount: 20, amountMicro: 5_000_000 },
+    enterprise: { minEmployeeCount: 200, amountMicro: 10_000_000 },
+  };
+
+  it('pays the tier an enriched company lands in', () => {
+    expect(
+      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: 20, tiers }),
+    ).toBe(5_000_000);
+  });
+
+  it('pays the most generous tier a company clears', () => {
+    expect(
+      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: 5000, tiers }),
+    ).toBe(10_000_000);
+  });
+
+  it('pays nothing below every tier', () => {
+    expect(
+      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: 19, tiers }),
+    ).toBeNull();
+  });
+
+  it('pays nothing when enrichment returned no employee count', () => {
+    expect(
+      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: null, tiers }),
+    ).toBeNull();
+  });
+
+  it('pays nothing while no tier is configured', () => {
+    expect(
+      getOnboardingEnrichmentCreditRewardMicro({
+        employeeCount: 5000,
+        tiers: {},
+      }),
+    ).toBeNull();
+    expect(
+      getOnboardingEnrichmentCreditRewardMicro({
+        employeeCount: 5000,
+        tiers: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it('pays every matched company when a tier asks for no minimum', () => {
+    expect(
+      getOnboardingEnrichmentCreditRewardMicro({
+        employeeCount: 1,
+        tiers: { anyCompany: { minEmployeeCount: 0, amountMicro: 5_000_000 } },
+      }),
+    ).toBe(5_000_000);
+  });
+
+  it('drops malformed tiers instead of reading them as a zero threshold', () => {
+    expect(
+      getOnboardingEnrichmentCreditRewardMicro({
+        employeeCount: 5000,
+        tiers: {
+          wordThreshold: { minEmployeeCount: 'twenty', amountMicro: 9_000_000 },
+          zeroAmount: { minEmployeeCount: 20, amountMicro: 0 },
+          missingThreshold: { amountMicro: 8_000_000 },
+          missingAmount: { minEmployeeCount: 20 },
+        } as never,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/onboarding/utils/__tests__/get-onboarding-enrichment-credit-reward-micro.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/utils/__tests__/get-onboarding-enrichment-credit-reward-micro.util.spec.ts
@@ -9,24 +9,27 @@ describe('getOnboardingEnrichmentCreditRewardMicro', () => {
   it('pays the tier an enriched company lands in', () => {
     expect(
       getOnboardingEnrichmentCreditRewardMicro({ employeeCount: 20, tiers }),
-    ).toBe(5_000_000);
+    ).toEqual({ amountMicro: 5_000_000, malformedTierKeys: [] });
   });
 
   it('pays the most generous tier a company clears', () => {
     expect(
-      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: 5000, tiers }),
+      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: 5000, tiers })
+        .amountMicro,
     ).toBe(10_000_000);
   });
 
   it('pays nothing below every tier', () => {
     expect(
-      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: 19, tiers }),
+      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: 19, tiers })
+        .amountMicro,
     ).toBeNull();
   });
 
   it('pays nothing when enrichment returned no employee count', () => {
     expect(
-      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: null, tiers }),
+      getOnboardingEnrichmentCreditRewardMicro({ employeeCount: null, tiers })
+        .amountMicro,
     ).toBeNull();
   });
 
@@ -35,13 +38,13 @@ describe('getOnboardingEnrichmentCreditRewardMicro', () => {
       getOnboardingEnrichmentCreditRewardMicro({
         employeeCount: 5000,
         tiers: {},
-      }),
+      }).amountMicro,
     ).toBeNull();
     expect(
       getOnboardingEnrichmentCreditRewardMicro({
         employeeCount: 5000,
         tiers: undefined,
-      }),
+      }).amountMicro,
     ).toBeNull();
   });
 
@@ -50,21 +53,60 @@ describe('getOnboardingEnrichmentCreditRewardMicro', () => {
       getOnboardingEnrichmentCreditRewardMicro({
         employeeCount: 1,
         tiers: { anyCompany: { minEmployeeCount: 0, amountMicro: 5_000_000 } },
-      }),
+      }).amountMicro,
     ).toBe(5_000_000);
   });
 
-  it('drops malformed tiers instead of reading them as a zero threshold', () => {
-    expect(
-      getOnboardingEnrichmentCreditRewardMicro({
-        employeeCount: 5000,
-        tiers: {
-          wordThreshold: { minEmployeeCount: 'twenty', amountMicro: 9_000_000 },
-          zeroAmount: { minEmployeeCount: 20, amountMicro: 0 },
-          missingThreshold: { amountMicro: 8_000_000 },
-          missingAmount: { minEmployeeCount: 20 },
-        } as never,
-      }),
-    ).toBeNull();
+  describe('malformed tiers', () => {
+    const malformedTiers = {
+      wordThreshold: { minEmployeeCount: 'twenty', amountMicro: 9_000_000 },
+      zeroAmount: { minEmployeeCount: 20, amountMicro: 0 },
+      missingThreshold: { amountMicro: 8_000_000 },
+      missingAmount: { minEmployeeCount: 20 },
+    } as never;
+
+    it('drops them instead of reading them as a zero threshold', () => {
+      expect(
+        getOnboardingEnrichmentCreditRewardMicro({
+          employeeCount: 5000,
+          tiers: malformedTiers,
+        }).amountMicro,
+      ).toBeNull();
+    });
+
+    it('names every dropped tier so the caller can report it', () => {
+      expect(
+        getOnboardingEnrichmentCreditRewardMicro({
+          employeeCount: 5000,
+          tiers: malformedTiers,
+        }).malformedTierKeys,
+      ).toEqual([
+        'wordThreshold',
+        'zeroAmount',
+        'missingThreshold',
+        'missingAmount',
+      ]);
+    });
+
+    it('still pays the tiers alongside them that are well formed', () => {
+      expect(
+        getOnboardingEnrichmentCreditRewardMicro({
+          employeeCount: 5000,
+          tiers: {
+            broken: { minEmployeeCount: 'twenty' },
+            midMarket: { minEmployeeCount: 20, amountMicro: 5_000_000 },
+          } as never,
+        }),
+      ).toEqual({ amountMicro: 5_000_000, malformedTierKeys: ['broken'] });
+    });
+
+    it('names them even for a company no tier would have matched', () => {
+      expect(
+        getOnboardingEnrichmentCreditRewardMicro({
+          employeeCount: null,
+          tiers: malformedTiers,
+        }).malformedTierKeys,
+      ).toHaveLength(4);
+    });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/onboarding/utils/get-onboarding-enrichment-credit-reward-micro.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/utils/get-onboarding-enrichment-credit-reward-micro.util.ts
@@ -17,20 +17,35 @@ export const getOnboardingEnrichmentCreditRewardMicro = ({
 }: {
   employeeCount: number | null;
   tiers: Record<string, OnboardingEnrichmentCreditRewardTier> | undefined;
-}): number | null => {
-  if (!isNumber(employeeCount) || !isDefined(tiers)) {
-    return null;
+}): { amountMicro: number | null; malformedTierKeys: string[] } => {
+  if (!isDefined(tiers)) {
+    return { amountMicro: null, malformedTierKeys: [] };
+  }
+
+  const entries = Object.entries(tiers);
+
+  // Reported whatever the employee count, so a mistyped tier surfaces on the
+  // first enrichment after the config change rather than waiting for a
+  // workspace that would have matched it.
+  const malformedTierKeys = entries
+    .filter(([, tier]) => !isUsableTier(tier))
+    .map(([key]) => key);
+
+  if (!isNumber(employeeCount)) {
+    return { amountMicro: null, malformedTierKeys };
   }
 
   // Tiers are keyed for legibility, not ordered, so every one is measured and
   // the most generous match is the one owed.
-  const matchedTiers = Object.values(tiers).filter(
-    (tier) => isUsableTier(tier) && employeeCount >= tier.minEmployeeCount,
-  );
+  const matchedAmounts = entries
+    .filter(
+      ([, tier]) =>
+        isUsableTier(tier) && employeeCount >= tier.minEmployeeCount,
+    )
+    .map(([, tier]) => tier.amountMicro);
 
-  if (matchedTiers.length === 0) {
-    return null;
-  }
-
-  return Math.max(...matchedTiers.map((tier) => tier.amountMicro));
+  return {
+    amountMicro: matchedAmounts.length > 0 ? Math.max(...matchedAmounts) : null,
+    malformedTierKeys,
+  };
 };

--- a/packages/twenty-server/src/engine/core-modules/onboarding/utils/get-onboarding-enrichment-credit-reward-micro.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/utils/get-onboarding-enrichment-credit-reward-micro.util.ts
@@ -1,0 +1,36 @@
+import { isNumber } from '@sniptt/guards';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type OnboardingEnrichmentCreditRewardTier } from 'src/engine/core-modules/onboarding/types/onboarding-enrichment-credit-reward-tier.type';
+
+// Tiers are hand-authored config, so a malformed entry must drop out rather
+// than coerce into a threshold of zero and pay every matched workspace.
+const isUsableTier = (tier: OnboardingEnrichmentCreditRewardTier): boolean =>
+  isNumber(tier?.minEmployeeCount) &&
+  tier.minEmployeeCount >= 0 &&
+  isNumber(tier?.amountMicro) &&
+  tier.amountMicro > 0;
+
+export const getOnboardingEnrichmentCreditRewardMicro = ({
+  employeeCount,
+  tiers,
+}: {
+  employeeCount: number | null;
+  tiers: Record<string, OnboardingEnrichmentCreditRewardTier> | undefined;
+}): number | null => {
+  if (!isNumber(employeeCount) || !isDefined(tiers)) {
+    return null;
+  }
+
+  // Tiers are keyed for legibility, not ordered, so every one is measured and
+  // the most generous match is the one owed.
+  const matchedTiers = Object.values(tiers).filter(
+    (tier) => isUsableTier(tier) && employeeCount >= tier.minEmployeeCount,
+  );
+
+  if (matchedTiers.length === 0) {
+    return null;
+  }
+
+  return Math.max(...matchedTiers.map((tier) => tier.amountMicro));
+};

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1080,6 +1080,7 @@ export class ConfigVariables {
     group: ConfigVariablesGroup.BILLING_CONFIG,
     description:
       'Credit reward tiers for workspaces enrichment matched to a real company, keyed by tier name, as {"midMarket":{"minEmployeeCount":20,"amountMicro":5000000}} (amounts in microCredits). The most generous matching tier wins; no tiers disables the reward. Independent of ONBOARDING_BOOK_CALL_MIN_EMPLOYEE_COUNT, so credits and the book-a-call offer can target different companies.',
+    isHiddenInAdminPanel: true,
     type: ConfigVariableType.JSON,
   })
   @IsOptional()

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -59,6 +59,7 @@ import {
   ConfigVariableException,
   ConfigVariableExceptionCode,
 } from 'src/engine/core-modules/twenty-config/twenty-config.exception';
+import { type OnboardingEnrichmentCreditRewardTier } from 'src/engine/core-modules/onboarding/types/onboarding-enrichment-credit-reward-tier.type';
 import { type AiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-providers-config.type';
 import {
   DEFAULT_DISABLED_MODELS,
@@ -1078,13 +1079,14 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.BILLING_CONFIG,
     description:
-      'Free credits granted when enrichment qualifies a workspace for the book-a-call onboarding step (in microCredits)',
-    type: ConfigVariableType.NUMBER,
+      'Credit reward tiers for workspaces enrichment matched to a real company, keyed by tier name, as {"midMarket":{"minEmployeeCount":20,"amountMicro":5000000}} (amounts in microCredits). The most generous matching tier wins; no tiers disables the reward. Independent of ONBOARDING_BOOK_CALL_MIN_EMPLOYEE_COUNT, so credits and the book-a-call offer can target different companies.',
+    type: ConfigVariableType.JSON,
   })
-  @CastToPositiveNumber()
-  @IsInt()
   @IsOptional()
-  ONBOARDING_BOOK_CALL_QUALIFICATION_CREDITS_REWARD = 5_000_000;
+  ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS: Record<
+    string,
+    OnboardingEnrichmentCreditRewardTier
+  > = {};
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1076,6 +1076,17 @@ export class ConfigVariables {
   ONBOARDING_INSTALL_APPS_CREDITS_REWARD_PER_APP = 500_000;
 
   @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.BILLING_CONFIG,
+    description:
+      'Free credits granted when enrichment qualifies a workspace for the book-a-call onboarding step (in microCredits)',
+    type: ConfigVariableType.NUMBER,
+  })
+  @CastToPositiveNumber()
+  @IsInt()
+  @IsOptional()
+  ONBOARDING_BOOK_CALL_QUALIFICATION_CREDITS_REWARD = 5_000_000;
+
+  @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description: 'Url for the frontend application',
     type: ConfigVariableType.STRING,


### PR DESCRIPTION
Workspaces that company enrichment matches to a real company now receive a credit grant during onboarding, so a prospect worth talking to starts their trial with room to explore.

## The bar

The grant reads the same enrichment as the book-a-call offer, but through its own threshold — a company worth credits and a company worth a demo are not necessarily the same company. Every condition is decided server side from enrichment data:

1. the enriching user is the workspace creator
2. their email domain is a work domain (`isWorkDomain` rejects free-mail and disposable providers)
3. People Data Labs matched that domain to a real company
4. the company clears a configured tier

Nothing on this path is client-reported, so a free-mail or unmatched signup cannot reach the grant.

## Configuration

`ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS` holds keyed tiers rather than a single amount, so what a qualified workspace is worth can vary by how well it qualifies:

```json
{
  "midMarket":  { "minEmployeeCount": 20,  "amountMicro": 5000000 },
  "enterprise": { "minEmployeeCount": 200, "amountMicro": 10000000 }
}
```

The most generous matching tier wins, which keeps tiers order-independent and leaves room for a qualification score to join `minEmployeeCount` as a second condition without disturbing the call sites. Tiers are keyed by name for legibility, following the `AI_PROVIDERS` precedent for JSON config — the JSON transformer validates with `IsObject()` and rejects arrays outright.

It defaults to no tiers, so an instance grants nothing until someone deliberately turns it on. Because the reward is independent of `ONBOARDING_BOOK_CALL_MIN_EMPLOYEE_COUNT` and `CALENDAR_BOOKING_PAGE_ID`, credits and the book-a-call offer can target different companies, and switching the offer off no longer silently stops the credits.

## Malformed configuration

Tiers are hand-authored, so the reward treats bad config as expected input rather than an invariant:

- A malformed **entry** (a non-numeric threshold, a missing or zero amount) drops out instead of reading as a threshold of zero and paying every matched workspace. The well-formed tiers alongside it still pay.
- A malformed **value** — one the JSON transformer cannot read as an object — makes the config read itself throw, so the read sits inside the same guard as the grant.

Either way onboarding continues, and either way it reaches Sentry: dropped tiers are captured by name, and a failed read is captured with the workspace. Silently dropping a tier would otherwise under-pay every workspace that should have matched it with nothing to notice it by.

## Notes for review

- The grant is keyed `onboarding-enrichment-qualified:${workspaceId}`, and that key is its only gate. Keyed on the workspace rather than the enriching user, so a re-run of the enrichment or a second member qualifying later replays instead of topping up a balance the workspace already received. `grantCredits` handles a replayed key by logging and repairing derived state, so this is safe rather than an error path.
- `grantCredits` no-ops when billing is disabled, so self-hosted instances are unaffected. The variable is also `isHiddenInAdminPanel`, matching `ONBOARDING_BOOK_CALL_MIN_EMPLOYEE_COUNT`, since it is meaningless without billing and enrichment.
- The book-a-call step is only reachable while the subscription is still incomplete, so these grants usually land before a billing period exists and take the existing 31-day provisional expiry rather than a period-end one.
- The grant is silent today — the workspace simply has a larger balance, and the reason shows in the admin panel. Surfacing it on the book-a-call screen would be a follow-up.
- `onboarding.service.ts` is additive only; the book-call path is unchanged.

## Testing

35 unit tests across 4 suites, including guards in both directions: credits are granted with the book-a-call step switched off entirely, and book-call qualification grants no credits. Tier selection is covered for the matched tier, the most generous match, below-threshold, unmatched enrichment, no configured tiers, a no-minimum tier, malformed entries alongside good ones, and a config read that throws.

`npx nx lint:diff-with-main twenty-server` and `npx tsgo -p tsconfig.json --noEmit` are clean for these files.