### PR TITLE
fix(twenty-ui): keep a long button label inside the button box

### DIFF
--- a/packages/twenty-ui/src/input/Button/__stories__/Button.stories.tsx
+++ b/packages/twenty-ui/src/input/Button/__stories__/Button.stories.tsx
@@ -6,6 +6,7 @@ import {
   type CatalogStory,
   ComponentDecorator,
 } from '@ui/testing';
+import { expect, within } from 'storybook/test';
 import {
   Button,
   type ButtonAccent,
@@ -329,6 +330,49 @@ export const FullWidth: Story = {
     Icon: { control: false },
   },
   decorators: [ComponentDecorator],
+};
+
+// nl-NL rendering of "Permanently Destroy {objectLabel}", the confirm label of
+// the destroy-records modal, which is where this overflow was reported.
+const OVERFLOWING_LABEL = 'Definitief vernietigen Workflowuitvoeringen';
+
+export const LongLabelInNarrowContainer: Story = {
+  args: {
+    title: OVERFLOWING_LABEL,
+    fullWidth: true,
+    size: 'medium',
+    variant: 'primary',
+    accent: 'danger',
+  },
+  argTypes: {
+    size: { control: false },
+    variant: { control: false },
+    accent: { control: false },
+    focus: { control: false },
+    disabled: { control: false },
+    fullWidth: { control: false },
+    soon: { control: false },
+    position: { control: false },
+    className: { control: false },
+    Icon: { control: false },
+  },
+  parameters: {
+    a11y: A11Y_DEFER_COLOR_CONTRAST,
+    container: { width: 240 },
+  },
+  decorators: [ComponentDecorator],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const button = canvas.getByRole('button');
+    const label = canvas.getByText(OVERFLOWING_LABEL);
+
+    const buttonBox = button.getBoundingClientRect();
+    const labelBox = label.getBoundingClientRect();
+
+    expect(labelBox.left).toBeGreaterThanOrEqual(buttonBox.left);
+    expect(labelBox.right).toBeLessThanOrEqual(buttonBox.right);
+  },
 };
 
 export const LoadingButton: Story = {

--- a/packages/twenty-ui/src/input/Button/internal/ButtonText.module.scss
+++ b/packages/twenty-ui/src/input/Button/internal/ButtonText.module.scss
@@ -17,14 +17,19 @@ $base-transition-timing: 300ms;
 .text {
   clip-path: inset(0 0 0 0);
   overflow: hidden;
-  // A label that does not fit is cut mid-glyph without this.
-  text-overflow: ellipsis;
   transform: none;
   transition:
     transform $base-transition-timing ease,
     clip-path $base-transition-timing ease;
   transition-delay: $base-transition-timing * 0.25;
   white-space: nowrap;
+
+  // A label that does not fit is cut mid-glyph without this. Scoped away from
+  // the loading state, where .ellipsis already renders its own dots at the same
+  // right edge and the two indicators would collide.
+  &:not([data-loading]) {
+    text-overflow: ellipsis;
+  }
 
   &[data-loading] {
     clip-path: inset(0 var(--t-spacing-12) 0 0);

--- a/packages/twenty-ui/src/input/Button/internal/ButtonText.module.scss
+++ b/packages/twenty-ui/src/input/Button/internal/ButtonText.module.scss
@@ -6,12 +6,19 @@ $base-transition-timing: 300ms;
   display: flex;
   height: 100%;
   justify-content: center;
+  // Flex items default to min-width:auto, so without this the wrapper keeps the
+  // label's full intrinsic width and .text never shrinks far enough for its own
+  // overflow to clip it. justify-content then centres the excess, and a label
+  // wider than the button spills past both of its edges.
+  min-width: 0;
   position: relative;
 }
 
 .text {
   clip-path: inset(0 0 0 0);
   overflow: hidden;
+  // A label that does not fit is cut mid-glyph without this.
+  text-overflow: ellipsis;
   transform: none;
   transition:
     transform $base-transition-timing ease,


### PR DESCRIPTION
Closes #23501

### What happens

In the destroy-records confirmation modal the confirm label is built as `` `${t`Permanently Destroy`} ${objectLabel}` `` (`DestroyRecordsCommand.tsx:91`). The modal is `narrowWidth`, which is `calc(400px - var(--t-spacing-32))` — 272px, leaving the `fullWidth` button roughly a 206px content box.

Once the label is wider than that box it does not clip: it renders **outside the button on both sides**, because `justify-content: center` centres the overflow. That is the clipped label in the issue screenshot.

### Root cause

`.textWrapper` in `ButtonText.module.scss` is a flex item of `.button` and never sets `min-width`. Flex items default to `min-width: auto`, so the wrapper keeps the label's full intrinsic width (the label is `white-space: nowrap`). `.text` already has `overflow: hidden`, but it is never squeezed narrow enough for that to clip anything — the wrapper hands it all the width it asks for.

So the clipping the original code intended was silently defeated by the flexbox default.

### Measurements

Measured in Chrome against the real cascade, `nl-NL`, `"Definitief vernietigen {objectLabel}"`, 206px button content box. `spill` is how far the label's right edge sits past the button's right edge:

| objectLabel | before | after |
|---|---|---|
| Bedrijven | inside (−24px) | inside |
| Personen | inside (−23px) | inside |
| Verkoopkansen | inside (−6px) | inside |
| Workflowuitvoeringen | **escapes (+11px each side)** | inside, ellipsised |

Labels that already fit are unchanged — measured identical widths before and after, so no visual diff for the normal case.

### The fix

In `ButtonText.module.scss`:

- `min-width: 0` on `.textWrapper` so it can shrink and let `.text`'s existing `overflow: hidden` do its job. This alone fixes the overflow.
- `text-overflow: ellipsis` on `.text`, scoped to `&:not([data-loading])`, so a label that does not fit ends in `…` rather than being cut mid-glyph — while leaving the loading animation's own `.ellipsis` dots as the sole indicator during loading, since both sit at the same right edge.

### On "have the button scale with the text content"

Worth flagging, since the issue asks for this: inside a 272px `narrowWidth` modal a `fullWidth` button has no room to grow horizontally, so the only ways to show the label in full are to widen the modal or to let the label wrap onto a second line — and wrapping means giving up the fixed `.small` / `.medium` button heights, which are a design-system invariant well beyond this bug.

This PR fixes the part that is unambiguously broken: the label escaping its button. Truncation is safe here because the modal title above the button already carries the full string (`` const title = t`Permanently Destroy ${objectLabel}` ``), so no information is lost. If you would rather have the label wrap, that is a deliberate change to the button height contract and I am happy to open a follow-up.

### Test

Added a `LongLabelInNarrowContainer` story that reproduces the reported case in a 240px container. Its play function asserts the label's bounding box stays within the button's, so the geometry is checked in a real browser rather than left to visual review.

I ran it both ways to confirm it actually catches the bug. With the `min-width` change reverted and Storybook rebuilt:

```
FAIL  src/input/Button/__stories__/Button.stories.tsx > Long Label In Narrow Container
AssertionError: expected 301.15625 to be less than or equal to 261
```

— the label's right edge 40px past the button's. With the fix restored, 8/8 pass.

- `vitest run --project=storybook src/input/Button/__stories__/Button.stories.tsx` — 8 passed; 1 failed without the fix
- `npx tsgo -p tsconfig.json --noEmit` in `packages/twenty-ui` — clean
- `npx nx lint twenty-ui` — 0 errors
- `npx nx fmt twenty-ui` — clean
