### PR TITLE
Swap Settings for a record-open switcher in the workspace dropdown

### DIFF
--- a/packages/twenty-e2e-testing/lib/pom/leftMenu.ts
+++ b/packages/twenty-e2e-testing/lib/pom/leftMenu.ts
@@ -22,7 +22,10 @@ export class LeftMenu {
     this.workspaceDropdown = page.getByTestId('workspace-dropdown');
     this.leftMenu = page.getByRole('button').first();
     this.searchSubTab = page.getByText('Search');
-    this.settingsTab = page.getByRole('link', { name: 'Settings' });
+    this.settingsTab = page.getByRole('button', {
+      name: 'Settings',
+      exact: true,
+    });
     this.peopleTab = page.getByRole('link', { name: 'People' });
     this.companiesTab = page.getByRole('link', { name: 'Companies' });
     this.opportunitiesTab = page.getByRole('link', { name: 'Opportunities' });
@@ -56,7 +59,6 @@ export class LeftMenu {
   }
 
   async goToSettings() {
-    await this.workspaceDropdown.click();
     await this.settingsTab.click();
   }
 

--- a/packages/twenty-e2e-testing/tests/create-kanban-view.spec.ts
+++ b/packages/twenty-e2e-testing/tests/create-kanban-view.spec.ts
@@ -4,8 +4,7 @@ test.describe.serial('Create Kanban View', () => {
 // the same database, and a duplicate label makes the form unsubmittable.
 const industryLabel = `Industry ${Date.now()}`;
 test('Create Industry Select Field', async ({ page }) => {
-    await page.getByTestId('workspace-dropdown').click();
-    await page.getByRole('link', { name: 'Settings' }).click();
+    await page.getByRole('button', { name: 'Settings', exact: true }).click();
     await page.getByRole('link', { name: 'Data model' }).click();
     await page.getByRole('link', { name: 'Opportunities' }).click();
     await expect(page.getByRole('button', { name: 'New Field' })).toBeVisible();

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/MultiWorkspaceDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/MultiWorkspaceDropdownButton.tsx
@@ -2,6 +2,7 @@ import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/st
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { MultiWorkspaceDropdownClickableComponent } from '@/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownClickableComponent';
 import { MultiWorkspaceDropdownDefaultComponents } from '@/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents';
+import { MultiWorkspaceDropdownOpenRecordInComponents } from '@/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownOpenRecordInComponents';
 import { MultiWorkspaceDropdownThemesComponents } from '@/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownThemesComponents';
 import { MultiWorkspaceDropdownWorkspacesListComponents } from '@/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownWorkspacesListComponents';
 import { MULTI_WORKSPACE_DROPDOWN_ID } from '@/ui/navigation/navigation-drawer/constants/MultiWorkspaceDropdownId';
@@ -28,6 +29,8 @@ export const MultiWorkspaceDropdownButton = ({
     switch (multiWorkspaceDropdown) {
       case 'themes':
         return MultiWorkspaceDropdownThemesComponents;
+      case 'open-record-in':
+        return MultiWorkspaceDropdownOpenRecordInComponents;
       case 'workspaces-list':
         return MultiWorkspaceDropdownWorkspacesListComponents;
       default:

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
@@ -9,6 +9,7 @@ import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWork
 import { useBuildWorkspaceUrl } from '@/domain-manager/hooks/useBuildWorkspaceUrl';
 import { useRedirectToDefaultDomain } from '@/domain-manager/hooks/useRedirectToDefaultDomain';
 import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
+import { useOpenRecordInPreference } from '@/settings/experience/hooks/useOpenRecordInPreference';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
@@ -16,15 +17,13 @@ import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { useOpenSettingsMenu } from '@/navigation/hooks/useOpenSettings';
 import { MULTI_WORKSPACE_DROPDOWN_ID } from '@/ui/navigation/navigation-drawer/constants/MultiWorkspaceDropdownId';
+import { OPEN_RECORD_IN_OPTIONS } from '@/ui/navigation/navigation-drawer/constants/OpenRecordInOptions';
 import { multiWorkspaceDropdownState } from '@/ui/navigation/navigation-drawer/states/multiWorkspaceDropdownState';
 import { useColorScheme } from '@/ui/theme/hooks/useColorScheme';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
-import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { isNonEmptyString } from '@sniptt/guards';
 import { AppPath, SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
@@ -34,7 +33,6 @@ import {
   IconLogout,
   IconMessage,
   IconPlus,
-  IconSettings,
   IconSwitchHorizontal,
   IconUserPlus,
 } from 'twenty-ui/icon';
@@ -47,11 +45,6 @@ import {
 import { type AvailableWorkspace } from '~/generated-metadata/graphql';
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
-
-const StyledDescription = styled.div`
-  color: ${themeCssVariables.font.color.light};
-  padding-left: ${themeCssVariables.spacing[1]};
-`;
 
 export const MultiWorkspaceDropdownDefaultComponents = () => {
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
@@ -77,7 +70,7 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
     multiWorkspaceDropdownState,
   );
 
-  const { openSettingsMenu } = useOpenSettingsMenu();
+  const { openRecordInPreference } = useOpenRecordInPreference();
 
   const handleSupport = () => {
     window.FrontChat?.('show');
@@ -194,14 +187,19 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
       <DropdownMenuItemsContainer>
         <MenuItem
           LeftIcon={colorSchemeList.find(({ id }) => id === colorScheme)?.icon}
-          text={
-            <>
-              {t`Theme `}
-              <StyledDescription>{` · ${colorScheme}`}</StyledDescription>
-            </>
-          }
+          text={t`Theme`}
+          contextualText={colorScheme}
           hasSubMenu={true}
           onClick={() => setMultiWorkspaceDropdown('themes')}
+        />
+        <MenuItem
+          LeftIcon={OPEN_RECORD_IN_OPTIONS[openRecordInPreference].Icon}
+          text={t`Open in`}
+          contextualText={t(
+            OPEN_RECORD_IN_OPTIONS[openRecordInPreference].label,
+          )}
+          hasSubMenu={true}
+          onClick={() => setMultiWorkspaceDropdown('open-record-in')}
         />
         <UndecoratedLink
           to={`${getSettingsPath(SettingsPath.WorkspaceMembersPage)}#invite`}
@@ -218,15 +216,6 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
             onClick={handleSupport}
           />
         )}
-        <UndecoratedLink
-          to={getSettingsPath(SettingsPath.ProfilePage)}
-          onClick={() => {
-            openSettingsMenu();
-            closeDropdown(MULTI_WORKSPACE_DROPDOWN_ID);
-          }}
-        >
-          <MenuItem LeftIcon={IconSettings} text={t`Settings`} />
-        </UndecoratedLink>
       </DropdownMenuItemsContainer>
     </DropdownContent>
   );

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
@@ -73,8 +73,6 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
 
   const { openRecordInPreference } = useOpenRecordInPreference();
 
-  // Mirrors resolveOpenRecordIn, which forces the record page on mobile: with
-  // no side panel to open a record in, the preference has nothing to switch.
   const canDisplaySidePanel = !useIsMobile();
 
   const handleSupport = () => {

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
@@ -42,6 +42,7 @@ import {
   MenuItemSelectAvatar,
   UndecoratedLink,
 } from 'twenty-ui/navigation';
+import { useIsMobile } from 'twenty-ui/utilities';
 import { type AvailableWorkspace } from '~/generated-metadata/graphql';
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
@@ -71,6 +72,10 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
   );
 
   const { openRecordInPreference } = useOpenRecordInPreference();
+
+  // Mirrors resolveOpenRecordIn, which forces the record page on mobile: with
+  // no side panel to open a record in, the preference has nothing to switch.
+  const canDisplaySidePanel = !useIsMobile();
 
   const handleSupport = () => {
     window.FrontChat?.('show');
@@ -192,15 +197,17 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
           hasSubMenu={true}
           onClick={() => setMultiWorkspaceDropdown('themes')}
         />
-        <MenuItem
-          LeftIcon={OPEN_RECORD_IN_OPTIONS[openRecordInPreference].Icon}
-          text={t`Open in`}
-          contextualText={t(
-            OPEN_RECORD_IN_OPTIONS[openRecordInPreference].label,
-          )}
-          hasSubMenu={true}
-          onClick={() => setMultiWorkspaceDropdown('open-record-in')}
-        />
+        {canDisplaySidePanel && (
+          <MenuItem
+            LeftIcon={OPEN_RECORD_IN_OPTIONS[openRecordInPreference].Icon}
+            text={t`Open in`}
+            contextualText={t(
+              OPEN_RECORD_IN_OPTIONS[openRecordInPreference].label,
+            )}
+            hasSubMenu={true}
+            onClick={() => setMultiWorkspaceDropdown('open-record-in')}
+          />
+        )}
         <UndecoratedLink
           to={`${getSettingsPath(SettingsPath.WorkspaceMembersPage)}#invite`}
           onClick={() => {

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownOpenRecordInComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownOpenRecordInComponents.tsx
@@ -1,0 +1,51 @@
+import { useOpenRecordInPreference } from '@/settings/experience/hooks/useOpenRecordInPreference';
+import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
+import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
+import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
+import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
+import { OPEN_RECORD_IN_OPTIONS } from '@/ui/navigation/navigation-drawer/constants/OpenRecordInOptions';
+import { multiWorkspaceDropdownState } from '@/ui/navigation/navigation-drawer/states/multiWorkspaceDropdownState';
+import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+import { useLingui } from '@lingui/react/macro';
+import { OpenRecordIn } from 'twenty-shared/types';
+import { IconCheck, IconChevronLeft } from 'twenty-ui/icon';
+import { MenuItem } from 'twenty-ui/navigation';
+
+export const MultiWorkspaceDropdownOpenRecordInComponents = () => {
+  const { t } = useLingui();
+
+  const { openRecordInPreference, setOpenRecordInPreference } =
+    useOpenRecordInPreference();
+
+  const setMultiWorkspaceDropdown = useSetAtomState(
+    multiWorkspaceDropdownState,
+  );
+
+  return (
+    <DropdownContent>
+      <DropdownMenuHeader
+        StartComponent={
+          <DropdownMenuHeaderLeftComponent
+            onClick={() => setMultiWorkspaceDropdown('default')}
+            Icon={IconChevronLeft}
+          />
+        }
+      >
+        {t`Open records in`}
+      </DropdownMenuHeader>
+      <DropdownMenuItemsContainer>
+        {Object.values(OpenRecordIn).map((openRecordIn) => (
+          <MenuItem
+            key={openRecordIn}
+            LeftIcon={OPEN_RECORD_IN_OPTIONS[openRecordIn].Icon}
+            text={t(OPEN_RECORD_IN_OPTIONS[openRecordIn].label)}
+            onClick={() => setOpenRecordInPreference(openRecordIn)}
+            RightIcon={
+              openRecordIn === openRecordInPreference ? IconCheck : undefined
+            }
+          />
+        ))}
+      </DropdownMenuItemsContainer>
+    </DropdownContent>
+  );
+};

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/constants/OpenRecordInOptions.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/constants/OpenRecordInOptions.ts
@@ -1,0 +1,24 @@
+import { type MessageDescriptor } from '@lingui/core';
+import { msg } from '@lingui/core/macro';
+import { OpenRecordIn } from 'twenty-shared/types';
+import {
+  IconAddressBook,
+  type IconComponent,
+  IconLayoutSidebarRight,
+} from 'twenty-ui/icon';
+
+// Keyed by OpenRecordIn so a new preference cannot ship without a label, and
+// offered in the enum's declaration order.
+export const OPEN_RECORD_IN_OPTIONS = {
+  [OpenRecordIn.SIDE_PANEL]: {
+    Icon: IconLayoutSidebarRight,
+    label: msg`Side panel`,
+  },
+  [OpenRecordIn.RECORD_PAGE]: {
+    Icon: IconAddressBook,
+    label: msg`Full page`,
+  },
+} satisfies Record<
+  OpenRecordIn,
+  { Icon: IconComponent; label: MessageDescriptor }
+>;

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/constants/OpenRecordInOptions.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/constants/OpenRecordInOptions.ts
@@ -7,8 +7,6 @@ import {
   IconLayoutSidebarRight,
 } from 'twenty-ui/icon';
 
-// Keyed by OpenRecordIn so a new preference cannot ship without a label, and
-// offered in the enum's declaration order.
 export const OPEN_RECORD_IN_OPTIONS = {
   [OpenRecordIn.SIDE_PANEL]: {
     Icon: IconLayoutSidebarRight,

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/multiWorkspaceDropdownState.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/multiWorkspaceDropdownState.ts
@@ -1,7 +1,7 @@
 import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
 
 export const multiWorkspaceDropdownState = createAtomState<
-  'default' | 'workspaces-list' | 'themes'
+  'default' | 'workspaces-list' | 'themes' | 'open-record-in'
 >({
   key: 'multiWorkspaceDropdownState',
   defaultValue: 'default',


### PR DESCRIPTION
Removes the **Settings** entry from the workspace dropdown and adds an **Open in** row right after Theme, so members can switch where records open (side panel vs. full page) without going into Settings.

### What changed

**Workspace dropdown**

- `Settings` is gone from the menu.
- New `Open in · Side panel` / `Open in · Full page` row after `Theme`, with the current value's icon on the left — same shape as the Theme row.
- Clicking it opens an `Open records in` sub-menu with the two options and a checkmark on the active one, mirroring `MultiWorkspaceDropdownThemesComponents`.

**Preference**

Nothing new is persisted. The row reads and writes the existing workspace-member `openRecordIn` preference through `useOpenRecordInPreference`, the same hook backing Settings → Experience → Navigation. Per-object overrides still win: an object set to `SIDE_PANEL`/`RECORD_PAGE` (rather than `USER_CHOICE`) ignores the member preference. `resolveOpenRecordIn` is untouched.

**Mobile**

The row is hidden on mobile. The dropdown also renders on the mobile home page (`MobileHomePage`), but `useResolveOpenRecordIn` passes `canDisplaySidePanel: !isMobile`, so a record always opens on its own page there whatever the preference says — offering the choice would invite a change with no effect.

**Icons**

Canonical ones from `icon-dictionary.md`: `IconLayoutSidebarRight` for Side Panel, `IconAddressBook` for Record Page.

**Theme row**

Moved off a local `StyledDescription` onto `MenuItem`'s `contextualText`, which already renders the `· value` suffix with the same color and padding (plus overflow tooltip). This keeps the two adjacent rows rendering identically.

### Settings reachability

Settings is still reachable from the navigation drawer's Home / AI / **Settings** mode switcher (`MainNavigationDrawerModeSwitcher`), which navigates to the profile page. Two e2e flows reached Settings through the workspace dropdown and now click that button instead:

- `lib/pom/leftMenu.ts` → `goToSettings()`
- `tests/create-kanban-view.spec.ts`

The locator moves from `link "Settings"` to `button "Settings"` because the mode switcher renders a `<button>`. Note `NavigationDrawerOtherSection`, which also has a Settings item, is not rendered anywhere — it is dead code and not the entry point being relied on here.

### Verification

- `oxlint --type-aware` on the touched module: clean.
- `tsgo -p tsconfig.json --noEmit` on `twenty-front`: 0 errors.
- `oxfmt` applied.
- No unit tests or stories cover this dropdown, and none exist for the sibling Theme sub-menu, so none were added.
- The two e2e changes were not executed here (they need a running app + database) — worth a look on CI.

### Not in this PR

Settings → Experience → Navigation still shows the same preference on mobile, where it is equally inert. That is pre-existing and untouched here; happy to hide it in a follow-up if wanted.

Translation catalogs were deliberately left out of the commit; the i18n pipeline regenerates them.