### PR TITLE
fix(server): release S3 sockets held by abandoned response bodies

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/front-component-shared-dependencies/front-component-shared-dependencies.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/front-component-shared-dependencies/front-component-shared-dependencies.controller.ts
@@ -101,6 +101,7 @@ export class FrontComponentSharedDependenciesController {
     try {
       await pipeline(fileResponse.stream, res);
     } catch (error) {
+      fileResponse.stream.destroy();
       this.logger.error(
         'Shared dependencies bundle stream failed mid-transfer',
         { error },

--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
@@ -109,7 +109,7 @@ export class S3Driver implements StorageDriver {
         throw new Error('Unable to get file stream');
       }
 
-      return Readable.from(file.Body);
+      return file.Body;
     } catch (error) {
       if (error.name === 'NoSuchKey') {
         throw new FileStorageException(

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.spec.ts
@@ -369,6 +369,7 @@ describe('FileController', () => {
       );
 
       expect(mockResponse.destroy).not.toHaveBeenCalled();
+      expect(mockStream.destroyed).toBe(true);
     });
 
     it('should destroy the response without throwing when the stream errors after headers are sent', async () => {
@@ -397,6 +398,7 @@ describe('FileController', () => {
       );
 
       expect(mockResponse.destroy).toHaveBeenCalledTimes(1);
+      expect(mockStream.destroyed).toBe(true);
     });
   });
 

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
@@ -100,6 +100,7 @@ export class FileController {
     try {
       await pipeline(fileResponse.stream, res);
     } catch (error) {
+      fileResponse.stream.destroy();
       this.logger.error(
         'Application registration file stream failed mid-transfer',
         { error },
@@ -176,6 +177,7 @@ export class FileController {
     try {
       await pipeline(fileResponse.stream, res);
     } catch (error) {
+      fileResponse.stream.destroy();
       this.logger.error('Public asset stream failed mid-transfer', { error });
 
       if (!res.headersSent) {
@@ -252,6 +254,7 @@ export class FileController {
     try {
       await pipeline(fileResponse.stream, res);
     } catch (error) {
+      fileResponse.stream.destroy();
       this.logger.error('File-by-id stream failed mid-transfer', { error });
 
       if (!res.headersSent) {

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/controllers/front-component.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/controllers/front-component.controller.ts
@@ -100,6 +100,7 @@ export class FrontComponentController {
     try {
       await pipeline(fileResponse.stream, res);
     } catch (error) {
+      fileResponse.stream.destroy();
       this.logger.error('Front component stream failed mid-transfer', {
         error,
       });


### PR DESCRIPTION
## Problem

Users cannot create workspaces. Over 30 hours, 101 users hard-failed at sign-up and ~80 more hit "Workspace creation failed" at activation, all on `TWENTY-SERVER-JVT`:

```
TimeoutError: @smithy/node-http-handler - the request socket did not establish
a connection with the server within the configured timeout of 30000 ms.
```

The 30s value fingerprints the file-storage S3 client specifically. The other AWS clients (60s and 10s connect timeouts) logged zero errors throughout, so S3 and the network were healthy. Affected pods only recovered by restarting.

## Root cause

An S3 `GetObject` body that is neither consumed nor destroyed keeps its socket checked out of the client's HTTPS agent. Nothing reclaims it: smithy clears its timers once response headers arrive. After `maxSockets` such bodies accumulate, every later S3 call queues behind an agent that will never free a slot. Smithy's connection timer is armed at request creation and fires for a request that never got a socket, which is why the error says "did not establish a connection" while the pod shows no TCP activity toward S3.

Two conditions had to hold for a socket to leak, and both are fixed here:

1. `S3Driver.readFile` returned `Readable.from(file.Body)`. Destroying that wrapper before its first read does not propagate to the underlying body, so even a caller that correctly destroys still pinned the socket.
2. The streaming controllers destroyed only the response on failure. When a client aborts during the acquisition window (guard + DB lookups + GetObject RTT), `pipeline()` rejects with `ERR_STREAM_UNABLE_TO_PIPE` without touching the source.

Neither fix alone is sufficient: `destroy()` on the wrapper is a no-op, and the driver change has nothing to trigger it.

### Why it started now

The leak dates to 2023. #23857 (Aug 6) added `maxSockets: 200` to this client, which converted a slow, invisible FD leak into a hard cap — and therefore into this outage.

## Scope

The load-bearing change for Twenty Cloud is `s3.driver.ts` plus the `destroy()` in `getApplicationRegistrationAsset`. With `STORAGE_S3_PRESIGNED_URL_ENABLED=true`, the other four streaming endpoints short-circuit to `res.redirect()` and never stream, so their `destroy()` calls are unreachable in that configuration. They are included because they are the same defect on the same pattern, and they do stream for self-hosted deployments and any deployment without presigning.

## Behaviour change worth reviewing

`readFile` now returns the SDK body directly instead of a `Readable.from()` wrapper. The declared `Promise<Readable>` still holds (`SdkStream<Readable>` is `Readable & SdkStreamMixin`, narrowed by the existing `instanceof Readable` guard), and this matches `local.driver.ts`, which already returns its raw stream. But the wrapper was an **objectMode** stream with `highWaterMark: 1`, while the body is byte-mode with a 16KB watermark, so chunking and backpressure change for all ~18 `readFile` callers. Consumers that buffer or sniff prefixes (`readReadablePrefix`, `streamToBuffer`) stay correct and get fewer, larger chunks.

## Verification

Reproduced red/green twice.

**1. Against a real S3 client** (installed `@aws-sdk/client-s3` + `@smithy/node-http-handler` 4.4.13, `maxSockets` and timeout scaled down proportionally):

| | before | after |
|---|---|---|
| after N aborted downloads | all N slots pinned, next call fails with the production error and stays failing | 0 slots retained, next call succeeds in 4ms |

Ablation: either half alone still wedges.

**2. End-to-end against a dev server on S3 storage**, storming `getApplicationRegistrationAsset` — the one endpoint that streams under the production config:

- before: probes hang past 40s, logs fill with `ERR_STREAM_UNABLE_TO_PIPE`, and the process eventually dies under the retained bodies
- after: survives the same storm, serves a 20MB file in 30ms afterwards, process healthy

Post-deploy, the metric to watch is whether `TWENTY-SERVER-JVT` drops.

## Not addressed here

- The fleet-wide OOM cycling is a separate defect (per-workspace metadata caches capped by entry count, sized at the heap ceiling).
- Sign-up performs a third-party image fetch and an S3 PUT *inside* `dataSource.transaction`, so a slow upload holds a Postgres transaction open. An earlier revision of this PR wrapped it in a try/catch; that was dropped because the catch also swallowed DB errors raised on the enclosing transaction, which corrupts the reported cause of any later failure. Moving the logo upload after commit is the correct fix and belongs in its own PR.
