### PR TITLE
Register transcription models alongside language models

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/constants/ai-model-kinds.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/constants/ai-model-kinds.const.ts
@@ -1,0 +1,1 @@
+export const AI_MODEL_KINDS = ['language', 'transcription'] as const;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts
@@ -196,13 +196,23 @@ export class AiModelRegistryService {
     modelDef: AiProviderModelConfig;
     sdkInstance: AiSdkProviderInstance | undefined;
   }): void {
+    // An omitted price bills nothing while the provider still charges, so the
+    // model is refused rather than run for free. An explicit 0 is allowed.
+    if (!isDefined(modelDef.costPerMinute)) {
+      this.logger.error(
+        `Skipping transcription model "${compositeId}": costPerMinute is required`,
+      );
+
+      return;
+    }
+
     this.transcriptionConfigCache.set(compositeId, {
       modelId: compositeId,
       sdkPackage: config.npm,
       label: modelDef.label,
       description: modelDef.description ?? compositeId,
       dataResidency: config.dataResidency,
-      costPerMinute: modelDef.costPerMinute ?? 0,
+      costPerMinute: modelDef.costPerMinute,
       isDeprecated: modelDef.isDeprecated,
     });
 
@@ -259,8 +269,11 @@ export class AiModelRegistryService {
     return this.transcriptionConfigCache.get(modelId);
   }
 
+  // Deliberately the same rule as getDefaultTranscriptionModel: a registry
+  // holding only deprecated models would otherwise advertise cloud dictation
+  // that every request without an explicit model id then fails to resolve.
   hasTranscriptionModel(): boolean {
-    return this.getAvailableTranscriptionModels().length > 0;
+    return isDefined(this.getDefaultTranscriptionModel());
   }
 
   private toAiModelConfig(

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts
@@ -20,7 +20,6 @@ import {
   SdkProviderFactoryService,
   type AiSdkProviderInstance,
 } from 'src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service';
-import { DEFAULT_AI_MODEL_KIND } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-kind.type';
 import { type AiModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-config.type';
 import { type AiTranscriptionModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-transcription-model-config.type';
 import { type AiProviderConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-provider-config.type';
@@ -65,8 +64,8 @@ export class AiModelRegistryService {
   private readonly logger = new Logger(AiModelRegistryService.name);
   private modelRegistry: Map<string, RegisteredAiModel> = new Map();
   private modelConfigCache: Map<string, AiModelConfig> = new Map();
-  // Transcription models are kept out of modelRegistry and modelConfigCache so
-  // they can never surface in the chat model picker or reach token costing.
+  // Kept out of modelRegistry and modelConfigCache so transcription models can
+  // never surface in the chat model picker or reach token costing.
   private transcriptionRegistry: Map<string, RegisteredAiTranscriptionModel> =
     new Map();
   private transcriptionConfigCache: Map<string, AiTranscriptionModelConfig> =
@@ -148,7 +147,7 @@ export class AiModelRegistryService {
       for (const modelDef of models) {
         const compositeId = buildCompositeModelId(providerKey, modelDef.name);
 
-        if ((modelDef.kind ?? DEFAULT_AI_MODEL_KIND) === 'transcription') {
+        if (modelDef.kind === 'transcription') {
           this.registerTranscriptionModel({
             compositeId,
             providerKey,
@@ -213,8 +212,6 @@ export class AiModelRegistryService {
 
     const createTranscriptionModel = sdkInstance.createTranscriptionModel;
 
-    // A transcription model pointed at a provider with no speech-to-text API is
-    // a config mistake worth naming at boot rather than at the first dictation.
     if (!isDefined(createTranscriptionModel)) {
       this.logger.warn(
         `Skipping transcription model "${compositeId}": ${config.npm} exposes no transcription API`,
@@ -246,8 +243,7 @@ export class AiModelRegistryService {
   }
 
   // Registration order follows the provider config, so the first entry is the
-  // one an operator listed first — the closest thing to an explicit default
-  // until dictation needs a preference of its own.
+  // one an operator listed first.
   getDefaultTranscriptionModel(): RegisteredAiTranscriptionModel | undefined {
     return this.getAvailableTranscriptionModels().find(
       (model) =>

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 
-import { type LanguageModel } from 'ai';
+import { type LanguageModel, type TranscriptionModel } from 'ai';
 import { isNonEmptyString } from '@sniptt/guards';
 import { type AiSdkPackage } from 'twenty-shared/ai';
 
@@ -16,8 +16,13 @@ import {
 } from 'src/engine/metadata-modules/ai/ai.exception';
 import { AiModelPreferencesService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-preferences.service';
 import { ProviderConfigService } from 'src/engine/metadata-modules/ai/ai-models/services/provider-config.service';
-import { SdkProviderFactoryService } from 'src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service';
+import {
+  SdkProviderFactoryService,
+  type AiSdkProviderInstance,
+} from 'src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service';
+import { DEFAULT_AI_MODEL_KIND } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-kind.type';
 import { type AiModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-config.type';
+import { type AiTranscriptionModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-transcription-model-config.type';
 import { type AiProviderConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-provider-config.type';
 import { type AiProviderModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.type';
 import { type AiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-providers-config.type';
@@ -26,7 +31,7 @@ import {
   AUTO_SELECT_FAST_MODEL_ID,
   AUTO_SELECT_SMART_MODEL_ID,
 } from 'twenty-shared/constants';
-import { isAutoSelectModelId } from 'twenty-shared/utils';
+import { isAutoSelectModelId, isDefined } from 'twenty-shared/utils';
 
 import { DEFAULT_MAX_OUTPUT_TOKENS } from 'src/engine/metadata-modules/ai/ai-models/types/default-max-output-tokens.const';
 import { buildCompositeModelId } from 'src/engine/metadata-modules/ai/ai-models/utils/composite-model-id.util';
@@ -48,11 +53,24 @@ export interface RegisteredAiModel {
   modelsDevName?: string;
 }
 
+export type RegisteredAiTranscriptionModel = {
+  modelId: string;
+  sdkPackage: AiSdkPackage;
+  model: TranscriptionModel;
+  providerName: string;
+};
+
 @Injectable()
 export class AiModelRegistryService {
   private readonly logger = new Logger(AiModelRegistryService.name);
   private modelRegistry: Map<string, RegisteredAiModel> = new Map();
   private modelConfigCache: Map<string, AiModelConfig> = new Map();
+  // Transcription models are kept out of modelRegistry and modelConfigCache so
+  // they can never surface in the chat model picker or reach token costing.
+  private transcriptionRegistry: Map<string, RegisteredAiTranscriptionModel> =
+    new Map();
+  private transcriptionConfigCache: Map<string, AiTranscriptionModelConfig> =
+    new Map();
   private providerModelDefCache: Map<
     string,
     { providerName: string; modelDef: AiProviderModelConfig }
@@ -97,6 +115,8 @@ export class AiModelRegistryService {
     this.modelRegistry.clear();
     this.sdkProviderFactory.clearCache();
     this.modelConfigCache.clear();
+    this.transcriptionRegistry.clear();
+    this.transcriptionConfigCache.clear();
     this.providerModelDefCache.clear();
 
     const providers = this.providerConfigService.getResolvedProviders({
@@ -128,6 +148,18 @@ export class AiModelRegistryService {
       for (const modelDef of models) {
         const compositeId = buildCompositeModelId(providerKey, modelDef.name);
 
+        if ((modelDef.kind ?? DEFAULT_AI_MODEL_KIND) === 'transcription') {
+          this.registerTranscriptionModel({
+            compositeId,
+            providerKey,
+            config,
+            modelDef,
+            sdkInstance,
+          });
+
+          continue;
+        }
+
         this.modelConfigCache.set(
           compositeId,
           this.toAiModelConfig(compositeId, config, modelDef),
@@ -150,6 +182,89 @@ export class AiModelRegistryService {
         }
       }
     }
+  }
+
+  private registerTranscriptionModel({
+    compositeId,
+    providerKey,
+    config,
+    modelDef,
+    sdkInstance,
+  }: {
+    compositeId: string;
+    providerKey: string;
+    config: AiProviderConfig;
+    modelDef: AiProviderModelConfig;
+    sdkInstance: AiSdkProviderInstance | undefined;
+  }): void {
+    this.transcriptionConfigCache.set(compositeId, {
+      modelId: compositeId,
+      sdkPackage: config.npm,
+      label: modelDef.label,
+      description: modelDef.description ?? compositeId,
+      dataResidency: config.dataResidency,
+      costPerMinute: modelDef.costPerMinute ?? 0,
+      isDeprecated: modelDef.isDeprecated,
+    });
+
+    if (!sdkInstance) {
+      return;
+    }
+
+    const createTranscriptionModel = sdkInstance.createTranscriptionModel;
+
+    // A transcription model pointed at a provider with no speech-to-text API is
+    // a config mistake worth naming at boot rather than at the first dictation.
+    if (!isDefined(createTranscriptionModel)) {
+      this.logger.warn(
+        `Skipping transcription model "${compositeId}": ${config.npm} exposes no transcription API`,
+      );
+
+      return;
+    }
+
+    this.transcriptionRegistry.set(compositeId, {
+      modelId: compositeId,
+      sdkPackage: config.npm,
+      model: createTranscriptionModel(modelDef.name),
+      providerName: providerKey,
+    });
+  }
+
+  getTranscriptionModel(
+    modelId: string,
+  ): RegisteredAiTranscriptionModel | undefined {
+    this.ensureFresh();
+
+    return this.transcriptionRegistry.get(modelId);
+  }
+
+  getAvailableTranscriptionModels(): RegisteredAiTranscriptionModel[] {
+    this.ensureFresh();
+
+    return Array.from(this.transcriptionRegistry.values());
+  }
+
+  // Registration order follows the provider config, so the first entry is the
+  // one an operator listed first — the closest thing to an explicit default
+  // until dictation needs a preference of its own.
+  getDefaultTranscriptionModel(): RegisteredAiTranscriptionModel | undefined {
+    return this.getAvailableTranscriptionModels().find(
+      (model) =>
+        this.getTranscriptionModelConfig(model.modelId)?.isDeprecated !== true,
+    );
+  }
+
+  getTranscriptionModelConfig(
+    modelId: string,
+  ): AiTranscriptionModelConfig | undefined {
+    this.ensureFresh();
+
+    return this.transcriptionConfigCache.get(modelId);
+  }
+
+  hasTranscriptionModel(): boolean {
+    return this.getAvailableTranscriptionModels().length > 0;
   }
 
   private toAiModelConfig(

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service.ts
@@ -13,8 +13,10 @@ import {
   wrapLanguageModel,
   type LanguageModel,
   type LanguageModelMiddleware,
+  type TranscriptionModel,
 } from 'ai';
 import { type AiSdkPackage } from 'twenty-shared/ai';
+import { isDefined } from 'twenty-shared/utils';
 
 import {
   AI_SDK_ANTHROPIC,
@@ -28,9 +30,13 @@ import {
 } from 'src/engine/metadata-modules/ai/ai-models/constants/ai-sdk-package.const';
 import { sanitizeGeminiToolResultRefsMiddleware } from 'src/engine/metadata-modules/ai/ai-models/middleware/sanitize-gemini-tool-result-refs.middleware';
 import { type AiProviderConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-provider-config.type';
+import { getTranscriptionModelFactory } from 'src/engine/metadata-modules/ai/ai-models/utils/get-transcription-model-factory.util';
 
 export type AiSdkProviderInstance = {
   createModel: (modelId: string) => LanguageModel;
+  // Absent on providers with no speech-to-text API, which is how the registry
+  // tells a transcription model it cannot build from one it can.
+  createTranscriptionModel?: (modelId: string) => TranscriptionModel;
   rawProvider: unknown;
   sdkPackage: AiSdkPackage;
 };
@@ -88,6 +94,21 @@ export class SdkProviderFactoryService {
     this.providerInstances.clear();
   }
 
+  private toProviderInstance(
+    provider: unknown,
+    sdkPackage: AiSdkPackage,
+    createModel: (modelId: string) => LanguageModel,
+  ): AiSdkProviderInstance {
+    const createTranscriptionModel = getTranscriptionModelFactory(provider);
+
+    return {
+      createModel,
+      ...(isDefined(createTranscriptionModel) && { createTranscriptionModel }),
+      rawProvider: provider,
+      sdkPackage,
+    };
+  }
+
   private buildProviderInstance(
     config: AiProviderConfig,
   ): AiSdkProviderInstance {
@@ -125,17 +146,13 @@ export class SdkProviderFactoryService {
       ...(config.baseUrl && { baseURL: config.baseUrl }),
     });
 
-    return {
-      createModel: (modelId: string) => {
-        const model = (provider as CallableFunction)(modelId);
+    return this.toProviderInstance(provider, config.npm, (modelId: string) => {
+      const model = (provider as CallableFunction)(modelId);
 
-        return options?.middleware
-          ? wrapLanguageModel({ model, middleware: options.middleware })
-          : model;
-      },
-      rawProvider: provider,
-      sdkPackage: config.npm,
-    };
+      return options?.middleware
+        ? wrapLanguageModel({ model, middleware: options.middleware })
+        : model;
+    });
   }
 
   private buildXaiProvider(config: AiProviderConfig): AiSdkProviderInstance {
@@ -144,11 +161,9 @@ export class SdkProviderFactoryService {
       ...(config.baseUrl && { baseURL: config.baseUrl }),
     });
 
-    return {
-      createModel: (modelId: string) => provider.responses(modelId),
-      rawProvider: provider,
-      sdkPackage: AI_SDK_XAI,
-    };
+    return this.toProviderInstance(provider, AI_SDK_XAI, (modelId: string) =>
+      provider.responses(modelId),
+    );
   }
 
   private buildBedrockProvider(
@@ -182,11 +197,11 @@ export class SdkProviderFactoryService {
         }),
     });
 
-    return {
-      createModel: (modelId: string) => provider(modelId),
-      rawProvider: provider,
-      sdkPackage: AI_SDK_BEDROCK,
-    };
+    return this.toProviderInstance(
+      provider,
+      AI_SDK_BEDROCK,
+      (modelId: string) => provider(modelId),
+    );
   }
 
   private buildOpenAiCompatibleProvider(
@@ -202,11 +217,11 @@ export class SdkProviderFactoryService {
       ...(config.apiKey && { apiKey: config.apiKey }),
     });
 
-    return {
-      createModel: (modelId: string) => provider(modelId),
-      rawProvider: provider,
-      sdkPackage: AI_SDK_OPENAI_COMPATIBLE,
-    };
+    return this.toProviderInstance(
+      provider,
+      AI_SDK_OPENAI_COMPATIBLE,
+      (modelId: string) => provider(modelId),
+    );
   }
 
   private buildAzureProvider(config: AiProviderConfig): AiSdkProviderInstance {
@@ -219,10 +234,8 @@ export class SdkProviderFactoryService {
       ...(config.apiKey && { apiKey: config.apiKey }),
     });
 
-    return {
-      createModel: (modelId: string) => provider(modelId),
-      rawProvider: provider,
-      sdkPackage: AI_SDK_AZURE,
-    };
+    return this.toProviderInstance(provider, AI_SDK_AZURE, (modelId: string) =>
+      provider(modelId),
+    );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service.ts
@@ -34,8 +34,7 @@ import { getTranscriptionModelFactory } from 'src/engine/metadata-modules/ai/ai-
 
 export type AiSdkProviderInstance = {
   createModel: (modelId: string) => LanguageModel;
-  // Absent on providers with no speech-to-text API, which is how the registry
-  // tells a transcription model it cannot build from one it can.
+  // Absent on providers with no speech-to-text API.
   createTranscriptionModel?: (modelId: string) => TranscriptionModel;
   rawProvider: unknown;
   sdkPackage: AiSdkPackage;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-model-kind.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-model-kind.type.ts
@@ -1,0 +1,8 @@
+// Transcription models reach a different SDK entry point than language models
+// and are priced per minute rather than per token, so the registry has to know
+// which kind a config entry describes before it builds anything from it.
+export const AI_MODEL_KINDS = ['language', 'transcription'] as const;
+
+export type AiModelKind = (typeof AI_MODEL_KINDS)[number];
+
+export const DEFAULT_AI_MODEL_KIND: AiModelKind = 'language';

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-model-kind.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-model-kind.type.ts
@@ -1,8 +1,0 @@
-// Transcription models reach a different SDK entry point than language models
-// and are priced per minute rather than per token, so the registry has to know
-// which kind a config entry describes before it builds anything from it.
-export const AI_MODEL_KINDS = ['language', 'transcription'] as const;
-
-export type AiModelKind = (typeof AI_MODEL_KINDS)[number];
-
-export const DEFAULT_AI_MODEL_KIND: AiModelKind = 'language';

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.schema.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.schema.ts
@@ -4,21 +4,32 @@ import { AI_MODEL_KINDS } from 'src/engine/metadata-modules/ai/ai-models/constan
 import { ModelFamily } from 'src/engine/metadata-modules/ai/ai-models/types/model-family.enum';
 import { longContextCostSchema } from 'src/engine/metadata-modules/ai/ai-models/types/long-context-cost.schema';
 
-export const aiProviderModelConfigSchema = z.object({
-  name: z.string(),
-  label: z.string(),
-  kind: z.enum(AI_MODEL_KINDS).optional(),
-  description: z.string().optional(),
-  modelFamily: z.nativeEnum(ModelFamily).optional(),
-  costPerMinute: z.number().nonnegative().optional(),
-  inputCostPerMillionTokens: z.number().optional(),
-  outputCostPerMillionTokens: z.number().optional(),
-  cachedInputCostPerMillionTokens: z.number().optional(),
-  cacheCreationCostPerMillionTokens: z.number().optional(),
-  longContextCost: longContextCostSchema.optional(),
-  contextWindowTokens: z.number().int().positive().optional(),
-  maxOutputTokens: z.number().int().positive().optional(),
-  modalities: z.array(z.string()).optional(),
-  supportsReasoning: z.boolean().optional(),
-  isDeprecated: z.boolean().optional(),
-});
+export const aiProviderModelConfigSchema = z
+  .object({
+    name: z.string(),
+    label: z.string(),
+    kind: z.enum(AI_MODEL_KINDS).optional(),
+    description: z.string().optional(),
+    modelFamily: z.nativeEnum(ModelFamily).optional(),
+    costPerMinute: z.number().nonnegative().optional(),
+    inputCostPerMillionTokens: z.number().optional(),
+    outputCostPerMillionTokens: z.number().optional(),
+    cachedInputCostPerMillionTokens: z.number().optional(),
+    cacheCreationCostPerMillionTokens: z.number().optional(),
+    longContextCost: longContextCostSchema.optional(),
+    contextWindowTokens: z.number().int().positive().optional(),
+    maxOutputTokens: z.number().int().positive().optional(),
+    modalities: z.array(z.string()).optional(),
+    supportsReasoning: z.boolean().optional(),
+    isDeprecated: z.boolean().optional(),
+  })
+  .refine(
+    (model) =>
+      model.kind !== 'transcription' || model.costPerMinute !== undefined,
+    {
+      // An omitted price bills nothing while the provider still charges, so a
+      // free model has to say so with an explicit 0.
+      message: 'costPerMinute is required for transcription models',
+      path: ['costPerMinute'],
+    },
+  );

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.schema.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { AI_MODEL_KINDS } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-kind.type';
+import { AI_MODEL_KINDS } from 'src/engine/metadata-modules/ai/ai-models/constants/ai-model-kinds.const';
 import { ModelFamily } from 'src/engine/metadata-modules/ai/ai-models/types/model-family.enum';
 import { longContextCostSchema } from 'src/engine/metadata-modules/ai/ai-models/types/long-context-cost.schema';
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.schema.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-provider-model-config.schema.ts
@@ -1,13 +1,16 @@
 import { z } from 'zod';
 
+import { AI_MODEL_KINDS } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-kind.type';
 import { ModelFamily } from 'src/engine/metadata-modules/ai/ai-models/types/model-family.enum';
 import { longContextCostSchema } from 'src/engine/metadata-modules/ai/ai-models/types/long-context-cost.schema';
 
 export const aiProviderModelConfigSchema = z.object({
   name: z.string(),
   label: z.string(),
+  kind: z.enum(AI_MODEL_KINDS).optional(),
   description: z.string().optional(),
   modelFamily: z.nativeEnum(ModelFamily).optional(),
+  costPerMinute: z.number().nonnegative().optional(),
   inputCostPerMillionTokens: z.number().optional(),
   outputCostPerMillionTokens: z.number().optional(),
   cachedInputCostPerMillionTokens: z.number().optional(),

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-transcription-model-config.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-transcription-model-config.type.ts
@@ -1,8 +1,7 @@
 import { type AiSdkPackage, type DataResidency } from 'twenty-shared/ai';
 
-// Kept separate from AiModelConfig rather than bolted on as optional fields:
-// transcription has no token semantics, so computeCostBreakdown must never be
-// reachable with one of these.
+// Separate from AiModelConfig so computeCostBreakdown is never reachable with a
+// model that has no token semantics.
 export type AiTranscriptionModelConfig = {
   modelId: string;
   sdkPackage: AiSdkPackage;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-transcription-model-config.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/types/ai-transcription-model-config.type.ts
@@ -1,0 +1,14 @@
+import { type AiSdkPackage, type DataResidency } from 'twenty-shared/ai';
+
+// Kept separate from AiModelConfig rather than bolted on as optional fields:
+// transcription has no token semantics, so computeCostBreakdown must never be
+// reachable with one of these.
+export type AiTranscriptionModelConfig = {
+  modelId: string;
+  sdkPackage: AiSdkPackage;
+  label: string;
+  description: string;
+  dataResidency?: DataResidency;
+  costPerMinute: number;
+  isDeprecated?: boolean;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/__tests__/get-transcription-model-factory.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/__tests__/get-transcription-model-factory.util.spec.ts
@@ -1,0 +1,36 @@
+import { getTranscriptionModelFactory } from 'src/engine/metadata-modules/ai/ai-models/utils/get-transcription-model-factory.util';
+
+describe('getTranscriptionModelFactory', () => {
+  it('returns a factory for a provider exposing transcription', () => {
+    const model = { modelId: 'whisper-1' };
+    const provider = { transcription: jest.fn().mockReturnValue(model) };
+
+    const factory = getTranscriptionModelFactory(provider);
+
+    expect(factory).toBeDefined();
+    expect(factory?.('whisper-1')).toBe(model);
+    expect(provider.transcription).toHaveBeenCalledWith('whisper-1');
+  });
+
+  it('keeps the provider as the receiver so provider-bound state survives', () => {
+    const provider = {
+      baseUrl: 'https://example.invalid',
+      transcription(this: { baseUrl: string }, modelId: string) {
+        return `${this.baseUrl}/${modelId}`;
+      },
+    };
+
+    const factory = getTranscriptionModelFactory(provider);
+
+    expect(factory?.('whisper-1')).toBe('https://example.invalid/whisper-1');
+  });
+
+  it.each([
+    ['a provider without the method', { languageModel: jest.fn() }],
+    ['a non-callable transcription property', { transcription: 'nope' }],
+    ['null', null],
+    ['undefined', undefined],
+  ])('returns undefined for %s', (_label, provider) => {
+    expect(getTranscriptionModelFactory(provider)).toBeUndefined();
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/__tests__/get-transcription-model-factory.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/__tests__/get-transcription-model-factory.util.spec.ts
@@ -9,6 +9,7 @@ describe('getTranscriptionModelFactory', () => {
 
     expect(factory).toBeDefined();
     expect(factory?.('whisper-1')).toBe(model);
+    expect(provider.transcription).toHaveBeenCalledTimes(1);
     expect(provider.transcription).toHaveBeenCalledWith('whisper-1');
   });
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/get-transcription-model-factory.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/get-transcription-model-factory.util.ts
@@ -10,11 +10,6 @@ const hasTranscriptionFactory = (
   typeof (provider as Partial<TranscriptionCapableProvider>)?.transcription ===
   'function';
 
-// Probed rather than kept as a per-package allowlist: Anthropic, Mistral, xAI
-// and Bedrock ship no speech-to-text today, and a provider that gains one later
-// starts working without a change here. An absent factory is also what the
-// registry reads to refuse a misconfigured transcription model up front,
-// instead of throwing on the first dictation.
 export const getTranscriptionModelFactory = (
   provider: unknown,
 ): ((modelId: string) => TranscriptionModel) | undefined => {

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/get-transcription-model-factory.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/get-transcription-model-factory.util.ts
@@ -1,0 +1,26 @@
+import { type TranscriptionModel } from 'ai';
+
+type TranscriptionCapableProvider = {
+  transcription: (modelId: string) => TranscriptionModel;
+};
+
+const hasTranscriptionFactory = (
+  provider: unknown,
+): provider is TranscriptionCapableProvider =>
+  typeof (provider as Partial<TranscriptionCapableProvider>)?.transcription ===
+  'function';
+
+// Probed rather than kept as a per-package allowlist: Anthropic, Mistral, xAI
+// and Bedrock ship no speech-to-text today, and a provider that gains one later
+// starts working without a change here. An absent factory is also what the
+// registry reads to refuse a misconfigured transcription model up front,
+// instead of throwing on the first dictation.
+export const getTranscriptionModelFactory = (
+  provider: unknown,
+): ((modelId: string) => TranscriptionModel) | undefined => {
+  if (!hasTranscriptionFactory(provider)) {
+    return undefined;
+  }
+
+  return (modelId: string) => provider.transcription(modelId);
+};


### PR DESCRIPTION
Stack 1/3 for dictation in the AI chat composer. This one only teaches the model registry that transcription models exist; nothing calls them yet.

## What changed

A config entry can now declare `kind: "transcription"` and `costPerMinute`. Both are optional, so every existing entry stays valid.

Transcription models are kept in their own registry and config cache, deliberately out of `modelRegistry` and `modelConfigCache`, so they can never surface in the chat model picker or reach `computeCostBreakdown` — which has no meaningful answer for audio.

Adding one to an environment then looks like this, inside the `azure-foundry` block that already exists in `twenty-infra/ai-models-config/`:

```json
{
  "name": "gpt-4o-transcribe",
  "label": "Dictation (Azure EU)",
  "kind": "transcription",
  "costPerMinute": 0.006
}
```

Because `prod-eu.json` already declares `azure-foundry` and `azure-foundry-us` separately, EU dictation needs no new residency work.

## Provider support is probed, not listed

`SdkProviderFactoryService` now exposes an optional `createTranscriptionModel`, populated by looking for a `transcription` factory on the provider instead of keeping a per-package allowlist. Anthropic, Mistral, xAI and Bedrock ship no speech-to-text today, and a provider that gains one later starts working with no change here.

An absent factory is also what the registry reads to refuse a misconfigured transcription model at boot, with a log line naming it, rather than throwing on someone's first dictation.

All five provider builders now route through one `toProviderInstance`, so the capability is probed in a single place.

## Note on `NON_LANGUAGE_PATTERNS`

Untouched on purpose. It screens the models.dev sync; these models arrive from explicit config, so they are never filtered.

## Testing

- Unit tests for the probe, covering the receiver binding and every shape that should yield no factory.
- `npx tsgo -p tsconfig.json --noEmit` clean in `twenty-server`.
- `npx nx lint:diff-with-main twenty-server` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133U8Y3KE88q5YE8gecYyyq)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

