### PR TITLE
Surface structured login verification errors

### DIFF
--- a/packages/twenty-front/src/modules/auth/hooks/__tests__/useVerifyLogin.test.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/__tests__/useVerifyLogin.test.ts
@@ -1,5 +1,6 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { renderHook } from '@testing-library/react';
 import { Provider as JotaiProvider } from 'jotai';
 
@@ -70,7 +71,7 @@ describe('useVerifyLogin', () => {
     expect(mockGetAuthTokensFromLoginToken).toHaveBeenCalledWith('test-token');
   });
 
-  it('should handle verification error', async () => {
+  it('should handle a non-GraphQL verification error', async () => {
     const error = new Error('Verification failed');
     mockGetAuthTokensFromLoginToken.mockRejectedValueOnce(error);
 
@@ -80,6 +81,22 @@ describe('useVerifyLogin', () => {
 
     expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({
       message: 'Authentication failed',
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(AppPath.SignInUp);
+  });
+
+  it('should preserve a GraphQL verification error for the snackbar', async () => {
+    const error = new CombinedGraphQLErrors({
+      errors: [{ message: 'Session could not be created' }],
+    });
+    mockGetAuthTokensFromLoginToken.mockRejectedValueOnce(error);
+
+    const { result } = renderHooks();
+
+    await result.current.verifyLoginToken('test-token');
+
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({
+      apolloError: error,
     });
     expect(mockNavigate).toHaveBeenCalledWith(AppPath.SignInUp);
   });

--- a/packages/twenty-front/src/modules/auth/hooks/useVerifyLogin.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useVerifyLogin.ts
@@ -2,6 +2,7 @@ import { isAppEffectRedirectEnabledState } from '@/app/states/isAppEffectRedirec
 import { useAuth } from '@/auth/hooks/useAuth';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { useLingui } from '@lingui/react/macro';
 import { AppPath } from 'twenty-shared/types';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
@@ -20,10 +21,14 @@ export const useVerifyLogin = () => {
     setIsAppEffectRedirectEnabled(false);
     try {
       await getAuthTokensFromLoginToken(loginToken);
-    } catch {
-      enqueueErrorSnackBar({
-        message: t`Authentication failed`,
-      });
+    } catch (error) {
+      enqueueErrorSnackBar(
+        CombinedGraphQLErrors.is(error)
+          ? { apolloError: error }
+          : {
+              message: t`Authentication failed`,
+            },
+      );
       navigate(AppPath.SignInUp);
     } finally {
       setIsAppEffectRedirectEnabled(true);


### PR DESCRIPTION
## Summary
- preserve Apollo GraphQL errors when login-token verification fails
- let the existing snackbar formatter show the actionable server error instead of replacing it with a generic authentication failure
- keep the generic fallback for non-GraphQL failures

## Root cause
The verification hook discarded every caught error and always showed a generic message before navigating back to sign-in. That hid whether the failure came from token validation, origin protection, or session creation, making this production issue much harder to identify.

## Tests
- focused useVerifyLogin Jest suite: 1 suite, 3 tests passed
- targeted type-aware Oxlint and Oxfmt checks passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

