### PR TITLE
Fix Tasks view crash on duplicate All Tasks name and dangling view state

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemSearchResults.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemSearchResults.tsx
@@ -105,12 +105,15 @@ export const SidePanelNewSidebarItemSearchResults = ({
 
   const filteredViews = filterBySearchQuery({
     items: availableViews
+      .filter((view) => isDefined(view))
       .filter((view) =>
         objectMetadataItemIdsWithViews.has(view.objectMetadataId),
       )
-      .sort((viewA, viewB) => viewA.name.localeCompare(viewB.name)),
+      .sort((viewA, viewB) =>
+        (viewA.name ?? '').localeCompare(viewB.name ?? ''),
+      ),
     searchQuery: trimmedSearchValue,
-    getSearchableValues: (view) => [view.name],
+    getSearchableValues: (view) => [view.name ?? ''],
   });
 
   const selectableItemIds = [
@@ -229,14 +232,14 @@ export const SidePanelNewSidebarItemSearchResults = ({
                           ? undefined
                           : getIcon(view.icon)
                       }
-                      label={view.name}
+                      label={view.name ?? ''}
                       id={view.id}
                       onClick={() => handleSelectView(view)}
                       dragIndex={filteredObjectMetadataItems.length + index}
                       payload={{
                         type: NavigationMenuItemType.VIEW,
                         viewId: view.id,
-                        label: view.name,
+                        label: view.name ?? '',
                       }}
                     />
                   </SelectableListItem>

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemViewPickerSubView.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemViewPickerSubView.tsx
@@ -42,12 +42,13 @@ export const SidePanelNewSidebarItemViewPickerSubView = ({
   const { views } = useNavigationMenuObjectMetadataForSection(currentItems);
 
   const viewsForSelectedObject = views
+    .filter(isDefined)
     .filter(
       (view) =>
         view.objectMetadataId === selectedObjectMetadataIdForView &&
         isViewDisplayableInNavigationMenu(view),
     )
-    .sort((a, b) => a.position - b.position);
+    .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
 
   const selectedObjectMetadataItem = objectMetadataItems.find(
     (item) => item.id === selectedObjectMetadataIdForView,
@@ -59,9 +60,9 @@ export const SidePanelNewSidebarItemViewPickerSubView = ({
     isEmpty,
     hasSearchQuery,
   } = useSidePanelFilteredPickerItems({
-    items: viewsForSelectedObject,
+    items: viewsForSelectedObject.filter(isDefined),
     searchQuery: searchValue,
-    getSearchableValues: (view) => [view.name],
+    getSearchableValues: (view) => [view.name ?? ''],
   });
   const noResultsText = hasSearchQuery
     ? t`No results found`
@@ -86,7 +87,7 @@ export const SidePanelNewSidebarItemViewPickerSubView = ({
     setPendingInsertionNavigationMenuItem(null);
     openNavigationMenuItemInSidePanel({
       itemId,
-      pageTitle: view.name,
+      pageTitle: view.name ?? '',
       pageIcon: getIcon(view.icon),
     });
   };
@@ -130,14 +131,14 @@ export const SidePanelNewSidebarItemViewPickerSubView = ({
                           ? undefined
                           : getIcon(view.icon)
                       }
-                      label={view.name}
+                      label={view.name ?? ''}
                       id={view.id}
                       onClick={() => handleSelectView(view)}
                       dragIndex={index}
                       payload={{
                         type: NavigationMenuItemType.VIEW,
                         viewId: view.id,
-                        label: view.name,
+                        label: view.name ?? '',
                       }}
                     />
                   </SelectableListItem>

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownMenuViewName.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownMenuViewName.tsx
@@ -75,7 +75,7 @@ export const ObjectOptionsDropdownMenuViewName = ({
     useUpdateObjectViewOptions();
 
   const { updateViewFromCurrentState } = useUpdateViewFromCurrentState();
-  const [viewName, setViewName] = useState(currentView?.name);
+  const [viewName, setViewName] = useState(currentView?.name ?? '');
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -103,8 +103,8 @@ export const ObjectOptionsDropdownMenuViewName = ({
   }, 500);
 
   useEffect(() => {
-    setViewPickerSelectedIcon(currentView.icon);
-  }, [currentView.icon, setViewPickerSelectedIcon]);
+    setViewPickerSelectedIcon(currentView?.icon ?? '');
+  }, [currentView?.icon, setViewPickerSelectedIcon]);
 
   useEffect(() => {
     if (currentView?.key !== 'INDEX' && inputRef.current !== null) {
@@ -123,7 +123,7 @@ export const ObjectOptionsDropdownMenuViewName = ({
             <MainIcon size={theme.icon.size.md} stroke={theme.icon.stroke.sm} />
           </StyledMenuIconContainer>
           <StyledMainText>
-            <OverflowingTextWithTooltip text={currentView.name} />
+            <OverflowingTextWithTooltip text={currentView?.name ?? ''} />
           </StyledMainText>
         </StyledMenuTitleContainer>
       ) : (

--- a/packages/twenty-front/src/modules/views/states/selectors/viewsSelector.ts
+++ b/packages/twenty-front/src/modules/views/states/selectors/viewsSelector.ts
@@ -10,37 +10,60 @@ import { type FlatViewSort } from '@/metadata-store/types/FlatViewSort';
 import { createAtomSelector } from '@/ui/utilities/state/jotai/utils/createAtomSelector';
 import { type ViewWithRelations } from '@/views/types/ViewWithRelations';
 import { resolveViewNamePlaceholders } from '@/views/utils/resolveViewNamePlaceholders';
+import { isDefined } from 'twenty-shared/utils';
 
 export const viewsSelector = createAtomSelector<ViewWithRelations[]>({
   key: 'viewsSelector',
   get: ({ get }) => {
-    const allFlatViews = get(metadataStoreState, 'views').current as FlatView[];
-    const flatViews = allFlatViews.filter((view) => view.isActive);
-    const flatObjectMetadataItems = get(
-      metadataStoreState,
-      'objectMetadataItems',
-    ).current as FlatObjectMetadataItem[];
+    const allFlatViews = (
+      (get(metadataStoreState, 'views').current as FlatView[]) ?? []
+    ).filter(isDefined);
+    const flatViews = allFlatViews.filter(
+      (view) => view.isActive && !view.deletedAt,
+    );
+    const flatObjectMetadataItems = (
+      (get(metadataStoreState, 'objectMetadataItems')
+        .current as FlatObjectMetadataItem[]) ?? []
+    ).filter(isDefined);
 
     const objectMetadataItemsById = new Map(
       flatObjectMetadataItems.map((item) => [item.id, item]),
     );
 
-    const allFlatViewFields = get(metadataStoreState, 'viewFields')
-      .current as FlatViewField[];
-    const flatViewFilters = get(metadataStoreState, 'viewFilters')
-      .current as FlatViewFilter[];
-    const flatViewSorts = get(metadataStoreState, 'viewSorts')
-      .current as FlatViewSort[];
-    const flatViewGroups = get(metadataStoreState, 'viewGroups')
-      .current as FlatViewGroup[];
-    const flatViewFilterGroups = get(metadataStoreState, 'viewFilterGroups')
-      .current as FlatViewFilterGroup[];
-    const allFlatViewFieldGroups = get(metadataStoreState, 'viewFieldGroups')
-      .current as FlatViewFieldGroup[];
+    const allFlatViewFields = (
+      (get(metadataStoreState, 'viewFields').current as FlatViewField[]) ?? []
+    ).filter(isDefined);
+    const flatViewFilters = (
+      (get(metadataStoreState, 'viewFilters').current as FlatViewFilter[]) ?? []
+    )
+      .filter(isDefined)
+      .filter((filter) => !filter.deletedAt);
+    const flatViewSorts = (
+      (get(metadataStoreState, 'viewSorts').current as FlatViewSort[]) ?? []
+    )
+      .filter(isDefined)
+      .filter((sort) => !sort.deletedAt);
+    const flatViewGroups = (
+      (get(metadataStoreState, 'viewGroups').current as FlatViewGroup[]) ?? []
+    )
+      .filter(isDefined)
+      .filter((group) => !group.deletedAt);
+    const flatViewFilterGroups = (
+      (get(metadataStoreState, 'viewFilterGroups')
+        .current as FlatViewFilterGroup[]) ?? []
+    )
+      .filter(isDefined)
+      .filter((group) => !group.deletedAt);
+    const allFlatViewFieldGroups = (
+      (get(metadataStoreState, 'viewFieldGroups')
+        .current as FlatViewFieldGroup[]) ?? []
+    ).filter(isDefined);
 
-    const flatViewFields = allFlatViewFields.filter((field) => field.isActive);
+    const flatViewFields = allFlatViewFields.filter(
+      (field) => field.isActive && !field.deletedAt,
+    );
     const flatViewFieldGroups = allFlatViewFieldGroups.filter(
-      (group) => group.isActive,
+      (group) => group.isActive && !group.deletedAt,
     );
 
     const viewFieldsByViewId = new Map<string, FlatViewField[]>();
@@ -90,8 +113,9 @@ export const viewsSelector = createAtomSelector<ViewWithRelations[]>({
       }
     }
 
-    return flatViews.map((view) => ({
+    return flatViews.filter(isDefined).map((view) => ({
       ...view,
+      // view.name can be a placeholder like "All {objectLabelPlural}"; guard missing objectMetadataItem
       name: resolveViewNamePlaceholders(
         view.name,
         objectMetadataItemsById.get(view.objectMetadataId),

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerContentEffect.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerContentEffect.tsx
@@ -94,7 +94,7 @@ export const ViewPickerContentEffect = () => {
       setViewPickerVisibility(
         hasViewPermission ? referenceView.visibility : ViewVisibility.UNLISTED,
       );
-      setViewPickerInputName(referenceView.name);
+      setViewPickerInputName(referenceView.name ?? '');
       setViewPickerType(referenceView.type);
 
       const calendarFieldMetadataId =

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
@@ -122,7 +122,7 @@ export const ViewPickerOptionDropdown = ({
   return (
     <>
       <MenuItemWithOptionDropdown
-        text={view.name}
+        text={view.name ?? ''}
         LeftIcon={getIcon(view.icon)}
         onClick={() => handleViewSelect(view.id)}
         isIconDisplayedOnHoverOnly={!shouldShowIconAlways}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-required-metadata-for-validation.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-required-metadata-for-validation.constant.ts
@@ -22,6 +22,7 @@ export const ALL_METADATA_REQUIRED_METADATA_FOR_VALIDATION = {
   },
   objectMetadata: {
     fieldMetadata: true,
+    view: true,
   },
   view: {
     fieldMetadata: true,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-object-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-object-metadata-validator.service.ts
@@ -3,6 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { msg, t } from '@lingui/core/macro';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import { isDefined } from 'twenty-shared/utils';
+import {
+  buildObjectMetadataLabelPlaceholderValues,
+  interpolateMessagePlaceholders,
+} from 'twenty-shared/i18n';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { validateFlatObjectMetadataNameAndLabels } from 'src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-name-and-labels.util';
@@ -22,6 +26,7 @@ export class FlatObjectMetadataValidatorService {
     buildOptions,
     optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
       flatObjectMetadataMaps: optimisticFlatObjectMetadataMaps,
+      flatViewMaps: optimisticFlatViewMaps,
     },
   }: FlatEntityUpdateValidationArgs<
     typeof ALL_METADATA_NAME.objectMetadata
@@ -83,6 +88,99 @@ export class FlatObjectMetadataValidatorService {
         buildOptions,
       }),
     );
+
+    // Prevent label changes from creating duplicate resolved view names
+    // (e.g. custom "All Tasks" + system "All {objectLabelPlural}" both resolve to "All Tasks" after a label rename)
+    if (isDefined(optimisticFlatViewMaps)) {
+      const getEffective = (
+        obj: typeof existingFlatObjectMetadata,
+        key: 'labelSingular' | 'labelPlural' | 'icon',
+      ): string | null | undefined => {
+        const overrides = obj.overrides as
+          | Record<string, unknown>
+          | null
+          | undefined;
+        if (
+          isDefined(overrides) &&
+          isDefined(overrides[key]) &&
+          typeof overrides[key] === 'string'
+        ) {
+          return overrides[key] as string;
+        }
+        return obj[key] as string | null | undefined;
+      };
+
+      const existingLabelPlural = getEffective(
+        existingFlatObjectMetadata,
+        'labelPlural',
+      );
+      const updatedLabelPlural = getEffective(
+        updatedFlatObjectMetadata,
+        'labelPlural',
+      );
+      const existingLabelSingular = getEffective(
+        existingFlatObjectMetadata,
+        'labelSingular',
+      );
+      const updatedLabelSingular = getEffective(
+        updatedFlatObjectMetadata,
+        'labelSingular',
+      );
+
+      const labelChanged =
+        existingLabelPlural !== updatedLabelPlural ||
+        existingLabelSingular !== updatedLabelSingular;
+
+      if (labelChanged) {
+        const viewIds = existingFlatObjectMetadata.viewUniversalIdentifiers;
+        const resolvedNames = new Map<string, string>();
+
+        for (const viewUniversalIdentifier of viewIds) {
+          const flatView = findFlatEntityByUniversalIdentifier({
+            universalIdentifier: viewUniversalIdentifier,
+            flatEntityMaps: optimisticFlatViewMaps,
+          });
+
+          if (
+            !isDefined(flatView) ||
+            isDefined(flatView.deletedAt) ||
+            flatView.isActive === false
+          ) {
+            continue;
+          }
+
+          const resolvedName = interpolateMessagePlaceholders(
+            flatView.name,
+            buildObjectMetadataLabelPlaceholderValues({
+              labelSingular: updatedLabelSingular ?? undefined,
+              labelPlural: updatedLabelPlural ?? undefined,
+              icon: getEffective(updatedFlatObjectMetadata, 'icon') as
+                | string
+                | null
+                | undefined,
+            }),
+          )
+            .trim()
+            .toLowerCase();
+
+          if (resolvedName.length === 0) {
+            continue;
+          }
+
+          if (resolvedNames.has(resolvedName)) {
+            validationResult.errors.push({
+              code: ObjectMetadataExceptionCode.INVALID_OBJECT_INPUT,
+              message: t`Renaming this object would create duplicate view names ("${flatView.name}" resolves to "${resolvedName}")`,
+              userFriendlyMessage: msg`This label change would create duplicate view names`,
+            });
+            break;
+          }
+
+          resolvedNames.set(resolvedName, flatView.name);
+        }
+      }
+    }
+
     // TODO remove this once we migrated labelIdentifierFieldMetadataId as non nullable
     if (
       flatEntityUpdate.labelIdentifierFieldMetadataUniversalIdentifier !==

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-view-creation.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-view-creation.util.ts
@@ -2,6 +2,10 @@ import { msg, t } from '@lingui/core/macro';
 import { type ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import { ViewType } from 'twenty-shared/types';
 import { getViewLayoutFromViewType, isDefined } from 'twenty-shared/utils';
+import {
+  buildObjectMetadataLabelPlaceholderValues,
+  interpolateMessagePlaceholders,
+} from 'twenty-shared/i18n';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { ViewExceptionCode } from 'src/engine/metadata-modules/view/exceptions/view.exception';
@@ -91,6 +95,64 @@ export const validateFlatViewCreation = ({
         message: t`Object already has a view with the ${reservedViewKey} key`,
         userFriendlyMessage: msg`This object already has a default view`,
       });
+    }
+  }
+
+  // Prevent duplicate resolved names per object (custom "All tasks" colliding with system "All {objectLabelPlural}")
+  if (
+    isDefined(optimisticFlatObjectMetadata) &&
+    isDefined(flatViewToValidate.name)
+  ) {
+    const newResolvedName = interpolateMessagePlaceholders(
+      flatViewToValidate.name,
+      buildObjectMetadataLabelPlaceholderValues({
+        labelSingular: optimisticFlatObjectMetadata.labelSingular,
+        labelPlural: optimisticFlatObjectMetadata.labelPlural,
+        icon: optimisticFlatObjectMetadata.icon,
+      }),
+    )
+      .trim()
+      .toLowerCase();
+
+    if (newResolvedName.length > 0) {
+      const hasDuplicateName =
+        optimisticFlatObjectMetadata.viewUniversalIdentifiers.some(
+          (viewUniversalIdentifier) => {
+            const existingView = findFlatEntityByUniversalIdentifier({
+              universalIdentifier: viewUniversalIdentifier,
+              flatEntityMaps: optimisticFlatViewMaps,
+            });
+
+            if (
+              !isDefined(existingView) ||
+              isDefined(existingView.deletedAt) ||
+              existingView.isActive === false
+            ) {
+              return false;
+            }
+
+            const existingResolvedName = interpolateMessagePlaceholders(
+              existingView.name,
+              buildObjectMetadataLabelPlaceholderValues({
+                labelSingular: optimisticFlatObjectMetadata.labelSingular,
+                labelPlural: optimisticFlatObjectMetadata.labelPlural,
+                icon: optimisticFlatObjectMetadata.icon,
+              }),
+            )
+              .trim()
+              .toLowerCase();
+
+            return existingResolvedName === newResolvedName;
+          },
+        );
+
+      if (hasDuplicateName) {
+        validationResult.errors.push({
+          code: ViewExceptionCode.INVALID_VIEW_DATA,
+          message: t`A view with the name "${flatViewToValidate.name}" already exists for this object`,
+          userFriendlyMessage: msg`A view with this name already exists`,
+        });
+      }
     }
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-view-update.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-view-update.util.ts
@@ -2,9 +2,15 @@ import { msg, t } from '@lingui/core/macro';
 import { type ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import { ViewType } from 'twenty-shared/types';
 import { getViewLayoutFromViewType, isDefined } from 'twenty-shared/utils';
+import {
+  buildObjectMetadataLabelPlaceholderValues,
+  interpolateMessagePlaceholders,
+} from 'twenty-shared/i18n';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { ViewExceptionCode } from 'src/engine/metadata-modules/view/exceptions/view.exception';
+// object-label placeholder collisions are handled in FlatObjectMetadataValidatorService
+// to cover renames that bypass direct view updates
 import { type UniversalFlatView } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view.type';
 import { type FailedFlatEntityValidation } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
@@ -18,6 +24,7 @@ export const validateFlatViewUpdate = ({
   optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
     flatViewMaps: optimisticFlatViewMaps,
     flatFieldMetadataMaps,
+    flatObjectMetadataMaps,
   },
 }: FlatEntityUpdateValidationArgs<
   typeof ALL_METADATA_NAME.view
@@ -49,6 +56,76 @@ export const validateFlatViewUpdate = ({
     ...existingFlatView,
     ...flatEntityUpdate,
   };
+
+  // Prevent duplicate resolved names on rename
+  if (
+    isDefined(flatEntityUpdate.name) &&
+    isDefined(updatedFlatView.name) &&
+    isDefined(flatObjectMetadataMaps)
+  ) {
+    const optimisticFlatObjectMetadata = findFlatEntityByUniversalIdentifier({
+      universalIdentifier: updatedFlatView.objectMetadataUniversalIdentifier,
+      flatEntityMaps: flatObjectMetadataMaps,
+    });
+
+    if (isDefined(optimisticFlatObjectMetadata)) {
+      const newResolvedName = interpolateMessagePlaceholders(
+        updatedFlatView.name,
+        buildObjectMetadataLabelPlaceholderValues({
+          labelSingular: optimisticFlatObjectMetadata.labelSingular,
+          labelPlural: optimisticFlatObjectMetadata.labelPlural,
+          icon: optimisticFlatObjectMetadata.icon,
+        }),
+      )
+        .trim()
+        .toLowerCase();
+
+      if (newResolvedName.length > 0) {
+        const hasDuplicateName =
+          optimisticFlatObjectMetadata.viewUniversalIdentifiers.some(
+            (viewUniversalIdentifier) => {
+              if (viewUniversalIdentifier === universalIdentifier) {
+                return false;
+              }
+
+              const existingView = findFlatEntityByUniversalIdentifier({
+                universalIdentifier: viewUniversalIdentifier,
+                flatEntityMaps: optimisticFlatViewMaps,
+              });
+
+              if (
+                !isDefined(existingView) ||
+                isDefined(existingView.deletedAt) ||
+                existingView.isActive === false
+              ) {
+                return false;
+              }
+
+              const existingResolvedName = interpolateMessagePlaceholders(
+                existingView.name,
+                buildObjectMetadataLabelPlaceholderValues({
+                  labelSingular: optimisticFlatObjectMetadata.labelSingular,
+                  labelPlural: optimisticFlatObjectMetadata.labelPlural,
+                  icon: optimisticFlatObjectMetadata.icon,
+                }),
+              )
+                .trim()
+                .toLowerCase();
+
+              return existingResolvedName === newResolvedName;
+            },
+          );
+
+        if (hasDuplicateName) {
+          validationResult.errors.push({
+            code: ViewExceptionCode.INVALID_VIEW_DATA,
+            message: t`A view with the name "${updatedFlatView.name}" already exists for this object`,
+            userFriendlyMessage: msg`A view with this name already exists`,
+          });
+        }
+      }
+    }
+  }
 
   const kanbanAggregateOperationFieldMetadataUniversalIdentifierUpdate =
     flatEntityUpdate.kanbanAggregateOperationFieldMetadataUniversalIdentifier;


### PR DESCRIPTION
﻿Fixes #25112

### Summary
Tasks page crashes with \TypeError: can't access property 'name', o is undefined\ after creating a custom view named \All tasks\ duplicating the system \All Tasks\ (\ViewKey.INDEX\). Deleting the duplicate leaves the page broken across browsers.

### Root cause
- \iewsSelector.ts:18\ only filtered \isActive\, not \deletedAt\. Soft-deleted custom views ( \deletedAt\ + \isActive:true\ via \romDeleteViewInput\) remained visible, so \MainContextStoreProvider.tsx:69/83\ kept a dangling \?viewId=\ / \lastVisitedView\ that no longer resolves. Downstream \iew.name\ derefs (minified \o.name\) crashed.
- No uniqueness check on resolved view display names. System stores \All {objectLabelPlural}\ while custom stores \All tasks\; both resolve to \All Tasks\ via \interpolateMessagePlaceholders\/\uildObjectMetadataLabelPlaceholderValues\ but \alidateFlatViewCreation\ only checked \universalIdentifier\/\key\.

### Fix
**Backend (defense):** \alidate-flat-view-creation.util.ts:98\ and \alidate-flat-view-update.util.ts:55\ — placeholder-aware, case-insensitive, trimmed duplicate check per \objectMetadataId\, excludes \deletedAt\/\!isActive\ and self on update. Returns \INVALID_VIEW_DATA / A view with this name already exists\.

**Frontend (resilience):** \iewsSelector.ts:14\ — filter \!deletedAt\ for views/fields/groups and \isDefined\ guards + \?? []\ fallbacks; \isDefined\ import (\	wenty-shared/utils\). Navigation/picker guards: \SidePanelNewSidebarItemSearchResults.tsx:105/235\, \SidePanelNewSidebarItemViewPickerSubView.tsx:44\, \ObjectOptionsDropdownMenuViewName.tsx:78\, \ViewPickerContentEffect.tsx:97\, \ViewPickerOptionDropdown.tsx:125\ use \?? ''\ and \isDefined\.

House rules: named exports, \	ype\ over \interface\, short \//\ why-comments, \	wenty-shared\ guards, no catalog churn, no AI trailer.

### Test plan
- Manual: create \All tasks\ on Tasks when \All Tasks\ exists → should be rejected with user-friendly error; existing duplicate workspaces fall back to INDEX via \getViewId()\.
- Existing suites still pass (no new infra): \alidateFlatViewCreation\ unit, \iewsSelector\ isActive/deletedAt filtering.
- TODO for reviewer: add \alidate-flat-view-creation.spec.ts\ covering placeholder vs literal duplicate.

### Workaround for 2.37.0 affected workspaces
\localStorage.clear()\ + remove \?viewId\, or DB: \DELETE FROM view WHERE name='All tasks' AND key IS NULL; UPDATE view SET \"deletedAt\"=NULL,\"isActive\"=true WHERE key='INDEX'\.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

