### PR TITLE
Remove no-op universal flat entity casts in side effect handlers

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-index-view-field-on-create-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-index-view-field-on-create-side-effect-handler.service.ts
@@ -34,12 +34,10 @@ export class FieldIndexViewFieldOnCreateSideEffectHandlerService extends Metadat
   },
 ) {
   buildSideEffects({
-    flatEntity: flatFieldMetadata,
+    flatEntity: sourceFlatFieldMetadata,
     allFlatEntityOperationRecordByMetadataName,
     relatedFlatEntityMaps,
   }: BuildSideEffectsArgs<'fieldMetadata'>): MetadataSideEffectResult {
-    const sourceFlatFieldMetadata =
-      flatFieldMetadata as UniversalFlatFieldMetadata;
     const { objectMetadataUniversalIdentifier } = sourceFlatFieldMetadata;
 
     const parentFlatObjectMetadata =

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-record-page-view-field-on-create-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-record-page-view-field-on-create-side-effect-handler.service.ts
@@ -34,12 +34,10 @@ export class FieldRecordPageViewFieldOnCreateSideEffectHandlerService extends Me
   },
 ) {
   buildSideEffects({
-    flatEntity: flatFieldMetadata,
+    flatEntity: sourceFlatFieldMetadata,
     allFlatEntityOperationRecordByMetadataName,
     relatedFlatEntityMaps,
   }: BuildSideEffectsArgs<'fieldMetadata'>): MetadataSideEffectResult {
-    const sourceFlatFieldMetadata =
-      flatFieldMetadata as UniversalFlatFieldMetadata;
     const { objectMetadataUniversalIdentifier } = sourceFlatFieldMetadata;
 
     const parentFlatObjectMetadata =

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-index-view-label-identifier-on-update-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-index-view-label-identifier-on-update-side-effect-handler.service.ts
@@ -14,7 +14,6 @@ import {
   MetadataSideEffectHandler,
 } from 'src/engine/metadata-modules/metadata-side-effect/interfaces/base-metadata-side-effect-handler.service';
 import { type MetadataSideEffectResult } from 'src/engine/metadata-modules/metadata-side-effect/types/metadata-side-effect-result.type';
-import { type UniversalFlatObjectMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-object-metadata.type';
 import { type UniversalFlatViewField } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-field.type';
 
 @Injectable()
@@ -28,11 +27,9 @@ export class ObjectIndexViewLabelIdentifierOnUpdateSideEffectHandlerService exte
   },
 ) {
   buildSideEffects({
-    flatEntity,
+    flatEntity: updatedFlatObjectMetadata,
     relatedFlatEntityMaps,
   }: BuildSideEffectsArgs<'objectMetadata'>): MetadataSideEffectResult {
-    const updatedFlatObjectMetadata = flatEntity as UniversalFlatObjectMetadata;
-
     const existingFlatObjectMetadata =
       relatedFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
         updatedFlatObjectMetadata.universalIdentifier

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-index-view-on-create-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-index-view-on-create-side-effect-handler.service.ts
@@ -10,7 +10,6 @@ import {
   MetadataSideEffectHandler,
 } from 'src/engine/metadata-modules/metadata-side-effect/interfaces/base-metadata-side-effect-handler.service';
 import { type MetadataSideEffectResult } from 'src/engine/metadata-modules/metadata-side-effect/types/metadata-side-effect-result.type';
-import { type UniversalFlatObjectMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-object-metadata.type';
 
 @Injectable()
 export class ObjectIndexViewOnCreateSideEffectHandlerService extends MetadataSideEffectHandler(
@@ -23,11 +22,9 @@ export class ObjectIndexViewOnCreateSideEffectHandlerService extends MetadataSid
   },
 ) {
   buildSideEffects({
-    flatEntity: flatObjectMetadata,
+    flatEntity: sourceFlatObjectMetadata,
     allFlatEntityOperationRecordByMetadataName,
   }: BuildSideEffectsArgs<'objectMetadata'>): MetadataSideEffectResult {
-    const sourceFlatObjectMetadata =
-      flatObjectMetadata as UniversalFlatObjectMetadata;
     const { applicationUniversalIdentifier } = sourceFlatObjectMetadata;
 
     const flatIndexViewToCreate = computeSystemViewToCreate({

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-record-page-label-identifier-on-update-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-record-page-label-identifier-on-update-side-effect-handler.service.ts
@@ -17,7 +17,6 @@ import {
 } from 'src/engine/metadata-modules/metadata-side-effect/interfaces/base-metadata-side-effect-handler.service';
 import { type MetadataSideEffectOperationsByMetadataName } from 'src/engine/metadata-modules/metadata-side-effect/types/metadata-side-effect-operations-by-metadata-name.type';
 import { type MetadataSideEffectResult } from 'src/engine/metadata-modules/metadata-side-effect/types/metadata-side-effect-result.type';
-import { type UniversalFlatObjectMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-object-metadata.type';
 import { type UniversalFlatViewField } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-field.type';
 
 @Injectable()
@@ -31,12 +30,10 @@ export class ObjectRecordPageLabelIdentifierOnUpdateSideEffectHandlerService ext
   },
 ) {
   buildSideEffects({
-    flatEntity,
+    flatEntity: updatedFlatObjectMetadata,
     allFlatEntityOperationRecordByMetadataName,
     relatedFlatEntityMaps,
   }: BuildSideEffectsArgs<'objectMetadata'>): MetadataSideEffectResult {
-    const updatedFlatObjectMetadata = flatEntity as UniversalFlatObjectMetadata;
-
     const existingFlatObjectMetadata =
       relatedFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
         updatedFlatObjectMetadata.universalIdentifier

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-record-page-on-create-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-record-page-on-create-side-effect-handler.service.ts
@@ -11,7 +11,6 @@ import {
   MetadataSideEffectHandler,
 } from 'src/engine/metadata-modules/metadata-side-effect/interfaces/base-metadata-side-effect-handler.service';
 import { type MetadataSideEffectResult } from 'src/engine/metadata-modules/metadata-side-effect/types/metadata-side-effect-result.type';
-import { type UniversalFlatObjectMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-object-metadata.type';
 
 @Injectable()
 export class ObjectRecordPageOnCreateSideEffectHandlerService extends MetadataSideEffectHandler(
@@ -24,11 +23,9 @@ export class ObjectRecordPageOnCreateSideEffectHandlerService extends MetadataSi
   },
 ) {
   buildSideEffects({
-    flatEntity: flatObjectMetadata,
+    flatEntity: sourceFlatObjectMetadata,
     allFlatEntityOperationRecordByMetadataName,
   }: BuildSideEffectsArgs<'objectMetadata'>): MetadataSideEffectResult {
-    const sourceFlatObjectMetadata =
-      flatObjectMetadata as UniversalFlatObjectMetadata;
     const { applicationUniversalIdentifier } = sourceFlatObjectMetadata;
 
     const flatRecordPageViewToCreate = computeSystemViewToCreate({

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-system-fields-on-create-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-system-fields-on-create-side-effect-handler.service.ts
@@ -8,7 +8,6 @@ import {
 } from 'src/engine/metadata-modules/metadata-side-effect/interfaces/base-metadata-side-effect-handler.service';
 import { type MetadataSideEffectResult } from 'src/engine/metadata-modules/metadata-side-effect/types/metadata-side-effect-result.type';
 import { buildReservedSystemFlatFieldMetadatasForCustomObject } from 'src/engine/metadata-modules/object-metadata/utils/build-reserved-system-flat-field-metadatas-for-custom-object.util';
-import { type UniversalFlatObjectMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-object-metadata.type';
 
 @Injectable()
 export class ObjectSystemFieldsOnCreateSideEffectHandlerService extends MetadataSideEffectHandler(
@@ -21,10 +20,8 @@ export class ObjectSystemFieldsOnCreateSideEffectHandlerService extends Metadata
   },
 ) {
   buildSideEffects({
-    flatEntity: flatObjectMetadata,
+    flatEntity: sourceFlatObjectMetadata,
   }: BuildSideEffectsArgs<'objectMetadata'>): MetadataSideEffectResult {
-    const sourceFlatObjectMetadata =
-      flatObjectMetadata as UniversalFlatObjectMetadata;
     const { applicationUniversalIdentifier, universalIdentifier } =
       sourceFlatObjectMetadata;
 

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-system-relations-on-create-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-system-relations-on-create-side-effect-handler.service.ts
@@ -35,12 +35,9 @@ export class ObjectSystemRelationsOnCreateSideEffectHandlerService extends Metad
   },
 ) {
   buildSideEffects({
-    flatEntity: flatObjectMetadata,
+    flatEntity: sourceFlatObjectMetadata,
     relatedFlatEntityMaps,
   }: BuildSideEffectsArgs<'objectMetadata'>): MetadataSideEffectResult {
-    const sourceFlatObjectMetadata =
-      flatObjectMetadata as UniversalFlatObjectMetadata;
-
     const standardTargetFlatObjectMetadataByNameSingular = {} as Record<
       DefaultRelationStandardObjectNameSingular,
       UniversalFlatObjectMetadata

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-system-relations-on-update-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-system-relations-on-update-side-effect-handler.service.ts
@@ -11,7 +11,6 @@ import {
   MetadataSideEffectHandler,
 } from 'src/engine/metadata-modules/metadata-side-effect/interfaces/base-metadata-side-effect-handler.service';
 import { type MetadataSideEffectResult } from 'src/engine/metadata-modules/metadata-side-effect/types/metadata-side-effect-result.type';
-import { type UniversalFlatObjectMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-object-metadata.type';
 
 @Injectable()
 export class ObjectSystemRelationsOnUpdateSideEffectHandlerService extends MetadataSideEffectHandler(
@@ -24,11 +23,9 @@ export class ObjectSystemRelationsOnUpdateSideEffectHandlerService extends Metad
   },
 ) {
   buildSideEffects({
-    flatEntity,
+    flatEntity: updatedFlatObjectMetadata,
     relatedFlatEntityMaps,
   }: BuildSideEffectsArgs<'objectMetadata'>): MetadataSideEffectResult {
-    const updatedFlatObjectMetadata = flatEntity as UniversalFlatObjectMetadata;
-
     const existingFlatObjectMetadata =
       relatedFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
         updatedFlatObjectMetadata.universalIdentifier


### PR DESCRIPTION
`BuildSideEffectsArgs<P>['flatEntity']` is already typed as `MetadataUniversalFlatEntity<P>`, which resolves to `UniversalFlatFieldMetadata` / `UniversalFlatObjectMetadata`, so the `as UniversalFlat...` casts on the received flat entity in the side effect handlers were no-ops.

This removes all nine of them by renaming the destructured `flatEntity` directly to the name the handler body uses (`sourceFlatFieldMetadata`, `sourceFlatObjectMetadata`, `updatedFlatObjectMetadata`), dropping the intermediate cast line and the now-unused `UniversalFlatObjectMetadata` imports.

No behavior change. Typecheck, diff lint and the metadata-side-effect unit tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwmCXkbBn6DWchh7JmH2qy)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

