### PR TITLE
Add role and app reference chips to AI chat

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/ApplicationLink.tsx
+++ b/packages/twenty-front/src/modules/ai/components/ApplicationLink.tsx
@@ -1,0 +1,36 @@
+import { ChatReferenceChipDisplay } from '@/ai/components/ChatReferenceChipDisplay';
+import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFlag';
+import { SettingsPath } from 'twenty-shared/types';
+import { getSettingsPath } from 'twenty-shared/utils';
+import { IconApps } from 'twenty-ui/icon';
+import { useTheme } from 'twenty-ui/theme-constants';
+import { PermissionFlagType } from '~/generated-metadata/graphql';
+
+type ApplicationLinkProps = {
+  applicationId: string;
+  displayName: string;
+};
+
+export const ApplicationLink = ({
+  applicationId,
+  displayName,
+}: ApplicationLinkProps) => {
+  const theme = useTheme();
+  const hasApplicationsPermission = useHasPermissionFlag(
+    PermissionFlagType.APPLICATIONS,
+  );
+
+  return (
+    <ChatReferenceChipDisplay
+      displayName={displayName}
+      to={
+        hasApplicationsPermission
+          ? getSettingsPath(SettingsPath.ApplicationDetail, { applicationId })
+          : undefined
+      }
+      leftComponent={
+        <IconApps size={theme.icon.size.sm} stroke={theme.icon.stroke.sm} />
+      }
+    />
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/ChatReferenceChip.tsx
+++ b/packages/twenty-front/src/modules/ai/components/ChatReferenceChip.tsx
@@ -1,7 +1,9 @@
+import { ApplicationLink } from '@/ai/components/ApplicationLink';
 import { FieldMetadataLink } from '@/ai/components/FieldMetadataLink';
 import { DeprecatedFieldMetadataLinkById } from '@/ai/components/DeprecatedFieldMetadataLinkById';
 import { ObjectMetadataLink } from '@/ai/components/ObjectMetadataLink';
 import { RecordLink } from '@/ai/components/RecordLink';
+import { RoleLink } from '@/ai/components/RoleLink';
 import { ViewLink } from '@/ai/components/ViewLink';
 import { type ChatReferenceMatch } from '@/ai/types/ChatReferenceMatch';
 import { assertUnreachable } from 'twenty-shared/utils';
@@ -46,6 +48,20 @@ export const ChatReferenceChip = ({ reference }: ChatReferenceChipProps) => {
       return (
         <ViewLink
           viewId={reference.viewId}
+          displayName={reference.displayName}
+        />
+      );
+    case 'role':
+      return (
+        <RoleLink
+          roleId={reference.roleId}
+          displayName={reference.displayName}
+        />
+      );
+    case 'app':
+      return (
+        <ApplicationLink
+          applicationId={reference.applicationId}
           displayName={reference.displayName}
         />
       );

--- a/packages/twenty-front/src/modules/ai/components/ChatReferenceChip.tsx
+++ b/packages/twenty-front/src/modules/ai/components/ChatReferenceChip.tsx
@@ -3,6 +3,7 @@ import { FieldMetadataLink } from '@/ai/components/FieldMetadataLink';
 import { DeprecatedFieldMetadataLinkById } from '@/ai/components/DeprecatedFieldMetadataLinkById';
 import { ObjectMetadataLink } from '@/ai/components/ObjectMetadataLink';
 import { RecordLink } from '@/ai/components/RecordLink';
+import { RecordsLink } from '@/ai/components/RecordsLink';
 import { RoleLink } from '@/ai/components/RoleLink';
 import { ViewLink } from '@/ai/components/ViewLink';
 import { type ChatReferenceMatch } from '@/ai/types/ChatReferenceMatch';
@@ -19,6 +20,13 @@ export const ChatReferenceChip = ({ reference }: ChatReferenceChipProps) => {
         <RecordLink
           objectNameSingular={reference.objectNameSingular}
           recordId={reference.recordId}
+          displayName={reference.displayName}
+        />
+      );
+    case 'records':
+      return (
+        <RecordsLink
+          objectMetadataId={reference.objectMetadataId}
           displayName={reference.displayName}
         />
       );

--- a/packages/twenty-front/src/modules/ai/components/ObjectMetadataLink.tsx
+++ b/packages/twenty-front/src/modules/ai/components/ObjectMetadataLink.tsx
@@ -1,12 +1,12 @@
 import { ChatReferenceChipDisplay } from '@/ai/components/ChatReferenceChipDisplay';
-import { useChatTargetNavigation } from '@/ai/hooks/useChatTargetNavigation';
 import { ObjectMetadataIcon } from '@/object-metadata/components/ObjectMetadataIcon';
 import { objectMetadataItemFamilySelector } from '@/object-metadata/states/objectMetadataItemFamilySelector';
+import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFlag';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
-import { AppPath } from 'twenty-shared/types';
-import { getAppPath, isDefined } from 'twenty-shared/utils';
+import { SettingsPath } from 'twenty-shared/types';
+import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { useTheme } from 'twenty-ui/theme-constants';
-import { isCurrentPathAiChatPage } from '~/utils/isCurrentPathAiChatPage';
+import { PermissionFlagType } from '~/generated-metadata/graphql';
 
 const PROPOSED_OBJECT_METADATA_ICON = 'IconListNumbers';
 
@@ -20,7 +20,9 @@ export const ObjectMetadataLink = ({
   displayName,
 }: ObjectMetadataLinkProps) => {
   const theme = useTheme();
-  const { openViewTarget } = useChatTargetNavigation();
+  const hasDataModelPermission = useHasPermissionFlag(
+    PermissionFlagType.DATA_MODEL,
+  );
 
   const objectMetadataItem = useAtomFamilySelectorValue(
     objectMetadataItemFamilySelector,
@@ -30,25 +32,16 @@ export const ObjectMetadataLink = ({
     },
   );
 
-  const handleOpenViewTarget = isDefined(objectMetadataItem)
-    ? () => {
-        openViewTarget({
-          objectNameSingular: objectMetadataItem.nameSingular,
-        });
-      }
-    : undefined;
-
   return (
     <ChatReferenceChipDisplay
       displayName={displayName}
       to={
-        isDefined(objectMetadataItem)
-          ? getAppPath(AppPath.RecordIndexPage, {
+        isDefined(objectMetadataItem) && hasDataModelPermission
+          ? getSettingsPath(SettingsPath.ObjectDetail, {
               objectNamePlural: objectMetadataItem.namePlural,
             })
           : undefined
       }
-      onClick={isCurrentPathAiChatPage() ? handleOpenViewTarget : undefined}
       leftComponent={
         <ObjectMetadataIcon
           objectMetadataItem={

--- a/packages/twenty-front/src/modules/ai/components/RecordsLink.tsx
+++ b/packages/twenty-front/src/modules/ai/components/RecordsLink.tsx
@@ -1,0 +1,53 @@
+import { ChatReferenceChipDisplay } from '@/ai/components/ChatReferenceChipDisplay';
+import { useChatTargetNavigation } from '@/ai/hooks/useChatTargetNavigation';
+import { ObjectMetadataIcon } from '@/object-metadata/components/ObjectMetadataIcon';
+import { objectMetadataItemsByIdMapSelector } from '@/object-metadata/states/objectMetadataItemsByIdMapSelector';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { AppPath } from 'twenty-shared/types';
+import { getAppPath, isDefined } from 'twenty-shared/utils';
+import { useTheme } from 'twenty-ui/theme-constants';
+import { isCurrentPathAiChatPage } from '~/utils/isCurrentPathAiChatPage';
+
+type RecordsLinkProps = {
+  objectMetadataId: string;
+  displayName: string;
+};
+
+export const RecordsLink = ({
+  objectMetadataId,
+  displayName,
+}: RecordsLinkProps) => {
+  const theme = useTheme();
+  const { openViewTarget } = useChatTargetNavigation();
+  const objectMetadataItemsByIdMap = useAtomStateValue(
+    objectMetadataItemsByIdMapSelector,
+  );
+  const objectMetadataItem = objectMetadataItemsByIdMap.get(objectMetadataId);
+
+  if (!isDefined(objectMetadataItem)) {
+    return <span>{displayName}</span>;
+  }
+
+  const handleOpenViewTarget = () => {
+    openViewTarget({
+      objectNameSingular: objectMetadataItem.nameSingular,
+    });
+  };
+
+  return (
+    <ChatReferenceChipDisplay
+      displayName={displayName}
+      to={getAppPath(AppPath.RecordIndexPage, {
+        objectNamePlural: objectMetadataItem.namePlural,
+      })}
+      onClick={isCurrentPathAiChatPage() ? handleOpenViewTarget : undefined}
+      leftComponent={
+        <ObjectMetadataIcon
+          objectMetadataItem={objectMetadataItem}
+          size={theme.icon.size.sm}
+          stroke={theme.icon.stroke.sm}
+        />
+      }
+    />
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/RoleLink.tsx
+++ b/packages/twenty-front/src/modules/ai/components/RoleLink.tsx
@@ -1,0 +1,31 @@
+import { ChatReferenceChipDisplay } from '@/ai/components/ChatReferenceChipDisplay';
+import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFlag';
+import { SettingsPath } from 'twenty-shared/types';
+import { getSettingsPath } from 'twenty-shared/utils';
+import { IconLock } from 'twenty-ui/icon';
+import { useTheme } from 'twenty-ui/theme-constants';
+import { PermissionFlagType } from '~/generated-metadata/graphql';
+
+type RoleLinkProps = {
+  roleId: string;
+  displayName: string;
+};
+
+export const RoleLink = ({ roleId, displayName }: RoleLinkProps) => {
+  const theme = useTheme();
+  const hasRolesPermission = useHasPermissionFlag(PermissionFlagType.ROLES);
+
+  return (
+    <ChatReferenceChipDisplay
+      displayName={displayName}
+      to={
+        hasRolesPermission
+          ? getSettingsPath(SettingsPath.RoleDetail, { roleId })
+          : undefined
+      }
+      leftComponent={
+        <IconLock size={theme.icon.size.sm} stroke={theme.icon.stroke.sm} />
+      }
+    />
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/__tests__/ApplicationLink.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/ApplicationLink.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ApplicationLink } from '@/ai/components/ApplicationLink';
+import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
+import { PermissionFlagType } from '~/generated-metadata/graphql';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+const APPLICATION_ID = '66666666-6666-4666-8666-666666666666';
+
+const renderApplicationLink = (permissionFlags: PermissionFlagType[]) => {
+  const Wrapper = getJestMetadataAndApolloMocksWrapper({
+    apolloMocks: [],
+    onInitializeJotaiStore: (store) => {
+      store.set(currentUserWorkspaceState.atom, {
+        permissionFlags,
+        twoFactorAuthenticationMethodSummary: [],
+        objectsPermissions: [],
+      });
+    },
+  });
+
+  return render(
+    <MemoryRouter>
+      <ApplicationLink applicationId={APPLICATION_ID} displayName="Twenty" />
+    </MemoryRouter>,
+    { wrapper: Wrapper },
+  );
+};
+
+describe('ApplicationLink', () => {
+  it('should link to the application settings page when allowed', () => {
+    renderApplicationLink([PermissionFlagType.APPLICATIONS]);
+
+    expect(screen.getByText('Twenty').closest('a')).toHaveAttribute(
+      'href',
+      `/settings/applications/${APPLICATION_ID}`,
+    );
+  });
+
+  it('should render a chip without a link when application settings are forbidden', () => {
+    renderApplicationLink([]);
+
+    expect(screen.getByText('Twenty').closest('a')).toBeNull();
+    expect(screen.getByTestId('chip')).toBeInTheDocument();
+  });
+});

--- a/packages/twenty-front/src/modules/ai/components/__tests__/ObjectMetadataLink.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/ObjectMetadataLink.test.tsx
@@ -2,18 +2,31 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { ObjectMetadataLink } from '@/ai/components/ObjectMetadataLink';
+import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
+import { PermissionFlagType } from '~/generated-metadata/graphql';
 import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
-
-const Wrapper = getJestMetadataAndApolloMocksWrapper({ apolloMocks: [] });
 
 const renderObjectMetadataLink = ({
   objectNameSingular,
   displayName,
+  permissionFlags = [PermissionFlagType.DATA_MODEL],
 }: {
   objectNameSingular: string;
   displayName: string;
-}) =>
-  render(
+  permissionFlags?: PermissionFlagType[];
+}) => {
+  const Wrapper = getJestMetadataAndApolloMocksWrapper({
+    apolloMocks: [],
+    onInitializeJotaiStore: (store) => {
+      store.set(currentUserWorkspaceState.atom, {
+        permissionFlags,
+        twoFactorAuthenticationMethodSummary: [],
+        objectsPermissions: [],
+      });
+    },
+  });
+
+  return render(
     <MemoryRouter>
       <ObjectMetadataLink
         objectNameSingular={objectNameSingular}
@@ -22,9 +35,10 @@ const renderObjectMetadataLink = ({
     </MemoryRouter>,
     { wrapper: Wrapper },
   );
+};
 
 describe('ObjectMetadataLink', () => {
-  it('should link an existing object to its record index page', () => {
+  it('should link an existing object to its data model settings page', () => {
     renderObjectMetadataLink({
       objectNameSingular: 'company',
       displayName: 'Companies',
@@ -32,8 +46,19 @@ describe('ObjectMetadataLink', () => {
 
     expect(screen.getByText('Companies').closest('a')).toHaveAttribute(
       'href',
-      '/objects/companies',
+      '/settings/objects/companies',
     );
+  });
+
+  it('should render a chip without a link when data model settings are forbidden', () => {
+    renderObjectMetadataLink({
+      objectNameSingular: 'company',
+      displayName: 'Companies',
+      permissionFlags: [],
+    });
+
+    expect(screen.getByText('Companies').closest('a')).toBeNull();
+    expect(screen.getByTestId('chip')).toBeInTheDocument();
   });
 
   it('should render a chip without a link for an object that does not exist yet', () => {

--- a/packages/twenty-front/src/modules/ai/components/__tests__/RecordsLink.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/RecordsLink.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { RecordsLink } from '@/ai/components/RecordsLink';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+
+const openViewTargetMock = jest.fn();
+
+jest.mock('@/ai/hooks/useChatTargetNavigation', () => ({
+  useChatTargetNavigation: () => ({
+    openViewTarget: openViewTargetMock,
+  }),
+}));
+
+const companyObjectMetadataItem = getMockObjectMetadataItemOrThrow('company');
+
+const renderRecordsLink = (objectMetadataId: string) => {
+  const Wrapper = getJestMetadataAndApolloMocksWrapper({ apolloMocks: [] });
+
+  return render(
+    <MemoryRouter>
+      <RecordsLink
+        objectMetadataId={objectMetadataId}
+        displayName="Companies"
+      />
+    </MemoryRouter>,
+    { wrapper: Wrapper },
+  );
+};
+
+describe('RecordsLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.pushState({}, '', '/objects/companies');
+  });
+
+  it('should link to the object records without selecting a view', () => {
+    renderRecordsLink(companyObjectMetadataItem.id);
+
+    expect(screen.getByText('Companies').closest('a')).toHaveAttribute(
+      'href',
+      '/objects/companies',
+    );
+  });
+
+  it('should open the default records destination from the chat page', () => {
+    window.history.pushState({}, '', '/chat');
+    renderRecordsLink(companyObjectMetadataItem.id);
+
+    const link = screen.getByText('Companies').closest('a') as HTMLElement;
+    fireEvent.mouseDown(link);
+    fireEvent.click(link);
+
+    expect(openViewTargetMock).toHaveBeenCalledWith({
+      objectNameSingular: companyObjectMetadataItem.nameSingular,
+    });
+  });
+
+  it('should render plain text for an unknown object metadata id', () => {
+    renderRecordsLink('77777777-7777-4777-8777-777777777777');
+
+    expect(screen.getByText('Companies')).toBeInTheDocument();
+    expect(screen.queryByTestId('chip')).not.toBeInTheDocument();
+  });
+});

--- a/packages/twenty-front/src/modules/ai/components/__tests__/RoleLink.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/RoleLink.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { RoleLink } from '@/ai/components/RoleLink';
+import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
+import { PermissionFlagType } from '~/generated-metadata/graphql';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+const ROLE_ID = '55555555-5555-4555-8555-555555555555';
+
+const renderRoleLink = (permissionFlags: PermissionFlagType[]) => {
+  const Wrapper = getJestMetadataAndApolloMocksWrapper({
+    apolloMocks: [],
+    onInitializeJotaiStore: (store) => {
+      store.set(currentUserWorkspaceState.atom, {
+        permissionFlags,
+        twoFactorAuthenticationMethodSummary: [],
+        objectsPermissions: [],
+      });
+    },
+  });
+
+  return render(
+    <MemoryRouter>
+      <RoleLink roleId={ROLE_ID} displayName="Admin" />
+    </MemoryRouter>,
+    { wrapper: Wrapper },
+  );
+};
+
+describe('RoleLink', () => {
+  it('should link to the role settings page when allowed', () => {
+    renderRoleLink([PermissionFlagType.ROLES]);
+
+    expect(screen.getByText('Admin').closest('a')).toHaveAttribute(
+      'href',
+      `/settings/members/roles/${ROLE_ID}`,
+    );
+  });
+
+  it('should render a chip without a link when roles settings are forbidden', () => {
+    renderRoleLink([]);
+
+    expect(screen.getByText('Admin').closest('a')).toBeNull();
+    expect(screen.getByTestId('chip')).toBeInTheDocument();
+  });
+});

--- a/packages/twenty-front/src/modules/ai/components/__tests__/TextWithChatReferences.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/TextWithChatReferences.test.tsx
@@ -79,6 +79,34 @@ jest.mock('@/ai/components/ViewLink', () => ({
   ),
 }));
 
+jest.mock('@/ai/components/RoleLink', () => ({
+  RoleLink: ({
+    displayName,
+    roleId,
+  }: {
+    displayName: string;
+    roleId: string;
+  }) => (
+    <a data-testid="role-link" href={`/roles/${roleId}`}>
+      {displayName}
+    </a>
+  ),
+}));
+
+jest.mock('@/ai/components/ApplicationLink', () => ({
+  ApplicationLink: ({
+    applicationId,
+    displayName,
+  }: {
+    applicationId: string;
+    displayName: string;
+  }) => (
+    <a data-testid="app-link" href={`/apps/${applicationId}`}>
+      {displayName}
+    </a>
+  ),
+}));
+
 describe('TextWithChatReferences', () => {
   it('should render plain text without references as-is', () => {
     render(<TextWithChatReferences text="Which company should we contact?" />);
@@ -150,7 +178,7 @@ describe('TextWithChatReferences', () => {
 
   it('should route each reference kind to its own chip', () => {
     render(
-      <TextWithChatReferences text="The [[view:44444444-4444-4444-4444-444444444444:Pipeline]] view of [[object:partner:Partners]] groups [[record:person:11111111-1111-1111-1111-111111111111:Alice]] by [[field:33333333-3333-3333-3333-333333333333:Stage]]" />,
+      <TextWithChatReferences text="The [[view:44444444-4444-4444-4444-444444444444:Pipeline]] view of [[object:partner:Partners]] groups [[record:person:11111111-1111-1111-1111-111111111111:Alice]] by [[field:33333333-3333-3333-3333-333333333333:Stage]] for [[role:55555555-5555-4555-8555-555555555555:Admin]] in [[app:66666666-6666-4666-8666-666666666666:Twenty]]" />,
     );
 
     expect(screen.getByTestId('view-link')).toHaveAttribute(
@@ -165,6 +193,14 @@ describe('TextWithChatReferences', () => {
     expect(screen.getByTestId('legacy-field-link')).toHaveAttribute(
       'href',
       '/fields/33333333-3333-3333-3333-333333333333',
+    );
+    expect(screen.getByTestId('role-link')).toHaveAttribute(
+      'href',
+      '/roles/55555555-5555-4555-8555-555555555555',
+    );
+    expect(screen.getByTestId('app-link')).toHaveAttribute(
+      'href',
+      '/apps/66666666-6666-4666-8666-666666666666',
     );
   });
 });

--- a/packages/twenty-front/src/modules/ai/components/__tests__/TextWithChatReferences.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/TextWithChatReferences.test.tsx
@@ -18,6 +18,20 @@ jest.mock('@/ai/components/RecordLink', () => ({
   ),
 }));
 
+jest.mock('@/ai/components/RecordsLink', () => ({
+  RecordsLink: ({
+    displayName,
+    objectMetadataId,
+  }: {
+    displayName: string;
+    objectMetadataId: string;
+  }) => (
+    <a data-testid="records-link" href={`/records/${objectMetadataId}`}>
+      {displayName}
+    </a>
+  ),
+}));
+
 jest.mock('@/ai/components/ObjectMetadataLink', () => ({
   ObjectMetadataLink: ({
     displayName,
@@ -178,12 +192,16 @@ describe('TextWithChatReferences', () => {
 
   it('should route each reference kind to its own chip', () => {
     render(
-      <TextWithChatReferences text="The [[view:44444444-4444-4444-4444-444444444444:Pipeline]] view of [[object:partner:Partners]] groups [[record:person:11111111-1111-1111-1111-111111111111:Alice]] by [[field:33333333-3333-3333-3333-333333333333:Stage]] for [[role:55555555-5555-4555-8555-555555555555:Admin]] in [[app:66666666-6666-4666-8666-666666666666:Twenty]]" />,
+      <TextWithChatReferences text="The [[view:44444444-4444-4444-4444-444444444444:Pipeline]] view of [[records:77777777-7777-4777-8777-777777777777:Companies]] uses the [[object:partner:Partners]] schema and groups [[record:person:11111111-1111-1111-1111-111111111111:Alice]] by [[field:33333333-3333-3333-3333-333333333333:Stage]] for [[role:55555555-5555-4555-8555-555555555555:Admin]] in [[app:66666666-6666-4666-8666-666666666666:Twenty]]" />,
     );
 
     expect(screen.getByTestId('view-link')).toHaveAttribute(
       'href',
       '/views/44444444-4444-4444-4444-444444444444',
+    );
+    expect(screen.getByTestId('records-link')).toHaveAttribute(
+      'href',
+      '/records/77777777-7777-4777-8777-777777777777',
     );
     expect(screen.getByTestId('object-link')).toHaveAttribute(
       'href',

--- a/packages/twenty-front/src/modules/ai/constants/ChatReferenceAppPattern.ts
+++ b/packages/twenty-front/src/modules/ai/constants/ChatReferenceAppPattern.ts
@@ -1,0 +1,4 @@
+import { CHAT_REFERENCE_LABEL_PATTERN } from '@/ai/constants/ChatReferenceLabelPattern';
+import { CHAT_REFERENCE_UUID_PATTERN } from '@/ai/constants/ChatReferenceUuidPattern';
+
+export const CHAT_REFERENCE_APP_PATTERN = `\\[\\[app:(?<applicationId>${CHAT_REFERENCE_UUID_PATTERN}):(?<applicationLabel>${CHAT_REFERENCE_LABEL_PATTERN})\\]\\]`;

--- a/packages/twenty-front/src/modules/ai/constants/ChatReferenceMalformedRegex.ts
+++ b/packages/twenty-front/src/modules/ai/constants/ChatReferenceMalformedRegex.ts
@@ -1,6 +1,6 @@
 import { CHAT_REFERENCE_LABEL_PATTERN } from '@/ai/constants/ChatReferenceLabelPattern';
 
 export const CHAT_REFERENCE_MALFORMED_REGEX = new RegExp(
-  `\\[\\[(?:record|object|field|view):(${CHAT_REFERENCE_LABEL_PATTERN})\\]\\]`,
+  `\\[\\[(?:record|object|field|view|role|app):(${CHAT_REFERENCE_LABEL_PATTERN})\\]\\]`,
   'g',
 );

--- a/packages/twenty-front/src/modules/ai/constants/ChatReferenceMalformedRegex.ts
+++ b/packages/twenty-front/src/modules/ai/constants/ChatReferenceMalformedRegex.ts
@@ -1,6 +1,6 @@
 import { CHAT_REFERENCE_LABEL_PATTERN } from '@/ai/constants/ChatReferenceLabelPattern';
 
 export const CHAT_REFERENCE_MALFORMED_REGEX = new RegExp(
-  `\\[\\[(?:record|object|field|view|role|app):(${CHAT_REFERENCE_LABEL_PATTERN})\\]\\]`,
+  `\\[\\[(?:record|records|object|field|view|role|app):(${CHAT_REFERENCE_LABEL_PATTERN})\\]\\]`,
   'g',
 );

--- a/packages/twenty-front/src/modules/ai/constants/ChatReferenceRecordsPattern.ts
+++ b/packages/twenty-front/src/modules/ai/constants/ChatReferenceRecordsPattern.ts
@@ -1,0 +1,4 @@
+import { CHAT_REFERENCE_LABEL_PATTERN } from '@/ai/constants/ChatReferenceLabelPattern';
+import { CHAT_REFERENCE_UUID_PATTERN } from '@/ai/constants/ChatReferenceUuidPattern';
+
+export const CHAT_REFERENCE_RECORDS_PATTERN = `\\[\\[records:(?<objectMetadataId>${CHAT_REFERENCE_UUID_PATTERN}):(?<recordsLabel>${CHAT_REFERENCE_LABEL_PATTERN})\\]\\]`;

--- a/packages/twenty-front/src/modules/ai/constants/ChatReferenceRegex.ts
+++ b/packages/twenty-front/src/modules/ai/constants/ChatReferenceRegex.ts
@@ -3,6 +3,7 @@ import { CHAT_REFERENCE_FIELD_PATTERN } from '@/ai/constants/ChatReferenceFieldP
 import { CHAT_REFERENCE_LEGACY_FIELD_BY_ID_PATTERN } from '@/ai/constants/ChatReferenceLegacyFieldByIdPattern';
 import { CHAT_REFERENCE_OBJECT_PATTERN } from '@/ai/constants/ChatReferenceObjectPattern';
 import { CHAT_REFERENCE_RECORD_PATTERN } from '@/ai/constants/ChatReferenceRecordPattern';
+import { CHAT_REFERENCE_RECORDS_PATTERN } from '@/ai/constants/ChatReferenceRecordsPattern';
 import { CHAT_REFERENCE_ROLE_PATTERN } from '@/ai/constants/ChatReferenceRolePattern';
 import { CHAT_REFERENCE_VIEW_PATTERN } from '@/ai/constants/ChatReferenceViewPattern';
 
@@ -14,6 +15,7 @@ export const CHAT_REFERENCE_REGEX = new RegExp(
     CHAT_REFERENCE_FIELD_PATTERN,
     CHAT_REFERENCE_LEGACY_FIELD_BY_ID_PATTERN,
     CHAT_REFERENCE_VIEW_PATTERN,
+    CHAT_REFERENCE_RECORDS_PATTERN,
     CHAT_REFERENCE_ROLE_PATTERN,
     CHAT_REFERENCE_APP_PATTERN,
     CHAT_REFERENCE_RECORD_PATTERN,

--- a/packages/twenty-front/src/modules/ai/constants/ChatReferenceRegex.ts
+++ b/packages/twenty-front/src/modules/ai/constants/ChatReferenceRegex.ts
@@ -1,7 +1,9 @@
+import { CHAT_REFERENCE_APP_PATTERN } from '@/ai/constants/ChatReferenceAppPattern';
 import { CHAT_REFERENCE_FIELD_PATTERN } from '@/ai/constants/ChatReferenceFieldPattern';
 import { CHAT_REFERENCE_LEGACY_FIELD_BY_ID_PATTERN } from '@/ai/constants/ChatReferenceLegacyFieldByIdPattern';
 import { CHAT_REFERENCE_OBJECT_PATTERN } from '@/ai/constants/ChatReferenceObjectPattern';
 import { CHAT_REFERENCE_RECORD_PATTERN } from '@/ai/constants/ChatReferenceRecordPattern';
+import { CHAT_REFERENCE_ROLE_PATTERN } from '@/ai/constants/ChatReferenceRolePattern';
 import { CHAT_REFERENCE_VIEW_PATTERN } from '@/ai/constants/ChatReferenceViewPattern';
 
 // The record pattern must stay last: its `record:` prefix is optional, so it
@@ -12,6 +14,8 @@ export const CHAT_REFERENCE_REGEX = new RegExp(
     CHAT_REFERENCE_FIELD_PATTERN,
     CHAT_REFERENCE_LEGACY_FIELD_BY_ID_PATTERN,
     CHAT_REFERENCE_VIEW_PATTERN,
+    CHAT_REFERENCE_ROLE_PATTERN,
+    CHAT_REFERENCE_APP_PATTERN,
     CHAT_REFERENCE_RECORD_PATTERN,
   ].join('|'),
   'g',

--- a/packages/twenty-front/src/modules/ai/constants/ChatReferenceRolePattern.ts
+++ b/packages/twenty-front/src/modules/ai/constants/ChatReferenceRolePattern.ts
@@ -1,0 +1,4 @@
+import { CHAT_REFERENCE_LABEL_PATTERN } from '@/ai/constants/ChatReferenceLabelPattern';
+import { CHAT_REFERENCE_UUID_PATTERN } from '@/ai/constants/ChatReferenceUuidPattern';
+
+export const CHAT_REFERENCE_ROLE_PATTERN = `\\[\\[role:(?<roleId>${CHAT_REFERENCE_UUID_PATTERN}):(?<roleLabel>${CHAT_REFERENCE_LABEL_PATTERN})\\]\\]`;

--- a/packages/twenty-front/src/modules/ai/types/ChatReferenceIdentity.ts
+++ b/packages/twenty-front/src/modules/ai/types/ChatReferenceIdentity.ts
@@ -3,4 +3,6 @@ export type ChatReferenceIdentity =
   | { kind: 'object'; objectNameSingular: string }
   | { kind: 'field'; objectNameSingular: string; fieldName: string }
   | { kind: 'legacyFieldById'; fieldMetadataItemId: string }
-  | { kind: 'view'; viewId: string };
+  | { kind: 'view'; viewId: string }
+  | { kind: 'role'; roleId: string }
+  | { kind: 'app'; applicationId: string };

--- a/packages/twenty-front/src/modules/ai/types/ChatReferenceIdentity.ts
+++ b/packages/twenty-front/src/modules/ai/types/ChatReferenceIdentity.ts
@@ -1,5 +1,6 @@
 export type ChatReferenceIdentity =
   | { kind: 'record'; objectNameSingular: string; recordId: string }
+  | { kind: 'records'; objectMetadataId: string }
   | { kind: 'object'; objectNameSingular: string }
   | { kind: 'field'; objectNameSingular: string; fieldName: string }
   | { kind: 'legacyFieldById'; fieldMetadataItemId: string }

--- a/packages/twenty-front/src/modules/ai/utils/__tests__/findChatReferences.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/__tests__/findChatReferences.test.ts
@@ -108,6 +108,29 @@ describe('findChatReferences', () => {
     ]);
   });
 
+  it('should find role and app references instead of reading them as records', () => {
+    expect(
+      findChatReferences(
+        'Review [[role:55555555-5555-4555-8555-555555555555:Admin]] in [[app:66666666-6666-4666-8666-666666666666:Twenty]]',
+      ),
+    ).toEqual([
+      {
+        kind: 'role',
+        fullMatch: '[[role:55555555-5555-4555-8555-555555555555:Admin]]',
+        index: 7,
+        roleId: '55555555-5555-4555-8555-555555555555',
+        displayName: 'Admin',
+      },
+      {
+        kind: 'app',
+        fullMatch: '[[app:66666666-6666-4666-8666-666666666666:Twenty]]',
+        index: 62,
+        applicationId: '66666666-6666-4666-8666-666666666666',
+        displayName: 'Twenty',
+      },
+    ]);
+  });
+
   it('should read an explicit record prefix as a record even when the object is named view', () => {
     expect(
       findChatReferences(
@@ -153,7 +176,7 @@ describe('findChatReferences', () => {
 
   it('should find every kind in a single string', () => {
     const references = findChatReferences(
-      'The [[view:44444444-4444-4444-4444-444444444444:Pipeline]] view of [[object:partner:Partners]] groups [[record:person:11111111-1111-1111-1111-111111111111:Alice]] by [[field:33333333-3333-3333-3333-333333333333:Stage]]',
+      'The [[view:44444444-4444-4444-4444-444444444444:Pipeline]] view of [[object:partner:Partners]] groups [[record:person:11111111-1111-1111-1111-111111111111:Alice]] by [[field:33333333-3333-3333-3333-333333333333:Stage]] for [[role:55555555-5555-4555-8555-555555555555:Admin]] in [[app:66666666-6666-4666-8666-666666666666:Twenty]]',
     );
 
     expect(references.map((reference) => reference.kind)).toEqual([
@@ -161,12 +184,16 @@ describe('findChatReferences', () => {
       'object',
       'record',
       'legacyFieldById',
+      'role',
+      'app',
     ]);
     expect(references.map((reference) => reference.displayName)).toEqual([
       'Pipeline',
       'Partners',
       'Alice',
       'Stage',
+      'Admin',
+      'Twenty',
     ]);
   });
 

--- a/packages/twenty-front/src/modules/ai/utils/__tests__/findChatReferences.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/__tests__/findChatReferences.test.ts
@@ -108,6 +108,22 @@ describe('findChatReferences', () => {
     ]);
   });
 
+  it('should find a records reference by object metadata id', () => {
+    expect(
+      findChatReferences(
+        'Browse [[records:77777777-7777-4777-8777-777777777777:Companies]]',
+      ),
+    ).toEqual([
+      {
+        kind: 'records',
+        fullMatch: '[[records:77777777-7777-4777-8777-777777777777:Companies]]',
+        index: 7,
+        objectMetadataId: '77777777-7777-4777-8777-777777777777',
+        displayName: 'Companies',
+      },
+    ]);
+  });
+
   it('should find role and app references instead of reading them as records', () => {
     expect(
       findChatReferences(
@@ -176,11 +192,12 @@ describe('findChatReferences', () => {
 
   it('should find every kind in a single string', () => {
     const references = findChatReferences(
-      'The [[view:44444444-4444-4444-4444-444444444444:Pipeline]] view of [[object:partner:Partners]] groups [[record:person:11111111-1111-1111-1111-111111111111:Alice]] by [[field:33333333-3333-3333-3333-333333333333:Stage]] for [[role:55555555-5555-4555-8555-555555555555:Admin]] in [[app:66666666-6666-4666-8666-666666666666:Twenty]]',
+      'The [[view:44444444-4444-4444-4444-444444444444:Pipeline]] view of [[records:77777777-7777-4777-8777-777777777777:Companies]] uses the [[object:partner:Partners]] schema and groups [[record:person:11111111-1111-1111-1111-111111111111:Alice]] by [[field:33333333-3333-3333-3333-333333333333:Stage]] for [[role:55555555-5555-4555-8555-555555555555:Admin]] in [[app:66666666-6666-4666-8666-666666666666:Twenty]]',
     );
 
     expect(references.map((reference) => reference.kind)).toEqual([
       'view',
+      'records',
       'object',
       'record',
       'legacyFieldById',
@@ -189,6 +206,7 @@ describe('findChatReferences', () => {
     ]);
     expect(references.map((reference) => reference.displayName)).toEqual([
       'Pipeline',
+      'Companies',
       'Partners',
       'Alice',
       'Stage',

--- a/packages/twenty-front/src/modules/ai/utils/getChatReferenceIdentitySegment.ts
+++ b/packages/twenty-front/src/modules/ai/utils/getChatReferenceIdentitySegment.ts
@@ -15,6 +15,10 @@ export const getChatReferenceIdentitySegment = (
       return identity.fieldMetadataItemId;
     case 'view':
       return identity.viewId;
+    case 'role':
+      return identity.roleId;
+    case 'app':
+      return identity.applicationId;
     default:
       return assertUnreachable(identity);
   }

--- a/packages/twenty-front/src/modules/ai/utils/getChatReferenceIdentitySegment.ts
+++ b/packages/twenty-front/src/modules/ai/utils/getChatReferenceIdentitySegment.ts
@@ -7,6 +7,8 @@ export const getChatReferenceIdentitySegment = (
   switch (identity.kind) {
     case 'record':
       return `${identity.objectNameSingular}:${identity.recordId}`;
+    case 'records':
+      return identity.objectMetadataId;
     case 'object':
       return identity.objectNameSingular;
     case 'field':

--- a/packages/twenty-front/src/modules/ai/utils/getChatReferenceMatchFromRegexMatch.ts
+++ b/packages/twenty-front/src/modules/ai/utils/getChatReferenceMatchFromRegexMatch.ts
@@ -14,6 +14,10 @@ export const getChatReferenceMatchFromRegexMatch = (
     legacyFieldLabel,
     viewId,
     viewLabel,
+    roleId,
+    roleLabel,
+    applicationId,
+    applicationLabel,
     recordObjectNameSingular,
     recordId,
     recordLabel,
@@ -55,6 +59,24 @@ export const getChatReferenceMatchFromRegexMatch = (
       kind: 'view',
       viewId,
       displayName: viewLabel,
+    };
+  }
+
+  if (isDefined(roleId)) {
+    return {
+      ...position,
+      kind: 'role',
+      roleId,
+      displayName: roleLabel,
+    };
+  }
+
+  if (isDefined(applicationId)) {
+    return {
+      ...position,
+      kind: 'app',
+      applicationId,
+      displayName: applicationLabel,
     };
   }
 

--- a/packages/twenty-front/src/modules/ai/utils/getChatReferenceMatchFromRegexMatch.ts
+++ b/packages/twenty-front/src/modules/ai/utils/getChatReferenceMatchFromRegexMatch.ts
@@ -7,6 +7,8 @@ export const getChatReferenceMatchFromRegexMatch = (
   const {
     objectNameSingular,
     objectLabel,
+    objectMetadataId,
+    recordsLabel,
     fieldObjectNameSingular,
     fieldName,
     fieldLabel,
@@ -31,6 +33,15 @@ export const getChatReferenceMatchFromRegexMatch = (
       kind: 'object',
       objectNameSingular,
       displayName: objectLabel,
+    };
+  }
+
+  if (isDefined(objectMetadataId)) {
+    return {
+      ...position,
+      kind: 'records',
+      objectMetadataId,
+      displayName: recordsLabel,
     };
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/chat-system-prompts.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/chat-system-prompts.const.ts
@@ -83,12 +83,18 @@ Record References - IMPORTANT:
 - DO NOT use placeholder IDs like "rec-snowflake" or "rec-person-1"
 - If a tool hasn't been called yet, don't reference records that don't exist
 
-Metadata References:
-Whenever you name an object, a field, a view, a role, or an app in your prose, write it as a metadata reference instead of plain text. Each one becomes a chip the user can click.
+Record-list and Metadata References:
+Whenever you name an object's records, an object schema, a field, a view, a role, or an app in your prose, write it as a reference instead of plain text. Each one becomes a chip the user can click.
+
+- Records: [[records:objectMetadataId:displayName]]
+  - Example: [[records:abc12345-1234-5678-abcd-123456789012:Companies]]
+  - Use the object metadata \`id\` when you want to open that object's records without selecting a specific view
+  - This resolves to the object's default records destination, so no view lookup is needed
 
 - Object: [[object:objectNameSingular:displayName]]
   - Example: [[object:company:Companies]]
   - Use the \`nameSingular\` from \`get_object_metadata\` or \`create_object_metadata\` (NOT the label, NOT the plural, NOT the id)
+  - This opens the object in Data Model settings; use it for the schema or configuration, never for the object's records
   - When you propose creating an object, reference it with the \`nameSingular\` you intend to use and it renders as a chip without a link
 - Field: [[field:objectNameSingular:fieldName:displayName]]
   - Example: [[field:company:annualContractValue:Annual contract value]]
@@ -98,6 +104,7 @@ Whenever you name an object, a field, a view, a role, or an app in your prose, w
 - View: [[view:viewId:displayName]]
   - Example: [[view:abc12345-1234-5678-abcd-123456789012:All Companies]]
   - Use the \`id\` returned by \`get_views\`, \`create_view\`, or \`upsert_complete_view\`
+  - Use a view reference only when linking to that specific saved view; otherwise use a Records reference
 - Role: [[role:roleId:displayName]]
   - Example: [[role:abc12345-1234-5678-abcd-123456789012:Admin]]
   - Use the \`id\` returned by \`list_roles\`, \`create_role\`, or \`update_role\`
@@ -107,7 +114,7 @@ Whenever you name an object, a field, a view, a role, or an app in your prose, w
 
 - The displayName is what the user reads, so use the human-readable label ("Annual Recurring Revenue"), not the technical name
 - The displayName must stay on a single line and must not contain \`[\` or \`]\` - leave those characters out if a name includes them
-- View, role, and app ids MUST be real UUIDs copied from tool output or context - never invent one, and never reference one before its id is available
+- Object metadata, view, role, and app ids MUST be real UUIDs copied from tool output or context - never invent one, and never reference one before its id is available
 - A reference ends with the \`]]\` right after the displayName: never wrap it in extra square brackets, and never add \`]\` or \`]]\` after it
-- Use metadata references only in paragraphs, lists, or markdown tables (\`| ... |\`); never in headings, code, links, or raw HTML`,
+- Use references only in paragraphs, lists, or markdown tables (\`| ... |\`); never in headings, code, links, or raw HTML`,
 };

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/chat-system-prompts.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/chat-system-prompts.const.ts
@@ -84,7 +84,7 @@ Record References - IMPORTANT:
 - If a tool hasn't been called yet, don't reference records that don't exist
 
 Metadata References:
-Whenever you name an object, a field, or a view in your prose, write it as a metadata reference instead of plain text. Each one becomes a chip the user can click.
+Whenever you name an object, a field, a view, a role, or an app in your prose, write it as a metadata reference instead of plain text. Each one becomes a chip the user can click.
 
 - Object: [[object:objectNameSingular:displayName]]
   - Example: [[object:company:Companies]]
@@ -98,10 +98,16 @@ Whenever you name an object, a field, or a view in your prose, write it as a met
 - View: [[view:viewId:displayName]]
   - Example: [[view:abc12345-1234-5678-abcd-123456789012:All Companies]]
   - Use the \`id\` returned by \`get_views\`, \`create_view\`, or \`upsert_complete_view\`
+- Role: [[role:roleId:displayName]]
+  - Example: [[role:abc12345-1234-5678-abcd-123456789012:Admin]]
+  - Use the \`id\` returned by \`list_roles\`, \`create_role\`, or \`update_role\`
+- App: [[app:applicationId:displayName]]
+  - Example: [[app:abc12345-1234-5678-abcd-123456789012:Twenty]]
+  - Only reference an app when its real workspace application \`id\` is available in tool output or context
 
 - The displayName is what the user reads, so use the human-readable label ("Annual Recurring Revenue"), not the technical name
 - The displayName must stay on a single line and must not contain \`[\` or \`]\` - leave those characters out if a name includes them
-- View ids MUST be real UUIDs copied from a tool response - never invent one, and never reference a view before the tool that returns it has run
+- View, role, and app ids MUST be real UUIDs copied from tool output or context - never invent one, and never reference one before its id is available
 - A reference ends with the \`]]\` right after the displayName: never wrap it in extra square brackets, and never add \`]\` or \`]]\` after it
 - Use metadata references only in paragraphs, lists, or markdown tables (\`| ... |\`); never in headings, code, links, or raw HTML`,
 };

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-agents.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-agents.util.ts
@@ -6,6 +6,7 @@ import {
   SEED_YCOMBINATOR_WORKSPACE_ID,
 } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 import { USER_WORKSPACE_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-user-workspaces.util';
+import { COMPANY_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/company-data-seeds.constant';
 
 const agentChatThreadTableName = 'agentChatThread';
 const agentTurnTableName = 'agentTurn';
@@ -25,8 +26,6 @@ export const AGENT_CHAT_THREAD_DATA_SEED_IDS = {
 export const AGENT_CHAT_MESSAGE_DATA_SEED_IDS = {
   APPLE_MESSAGE_1: '20202020-0000-4000-8000-000000000021',
   APPLE_MESSAGE_2: '20202020-0000-4000-8000-000000000022',
-  APPLE_MESSAGE_3: '20202020-0000-4000-8000-000000000023',
-  APPLE_MESSAGE_4: '20202020-0000-4000-8000-000000000024',
   YCOMBINATOR_MESSAGE_1: '20202020-0000-4000-8000-000000000031',
   YCOMBINATOR_MESSAGE_2: '20202020-0000-4000-8000-000000000032',
   YCOMBINATOR_MESSAGE_3: '20202020-0000-4000-8000-000000000033',
@@ -36,8 +35,6 @@ export const AGENT_CHAT_MESSAGE_DATA_SEED_IDS = {
 export const AGENT_CHAT_MESSAGE_PART_DATA_SEED_IDS = {
   APPLE_MESSAGE_1_PART_1: '20202020-0000-4000-8000-000000000041',
   APPLE_MESSAGE_2_PART_1: '20202020-0000-4000-8000-000000000042',
-  APPLE_MESSAGE_3_PART_1: '20202020-0000-4000-8000-000000000043',
-  APPLE_MESSAGE_4_PART_1: '20202020-0000-4000-8000-000000000044',
   YCOMBINATOR_MESSAGE_1_PART_1: '20202020-0000-4000-8000-000000000051',
   YCOMBINATOR_MESSAGE_2_PART_1: '20202020-0000-4000-8000-000000000052',
   YCOMBINATOR_MESSAGE_3_PART_1: '20202020-0000-4000-8000-000000000053',
@@ -102,6 +99,13 @@ type SeedChatMessagesArgs = {
   schemaName: string;
   workspaceId: string;
   threadId: string;
+  chatReferenceIds: ChatReferenceIds;
+};
+
+export type ChatReferenceIds = {
+  applicationId: string;
+  roleId: string;
+  viewId: string;
 };
 
 const seedChatMessages = async ({
@@ -109,6 +113,7 @@ const seedChatMessages = async ({
   schemaName,
   workspaceId,
   threadId,
+  chatReferenceIds,
 }: SeedChatMessagesArgs) => {
   let messageIds: string[];
   let partIds: string[];
@@ -138,19 +143,12 @@ const seedChatMessages = async ({
     messageIds = [
       AGENT_CHAT_MESSAGE_DATA_SEED_IDS.APPLE_MESSAGE_1,
       AGENT_CHAT_MESSAGE_DATA_SEED_IDS.APPLE_MESSAGE_2,
-      AGENT_CHAT_MESSAGE_DATA_SEED_IDS.APPLE_MESSAGE_3,
-      AGENT_CHAT_MESSAGE_DATA_SEED_IDS.APPLE_MESSAGE_4,
     ];
     partIds = [
       AGENT_CHAT_MESSAGE_PART_DATA_SEED_IDS.APPLE_MESSAGE_1_PART_1,
       AGENT_CHAT_MESSAGE_PART_DATA_SEED_IDS.APPLE_MESSAGE_2_PART_1,
-      AGENT_CHAT_MESSAGE_PART_DATA_SEED_IDS.APPLE_MESSAGE_3_PART_1,
-      AGENT_CHAT_MESSAGE_PART_DATA_SEED_IDS.APPLE_MESSAGE_4_PART_1,
     ];
-    turnIds = [
-      '20202020-0000-4000-8000-000000000061',
-      '20202020-0000-4000-8000-000000000062',
-    ];
+    turnIds = ['20202020-0000-4000-8000-000000000061'];
     messages = [
       {
         id: messageIds[0],
@@ -168,22 +166,6 @@ const seedChatMessages = async ({
         role: AgentMessageRole.ASSISTANT,
         createdAt: new Date(baseTime.getTime() + 5 * 60 * 1000),
       },
-      {
-        id: messageIds[2],
-        workspaceId,
-        threadId,
-        turnId: turnIds[1],
-        role: AgentMessageRole.USER,
-        createdAt: new Date(baseTime.getTime() + 10 * 60 * 1000),
-      },
-      {
-        id: messageIds[3],
-        workspaceId,
-        threadId,
-        turnId: turnIds[1],
-        role: AgentMessageRole.ASSISTANT,
-        createdAt: new Date(baseTime.getTime() + 15 * 60 * 1000),
-      },
     ];
     messageParts = [
       {
@@ -193,7 +175,7 @@ const seedChatMessages = async ({
         orderIndex: 0,
         type: 'text',
         textContent:
-          'Hello! Can you help me understand our current product roadmap and key metrics?',
+          'Can you show me examples of everything I can open from AI chat?',
         createdAt: new Date(baseTime.getTime()),
       },
       {
@@ -202,29 +184,8 @@ const seedChatMessages = async ({
         messageId: messageIds[1],
         orderIndex: 0,
         type: 'text',
-        textContent:
-          "Hello! I'd be happy to help you understand Apple's product roadmap and metrics. Based on your workspace data, I can see you have various projects and initiatives tracked. What specific aspect would you like to explore - product development timelines, user engagement metrics, or revenue targets?",
+        textContent: `Here are linked examples: [[record:company:${COMPANY_DATA_SEED_IDS.ID_1}:Google]] is a record in [[object:company:Companies]]. Open [[view:${chatReferenceIds.viewId}:All Companies]], inspect [[field:company:domainName:Domain name]], review [[role:${chatReferenceIds.roleId}:Admin]], or manage [[app:${chatReferenceIds.applicationId}:Twenty]].`,
         createdAt: new Date(baseTime.getTime() + 5 * 60 * 1000),
-      },
-      {
-        id: partIds[2],
-        workspaceId,
-        messageId: messageIds[2],
-        orderIndex: 0,
-        type: 'text',
-        textContent:
-          "I'd like to focus on our user engagement metrics and how they're trending over the last quarter.",
-        createdAt: new Date(baseTime.getTime() + 10 * 60 * 1000),
-      },
-      {
-        id: partIds[3],
-        workspaceId,
-        messageId: messageIds[3],
-        orderIndex: 0,
-        type: 'text',
-        textContent:
-          'Great! Looking at your user engagement data, I can see several key trends from the last quarter. Your active user base has grown by 15%, with particularly strong engagement in the mobile app. Daily active users are averaging 2.3 million, and session duration has increased by 8%. Would you like me to dive deeper into any specific engagement metrics or create a detailed report?',
-        createdAt: new Date(baseTime.getTime() + 15 * 60 * 1000),
       },
     ];
   } else if (workspaceId === SEED_YCOMBINATOR_WORKSPACE_ID) {
@@ -382,17 +343,15 @@ type SeedAgentsArgs = {
   queryRunner: QueryRunner;
   schemaName: string;
   workspaceId: string;
+  chatReferenceIds: ChatReferenceIds;
 };
 
 export const seedAgents = async ({
   queryRunner,
   schemaName,
   workspaceId,
+  chatReferenceIds,
 }: SeedAgentsArgs) => {
-  if (workspaceId === SEED_APPLE_WORKSPACE_ID) {
-    return;
-  }
-
   const threadId = await seedChatThreads({
     queryRunner,
     schemaName,
@@ -404,5 +363,6 @@ export const seedAgents = async ({
     schemaName,
     workspaceId,
     threadId,
+    chatReferenceIds,
   });
 };

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-agents.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-agents.util.ts
@@ -104,6 +104,7 @@ type SeedChatMessagesArgs = {
 
 export type ChatReferenceIds = {
   applicationId: string;
+  objectMetadataId: string;
   roleId: string;
   viewId: string;
 };
@@ -184,7 +185,7 @@ const seedChatMessages = async ({
         messageId: messageIds[1],
         orderIndex: 0,
         type: 'text',
-        textContent: `Here are linked examples: [[record:company:${COMPANY_DATA_SEED_IDS.ID_1}:Google]] is a record in [[object:company:Companies]]. Open [[view:${chatReferenceIds.viewId}:All Companies]], inspect [[field:company:domainName:Domain name]], review [[role:${chatReferenceIds.roleId}:Admin]], or manage [[app:${chatReferenceIds.applicationId}:Twenty]].`,
+        textContent: `Here are linked examples: [[record:company:${COMPANY_DATA_SEED_IDS.ID_1}:Google]] is one record. Browse [[records:${chatReferenceIds.objectMetadataId}:Company records]], open the specific [[view:${chatReferenceIds.viewId}:All Companies]] view, configure the [[object:company:Companies]] data model, inspect [[field:company:domainName:Domain name]], review [[role:${chatReferenceIds.roleId}:Admin]], or manage [[app:${chatReferenceIds.applicationId}:Twenty]].`,
         createdAt: new Date(baseTime.getTime() + 5 * 60 * 1000),
       },
     ];

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 
 import { DataSource, Repository } from 'typeorm';
+import { ViewKey } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 
 import { ApplicationRegistrationService } from 'src/engine/core-modules/application/application-registration/application-registration.service';
@@ -16,6 +18,8 @@ import { UpgradeSequenceReaderService } from 'src/engine/core-modules/upgrade/se
 import { type UpgradeMigrationStatus } from 'src/engine/core-modules/upgrade/upgrade-migration.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
+import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceSchemaService } from 'src/engine/workspace-datasource/workspace-schema.service';
@@ -26,7 +30,10 @@ import {
   SEEDER_CREATE_WORKSPACE_INPUT,
 } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 import { DevSeederPermissionsService } from 'src/engine/workspace-manager/dev-seeder/core/services/dev-seeder-permissions.service';
-import { seedAgents } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-agents.util';
+import {
+  type ChatReferenceIds,
+  seedAgents,
+} from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-agents.util';
 import { seedApiKeys } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-api-keys.util';
 import { seedEmailingDomains } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-emailing-domains.util';
 import { seedFeatureFlags } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-feature-flags.util';
@@ -45,6 +52,7 @@ import { PrefillFrontComponentService } from 'src/engine/workspace-manager/stand
 import { PrefillLogicFunctionService } from 'src/engine/workspace-manager/standard-objects-prefill-data/services/prefill-logic-function.service';
 import { getSeedFrontComponentDefinitions } from 'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-front-component-definitions.util';
 import { getCreateCompanyWhenAddingNewPersonCodeStepLogicFunctionDefinitions } from 'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflow-code-step-logic-functions.util';
+import { STANDARD_ROLE } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-role.constant';
 import { TwentyStandardApplicationService } from 'src/engine/workspace-manager/twenty-standard-application/services/twenty-standard-application.service';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
 
@@ -163,6 +171,26 @@ export class DevSeederService {
       relations: { fields: true },
     });
 
+    const companyObjectMetadataItem = objectMetadataItems.find(
+      (objectMetadataItem) => objectMetadataItem.nameSingular === 'company',
+    );
+
+    if (!isDefined(companyObjectMetadataItem)) {
+      throw new Error('Company object metadata is required to seed AI chat');
+    }
+
+    const [allCompaniesView, adminRole] = await Promise.all([
+      this.coreDataSource.getRepository(ViewEntity).findOneByOrFail({
+        workspaceId,
+        objectMetadataId: companyObjectMetadataItem.id,
+        key: ViewKey.INDEX,
+      }),
+      this.coreDataSource.getRepository(RoleEntity).findOneByOrFail({
+        workspaceId,
+        universalIdentifier: STANDARD_ROLE.admin.universalIdentifier,
+      }),
+    ]);
+
     await this.prefillLogicFunctionService.ensureSeeded({
       workspaceId,
       definitions:
@@ -191,7 +219,45 @@ export class DevSeederService {
       light,
     });
 
+    await this.seedAgentChat({
+      workspaceId,
+      chatReferenceIds: {
+        applicationId: twentyStandardFlatApplication.id,
+        roleId: adminRole.id,
+        viewId: allCompaniesView.id,
+      },
+    });
+
     await this.workspaceCacheStorageService.flush(workspaceId);
+  }
+
+  private async seedAgentChat({
+    workspaceId,
+    chatReferenceIds,
+  }: {
+    workspaceId: SeededWorkspacesIds;
+    chatReferenceIds: ChatReferenceIds;
+  }) {
+    const queryRunner = this.coreDataSource.createQueryRunner();
+
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      await seedAgents({
+        queryRunner,
+        schemaName: 'core',
+        workspaceId,
+        chatReferenceIds,
+      });
+
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
   }
 
   private async seedCoreSchema({
@@ -254,7 +320,6 @@ export class DevSeederService {
         queryRunner,
       );
 
-      await seedAgents({ queryRunner, schemaName, workspaceId });
       await seedApiKeys({ queryRunner, schemaName, workspaceId });
       if (
         this.twentyConfigService.get('EMAILING_DOMAIN_DRIVER') ===

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
@@ -223,6 +223,7 @@ export class DevSeederService {
       workspaceId,
       chatReferenceIds: {
         applicationId: twentyStandardFlatApplication.id,
+        objectMetadataId: companyObjectMetadataItem.id,
         roleId: adminRole.id,
         viewId: allCompaniesView.id,
       },


### PR DESCRIPTION
## Context

AI chat already renders link chips for records, objects, fields, and views. This adds roles and apps, and makes the difference between object metadata and an object's records explicit.

## Changes

- parse and render `role` and `app` chat references
- make `object` references open Data Model settings, gated by the data-model permission
- add `[[records:<objectMetadataId>:<label>]]` for opening an object's default records destination without fetching a view
- keep `view` references for links to a specific saved view
- link role/app chips to their settings pages when the user has the corresponding permission, while keeping a non-clickable chip otherwise
- document all supported reference formats and selection rules in the AI system prompt
- seed Tim Apple with one user message and one assistant reply demonstrating record, records, view, object, field, role, and app chips
- resolve seeded object, view, role, and app instance IDs after metadata synchronization so every link is valid
- leave workflows out until their schema is ready for this reference model

## Testing

- 6 focused Jest suites, 40 tests passed
- changed frontend and server files pass oxlint
- changed files pass oxfmt and `git diff --check`