### PR TITLE
Fail closed when issuing required user sessions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/user-session/services/user-session.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/services/user-session.service.spec.ts
@@ -1,0 +1,88 @@
+import { JwtTokenTypeEnum } from 'src/engine/core-modules/auth/types/jwt-token-type.enum';
+import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/workspace.type';
+
+import { UserSessionService } from './user-session.service';
+
+describe('UserSessionService.issueSessionForTokenPair', () => {
+  const userSessionRepository = {
+    create: jest.fn((input) => input),
+    save: jest.fn(),
+  };
+  const jwtWrapperService = {
+    decode: jest.fn().mockReturnValue({
+      type: JwtTokenTypeEnum.ACCESS,
+      userId: 'user-id',
+      workspaceId: 'workspace-id',
+      userWorkspaceId: 'user-workspace-id',
+      authProvider: AuthProviderEnum.Password,
+    }),
+  };
+  const twentyConfigService = {
+    get: jest.fn().mockReturnValue('30d'),
+  };
+  const userSessionCookieService = {
+    attachSessionTokenToResponse: jest.fn(),
+    clearSessionCookie: jest.fn(),
+    extractSessionTokenFromRequest: jest.fn(),
+  };
+  const service = new UserSessionService(
+    userSessionRepository as never,
+    {} as never,
+    {} as never,
+    twentyConfigService as never,
+    jwtWrapperService as never,
+    {} as never,
+    userSessionCookieService as never,
+  );
+  const tokenPair = {
+    accessOrWorkspaceAgnosticToken: {
+      token: 'access-token',
+      expiresAt: new Date('2026-01-01T00:00:00.000Z'),
+    },
+    refreshToken: {
+      token: 'refresh-token',
+      expiresAt: new Date('2026-01-01T00:00:00.000Z'),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves the presented session when replacement creation fails', async () => {
+    const creationError = new Error('session insert failed');
+
+    userSessionCookieService.extractSessionTokenFromRequest.mockReturnValue(
+      'presented-session-token',
+    );
+    userSessionRepository.save.mockRejectedValue(creationError);
+
+    const revokeSessionByToken = jest.spyOn(service, 'revokeSessionByToken');
+
+    await expect(
+      service.issueSessionForTokenPair({
+        tokenPair,
+        request: { headers: {}, ip: '127.0.0.1', res: {} } as never,
+        origin: 'sign_in',
+      }),
+    ).rejects.toBe(creationError);
+
+    expect(revokeSessionByToken).not.toHaveBeenCalled();
+    expect(
+      userSessionCookieService.attachSessionTokenToResponse,
+    ).not.toHaveBeenCalled();
+    expect(userSessionCookieService.clearSessionCookie).not.toHaveBeenCalled();
+  });
+
+  it('fails when the required response is unavailable', async () => {
+    await expect(
+      service.issueSessionForTokenPair({
+        tokenPair,
+        request: { headers: {} } as never,
+        origin: 'sign_in',
+      }),
+    ).rejects.toThrow('Cannot issue a user session without an HTTP response');
+
+    expect(userSessionRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/user-session/services/user-session.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/services/user-session.service.ts
@@ -66,8 +66,6 @@ export class UserSessionService {
     private readonly userSessionCookieService: UserSessionCookieService,
   ) {}
 
-  // Best effort by design: while token pairs remain the primary credential, a
-  // session failure must never break an otherwise successful sign-in.
   async issueSessionForTokenPair({
     tokenPair,
     request,
@@ -80,7 +78,7 @@ export class UserSessionService {
     const response = request.res;
 
     if (!isDefined(response)) {
-      return;
+      throw new Error('Cannot issue a user session without an HTTP response');
     }
 
     // Cannot live in the CSRF middleware, which cannot know a request is about
@@ -90,7 +88,10 @@ export class UserSessionService {
         `Refused to issue a session cookie to origin ${request.headers.origin}`,
       );
 
-      return;
+      throw new AuthException(
+        'Request origin is not allowed to receive a session cookie',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+      );
     }
 
     try {
@@ -101,53 +102,38 @@ export class UserSessionService {
       );
 
       if (!isDefined(sessionInput)) {
-        return;
+        throw new AuthException(
+          'Cannot issue a session from an invalid token pair',
+          AuthExceptionCode.UNAUTHENTICATED,
+        );
       }
 
       const presentedSessionToken =
         this.userSessionCookieService.extractSessionTokenFromRequest(request);
 
-      if (isDefined(presentedSessionToken)) {
-        if (origin === 'renewal_bridge') {
-          try {
-            const { payload: presentedPayload } = await this.resolveSession(
-              presentedSessionToken,
-            );
+      if (isDefined(presentedSessionToken) && origin === 'renewal_bridge') {
+        try {
+          const { payload: presentedPayload } = await this.resolveSession(
+            presentedSessionToken,
+          );
 
-            if (
-              this.isSessionScopeMatchingRenewal(presentedPayload, sessionInput)
-            ) {
-              return;
-            }
-
-            await this.revokeSessionByToken(
-              presentedSessionToken,
-              UserSessionRevokedReason.Superseded,
-            );
-          } catch (error) {
-            if (
-              !(error instanceof AuthException) ||
-              error.code !== AuthExceptionCode.UNAUTHENTICATED
-            ) {
-              throw error;
-            }
+          if (
+            this.isSessionScopeMatchingRenewal(presentedPayload, sessionInput)
+          ) {
+            return;
           }
-        } else if (sessionInput.isImpersonating === true) {
-          // The one sign-in that must not revoke what it replaces: parking the
-          // impersonator's session lets stopImpersonation hand back the credential
-          // they already held.
-          this.userSessionCookieService.attachImpersonatorSessionTokenToResponse(
-            response,
-            presentedSessionToken,
-          );
-        } else {
-          await this.revokeSessionByToken(
-            presentedSessionToken,
-            UserSessionRevokedReason.Superseded,
-          );
+        } catch (error) {
+          if (
+            !(error instanceof AuthException) ||
+            error.code !== AuthExceptionCode.UNAUTHENTICATED
+          ) {
+            throw error;
+          }
         }
       }
 
+      // Create the replacement before touching the presented session. If the
+      // insert fails, the browser keeps its last working credential.
       const { sessionToken, session } = await this.createSession(sessionInput);
 
       this.userSessionCookieService.attachSessionTokenToResponse(
@@ -155,21 +141,45 @@ export class UserSessionService {
         sessionToken,
         session.expiresAt,
       );
-    } catch (error) {
-      // Sign-in only: the presented cookie may be the previous account's. On
-      // renewal it is this user's own live session, which a transient failure
-      // must not kill.
-      if (origin === 'sign_in') {
-        try {
-          this.userSessionCookieService.clearSessionCookie(response);
-        } catch {}
+
+      if (!isDefined(presentedSessionToken)) {
+        return;
       }
 
+      if (sessionInput.isImpersonating === true) {
+        // The one sign-in that must not revoke what it replaces: parking the
+        // impersonator's session lets stopImpersonation hand back the credential
+        // they already held.
+        this.userSessionCookieService.attachImpersonatorSessionTokenToResponse(
+          response,
+          presentedSessionToken,
+        );
+
+        return;
+      }
+
+      try {
+        await this.revokeSessionByToken(
+          presentedSessionToken,
+          UserSessionRevokedReason.Superseded,
+        );
+      } catch (error) {
+        // The replacement session and cookie are already valid. A cleanup
+        // failure must not turn that successful handoff into another logout.
+        this.logger.error(
+          `Failed to revoke the superseded session: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    } catch (error) {
       this.logger.error(
-        `Failed to issue a session alongside the token pair: ${
+        `Failed to issue a required session: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
+
+      throw error;
     }
   }
 

--- a/packages/twenty-server/test/integration/graphql/suites/auth.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/auth.integration-spec.ts
@@ -35,7 +35,8 @@ describe('AuthResolve (integration)', () => {
 
     return client
       .post('/metadata')
-      .set('Origin', ORIGIN.toString())
+      .set('Host', ORIGIN.host)
+      .set('Origin', ORIGIN.origin)
       .send(queryData)
       .expect(200)
       .expect((res) => {
@@ -69,7 +70,8 @@ describe('AuthResolve (integration)', () => {
 
     return client
       .post('/metadata')
-      .set('Origin', ORIGIN.toString())
+      .set('Host', ORIGIN.host)
+      .set('Origin', ORIGIN.origin)
       .send(queryData)
       .expect(200)
       .expect((res) => {

--- a/packages/twenty-server/test/integration/graphql/suites/auth/user-sessions/failing-session-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/auth/user-sessions/failing-session-creation.integration-spec.ts
@@ -1,14 +1,21 @@
+import * as jwt from 'jsonwebtoken';
 import { buildAppleWorkspaceOrigin } from 'test/integration/graphql/utils/build-apple-workspace-origin.util';
+import { forgeLegacyHs256Token } from 'test/integration/graphql/utils/forge-legacy-hs256-token.util';
+import { getAuthTokensFromLoginTokenQueryFactory } from 'test/integration/graphql/utils/get-auth-tokens-from-login-token.query-factory.util';
 import { getLoginTokenFromCredentialsQueryFactory } from 'test/integration/graphql/utils/get-login-token-from-credentials.query-factory.util';
 import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
 import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
 
 import {
   extractSessionCookie,
+  hasClearingCookie,
+  postMetadataOperationWithHeaders,
   signInWithCookieCapture,
 } from 'test/integration/graphql/suites/auth/user-sessions/utils/sign-in-with-cookie-capture.util';
 
+import { type LoginTokenJwtPayload } from 'src/engine/core-modules/auth/types/login-token-jwt-payload.type';
 import { UserSessionEntity } from 'src/engine/core-modules/user-session/user-session.entity';
+import { hashUserSessionToken } from 'src/engine/core-modules/user-session/utils/hash-user-session-token.util';
 
 import {
   ALLOWED_ORIGIN,
@@ -16,7 +23,7 @@ import {
 } from 'test/integration/graphql/suites/auth/user-sessions/constants/session-origins.constants';
 
 describe('failing user session creation on auth exchanges (integration)', () => {
-  it('should refuse the cookie but still return tokens on a sign-in from a disallowed origin (login-CSRF)', async () => {
+  it('should fail the exchange when a disallowed origin cannot receive its required session cookie', async () => {
     const userSessionRepository =
       getCoreRepository<UserSessionEntity>(UserSessionEntity);
     const sessionCountBefore = await userSessionRepository.count();
@@ -25,14 +32,75 @@ describe('failing user session creation on auth exchanges (integration)', () => 
       originHeader: DISALLOWED_ORIGIN,
     });
 
-    expect(
-      response.body.data.getAuthTokensFromLoginToken.tokens.refreshToken.token,
-    ).toBeDefined();
+    expect(response.body.errors).toBeDefined();
+    expect(response.body.data?.getAuthTokensFromLoginToken).toBeFalsy();
     expect(extractSessionCookie(response)).toBeUndefined();
 
     const sessionCountAfter = await userSessionRepository.count();
 
     expect(sessionCountAfter).toBe(sessionCountBefore);
+  });
+
+  it('should preserve the presented session when replacement session creation fails', async () => {
+    const existingSessionResponse = await signInWithCookieCapture({
+      originHeader: ALLOWED_ORIGIN,
+    });
+    const existingSessionCookie = extractSessionCookie(existingSessionResponse);
+
+    if (!existingSessionCookie) {
+      throw new Error('Expected an existing session cookie');
+    }
+
+    const workspaceOrigin = buildAppleWorkspaceOrigin();
+    const loginTokenResponse = await postMetadataOperationWithHeaders(
+      getLoginTokenFromCredentialsQueryFactory({
+        email: 'tim@apple.dev',
+        password: 'tim@apple.dev',
+        origin: workspaceOrigin,
+      }),
+      {
+        originHeader: ALLOWED_ORIGIN,
+        cookieHeader: existingSessionCookie.cookieHeader,
+      },
+    );
+    const validLoginToken =
+      loginTokenResponse.body.data.getLoginTokenFromCredentials.loginToken
+        .token;
+    const validPayload = jwt.decode(validLoginToken) as LoginTokenJwtPayload;
+    const loginTokenWithoutProvider = forgeLegacyHs256Token(
+      {
+        sub: validPayload.sub,
+        type: validPayload.type,
+        workspaceId: validPayload.workspaceId,
+      },
+      validPayload.workspaceId,
+    );
+
+    const failedExchangeResponse = await postMetadataOperationWithHeaders(
+      getAuthTokensFromLoginTokenQueryFactory({
+        loginToken: loginTokenWithoutProvider,
+        origin: workspaceOrigin,
+      }),
+      {
+        originHeader: ALLOWED_ORIGIN,
+        cookieHeader: existingSessionCookie.cookieHeader,
+      },
+    );
+
+    expect(failedExchangeResponse.body.errors).toBeDefined();
+    expect(
+      failedExchangeResponse.body.data?.getAuthTokensFromLoginToken,
+    ).toBeFalsy();
+    expect(extractSessionCookie(failedExchangeResponse)).toBeUndefined();
+    expect(hasClearingCookie(failedExchangeResponse)).toBe(false);
+
+    const existingSession = await getCoreRepository<UserSessionEntity>(
+      UserSessionEntity,
+    ).findOneBy({
+      tokenHash: hashUserSessionToken(existingSessionCookie.sessionToken),
+    });
+
+    expect(existingSession?.revokedAt).toBeNull();
   });
 
   it('should mint nothing when the credentials exchange itself fails', async () => {


### PR DESCRIPTION
## Summary
- make authentication exchanges fail when their required browser session cannot be issued
- create the replacement session before revoking the presented session
- preserve impersonation handoff behavior and avoid converting post-handoff cleanup failures into logouts
- add focused unit and integration regressions

## Root cause
Session issuance was implemented as best effort. Errors were swallowed, so GraphQL could report a successful token exchange even when no session cookie was created. It also revoked the existing session before inserting its replacement, so an insert failure destroyed the last working credential. Since the frontend no longer persists the legacy token pair as its primary credential, either path presents as an immediate logout after workspace creation.

## Tests
- focused user-session Jest suite: 1 suite, 2 tests passed
- targeted type-aware Oxlint and Oxfmt checks passed
- DB-backed integration regression was added; local execution reached application startup but could not run because no test PostgreSQL instance was available

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

