### PR TITLE
Enforce role object permissions on writes to system objects

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
@@ -1,6 +1,5 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import isEmpty from 'lodash.isempty';
-import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   type ObjectsPermissions,
   type RestrictedFieldsPermissions,
@@ -20,9 +19,6 @@ import {
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { validateWritabilityOrThrow } from 'src/engine/twenty-orm/repository/validate-writability-or-throw.util';
 import { getColumnNameToFieldMetadataIdMap } from 'src/engine/twenty-orm/utils/get-column-name-to-field-metadata-id.util';
-
-const WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER =
-  STANDARD_OBJECTS.workspaceMember.universalIdentifier;
 
 export type OperationType =
   | 'select'
@@ -91,16 +87,6 @@ export const validateOperationIsPermittedOrThrow = ({
     flatFieldMetadataMaps,
     authContext,
   });
-
-  const objectMetadataIsSystem = objectMetadata.isSystem === true;
-  const isWorkspaceMemberObject =
-    objectMetadata.universalIdentifier ===
-    WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER;
-
-  // TODO: this should be improved, we may have more complex permission configuration for is system objects
-  if (objectMetadataIsSystem && !isWorkspaceMemberObject) {
-    return;
-  }
 
   const permissionsForEntity = objectsPermissions[objectMetadataIdForEntity];
 

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -39,6 +39,7 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
         const calendarChannelEventAssociationRepository =
           this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
             'calendarChannelEventAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         const calendarChannelCalendarEventsAssociations =

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -40,6 +40,7 @@ export class ApplyMessagesVisibilityRestrictionsService {
         const messageChannelMessageAssociationRepository =
           this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         const messageChannelMessagesAssociations =

--- a/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/system-object-records-permissions.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/system-object-records-permissions.integration-spec.ts
@@ -1,0 +1,291 @@
+import { randomUUID } from 'node:crypto';
+
+import gql from 'graphql-tag';
+import { default as request } from 'supertest';
+import { MESSAGE_GQL_FIELDS } from 'test/integration/constants/message-gql-fields.constants';
+import { PERSON_GQL_FIELDS } from 'test/integration/constants/person-gql-fields.constants';
+import { createRoleOperation } from 'test/integration/graphql/utils/create-custom-role-operation-factory.util';
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { deleteOneOperationFactory } from 'test/integration/graphql/utils/delete-one-operation-factory.util';
+import { deleteRole } from 'test/integration/graphql/utils/delete-one-role.util';
+import { destroyOneOperationFactory } from 'test/integration/graphql/utils/destroy-one-operation-factory.util';
+import { findOneOperationFactory } from 'test/integration/graphql/utils/find-one-operation-factory.util';
+import { makeGraphqlAPIRequestWithMemberRole } from 'test/integration/graphql/utils/make-graphql-api-request-with-member-role.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { updateOneOperationFactory } from 'test/integration/graphql/utils/update-one-operation-factory.util';
+import { updateWorkspaceMemberRole } from 'test/integration/graphql/utils/update-workspace-member-role.util';
+import { createUpsertObjectPermissionsOperation } from 'test/integration/graphql/utils/upsert-object-permission-operation-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+
+import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { PermissionsExceptionMessage } from 'src/engine/metadata-modules/permissions/permissions.exception';
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+const client = request(`http://localhost:${APP_PORT}`);
+
+type GraphqlResponse = {
+  body: {
+    errors: { message: string; extensions: { code: string } }[];
+  };
+};
+
+describe('systemObjectRecordsPermissions', () => {
+  const messageId = randomUUID();
+  const personId = randomUUID();
+
+  let originalMemberRoleId: string;
+  let messageObjectId: string;
+  let customRoleId: string | undefined;
+
+  const createCustomRole = async ({
+    label,
+    canUpdateAllObjectRecords = true,
+    canSoftDeleteAllObjectRecords = true,
+    canDestroyAllObjectRecords = true,
+  }: {
+    label: string;
+    canUpdateAllObjectRecords?: boolean;
+    canSoftDeleteAllObjectRecords?: boolean;
+    canDestroyAllObjectRecords?: boolean;
+  }) => {
+    const response = await makeMetadataAPIRequest(
+      createRoleOperation({
+        label,
+        description: 'Role asserting permissions on system objects',
+        canUpdateAllSettings: false,
+        canReadAllObjectRecords: true,
+        canUpdateAllObjectRecords,
+        canSoftDeleteAllObjectRecords,
+        canDestroyAllObjectRecords,
+      }),
+    );
+
+    expect(response.body.errors).toBeUndefined();
+
+    const roleId: string = response.body.data.createOneRole.id;
+
+    customRoleId = roleId;
+
+    return roleId;
+  };
+
+  const assignRoleToMember = async (roleId: string) =>
+    updateWorkspaceMemberRole({
+      client,
+      roleId,
+      workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+    });
+
+  const expectPermissionDenied = (response: GraphqlResponse) => {
+    expect(response.body.errors).toBeDefined();
+    expect(response.body.errors[0].message).toBe(
+      PermissionsExceptionMessage.PERMISSION_DENIED,
+    );
+    expect(response.body.errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+  };
+
+  beforeAll(async () => {
+    const rolesResponse = await makeMetadataAPIRequest({
+      query: gql`
+        query GetRoles {
+          getRoles {
+            id
+            label
+          }
+        }
+      `,
+    });
+
+    originalMemberRoleId = rolesResponse.body.data.getRoles.find(
+      (role: { label: string }) => role.label === 'Member',
+    ).id;
+
+    const objectMetadataResponse = await makeMetadataAPIRequest({
+      query: gql`
+        query {
+          objects(paging: { first: 1000 }) {
+            edges {
+              node {
+                id
+                nameSingular
+              }
+            }
+          }
+        }
+      `,
+    });
+
+    const objects = objectMetadataResponse.body.data.objects.edges;
+
+    messageObjectId = objects.find(
+      (object: { node: { nameSingular: string } }) =>
+        object.node.nameSingular === 'message',
+    )?.node.id;
+
+    expect(messageObjectId).toBeDefined();
+
+    await makeGraphqlAPIRequest(
+      createOneOperationFactory({
+        objectMetadataSingularName: 'message',
+        gqlFields: MESSAGE_GQL_FIELDS,
+        data: {
+          id: messageId,
+          subject: 'System object permissions',
+          text: 'Original text',
+        },
+      }),
+    );
+
+    await makeGraphqlAPIRequest(
+      createOneOperationFactory({
+        objectMetadataSingularName: 'person',
+        gqlFields: PERSON_GQL_FIELDS,
+        data: { id: personId, jobTitle: 'Software Engineer' },
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    if (customRoleId !== undefined) {
+      await deleteRole(client, customRoleId);
+      customRoleId = undefined;
+    }
+
+    await assignRoleToMember(originalMemberRoleId);
+  });
+
+  afterAll(async () => {
+    await makeGraphqlAPIRequest(
+      destroyOneOperationFactory({
+        objectMetadataSingularName: 'message',
+        gqlFields: 'id',
+        recordId: messageId,
+      }),
+    );
+
+    await makeGraphqlAPIRequest(
+      destroyOneOperationFactory({
+        objectMetadataSingularName: 'person',
+        gqlFields: 'id',
+        recordId: personId,
+      }),
+    );
+  });
+
+  describe('when the role overrides a system object to read-only', () => {
+    beforeEach(async () => {
+      const roleId = await createCustomRole({
+        label: `MessageReadOnlyRole-${randomUUID()}`,
+      });
+
+      await makeMetadataAPIRequest(
+        createUpsertObjectPermissionsOperation(roleId, [
+          {
+            objectMetadataId: messageObjectId,
+            canReadObjectRecords: true,
+            canUpdateObjectRecords: false,
+            canSoftDeleteObjectRecords: false,
+            canDestroyObjectRecords: false,
+          },
+        ]),
+      );
+
+      await assignRoleToMember(roleId);
+    });
+
+    it('should still allow reading a message', async () => {
+      const response = await makeGraphqlAPIRequestWithMemberRole(
+        findOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: MESSAGE_GQL_FIELDS,
+          filter: { id: { eq: messageId } },
+        }),
+      );
+
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.message.id).toBe(messageId);
+    });
+
+    it('should deny updating a message', async () => {
+      const response = await makeGraphqlAPIRequestWithMemberRole(
+        updateOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: MESSAGE_GQL_FIELDS,
+          recordId: messageId,
+          data: { text: 'Updated by a read-only role' },
+        }),
+      );
+
+      expectPermissionDenied(response);
+    });
+
+    it('should deny soft-deleting a message', async () => {
+      const response = await makeGraphqlAPIRequestWithMemberRole(
+        deleteOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: 'id',
+          recordId: messageId,
+        }),
+      );
+
+      expectPermissionDenied(response);
+    });
+
+    it('should deny destroying a message', async () => {
+      const response = await makeGraphqlAPIRequestWithMemberRole(
+        destroyOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: 'id',
+          recordId: messageId,
+        }),
+      );
+
+      expectPermissionDenied(response);
+    });
+  });
+
+  describe('when the role sets no override on a system object', () => {
+    beforeEach(async () => {
+      const roleId = await createCustomRole({
+        label: `NoMessageOverrideRole-${randomUUID()}`,
+        canUpdateAllObjectRecords: false,
+        canSoftDeleteAllObjectRecords: false,
+        canDestroyAllObjectRecords: false,
+      });
+
+      await assignRoleToMember(roleId);
+    });
+
+    // System objects stay writable when a role expresses no opinion on them: the
+    // default lives in the permissions cache, so removing the ORM-level bypass
+    // must not turn "no override" into a denial.
+    it('should allow updating a message', async () => {
+      const response = await makeGraphqlAPIRequestWithMemberRole(
+        updateOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: MESSAGE_GQL_FIELDS,
+          recordId: messageId,
+          data: { text: 'Updated through the system object default' },
+        }),
+      );
+
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.updateMessage.text).toBe(
+        'Updated through the system object default',
+      );
+    });
+
+    it('should deny updating a non-system object', async () => {
+      const response = await makeGraphqlAPIRequestWithMemberRole(
+        updateOneOperationFactory({
+          objectMetadataSingularName: 'person',
+          gqlFields: PERSON_GQL_FIELDS,
+          recordId: personId,
+          data: { jobTitle: 'Senior Software Engineer' },
+        }),
+      );
+
+      expectPermissionDenied(response);
+    });
+  });
+});


### PR DESCRIPTION
 # Enforce role object permissions on writes to system objects

Fixes #24309

## Bug

A role holding read-only `objectPermissions` overrides on a system object could still
mutate its records. With `canRead: true` and `canUpdate / canSoftDelete / canDestroy: false`
on `message`, an API key or workspace member assigned that role could still run
`updateMessage`, `deleteMessage` and `destroyMessage` successfully. Reads behaved
correctly, and the identical override shape on a standard object (`person`, `company`)
denied writes as expected — the gap was writes to system objects specifically.

Impact: a least-privilege integration key scoped to *read* synced mail could not be
prevented from mutating or destroying the synced source messages.

## Root cause

`validateOperationIsPermittedOrThrow` returned early for every system object except
`workspaceMember`, before consulting the role's permissions:

```ts
// TODO: this should be improved, we may have more complex permission configuration for is system objects
if (objectMetadataIsSystem && !isWorkspaceMemberObject) {
  return;
}
```

`d6c186a` (#23280) already fixed the other half of this: it flipped precedence in
`WorkspaceRolesPermissionsCacheService` so an explicit role override wins over the
system-object default (`overrideValue ?? (isSystem ? true : defaultValue)`). The ORM
validator never caught up, so the cache computed the right answer and the validator
threw it away.

## Fix

**1. Delete the early return outright** rather than conditioning it, so the permissions
cache stays the single source of truth for the system-object default. The unused
`STANDARD_OBJECTS` import and `WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER` constant
go with it.

Conditioning the return was considered and rejected: for a resolved role,
`computeForCache` writes an entry for every object in the workspace, so a
`isDefined(permissionsForEntity)` guard would never fire and would silently remove the
bypass for all system objects anyway. Roles that express no override still resolve to
the permissive default through `getPermissionValue`, so nothing changes for them.

**2. Declare the bypass explicitly on two visibility-restriction services.**
Removing the early return exposed a latent defect it had been masking.
`resolveObjectRecordsPermissions` returns an **empty permissions map with enforcement
enabled** when `getRepository` is called without a `rolePermissionConfig`:

```ts
if (!isDefined(rolePermissionConfig)) {
  return { objectRecordsPermissions: {}, shouldBypassPermissionChecks: false };
}
```

An empty map denies every object — it does not inherit the ambient auth context, even a
system one. `ApplyMessagesVisibilityRestrictionsService` and
`ApplyCalendarEventsVisibilityRestrictionsService` both build a system auth context via
`buildSystemAuthContext` and pass it to `executeInWorkspaceContext`, but their
`getRepository` calls omitted the config. Their reads of
`messageChannelMessageAssociation` / `calendarChannelEventAssociation` were surviving
only because of the system-object bypass.

Without this second part, removing the bypass turns a permissions hole into a denial of
legitimate reads: every `message` read fails with `PERMISSION_DENIED`, because applying
channel visibility is on the read path.

## Blast radius

- **System objects with no role override** — unchanged. The cache still resolves them to
  the permissive default, so the existing guest-role case in
  `update-one-object-records-permissions.integration-spec.ts`
  (*"should allow to update a system object record even without update permission"*)
  still passes. The new spec pins this explicitly.
- **`workflowRun` / `workflowVersion`** — these are system objects gated on the
  `WORKFLOWS` flag in the cache, so they move from *never checked* to *checked* at the
  ORM layer. This aligns them with `workflow`, which is not a system object and is
  already gated today, so a role without `WORKFLOWS` sees consistent behaviour across
  the three. The workflow engine writes `workflowRun` through
  `workflow-run.workspace-service.ts` with `shouldBypassPermissionChecks: true` and a
  system auth context, so execution is unaffected. The role-based readers are the AI
  workflow tools (`list-workflow-runs`, `get-workflow-run`), which already fail on
  `workflow` for such a role.
- **Config-less `getRepository` call sites** — 52 call sites pass no
  `rolePermissionConfig`, most of them on system objects (`noteTarget`, `taskTarget`,
  `messageParticipant`, `calendarEventParticipant`, `calendarChannelEventAssociation`,
  `workflowAutomatedTrigger`, …). All were relying on the bypass. Two are fixed here
  because they are on the read path the suites exercise; see Follow-up.

## Testing

New `test/integration/graphql/suites/object-records-permissions/system-object-records-permissions.integration-spec.ts`,
6 cases:

*Role with read-only overrides on `message`:*
- reading a message is still allowed
- updating a message is denied
- soft-deleting a message is denied
- destroying a message is denied

*Role with no override on `message` and all global write flags `false`:*
- updating a message is allowed (system-object default via the cache)
- updating a non-system object is denied

The three deny cases fail on `main` and pass with this change. The fifth case is the
guard against over-broadening: it fails if the bypass removal is applied to roles that
express no opinion.

Verified locally:
- `object-records-permissions` integration suite: **16 suites, 65 tests passed** (on a
  freshly reset test database)
- `twenty-server` unit tests: **970 suites, 6934 tests passed**
- `tsgo -p tsconfig.json --noEmit`: 0 errors
- `oxlint --type-aware` + `oxfmt --check`: 0 errors

## Follow-up

The durable fix for the config-less `getRepository` shape is to make
`resolveObjectRecordsPermissions` inherit the ambient auth context instead of returning
a deny-all map — a system context would then resolve to
`shouldBypassPermissionChecks: true` on its own, and the remaining ~50 call sites would
need no annotation. That changes a security default, so it is left out of this PR and
raised for maintainers to decide.

Separately, `match-participant.service.ts` reads `messageParticipant` and
`calendarEventParticipant` through the same config-less shape (observed on person
creation). The denial is currently swallowed, so participant matching degrades silently
rather than erroring; worth a look independently of this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

