### PR TITLE
Drop the tab list from the walkthrough modal when there is a single tab

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsCustomizeVideoModal.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsCustomizeVideoModal.tsx
@@ -5,7 +5,7 @@ import { styled } from '@linaria/react';
 import { useState } from 'react';
 import { type IconComponent, IconX } from 'twenty-ui/icon';
 import { IconButton } from 'twenty-ui/input';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables, useTheme } from 'twenty-ui/theme-constants';
 
 export type SettingsCustomizeVideoModalTab = {
   id: string;
@@ -21,8 +21,14 @@ type SettingsCustomizeVideoModalProps = {
   tabs: SettingsCustomizeVideoModalTab[];
 };
 
-const StyledHeader = styled.div`
+// the tab list draws its own separator, so the header only needs one when the
+// single tab is replaced by a plain title
+const StyledHeader = styled.div<{ $hasBottomBorder: boolean }>`
   align-items: center;
+  border-bottom: ${({ $hasBottomBorder }) =>
+    $hasBottomBorder
+      ? `1px solid ${themeCssVariables.border.color.light}`
+      : 'none'};
   display: flex;
   gap: ${themeCssVariables.spacing[2]};
   height: 48px;
@@ -34,6 +40,27 @@ const StyledTabsContainer = styled.div`
   flex: 1 1 auto;
   min-width: 0;
   padding-left: ${themeCssVariables.spacing[3]};
+`;
+
+const StyledTitle = styled.div`
+  align-items: center;
+  color: ${themeCssVariables.font.color.primary};
+  display: flex;
+  flex: 1 1 auto;
+  font-weight: ${themeCssVariables.font.weight.medium};
+  gap: ${themeCssVariables.spacing[1]};
+  min-width: 0;
+  padding-left: ${themeCssVariables.spacing[5]};
+
+  & > svg {
+    flex-shrink: 0;
+  }
+`;
+
+const StyledTitleText = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const StyledVideoContainer = styled.div`
@@ -58,6 +85,7 @@ export const SettingsCustomizeVideoModal = ({
   tabsInstanceId,
   tabs,
 }: SettingsCustomizeVideoModalProps) => {
+  const theme = useTheme();
   const { closeModal } = useModal();
   const [activeTabId, setActiveTabId] = useState<string>(tabs[0]?.id ?? '');
 
@@ -66,6 +94,8 @@ export const SettingsCustomizeVideoModal = ({
   }
 
   const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0];
+  const hasMultipleTabs = tabs.length > 1;
+  const ActiveTabIcon = activeTab.Icon;
 
   const handleClose = () => {
     closeModal(modalInstanceId);
@@ -80,15 +110,26 @@ export const SettingsCustomizeVideoModal = ({
       onClose={handleClose}
       renderInDocumentBody
     >
-      <StyledHeader>
-        <StyledTabsContainer>
-          <TabList
-            tabs={tabs}
-            behaveAsLinks={false}
-            componentInstanceId={tabsInstanceId}
-            onChangeTab={(tabId) => setActiveTabId(tabId)}
-          />
-        </StyledTabsContainer>
+      <StyledHeader $hasBottomBorder={!hasMultipleTabs}>
+        {hasMultipleTabs ? (
+          <StyledTabsContainer>
+            <TabList
+              tabs={tabs}
+              behaveAsLinks={false}
+              componentInstanceId={tabsInstanceId}
+              onChangeTab={(tabId) => setActiveTabId(tabId)}
+            />
+          </StyledTabsContainer>
+        ) : (
+          <StyledTitle>
+            <ActiveTabIcon
+              size={theme.icon.size.md}
+              color={theme.font.color.primary}
+              aria-hidden
+            />
+            <StyledTitleText>{activeTab.title}</StyledTitleText>
+          </StyledTitle>
+        )}
         <IconButton Icon={IconX} onClick={handleClose} size="small" />
       </StyledHeader>
       <StyledVideoContainer>


### PR DESCRIPTION
Every settings hero card (`Data model`, `AI`, `API & Webhooks`, `Layout`, `Members`, `Applications`) opens `SettingsCustomizeVideoModal` with exactly one tab, so the modal rendered a full tab list — hover state, active underline — for a tab that has nothing to switch to.

When there is a single tab, the modal now renders that tab's icon and title as a plain header instead. The tab list is still used as soon as there is more than one video to pick from, so the multi-tab path is unchanged.

Details:
- the title sits at the same horizontal offset the tab label had (`spacing[5]` = the tab list's `spacing[3]` padding plus the tab button's own `spacing[2]`), so the header does not visually shift
- the header carries its own bottom border in the single-title case, since that separator was previously drawn by the tab list itself
- long titles truncate with an ellipsis rather than pushing the close button

## Test
- `npx tsgo -p tsconfig.json --noEmit` in `packages/twenty-front` — clean
- `npx oxlint --type-aware -c .oxlintrc.json` and `npx oxfmt --check` on the changed file — clean