### PR TITLE
Fix morph junction relation picker in field widgets

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -13,8 +13,7 @@ import { useAddNewRecordAndOpenSidePanel } from '@/object-record/record-field/ui
 import { useUpdateRelationOneToManyFieldInput } from '@/object-record/record-field/ui/meta-types/input/hooks/useUpdateRelationOneToManyFieldInput';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
-import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionRelationPickerData } from '@/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
 import { MultipleRecordPicker } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker';
 import { useMultipleRecordPickerOpen } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerOpen';
@@ -74,23 +73,13 @@ export const RecordDetailRelationSectionDropdownToMany = ({
   const relationFieldDefinition =
     fieldDefinition as FieldDefinition<FieldRelationMetadata>;
 
-  const { updateJunctionRelationFromCell, isJunctionConfigValid } =
+  const { updateJunctionRelationFromCell, junctionConfig } =
     useUpdateJunctionRelationFromCell({
       fieldMetadataItem,
       fieldDefinition: relationFieldDefinition,
       recordId,
     });
 
-  const junctionConfig = isJunctionConfigValid
-    ? getJunctionConfig({
-        settings: fieldMetadataItem.settings,
-        relationObjectMetadataId:
-          relationFieldDefinition.metadata.relationObjectMetadataId,
-        relationTargetFieldMetadataId: relationFieldMetadataId,
-        sourceObjectMetadataId: objectMetadataItem.id,
-        objectMetadataItems,
-      })
-    : null;
   const isJunctionRelation = isDefined(junctionConfig);
 
   const firstJunctionTargetField =
@@ -110,11 +99,6 @@ export const RecordDetailRelationSectionDropdownToMany = ({
       objectNameSingular: relationObjectMetadataNameSingular,
     });
 
-  const pickerObjectMetadataItem =
-    isJunctionRelation && isDefined(junctionTargetObjectMetadata)
-      ? junctionTargetObjectMetadata
-      : relationObjectMetadataItem;
-
   const relationFieldMetadataItem = relationObjectMetadataItem.fields.find(
     ({ id }) => id === relationFieldMetadataId,
   );
@@ -132,22 +116,23 @@ export const RecordDetailRelationSectionDropdownToMany = ({
 
   const relationRecords: ObjectRecord[] = (fieldValue as ObjectRecord[]) ?? [];
 
-  const pickerRecords =
-    isJunctionRelation &&
-    isDefined(junctionConfig) &&
-    isDefined(junctionTargetObjectMetadata)
-      ? extractTargetRecordsFromJunction({
-          junctionRecords: relationRecords,
-          targetFields: junctionConfig.targetFields,
-          objectMetadataItems,
-        }).map((extracted) => ({
-          recordId: extracted.recordId,
-          objectMetadataId: extracted.objectMetadataId,
-        }))
-      : relationRecords.map((record) => ({
-          recordId: record.id,
-          objectMetadataId: pickerObjectMetadataItem.id,
-        }));
+  const { pickableMorphItems, searchableObjectMetadataItems } = isDefined(
+    junctionConfig,
+  )
+    ? getJunctionRelationPickerData({
+        junctionRecords: relationRecords,
+        targetFields: junctionConfig.targetFields,
+        objectMetadataItems,
+      })
+    : {
+        pickableMorphItems: relationRecords.map(({ id: recordId }) => ({
+          recordId,
+          objectMetadataId: relationObjectMetadataItem.id,
+          isSelected: true,
+          isMatchingSearchFilter: true,
+        })),
+        searchableObjectMetadataItems: [relationObjectMetadataItem],
+      };
 
   const dropdownId = getRecordFieldCardRelationPickerDropdownId({
     fieldDefinition,
@@ -217,16 +202,9 @@ export const RecordDetailRelationSectionDropdownToMany = ({
   });
 
   const handleOpenRelationPickerDropdown = () => {
-    const pickableMorphItems = pickerRecords.map((item) => ({
-      recordId: item.recordId,
-      objectMetadataId: item.objectMetadataId,
-      isSelected: true,
-      isMatchingSearchFilter: true,
-    }));
-
-    setMultipleRecordPickerSearchableObjectMetadataItems([
-      pickerObjectMetadataItem,
-    ]);
+    setMultipleRecordPickerSearchableObjectMetadataItems(
+      searchableObjectMetadataItems,
+    );
     setMultipleRecordPickerSearchFilter('');
     setMultipleRecordPickerPickableMorphItems(pickableMorphItems);
 
@@ -235,7 +213,7 @@ export const RecordDetailRelationSectionDropdownToMany = ({
     multipleRecordPickerPerformSearch({
       multipleRecordPickerInstanceId: dropdownId,
       forceSearchFilter: '',
-      forceSearchableObjectMetadataItems: [pickerObjectMetadataItem],
+      forceSearchableObjectMetadataItems: searchableObjectMetadataItems,
       forcePickableMorphItems: pickableMorphItems,
     });
   };
@@ -265,7 +243,7 @@ export const RecordDetailRelationSectionDropdownToMany = ({
         multipleRecordPickerPerformSearch({
           multipleRecordPickerInstanceId: dropdownId,
           forceSearchFilter: searchString,
-          forceSearchableObjectMetadataItems: [pickerObjectMetadataItem],
+          forceSearchableObjectMetadataItems: searchableObjectMetadataItems,
           forcePickableMorphItems: newMorphItems,
         });
       };
@@ -334,8 +312,8 @@ export const RecordDetailRelationSectionDropdownToMany = ({
       multipleRecordPickerPickableMorphItemsCallbackState,
       multipleRecordPickerPerformSearch,
       objectMetadataItem,
-      pickerObjectMetadataItem,
       recordId,
+      searchableObjectMetadataItems,
       store,
     ],
   );
@@ -349,18 +327,13 @@ export const RecordDetailRelationSectionDropdownToMany = ({
 
   const handleChange = useCallback(
     (morphItem: Parameters<typeof updateRelation>[0]) => {
-      if (isJunctionRelation && isJunctionConfigValid) {
+      if (isJunctionRelation) {
         updateJunctionRelationFromCell({ morphItem });
       } else {
         updateRelation(morphItem);
       }
     },
-    [
-      isJunctionRelation,
-      isJunctionConfigValid,
-      updateJunctionRelationFromCell,
-      updateRelation,
-    ],
+    [isJunctionRelation, updateJunctionRelationFromCell, updateRelation],
   );
 
   return (

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput.ts
@@ -5,9 +5,8 @@ import {
   type FieldRelationMetadata,
   type FieldRelationValue,
 } from '@/object-record/record-field/ui/types/FieldMetadata';
-import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
 import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
-import { getSearchableObjectMetadataItems } from '@/object-record/record-field/ui/utils/junction/getSearchableObjectMetadataItems';
+import { getJunctionRelationPickerData } from '@/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData';
 import { useMultipleRecordPickerOpen } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerOpen';
 import { useMultipleRecordPickerPerformSearch } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerPerformSearch';
 import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerPickableMorphItemsComponentState';
@@ -82,23 +81,12 @@ export const useOpenJunctionRelationFieldInput = () => {
         }),
       ) as FieldRelationValue<FieldRelationFromManyValue>;
 
-      const selectedTargetRecords = extractTargetRecordsFromJunction({
-        junctionRecords,
-        targetFields,
-        objectMetadataItems,
-      });
-
-      const searchableObjectMetadataItems = getSearchableObjectMetadataItems(
-        targetFields,
-        objectMetadataItems,
-      );
-
-      const pickableMorphItems = selectedTargetRecords.map((record) => ({
-        recordId: record.recordId,
-        objectMetadataId: record.objectMetadataId,
-        isSelected: true,
-        isMatchingSearchFilter: true,
-      }));
+      const { pickableMorphItems, searchableObjectMetadataItems } =
+        getJunctionRelationPickerData({
+          junctionRecords,
+          targetFields,
+          objectMetadataItems,
+        });
 
       store.set(
         multipleRecordPickerPickableMorphItemsComponentState.atomFamily({

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -305,14 +305,15 @@ export const useUpdateJunctionRelationFromCell = ({
     ],
   );
 
-  const isJunctionConfigValid =
+  const validJunctionConfig =
     isDefined(junctionConfig) &&
     isDefined(sourceFieldOnJunction) &&
-    isDefined(junctionConfig.targetFields) &&
-    junctionConfig.targetFields.length > 0;
+    junctionConfig.targetFields.length > 0
+      ? junctionConfig
+      : null;
 
   return {
     updateJunctionRelationFromCell,
-    isJunctionConfigValid,
+    junctionConfig: validJunctionConfig,
   };
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationOneToManyFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationOneToManyFieldInput.tsx
@@ -15,7 +15,6 @@ import { RecordFieldComponentInstanceContext } from '@/object-record/record-fiel
 import { recordFieldInputLayoutDirectionComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionComponentState';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
 import { MultipleRecordPicker } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker';
 import { useMultipleRecordPickerPerformSearch } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerPerformSearch';
@@ -58,24 +57,13 @@ export const RelationOneToManyFieldInput = () => {
   const relationFieldDefinition =
     fieldDefinition as FieldDefinition<FieldRelationMetadata>;
 
-  const { updateJunctionRelationFromCell, isJunctionConfigValid } =
+  const { updateJunctionRelationFromCell, junctionConfig } =
     useUpdateJunctionRelationFromCell({
       fieldMetadataItem,
       fieldDefinition: relationFieldDefinition,
       recordId,
     });
 
-  const junctionConfig = isJunctionConfigValid
-    ? getJunctionConfig({
-        settings: fieldMetadataItem.settings,
-        relationObjectMetadataId:
-          relationFieldDefinition.metadata.relationObjectMetadataId,
-        relationTargetFieldMetadataId:
-          fieldMetadataItem.relation?.targetFieldMetadata.id,
-        sourceObjectMetadataId: objectMetadataItem.id,
-        objectMetadataItems,
-      })
-    : null;
   const isJunctionRelation = isDefined(junctionConfig);
 
   const junctionTargetObjectMetadata = (() => {
@@ -261,7 +249,7 @@ export const RelationOneToManyFieldInput = () => {
       componentInstanceId={instanceId}
       onSubmit={handleSubmit}
       onChange={(morphItem) => {
-        if (isJunctionRelation && isJunctionConfigValid) {
+        if (isJunctionRelation) {
           updateJunctionRelationFromCell({
             morphItem,
           });

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/getJunctionRelationPickerData.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/getJunctionRelationPickerData.test.ts
@@ -1,0 +1,129 @@
+import { getJunctionRelationPickerData } from '@/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getObjectMorphJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getObjectMorphJunctionConfig';
+import { getMockFieldMetadataItemOrThrow } from '~/testing/utils/getMockFieldMetadataItemOrThrow';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+
+describe('getJunctionRelationPickerData', () => {
+  it('uses morph targets instead of junction records as picker items', () => {
+    const objectMetadataItems = getTestEnrichedObjectMetadataItemsMock();
+    const taskObjectMetadata = getMockObjectMetadataItemOrThrow('task');
+    const taskTargetObjectMetadata =
+      getMockObjectMetadataItemOrThrow('taskTarget');
+    const companyObjectMetadata = getMockObjectMetadataItemOrThrow('company');
+    const personObjectMetadata = getMockObjectMetadataItemOrThrow('person');
+
+    const junctionConfig = getObjectMorphJunctionConfig({
+      objectMetadata: taskObjectMetadata,
+      objectMetadataItems,
+    });
+
+    expect(junctionConfig).not.toBeNull();
+
+    if (junctionConfig === null) {
+      throw new Error('Task morph junction config not found');
+    }
+
+    const { pickableMorphItems, searchableObjectMetadataItems } =
+      getJunctionRelationPickerData({
+        junctionRecords: [
+          {
+            id: 'task-target-company-id',
+            __typename: 'TaskTarget',
+            targetCompany: { id: 'company-id' },
+          },
+          {
+            id: 'task-target-person-id',
+            __typename: 'TaskTarget',
+            targetPerson: { id: 'person-id' },
+          },
+        ],
+        targetFields: junctionConfig.targetFields,
+        objectMetadataItems,
+      });
+
+    expect(pickableMorphItems).toEqual([
+      {
+        recordId: 'company-id',
+        objectMetadataId: companyObjectMetadata.id,
+        isSelected: true,
+        isMatchingSearchFilter: true,
+      },
+      {
+        recordId: 'person-id',
+        objectMetadataId: personObjectMetadata.id,
+        isSelected: true,
+        isMatchingSearchFilter: true,
+      },
+    ]);
+
+    const searchableObjectMetadataIds = searchableObjectMetadataItems.map(
+      ({ id }) => id,
+    );
+    const morphTargetObjectMetadataIds = junctionConfig.targetFields.flatMap(
+      (targetField) =>
+        targetField.morphRelations?.map(
+          ({ targetObjectMetadata }) => targetObjectMetadata.id,
+        ) ?? [],
+    );
+
+    expect([...searchableObjectMetadataIds].sort()).toEqual(
+      [...morphTargetObjectMetadataIds].sort(),
+    );
+    expect(searchableObjectMetadataIds).not.toContain(
+      taskTargetObjectMetadata.id,
+    );
+  });
+
+  it('keeps terminal records and metadata for a regular junction', () => {
+    const objectMetadataItems = getTestEnrichedObjectMetadataItemsMock();
+    const personObjectMetadata = getMockObjectMetadataItemOrThrow('person');
+    const companyObjectMetadata = getMockObjectMetadataItemOrThrow('company');
+    const previousCompaniesField = getMockFieldMetadataItemOrThrow({
+      objectMetadataItem: personObjectMetadata,
+      fieldName: 'previousCompanies',
+    });
+
+    const junctionConfig = getJunctionConfig({
+      settings: previousCompaniesField.settings,
+      relationObjectMetadataId:
+        previousCompaniesField.relation?.targetObjectMetadata.id ?? '',
+      relationTargetFieldMetadataId:
+        previousCompaniesField.relation?.targetFieldMetadata.id,
+      sourceObjectMetadataId: personObjectMetadata.id,
+      objectMetadataItems,
+    });
+
+    expect(junctionConfig).not.toBeNull();
+
+    if (junctionConfig === null) {
+      throw new Error('Previous companies junction config not found');
+    }
+
+    const { pickableMorphItems, searchableObjectMetadataItems } =
+      getJunctionRelationPickerData({
+        junctionRecords: [
+          {
+            id: 'employment-history-id',
+            __typename: 'EmploymentHistory',
+            company: { id: 'company-id' },
+          },
+        ],
+        targetFields: junctionConfig.targetFields,
+        objectMetadataItems,
+      });
+
+    expect(pickableMorphItems).toEqual([
+      {
+        recordId: 'company-id',
+        objectMetadataId: companyObjectMetadata.id,
+        isSelected: true,
+        isMatchingSearchFilter: true,
+      },
+    ]);
+    expect(searchableObjectMetadataItems.map(({ id }) => id)).toEqual([
+      companyObjectMetadata.id,
+    ]);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData.ts
@@ -1,0 +1,34 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
+import { getSearchableObjectMetadataItems } from '@/object-record/record-field/ui/utils/junction/getSearchableObjectMetadataItems';
+import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+
+export const getJunctionRelationPickerData = ({
+  junctionRecords,
+  targetFields,
+  objectMetadataItems,
+}: {
+  junctionRecords: ObjectRecord[] | undefined | null;
+  targetFields: FieldMetadataItem[];
+  objectMetadataItems: EnrichedObjectMetadataItem[];
+}): {
+  pickableMorphItems: RecordPickerPickableMorphItem[];
+  searchableObjectMetadataItems: EnrichedObjectMetadataItem[];
+} => ({
+  pickableMorphItems: extractTargetRecordsFromJunction({
+    junctionRecords,
+    targetFields,
+    objectMetadataItems,
+  }).map(({ recordId, objectMetadataId }) => ({
+    recordId,
+    objectMetadataId,
+    isSelected: true,
+    isMatchingSearchFilter: true,
+  })),
+  searchableObjectMetadataItems: getSearchableObjectMetadataItems(
+    targetFields,
+    objectMetadataItems,
+  ),
+});


### PR DESCRIPTION
## Context

The standalone field-widget editor treated morph-junction rows as picker records. For Task Relations, that made the picker search TaskTarget and seed TaskTarget IDs instead of the terminal Person, Company, Opportunity, or custom records. Selecting a result then reached the junction writer with the pivot metadata ID, which could not resolve a morph target branch and returned without persisting.

This was latent since generic junction field-widget support landed in #19518. The activity-target migration in #24766 exposed it on Tasks and Notes; #24929 addresses nested two-hop widget scoping and is unrelated.

## Changes

- Resolve selected terminal records and searchable target metadata through one shared junction-picker utility.
- Reuse that utility from both the inline relation input and standalone field-widget dropdown.
- Return the already-resolved valid junction config from the update hook, removing duplicate config resolution in both consumers.
- Cover the Task morph junction and an ordinary Person to Employment History to Company junction.

## Verification

- 22 junction utility tests pass across 6 suites.
- twenty-front TypeScript check passes.
- twenty-front diff lint and formatting pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

