### PR TITLE
Keep junction picker mutations consistent

### DIFF
--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/__tests__/triggerUpdateRelationsOptimisticEffect.test.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/__tests__/triggerUpdateRelationsOptimisticEffect.test.ts
@@ -39,22 +39,65 @@ const targetObject = {
   namePlural: 'targets',
 };
 
-const createRelation = ({
-  sourceFieldId,
-  sourceFieldName,
-  targetFieldId,
-  targetFieldName,
+const createFields = ({ isMorph = false }: { isMorph?: boolean } = {}) => {
+  const sourceFieldName = isMorph ? 'linkedTarget' : 'target';
+  const relation = {
+    type: RelationType.MANY_TO_ONE,
+    sourceFieldMetadata: {
+      id: 'source-target-field-id',
+      name: sourceFieldName,
+    },
+    targetFieldMetadata: {
+      id: 'target-sources-field-id',
+      name: 'sources',
+    },
+    sourceObjectMetadata: sourceObject,
+    targetObjectMetadata: targetObject,
+  } satisfies FieldMetadataItemRelation;
+
+  const sourceField = {
+    id: relation.sourceFieldMetadata.id,
+    name: sourceFieldName,
+    type: isMorph
+      ? FieldMetadataType.MORPH_RELATION
+      : FieldMetadataType.RELATION,
+    ...(isMorph ? { morphRelations: [relation] } : { relation }),
+  } as FieldMetadataItem;
+  const targetField = {
+    id: relation.targetFieldMetadata.id,
+    name: relation.targetFieldMetadata.name,
+    type: isMorph
+      ? FieldMetadataType.MORPH_RELATION
+      : FieldMetadataType.RELATION,
+  } as FieldMetadataItem;
+  const recordFieldName = isMorph
+    ? computeMorphRelationGqlFieldName({
+        fieldName: sourceFieldName,
+        relationType: relation.type,
+        targetObjectMetadataNameSingular: targetObject.nameSingular,
+        targetObjectMetadataNamePlural: targetObject.namePlural,
+      })
+    : sourceFieldName;
+
+  return { recordFieldName, sourceField, targetField };
+};
+
+const createSourceRecord = ({
+  deletedAt,
+  recordFieldName,
+  targetRecordId,
 }: {
-  sourceFieldId: string;
-  sourceFieldName: string;
-  targetFieldId: string;
-  targetFieldName: string;
-}): FieldMetadataItemRelation => ({
-  type: RelationType.MANY_TO_ONE,
-  sourceFieldMetadata: { id: sourceFieldId, name: sourceFieldName },
-  targetFieldMetadata: { id: targetFieldId, name: targetFieldName },
-  sourceObjectMetadata: sourceObject,
-  targetObjectMetadata: targetObject,
+  deletedAt: string | null;
+  recordFieldName: string;
+  targetRecordId: string;
+}): RecordGqlNode => ({
+  id: 'source-record-id',
+  __typename: 'Source',
+  deletedAt,
+  [recordFieldName]: {
+    id: targetRecordId,
+    __typename: 'Target',
+  },
 });
 
 const callOptimisticEffect = ({
@@ -94,41 +137,24 @@ describe('triggerUpdateRelationsOptimisticEffect restoration', () => {
     jest.mocked(getJunctionObjectMetadataIds).mockReturnValue(new Set());
   });
 
-  it('reattaches an unchanged relation when a soft-deleted record is restored', () => {
-    const relation = createRelation({
-      sourceFieldId: 'source-target-field-id',
-      sourceFieldName: 'target',
-      targetFieldId: 'target-sources-field-id',
-      targetFieldName: 'sources',
+  it.each([
+    ['relation', false],
+    ['morph relation', true],
+  ])('reattaches an unchanged %s', (_, isMorph) => {
+    const { recordFieldName, sourceField, targetField } = createFields({
+      isMorph,
     });
-    const sourceField = {
-      id: 'source-target-field-id',
-      name: 'target',
-      type: FieldMetadataType.RELATION,
-      relation,
-    } as FieldMetadataItem;
-    const targetField = {
-      id: 'target-sources-field-id',
-      name: 'sources',
-      type: FieldMetadataType.RELATION,
-    } as FieldMetadataItem;
-    const relatedRecord = {
-      id: 'target-record-id',
-      __typename: 'Target',
-    };
+    const currentSourceRecord = createSourceRecord({
+      deletedAt: '2026-08-31T12:00:00.000Z',
+      recordFieldName,
+      targetRecordId: 'target-record-id',
+    });
 
     callOptimisticEffect({
-      currentSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
-        deletedAt: '2026-08-31T12:00:00.000Z',
-        target: relatedRecord,
-      },
+      currentSourceRecord,
       updatedSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
+        ...currentSourceRecord,
         deletedAt: null,
-        target: relatedRecord,
       },
       sourceField,
       targetField,
@@ -146,41 +172,16 @@ describe('triggerUpdateRelationsOptimisticEffect restoration', () => {
   });
 
   it('does not touch an unchanged relation during a regular update', () => {
-    const relation = createRelation({
-      sourceFieldId: 'source-target-field-id',
-      sourceFieldName: 'target',
-      targetFieldId: 'target-sources-field-id',
-      targetFieldName: 'sources',
+    const { recordFieldName, sourceField, targetField } = createFields();
+    const currentSourceRecord = createSourceRecord({
+      deletedAt: null,
+      recordFieldName,
+      targetRecordId: 'target-record-id',
     });
-    const sourceField = {
-      id: 'source-target-field-id',
-      name: 'target',
-      type: FieldMetadataType.RELATION,
-      relation,
-    } as FieldMetadataItem;
-    const targetField = {
-      id: 'target-sources-field-id',
-      name: 'sources',
-      type: FieldMetadataType.RELATION,
-    } as FieldMetadataItem;
-    const relatedRecord = {
-      id: 'target-record-id',
-      __typename: 'Target',
-    };
 
     callOptimisticEffect({
-      currentSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
-        deletedAt: null,
-        target: relatedRecord,
-      },
-      updatedSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
-        deletedAt: null,
-        target: relatedRecord,
-      },
+      currentSourceRecord,
+      updatedSourceRecord: { ...currentSourceRecord },
       sourceField,
       targetField,
     });
@@ -189,44 +190,20 @@ describe('triggerUpdateRelationsOptimisticEffect restoration', () => {
     expect(triggerAttachRelationOptimisticEffect).not.toHaveBeenCalled();
   });
 
-  it('preserves detach and attach behavior for a changed relation during restoration', () => {
-    const relation = createRelation({
-      sourceFieldId: 'source-target-field-id',
-      sourceFieldName: 'target',
-      targetFieldId: 'target-sources-field-id',
-      targetFieldName: 'sources',
-    });
-    const sourceField = {
-      id: 'source-target-field-id',
-      name: 'target',
-      type: FieldMetadataType.RELATION,
-      relation,
-    } as FieldMetadataItem;
-    const targetField = {
-      id: 'target-sources-field-id',
-      name: 'sources',
-      type: FieldMetadataType.RELATION,
-    } as FieldMetadataItem;
+  it('preserves detach and attach for a changed relation during restoration', () => {
+    const { recordFieldName, sourceField, targetField } = createFields();
 
     callOptimisticEffect({
-      currentSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
+      currentSourceRecord: createSourceRecord({
         deletedAt: '2026-08-31T12:00:00.000Z',
-        target: {
-          id: 'previous-target-record-id',
-          __typename: 'Target',
-        },
-      },
-      updatedSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
+        recordFieldName,
+        targetRecordId: 'previous-target-record-id',
+      }),
+      updatedSourceRecord: createSourceRecord({
         deletedAt: null,
-        target: {
-          id: 'next-target-record-id',
-          __typename: 'Target',
-        },
-      },
+        recordFieldName,
+        targetRecordId: 'next-target-record-id',
+      }),
       sourceField,
       targetField,
     });
@@ -245,44 +222,22 @@ describe('triggerUpdateRelationsOptimisticEffect restoration', () => {
     );
   });
 
-  it('does not reattach an unchanged cascade-deleted relation during restoration', () => {
+  it('does not reattach an unchanged cascade-deleted relation', () => {
     jest
       .mocked(getJunctionObjectMetadataIds)
       .mockReturnValue(new Set([targetObject.id]));
-    const relation = createRelation({
-      sourceFieldId: 'source-target-field-id',
-      sourceFieldName: 'target',
-      targetFieldId: 'target-sources-field-id',
-      targetFieldName: 'sources',
+    const { recordFieldName, sourceField, targetField } = createFields();
+    const currentSourceRecord = createSourceRecord({
+      deletedAt: '2026-08-31T12:00:00.000Z',
+      recordFieldName,
+      targetRecordId: 'target-record-id',
     });
-    const sourceField = {
-      id: 'source-target-field-id',
-      name: 'target',
-      type: FieldMetadataType.RELATION,
-      relation,
-    } as FieldMetadataItem;
-    const targetField = {
-      id: 'target-sources-field-id',
-      name: 'sources',
-      type: FieldMetadataType.RELATION,
-    } as FieldMetadataItem;
-    const relatedRecord = {
-      id: 'target-record-id',
-      __typename: 'Target',
-    };
 
     callOptimisticEffect({
-      currentSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
-        deletedAt: '2026-08-31T12:00:00.000Z',
-        target: relatedRecord,
-      },
+      currentSourceRecord,
       updatedSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
+        ...currentSourceRecord,
         deletedAt: null,
-        target: relatedRecord,
       },
       sourceField,
       targetField,
@@ -291,62 +246,5 @@ describe('triggerUpdateRelationsOptimisticEffect restoration', () => {
     expect(triggerDestroyRecordsOptimisticEffect).not.toHaveBeenCalled();
     expect(triggerDetachRelationOptimisticEffect).not.toHaveBeenCalled();
     expect(triggerAttachRelationOptimisticEffect).not.toHaveBeenCalled();
-  });
-
-  it('reattaches an unchanged morph relation when a record is restored', () => {
-    const relation = createRelation({
-      sourceFieldId: 'source-morph-field-id',
-      sourceFieldName: 'linkedTarget',
-      targetFieldId: 'target-sources-field-id',
-      targetFieldName: 'sources',
-    });
-    const sourceField = {
-      id: 'source-morph-field-id',
-      name: 'linkedTarget',
-      type: FieldMetadataType.MORPH_RELATION,
-      morphRelations: [relation],
-    } as FieldMetadataItem;
-    const targetField = {
-      id: 'target-sources-field-id',
-      name: 'sources',
-      type: FieldMetadataType.MORPH_RELATION,
-    } as FieldMetadataItem;
-    const morphFieldName = computeMorphRelationGqlFieldName({
-      fieldName: sourceField.name,
-      relationType: relation.type,
-      targetObjectMetadataNameSingular: targetObject.nameSingular,
-      targetObjectMetadataNamePlural: targetObject.namePlural,
-    });
-    const relatedRecord = {
-      id: 'target-record-id',
-      __typename: 'Target',
-    };
-
-    callOptimisticEffect({
-      currentSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
-        deletedAt: '2026-08-31T12:00:00.000Z',
-        [morphFieldName]: relatedRecord,
-      },
-      updatedSourceRecord: {
-        id: 'source-record-id',
-        __typename: 'Source',
-        deletedAt: null,
-        [morphFieldName]: relatedRecord,
-      },
-      sourceField,
-      targetField,
-    });
-
-    expect(triggerDetachRelationOptimisticEffect).not.toHaveBeenCalled();
-    expect(triggerAttachRelationOptimisticEffect).toHaveBeenCalledTimes(1);
-    expect(triggerAttachRelationOptimisticEffect).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourceRecordId: 'source-record-id',
-        targetRecordId: 'target-record-id',
-        fieldNameOnTargetRecord: 'sources',
-      }),
-    );
   });
 });

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/__tests__/triggerUpdateRelationsOptimisticEffect.test.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/__tests__/triggerUpdateRelationsOptimisticEffect.test.ts
@@ -1,0 +1,352 @@
+import { triggerAttachRelationOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerAttachRelationOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
+import { triggerDetachRelationOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDetachRelationOptimisticEffect';
+import { triggerUpdateRelationsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type FieldMetadataItemRelation } from '@/object-metadata/types/FieldMetadataItemRelation';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type RecordGqlNode } from '@/object-record/graphql/types/RecordGqlNode';
+import { getJunctionObjectMetadataIds } from '@/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds';
+import { type ApolloCache } from '@apollo/client';
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+import { computeMorphRelationGqlFieldName } from 'twenty-shared/utils';
+
+jest.mock(
+  '@/apollo/optimistic-effect/utils/triggerAttachRelationOptimisticEffect',
+  () => ({ triggerAttachRelationOptimisticEffect: jest.fn() }),
+);
+jest.mock(
+  '@/apollo/optimistic-effect/utils/triggerDetachRelationOptimisticEffect',
+  () => ({ triggerDetachRelationOptimisticEffect: jest.fn() }),
+);
+jest.mock(
+  '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect',
+  () => ({ triggerDestroyRecordsOptimisticEffect: jest.fn() }),
+);
+jest.mock(
+  '@/object-record/record-field/ui/utils/junction/getJunctionObjectMetadataIds',
+  () => ({ getJunctionObjectMetadataIds: jest.fn() }),
+);
+
+const sourceObject = {
+  id: 'source-object-id',
+  nameSingular: 'source',
+  namePlural: 'sources',
+};
+const targetObject = {
+  id: 'target-object-id',
+  nameSingular: 'target',
+  namePlural: 'targets',
+};
+
+const createRelation = ({
+  sourceFieldId,
+  sourceFieldName,
+  targetFieldId,
+  targetFieldName,
+}: {
+  sourceFieldId: string;
+  sourceFieldName: string;
+  targetFieldId: string;
+  targetFieldName: string;
+}): FieldMetadataItemRelation => ({
+  type: RelationType.MANY_TO_ONE,
+  sourceFieldMetadata: { id: sourceFieldId, name: sourceFieldName },
+  targetFieldMetadata: { id: targetFieldId, name: targetFieldName },
+  sourceObjectMetadata: sourceObject,
+  targetObjectMetadata: targetObject,
+});
+
+const callOptimisticEffect = ({
+  currentSourceRecord,
+  sourceField,
+  targetField,
+  updatedSourceRecord,
+}: {
+  currentSourceRecord: RecordGqlNode;
+  sourceField: FieldMetadataItem;
+  targetField: FieldMetadataItem;
+  updatedSourceRecord: RecordGqlNode;
+}) => {
+  const sourceObjectMetadataItem = {
+    ...sourceObject,
+    fields: [sourceField],
+  } as EnrichedObjectMetadataItem;
+  const targetObjectMetadataItem = {
+    ...targetObject,
+    fields: [targetField],
+  } as EnrichedObjectMetadataItem;
+
+  triggerUpdateRelationsOptimisticEffect({
+    cache: {} as ApolloCache,
+    sourceObjectMetadataItem,
+    currentSourceRecord,
+    updatedSourceRecord,
+    objectMetadataItems: [sourceObjectMetadataItem, targetObjectMetadataItem],
+    objectPermissionsByObjectMetadataId: {},
+    upsertRecordsInStore: jest.fn(),
+  });
+};
+
+describe('triggerUpdateRelationsOptimisticEffect restoration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getJunctionObjectMetadataIds).mockReturnValue(new Set());
+  });
+
+  it('reattaches an unchanged relation when a soft-deleted record is restored', () => {
+    const relation = createRelation({
+      sourceFieldId: 'source-target-field-id',
+      sourceFieldName: 'target',
+      targetFieldId: 'target-sources-field-id',
+      targetFieldName: 'sources',
+    });
+    const sourceField = {
+      id: 'source-target-field-id',
+      name: 'target',
+      type: FieldMetadataType.RELATION,
+      relation,
+    } as FieldMetadataItem;
+    const targetField = {
+      id: 'target-sources-field-id',
+      name: 'sources',
+      type: FieldMetadataType.RELATION,
+    } as FieldMetadataItem;
+    const relatedRecord = {
+      id: 'target-record-id',
+      __typename: 'Target',
+    };
+
+    callOptimisticEffect({
+      currentSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: '2026-08-31T12:00:00.000Z',
+        target: relatedRecord,
+      },
+      updatedSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: null,
+        target: relatedRecord,
+      },
+      sourceField,
+      targetField,
+    });
+
+    expect(triggerDetachRelationOptimisticEffect).not.toHaveBeenCalled();
+    expect(triggerAttachRelationOptimisticEffect).toHaveBeenCalledTimes(1);
+    expect(triggerAttachRelationOptimisticEffect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceRecordId: 'source-record-id',
+        targetRecordId: 'target-record-id',
+        fieldNameOnTargetRecord: 'sources',
+      }),
+    );
+  });
+
+  it('does not touch an unchanged relation during a regular update', () => {
+    const relation = createRelation({
+      sourceFieldId: 'source-target-field-id',
+      sourceFieldName: 'target',
+      targetFieldId: 'target-sources-field-id',
+      targetFieldName: 'sources',
+    });
+    const sourceField = {
+      id: 'source-target-field-id',
+      name: 'target',
+      type: FieldMetadataType.RELATION,
+      relation,
+    } as FieldMetadataItem;
+    const targetField = {
+      id: 'target-sources-field-id',
+      name: 'sources',
+      type: FieldMetadataType.RELATION,
+    } as FieldMetadataItem;
+    const relatedRecord = {
+      id: 'target-record-id',
+      __typename: 'Target',
+    };
+
+    callOptimisticEffect({
+      currentSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: null,
+        target: relatedRecord,
+      },
+      updatedSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: null,
+        target: relatedRecord,
+      },
+      sourceField,
+      targetField,
+    });
+
+    expect(triggerDetachRelationOptimisticEffect).not.toHaveBeenCalled();
+    expect(triggerAttachRelationOptimisticEffect).not.toHaveBeenCalled();
+  });
+
+  it('preserves detach and attach behavior for a changed relation during restoration', () => {
+    const relation = createRelation({
+      sourceFieldId: 'source-target-field-id',
+      sourceFieldName: 'target',
+      targetFieldId: 'target-sources-field-id',
+      targetFieldName: 'sources',
+    });
+    const sourceField = {
+      id: 'source-target-field-id',
+      name: 'target',
+      type: FieldMetadataType.RELATION,
+      relation,
+    } as FieldMetadataItem;
+    const targetField = {
+      id: 'target-sources-field-id',
+      name: 'sources',
+      type: FieldMetadataType.RELATION,
+    } as FieldMetadataItem;
+
+    callOptimisticEffect({
+      currentSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: '2026-08-31T12:00:00.000Z',
+        target: {
+          id: 'previous-target-record-id',
+          __typename: 'Target',
+        },
+      },
+      updatedSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: null,
+        target: {
+          id: 'next-target-record-id',
+          __typename: 'Target',
+        },
+      },
+      sourceField,
+      targetField,
+    });
+
+    expect(triggerDetachRelationOptimisticEffect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceRecordId: 'source-record-id',
+        targetRecordId: 'previous-target-record-id',
+      }),
+    );
+    expect(triggerAttachRelationOptimisticEffect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceRecordId: 'source-record-id',
+        targetRecordId: 'next-target-record-id',
+      }),
+    );
+  });
+
+  it('does not reattach an unchanged cascade-deleted relation during restoration', () => {
+    jest
+      .mocked(getJunctionObjectMetadataIds)
+      .mockReturnValue(new Set([targetObject.id]));
+    const relation = createRelation({
+      sourceFieldId: 'source-target-field-id',
+      sourceFieldName: 'target',
+      targetFieldId: 'target-sources-field-id',
+      targetFieldName: 'sources',
+    });
+    const sourceField = {
+      id: 'source-target-field-id',
+      name: 'target',
+      type: FieldMetadataType.RELATION,
+      relation,
+    } as FieldMetadataItem;
+    const targetField = {
+      id: 'target-sources-field-id',
+      name: 'sources',
+      type: FieldMetadataType.RELATION,
+    } as FieldMetadataItem;
+    const relatedRecord = {
+      id: 'target-record-id',
+      __typename: 'Target',
+    };
+
+    callOptimisticEffect({
+      currentSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: '2026-08-31T12:00:00.000Z',
+        target: relatedRecord,
+      },
+      updatedSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: null,
+        target: relatedRecord,
+      },
+      sourceField,
+      targetField,
+    });
+
+    expect(triggerDestroyRecordsOptimisticEffect).not.toHaveBeenCalled();
+    expect(triggerDetachRelationOptimisticEffect).not.toHaveBeenCalled();
+    expect(triggerAttachRelationOptimisticEffect).not.toHaveBeenCalled();
+  });
+
+  it('reattaches an unchanged morph relation when a record is restored', () => {
+    const relation = createRelation({
+      sourceFieldId: 'source-morph-field-id',
+      sourceFieldName: 'linkedTarget',
+      targetFieldId: 'target-sources-field-id',
+      targetFieldName: 'sources',
+    });
+    const sourceField = {
+      id: 'source-morph-field-id',
+      name: 'linkedTarget',
+      type: FieldMetadataType.MORPH_RELATION,
+      morphRelations: [relation],
+    } as FieldMetadataItem;
+    const targetField = {
+      id: 'target-sources-field-id',
+      name: 'sources',
+      type: FieldMetadataType.MORPH_RELATION,
+    } as FieldMetadataItem;
+    const morphFieldName = computeMorphRelationGqlFieldName({
+      fieldName: sourceField.name,
+      relationType: relation.type,
+      targetObjectMetadataNameSingular: targetObject.nameSingular,
+      targetObjectMetadataNamePlural: targetObject.namePlural,
+    });
+    const relatedRecord = {
+      id: 'target-record-id',
+      __typename: 'Target',
+    };
+
+    callOptimisticEffect({
+      currentSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: '2026-08-31T12:00:00.000Z',
+        [morphFieldName]: relatedRecord,
+      },
+      updatedSourceRecord: {
+        id: 'source-record-id',
+        __typename: 'Source',
+        deletedAt: null,
+        [morphFieldName]: relatedRecord,
+      },
+      sourceField,
+      targetField,
+    });
+
+    expect(triggerDetachRelationOptimisticEffect).not.toHaveBeenCalled();
+    expect(triggerAttachRelationOptimisticEffect).toHaveBeenCalledTimes(1);
+    expect(triggerAttachRelationOptimisticEffect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceRecordId: 'source-record-id',
+        targetRecordId: 'target-record-id',
+        fieldNameOnTargetRecord: 'sources',
+      }),
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect.ts
@@ -63,6 +63,11 @@ export const triggerUpdateRelationsOptimisticEffect = ({
   const isDeletion =
     isDefined(updatedSourceRecord) &&
     isDefined(updatedSourceRecord['deletedAt']);
+  const isRestoration =
+    isDefined(currentSourceRecord) &&
+    isDefined(currentSourceRecord['deletedAt']) &&
+    isDefined(updatedSourceRecord) &&
+    !isDefined(updatedSourceRecord['deletedAt']);
   const junctionObjectMetadataIds =
     getJunctionObjectMetadataIds(objectMetadataItems);
 
@@ -83,6 +88,7 @@ export const triggerUpdateRelationsOptimisticEffect = ({
         sourceObjectMetadataItem,
         cache,
         isDeletion,
+        isRestoration,
         upsertRecordsInStore,
         objectPermissionsByObjectMetadataId,
         junctionObjectMetadataIds,
@@ -98,6 +104,7 @@ export const triggerUpdateRelationsOptimisticEffect = ({
         sourceObjectMetadataItem,
         cache,
         isDeletion,
+        isRestoration,
         upsertRecordsInStore,
         objectPermissionsByObjectMetadataId,
         junctionObjectMetadataIds,
@@ -114,6 +121,7 @@ const triggerUpdateRelationOptimisticEffect = ({
   sourceObjectMetadataItem,
   cache,
   isDeletion,
+  isRestoration,
   upsertRecordsInStore,
   objectPermissionsByObjectMetadataId,
   junctionObjectMetadataIds,
@@ -125,6 +133,7 @@ const triggerUpdateRelationOptimisticEffect = ({
   sourceObjectMetadataItem: EnrichedObjectMetadataItem;
   cache: ApolloCache;
   isDeletion: boolean;
+  isRestoration: boolean;
   upsertRecordsInStore: (props: { partialRecords: ObjectRecord[] }) => void;
   objectPermissionsByObjectMetadataId: Record<
     string,
@@ -182,22 +191,16 @@ const triggerUpdateRelationOptimisticEffect = ({
     updatedFieldValueOnSourceRecord,
     { strict: true },
   );
-  if (noDiff && !isDeletion) {
-    return;
-  }
-
-  const recordToExtractDetachFrom = isDeletion
-    ? updatedFieldValueOnSourceRecord
-    : currentFieldValueOnSourceRecord;
-  const targetRecordsToDetachFrom = extractTargetRecordsFromRelation(
-    recordToExtractDetachFrom,
-    relation,
-  );
-
   const shouldCascadeDeleteTargetRecords = shouldCascadeDeleteOnDetach({
     targetObjectMetadata,
     junctionObjectMetadataIds,
   });
+  const shouldReattachUnchangedRelationOnRestoration =
+    isRestoration && noDiff && !shouldCascadeDeleteTargetRecords;
+
+  if (noDiff && !isDeletion && !shouldReattachUnchangedRelationOnRestoration) {
+    return;
+  }
 
   const gqlFieldNameOnTargetRecord =
     targetFieldMetadataFullObject.type === FieldMetadataType.RELATION
@@ -209,35 +212,46 @@ const triggerUpdateRelationOptimisticEffect = ({
             sourceObjectMetadataItem.nameSingular,
           targetObjectMetadataNamePlural: sourceObjectMetadataItem.namePlural,
         });
-  if (
-    shouldCascadeDeleteTargetRecords &&
-    targetRecordsToDetachFrom.length > 0
-  ) {
-    triggerDestroyRecordsOptimisticEffect({
-      cache,
-      objectMetadataItem: fullTargetObjectMetadataItem,
-      recordsToDestroy: targetRecordsToDetachFrom,
-      objectMetadataItems,
-      upsertRecordsInStore,
-      objectPermissionsByObjectMetadataId,
-    });
-  } else if (
-    isDefined(currentSourceRecord) &&
-    targetRecordsToDetachFrom.length > 0
-  ) {
-    targetRecordsToDetachFrom.forEach((targetRecordToDetachFrom) => {
-      triggerDetachRelationOptimisticEffect({
+
+  if (!shouldReattachUnchangedRelationOnRestoration) {
+    const recordToExtractDetachFrom = isDeletion
+      ? updatedFieldValueOnSourceRecord
+      : currentFieldValueOnSourceRecord;
+    const targetRecordsToDetachFrom = extractTargetRecordsFromRelation(
+      recordToExtractDetachFrom,
+      relation,
+    );
+
+    if (
+      shouldCascadeDeleteTargetRecords &&
+      targetRecordsToDetachFrom.length > 0
+    ) {
+      triggerDestroyRecordsOptimisticEffect({
         cache,
-        sourceObjectNameSingular: sourceObjectMetadataItem.nameSingular,
-        sourceRecordId: currentSourceRecord.id,
-        fieldNameOnTargetRecord: gqlFieldNameOnTargetRecord,
-        targetObjectMetadataItem: fullTargetObjectMetadataItem,
-        targetRecordId: targetRecordToDetachFrom.id,
+        objectMetadataItem: fullTargetObjectMetadataItem,
+        recordsToDestroy: targetRecordsToDetachFrom,
         objectMetadataItems,
-        objectPermissionsByObjectMetadataId,
         upsertRecordsInStore,
+        objectPermissionsByObjectMetadataId,
       });
-    });
+    } else if (
+      isDefined(currentSourceRecord) &&
+      targetRecordsToDetachFrom.length > 0
+    ) {
+      targetRecordsToDetachFrom.forEach((targetRecordToDetachFrom) => {
+        triggerDetachRelationOptimisticEffect({
+          cache,
+          sourceObjectNameSingular: sourceObjectMetadataItem.nameSingular,
+          sourceRecordId: currentSourceRecord.id,
+          fieldNameOnTargetRecord: gqlFieldNameOnTargetRecord,
+          targetObjectMetadataItem: fullTargetObjectMetadataItem,
+          targetRecordId: targetRecordToDetachFrom.id,
+          objectMetadataItems,
+          objectPermissionsByObjectMetadataId,
+          upsertRecordsInStore,
+        });
+      });
+    }
   }
 
   if (!isDeletion && isDefined(updatedSourceRecord)) {
@@ -270,6 +284,7 @@ const triggerUpdateMorphRelationOptimisticEffect = ({
   sourceObjectMetadataItem,
   cache,
   isDeletion,
+  isRestoration,
   objectPermissionsByObjectMetadataId,
   upsertRecordsInStore,
   junctionObjectMetadataIds,
@@ -281,6 +296,7 @@ const triggerUpdateMorphRelationOptimisticEffect = ({
   sourceObjectMetadataItem: EnrichedObjectMetadataItem;
   cache: ApolloCache;
   isDeletion: boolean;
+  isRestoration: boolean;
   upsertRecordsInStore: (props: { partialRecords: ObjectRecord[] }) => void;
   objectPermissionsByObjectMetadataId: Record<
     string,
@@ -348,51 +364,60 @@ const triggerUpdateMorphRelationOptimisticEffect = ({
       updatedFieldValueOnSourceRecord,
       { strict: true },
     );
-    if (noDiff && !isDeletion) {
-      return;
-    }
-
-    const recordToExtractDetachFrom = isDeletion
-      ? updatedFieldValueOnSourceRecord
-      : currentFieldValueOnSourceRecord;
-    const targetRecordsToDetachFrom = extractTargetRecordsFromRelation(
-      recordToExtractDetachFrom,
-      morphRelation,
-    );
-
     const shouldCascadeDeleteTargetRecords = shouldCascadeDeleteOnDetach({
       targetObjectMetadata,
       junctionObjectMetadataIds,
     });
+    const shouldReattachUnchangedRelationOnRestoration =
+      isRestoration && noDiff && !shouldCascadeDeleteTargetRecords;
+
     if (
-      shouldCascadeDeleteTargetRecords &&
-      targetRecordsToDetachFrom.length > 0
+      noDiff &&
+      !isDeletion &&
+      !shouldReattachUnchangedRelationOnRestoration
     ) {
-      triggerDestroyRecordsOptimisticEffect({
-        cache,
-        objectMetadataItem: fullTargetObjectMetadataItem,
-        recordsToDestroy: targetRecordsToDetachFrom,
-        objectMetadataItems,
-        objectPermissionsByObjectMetadataId,
-        upsertRecordsInStore,
-      });
-    } else if (
-      isDefined(currentSourceRecord) &&
-      targetRecordsToDetachFrom.length > 0
-    ) {
-      targetRecordsToDetachFrom.forEach((targetRecordToDetachFrom) => {
-        triggerDetachRelationOptimisticEffect({
+      return;
+    }
+
+    if (!shouldReattachUnchangedRelationOnRestoration) {
+      const recordToExtractDetachFrom = isDeletion
+        ? updatedFieldValueOnSourceRecord
+        : currentFieldValueOnSourceRecord;
+      const targetRecordsToDetachFrom = extractTargetRecordsFromRelation(
+        recordToExtractDetachFrom,
+        morphRelation,
+      );
+
+      if (
+        shouldCascadeDeleteTargetRecords &&
+        targetRecordsToDetachFrom.length > 0
+      ) {
+        triggerDestroyRecordsOptimisticEffect({
           cache,
-          sourceObjectNameSingular: sourceObjectMetadataItem.nameSingular,
-          sourceRecordId: currentSourceRecord.id,
-          fieldNameOnTargetRecord: targetFieldMetadata.name,
-          targetObjectMetadataItem: fullTargetObjectMetadataItem,
+          objectMetadataItem: fullTargetObjectMetadataItem,
+          recordsToDestroy: targetRecordsToDetachFrom,
           objectMetadataItems,
           objectPermissionsByObjectMetadataId,
-          targetRecordId: targetRecordToDetachFrom.id,
           upsertRecordsInStore,
         });
-      });
+      } else if (
+        isDefined(currentSourceRecord) &&
+        targetRecordsToDetachFrom.length > 0
+      ) {
+        targetRecordsToDetachFrom.forEach((targetRecordToDetachFrom) => {
+          triggerDetachRelationOptimisticEffect({
+            cache,
+            sourceObjectNameSingular: sourceObjectMetadataItem.nameSingular,
+            sourceRecordId: currentSourceRecord.id,
+            fieldNameOnTargetRecord: targetFieldMetadata.name,
+            targetObjectMetadataItem: fullTargetObjectMetadataItem,
+            objectMetadataItems,
+            objectPermissionsByObjectMetadataId,
+            targetRecordId: targetRecordToDetachFrom.id,
+            upsertRecordsInStore,
+          });
+        });
+      }
     }
 
     if (!isDeletion && isDefined(updatedSourceRecord)) {

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect.ts
@@ -195,12 +195,6 @@ const triggerUpdateRelationOptimisticEffect = ({
     targetObjectMetadata,
     junctionObjectMetadataIds,
   });
-  const shouldReattachUnchangedRelationOnRestoration =
-    isRestoration && noDiff && !shouldCascadeDeleteTargetRecords;
-
-  if (noDiff && !isDeletion && !shouldReattachUnchangedRelationOnRestoration) {
-    return;
-  }
 
   const gqlFieldNameOnTargetRecord =
     targetFieldMetadataFullObject.type === FieldMetadataType.RELATION
@@ -213,7 +207,11 @@ const triggerUpdateRelationOptimisticEffect = ({
           targetObjectMetadataNamePlural: sourceObjectMetadataItem.namePlural,
         });
 
-  if (!shouldReattachUnchangedRelationOnRestoration) {
+  if (noDiff && !isDeletion) {
+    if (!isRestoration || shouldCascadeDeleteTargetRecords) {
+      return;
+    }
+  } else {
     const recordToExtractDetachFrom = isDeletion
       ? updatedFieldValueOnSourceRecord
       : currentFieldValueOnSourceRecord;
@@ -368,18 +366,12 @@ const triggerUpdateMorphRelationOptimisticEffect = ({
       targetObjectMetadata,
       junctionObjectMetadataIds,
     });
-    const shouldReattachUnchangedRelationOnRestoration =
-      isRestoration && noDiff && !shouldCascadeDeleteTargetRecords;
 
-    if (
-      noDiff &&
-      !isDeletion &&
-      !shouldReattachUnchangedRelationOnRestoration
-    ) {
-      return;
-    }
-
-    if (!shouldReattachUnchangedRelationOnRestoration) {
+    if (noDiff && !isDeletion) {
+      if (!isRestoration || shouldCascadeDeleteTargetRecords) {
+        return;
+      }
+    } else {
       const recordToExtractDetachFrom = isDeletion
         ? updatedFieldValueOnSourceRecord
         : currentFieldValueOnSourceRecord;

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSectionDropdownOneToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSectionDropdownOneToMany.tsx
@@ -171,9 +171,7 @@ export const RecordDetailMorphRelationSectionDropdownOneToMany = ({
         <MultipleRecordPicker
           focusId={dropdownId}
           componentInstanceId={dropdownId}
-          onChange={(morphItem) => {
-            updateMorphRelationOneToMany(morphItem);
-          }}
+          onChange={(morphItem) => updateMorphRelationOneToMany(morphItem)}
           onSubmit={() => {
             closeDropdown(dropdownId);
           }}

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -328,10 +328,10 @@ export const RecordDetailRelationSectionDropdownToMany = ({
   const handleChange = useCallback(
     (morphItem: Parameters<typeof updateRelation>[0]) => {
       if (isJunctionRelation) {
-        updateJunctionRelationFromCell({ morphItem });
-      } else {
-        updateRelation(morphItem);
+        return updateJunctionRelationFromCell({ morphItem });
       }
+
+      return updateRelation(morphItem);
     },
     [isJunctionRelation, updateJunctionRelationFromCell, updateRelation],
   );

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/__tests__/useUpdateJunctionRelationFromCell.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/__tests__/useUpdateJunctionRelationFromCell.test.tsx
@@ -1,0 +1,289 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { useUpdateJunctionRelationFromCell } from '@/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell';
+import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
+import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
+import { searchRecordStoreFamilyState } from '@/object-record/record-picker/multiple-record-picker/states/searchRecordStoreComponentFamilyState';
+import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { getMockFieldMetadataItemOrThrow } from '~/testing/utils/getMockFieldMetadataItemOrThrow';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+
+const mockCreateJunctionRecords = jest.fn();
+const mockDeleteJunctionRecord = jest.fn();
+
+jest.mock('@/object-metadata/hooks/useObjectMetadataItems');
+
+jest.mock('@/object-record/hooks/useCreateManyRecords', () => ({
+  useCreateManyRecords: () => ({
+    createManyRecords: mockCreateJunctionRecords,
+  }),
+}));
+
+jest.mock('@/object-record/hooks/useDeleteOneRecord', () => ({
+  useDeleteOneRecord: () => ({
+    deleteOneRecord: mockDeleteJunctionRecord,
+  }),
+}));
+
+const sourceRecordId = 'source-record-id';
+const targetRecordId = 'target-record-id';
+
+describe('useUpdateJunctionRelationFromCell', () => {
+  const objectMetadataItems = getTestEnrichedObjectMetadataItemsMock();
+  const taskObjectMetadata = getMockObjectMetadataItemOrThrow('task');
+  const taskTargetObjectMetadata =
+    getMockObjectMetadataItemOrThrow('taskTarget');
+  const personObjectMetadata = getMockObjectMetadataItemOrThrow('person');
+  const taskTargetsFieldMetadata = getMockFieldMetadataItemOrThrow({
+    objectMetadataItem: taskObjectMetadata,
+    fieldName: 'taskTargets',
+  });
+
+  const fieldDefinition = {
+    fieldMetadataId: taskTargetsFieldMetadata.id,
+    label: taskTargetsFieldMetadata.label,
+    iconName: taskTargetsFieldMetadata.icon,
+    type: taskTargetsFieldMetadata.type,
+    metadata: {
+      fieldName: taskTargetsFieldMetadata.name,
+      objectMetadataNameSingular: taskObjectMetadata.nameSingular,
+      relationFieldMetadataId:
+        taskTargetsFieldMetadata.relation?.targetFieldMetadata.id ?? '',
+      relationObjectMetadataId: taskTargetObjectMetadata.id,
+      relationObjectMetadataNamePlural: taskTargetObjectMetadata.namePlural,
+      relationObjectMetadataNameSingular: taskTargetObjectMetadata.nameSingular,
+      relationType: taskTargetsFieldMetadata.relation?.type,
+      settings: taskTargetsFieldMetadata.settings,
+    },
+  } as FieldDefinition<FieldRelationMetadata>;
+  const selectedMorphItem = {
+    recordId: targetRecordId,
+    objectMetadataId: personObjectMetadata.id,
+    isSelected: true,
+    isMatchingSearchFilter: true,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDeleteJunctionRecord.mockResolvedValue(undefined);
+    jest.mocked(useObjectMetadataItems).mockReturnValue({
+      objectMetadataItems,
+    });
+  });
+
+  const setup = ({
+    includeTargetSearchRecord = true,
+    metadataItems = objectMetadataItems,
+  }: {
+    includeTargetSearchRecord?: boolean;
+    metadataItems?: EnrichedObjectMetadataItem[];
+  } = {}) => {
+    jest.mocked(useObjectMetadataItems).mockReturnValue({
+      objectMetadataItems: metadataItems,
+    });
+
+    const store = createStore();
+    store.set(recordStoreFamilyState.atomFamily(sourceRecordId), {
+      id: sourceRecordId,
+      __typename: 'Task',
+      taskTargets: [],
+    });
+
+    if (includeTargetSearchRecord) {
+      store.set(searchRecordStoreFamilyState.atomFamily(targetRecordId), {
+        label: 'Target person',
+        objectLabelSingular: personObjectMetadata.labelSingular,
+        objectNameSingular: personObjectMetadata.nameSingular,
+        recordId: targetRecordId,
+        tsRank: 1,
+        tsRankCD: 1,
+        record: {
+          id: targetRecordId,
+          __typename: 'Person',
+        },
+      });
+    }
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={store}>{children}</JotaiProvider>
+    );
+    const renderedHook = renderHook(
+      () =>
+        useUpdateJunctionRelationFromCell({
+          fieldMetadataItem: taskTargetsFieldMetadata,
+          fieldDefinition,
+          recordId: sourceRecordId,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    return { ...renderedHook, store };
+  };
+
+  it('rejects an empty create response and removes the optimistic junction', async () => {
+    let resolveCreate: (records: []) => void = () => {};
+    const createPromise = new Promise<[]>((resolve) => {
+      resolveCreate = resolve;
+    });
+    mockCreateJunctionRecords.mockReturnValue(createPromise);
+
+    const { result, store } = setup();
+
+    let updatePromise: Promise<void> = Promise.resolve();
+    act(() => {
+      updatePromise = result.current.updateJunctionRelationFromCell({
+        morphItem: selectedMorphItem,
+      });
+    });
+
+    expect(
+      store.get(recordStoreFamilyState.atomFamily(sourceRecordId))?.taskTargets,
+    ).toHaveLength(1);
+
+    await act(async () => {
+      resolveCreate([]);
+      await expect(updatePromise).rejects.toThrow(
+        'Failed to create junction record',
+      );
+    });
+
+    expect(mockCreateJunctionRecords).toHaveBeenCalledWith({
+      recordsToCreate: [
+        {
+          taskId: sourceRecordId,
+          targetPersonId: targetRecordId,
+        },
+      ],
+      upsert: true,
+    });
+    expect(
+      store.get(recordStoreFamilyState.atomFamily(sourceRecordId))?.taskTargets,
+    ).toEqual([]);
+  });
+
+  it('rejects selection when junction configuration is unavailable', async () => {
+    const { result } = setup({
+      metadataItems: objectMetadataItems.filter(
+        ({ id }) => id !== taskTargetObjectMetadata.id,
+      ),
+    });
+
+    await expect(
+      result.current.updateJunctionRelationFromCell({
+        morphItem: selectedMorphItem,
+      }),
+    ).rejects.toThrow('valid junction configuration');
+    expect(mockCreateJunctionRecords).not.toHaveBeenCalled();
+  });
+
+  it('rejects selection when source metadata is unavailable', async () => {
+    const { result } = setup({
+      metadataItems: objectMetadataItems.filter(
+        ({ id }) => id !== taskObjectMetadata.id,
+      ),
+    });
+
+    await expect(
+      result.current.updateJunctionRelationFromCell({
+        morphItem: selectedMorphItem,
+      }),
+    ).rejects.toThrow('source object metadata');
+    expect(mockCreateJunctionRecords).not.toHaveBeenCalled();
+  });
+
+  it('rejects selection of an unsupported target object', async () => {
+    const { result } = setup();
+
+    await expect(
+      result.current.updateJunctionRelationFromCell({
+        morphItem: {
+          ...selectedMorphItem,
+          objectMetadataId: taskObjectMetadata.id,
+        },
+      }),
+    ).rejects.toThrow('unsupported target object');
+    expect(mockCreateJunctionRecords).not.toHaveBeenCalled();
+  });
+
+  it('rejects selection when the target search record is unavailable', async () => {
+    const { result } = setup({ includeTargetSearchRecord: false });
+
+    await expect(
+      result.current.updateJunctionRelationFromCell({
+        morphItem: selectedMorphItem,
+      }),
+    ).rejects.toThrow('target record is unavailable');
+    expect(mockCreateJunctionRecords).not.toHaveBeenCalled();
+  });
+
+  it('treats deselecting a missing junction as an idempotent success', async () => {
+    const { result } = setup();
+
+    await expect(
+      result.current.updateJunctionRelationFromCell({
+        morphItem: {
+          ...selectedMorphItem,
+          isSelected: false,
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(mockDeleteJunctionRecord).not.toHaveBeenCalled();
+  });
+
+  it('deletes the persisted junction ID after a create completes', async () => {
+    const persistedJunctionId = 'persisted-junction-id';
+    let resolveCreate: (
+      records: { id: string; __typename: string }[],
+    ) => void = () => {};
+    const createPromise = new Promise<{ id: string; __typename: string }[]>(
+      (resolve) => {
+        resolveCreate = resolve;
+      },
+    );
+    mockCreateJunctionRecords.mockReturnValue(createPromise);
+    const { result, store } = setup();
+
+    let updatePromise: Promise<void> = Promise.resolve();
+    act(() => {
+      updatePromise = result.current.updateJunctionRelationFromCell({
+        morphItem: selectedMorphItem,
+      });
+    });
+
+    expect(
+      store.get(recordStoreFamilyState.atomFamily(sourceRecordId))
+        ?.taskTargets[0].id,
+    ).not.toBe(persistedJunctionId);
+
+    await act(async () => {
+      resolveCreate([
+        {
+          id: persistedJunctionId,
+          __typename: 'TaskTarget',
+        },
+      ]);
+      await updatePromise;
+    });
+
+    expect(
+      store.get(recordStoreFamilyState.atomFamily(sourceRecordId))
+        ?.taskTargets[0].id,
+    ).toBe(persistedJunctionId);
+
+    await act(async () => {
+      await result.current.updateJunctionRelationFromCell({
+        morphItem: {
+          ...selectedMorphItem,
+          isSelected: false,
+        },
+      });
+    });
+
+    expect(mockDeleteJunctionRecord).toHaveBeenCalledWith(persistedJunctionId);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/__tests__/useUpdateJunctionRelationFromCell.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/__tests__/useUpdateJunctionRelationFromCell.test.tsx
@@ -285,5 +285,8 @@ describe('useUpdateJunctionRelationFromCell', () => {
     });
 
     expect(mockDeleteJunctionRecord).toHaveBeenCalledWith(persistedJunctionId);
+    expect(
+      store.get(recordStoreFamilyState.atomFamily(sourceRecordId))?.taskTargets,
+    ).toEqual([]);
   });
 });

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useStore } from 'jotai';
 import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
+import { t } from '@lingui/core/macro';
 
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
@@ -79,13 +80,13 @@ export const useUpdateJunctionRelationFromCell = ({
         targetFields.length === 0
       ) {
         throw new Error(
-          'Cannot update junction relation without a valid junction configuration',
+          t`Cannot update junction relation without a valid junction configuration`,
         );
       }
 
       if (!isDefined(sourceObjectMetadata)) {
         throw new Error(
-          'Cannot update junction relation without source object metadata',
+          t`Cannot update junction relation without source object metadata`,
         );
       }
 
@@ -100,7 +101,7 @@ export const useUpdateJunctionRelationFromCell = ({
 
       if (!isDefined(targetFieldInfo)) {
         throw new Error(
-          'Cannot update junction relation for an unsupported target object',
+          t`Cannot update junction relation for an unsupported target object`,
         );
       }
 
@@ -165,7 +166,7 @@ export const useUpdateJunctionRelationFromCell = ({
 
         if (!isDefined(searchRecord?.record)) {
           throw new Error(
-            'Cannot create junction relation because the target record is unavailable',
+            t`Cannot create junction relation because the target record is unavailable`,
           );
         }
 
@@ -177,13 +178,13 @@ export const useUpdateJunctionRelationFromCell = ({
 
         if (!isDefined(sourceJoinColumnName)) {
           throw new Error(
-            'Cannot create junction relation without a source join column',
+            t`Cannot create junction relation without a source join column`,
           );
         }
 
         if (!isDefined(targetJoinColumnName)) {
           throw new Error(
-            'Cannot create junction relation without a target join column',
+            t`Cannot create junction relation without a target join column`,
           );
         }
 
@@ -232,7 +233,7 @@ export const useUpdateJunctionRelationFromCell = ({
           });
 
           if (!isDefined(persistedJunctionRecordNode)) {
-            throw new Error('Failed to create junction record');
+            throw new Error(t`Failed to create junction record`);
           }
 
           const persistedJunctionRecord = getRecordFromRecordNode({

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -114,6 +114,33 @@ export const useUpdateJunctionRelationFromCell = ({
           | FieldRelationValue<FieldRelationFromManyValue>
           | undefined) ?? [];
 
+      const removeJunctionRecordFromStore = (junctionRecordId: string) =>
+        store.set(
+          recordStoreFamilyState.atomFamily(recordId),
+          (currentRecord: ObjectRecord | null | undefined) => {
+            if (!isDefined(currentRecord)) {
+              return currentRecord;
+            }
+
+            const currentFieldValue = currentRecord[fieldName];
+
+            if (!Array.isArray(currentFieldValue)) {
+              return currentRecord;
+            }
+
+            const updatedJunctionRecords = currentFieldValue.filter(
+              (junctionRecord) => junctionRecord.id !== junctionRecordId,
+            );
+
+            return updatedJunctionRecords.length === currentFieldValue.length
+              ? currentRecord
+              : ({
+                  ...currentRecord,
+                  [fieldName]: updatedJunctionRecords,
+                } as ObjectRecord);
+          },
+        );
+
       // morphItem.isSelected represents the NEW state (what the user wants)
       if (!morphItem.isSelected) {
         const junctionRecordToDelete = findJunctionRecordByTargetId({
@@ -127,6 +154,10 @@ export const useUpdateJunctionRelationFromCell = ({
         }
 
         await deleteJunctionRecord(junctionRecordToDelete.id);
+
+        // The shared delete effect normally detaches the pivot. Keep this
+        // idempotent fallback for upsert-created records missing from Apollo.
+        removeJunctionRecordFromStore(junctionRecordToDelete.id);
       } else {
         const searchRecord = store.get(
           searchRecordStoreFamilyState.atomFamily(morphItem.recordId),
@@ -189,28 +220,6 @@ export const useUpdateJunctionRelationFromCell = ({
           },
         );
 
-        const removeOptimisticJunctionRecord = () =>
-          store.set(
-            recordStoreFamilyState.atomFamily(recordId),
-            (currentRecord: Record<string, unknown> | null | undefined) => {
-              if (!isDefined(currentRecord)) {
-                return currentRecord;
-              }
-
-              const currentFieldValue = currentRecord[fieldName];
-
-              return {
-                ...currentRecord,
-                [fieldName]: Array.isArray(currentFieldValue)
-                  ? currentFieldValue.filter(
-                      (junctionRecord) =>
-                        junctionRecord.id !== optimisticJunctionId,
-                    )
-                  : currentFieldValue,
-              } as ObjectRecord;
-            },
-          );
-
         try {
           const [persistedJunctionRecordNode] = await createJunctionRecords({
             recordsToCreate: [
@@ -265,7 +274,7 @@ export const useUpdateJunctionRelationFromCell = ({
             },
           );
         } catch (error) {
-          removeOptimisticJunctionRecord();
+          removeJunctionRecordFromStore(optimisticJunctionId);
 
           throw error;
         }

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -78,17 +78,16 @@ export const useUpdateJunctionRelationFromCell = ({
         !isDefined(targetFields) ||
         targetFields.length === 0
       ) {
-        return;
+        throw new Error(
+          'Cannot update junction relation without a valid junction configuration',
+        );
       }
 
       if (!isDefined(sourceObjectMetadata)) {
-        return;
+        throw new Error(
+          'Cannot update junction relation without source object metadata',
+        );
       }
-
-      const sourceJoinColumnName = getSourceJoinColumnName({
-        sourceField: sourceFieldOnJunction,
-        sourceObjectMetadata,
-      });
 
       const fieldName = fieldDefinition.metadata.fieldName;
       const junctionObjectName = junctionObjectMetadata.nameSingular;
@@ -100,18 +99,12 @@ export const useUpdateJunctionRelationFromCell = ({
       );
 
       if (!isDefined(targetFieldInfo)) {
-        return;
+        throw new Error(
+          'Cannot update junction relation for an unsupported target object',
+        );
       }
 
       const targetFieldName = targetFieldInfo.fieldName;
-      const targetJoinColumnName = targetFieldInfo.joinColumnName;
-
-      if (
-        !isDefined(sourceJoinColumnName) ||
-        !isDefined(targetJoinColumnName)
-      ) {
-        return;
-      }
 
       const recordFromStore = store.get(
         recordStoreFamilyState.atomFamily(recordId),
@@ -134,44 +127,33 @@ export const useUpdateJunctionRelationFromCell = ({
         }
 
         await deleteJunctionRecord(junctionRecordToDelete.id);
-
-        const recordFromStoreForDelete = store.get(
-          recordStoreFamilyState.atomFamily(recordId),
-        );
-        const currentFieldValue = recordFromStoreForDelete?.[fieldName] as
-          | FieldRelationValue<FieldRelationFromManyValue>
-          | undefined;
-
-        if (
-          !isDefined(currentFieldValue) ||
-          !Array.isArray(currentFieldValue)
-        ) {
-          return;
-        }
-
-        const updatedJunctionRecords = currentFieldValue.filter(
-          (record) => record.id !== junctionRecordToDelete.id,
-        );
-
-        store.set(
-          recordStoreFamilyState.atomFamily(recordId),
-          (currentRecord: Record<string, unknown> | null | undefined) => {
-            if (!isDefined(currentRecord)) {
-              return currentRecord;
-            }
-            return {
-              ...currentRecord,
-              [fieldName]: updatedJunctionRecords,
-            } as ObjectRecord;
-          },
-        );
       } else {
         const searchRecord = store.get(
           searchRecordStoreFamilyState.atomFamily(morphItem.recordId),
         );
 
         if (!isDefined(searchRecord?.record)) {
-          return;
+          throw new Error(
+            'Cannot create junction relation because the target record is unavailable',
+          );
+        }
+
+        const sourceJoinColumnName = getSourceJoinColumnName({
+          sourceField: sourceFieldOnJunction,
+          sourceObjectMetadata,
+        });
+        const targetJoinColumnName = targetFieldInfo.joinColumnName;
+
+        if (!isDefined(sourceJoinColumnName)) {
+          throw new Error(
+            'Cannot create junction relation without a source join column',
+          );
+        }
+
+        if (!isDefined(targetJoinColumnName)) {
+          throw new Error(
+            'Cannot create junction relation without a target join column',
+          );
         }
 
         const targetRecord = searchRecord.record;
@@ -229,66 +211,64 @@ export const useUpdateJunctionRelationFromCell = ({
             },
           );
 
-        const persistedJunctionRecordNode = await createJunctionRecords({
-          recordsToCreate: [
-            {
-              [sourceJoinColumnName]: recordId,
-              [targetJoinColumnName]: morphItem.recordId,
-            },
-          ],
-          upsert: true,
-        })
-          .then(([createdJunctionRecordNode]) => createdJunctionRecordNode)
-          .catch((error: Error) => {
-            removeOptimisticJunctionRecord();
-
-            throw error;
+        try {
+          const [persistedJunctionRecordNode] = await createJunctionRecords({
+            recordsToCreate: [
+              {
+                [sourceJoinColumnName]: recordId,
+                [targetJoinColumnName]: morphItem.recordId,
+              },
+            ],
+            upsert: true,
           });
 
-        if (!isDefined(persistedJunctionRecordNode)) {
-          removeOptimisticJunctionRecord();
+          if (!isDefined(persistedJunctionRecordNode)) {
+            throw new Error('Failed to create junction record');
+          }
 
-          return;
-        }
+          const persistedJunctionRecord = getRecordFromRecordNode({
+            recordNode: persistedJunctionRecordNode,
+          });
 
-        const persistedJunctionRecord = getRecordFromRecordNode({
-          recordNode: persistedJunctionRecordNode,
-        });
+          store.set(
+            recordStoreFamilyState.atomFamily(recordId),
+            (currentRecord: Record<string, unknown> | null | undefined) => {
+              if (!isDefined(currentRecord)) {
+                return currentRecord;
+              }
 
-        store.set(
-          recordStoreFamilyState.atomFamily(recordId),
-          (currentRecord: Record<string, unknown> | null | undefined) => {
-            if (!isDefined(currentRecord)) {
-              return currentRecord;
-            }
+              const currentFieldValue = currentRecord[fieldName];
 
-            const currentFieldValue = currentRecord[fieldName];
+              if (!Array.isArray(currentFieldValue)) {
+                return currentRecord as ObjectRecord;
+              }
 
-            if (!Array.isArray(currentFieldValue)) {
-              return currentRecord as ObjectRecord;
-            }
-
-            const junctionRecordsWithoutOptimistic = currentFieldValue.filter(
-              (junctionRecord) => junctionRecord.id !== optimisticJunctionId,
-            );
-
-            const isPersistedJunctionRecordAlreadyInStore =
-              junctionRecordsWithoutOptimistic.some(
-                (junctionRecord) =>
-                  junctionRecord.id === persistedJunctionRecord.id,
+              const junctionRecordsWithoutOptimistic = currentFieldValue.filter(
+                (junctionRecord) => junctionRecord.id !== optimisticJunctionId,
               );
 
-            return {
-              ...currentRecord,
-              [fieldName]: isPersistedJunctionRecordAlreadyInStore
-                ? junctionRecordsWithoutOptimistic
-                : [
-                    ...junctionRecordsWithoutOptimistic,
-                    { ...junctionRecordForStore, ...persistedJunctionRecord },
-                  ],
-            } as ObjectRecord;
-          },
-        );
+              const isPersistedJunctionRecordAlreadyInStore =
+                junctionRecordsWithoutOptimistic.some(
+                  (junctionRecord) =>
+                    junctionRecord.id === persistedJunctionRecord.id,
+                );
+
+              return {
+                ...currentRecord,
+                [fieldName]: isPersistedJunctionRecordAlreadyInStore
+                  ? junctionRecordsWithoutOptimistic
+                  : [
+                      ...junctionRecordsWithoutOptimistic,
+                      { ...junctionRecordForStore, ...persistedJunctionRecord },
+                    ],
+              } as ObjectRecord;
+            },
+          );
+        } catch (error) {
+          removeOptimisticJunctionRecord();
+
+          throw error;
+        }
       }
     },
     [

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MorphRelationOneToManyFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MorphRelationOneToManyFieldInput.tsx
@@ -32,9 +32,7 @@ export const MorphRelationOneToManyFieldInput = () => {
       focusId={instanceId}
       componentInstanceId={instanceId}
       onSubmit={handleSubmit}
-      onChange={(morphItem) => {
-        updateMorphRelationOneToMany(morphItem);
-      }}
+      onChange={(morphItem) => updateMorphRelationOneToMany(morphItem)}
       onClickOutside={handleSubmit}
       layoutDirection={
         recordFieldInputLayoutDirection === 'downward'

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationOneToManyFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationOneToManyFieldInput.tsx
@@ -250,12 +250,12 @@ export const RelationOneToManyFieldInput = () => {
       onSubmit={handleSubmit}
       onChange={(morphItem) => {
         if (isJunctionRelation) {
-          updateJunctionRelationFromCell({
+          return updateJunctionRelationFromCell({
             morphItem,
           });
-        } else {
-          updateRelation(morphItem);
         }
+
+        return updateRelation(morphItem);
       }}
       onCreate={canCreateNew ? handleCreateNew : undefined}
       objectMetadataItemIdForCreate={objectMetadataItemIdForCreate}

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker.tsx
@@ -12,7 +12,7 @@ import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-r
 import { multipleRecordPickerSearchFilterComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerSearchFilterComponentState';
 import { getMultipleRecordPickerSelectableListId } from '@/object-record/record-picker/multiple-record-picker/utils/getMultipleRecordPickerSelectableListId';
 import { type RecordPickerLayoutDirection } from '@/object-record/record-picker/types/RecordPickerLayoutDirection';
-import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
 import { CreateNewButton } from '@/ui/input/relation-picker/components/CreateNewButton';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
@@ -25,7 +25,7 @@ import { t } from '@lingui/core/macro';
 import { IconPlus } from 'twenty-ui/icon';
 
 type MultipleRecordPickerProps = {
-  onChange?: (morphItem: RecordPickerPickableMorphItem) => void;
+  onChange?: RecordPickerOnChange;
   onSubmit?: () => void;
   onCreate?: ((searchInput?: string) => void) | (() => void);
   layoutDirection?: RecordPickerLayoutDirection;

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker.tsx
@@ -12,7 +12,7 @@ import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-r
 import { multipleRecordPickerSearchFilterComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerSearchFilterComponentState';
 import { getMultipleRecordPickerSelectableListId } from '@/object-record/record-picker/multiple-record-picker/utils/getMultipleRecordPickerSelectableListId';
 import { type RecordPickerLayoutDirection } from '@/object-record/record-picker/types/RecordPickerLayoutDirection';
-import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerOnChange';
 import { CreateNewButton } from '@/ui/input/relation-picker/components/CreateNewButton';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerItemsDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerItemsDisplay.tsx
@@ -1,6 +1,6 @@
 import { MultipleRecordPickerLoadingEffect } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerLoadingEffect';
 import { MultipleRecordPickerMenuItems } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems';
-import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerOnChange';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 
 export const MultipleRecordPickerItemsDisplay = ({

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerItemsDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerItemsDisplay.tsx
@@ -1,13 +1,13 @@
 import { MultipleRecordPickerLoadingEffect } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerLoadingEffect';
 import { MultipleRecordPickerMenuItems } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems';
-import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 
 export const MultipleRecordPickerItemsDisplay = ({
   onChange,
   focusId,
 }: {
-  onChange?: (morphItem: RecordPickerPickableMorphItem) => void;
+  onChange?: RecordPickerOnChange;
   focusId: string;
 }) => {
   return (

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
@@ -3,24 +3,21 @@ import { RecordPickerLoadingSkeletonList } from '@/object-record/record-picker/c
 import { RecordPickerNoRecordFoundMenuItem } from '@/object-record/record-picker/components/RecordPickerNoRecordFoundMenuItem';
 import { MultipleRecordPickerFetchMoreLoader } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerFetchMoreLoader';
 import { MultipleRecordPickerMenuItem } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItem';
+import { useMultipleRecordPickerChange } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerChange';
 import { MultipleRecordPickerComponentInstanceContext } from '@/object-record/record-picker/multiple-record-picker/states/contexts/MultipleRecordPickerComponentInstanceContext';
-import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerPickableMorphItemsComponentState';
 import { multipleRecordPickerShouldShowInitialLoadingComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerShouldShowInitialLoadingComponentState';
 import { multipleRecordPickerShouldShowSkeletonComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerShouldShowSkeletonComponentState';
 import { multipleRecordPickerPickableRecordIdsMatchingSearchComponentSelector } from '@/object-record/record-picker/multiple-record-picker/states/selectors/multipleRecordPickerPickableRecordIdsMatchingSearchComponentSelector';
 import { getMultipleRecordPickerSelectableListId } from '@/object-record/record-picker/multiple-record-picker/utils/getMultipleRecordPickerSelectableListId';
-import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
-import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { useCallback } from 'react';
-import { useStore } from 'jotai';
 
 type MultipleRecordPickerMenuItemsProps = {
-  onChange?: (morphItem: RecordPickerPickableMorphItem) => void;
+  onChange?: RecordPickerOnChange;
   focusId: string;
 };
 
@@ -28,7 +25,6 @@ export const MultipleRecordPickerMenuItems = ({
   onChange,
   focusId,
 }: MultipleRecordPickerMenuItemsProps) => {
-  const store = useStore();
   const componentInstanceId = useAvailableComponentInstanceIdOrThrow(
     MultipleRecordPickerComponentInstanceContext,
   );
@@ -41,34 +37,7 @@ export const MultipleRecordPickerMenuItems = ({
     componentInstanceId,
   );
 
-  const multipleRecordPickerPickableMorphItems =
-    useAtomComponentStateCallbackState(
-      multipleRecordPickerPickableMorphItemsComponentState,
-      componentInstanceId,
-    );
-
-  const handleChange = useCallback(
-    (morphItem: RecordPickerPickableMorphItem) => {
-      const previousMorphItems = store.get(
-        multipleRecordPickerPickableMorphItems,
-      );
-
-      const existingMorphItemIndex = previousMorphItems.findIndex(
-        (item) => item.recordId === morphItem.recordId,
-      );
-
-      const newMorphItems = [...previousMorphItems];
-
-      if (existingMorphItemIndex === -1) {
-        newMorphItems.push(morphItem);
-      } else {
-        newMorphItems[existingMorphItemIndex] = morphItem;
-      }
-
-      store.set(multipleRecordPickerPickableMorphItems, newMorphItems);
-    },
-    [multipleRecordPickerPickableMorphItems, store],
-  );
+  const { handleChange } = useMultipleRecordPickerChange({ onChange });
 
   const multipleRecordPickerShouldShowInitialLoading =
     useAtomComponentStateValue(
@@ -101,8 +70,7 @@ export const MultipleRecordPickerMenuItems = ({
                 key={recordId}
                 recordId={recordId}
                 onChange={(morphItem) => {
-                  handleChange(morphItem);
-                  onChange?.(morphItem);
+                  void handleChange(morphItem);
                 }}
               />
             );

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
@@ -9,7 +9,7 @@ import { multipleRecordPickerShouldShowInitialLoadingComponentState } from '@/ob
 import { multipleRecordPickerShouldShowSkeletonComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerShouldShowSkeletonComponentState';
 import { multipleRecordPickerPickableRecordIdsMatchingSearchComponentSelector } from '@/object-record/record-picker/multiple-record-picker/states/selectors/multipleRecordPickerPickableRecordIdsMatchingSearchComponentSelector';
 import { getMultipleRecordPickerSelectableListId } from '@/object-record/record-picker/multiple-record-picker/utils/getMultipleRecordPickerSelectableListId';
-import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerOnChange';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/__tests__/useMultipleRecordPickerChange.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/__tests__/useMultipleRecordPickerChange.test.tsx
@@ -209,6 +209,42 @@ describe('useMultipleRecordPickerChange', () => {
     });
   });
 
+  it('isolates queues for pickers backed by different stores', async () => {
+    const firstChange = createDeferred();
+    const firstOnChange = jest.fn(() => firstChange.promise);
+    const secondOnChange = jest.fn();
+    const initialMorphItem = createMorphItem('record-id', false);
+    const firstPicker = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange: firstOnChange,
+    });
+    const secondPicker = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange: secondOnChange,
+    });
+
+    let firstChangeResult: Promise<void> = Promise.resolve();
+    let secondChangeResult: Promise<void> = Promise.resolve();
+    act(() => {
+      firstChangeResult = firstPicker.result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+      secondChangeResult = secondPicker.result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+    });
+
+    await waitFor(() => expect(firstOnChange).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(secondOnChange).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      firstChange.resolve();
+      await Promise.all([firstChangeResult, secondChangeResult]);
+    });
+  });
+
   it('rolls back and reports the latest rejected change', async () => {
     const change = createDeferred();
     const error = new Error('Could not update relation');

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/__tests__/useMultipleRecordPickerChange.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/__tests__/useMultipleRecordPickerChange.test.tsx
@@ -1,0 +1,409 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { useMultipleRecordPickerChange } from '@/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerChange';
+import { MultipleRecordPickerComponentInstanceContext } from '@/object-record/record-picker/multiple-record-picker/states/contexts/MultipleRecordPickerComponentInstanceContext';
+import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerPickableMorphItemsComponentState';
+import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+
+jest.mock('@/ui/feedback/snack-bar-manager/hooks/useSnackBar');
+
+const mockEnqueueErrorSnackBar = jest.fn();
+
+const componentInstanceId = 'multiple-record-picker-test';
+const objectMetadataId = 'person-object-metadata-id';
+
+const createMorphItem = (
+  recordId: string,
+  isSelected: boolean,
+): RecordPickerPickableMorphItem => ({
+  recordId,
+  objectMetadataId,
+  isSelected,
+  isMatchingSearchFilter: true,
+});
+
+const createDeferred = () => {
+  let resolve: () => void = () => {};
+  let reject: (error: Error) => void = () => {};
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+};
+
+describe('useMultipleRecordPickerChange', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useSnackBar).mockReturnValue({
+      enqueueErrorSnackBar: mockEnqueueErrorSnackBar,
+    } as unknown as ReturnType<typeof useSnackBar>);
+  });
+
+  const setup = ({
+    initialMorphItems,
+    onChange,
+  }: {
+    initialMorphItems: RecordPickerPickableMorphItem[];
+    onChange?: (
+      morphItem: RecordPickerPickableMorphItem,
+    ) => void | Promise<void>;
+  }) => {
+    const store = createStore();
+    const pickableMorphItemsState =
+      multipleRecordPickerPickableMorphItemsComponentState.atomFamily({
+        instanceId: componentInstanceId,
+      });
+
+    store.set(pickableMorphItemsState, initialMorphItems);
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={store}>
+        <MultipleRecordPickerComponentInstanceContext.Provider
+          value={{ instanceId: componentInstanceId }}
+        >
+          {children}
+        </MultipleRecordPickerComponentInstanceContext.Provider>
+      </JotaiProvider>
+    );
+
+    const renderChangeHook = () =>
+      renderHook(() => useMultipleRecordPickerChange({ onChange }), {
+        wrapper: Wrapper,
+      });
+    const renderedHook = renderChangeHook();
+
+    return {
+      ...renderedHook,
+      getMorphItems: () => store.get(pickableMorphItemsState),
+      remount: renderChangeHook,
+      resetMorphItems: () => store.set(pickableMorphItemsState, []),
+      setMorphItems: (morphItems: RecordPickerPickableMorphItem[]) =>
+        store.set(pickableMorphItemsState, morphItems),
+    };
+  };
+
+  it('serializes changes for the same morph item', async () => {
+    const firstChange = createDeferred();
+    const secondChange = createDeferred();
+    const onChange = jest
+      .fn()
+      .mockReturnValueOnce(firstChange.promise)
+      .mockReturnValueOnce(secondChange.promise);
+    const initialMorphItem = createMorphItem('record-id', false);
+    const { getMorphItems, result } = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange,
+    });
+
+    let firstChangeResult: Promise<void> = Promise.resolve();
+    let secondChangeResult: Promise<void> = Promise.resolve();
+    act(() => {
+      firstChangeResult = result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+      secondChangeResult = result.current.handleChange(initialMorphItem);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(getMorphItems()[0].isSelected).toBe(false);
+
+    await act(async () => {
+      firstChange.resolve();
+      await firstChangeResult;
+    });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      secondChange.resolve();
+      await secondChangeResult;
+    });
+  });
+
+  it('keeps the item queue across picker unmount and remount', async () => {
+    const selection = createDeferred();
+    const deselection = createDeferred();
+    const onChange = jest
+      .fn()
+      .mockReturnValueOnce(selection.promise)
+      .mockReturnValueOnce(deselection.promise);
+    const initialMorphItem = createMorphItem('record-id', false);
+    const { remount, result, setMorphItems, unmount } = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange,
+    });
+
+    let selectionResult: Promise<void> = Promise.resolve();
+    act(() => {
+      selectionResult = result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+    });
+
+    unmount();
+    setMorphItems([{ ...initialMorphItem, isSelected: true }]);
+    const remountedHook = remount();
+
+    let deselectionResult: Promise<void> = Promise.resolve();
+    act(() => {
+      deselectionResult =
+        remountedHook.result.current.handleChange(initialMorphItem);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      selection.resolve();
+      await selectionResult;
+    });
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      deselection.resolve();
+      await deselectionResult;
+    });
+
+    remountedHook.unmount();
+  });
+
+  it('runs changes for different morph items in parallel', async () => {
+    const firstChange = createDeferred();
+    const secondChange = createDeferred();
+    const onChange = jest
+      .fn()
+      .mockReturnValueOnce(firstChange.promise)
+      .mockReturnValueOnce(secondChange.promise);
+    const firstMorphItem = createMorphItem('first-record-id', false);
+    const secondMorphItem = createMorphItem('second-record-id', false);
+    const { result } = setup({
+      initialMorphItems: [firstMorphItem, secondMorphItem],
+      onChange,
+    });
+
+    let firstChangeResult: Promise<void> = Promise.resolve();
+    let secondChangeResult: Promise<void> = Promise.resolve();
+    act(() => {
+      firstChangeResult = result.current.handleChange({
+        ...firstMorphItem,
+        isSelected: true,
+      });
+      secondChangeResult = result.current.handleChange({
+        ...secondMorphItem,
+        isSelected: true,
+      });
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      firstChange.resolve();
+      secondChange.resolve();
+      await Promise.all([firstChangeResult, secondChangeResult]);
+    });
+  });
+
+  it('rolls back and reports the latest rejected change', async () => {
+    const change = createDeferred();
+    const error = new Error('Could not update relation');
+    const initialMorphItem = createMorphItem('record-id', false);
+    const { getMorphItems, result } = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange: () => change.promise,
+    });
+
+    let changeResult: Promise<void> = Promise.resolve();
+    act(() => {
+      changeResult = result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+    });
+
+    expect(getMorphItems()[0].isSelected).toBe(true);
+
+    await act(async () => {
+      change.reject(error);
+      await changeResult;
+    });
+
+    expect(getMorphItems()[0].isSelected).toBe(false);
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({
+      apolloError: error,
+    });
+  });
+
+  it('keeps a newer intent and continues its queue after a stale failure', async () => {
+    const firstChange = createDeferred();
+    const secondChange = createDeferred();
+    const onChange = jest
+      .fn()
+      .mockReturnValueOnce(firstChange.promise)
+      .mockReturnValueOnce(secondChange.promise);
+    const initialMorphItem = createMorphItem('record-id', false);
+    const { getMorphItems, result } = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange,
+    });
+
+    let firstChangeResult: Promise<void> = Promise.resolve();
+    let secondChangeResult: Promise<void> = Promise.resolve();
+    act(() => {
+      firstChangeResult = result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+      secondChangeResult = result.current.handleChange(initialMorphItem);
+    });
+
+    await act(async () => {
+      firstChange.reject(new Error('Stale failure'));
+      await firstChangeResult;
+    });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
+    expect(getMorphItems()[0].isSelected).toBe(false);
+    expect(mockEnqueueErrorSnackBar).not.toHaveBeenCalled();
+
+    await act(async () => {
+      secondChange.resolve();
+      await secondChangeResult;
+    });
+  });
+
+  it('rolls consecutive failures back to the last confirmed selection', async () => {
+    const deselection = createDeferred();
+    const selection = createDeferred();
+    const latestError = new Error('Could not restore relation');
+    const onChange = jest
+      .fn()
+      .mockReturnValueOnce(deselection.promise)
+      .mockReturnValueOnce(selection.promise);
+    const initialMorphItem = createMorphItem('record-id', true);
+    const { getMorphItems, result } = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange,
+    });
+
+    let deselectionResult: Promise<void> = Promise.resolve();
+    let selectionResult: Promise<void> = Promise.resolve();
+    act(() => {
+      deselectionResult = result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: false,
+      });
+      selectionResult = result.current.handleChange(initialMorphItem);
+    });
+
+    await act(async () => {
+      deselection.reject(new Error('Could not remove relation'));
+      await deselectionResult;
+    });
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      selection.reject(latestError);
+      await selectionResult;
+    });
+
+    expect(getMorphItems()[0].isSelected).toBe(true);
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({
+      apolloError: latestError,
+    });
+  });
+
+  it('rolls a failed queued deselection back to the preceding successful selection', async () => {
+    const selection = createDeferred();
+    const deselectionError = new Error('Could not remove relation');
+    const onChange = jest
+      .fn()
+      .mockReturnValueOnce(selection.promise)
+      .mockRejectedValueOnce(deselectionError);
+    const initialMorphItem = createMorphItem('record-id', false);
+    const { getMorphItems, result } = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange,
+    });
+
+    let selectionResult: Promise<void> = Promise.resolve();
+    let deselectionResult: Promise<void> = Promise.resolve();
+    act(() => {
+      selectionResult = result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+      deselectionResult = result.current.handleChange(initialMorphItem);
+    });
+
+    expect(getMorphItems()[0].isSelected).toBe(false);
+
+    await act(async () => {
+      selection.resolve();
+      await selectionResult;
+    });
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
+    await act(async () => await deselectionResult);
+
+    expect(getMorphItems()[0].isSelected).toBe(true);
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({
+      apolloError: deselectionError,
+    });
+  });
+
+  it('rolls back and reports a synchronous persistence error', async () => {
+    const error = new Error('Synchronous failure');
+    const initialMorphItem = createMorphItem('record-id', false);
+    const { getMorphItems, result } = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange: () => {
+        throw error;
+      },
+    });
+
+    await act(async () => {
+      await result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+    });
+
+    expect(getMorphItems()[0].isSelected).toBe(false);
+    expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith({
+      apolloError: error,
+    });
+  });
+
+  it('does not repopulate picker state cleared while a change is pending', async () => {
+    const change = createDeferred();
+    const initialMorphItem = createMorphItem('record-id', false);
+    const { getMorphItems, resetMorphItems, result } = setup({
+      initialMorphItems: [initialMorphItem],
+      onChange: () => change.promise,
+    });
+
+    let changeResult: Promise<void> = Promise.resolve();
+    act(() => {
+      changeResult = result.current.handleChange({
+        ...initialMorphItem,
+        isSelected: true,
+      });
+      resetMorphItems();
+    });
+
+    await act(async () => {
+      change.reject(new Error('Failed after close'));
+      await changeResult;
+    });
+
+    expect(getMorphItems()).toEqual([]);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/__tests__/useMultipleRecordPickerChange.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/__tests__/useMultipleRecordPickerChange.test.tsx
@@ -110,7 +110,7 @@ describe('useMultipleRecordPickerChange', () => {
       secondChangeResult = result.current.handleChange(initialMorphItem);
     });
 
-    expect(onChange).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
     expect(getMorphItems()[0].isSelected).toBe(false);
 
     await act(async () => {
@@ -157,7 +157,7 @@ describe('useMultipleRecordPickerChange', () => {
         remountedHook.result.current.handleChange(initialMorphItem);
     });
 
-    expect(onChange).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       selection.resolve();
@@ -200,7 +200,7 @@ describe('useMultipleRecordPickerChange', () => {
       });
     });
 
-    expect(onChange).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
 
     await act(async () => {
       firstChange.resolve();

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerChange.ts
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerChange.ts
@@ -1,0 +1,155 @@
+import { useCallback } from 'react';
+import { useStore } from 'jotai';
+
+import { MultipleRecordPickerComponentInstanceContext } from '@/object-record/record-picker/multiple-record-picker/states/contexts/MultipleRecordPickerComponentInstanceContext';
+import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerPickableMorphItemsComponentState';
+import {
+  type RecordPickerOnChange,
+  type RecordPickerPickableMorphItem,
+} from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
+import { isErrorLike } from '@apollo/client/errors';
+
+const getMorphItemKey = ({
+  objectMetadataId,
+  recordId,
+}: Pick<RecordPickerPickableMorphItem, 'objectMetadataId' | 'recordId'>) =>
+  `${objectMetadataId}:${recordId}`;
+
+type PickerMorphItemChangeQueue = {
+  confirmedIsSelected: boolean;
+  latestChangeToken: symbol;
+  pendingChange: Promise<void>;
+};
+
+const changeQueueByPickerMorphItemKey = new Map<
+  string,
+  PickerMorphItemChangeQueue
+>();
+
+export const useMultipleRecordPickerChange = ({
+  onChange,
+}: {
+  onChange?: RecordPickerOnChange;
+}) => {
+  const store = useStore();
+  const { enqueueErrorSnackBar } = useSnackBar();
+  const componentInstanceId = useAvailableComponentInstanceIdOrThrow(
+    MultipleRecordPickerComponentInstanceContext,
+  );
+
+  const pickableMorphItemsState = useAtomComponentStateCallbackState(
+    multipleRecordPickerPickableMorphItemsComponentState,
+    componentInstanceId,
+  );
+
+  const handleChange = useCallback(
+    (morphItem: RecordPickerPickableMorphItem) => {
+      const morphItemKey = getMorphItemKey(morphItem);
+      const pickerMorphItemKey = `${componentInstanceId}:${morphItemKey}`;
+      const changeToken = Symbol(morphItemKey);
+      const previousMorphItems = store.get(pickableMorphItemsState);
+      const previousMorphItem = previousMorphItems.find(
+        (item) => getMorphItemKey(item) === morphItemKey,
+      );
+      const existingChangeQueue =
+        changeQueueByPickerMorphItemKey.get(pickerMorphItemKey);
+      const confirmedIsSelected =
+        existingChangeQueue?.confirmedIsSelected ??
+        previousMorphItem?.isSelected ??
+        false;
+
+      const nextMorphItems = previousMorphItems.some(
+        (item) => getMorphItemKey(item) === morphItemKey,
+      )
+        ? previousMorphItems.map((item) =>
+            getMorphItemKey(item) === morphItemKey ? morphItem : item,
+          )
+        : [...previousMorphItems, morphItem];
+
+      store.set(pickableMorphItemsState, nextMorphItems);
+
+      const runOnChange = () => {
+        try {
+          return Promise.resolve(onChange?.(morphItem));
+        } catch (error) {
+          return Promise.reject(error);
+        }
+      };
+
+      const currentChange = existingChangeQueue
+        ? existingChangeQueue.pendingChange
+            .catch(() => undefined)
+            .then(runOnChange)
+        : runOnChange();
+
+      changeQueueByPickerMorphItemKey.set(pickerMorphItemKey, {
+        confirmedIsSelected,
+        latestChangeToken: changeToken,
+        pendingChange: currentChange,
+      });
+
+      return currentChange.then(
+        () => {
+          const currentChangeQueue =
+            changeQueueByPickerMorphItemKey.get(pickerMorphItemKey);
+
+          if (!currentChangeQueue) {
+            return;
+          }
+
+          currentChangeQueue.confirmedIsSelected = morphItem.isSelected;
+
+          if (currentChangeQueue.pendingChange === currentChange) {
+            changeQueueByPickerMorphItemKey.delete(pickerMorphItemKey);
+          }
+        },
+        (error: unknown) => {
+          const currentChangeQueue =
+            changeQueueByPickerMorphItemKey.get(pickerMorphItemKey);
+          const isLatestChange =
+            currentChangeQueue?.latestChangeToken === changeToken;
+
+          if (isLatestChange && currentChangeQueue !== undefined) {
+            store.set(pickableMorphItemsState, (currentMorphItems) =>
+              currentMorphItems.map((currentMorphItem) =>
+                getMorphItemKey(currentMorphItem) === morphItemKey &&
+                currentMorphItem.isSelected === morphItem.isSelected
+                  ? {
+                      ...currentMorphItem,
+                      isSelected: currentChangeQueue.confirmedIsSelected,
+                    }
+                  : currentMorphItem,
+              ),
+            );
+          }
+
+          if (currentChangeQueue?.pendingChange === currentChange) {
+            changeQueueByPickerMorphItemKey.delete(pickerMorphItemKey);
+          }
+
+          if (isLatestChange) {
+            enqueueErrorSnackBar(
+              isErrorLike(error)
+                ? { apolloError: error }
+                : error instanceof Error
+                  ? { message: error.message }
+                  : {},
+            );
+          }
+        },
+      );
+    },
+    [
+      componentInstanceId,
+      enqueueErrorSnackBar,
+      onChange,
+      pickableMorphItemsState,
+      store,
+    ],
+  );
+
+  return { handleChange };
+};

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerChange.ts
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerChange.ts
@@ -22,10 +22,24 @@ type PickerMorphItemChangeQueue = {
   pendingChange: Promise<void>;
 };
 
-const changeQueueByPickerMorphItemKey = new Map<
-  string,
-  PickerMorphItemChangeQueue
+const changeQueuesByStore = new WeakMap<
+  ReturnType<typeof useStore>,
+  Map<string, PickerMorphItemChangeQueue>
 >();
+
+const getChangeQueueForStore = (store: ReturnType<typeof useStore>) => {
+  const existingChangeQueue = changeQueuesByStore.get(store);
+
+  if (existingChangeQueue) {
+    return existingChangeQueue;
+  }
+
+  const changeQueue = new Map<string, PickerMorphItemChangeQueue>();
+
+  changeQueuesByStore.set(store, changeQueue);
+
+  return changeQueue;
+};
 
 export const useMultipleRecordPickerChange = ({
   onChange,
@@ -45,6 +59,7 @@ export const useMultipleRecordPickerChange = ({
 
   const handleChange = useCallback(
     (morphItem: RecordPickerPickableMorphItem) => {
+      const changeQueueByPickerMorphItemKey = getChangeQueueForStore(store);
       const morphItemKey = getMorphItemKey(morphItem);
       const pickerMorphItemKey = `${componentInstanceId}:${morphItemKey}`;
       const changeToken = Symbol(morphItemKey);

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerChange.ts
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/hooks/useMultipleRecordPickerChange.ts
@@ -3,10 +3,8 @@ import { useStore } from 'jotai';
 
 import { MultipleRecordPickerComponentInstanceContext } from '@/object-record/record-picker/multiple-record-picker/states/contexts/MultipleRecordPickerComponentInstanceContext';
 import { multipleRecordPickerPickableMorphItemsComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerPickableMorphItemsComponentState';
-import {
-  type RecordPickerOnChange,
-  type RecordPickerPickableMorphItem,
-} from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+import { type RecordPickerOnChange } from '@/object-record/record-picker/types/RecordPickerOnChange';
+import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
@@ -71,19 +69,9 @@ export const useMultipleRecordPickerChange = ({
 
       store.set(pickableMorphItemsState, nextMorphItems);
 
-      const runOnChange = () => {
-        try {
-          return Promise.resolve(onChange?.(morphItem));
-        } catch (error) {
-          return Promise.reject(error);
-        }
-      };
-
-      const currentChange = existingChangeQueue
-        ? existingChangeQueue.pendingChange
-            .catch(() => undefined)
-            .then(runOnChange)
-        : runOnChange();
+      const currentChange = Promise.resolve(existingChangeQueue?.pendingChange)
+        .catch(() => undefined)
+        .then(() => onChange?.(morphItem));
 
       changeQueueByPickerMorphItemKey.set(pickerMorphItemKey, {
         confirmedIsSelected,
@@ -132,11 +120,7 @@ export const useMultipleRecordPickerChange = ({
 
           if (isLatestChange) {
             enqueueErrorSnackBar(
-              isErrorLike(error)
-                ? { apolloError: error }
-                : error instanceof Error
-                  ? { message: error.message }
-                  : {},
+              isErrorLike(error) ? { apolloError: error } : {},
             );
           }
         },

--- a/packages/twenty-front/src/modules/object-record/record-picker/types/RecordPickerOnChange.ts
+++ b/packages/twenty-front/src/modules/object-record/record-picker/types/RecordPickerOnChange.ts
@@ -1,0 +1,5 @@
+import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
+
+export type RecordPickerOnChange = (
+  morphItem: RecordPickerPickableMorphItem,
+) => void | Promise<void>;

--- a/packages/twenty-front/src/modules/object-record/record-picker/types/RecordPickerPickableMorphItem.ts
+++ b/packages/twenty-front/src/modules/object-record/record-picker/types/RecordPickerPickableMorphItem.ts
@@ -4,3 +4,7 @@ export type RecordPickerPickableMorphItem = {
   isSelected: boolean;
   isMatchingSearchFilter: boolean;
 };
+
+export type RecordPickerOnChange = (
+  morphItem: RecordPickerPickableMorphItem,
+) => void | Promise<void>;

--- a/packages/twenty-front/src/modules/object-record/record-picker/types/RecordPickerPickableMorphItem.ts
+++ b/packages/twenty-front/src/modules/object-record/record-picker/types/RecordPickerPickableMorphItem.ts
@@ -4,7 +4,3 @@ export type RecordPickerPickableMorphItem = {
   isSelected: boolean;
   isMatchingSearchFilter: boolean;
 };
-
-export type RecordPickerOnChange = (
-  morphItem: RecordPickerPickableMorphItem,
-) => void | Promise<void>;


### PR DESCRIPTION
## Problem

The multiple-record picker updated its checkbox state synchronously but discarded the persistence promise. Junction creation first inserted a provisional pivot ID, so a rapid select then deselect could delete that provisional ID while the server later created a different persisted record. Mutation failures also left the picker and inverse relation stores out of sync.

## Changes

- centralize picker changes in one hook and propagate persistence promises through picker consumers
- serialize changes per picker, object, and record while allowing unrelated records to update in parallel
- retain the queue across dropdown remounts, scope it per Jotai store with a WeakMap, and roll the latest failed intent back to the last server-confirmed state
- replace provisional junction records with the server-returned record before a queued delete can run
- reject invalid create preconditions so optimistic UI can roll back
- reuse one idempotent store-removal helper for failed creates and successful deletes, including pivots absent from Apollo cache
- restore unchanged non-cascade inverse relations when a soft-delete mutation fails
- translate every user-visible junction failure message with Lingui

## Tests

- picker queue, remount, cross-store isolation, stale failure, consecutive failure, and rollback coverage
- junction create failure, precondition, idempotent delete, persisted-ID, and cache-miss cleanup coverage
- relation and morph soft-delete restoration coverage
- 3 focused suites, 21 tests; review follow-up rerun: 2 suites, 17 tests
- twenty-front typecheck
- type-aware oxlint, oxfmt, and git diff checks

## Export layout

- AST audit: all 11 changed production files declare exactly one export
- move RecordPickerOnChange into its own purpose-named type file; no compatibility barrel
