### PR TITLE
Preserve record widget settings on data source change

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/__tests__/useAddDraftViewForRecordTableWidget.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/__tests__/useAddDraftViewForRecordTableWidget.test.tsx
@@ -1,0 +1,133 @@
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
+import { recordTableWidgetViewDraftComponentState } from '@/page-layout/states/recordTableWidgetViewDraftComponentState';
+import {
+  makeDraft,
+  makeTab,
+} from '@/page-layout/testing/pageLayoutDraftFixtures';
+import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
+import { createDefaultRecordTableWidget } from '@/page-layout/utils/createDefaultRecordTableWidget';
+import { useAddDraftViewForRecordTableWidget } from '@/page-layout/widgets/record-table/hooks/useAddDraftViewForRecordTableWidget';
+import { act, renderHook } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+import {
+  PageLayoutTabLayoutMode,
+  WidgetConfigurationType,
+} from '~/generated-metadata/graphql';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+
+const PAGE_LAYOUT_ID = 'page-layout-id';
+const WIDGET_ID = 'widget-id';
+
+const getWrapper =
+  (store: ReturnType<typeof createStore>) =>
+  ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={store}>{children}</JotaiProvider>
+  );
+
+describe('useAddDraftViewForRecordTableWidget', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('merges the new view id into the latest widget configuration', () => {
+    let scheduledFrame: FrameRequestCallback | undefined;
+
+    jest
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback) => {
+        scheduledFrame = callback;
+        return 1;
+      });
+
+    const store = createStore();
+    const pageLayoutDraftState = pageLayoutDraftComponentState.atomFamily({
+      instanceId: PAGE_LAYOUT_ID,
+    });
+
+    const recordTableWidget: PageLayoutWidget = {
+      ...createDefaultRecordTableWidget({
+        id: WIDGET_ID,
+        pageLayoutTabId: 'tab-id',
+        title: 'Companies',
+        objectMetadataId: 'object-metadata-id',
+        isUIEditable: true,
+        position: {
+          __typename: 'PageLayoutWidgetGridPosition',
+          layoutMode: PageLayoutTabLayoutMode.GRID,
+          row: 0,
+          column: 0,
+          rowSpan: 4,
+          columnSpan: 4,
+        },
+      }),
+      configuration: {
+        configurationType: WidgetConfigurationType.RECORD_TABLE,
+        viewId: 'previous-view-id',
+        recordLimit: 12,
+        isUIEditable: true,
+      },
+    };
+
+    store.set(
+      pageLayoutDraftState,
+      makeDraft([makeTab('tab-id', [recordTableWidget])]),
+    );
+
+    const { result } = renderHook(
+      () => useAddDraftViewForRecordTableWidget(PAGE_LAYOUT_ID),
+      { wrapper: getWrapper(store) },
+    );
+
+    act(() => {
+      result.current.addDraftViewForRecordTableWidget(
+        WIDGET_ID,
+        getMockObjectMetadataItemOrThrow('company'),
+      );
+    });
+
+    act(() => {
+      store.set(pageLayoutDraftState, (previousDraft) => ({
+        ...previousDraft,
+        tabs: previousDraft.tabs.map((tab) => ({
+          ...tab,
+          widgets: tab.widgets.map((widget) =>
+            widget.id === WIDGET_ID
+              ? {
+                  ...widget,
+                  configuration: {
+                    ...widget.configuration,
+                    isUIEditable: false,
+                  },
+                }
+              : widget,
+          ),
+        })),
+      }));
+    });
+
+    expect(scheduledFrame).toBeDefined();
+
+    act(() => {
+      scheduledFrame?.(0);
+    });
+
+    const updatedWidget = store
+      .get(pageLayoutDraftState)
+      .tabs.flatMap((tab) => tab.widgets)
+      .find((widget) => widget.id === WIDGET_ID);
+
+    const newViewId = store.get(
+      recordTableWidgetViewDraftComponentState.atomFamily({
+        instanceId: PAGE_LAYOUT_ID,
+      }),
+    )[WIDGET_ID].view.id;
+
+    expect(updatedWidget?.configuration).toEqual({
+      configurationType: WidgetConfigurationType.RECORD_TABLE,
+      viewId: newViewId,
+      recordLimit: 12,
+      isUIEditable: false,
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useAddDraftViewForRecordTableWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useAddDraftViewForRecordTableWidget.ts
@@ -1,14 +1,29 @@
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { useUpdatePageLayoutWidget } from '@/page-layout/hooks/useUpdatePageLayoutWidget';
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
 import { recordTableWidgetViewDraftComponentState } from '@/page-layout/states/recordTableWidgetViewDraftComponentState';
+import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { buildRecordTableWidgetViewSnapshot } from '@/page-layout/widgets/record-table/utils/buildRecordTableWidgetViewSnapshot';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { useStore } from 'jotai';
 import { useCallback } from 'react';
-import { WidgetConfigurationType } from '~/generated-metadata/graphql';
+import {
+  type RecordTableConfiguration,
+  WidgetConfigurationType,
+} from '~/generated-metadata/graphql';
+
+const isRecordTableConfiguration = (
+  configuration: PageLayoutWidget['configuration'] | undefined,
+): configuration is RecordTableConfiguration =>
+  configuration?.configurationType === WidgetConfigurationType.RECORD_TABLE;
 
 export const useAddDraftViewForRecordTableWidget = (pageLayoutId: string) => {
   const { updatePageLayoutWidget } = useUpdatePageLayoutWidget(pageLayoutId);
+
+  const pageLayoutDraftState = useAtomComponentStateCallbackState(
+    pageLayoutDraftComponentState,
+    pageLayoutId,
+  );
 
   const recordTableWidgetViewDraftState = useAtomComponentStateCallbackState(
     recordTableWidgetViewDraftComponentState,
@@ -27,15 +42,33 @@ export const useAddDraftViewForRecordTableWidget = (pageLayoutId: string) => {
       }));
 
       requestAnimationFrame(() => {
+        const latestWidgetConfiguration = store
+          .get(pageLayoutDraftState)
+          .tabs.flatMap((tab) => tab.widgets)
+          .find((widget) => widget.id === widgetId)?.configuration;
+
+        const recordTableConfigurationToPreserve = isRecordTableConfiguration(
+          latestWidgetConfiguration,
+        )
+          ? latestWidgetConfiguration
+          : {
+              configurationType: WidgetConfigurationType.RECORD_TABLE,
+            };
+
         updatePageLayoutWidget(widgetId, {
           configuration: {
-            configurationType: WidgetConfigurationType.RECORD_TABLE,
+            ...recordTableConfigurationToPreserve,
             viewId: snapshot.view.id,
           },
         });
       });
     },
-    [store, recordTableWidgetViewDraftState, updatePageLayoutWidget],
+    [
+      store,
+      pageLayoutDraftState,
+      recordTableWidgetViewDraftState,
+      updatePageLayoutWidget,
+    ],
   );
 
   return { addDraftViewForRecordTableWidget };


### PR DESCRIPTION
## Summary

- Merge a newly created draft view ID into the latest record-table widget configuration.
- Preserve existing and concurrently updated settings such as `recordLimit` and `isUIEditable` when changing the widget data source.
- Add a regression test covering the deferred `requestAnimationFrame` update.

## Why

Changing a record-table widget's data source schedules its new view ID for the next animation frame. The existing callback replaces the complete configuration, which can silently discard settings retained or changed before that frame runs.

This standalone fix was identified while working on #25111 and does not include the discarded viewer-controls proposal.

## Validation

- Focused frontend Jest: 1 suite, 1 test passed
- Type-aware Oxlint: no findings
- Oxfmt
- `git diff --check`

Manual browser QA was not run in this environment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

