### PR TITLE
Load saved any-field filters in record widgets

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/__tests__/useLoadRecordIndexStates.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/__tests__/useLoadRecordIndexStates.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook } from '@testing-library/react';
+
+import { useLoadRecordIndexStates } from '@/object-record/record-index/hooks/useLoadRecordIndexStates';
+import { anyFieldFilterValueComponentState } from '@/object-record/record-filter/states/anyFieldFilterValueComponentState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { type View } from '@/views/types/View';
+import { act } from 'react';
+import { ViewType, ViewVisibility } from '~/generated-metadata/graphql';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+
+const recordIndexId = 'record-table-widget-record-index-id';
+const objectMetadataItem = getMockObjectMetadataItemOrThrow('company');
+
+const makeView = (anyFieldFilterValue: string | null): View => ({
+  id: 'view-id',
+  name: 'Widget view',
+  type: ViewType.TABLE,
+  objectMetadataId: objectMetadataItem.id,
+  isCompact: false,
+  viewFields: [],
+  viewGroups: [],
+  viewFilters: [],
+  viewFilterGroups: [],
+  viewSorts: [],
+  shouldHideEmptyGroups: false,
+  position: 0,
+  icon: 'IconTable',
+  anyFieldFilterValue,
+  visibility: ViewVisibility.WORKSPACE,
+  isActive: true,
+});
+
+const renderUseLoadRecordIndexStates = () =>
+  renderHook(() => useLoadRecordIndexStates(), {
+    wrapper: getJestMetadataAndApolloMocksWrapper({
+      apolloMocks: [],
+      objectMetadataItems: [objectMetadataItem],
+    }),
+  });
+
+describe('useLoadRecordIndexStates', () => {
+  it('hydrates the scoped any-field filter from the loaded view', () => {
+    const { result } = renderUseLoadRecordIndexStates();
+
+    act(() => {
+      result.current.loadRecordIndexStates(
+        makeView('Acme'),
+        objectMetadataItem,
+        {
+          skipGlobalIndexStates: true,
+          recordIndexId,
+        },
+      );
+    });
+
+    expect(
+      jotaiStore.get(
+        anyFieldFilterValueComponentState.atomFamily({
+          instanceId: recordIndexId,
+        }),
+      ),
+    ).toBe('Acme');
+  });
+
+  it('clears a stale scoped any-field filter when the loaded view has none', () => {
+    const anyFieldFilterValueAtom =
+      anyFieldFilterValueComponentState.atomFamily({
+        instanceId: recordIndexId,
+      });
+
+    const { result } = renderUseLoadRecordIndexStates();
+
+    act(() => {
+      jotaiStore.set(anyFieldFilterValueAtom, 'stale value');
+      result.current.loadRecordIndexStates(makeView(null), objectMetadataItem, {
+        skipGlobalIndexStates: true,
+        recordIndexId,
+      });
+    });
+
+    expect(jotaiStore.get(anyFieldFilterValueAtom)).toBe('');
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexStates.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexStates.ts
@@ -9,6 +9,7 @@ import { isHiddenSystemField } from '@/object-metadata/utils/isHiddenSystemField
 import { currentRecordFieldsComponentState } from '@/object-record/record-field/states/currentRecordFieldsComponentState';
 import { type FieldMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
+import { anyFieldFilterValueComponentState } from '@/object-record/record-filter/states/anyFieldFilterValueComponentState';
 import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
 import { useSetRecordGroups } from '@/object-record/record-group/hooks/useSetRecordGroups';
 import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record/record-index/states/recordIndexGroupFieldMetadataComponentState';
@@ -282,6 +283,10 @@ export const useLoadRecordIndexStates = () => {
         currentRecordFiltersComponentState.atomFamily({
           instanceId: recordIndexId,
         });
+      const anyFieldFilterValueAtom =
+        anyFieldFilterValueComponentState.atomFamily({
+          instanceId: recordIndexId,
+        });
       const currentRecordFilterGroupsAtom =
         currentRecordFilterGroupsComponentState.atomFamily({
           instanceId: recordIndexId,
@@ -311,6 +316,7 @@ export const useLoadRecordIndexStates = () => {
         atom(null, (get, batchSet) => {
           batchSet(currentRecordFiltersAtom, recordFilters);
           batchSet(currentRecordFilterGroupsAtom, recordFilterGroups);
+          batchSet(anyFieldFilterValueAtom, view.anyFieldFilterValue ?? '');
           batchSet(hasInitializedFiltersAtom, true);
 
           batchSet(currentRecordSortsAtom, view.viewSorts);

--- a/packages/twenty-front/src/modules/object-record/record-table-widget/utils/__tests__/computeRecordTableWidgetViewLoadContentSignature.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table-widget/utils/__tests__/computeRecordTableWidgetViewLoadContentSignature.test.ts
@@ -28,4 +28,18 @@ describe('computeRecordTableWidgetViewLoadContentSignature', () => {
       computeRecordTableWidgetViewLoadContentSignature(makeView(null)),
     );
   });
+
+  it('should include the any-field filter in the record table widget view load signature', () => {
+    expect(
+      computeRecordTableWidgetViewLoadContentSignature({
+        ...makeView(null),
+        anyFieldFilterValue: 'Acme',
+      }),
+    ).not.toEqual(
+      computeRecordTableWidgetViewLoadContentSignature({
+        ...makeView(null),
+        anyFieldFilterValue: '',
+      }),
+    );
+  });
 });

--- a/packages/twenty-front/src/modules/object-record/record-table-widget/utils/computeRecordTableWidgetViewLoadContentSignature.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table-widget/utils/computeRecordTableWidgetViewLoadContentSignature.ts
@@ -27,6 +27,7 @@ export const computeRecordTableWidgetViewLoadContentSignature = (
       logicalOperator: group.logicalOperator,
       parentViewFilterGroupId: group.parentViewFilterGroupId,
     })),
+    anyFieldFilterValue: view.anyFieldFilterValue,
     sorts: view.viewSorts.map((sort) => ({
       id: sort.id,
       fieldMetadataId: sort.fieldMetadataId,


### PR DESCRIPTION
## Summary

- Hydrate `anyFieldFilterValueComponentState` from the loaded view in the same scoped record-index state as filters and sorts.
- Clear stale any-field filter state when the loaded view has no saved value.
- Include the any-field filter in the record-table widget load signature so saved-value changes trigger rehydration.
- Add direct state-hydration and signature regression tests.

## Why

Embedded record widgets load a backing view's filters, filter groups, and sorts, but currently omit its saved any-field filter even though widget queries consume that atom. This can make a widget ignore the backing view's saved search or retain a stale value.

This standalone fix was identified while working on #25111 and does not include the discarded viewer-controls proposal.

## Validation

- Focused frontend Jest: 2 suites, 4 tests passed
- Type-aware Oxlint: no findings
- Oxfmt
- `git diff --check`

Manual browser QA was not run in this environment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

