### PR TITLE
fix(server): persist user locale on userWorkspace create

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -721,6 +721,7 @@ export class SignInUpService {
                 : userData.newUserWithPicture.picture,
               applicationUniversalIdentifier:
                 customApplication.universalIdentifier,
+              locale: user.locale,
             },
             queryRunner,
           );

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -235,12 +235,14 @@ export class UserWorkspaceService {
 
     const userWorkspace = await this.create({
       userId: user.id,
-      workspaceId: workspace.i    const userWorkspace = await this.create({
-      userId: user.id,
       workspaceId: workspace.id,
       isExistingUser: true,
       locale: user.locale,
-    });oleToManyUserWorkspace({
+    });
+
+    await this.createWorkspaceMember(workspace.id, user);
+
+    await this.userRoleService.assignRoleToManyUserWorkspace({
       workspaceId: workspace.id,
       userWorkspaceIds: [userWorkspace.id],
       roleId: resolvedRoleId,

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -124,12 +124,14 @@ export class UserWorkspaceService {
       isExistingUser,
       pictureUrl,
       applicationUniversalIdentifier,
+      locale,
     }: {
       userId: string;
       workspaceId: string;
       isExistingUser: boolean;
       pictureUrl?: string;
       applicationUniversalIdentifier?: string;
+      locale?: UserWorkspaceEntity['locale'];
     },
     queryRunner?: QueryRunner,
   ): Promise<UserWorkspaceEntity> {
@@ -146,6 +148,7 @@ export class UserWorkspaceService {
       userId,
       workspaceId,
       defaultAvatarUrl,
+      locale: locale ?? SOURCE_LOCALE,
     });
 
     return queryRunner
@@ -232,13 +235,12 @@ export class UserWorkspaceService {
 
     const userWorkspace = await this.create({
       userId: user.id,
+      workspaceId: workspace.i    const userWorkspace = await this.create({
+      userId: user.id,
       workspaceId: workspace.id,
       isExistingUser: true,
-    });
-
-    await this.createWorkspaceMember(workspace.id, user);
-
-    await this.userRoleService.assignRoleToManyUserWorkspace({
+      locale: user.locale,
+    });oleToManyUserWorkspace({
       workspaceId: workspace.id,
       userWorkspaceIds: [userWorkspace.id],
       roleId: resolvedRoleId,


### PR DESCRIPTION
## Why

After signup, `user.locale` and `workspaceMember.locale` are set correctly, but `userWorkspace.locale` stays at the column default `en`.

Request locale binding prefers `userWorkspace.locale` over `x-locale`, so standard object labels (People / Companies / Opportunities, `+ New Opportunity`) stay English even when the rest of the UI is translated.

This is leftover from #13247 / #22675: `createWorkspaceMember()` copies `user.locale`, but `UserWorkspaceService.create()` never wrote it.

Fixes #25096

## What

- Accept optional `locale` on `UserWorkspaceService.create()` and persist `locale ?? SOURCE_LOCALE`
- Pass `user.locale` from signup (`sign-in-up.service.ts`) and from `addUserToWorkspaceIfUserNotInWorkspace`
- Do **not** look up the user inside `create()` — signup runs this inside a transaction, so the new user may not be visible yet

Existing `en` rows are unchanged. Settings → Experience already updates `userWorkspace.locale` for current users.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

