### PR TITLE
Validate junction relation target settings

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityRecordGqlFields.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/utils/getTimelineActivityRecordGqlFields.ts
@@ -1,8 +1,6 @@
 import { type RecordGqlFields } from '@/object-record/graphql/record-gql-fields/types/RecordGqlFields';
-import {
-  generateDepthRecordGqlFieldsFromFields,
-  type GenerateDepthRecordGqlFieldsFromFields,
-} from '@/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields';
+import { type GenerateDepthRecordGqlFieldsFromFields } from '@/object-record/graphql/record-gql-fields/types/GenerateDepthRecordGqlFieldsFromFields';
+import { generateDepthRecordGqlFieldsFromFields } from '@/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields';
 import { FieldMetadataType } from 'twenty-shared/types';
 
 type GetTimelineActivityRecordGqlFieldsParams = Pick<

--- a/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/types/GenerateDepthRecordGqlFieldsFromFields.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/types/GenerateDepthRecordGqlFieldsFromFields.ts
@@ -1,0 +1,22 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+
+export type GenerateDepthRecordGqlFieldsFromFields = {
+  objectMetadataItems: Pick<
+    EnrichedObjectMetadataItem,
+    | 'id'
+    | 'fields'
+    | 'labelIdentifierFieldMetadataId'
+    | 'imageIdentifierFieldMetadataId'
+    | 'nameSingular'
+    | 'namePlural'
+  >[];
+  // Required to resolve the junction records held by the reverse side of a junction
+  sourceObjectMetadataItem?: Pick<EnrichedObjectMetadataItem, 'id'>;
+  fields: Pick<
+    FieldMetadataItem,
+    'id' | 'name' | 'type' | 'settings' | 'morphRelations' | 'relation'
+  >[];
+  depth: 0 | 1;
+  shouldOnlyLoadRelationIdentifiers?: boolean;
+};

--- a/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/__tests__/generateDepthRecordGqlFieldsFromFields.test.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/__tests__/generateDepthRecordGqlFieldsFromFields.test.ts
@@ -1,0 +1,35 @@
+import { generateDepthRecordGqlFieldsFromFields } from '@/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields';
+import { getMockFieldMetadataItemOrThrow } from '~/testing/utils/getMockFieldMetadataItemOrThrow';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+
+describe('generateDepthRecordGqlFieldsFromFields', () => {
+  it('does not query pivots for an invalid configured junction', () => {
+    const taskMetadata = getMockObjectMetadataItemOrThrow('task');
+    const taskTargetsField = getMockFieldMetadataItemOrThrow({
+      objectMetadataItem: taskMetadata,
+      fieldName: 'taskTargets',
+    });
+
+    if (!taskTargetsField.relation) {
+      throw new Error('Task targets relation not found');
+    }
+
+    const invalidTaskTargetsField = {
+      ...taskTargetsField,
+      settings: {
+        ...taskTargetsField.settings,
+        junctionTargetFieldId: taskTargetsField.relation.targetFieldMetadata.id,
+      },
+    };
+
+    expect(
+      generateDepthRecordGqlFieldsFromFields({
+        objectMetadataItems: getTestEnrichedObjectMetadataItemsMock(),
+        sourceObjectMetadataItem: taskMetadata,
+        fields: [invalidTaskTargetsField],
+        depth: 1,
+      }),
+    ).not.toHaveProperty('taskTargets');
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields.ts
@@ -4,6 +4,10 @@ import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/Enriche
 import { type RecordGqlFields } from '@/object-record/graphql/record-gql-fields/types/RecordGqlFields';
 import { buildIdentifierGqlFields } from '@/object-record/graphql/record-gql-fields/utils/buildIdentifierGqlFields';
 import { generateJunctionRelationGqlFields } from '@/object-record/graphql/record-gql-fields/utils/generateJunctionRelationGqlFields';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getReverseJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getReverseJunctionConfig';
 import {
   computeMorphRelationGqlFieldName,
@@ -59,6 +63,23 @@ export const generateDepthRecordGqlFieldsFromFields = ({
           );
         }
 
+        const junctionConfig = getJunctionConfig({
+          settings: fieldMetadata.settings,
+          relationObjectMetadataId: targetObjectMetadataItem.id,
+          relationTargetFieldMetadataId:
+            fieldMetadata.relation?.targetFieldMetadata.id,
+          sourceObjectMetadataId:
+            fieldMetadata.relation?.sourceObjectMetadata.id,
+          objectMetadataItems,
+        });
+
+        if (
+          isDefined(junctionConfig) &&
+          !isUsableJunctionConfig(junctionConfig)
+        ) {
+          return recordGqlFields;
+        }
+
         const reverseJunctionConfig = getReverseJunctionConfig({
           junctionObjectMetadataId: targetObjectMetadataItem.id,
           sourceObjectMetadataId: sourceObjectMetadataItem?.id,
@@ -80,15 +101,13 @@ export const generateDepthRecordGqlFieldsFromFields = ({
           };
         }
 
-        const junctionGqlFields = generateJunctionRelationGqlFields({
-          fieldMetadataItem: fieldMetadata,
-          objectMetadataItems,
-        });
-
-        if (isDefined(junctionGqlFields) && depth === 1) {
+        if (isUsableJunctionConfig(junctionConfig) && depth === 1) {
           return {
             ...recordGqlFields,
-            [fieldMetadata.name]: junctionGqlFields,
+            [fieldMetadata.name]: generateJunctionRelationGqlFields({
+              junctionConfig,
+              objectMetadataItems,
+            }),
           };
         }
 

--- a/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields.ts
@@ -1,38 +1,15 @@
 import { FieldMetadataType, RelationType } from 'twenty-shared/types';
-import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
-import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type GenerateDepthRecordGqlFieldsFromFields } from '@/object-record/graphql/record-gql-fields/types/GenerateDepthRecordGqlFieldsFromFields';
 import { type RecordGqlFields } from '@/object-record/graphql/record-gql-fields/types/RecordGqlFields';
 import { buildIdentifierGqlFields } from '@/object-record/graphql/record-gql-fields/utils/buildIdentifierGqlFields';
 import { generateJunctionRelationGqlFields } from '@/object-record/graphql/record-gql-fields/utils/generateJunctionRelationGqlFields';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getReverseJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getReverseJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import {
   computeMorphRelationGqlFieldName,
   isDefined,
 } from 'twenty-shared/utils';
-
-export type GenerateDepthRecordGqlFieldsFromFields = {
-  objectMetadataItems: Pick<
-    EnrichedObjectMetadataItem,
-    | 'id'
-    | 'fields'
-    | 'labelIdentifierFieldMetadataId'
-    | 'imageIdentifierFieldMetadataId'
-    | 'nameSingular'
-    | 'namePlural'
-  >[];
-  // Required to resolve the junction records held by the reverse side of a junction
-  sourceObjectMetadataItem?: Pick<EnrichedObjectMetadataItem, 'id'>;
-  fields: Pick<
-    FieldMetadataItem,
-    'id' | 'name' | 'type' | 'settings' | 'morphRelations' | 'relation'
-  >[];
-  depth: 0 | 1;
-  shouldOnlyLoadRelationIdentifiers?: boolean;
-};
 
 export const generateDepthRecordGqlFieldsFromFields = ({
   objectMetadataItems,

--- a/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateJunctionRelationGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateJunctionRelationGqlFields.ts
@@ -1,10 +1,8 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { type RecordGqlFields } from '@/object-record/graphql/record-gql-fields/types/RecordGqlFields';
 import { buildIdentifierGqlFields } from '@/object-record/graphql/record-gql-fields/utils/buildIdentifierGqlFields';
-import {
-  type JunctionObjectMetadataItem,
-  type ValidJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { type JunctionObjectMetadataItem } from '@/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem';
+import { type ValidJunctionConfig } from '@/object-record/record-field/ui/utils/junction/types/ValidJunctionConfig';
 import { FieldMetadataType } from 'twenty-shared/types';
 import {
   computeMorphRelationGqlFieldName,

--- a/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateJunctionRelationGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateJunctionRelationGqlFields.ts
@@ -2,8 +2,8 @@ import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataIte
 import { type RecordGqlFields } from '@/object-record/graphql/record-gql-fields/types/RecordGqlFields';
 import { buildIdentifierGqlFields } from '@/object-record/graphql/record-gql-fields/utils/buildIdentifierGqlFields';
 import {
-  getJunctionConfig,
   type JunctionObjectMetadataItem,
+  type ValidJunctionConfig,
 } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { FieldMetadataType } from 'twenty-shared/types';
 import {
@@ -17,7 +17,7 @@ type JunctionFieldMetadataItem = Pick<
 >;
 
 type GenerateJunctionRelationGqlFieldsArgs = {
-  fieldMetadataItem: JunctionFieldMetadataItem;
+  junctionConfig: ValidJunctionConfig;
   objectMetadataItems: JunctionObjectMetadataItem[];
 };
 
@@ -83,22 +83,9 @@ const buildTargetFieldGqlFields = (
 };
 
 export const generateJunctionRelationGqlFields = ({
-  fieldMetadataItem,
+  junctionConfig,
   objectMetadataItems,
-}: GenerateJunctionRelationGqlFieldsArgs): RecordGqlFields | null => {
-  const junctionConfig = getJunctionConfig({
-    settings: fieldMetadataItem.settings,
-    relationObjectMetadataId:
-      fieldMetadataItem.relation?.targetObjectMetadata.id ?? '',
-    relationTargetFieldMetadataId:
-      fieldMetadataItem.relation?.targetFieldMetadata.id,
-    objectMetadataItems,
-  });
-
-  if (!isDefined(junctionConfig)) {
-    return null;
-  }
-
+}: GenerateJunctionRelationGqlFieldsArgs): RecordGqlFields => {
   const { junctionObjectMetadata, targetFields } = junctionConfig;
 
   const junctionTargetFields = targetFields.reduce<RecordGqlFields>(

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -336,6 +336,10 @@ export const RecordDetailRelationSectionDropdownToMany = ({
     [isJunctionRelation, updateJunctionRelationFromCell, updateRelation],
   );
 
+  if (junctionConfig?.isValid === false) {
+    return null;
+  }
+
   return (
     <Dropdown
       dropdownId={dropdownId}

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -13,6 +13,7 @@ import { useAddNewRecordAndOpenSidePanel } from '@/object-record/record-field/ui
 import { useUpdateRelationOneToManyFieldInput } from '@/object-record/record-field/ui/meta-types/input/hooks/useUpdateRelationOneToManyFieldInput';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getJunctionRelationPickerData } from '@/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
 import { MultipleRecordPicker } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker';
@@ -80,7 +81,9 @@ export const RecordDetailRelationSectionDropdownToMany = ({
       recordId,
     });
 
-  const isJunctionRelation = isDefined(junctionConfig);
+  const isJunctionRelation = isUsableJunctionConfig(junctionConfig);
+  const isInvalidJunctionRelation =
+    isDefined(junctionConfig) && !isJunctionRelation;
 
   const firstJunctionTargetField =
     junctionConfig && !junctionConfig.isMorphRelation
@@ -336,7 +339,7 @@ export const RecordDetailRelationSectionDropdownToMany = ({
     [isJunctionRelation, updateJunctionRelationFromCell, updateRelation],
   );
 
-  if (junctionConfig?.isValid === false) {
+  if (isInvalidJunctionRelation) {
     return null;
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -13,9 +13,9 @@ import { useAddNewRecordAndOpenSidePanel } from '@/object-record/record-field/ui
 import { useUpdateRelationOneToManyFieldInput } from '@/object-record/record-field/ui/meta-types/input/hooks/useUpdateRelationOneToManyFieldInput';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
-import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getJunctionRelationPickerData } from '@/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { MultipleRecordPicker } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker';
 import { useMultipleRecordPickerOpen } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerOpen';
 import { useMultipleRecordPickerPerformSearch } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerPerformSearch';

--- a/packages/twenty-front/src/modules/object-record/record-field-list/utils/__tests__/categorizeRelationFields.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/utils/__tests__/categorizeRelationFields.test.ts
@@ -23,4 +23,36 @@ describe('categorizeRelationFields', () => {
       boxedRelationFields: [],
     });
   });
+
+  it('does not expose an invalid configured junction as a regular relation', () => {
+    const taskMetadata = getMockObjectMetadataItemOrThrow('task');
+    const taskTargetsField = getMockFieldMetadataItemOrThrow({
+      objectMetadataItem: taskMetadata,
+      fieldName: 'taskTargets',
+    });
+
+    if (!taskTargetsField.relation) {
+      throw new Error('Task targets relation not found');
+    }
+
+    const invalidTaskTargetsField = {
+      ...taskTargetsField,
+      settings: {
+        ...taskTargetsField.settings,
+        junctionTargetFieldId: taskTargetsField.relation.targetFieldMetadata.id,
+      },
+    };
+
+    expect(
+      categorizeRelationFields({
+        relationFields: [invalidTaskTargetsField],
+        objectMetadataItems: getTestEnrichedObjectMetadataItemsMock(),
+        objectPermissionsByObjectMetadataId: {},
+      }),
+    ).toEqual({
+      inlineRelationFields: [],
+      junctionRelationFields: [],
+      boxedRelationFields: [],
+    });
+  });
 });

--- a/packages/twenty-front/src/modules/object-record/record-field-list/utils/categorizeRelationFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/utils/categorizeRelationFields.ts
@@ -1,10 +1,8 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { getObjectPermissionsForObject } from '@/object-metadata/utils/getObjectPermissionsForObject';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { type ObjectPermissions } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 

--- a/packages/twenty-front/src/modules/object-record/record-field-list/utils/categorizeRelationFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/utils/categorizeRelationFields.ts
@@ -1,7 +1,10 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { getObjectPermissionsForObject } from '@/object-metadata/utils/getObjectPermissionsForObject';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { type ObjectPermissions } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -64,8 +67,11 @@ export const categorizeRelationFields = ({
     });
 
     if (isDefined(junctionConfig)) {
-      inlineRelationFields.push(field);
-      junctionRelationFields.push(field);
+      if (isUsableJunctionConfig(junctionConfig)) {
+        inlineRelationFields.push(field);
+        junctionRelationFields.push(field);
+      }
+
       continue;
     }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/__tests__/useOpenFieldInputEditMode.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/__tests__/useOpenFieldInputEditMode.test.tsx
@@ -1,0 +1,167 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { formatFieldMetadataItemAsFieldDefinition } from '@/object-metadata/utils/formatFieldMetadataItemAsFieldDefinition';
+import { useOpenFieldInputEditMode } from '@/object-record/record-field/ui/hooks/useOpenFieldInputEditMode';
+import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
+import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
+import { useOpenFieldWidgetFieldInputEditMode } from '@/page-layout/widgets/field/hooks/useOpenFieldWidgetFieldInputEditMode';
+import { act, renderHook } from '@testing-library/react';
+import { getMockFieldMetadataItemOrThrow } from '~/testing/utils/getMockFieldMetadataItemOrThrow';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+
+const mockOpenJunctionRelationFieldInput = jest.fn();
+const mockOpenRelationFromManyFieldInput = jest.fn();
+const mockOpenRelationToOneFieldInput = jest.fn();
+const mockOpenMorphRelationOneToManyFieldInput = jest.fn();
+const mockOpenMorphRelationManyToOneFieldInput = jest.fn();
+const mockPushFocusItemToFocusStack = jest.fn();
+const mockRemoveFocusItemFromFocusStackById = jest.fn();
+
+const mockObjectMetadataItems = getTestEnrichedObjectMetadataItemsMock();
+const mockTaskMetadata = getMockObjectMetadataItemOrThrow('task');
+const mockTaskTargetsField = getMockFieldMetadataItemOrThrow({
+  objectMetadataItem: mockTaskMetadata,
+  fieldName: 'taskTargets',
+});
+
+if (!mockTaskTargetsField.relation) {
+  throw new Error('Task targets relation not found');
+}
+
+const mockInvalidTaskTargetsField = {
+  ...mockTaskTargetsField,
+  settings: {
+    ...mockTaskTargetsField.settings,
+    junctionTargetFieldId: mockTaskTargetsField.relation.targetFieldMetadata.id,
+  },
+} as FieldMetadataItem;
+const mockInvalidFieldDefinition = formatFieldMetadataItemAsFieldDefinition({
+  field: mockInvalidTaskTargetsField,
+  objectMetadataItem: mockTaskMetadata,
+}) as FieldDefinition<FieldRelationMetadata>;
+
+jest.mock('jotai', () => ({
+  useStore: () => ({
+    get: () => mockObjectMetadataItems,
+  }),
+}));
+
+jest.mock('@/object-metadata/hooks/useObjectMetadataItems', () => ({
+  useObjectMetadataItems: () => ({
+    objectMetadataItems: mockObjectMetadataItems,
+  }),
+}));
+
+jest.mock('@/object-metadata/states/objectMetadataItemsSelector', () => ({
+  objectMetadataItemsSelector: { atom: 'object-metadata-items-atom' },
+}));
+
+jest.mock('@/object-record/hooks/useUpdateOneRecord', () => ({
+  useUpdateOneRecord: () => ({ updateOneRecord: jest.fn() }),
+}));
+
+jest.mock(
+  '@/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput',
+  () => ({
+    useOpenJunctionRelationFieldInput: () => ({
+      openJunctionRelationFieldInput: mockOpenJunctionRelationFieldInput,
+    }),
+  }),
+);
+
+jest.mock(
+  '@/object-record/record-field/ui/meta-types/input/hooks/useOpenFilesFieldInput',
+  () => ({
+    useOpenFilesFieldInput: () => ({ openFilesFieldInput: jest.fn() }),
+  }),
+);
+
+jest.mock(
+  '@/object-record/record-field/ui/meta-types/input/hooks/useOpenRelationFromManyFieldInput',
+  () => ({
+    useOpenRelationFromManyFieldInput: () => ({
+      openRelationFromManyFieldInput: mockOpenRelationFromManyFieldInput,
+    }),
+  }),
+);
+
+jest.mock(
+  '@/object-record/record-field/ui/meta-types/input/hooks/useOpenRelationToOneFieldInput',
+  () => ({
+    useOpenRelationToOneFieldInput: () => ({
+      openRelationToOneFieldInput: mockOpenRelationToOneFieldInput,
+    }),
+  }),
+);
+
+jest.mock(
+  '@/object-record/record-field/ui/meta-types/input/hooks/useOpenMorphRelationOneToManyFieldInput',
+  () => ({
+    useOpenMorphRelationOneToManyFieldInput: () => ({
+      openMorphRelationOneToManyFieldInput:
+        mockOpenMorphRelationOneToManyFieldInput,
+    }),
+  }),
+);
+
+jest.mock(
+  '@/object-record/record-field/ui/meta-types/input/hooks/useOpenMorphRelationManyToOneFieldInput',
+  () => ({
+    useOpenMorphRelationManyToOneFieldInput: () => ({
+      openMorphRelationManyToOneFieldInput:
+        mockOpenMorphRelationManyToOneFieldInput,
+    }),
+  }),
+);
+
+jest.mock('@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack', () => ({
+  usePushFocusItemToFocusStack: () => ({
+    pushFocusItemToFocusStack: mockPushFocusItemToFocusStack,
+  }),
+}));
+
+jest.mock(
+  '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById',
+  () => ({
+    useRemoveFocusItemFromFocusStackById: () => ({
+      removeFocusItemFromFocusStackById: mockRemoveFocusItemFromFocusStackById,
+    }),
+  }),
+);
+
+jest.mock(
+  '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow',
+  () => ({
+    useAvailableComponentInstanceIdOrThrow: () => 'field-widget-instance-id',
+  }),
+);
+
+describe('invalid configured junction edit mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    {
+      name: 'table field',
+      useOpenEditMode: useOpenFieldInputEditMode,
+    },
+    {
+      name: 'field widget',
+      useOpenEditMode: useOpenFieldWidgetFieldInputEditMode,
+    },
+  ])('does not open an editor from a $name', ({ useOpenEditMode }) => {
+    const { result } = renderHook(() => useOpenEditMode());
+
+    act(() => {
+      result.current.openFieldInput({
+        fieldDefinition: mockInvalidFieldDefinition,
+        recordId: 'task-record-id',
+      });
+    });
+
+    expect(mockOpenJunctionRelationFieldInput).not.toHaveBeenCalled();
+    expect(mockOpenRelationFromManyFieldInput).not.toHaveBeenCalled();
+    expect(mockPushFocusItemToFocusStack).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenFieldInputEditMode.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenFieldInputEditMode.ts
@@ -14,7 +14,10 @@ import { isFieldMorphRelationManyToOne } from '@/object-record/record-field/ui/t
 import { isFieldMorphRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldMorphRelationOneToMany';
 import { isFieldRelationManyToOne } from '@/object-record/record-field/ui/types/guards/isFieldRelationManyToOne';
 import { isFieldRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldRelationOneToMany';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
@@ -62,10 +65,8 @@ export const useOpenFieldInputEditMode = () => {
         ({ nameSingular }) =>
           nameSingular === fieldDefinition.metadata.objectMetadataNameSingular,
       )?.id;
-      const fieldHasJunctionConfig =
-        isFieldRelationOneToMany(fieldDefinition) &&
-        isDefined(
-          getJunctionConfig({
+      const junctionConfig = isFieldRelationOneToMany(fieldDefinition)
+        ? getJunctionConfig({
             settings: fieldDefinition.metadata.settings,
             relationObjectMetadataId:
               fieldDefinition.metadata.relationObjectMetadataId,
@@ -73,8 +74,8 @@ export const useOpenFieldInputEditMode = () => {
               fieldDefinition.metadata.relationFieldMetadataId,
             sourceObjectMetadataId,
             objectMetadataItems,
-          }),
-        );
+          })
+        : null;
 
       if (isFieldFiles(fieldDefinition)) {
         const objectMetadataItem = objectMetadataItems.find(
@@ -107,12 +108,18 @@ export const useOpenFieldInputEditMode = () => {
         }
       }
 
-      if (isFieldRelationOneToMany(fieldDefinition) && fieldHasJunctionConfig) {
-        openJunctionRelationFieldInput({
-          fieldDefinition,
-          recordId,
-          prefix,
-        });
+      if (
+        isFieldRelationOneToMany(fieldDefinition) &&
+        isDefined(junctionConfig)
+      ) {
+        if (isUsableJunctionConfig(junctionConfig)) {
+          openJunctionRelationFieldInput({
+            fieldDefinition,
+            recordId,
+            prefix,
+          });
+        }
+
         return;
       }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenFieldInputEditMode.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenFieldInputEditMode.ts
@@ -14,10 +14,8 @@ import { isFieldMorphRelationManyToOne } from '@/object-record/record-field/ui/t
 import { isFieldMorphRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldMorphRelationOneToMany';
 import { isFieldRelationManyToOne } from '@/object-record/record-field/ui/types/guards/isFieldRelationManyToOne';
 import { isFieldRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldRelationOneToMany';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput.ts
@@ -5,7 +5,10 @@ import {
   type FieldRelationMetadata,
   type FieldRelationValue,
 } from '@/object-record/record-field/ui/types/FieldMetadata';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getJunctionRelationPickerData } from '@/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData';
 import { useMultipleRecordPickerOpen } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerOpen';
 import { useMultipleRecordPickerPerformSearch } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerPerformSearch';
@@ -18,7 +21,6 @@ import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePush
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
 import { useStore } from 'jotai';
 import { useCallback } from 'react';
-import { isDefined } from 'twenty-shared/utils';
 
 export const useOpenJunctionRelationFieldInput = () => {
   const { performSearch } = useMultipleRecordPickerPerformSearch();
@@ -56,7 +58,7 @@ export const useOpenJunctionRelationFieldInput = () => {
         objectMetadataItems,
       });
 
-      if (!isDefined(junctionConfig) || !junctionConfig.isValid) {
+      if (!isUsableJunctionConfig(junctionConfig)) {
         return;
       }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput.ts
@@ -5,11 +5,9 @@ import {
   type FieldRelationMetadata,
   type FieldRelationValue,
 } from '@/object-record/record-field/ui/types/FieldMetadata';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getJunctionRelationPickerData } from '@/object-record/record-field/ui/utils/junction/getJunctionRelationPickerData';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { useMultipleRecordPickerOpen } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerOpen';
 import { useMultipleRecordPickerPerformSearch } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerPerformSearch';
 import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerPickableMorphItemsComponentState';

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenJunctionRelationFieldInput.ts
@@ -56,15 +56,11 @@ export const useOpenJunctionRelationFieldInput = () => {
         objectMetadataItems,
       });
 
-      if (!isDefined(junctionConfig)) {
+      if (!isDefined(junctionConfig) || !junctionConfig.isValid) {
         return;
       }
 
       const { targetFields } = junctionConfig;
-
-      if (targetFields.length === 0) {
-        return;
-      }
 
       const resolvedRecordPickerInstanceId =
         recordPickerInstanceId ??

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -305,15 +305,8 @@ export const useUpdateJunctionRelationFromCell = ({
     ],
   );
 
-  const validJunctionConfig =
-    isDefined(junctionConfig) &&
-    isDefined(sourceFieldOnJunction) &&
-    junctionConfig.targetFields.length > 0
-      ? junctionConfig
-      : null;
-
   return {
     updateJunctionRelationFromCell,
-    junctionConfig: validJunctionConfig,
+    junctionConfig,
   };
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -17,11 +17,9 @@ import {
 } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { findJunctionRecordByTargetId } from '@/object-record/record-field/ui/utils/junction/findJunctionRecordByTargetId';
 import { findTargetFieldInfo } from '@/object-record/record-field/ui/utils/junction/findTargetFieldInfo';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { searchRecordStoreFamilyState } from '@/object-record/record-picker/multiple-record-picker/states/searchRecordStoreComponentFamilyState';
 import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -17,7 +17,10 @@ import {
 } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { findJunctionRecordByTargetId } from '@/object-record/record-field/ui/utils/junction/findJunctionRecordByTargetId';
 import { findTargetFieldInfo } from '@/object-record/record-field/ui/utils/junction/findTargetFieldInfo';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
 import { searchRecordStoreFamilyState } from '@/object-record/record-picker/multiple-record-picker/states/searchRecordStoreComponentFamilyState';
 import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
@@ -73,6 +76,7 @@ export const useUpdateJunctionRelationFromCell = ({
       const targetFields = junctionConfig?.targetFields;
 
       if (
+        !isUsableJunctionConfig(junctionConfig) ||
         !isDefined(junctionObjectMetadata) ||
         !isDefined(sourceFieldOnJunction) ||
         !isDefined(targetFields) ||

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -7,7 +7,10 @@ import { useFieldFocus } from '@/object-record/record-field/ui/hooks/useFieldFoc
 import { MAX_RELATION_CHIPS_DISPLAYED_INLINE } from '@/object-record/record-field/ui/meta-types/display/constants/MaxRelationChipsDisplayedInline';
 import { useRelationFromManyFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRelationFromManyFieldDisplay';
 import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getReverseJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getReverseJunctionConfig';
 
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
@@ -70,6 +73,10 @@ export const RelationFromManyFieldDisplay = () => {
   }
 
   if (isDefined(junctionConfig)) {
+    if (!isUsableJunctionConfig(junctionConfig)) {
+      return null;
+    }
+
     const { targetFields } = junctionConfig;
 
     if (targetFields.length === 0) {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -7,11 +7,9 @@ import { useFieldFocus } from '@/object-record/record-field/ui/hooks/useFieldFoc
 import { MAX_RELATION_CHIPS_DISPLAYED_INLINE } from '@/object-record/record-field/ui/meta-types/display/constants/MaxRelationChipsDisplayedInline';
 import { useRelationFromManyFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRelationFromManyFieldDisplay';
 import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getReverseJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getReverseJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
 import { styled } from '@linaria/react';

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationOneToManyFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationOneToManyFieldInput.tsx
@@ -15,8 +15,8 @@ import { RecordFieldComponentInstanceContext } from '@/object-record/record-fiel
 import { recordFieldInputLayoutDirectionComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionComponentState';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
-import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { MultipleRecordPicker } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker';
 import { useMultipleRecordPickerPerformSearch } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerPerformSearch';
 import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerPickableMorphItemsComponentState';

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationOneToManyFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationOneToManyFieldInput.tsx
@@ -15,6 +15,7 @@ import { RecordFieldComponentInstanceContext } from '@/object-record/record-fiel
 import { recordFieldInputLayoutDirectionComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionComponentState';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
 import { MultipleRecordPicker } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker';
 import { useMultipleRecordPickerPerformSearch } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerPerformSearch';
@@ -64,7 +65,9 @@ export const RelationOneToManyFieldInput = () => {
       recordId,
     });
 
-  const isJunctionRelation = isDefined(junctionConfig);
+  const isJunctionRelation = isUsableJunctionConfig(junctionConfig);
+  const isInvalidJunctionRelation =
+    isDefined(junctionConfig) && !isJunctionRelation;
 
   const junctionTargetObjectMetadata = (() => {
     if (!junctionConfig || junctionConfig.isMorphRelation) {
@@ -242,6 +245,10 @@ export const RelationOneToManyFieldInput = () => {
     isJunctionRelation && isDefined(junctionTargetObjectMetadata)
       ? junctionTargetObjectMetadata.id
       : relationObjectMetadataItem.id;
+
+  if (isInvalidJunctionRelation) {
+    return null;
+  }
 
   return (
     <MultipleRecordPicker

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/__tests__/getJunctionConfig.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/__tests__/getJunctionConfig.test.ts
@@ -9,9 +9,13 @@ const createMockRelation = (
   targetObjectId: string,
   targetObjectName: string,
   type: RelationType = RelationType.MANY_TO_ONE,
+  sourceFieldMetadataId = 'source-field-id',
 ): FieldMetadataItemRelation => ({
   type,
-  sourceFieldMetadata: { id: 'source-field-id', name: 'sourceField' },
+  sourceFieldMetadata: {
+    id: sourceFieldMetadataId,
+    name: 'sourceField',
+  },
   targetFieldMetadata: {
     id: 'target-field-id',
     name: 'targetField',
@@ -95,6 +99,14 @@ describe('getJunctionConfig', () => {
       const morphTargetField = createMockField({
         id: 'morph-target-field-id',
         type: FieldMetadataType.MORPH_RELATION,
+        morphRelations: [
+          createMockRelation(
+            'target-object-id',
+            'targetObject',
+            RelationType.MANY_TO_ONE,
+            'morph-target-field-id',
+          ),
+        ],
       });
       const labelIdentifierField = createMockField({
         id: 'label-identifier-field-id',
@@ -178,12 +190,13 @@ describe('getJunctionConfig', () => {
       });
 
       expect(result).not.toBeNull();
+      expect(result!.isValid).toBe(true);
       expect(result!.isMorphRelation).toBe(false);
       expect(result!.targetFields).toHaveLength(1);
       expect(result!.targetFields[0].name).toBe('company');
     });
 
-    it('should return null when target field not found', () => {
+    it('should return an invalid junction when configured target field is not found', () => {
       const junctionObject = createMockObjectMetadata({
         id: 'junction-id',
         fields: [],
@@ -195,10 +208,10 @@ describe('getJunctionConfig', () => {
         objectMetadataItems: [junctionObject],
       });
 
-      expect(result).toBeNull();
+      expect(result).toMatchObject({ isValid: false, targetFields: [] });
     });
 
-    it('should return null for regular relation without relation property', () => {
+    it('should return an invalid junction for a configured relation without relation metadata', () => {
       const targetField = createMockField({
         id: 'target-field-id',
         name: 'company',
@@ -216,7 +229,7 @@ describe('getJunctionConfig', () => {
         objectMetadataItems: [junctionObject],
       });
 
-      expect(result).toBeNull();
+      expect(result).toMatchObject({ isValid: false, targetFields: [] });
     });
 
     it('should handle MORPH_RELATION field referenced by ID', () => {
@@ -224,6 +237,9 @@ describe('getJunctionConfig', () => {
         id: 'morph-field-id',
         name: 'linkedObject',
         type: FieldMetadataType.MORPH_RELATION,
+        morphRelations: [
+          createMockRelation('target-object-id', 'targetObject'),
+        ],
       });
       const junctionObject = createMockObjectMetadata({
         id: 'junction-id',
@@ -237,9 +253,56 @@ describe('getJunctionConfig', () => {
       });
 
       expect(result).not.toBeNull();
+      expect(result!.isValid).toBe(true);
       expect(result!.isMorphRelation).toBe(true);
       expect(result!.targetFields).toHaveLength(1);
       expect(result!.targetFields[0].name).toBe('linkedObject');
+    });
+
+    it('returns an invalid junction instead of falling back for a one-to-many morph target', () => {
+      const morphField = createMockField({
+        id: 'morph-field-id',
+        type: FieldMetadataType.MORPH_RELATION,
+        morphRelations: [
+          createMockRelation(
+            'target-object-id',
+            'targetObject',
+            RelationType.ONE_TO_MANY,
+          ),
+        ],
+      });
+      const junctionObject = createMockObjectMetadata({
+        id: 'junction-id',
+        fields: [morphField],
+      });
+
+      expect(
+        getJunctionConfig({
+          settings: { junctionTargetFieldId: 'morph-field-id' },
+          relationObjectMetadataId: 'junction-id',
+          objectMetadataItems: [junctionObject],
+        }),
+      ).toMatchObject({ isValid: false, targetFields: [] });
+    });
+
+    it('returns an invalid junction instead of falling back when source and target are the same field', () => {
+      const sourceField = createMockField({
+        id: 'source-field-id',
+        relation: createMockRelation('source-object-id', 'sourceObject'),
+      });
+      const junctionObject = createMockObjectMetadata({
+        id: 'junction-id',
+        fields: [sourceField],
+      });
+
+      expect(
+        getJunctionConfig({
+          settings: { junctionTargetFieldId: 'source-field-id' },
+          relationObjectMetadataId: 'junction-id',
+          relationTargetFieldMetadataId: 'source-field-id',
+          objectMetadataItems: [junctionObject],
+        }),
+      ).toMatchObject({ isValid: false, targetFields: [] });
     });
 
     it('should find sourceField excluding the target field', () => {
@@ -284,6 +347,7 @@ describe('getJunctionConfig', () => {
         name: 'company',
         morphId: 'morph-group-1',
         type: FieldMetadataType.MORPH_RELATION,
+        morphRelations: [createMockRelation('company-metadata-id', 'company')],
       });
       const junctionObject = createMockObjectMetadata({
         id: 'junction-id',

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/__tests__/getJunctionConfig.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/__tests__/getJunctionConfig.test.ts
@@ -197,9 +197,16 @@ describe('getJunctionConfig', () => {
     });
 
     it('should return an invalid junction when configured target field is not found', () => {
+      const inferredMorphTarget = createMockField({
+        id: 'legacy-inferred-morph-target-id',
+        type: FieldMetadataType.MORPH_RELATION,
+        morphRelations: [
+          createMockRelation('target-object-id', 'targetObject'),
+        ],
+      });
       const junctionObject = createMockObjectMetadata({
         id: 'junction-id',
-        fields: [],
+        fields: [inferredMorphTarget],
       });
 
       const result = getJunctionConfig({

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/getJunctionObjectMetadataIds.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/getJunctionObjectMetadataIds.test.ts
@@ -1,0 +1,50 @@
+import { getJunctionObjectMetadataIds } from '@/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds';
+import { getMockFieldMetadataItemOrThrow } from '~/testing/utils/getMockFieldMetadataItemOrThrow';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+
+describe('getJunctionObjectMetadataIds', () => {
+  const objectMetadataItems = getTestEnrichedObjectMetadataItemsMock();
+  const taskObjectMetadata = getMockObjectMetadataItemOrThrow('task');
+  const taskTargetObjectMetadata =
+    getMockObjectMetadataItemOrThrow('taskTarget');
+  const taskTargetsField = getMockFieldMetadataItemOrThrow({
+    objectMetadataItem: taskObjectMetadata,
+    fieldName: 'taskTargets',
+  });
+
+  it('includes objects reached through a valid junction configuration', () => {
+    expect(getJunctionObjectMetadataIds(objectMetadataItems)).toContain(
+      taskTargetObjectMetadata.id,
+    );
+  });
+
+  it('does not make an invalid configured target eligible for junction cascade deletion', () => {
+    const objectMetadataItemsWithInvalidTaskJunction = objectMetadataItems.map(
+      (objectMetadataItem) =>
+        objectMetadataItem.id === taskObjectMetadata.id
+          ? {
+              ...objectMetadataItem,
+              fields: objectMetadataItem.fields.map((field) =>
+                field.id === taskTargetsField.id
+                  ? {
+                      ...field,
+                      settings: {
+                        ...field.settings,
+                        junctionTargetFieldId:
+                          field.relation?.targetFieldMetadata.id,
+                      },
+                    }
+                  : field,
+              ),
+            }
+          : objectMetadataItem,
+    );
+
+    expect(
+      getJunctionObjectMetadataIds(
+        objectMetadataItemsWithInvalidTaskJunction,
+      ),
+    ).not.toContain(taskTargetObjectMetadata.id);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/getJunctionObjectMetadataIds.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/getJunctionObjectMetadataIds.test.ts
@@ -42,9 +42,7 @@ describe('getJunctionObjectMetadataIds', () => {
     );
 
     expect(
-      getJunctionObjectMetadataIds(
-        objectMetadataItemsWithInvalidTaskJunction,
-      ),
+      getJunctionObjectMetadataIds(objectMetadataItemsWithInvalidTaskJunction),
     ).not.toContain(taskTargetObjectMetadata.id);
   });
 });

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/isValidJunctionTargetField.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/__tests__/isValidJunctionTargetField.test.ts
@@ -1,0 +1,121 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type FieldMetadataItemRelation } from '@/object-metadata/types/FieldMetadataItemRelation';
+import { isValidJunctionTargetField } from '@/object-record/record-field/ui/utils/junction/isValidJunctionTargetField';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { RelationType } from '~/generated-metadata/graphql';
+
+const createRelation = ({
+  sourceFieldMetadataId,
+  type = RelationType.MANY_TO_ONE,
+}: {
+  sourceFieldMetadataId: string;
+  type?: RelationType;
+}): FieldMetadataItemRelation => ({
+  type,
+  sourceFieldMetadata: {
+    id: sourceFieldMetadataId,
+    name: sourceFieldMetadataId,
+  },
+  targetFieldMetadata: { id: 'target-field-id', name: 'targetField' },
+  sourceObjectMetadata: {
+    id: 'junction-object-id',
+    nameSingular: 'junctionObject',
+    namePlural: 'junctionObjects',
+  },
+  targetObjectMetadata: {
+    id: 'target-object-id',
+    nameSingular: 'targetObject',
+    namePlural: 'targetObjects',
+  },
+});
+
+const createField = (
+  overrides: Partial<FieldMetadataItem>,
+): FieldMetadataItem =>
+  ({
+    id: 'field-id',
+    name: 'field',
+    type: FieldMetadataType.RELATION,
+    ...overrides,
+  }) as FieldMetadataItem;
+
+describe('isValidJunctionTargetField', () => {
+  it('accepts a many-to-one relation', () => {
+    const field = createField({
+      relation: createRelation({ sourceFieldMetadataId: 'field-id' }),
+    });
+
+    expect(isValidJunctionTargetField({ fieldMetadataItem: field })).toBe(true);
+  });
+
+  it('rejects a one-to-many relation', () => {
+    const field = createField({
+      relation: createRelation({
+        sourceFieldMetadataId: 'field-id',
+        type: RelationType.ONE_TO_MANY,
+      }),
+    });
+
+    expect(isValidJunctionTargetField({ fieldMetadataItem: field })).toBe(
+      false,
+    );
+  });
+
+  it('accepts a morph relation when every target is many-to-one', () => {
+    const field = createField({
+      type: FieldMetadataType.MORPH_RELATION,
+      morphRelations: [
+        createRelation({ sourceFieldMetadataId: 'morph-field-a' }),
+        createRelation({ sourceFieldMetadataId: 'morph-field-b' }),
+      ],
+    });
+
+    expect(isValidJunctionTargetField({ fieldMetadataItem: field })).toBe(true);
+  });
+
+  it('rejects a one-to-many morph relation', () => {
+    const field = createField({
+      type: FieldMetadataType.MORPH_RELATION,
+      morphRelations: [
+        createRelation({
+          sourceFieldMetadataId: 'morph-field-a',
+          type: RelationType.ONE_TO_MANY,
+        }),
+      ],
+    });
+
+    expect(isValidJunctionTargetField({ fieldMetadataItem: field })).toBe(
+      false,
+    );
+  });
+
+  it('rejects the source field itself', () => {
+    const field = createField({
+      relation: createRelation({ sourceFieldMetadataId: 'field-id' }),
+    });
+
+    expect(
+      isValidJunctionTargetField({
+        fieldMetadataItem: field,
+        sourceFieldMetadataId: 'field-id',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects a morph group containing the source field', () => {
+    const field = createField({
+      type: FieldMetadataType.MORPH_RELATION,
+      morphRelations: [
+        createRelation({ sourceFieldMetadataId: 'morph-field-a' }),
+        createRelation({ sourceFieldMetadataId: 'source-field-id' }),
+      ],
+    });
+
+    expect(
+      isValidJunctionTargetField({
+        fieldMetadataItem: field,
+        sourceFieldMetadataId: 'source-field-id',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getFieldRelations.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getFieldRelations.ts
@@ -1,0 +1,11 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { isDefined } from 'twenty-shared/utils';
+
+export const getFieldRelations = (
+  fieldMetadataItem: Pick<FieldMetadataItem, 'relation' | 'morphRelations'>,
+) => [
+  ...(isDefined(fieldMetadataItem.relation)
+    ? [fieldMetadataItem.relation]
+    : []),
+  ...(fieldMetadataItem.morphRelations ?? []),
+];

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
@@ -97,7 +97,7 @@ export const getJunctionConfig = ({
 
   // Legacy workspaces can lack the target marker. Only infer a pure junction:
   // an unlabeled intermediate record with exactly one morph target.
-  const inferredMorphTargetFields = isDefined(configuredTargetField)
+  const inferredMorphTargetFields = hasConfiguredTargetField
     ? []
     : junctionObjectMetadata.fields.filter(
         (field) => field.type === FieldMetadataType.MORPH_RELATION,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
@@ -3,6 +3,7 @@ import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/Enriche
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { hasJunctionTargetFieldId } from './hasJunctionTargetFieldId';
+import { isValidJunctionTargetField } from './isValidJunctionTargetField';
 
 export type JunctionObjectMetadataItem = Pick<
   EnrichedObjectMetadataItem,
@@ -19,6 +20,7 @@ export type JunctionConfig = {
   targetFields: FieldMetadataItem[];
   sourceField?: FieldMetadataItem;
   isMorphRelation: boolean;
+  isValid: boolean;
 };
 
 type GetJunctionConfigArgs = {
@@ -73,7 +75,8 @@ export const getJunctionConfig = ({
     );
   };
 
-  const configuredTargetField = hasJunctionTargetFieldId(settings)
+  const hasConfiguredTargetField = hasJunctionTargetFieldId(settings);
+  const configuredTargetField = hasConfiguredTargetField
     ? junctionObjectMetadata.fields.find(
         (field) => field.id === settings.junctionTargetFieldId,
       )
@@ -85,6 +88,12 @@ export const getJunctionConfig = ({
     : undefined;
   const sourceField =
     relationSourceField ?? findSourceField(configuredTargetField?.id);
+  const invalidConfiguredJunction: JunctionConfig = {
+    junctionObjectMetadata,
+    targetFields: [],
+    isMorphRelation: false,
+    isValid: false,
+  };
 
   // Legacy workspaces can lack the target marker. Only infer a pure junction:
   // an unlabeled intermediate record with exactly one morph target.
@@ -106,19 +115,25 @@ export const getJunctionConfig = ({
       : undefined);
 
   if (!isDefined(targetField)) {
-    return null;
+    return hasConfiguredTargetField ? invalidConfiguredJunction : null;
+  }
+
+  if (
+    !isValidJunctionTargetField({
+      fieldMetadataItem: targetField,
+      sourceFieldMetadataId: relationTargetFieldMetadataId,
+    })
+  ) {
+    return hasConfiguredTargetField ? invalidConfiguredJunction : null;
   }
 
   const isMorphRelation = targetField.type === FieldMetadataType.MORPH_RELATION;
-
-  if (!isMorphRelation && !isDefined(targetField.relation)) {
-    return null;
-  }
 
   return {
     junctionObjectMetadata,
     targetFields: [targetField],
     sourceField,
     isMorphRelation,
+    isValid: true,
   };
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
@@ -1,43 +1,10 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
-import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type JunctionConfig } from '@/object-record/record-field/ui/utils/junction/types/JunctionConfig';
+import { type JunctionObjectMetadataItem } from '@/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { hasJunctionTargetFieldId } from './hasJunctionTargetFieldId';
 import { isValidJunctionTargetField } from './isValidJunctionTargetField';
-
-export type JunctionObjectMetadataItem = Pick<
-  EnrichedObjectMetadataItem,
-  | 'id'
-  | 'fields'
-  | 'labelIdentifierFieldMetadataId'
-  | 'imageIdentifierFieldMetadataId'
-  | 'nameSingular'
-  | 'namePlural'
->;
-
-type BaseJunctionConfig = {
-  junctionObjectMetadata: JunctionObjectMetadataItem;
-};
-
-export type ValidJunctionConfig = BaseJunctionConfig & {
-  targetFields: FieldMetadataItem[];
-  sourceField?: FieldMetadataItem;
-  isMorphRelation: boolean;
-  isValid: true;
-};
-
-export type InvalidJunctionConfig = BaseJunctionConfig & {
-  targetFields: [];
-  sourceField?: never;
-  isMorphRelation: false;
-  isValid: false;
-};
-
-export type JunctionConfig = ValidJunctionConfig | InvalidJunctionConfig;
-
-export const isUsableJunctionConfig = (
-  junctionConfig: JunctionConfig | null | undefined,
-): junctionConfig is ValidJunctionConfig => junctionConfig?.isValid === true;
 
 type GetJunctionConfigArgs = {
   settings: FieldMetadataItem['settings'] | undefined;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
@@ -15,13 +15,29 @@ export type JunctionObjectMetadataItem = Pick<
   | 'namePlural'
 >;
 
-export type JunctionConfig = {
+type BaseJunctionConfig = {
   junctionObjectMetadata: JunctionObjectMetadataItem;
+};
+
+export type ValidJunctionConfig = BaseJunctionConfig & {
   targetFields: FieldMetadataItem[];
   sourceField?: FieldMetadataItem;
   isMorphRelation: boolean;
-  isValid: boolean;
+  isValid: true;
 };
+
+export type InvalidJunctionConfig = BaseJunctionConfig & {
+  targetFields: [];
+  sourceField?: never;
+  isMorphRelation: false;
+  isValid: false;
+};
+
+export type JunctionConfig = ValidJunctionConfig | InvalidJunctionConfig;
+
+export const isUsableJunctionConfig = (
+  junctionConfig: JunctionConfig | null | undefined,
+): junctionConfig is ValidJunctionConfig => junctionConfig?.isValid === true;
 
 type GetJunctionConfigArgs = {
   settings: FieldMetadataItem['settings'] | undefined;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds.ts
@@ -1,6 +1,7 @@
 import {
   getJunctionConfig,
   type JunctionObjectMetadataItem,
+  isUsableJunctionConfig,
 } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -12,18 +13,19 @@ export const getJunctionObjectMetadataIds = (
   new Set(
     objectMetadataItems.flatMap((objectMetadataItem) =>
       objectMetadataItem.fields
-        .filter(
-          (field) =>
-            getJunctionConfig({
-              settings: field.settings,
-              relationObjectMetadataId:
-                field.relation?.targetObjectMetadata.id ?? '',
-              relationTargetFieldMetadataId:
-                field.relation?.targetFieldMetadata.id,
-              sourceObjectMetadataId: objectMetadataItem.id,
-              objectMetadataItems,
-            })?.isValid === true,
-        )
+        .filter((field) => {
+          const junctionConfig = getJunctionConfig({
+            settings: field.settings,
+            relationObjectMetadataId:
+              field.relation?.targetObjectMetadata.id ?? '',
+            relationTargetFieldMetadataId:
+              field.relation?.targetFieldMetadata.id,
+            sourceObjectMetadataId: objectMetadataItem.id,
+            objectMetadataItems,
+          });
+
+          return isUsableJunctionConfig(junctionConfig);
+        })
         .map((junctionField) => junctionField.relation?.targetObjectMetadata.id)
         .filter(isDefined),
     ),

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds.ts
@@ -1,8 +1,6 @@
-import {
-  getJunctionConfig,
-  type JunctionObjectMetadataItem,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
+import { type JunctionObjectMetadataItem } from '@/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 
 // A junction object carries no marker of its own, so the relation graph is walked to

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds.ts
@@ -12,8 +12,8 @@ export const getJunctionObjectMetadataIds = (
   new Set(
     objectMetadataItems.flatMap((objectMetadataItem) =>
       objectMetadataItem.fields
-        .filter((field) =>
-          isDefined(
+        .filter(
+          (field) =>
             getJunctionConfig({
               settings: field.settings,
               relationObjectMetadataId:
@@ -22,8 +22,7 @@ export const getJunctionObjectMetadataIds = (
                 field.relation?.targetFieldMetadata.id,
               sourceObjectMetadataId: objectMetadataItem.id,
               objectMetadataItems,
-            }),
-          ),
+            })?.isValid === true,
         )
         .map((junctionField) => junctionField.relation?.targetObjectMetadata.id)
         .filter(isDefined),

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getObjectMorphJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getObjectMorphJunctionConfig.ts
@@ -1,12 +1,10 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
-import {
-  getJunctionConfig,
-  type JunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
 import { isConfiguredJunctionRelationField } from '@/object-record/record-field/ui/utils/junction/isConfiguredJunctionRelationField';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
+import { type JunctionConfig } from '@/object-record/record-field/ui/utils/junction/types/JunctionConfig';
 import { isDefined } from 'twenty-shared/utils';
 
 type ObjectMorphJunctionConfig = JunctionConfig & {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getObjectMorphJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getObjectMorphJunctionConfig.ts
@@ -3,6 +3,7 @@ import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/Enriche
 import {
   getJunctionConfig,
   type JunctionConfig,
+  isUsableJunctionConfig,
 } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
 import { isConfiguredJunctionRelationField } from '@/object-record/record-field/ui/utils/junction/isConfiguredJunctionRelationField';
@@ -39,7 +40,8 @@ export const getObjectMorphJunctionConfig = ({
     });
 
     if (
-      !junctionConfig?.isMorphRelation ||
+      !isUsableJunctionConfig(junctionConfig) ||
+      !junctionConfig.isMorphRelation ||
       !isDefined(junctionConfig.sourceField)
     ) {
       continue;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getReverseJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getReverseJunctionConfig.ts
@@ -1,6 +1,7 @@
 import {
   getJunctionConfig,
   type JunctionObjectMetadataItem,
+  isUsableJunctionConfig,
 } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getTargetObjectMetadataIdsFromField } from '@/object-record/record-field/ui/utils/junction/getTargetObjectMetadataIdsFromField';
 import { isDefined } from 'twenty-shared/utils';
@@ -49,7 +50,10 @@ export const getReverseJunctionConfig = ({
         objectMetadataItems,
       });
 
-      if (!isDefined(junctionConfig?.sourceField)) {
+      if (
+        !isUsableJunctionConfig(junctionConfig) ||
+        !isDefined(junctionConfig.sourceField)
+      ) {
         continue;
       }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getReverseJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getReverseJunctionConfig.ts
@@ -1,9 +1,7 @@
-import {
-  getJunctionConfig,
-  type JunctionObjectMetadataItem,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getTargetObjectMetadataIdsFromField } from '@/object-record/record-field/ui/utils/junction/getTargetObjectMetadataIdsFromField';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
+import { type JunctionObjectMetadataItem } from '@/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 
 type ReverseJunctionConfig = {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isJunctionRelationForbidden.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isJunctionRelationForbidden.ts
@@ -1,6 +1,9 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { getObjectPermissionsForObject } from '@/object-metadata/utils/getObjectPermissionsForObject';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getTargetObjectMetadataIdsFromField } from '@/object-record/record-field/ui/utils/junction/getTargetObjectMetadataIdsFromField';
 import { type ObjectPermissions } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -43,6 +46,10 @@ export const isJunctionRelationForbidden = ({
 
   if (!isDefined(junctionConfig)) {
     return false;
+  }
+
+  if (!isUsableJunctionConfig(junctionConfig)) {
+    return true;
   }
 
   const junctionPermissions = getObjectPermissionsForObject(

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isJunctionRelationForbidden.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isJunctionRelationForbidden.ts
@@ -1,14 +1,11 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { getObjectPermissionsForObject } from '@/object-metadata/utils/getObjectPermissionsForObject';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getTargetObjectMetadataIdsFromField } from '@/object-record/record-field/ui/utils/junction/getTargetObjectMetadataIdsFromField';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
+import { type JunctionObjectMetadataItem } from '@/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem';
 import { type ObjectPermissions } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-
-import { type JunctionObjectMetadataItem } from './getJunctionConfig';
 
 type ObjectPermissionsByObjectMetadataId = Record<
   string,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isUsableJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isUsableJunctionConfig.ts
@@ -1,0 +1,4 @@
+export const isUsableJunctionConfig = <Config extends { isValid: boolean }>(
+  junctionConfig: Config | null | undefined,
+): junctionConfig is Config & { isValid: true } =>
+  junctionConfig?.isValid === true;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isValidJunctionTargetField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isValidJunctionTargetField.ts
@@ -1,0 +1,30 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { RelationType } from '~/generated-metadata/graphql';
+
+export const isValidJunctionTargetField = ({
+  fieldMetadataItem,
+  sourceFieldMetadataId,
+}: {
+  fieldMetadataItem: FieldMetadataItem;
+  sourceFieldMetadataId?: string;
+}): boolean => {
+  const relations =
+    fieldMetadataItem.type === FieldMetadataType.RELATION
+      ? fieldMetadataItem.relation
+        ? [fieldMetadataItem.relation]
+        : []
+      : fieldMetadataItem.type === FieldMetadataType.MORPH_RELATION
+        ? (fieldMetadataItem.morphRelations ?? [])
+        : [];
+
+  return (
+    relations.length > 0 &&
+    relations.every(({ type }) => type === RelationType.MANY_TO_ONE) &&
+    fieldMetadataItem.id !== sourceFieldMetadataId &&
+    relations.every(
+      ({ sourceFieldMetadata }) =>
+        sourceFieldMetadata.id !== sourceFieldMetadataId,
+    )
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isValidJunctionTargetField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/isValidJunctionTargetField.ts
@@ -1,5 +1,5 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
-import { FieldMetadataType } from 'twenty-shared/types';
+import { getFieldRelations } from '@/object-record/record-field/ui/utils/junction/getFieldRelations';
 import { RelationType } from '~/generated-metadata/graphql';
 
 export const isValidJunctionTargetField = ({
@@ -9,14 +9,10 @@ export const isValidJunctionTargetField = ({
   fieldMetadataItem: FieldMetadataItem;
   sourceFieldMetadataId?: string;
 }): boolean => {
-  const relations =
-    fieldMetadataItem.type === FieldMetadataType.RELATION
-      ? fieldMetadataItem.relation
-        ? [fieldMetadataItem.relation]
-        : []
-      : fieldMetadataItem.type === FieldMetadataType.MORPH_RELATION
-        ? (fieldMetadataItem.morphRelations ?? [])
-        : [];
+  // The server validates universal flat metadata in
+  // validateJunctionTargetSettings. Keep relation direction and source-group
+  // exclusion aligned there when this resolved GraphQL representation changes.
+  const relations = getFieldRelations(fieldMetadataItem);
 
   return (
     relations.length > 0 &&

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/types/JunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/types/JunctionConfig.ts
@@ -1,0 +1,13 @@
+import { type ValidJunctionConfig } from '@/object-record/record-field/ui/utils/junction/types/ValidJunctionConfig';
+
+type InvalidJunctionConfig = Pick<
+  ValidJunctionConfig,
+  'junctionObjectMetadata'
+> & {
+  targetFields: [];
+  sourceField?: never;
+  isMorphRelation: false;
+  isValid: false;
+};
+
+export type JunctionConfig = ValidJunctionConfig | InvalidJunctionConfig;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem.ts
@@ -1,0 +1,11 @@
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+
+export type JunctionObjectMetadataItem = Pick<
+  EnrichedObjectMetadataItem,
+  | 'id'
+  | 'fields'
+  | 'labelIdentifierFieldMetadataId'
+  | 'imageIdentifierFieldMetadataId'
+  | 'nameSingular'
+  | 'namePlural'
+>;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/types/ValidJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/types/ValidJunctionConfig.ts
@@ -1,0 +1,10 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type JunctionObjectMetadataItem } from '@/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem';
+
+export type ValidJunctionConfig = {
+  junctionObjectMetadata: JunctionObjectMetadataItem;
+  targetFields: FieldMetadataItem[];
+  sourceField?: FieldMetadataItem;
+  isMorphRelation: boolean;
+  isValid: true;
+};

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextGeneric.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextGeneric.tsx
@@ -6,7 +6,10 @@ import { type RecordField } from '@/object-record/record-field/types/RecordField
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { isFieldRelationManyToOne } from '@/object-record/record-field/ui/types/guards/isFieldRelationManyToOne';
 import { isFieldRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldRelationOneToMany';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getTargetObjectMetadataIdsFromField } from '@/object-record/record-field/ui/utils/junction/getTargetObjectMetadataIdsFromField';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
@@ -47,6 +50,7 @@ export const RecordTableCellFieldContextGeneric = ({
     useGetIsMetadataItemFromStandardApplication();
 
   let hasObjectReadPermissions = objectPermissions.canReadObjectRecords;
+  let isInvalidJunctionRelation = false;
 
   // todo @guillim : adjust this to handle morph relations permissions display
   if (
@@ -74,6 +78,12 @@ export const RecordTableCellFieldContextGeneric = ({
       });
 
       if (isDefined(junctionConfig)) {
+        isInvalidJunctionRelation = !isUsableJunctionConfig(junctionConfig);
+
+        if (isInvalidJunctionRelation) {
+          hasObjectReadPermissions = false;
+        }
+
         const targetObjectMetadataIds = junctionConfig.targetFields.flatMap(
           getTargetObjectMetadataIdsFromField,
         );
@@ -108,6 +118,7 @@ export const RecordTableCellFieldContextGeneric = ({
         displayedMaxRows: 1,
         isRecordFieldReadOnly:
           isRecordTableCellsNonEditable ||
+          isInvalidJunctionRelation ||
           isRecordFieldReadOnly({
             isRecordReadOnly: isRecordReadOnly ?? false,
             isSystemObject: objectMetadataItem.isSystem,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextGeneric.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextGeneric.tsx
@@ -6,11 +6,9 @@ import { type RecordField } from '@/object-record/record-field/types/RecordField
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { isFieldRelationManyToOne } from '@/object-record/record-field/ui/types/guards/isFieldRelationManyToOne';
 import { isFieldRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldRelationOneToMany';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { getTargetObjectMetadataIdsFromField } from '@/object-record/record-field/ui/utils/junction/getTargetObjectMetadataIdsFromField';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useRecordTableRowContextOrThrow } from '@/object-record/record-table/contexts/RecordTableRowContext';

--- a/packages/twenty-front/src/modules/object-record/utils/__tests__/isFieldCellSupported.test.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/__tests__/isFieldCellSupported.test.ts
@@ -1,0 +1,37 @@
+import { isFieldCellSupported } from '@/object-record/utils/isFieldCellSupported';
+import { getMockFieldMetadataItemOrThrow } from '~/testing/utils/getMockFieldMetadataItemOrThrow';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+
+describe('isFieldCellSupported', () => {
+  const objectMetadataItems = getTestEnrichedObjectMetadataItemsMock();
+  const taskMetadata = getMockObjectMetadataItemOrThrow('task');
+  const taskTargetsField = getMockFieldMetadataItemOrThrow({
+    objectMetadataItem: taskMetadata,
+    fieldName: 'taskTargets',
+  });
+
+  it('supports a valid configured junction field', () => {
+    expect(isFieldCellSupported(taskTargetsField, objectMetadataItems)).toBe(
+      true,
+    );
+  });
+
+  it('does not advertise an invalid configured junction as editable', () => {
+    if (!taskTargetsField.relation) {
+      throw new Error('Task targets relation not found');
+    }
+
+    const invalidTaskTargetsField = {
+      ...taskTargetsField,
+      settings: {
+        ...taskTargetsField.settings,
+        junctionTargetFieldId: taskTargetsField.relation.targetFieldMetadata.id,
+      },
+    };
+
+    expect(
+      isFieldCellSupported(invalidTaskTargetsField, objectMetadataItems),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/utils/isFieldCellSupported.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/isFieldCellSupported.ts
@@ -2,7 +2,10 @@ import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataIte
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { isHiddenSystemField } from '@/object-metadata/utils/isHiddenSystemField';
 import { isObjectMetadataAvailableForRelation } from '@/object-metadata/utils/isObjectMetadataAvailableForRelation';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
@@ -40,7 +43,7 @@ export const isFieldCellSupported = (
     });
 
     if (isDefined(junctionConfig)) {
-      return true;
+      return isUsableJunctionConfig(junctionConfig);
     }
 
     if (!fieldMetadataItem.relation || !relationObjectMetadataItem) {

--- a/packages/twenty-front/src/modules/object-record/utils/isFieldCellSupported.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/isFieldCellSupported.ts
@@ -2,10 +2,8 @@ import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataIte
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { isHiddenSystemField } from '@/object-metadata/utils/isHiddenSystemField';
 import { isObjectMetadataAvailableForRelation } from '@/object-metadata/utils/isObjectMetadataAvailableForRelation';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
@@ -6,10 +6,8 @@ import { isFieldMorphRelation } from '@/object-record/record-field/ui/types/guar
 import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/isFieldRelation';
 import { isFieldRichText } from '@/object-record/record-field/ui/types/guards/isFieldRichText';
 import { isFieldText } from '@/object-record/record-field/ui/types/guards/isFieldText';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { recordStoreFamilySelector } from '@/object-record/record-store/states/selectors/recordStoreFamilySelector';
 import { useResolveFieldMetadataIdFromNameOrId } from '@/page-layout/hooks/useResolveFieldMetadataIdFromNameOrId';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
@@ -6,7 +6,10 @@ import { isFieldMorphRelation } from '@/object-record/record-field/ui/types/guar
 import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/isFieldRelation';
 import { isFieldRichText } from '@/object-record/record-field/ui/types/guards/isFieldRichText';
 import { isFieldText } from '@/object-record/record-field/ui/types/guards/isFieldText';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { recordStoreFamilySelector } from '@/object-record/record-store/states/selectors/recordStoreFamilySelector';
 import { useResolveFieldMetadataIdFromNameOrId } from '@/page-layout/hooks/useResolveFieldMetadataIdFromNameOrId';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
@@ -136,7 +139,7 @@ export const FieldWidget = ({ widget }: FieldWidgetProps) => {
     });
 
     if (isDefined(junctionConfig)) {
-      if (!junctionConfig.isValid) {
+      if (!isUsableJunctionConfig(junctionConfig)) {
         return null;
       }
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
@@ -125,19 +125,21 @@ export const FieldWidget = ({ widget }: FieldWidgetProps) => {
   }
 
   if (isFieldRelation(fieldDefinition)) {
-    const isJunctionRelation = isDefined(
-      getJunctionConfig({
-        settings: fieldDefinition.metadata.settings,
-        relationObjectMetadataId:
-          fieldDefinition.metadata.relationObjectMetadataId,
-        relationTargetFieldMetadataId:
-          fieldDefinition.metadata.relationFieldMetadataId,
-        sourceObjectMetadataId: objectMetadataItem.id,
-        objectMetadataItems,
-      }),
-    );
+    const junctionConfig = getJunctionConfig({
+      settings: fieldDefinition.metadata.settings,
+      relationObjectMetadataId:
+        fieldDefinition.metadata.relationObjectMetadataId,
+      relationTargetFieldMetadataId:
+        fieldDefinition.metadata.relationFieldMetadataId,
+      sourceObjectMetadataId: objectMetadataItem.id,
+      objectMetadataItems,
+    });
 
-    if (isJunctionRelation) {
+    if (isDefined(junctionConfig)) {
+      if (!junctionConfig.isValid) {
+        return null;
+      }
+
       if (fieldDisplayMode === FieldDisplayMode.CARD) {
         return (
           <FieldWidgetJunctionRelationCard

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetJunctionRelationCard.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetJunctionRelationCard.tsx
@@ -17,7 +17,10 @@ import { usePersistField } from '@/object-record/record-field/ui/hooks/usePersis
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { StyledWidgetContentContainer } from '@/ui/layout/components/WidgetContentContainer';
 import { FieldWidgetShowMoreButton } from '@/page-layout/widgets/field/components/FieldWidgetShowMoreButton';
 import { FIELD_WIDGET_RELATION_CARD_INITIAL_VISIBLE_ITEMS } from '@/page-layout/widgets/field/constants/FieldWidgetRelationCardInitialVisibleItems';
@@ -121,7 +124,7 @@ export const FieldWidgetJunctionRelationCard = ({
     objectMetadataItems,
   });
 
-  if (!isDefined(junctionConfig)) {
+  if (!isUsableJunctionConfig(junctionConfig)) {
     return null;
   }
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetJunctionRelationCard.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetJunctionRelationCard.tsx
@@ -17,10 +17,8 @@ import { usePersistField } from '@/object-record/record-field/ui/hooks/usePersis
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { StyledWidgetContentContainer } from '@/ui/layout/components/WidgetContentContainer';
 import { FieldWidgetShowMoreButton } from '@/page-layout/widgets/field/components/FieldWidgetShowMoreButton';
 import { FIELD_WIDGET_RELATION_CARD_INITIAL_VISIBLE_ITEMS } from '@/page-layout/widgets/field/constants/FieldWidgetRelationCardInitialVisibleItems';

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetJunctionRelationField.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetJunctionRelationField.tsx
@@ -3,10 +3,8 @@ import { RecordChip } from '@/object-record/components/RecordChip';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { SidePanelProvider } from '@/ui/layout/side-panel/contexts/SidePanelContext';
 import { styled } from '@linaria/react';
 import { isDefined } from 'twenty-shared/utils';

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetJunctionRelationField.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetJunctionRelationField.tsx
@@ -3,7 +3,10 @@ import { RecordChip } from '@/object-record/components/RecordChip';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { SidePanelProvider } from '@/ui/layout/side-panel/contexts/SidePanelContext';
 import { styled } from '@linaria/react';
 import { isDefined } from 'twenty-shared/utils';
@@ -46,7 +49,7 @@ export const FieldWidgetJunctionRelationField = ({
     objectMetadataItems,
   });
 
-  if (!isDefined(junctionConfig)) {
+  if (!isUsableJunctionConfig(junctionConfig)) {
     return null;
   }
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetActionVisibility.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetActionVisibility.ts
@@ -60,18 +60,16 @@ export const useFieldWidgetActionVisibility = ({
     widget.configuration.nestedRelationFieldMetadataId,
   );
 
-  const isJunctionRelation = isDefined(
-    isDefined(relationMetadata)
-      ? getJunctionConfig({
-          settings: relationMetadata.settings,
-          relationObjectMetadataId: relationMetadata.relationObjectMetadataId,
-          relationTargetFieldMetadataId:
-            relationMetadata.relationFieldMetadataId,
-          sourceObjectMetadataId: objectMetadataItem.id,
-          objectMetadataItems,
-        })
-      : null,
-  );
+  const junctionConfig = isDefined(relationMetadata)
+    ? getJunctionConfig({
+        settings: relationMetadata.settings,
+        relationObjectMetadataId: relationMetadata.relationObjectMetadataId,
+        relationTargetFieldMetadataId: relationMetadata.relationFieldMetadataId,
+        sourceObjectMetadataId: objectMetadataItem.id,
+        objectMetadataItems,
+      })
+    : null;
+  const isJunctionRelation = isDefined(junctionConfig);
 
   const showSeeAll =
     isOneToManyRelation && !isNestedRelationWidget && !isJunctionRelation;
@@ -96,7 +94,10 @@ export const useFieldWidgetActionVisibility = ({
   // The read-only chain already hides edit during layout customization
   // (useIsRecordReadOnly returns true then); the explicit check states the
   // rule here instead of leaving it implicit.
-  const showEdit = !isPageLayoutInEditMode && !isFieldReadOnly;
+  const showEdit =
+    !isPageLayoutInEditMode &&
+    !isFieldReadOnly &&
+    junctionConfig?.isValid !== false;
 
   return { showSeeAll, showEdit };
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetActionVisibility.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetActionVisibility.ts
@@ -4,10 +4,8 @@ import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions
 import { useIsRecordReadOnly } from '@/object-record/read-only/hooks/useIsRecordReadOnly';
 import { isRecordFieldReadOnly } from '@/object-record/read-only/utils/isRecordFieldReadOnly';
 import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/isFieldRelation';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { useIsPageLayoutInEditMode } from '@/page-layout/hooks/useIsPageLayoutInEditMode';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { useFieldWidgetFieldDefinition } from '@/page-layout/widgets/field/hooks/useFieldWidgetFieldDefinition';

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetActionVisibility.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetActionVisibility.ts
@@ -4,7 +4,10 @@ import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions
 import { useIsRecordReadOnly } from '@/object-record/read-only/hooks/useIsRecordReadOnly';
 import { isRecordFieldReadOnly } from '@/object-record/read-only/utils/isRecordFieldReadOnly';
 import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/isFieldRelation';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { useIsPageLayoutInEditMode } from '@/page-layout/hooks/useIsPageLayoutInEditMode';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { useFieldWidgetFieldDefinition } from '@/page-layout/widgets/field/hooks/useFieldWidgetFieldDefinition';
@@ -97,7 +100,7 @@ export const useFieldWidgetActionVisibility = ({
   const showEdit =
     !isPageLayoutInEditMode &&
     !isFieldReadOnly &&
-    junctionConfig?.isValid !== false;
+    (!isDefined(junctionConfig) || isUsableJunctionConfig(junctionConfig));
 
   return { showSeeAll, showEdit };
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useOpenFieldWidgetFieldInputEditMode.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useOpenFieldWidgetFieldInputEditMode.ts
@@ -12,7 +12,10 @@ import { isFieldMorphRelationManyToOne } from '@/object-record/record-field/ui/t
 import { isFieldMorphRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldMorphRelationOneToMany';
 import { isFieldRelationManyToOne } from '@/object-record/record-field/ui/types/guards/isFieldRelationManyToOne';
 import { isFieldRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldRelationOneToMany';
-import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import {
+  getJunctionConfig,
+  isUsableJunctionConfig,
+} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
@@ -49,10 +52,8 @@ export const useOpenFieldWidgetFieldInputEditMode = () => {
       fieldDefinition: FieldDefinition<FieldMetadata>;
       recordId: string;
     }) => {
-      if (
-        isFieldRelationOneToMany(fieldDefinition) &&
-        isDefined(
-          getJunctionConfig({
+      const junctionConfig = isFieldRelationOneToMany(fieldDefinition)
+        ? getJunctionConfig({
             settings: fieldDefinition.metadata.settings,
             relationObjectMetadataId:
               fieldDefinition.metadata.relationObjectMetadataId,
@@ -64,14 +65,21 @@ export const useOpenFieldWidgetFieldInputEditMode = () => {
                 fieldDefinition.metadata.objectMetadataNameSingular,
             )?.id,
             objectMetadataItems,
-          }),
-        )
+          })
+        : null;
+
+      if (
+        isFieldRelationOneToMany(fieldDefinition) &&
+        isDefined(junctionConfig)
       ) {
-        openJunctionRelationFieldInput({
-          fieldDefinition,
-          recordId,
-          recordPickerInstanceId: instanceId,
-        });
+        if (isUsableJunctionConfig(junctionConfig)) {
+          openJunctionRelationFieldInput({
+            fieldDefinition,
+            recordId,
+            recordPickerInstanceId: instanceId,
+          });
+        }
+
         return;
       }
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useOpenFieldWidgetFieldInputEditMode.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useOpenFieldWidgetFieldInputEditMode.ts
@@ -12,10 +12,8 @@ import { isFieldMorphRelationManyToOne } from '@/object-record/record-field/ui/t
 import { isFieldMorphRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldMorphRelationOneToMany';
 import { isFieldRelationManyToOne } from '@/object-record/record-field/ui/types/guards/isFieldRelationManyToOne';
 import { isFieldRelationOneToMany } from '@/object-record/record-field/ui/types/guards/isFieldRelationOneToMany';
-import {
-  getJunctionConfig,
-  isUsableJunctionConfig,
-} from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationFormCard.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationFormCard.tsx
@@ -135,6 +135,7 @@ export const SettingsDataModelFieldRelationFormCard = ({
           {isJunctionRelationsEnabled && (
             <SettingsDataModelFieldRelationJunctionForm
               objectNameSingular={objectNameSingular}
+              existingFieldMetadataId={existingFieldMetadataId}
             />
           )}
         </>

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationJunctionForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationJunctionForm.tsx
@@ -6,6 +6,8 @@ import { IconLink } from 'twenty-ui/icon';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetadataItemById';
+import { isValidJunctionTargetField } from '@/object-record/record-field/ui/utils/junction/isValidJunctionTargetField';
 import { SettingsOptionCardContentSelect } from '@/settings/components/SettingsOptions/SettingsOptionCardContentSelect';
 import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
 import { Select } from '@/ui/input/components/Select';
@@ -16,10 +18,12 @@ import { type SettingsDataModelFieldEditFormValues } from '~/pages/settings/data
 
 type SettingsDataModelFieldRelationJunctionFormProps = {
   objectNameSingular: string;
+  existingFieldMetadataId: string;
 };
 
 export const SettingsDataModelFieldRelationJunctionForm = ({
   objectNameSingular,
+  existingFieldMetadataId,
 }: SettingsDataModelFieldRelationJunctionFormProps) => {
   const { t } = useLingui();
   const { watch, setValue } =
@@ -31,6 +35,8 @@ export const SettingsDataModelFieldRelationJunctionForm = ({
     useObjectMetadataItem({ objectNameSingular });
 
   const { objectMetadataItems } = useObjectMetadataItems();
+  const { fieldMetadataItem: existingFieldMetadataItem } =
+    useFieldMetadataItemById(existingFieldMetadataId);
 
   const relationType = watch('relationType') ?? RelationType.ONE_TO_MANY;
   const targetObjectIds = watch('morphRelationObjectMetadataIds') ?? [];
@@ -54,6 +60,12 @@ export const SettingsDataModelFieldRelationJunctionForm = ({
   }
 
   const sourceObjectMetadataId = sourceObjectMetadataItem?.id;
+  const sourceFieldMetadataId =
+    existingFieldMetadataItem?.relation?.targetFieldMetadata.id ??
+    existingFieldMetadataItem?.morphRelations?.find(
+      ({ targetObjectMetadata }) =>
+        targetObjectMetadata.id === junctionObjectMetadataItem.id,
+    )?.targetFieldMetadata.id;
 
   // Self-referential relations cannot be junction objects
   if (sourceObjectMetadataId === junctionObjectMetadataItem.id) {
@@ -61,51 +73,41 @@ export const SettingsDataModelFieldRelationJunctionForm = ({
   }
 
   const junctionFieldOptions: { label: string; value: string }[] = [];
-
-  // Add MORPH_RELATION fields (use first field of each morphId group)
-  // morphRelations already contains all targets, so any sibling works
   const morphIdsSeen = new Set<string>();
-  junctionObjectMetadataItem.fields
-    .filter(
-      (field) =>
-        field.type === FieldMetadataType.MORPH_RELATION &&
-        isDefined(field.morphId),
-    )
-    .forEach((field) => {
-      if (!morphIdsSeen.has(field.morphId!)) {
-        morphIdsSeen.add(field.morphId!);
-        junctionFieldOptions.push({
-          label: `${field.label} (polymorphic)`,
-          value: field.id,
-        });
-      }
-    });
+  for (const field of junctionObjectMetadataItem.fields) {
+    if (
+      !isValidJunctionTargetField({
+        fieldMetadataItem: field,
+        sourceFieldMetadataId,
+      })
+    ) {
+      continue;
+    }
 
-  junctionObjectMetadataItem.fields
-    .filter((field) => {
-      if (
-        field.type !== FieldMetadataType.RELATION ||
-        field.relation?.type !== RelationType.MANY_TO_ONE
-      ) {
-        return false;
+    if (
+      field.type === FieldMetadataType.MORPH_RELATION &&
+      isDefined(field.morphId)
+    ) {
+      if (morphIdsSeen.has(field.morphId)) {
+        continue;
       }
-      return (
-        !isDefined(sourceObjectMetadataId) ||
-        field.relation?.targetObjectMetadata.id !== sourceObjectMetadataId
-      );
-    })
-    .forEach((field) => {
-      junctionFieldOptions.push({
-        label: field.label,
-        value: field.id,
-      });
-    });
+      morphIdsSeen.add(field.morphId);
+    }
 
-  if (junctionFieldOptions.length === 0) {
-    return null;
+    junctionFieldOptions.push({
+      label: `${field.label}${field.type === FieldMetadataType.MORPH_RELATION ? ' (polymorphic)' : ''}`,
+      value: field.id,
+    });
   }
 
   const isJunctionConfigEnabled = isDefined(junctionTargetFieldId);
+  const isConfiguredTargetValid = junctionFieldOptions.some(
+    ({ value }) => value === junctionTargetFieldId,
+  );
+
+  if (junctionFieldOptions.length === 0 && !isJunctionConfigEnabled) {
+    return null;
+  }
 
   const handleJunctionToggle = (checked: boolean) => {
     if (checked && junctionFieldOptions.length > 0) {
@@ -154,11 +156,11 @@ export const SettingsDataModelFieldRelationJunctionForm = ({
         description={t`Build many-to-many relations`}
         checked={isJunctionConfigEnabled}
         onChange={handleJunctionToggle}
-        divider={isJunctionConfigEnabled}
+        divider={isJunctionConfigEnabled && junctionFieldOptions.length > 0}
         advancedMode
       />
 
-      {isJunctionConfigEnabled && (
+      {isJunctionConfigEnabled && junctionFieldOptions.length > 0 && (
         <SettingsOptionCardContentSelect
           title={t`Target relation on Junction Object`}
           description={t`Skip the junction object (similar to many-to-many relations)`}
@@ -168,6 +170,14 @@ export const SettingsDataModelFieldRelationJunctionForm = ({
             selectSizeVariant="small"
             dropdownWidth={120}
             value={junctionTargetFieldId}
+            emptyOption={
+              !isConfiguredTargetValid && isDefined(junctionTargetFieldId)
+                ? {
+                    label: t`Select a valid target`,
+                    value: junctionTargetFieldId,
+                  }
+                : undefined
+            }
             options={junctionFieldOptions}
             onChange={handleSelectionChange}
           />

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.ts
@@ -15,6 +15,7 @@ import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/
 import { isFieldMetadataSettingsOfType } from 'src/engine/metadata-modules/field-metadata/utils/is-field-metadata-settings-of-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
 
@@ -258,17 +259,10 @@ export class BackfillActivityTargetsJunctionTargetCommand extends ProvisionedWor
       return undefined;
     }
 
-    const junctionTargetSettings = junctionTargetFlatFieldMetadata.settings;
-    const isMorphTarget =
-      junctionTargetFlatFieldMetadata.type === FieldMetadataType.MORPH_RELATION;
-
     if (
-      !isMorphTarget &&
-      (!isFieldMetadataSettingsOfType(
-        junctionTargetSettings,
-        FieldMetadataType.RELATION,
-      ) ||
-        junctionTargetSettings.relationType !== RelationType.MANY_TO_ONE)
+      !isMorphOrRelationFlatFieldMetadata(junctionTargetFlatFieldMetadata) ||
+      junctionTargetFlatFieldMetadata.settings.relationType !==
+        RelationType.MANY_TO_ONE
     ) {
       this.logger.warn(
         `Junction target field for ${label} is not a many to one relation in workspace ${workspaceId}, skipping`,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.ts
@@ -15,7 +15,6 @@ import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/
 import { isFieldMetadataSettingsOfType } from 'src/engine/metadata-modules/field-metadata/utils/is-field-metadata-settings-of-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
 
@@ -259,10 +258,17 @@ export class BackfillActivityTargetsJunctionTargetCommand extends ProvisionedWor
       return undefined;
     }
 
+    const junctionTargetSettings = junctionTargetFlatFieldMetadata.settings;
+    const isMorphTarget =
+      junctionTargetFlatFieldMetadata.type === FieldMetadataType.MORPH_RELATION;
+
     if (
-      !isMorphOrRelationFlatFieldMetadata(junctionTargetFlatFieldMetadata) ||
-      junctionTargetFlatFieldMetadata.settings.relationType !==
-        RelationType.MANY_TO_ONE
+      !isMorphTarget &&
+      (!isFieldMetadataSettingsOfType(
+        junctionTargetSettings,
+        FieldMetadataType.RELATION,
+      ) ||
+        junctionTargetSettings.relationType !== RelationType.MANY_TO_ONE)
     ) {
       this.logger.warn(
         `Junction target field for ${label} is not a many to one relation in workspace ${workspaceId}, skipping`,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/__tests__/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/__tests__/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.spec.ts
@@ -103,6 +103,7 @@ const LEGACY_TASK_TARGET_PERSON_FLAT_FIELD_METADATA = buildFlatFieldMetadata({
 describe('BackfillActivityTargetsJunctionTargetCommand', () => {
   let command: BackfillActivityTargetsJunctionTargetCommand;
   let findOneMock: jest.Mock;
+  let getOrRecomputeMock: jest.Mock;
   let updateMock: jest.Mock;
 
   beforeEach(() => {
@@ -117,6 +118,14 @@ describe('BackfillActivityTargetsJunctionTargetCommand', () => {
         settings: { relationType: RelationType.ONE_TO_MANY },
       });
     updateMock = jest.fn();
+    getOrRecomputeMock = jest.fn().mockResolvedValue({
+      flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+        NOTE_TARGETS_FLAT_FIELD_METADATA,
+        TASK_TARGETS_FLAT_FIELD_METADATA,
+        LEGACY_NOTE_TARGET_PERSON_FLAT_FIELD_METADATA,
+        LEGACY_TASK_TARGET_PERSON_FLAT_FIELD_METADATA,
+      ]),
+    });
 
     const transactionalRepository = {
       findOne: findOneMock,
@@ -140,14 +149,7 @@ describe('BackfillActivityTargetsJunctionTargetCommand', () => {
     command = new BackfillActivityTargetsJunctionTargetCommand(
       {} as WorkspaceIteratorService,
       {
-        getOrRecompute: jest.fn().mockResolvedValue({
-          flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
-            NOTE_TARGETS_FLAT_FIELD_METADATA,
-            TASK_TARGETS_FLAT_FIELD_METADATA,
-            LEGACY_NOTE_TARGET_PERSON_FLAT_FIELD_METADATA,
-            LEGACY_TASK_TARGET_PERSON_FLAT_FIELD_METADATA,
-          ]),
-        }),
+        getOrRecompute: getOrRecomputeMock,
       } as unknown as WorkspaceCacheService,
       {} as WorkspaceMigrationRunnerService,
       fieldMetadataRepository,
@@ -186,5 +188,28 @@ describe('BackfillActivityTargetsJunctionTargetCommand', () => {
       workspaceId: WORKSPACE_ID,
       workspaceMigrationRunnerService: expect.anything(),
     });
+  });
+
+  it('does not backfill a one-to-many morph target', async () => {
+    getOrRecomputeMock.mockResolvedValueOnce({
+      flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+        NOTE_TARGETS_FLAT_FIELD_METADATA,
+        {
+          ...LEGACY_NOTE_TARGET_PERSON_FLAT_FIELD_METADATA,
+          type: FieldMetadataType.MORPH_RELATION,
+          settings: { relationType: RelationType.ONE_TO_MANY },
+        },
+      ]),
+    });
+
+    await command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      options: {},
+      index: 0,
+      total: 1,
+    });
+
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(invalidateFieldMetadataCacheMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/__tests__/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-33/__tests__/2-33-workspace-command-1787123540000-backfill-activity-targets-junction-target.command.spec.ts
@@ -103,7 +103,6 @@ const LEGACY_TASK_TARGET_PERSON_FLAT_FIELD_METADATA = buildFlatFieldMetadata({
 describe('BackfillActivityTargetsJunctionTargetCommand', () => {
   let command: BackfillActivityTargetsJunctionTargetCommand;
   let findOneMock: jest.Mock;
-  let getOrRecomputeMock: jest.Mock;
   let updateMock: jest.Mock;
 
   beforeEach(() => {
@@ -118,14 +117,6 @@ describe('BackfillActivityTargetsJunctionTargetCommand', () => {
         settings: { relationType: RelationType.ONE_TO_MANY },
       });
     updateMock = jest.fn();
-    getOrRecomputeMock = jest.fn().mockResolvedValue({
-      flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
-        NOTE_TARGETS_FLAT_FIELD_METADATA,
-        TASK_TARGETS_FLAT_FIELD_METADATA,
-        LEGACY_NOTE_TARGET_PERSON_FLAT_FIELD_METADATA,
-        LEGACY_TASK_TARGET_PERSON_FLAT_FIELD_METADATA,
-      ]),
-    });
 
     const transactionalRepository = {
       findOne: findOneMock,
@@ -149,7 +140,14 @@ describe('BackfillActivityTargetsJunctionTargetCommand', () => {
     command = new BackfillActivityTargetsJunctionTargetCommand(
       {} as WorkspaceIteratorService,
       {
-        getOrRecompute: getOrRecomputeMock,
+        getOrRecompute: jest.fn().mockResolvedValue({
+          flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+            NOTE_TARGETS_FLAT_FIELD_METADATA,
+            TASK_TARGETS_FLAT_FIELD_METADATA,
+            LEGACY_NOTE_TARGET_PERSON_FLAT_FIELD_METADATA,
+            LEGACY_TASK_TARGET_PERSON_FLAT_FIELD_METADATA,
+          ]),
+        }),
       } as unknown as WorkspaceCacheService,
       {} as WorkspaceMigrationRunnerService,
       fieldMetadataRepository,
@@ -188,28 +186,5 @@ describe('BackfillActivityTargetsJunctionTargetCommand', () => {
       workspaceId: WORKSPACE_ID,
       workspaceMigrationRunnerService: expect.anything(),
     });
-  });
-
-  it('does not backfill a one-to-many morph target', async () => {
-    getOrRecomputeMock.mockResolvedValueOnce({
-      flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
-        NOTE_TARGETS_FLAT_FIELD_METADATA,
-        {
-          ...LEGACY_NOTE_TARGET_PERSON_FLAT_FIELD_METADATA,
-          type: FieldMetadataType.MORPH_RELATION,
-          settings: { relationType: RelationType.ONE_TO_MANY },
-        },
-      ]),
-    });
-
-    await command.runOnWorkspace({
-      workspaceId: WORKSPACE_ID,
-      options: {},
-      index: 0,
-      total: 1,
-    });
-
-    expect(updateMock).not.toHaveBeenCalled();
-    expect(invalidateFieldMetadataCacheMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/__tests__/validate-junction-target-settings.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/__tests__/validate-junction-target-settings.util.spec.ts
@@ -1,0 +1,140 @@
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { type FlatFieldMetadataValidationError } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata-validation-error.type';
+import { validateJunctionTargetSettings } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-junction-target-settings.util';
+import { type UniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-maps.type';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+
+const JUNCTION_OBJECT_ID = 'junction-object-id';
+const SOURCE_FIELD_ID = 'source-field-id';
+const TARGET_FIELD_ID = 'target-field-id';
+
+const createRelationField = ({
+  universalIdentifier,
+  type = FieldMetadataType.RELATION,
+  relationType = RelationType.MANY_TO_ONE,
+  morphId = null,
+}: {
+  universalIdentifier: string;
+  type?: FieldMetadataType.RELATION | FieldMetadataType.MORPH_RELATION;
+  relationType?: RelationType;
+  morphId?: string | null;
+}): UniversalFlatFieldMetadata =>
+  ({
+    universalIdentifier,
+    objectMetadataUniversalIdentifier: JUNCTION_OBJECT_ID,
+    type,
+    morphId,
+    universalSettings: { relationType },
+  }) as UniversalFlatFieldMetadata;
+
+const createJunctionField = ({
+  sourceFieldUniversalIdentifier = SOURCE_FIELD_ID,
+  targetFieldUniversalIdentifier = TARGET_FIELD_ID,
+}: {
+  sourceFieldUniversalIdentifier?: string;
+  targetFieldUniversalIdentifier?: string;
+} = {}): UniversalFlatFieldMetadata<FieldMetadataType.RELATION> =>
+  ({
+    universalIdentifier: 'junction-field-id',
+    objectMetadataUniversalIdentifier: 'source-object-id',
+    relationTargetObjectMetadataUniversalIdentifier: JUNCTION_OBJECT_ID,
+    relationTargetFieldMetadataUniversalIdentifier:
+      sourceFieldUniversalIdentifier,
+    type: FieldMetadataType.RELATION,
+    morphId: null,
+    universalSettings: {
+      relationType: RelationType.ONE_TO_MANY,
+      junctionTargetFieldUniversalIdentifier: targetFieldUniversalIdentifier,
+    },
+  }) as UniversalFlatFieldMetadata<FieldMetadataType.RELATION>;
+
+const createFieldMaps = (
+  ...fields: UniversalFlatFieldMetadata[]
+): UniversalFlatEntityMaps<UniversalFlatFieldMetadata> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    fields.map((field) => [field.universalIdentifier, field]),
+  ),
+});
+
+const errorMessages = (errors: FlatFieldMetadataValidationError[]) =>
+  errors.map(({ message }) => message);
+
+describe('validateJunctionTargetSettings', () => {
+  it('accepts a many-to-one morph target', () => {
+    const sourceField = createRelationField({
+      universalIdentifier: SOURCE_FIELD_ID,
+    });
+    const targetField = createRelationField({
+      universalIdentifier: TARGET_FIELD_ID,
+      type: FieldMetadataType.MORPH_RELATION,
+      morphId: 'target-morph-id',
+    });
+
+    expect(
+      validateJunctionTargetSettings({
+        universalFlatFieldMetadata: createJunctionField(),
+        flatFieldMetadataMaps: createFieldMaps(sourceField, targetField),
+      }),
+    ).toEqual([]);
+  });
+
+  it('rejects a one-to-many morph target', () => {
+    const targetField = createRelationField({
+      universalIdentifier: TARGET_FIELD_ID,
+      type: FieldMetadataType.MORPH_RELATION,
+      relationType: RelationType.ONE_TO_MANY,
+      morphId: 'target-morph-id',
+    });
+
+    expect(
+      errorMessages(
+        validateJunctionTargetSettings({
+          universalFlatFieldMetadata: createJunctionField(),
+          flatFieldMetadataMaps: createFieldMaps(targetField),
+        }),
+      ),
+    ).toEqual([
+      `Junction target field ${TARGET_FIELD_ID} is not a MANY_TO_ONE relation`,
+    ]);
+  });
+
+  it('rejects the source field as the target', () => {
+    const sourceField = createRelationField({
+      universalIdentifier: SOURCE_FIELD_ID,
+    });
+
+    expect(
+      errorMessages(
+        validateJunctionTargetSettings({
+          universalFlatFieldMetadata: createJunctionField({
+            targetFieldUniversalIdentifier: SOURCE_FIELD_ID,
+          }),
+          flatFieldMetadataMaps: createFieldMaps(sourceField),
+        }),
+      ),
+    ).toEqual(['Junction source and target fields must be different']);
+  });
+
+  it('rejects another member of the source morph group as the target', () => {
+    const sourceField = createRelationField({
+      universalIdentifier: SOURCE_FIELD_ID,
+      type: FieldMetadataType.MORPH_RELATION,
+      morphId: 'source-morph-id',
+    });
+    const targetField = createRelationField({
+      universalIdentifier: TARGET_FIELD_ID,
+      type: FieldMetadataType.MORPH_RELATION,
+      morphId: 'source-morph-id',
+    });
+
+    expect(
+      errorMessages(
+        validateJunctionTargetSettings({
+          universalFlatFieldMetadata: createJunctionField(),
+          flatFieldMetadataMaps: createFieldMaps(sourceField, targetField),
+        }),
+      ),
+    ).toEqual(['Junction source and target fields must be different']);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-junction-target-settings.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-junction-target-settings.util.ts
@@ -112,6 +112,9 @@ export const validateJunctionTargetSettings = ({
     ];
   }
 
+  // The frontend mirrors the direction and source-group checks in
+  // isValidJunctionTargetField after resolving GraphQL relation groups. These
+  // representations use different identifiers, so update both together.
   const sourceFieldUniversalIdentifier =
     universalFlatFieldMetadata.relationTargetFieldMetadataUniversalIdentifier;
   const sourceField = isDefined(sourceFieldUniversalIdentifier)

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-junction-target-settings.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-junction-target-settings.util.ts
@@ -1,6 +1,6 @@
 import { type MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
-import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import { RelationType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { FieldMetadataExceptionCode } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
@@ -60,17 +60,21 @@ export const validateJunctionTargetSettings = ({
     ];
   }
 
-  const targetField =
+  const findFieldByUniversalIdentifier = (universalIdentifier: string) =>
     (isDefined(remainingFlatFieldMetadataMaps)
       ? findFlatEntityByUniversalIdentifier({
-          universalIdentifier: junctionTargetFieldUniversalIdentifier,
+          universalIdentifier,
           flatEntityMaps: remainingFlatFieldMetadataMaps,
         })
       : undefined) ??
     findFlatEntityByUniversalIdentifier({
-      universalIdentifier: junctionTargetFieldUniversalIdentifier,
+      universalIdentifier,
       flatEntityMaps: flatFieldMetadataMaps,
     });
+
+  const targetField = findFieldByUniversalIdentifier(
+    junctionTargetFieldUniversalIdentifier,
+  );
 
   if (!isDefined(targetField)) {
     return [
@@ -108,9 +112,28 @@ export const validateJunctionTargetSettings = ({
     ];
   }
 
-  // MORPH_RELATION fields are polymorphic and don't require MANY_TO_ONE check
-  if (targetField.type === FieldMetadataType.MORPH_RELATION) {
-    return [];
+  const sourceFieldUniversalIdentifier =
+    universalFlatFieldMetadata.relationTargetFieldMetadataUniversalIdentifier;
+  const sourceField = isDefined(sourceFieldUniversalIdentifier)
+    ? findFieldByUniversalIdentifier(sourceFieldUniversalIdentifier)
+    : undefined;
+  const targetsSourceMorphRelation =
+    isDefined(sourceField) &&
+    isDefined(sourceField.morphId) &&
+    sourceField.morphId === targetField.morphId;
+
+  if (
+    junctionTargetFieldUniversalIdentifier === sourceFieldUniversalIdentifier ||
+    targetsSourceMorphRelation
+  ) {
+    return [
+      createError(
+        FieldMetadataExceptionCode.INVALID_FIELD_INPUT,
+        'Junction source and target fields must be different',
+        msg`Junction source and target fields must be different`,
+        junctionTargetFieldUniversalIdentifier,
+      ),
+    ];
   }
 
   if (targetField.universalSettings.relationType !== RelationType.MANY_TO_ONE) {


### PR DESCRIPTION
## Problem

Junction settings offered relation targets that cannot form a valid join, especially one-to-many morph fields. The server also accepted every morph target without checking its relation direction. A source field selected as its own target can overwrite the source join column, while invalid legacy settings could fall through to raw pivot UX or leave clickable no-op editors.

## Changes

- reuse one frontend validity predicate in junction resolution and the settings form
- normalize relation and morph-relation branches through one `getFieldRelations` utility
- require target relations, including morph branches, to be many-to-one and distinct from the source join
- enforce the same invariants in metadata validation
- cross-reference frontend and backend validators explicitly; their runtime GraphQL and universal flat-metadata representations are intentionally not collapsed into a misleading shared predicate
- model valid and invalid JunctionConfig values as a discriminated union with one shared usability guard
- preserve invalid configured junctions as an explicit fail-closed state while leaving settings editable so they can be repaired
- audit every production consumer so invalid junctions are unsupported/read-only, omitted from queries and categorization, and never fall through to generic relation UX
- never replace a dangling explicit target with legacy inference
- exclude invalid configurations from junction cascade-deletion classification

The valid self-referential many-to-many case remains supported when the two junction joins are distinct. Historical upgrade commands remain unchanged.

## Tests

- frontend resolver, validation, query, categorization, cell support, and edit routing: 8 suites / 32 tests
- server metadata validator: 4 tests
- twenty-front typecheck
- type-aware oxlint for changed frontend and server files
- oxfmt and git diff checks

## Export layout

- AST audit: all 32 changed production files declare exactly one export
- split the junction function, union, valid shape, metadata shape, usability guard, GraphQL argument type, and relation normalization into purpose-named files
- remove the unused public InvalidJunctionConfig export; no compatibility barrels
