### PR TITLE
Hide Twenty-operated config variables from the admin panel

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -559,6 +559,7 @@ export class ConfigVariables {
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description:
       'Deployment region that determines the DPA hosting location shown to customers. The Processor entity (Twenty.com PBC) and governing law (Delaware, USA) are the same for all regions. EU (default) = Frankfurt, Germany; US = United States. Must match where Customer Personal Data actually lives.',
+    isHiddenInAdminPanel: true,
     type: ConfigVariableType.ENUM,
     options: Object.values(DpaRegion),
     // Deployment-fixed: must mirror where data actually lives. Allowing a
@@ -1528,6 +1529,7 @@ export class ConfigVariables {
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description:
       'ISO date from which HTTP logic functions are no longer served on the legacy /s/ route. Functions created on or after this date are only reachable on the isolated public domain (*.withtwenty.com). Only enforced when PUBLIC_DOMAIN_URL is set; leave empty to keep serving every function on /s/ (default for self-hosting).',
+    isHiddenInAdminPanel: true,
     type: ConfigVariableType.STRING,
   })
   @IsDateString()
@@ -2306,6 +2308,7 @@ export class ConfigVariables {
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,
     description:
       'Client ID of the GitHub OAuth app used to verify app ownership when claiming a marketplace application',
+    isHiddenInAdminPanel: true,
     type: ConfigVariableType.STRING,
   })
   @IsString()
@@ -2317,6 +2320,7 @@ export class ConfigVariables {
     isSensitive: true,
     description:
       'Client secret of the GitHub OAuth app used to verify app ownership when claiming a marketplace application',
+    isHiddenInAdminPanel: true,
     type: ConfigVariableType.STRING,
   })
   @IsString()


### PR DESCRIPTION
Follow-up to #25063 (now merged, so this targets `main` rather than stacking).

## First, the thing worth knowing

Most of what looks self-hoster-irrelevant is **already hidden**, one level up. `CONFIG_VARIABLES_GROUP_METADATA` carries its own `isHiddenInAdminPanel`, set on `BILLING_CONFIG` ("We use Stripe in our Cloud app to charge customers. Not relevant to Self-hosters."), `CLOUDFLARE_CONFIG`, `SUPPORT_CHAT_CONFIG`, `ANALYTICS_CONFIG`, `AWS_SES_SETTINGS` and `RESEND_SETTINGS`. `AdminPanelConfigService.getConfigVariablesGrouped` filters on both the per-variable flag and the group flag, so every Stripe key, trial duration, credit reward and Front/Cloudflare setting is already invisible.

That leaves only variables sitting in a group that is otherwise relevant, which is what this PR is. Four of them.

## The four

Each identifies itself in its own description:

| Variable | Why |
| --- | --- |
| `DPA_DEPLOYMENT_REGION` | Names **Twenty.com PBC** as the processor and Delaware as governing law. A self-hoster is their own processor, so offering them this region picker is not just noise — it is misleading about who processes their data. |
| `LOGIC_FUNCTION_LEGACY_ROUTE_CUTOFF` | Routes functions onto `*.withtwenty.com`, and the description already says empty is "default for self-hosting". |
| `APP_CLAIM_GITHUB_CLIENT_ID` | The OAuth app used to verify ownership when claiming an app on the marketplace Twenty operates centrally. |
| `APP_CLAIM_GITHUB_CLIENT_SECRET` | Same, and already `isSensitive`. |

## Deliberately left visible — say so if you disagree

- `LOGIC_FUNCTION_LAMBDA_SUBHOSTING_ROLE` — "dedicated AWS account" is our multi-tenant pattern, but isolating functions into a separate AWS account is a legitimate single-tenant hardening move too, so I did not want to decide it for them.
- `ALLOW_REQUESTS_TO_TWENTY_ICONS` — reaches our icon service, which makes it exactly the kind of knob an air-gapped self-hoster wants to find.
- `PEOPLE_DATA_LABS_API_KEY`, `GOOGLE_MAP_API_KEY`, `E2B_API_KEY`, Sentry — third-party services anyone can buy an account for.
- `ENTERPRISE_KEY`, `ENTERPRISE_INSTANCE_TYPE` — self-hosted Enterprise customers are the ones who set these.
- `SHOULD_SEED_STANDARD_RECORD_PAGE_LAYOUTS` — irrelevant to everyone, not just self-hosters: its description says "Deprecated - record page layouts are now always seeded (GA)". That wants deleting rather than hiding, so it is out of scope here.

## One correction to #25063

The `isHiddenInAdminPanel: true` I added to `ONBOARDING_ENRICHMENT_CREDIT_REWARD_TIERS` there is redundant — it lives in `BILLING_CONFIG`, which the group flag already hides. It is harmless and stays correct if that group is ever unhidden, but it was not what made the variable invisible, and its sibling reward variables carry no per-variable flag. Happy to drop the line in a follow-up if you would rather keep that file consistent.

## Testing

Nothing asserts on the visible-variable set, so there is no test to update; the only config spec checks group metadata against the enum. 182 tests across the `twenty-config` and `admin-panel` suites pass, and lint, format and typecheck are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLmKjL7jSBd6NRJsQUGoDQ)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

