### PR TITLE
Resolve related records for visible junction relations on board cards

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/hooks/__tests__/useRelevantRecordsGqlFields.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/hooks/__tests__/useRelevantRecordsGqlFields.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { useRelevantRecordsGqlFields } from '@/object-record/record-field/hooks/useRelevantRecordsGqlFields';
+import { currentRecordFieldsComponentState } from '@/object-record/record-field/states/currentRecordFieldsComponentState';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+import { JestRecordIndexContextProviderWrapper } from '~/testing/jest/JestRecordIndexContextProviderWrapper';
+import { getMockFieldMetadataItemOrThrow } from '~/testing/utils/getMockFieldMetadataItemOrThrow';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+
+const COMPONENT_INSTANCE_ID = 'instanceId';
+
+const companyObjectMetadataItem = getMockObjectMetadataItemOrThrow('company');
+
+const noteTargetsFieldMetadataItem = getMockFieldMetadataItemOrThrow({
+  objectMetadataItem: companyObjectMetadataItem,
+  fieldName: 'noteTargets',
+});
+
+const getWrapper = (visibleFieldMetadataItemIds: string[]) => {
+  const MetadataAndApolloMocksWrapper = getJestMetadataAndApolloMocksWrapper({
+    onInitializeJotaiStore: (store) => {
+      store.set(
+        currentRecordFieldsComponentState.atomFamily({
+          instanceId: COMPONENT_INSTANCE_ID,
+        }),
+        visibleFieldMetadataItemIds.map((fieldMetadataItemId, index) => ({
+          id: `record-field-${fieldMetadataItemId}`,
+          fieldMetadataItemId,
+          position: index,
+          isVisible: true,
+          size: 100,
+        })),
+      );
+    },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <MetadataAndApolloMocksWrapper>
+      <JestRecordIndexContextProviderWrapper
+        objectMetadataItem={companyObjectMetadataItem}
+      >
+        {children}
+      </JestRecordIndexContextProviderWrapper>
+    </MetadataAndApolloMocksWrapper>
+  );
+};
+
+describe('useRelevantRecordsGqlFields', () => {
+  it('resolves the related record of a junction relation that is not visible', async () => {
+    const { result } = renderHook(
+      () =>
+        useRelevantRecordsGqlFields({
+          objectMetadataItem: companyObjectMetadataItem,
+        }),
+      { wrapper: getWrapper([]) },
+    );
+
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        noteTargets: {
+          id: true,
+          note: {
+            id: true,
+            title: true,
+          },
+        },
+      }),
+    );
+  });
+
+  it('resolves the related record of a junction relation that is visible', async () => {
+    const { result } = renderHook(
+      () =>
+        useRelevantRecordsGqlFields({
+          objectMetadataItem: companyObjectMetadataItem,
+        }),
+      { wrapper: getWrapper([noteTargetsFieldMetadataItem.id]) },
+    );
+
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        noteTargets: {
+          id: true,
+          note: {
+            id: true,
+            title: true,
+          },
+        },
+      }),
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/hooks/useRelevantRecordsGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/hooks/useRelevantRecordsGqlFields.ts
@@ -64,8 +64,12 @@ export const useRelevantRecordsGqlFields = ({
     ...additionalFieldMetadataItems,
   ].filter(filterDuplicatesById);
 
+  // The source object is what lets a junction relation resolve its reverse config; without
+  // it a visible junction field collapses to junction ids and, being spread in last, would
+  // overwrite the resolved entry that junctionRelationGqlFields contributes below.
   const allDepthOneGqlFields = generateDepthRecordGqlFieldsFromFields({
     objectMetadataItems,
+    sourceObjectMetadataItem: objectMetadataItem,
     fields: fieldMetadataItemsToUse,
     depth: 1,
   });


### PR DESCRIPTION
Fixes #25103

### Problem

On a kanban/board view, a **visible** junction relation field (e.g. `noteTargets`) was fetched with its junction ids only, so the card rendered an empty chip. Opening the record side panel populated the cache and the chip appeared until the next reload.

As reported in the issue, the board query asked for the junction edges but omitted the nested target, while every sibling relation in the same query did include it:

```graphql
noteTargets          { edges { node { __typename id } } }                                   # no nested note
taskTargets          { edges { node { __typename id task { __typename id title } } } }
messageThreadTargets { edges { node { __typename id messageThread { __typename id subject } } } }
```

### Root cause

`useRelevantRecordsGqlFields` builds the selection from two calls to `generateDepthRecordGqlFieldsFromFields`:

- the junction call passes `sourceObjectMetadataItem`
- the visible-fields call (`allDepthOneGqlFields`) did not

`getReverseJunctionConfig` returns `null` as soon as `sourceObjectMetadataId` is undefined, so in the visible-fields call the relation never resolved its reverse junction config and fell through to the plain identifier branch — the junction object's own identifiers. Because `...allDepthOneGqlFields` is spread in **after** `...junctionRelationGqlFields`, that shallow entry overwrote the correctly resolved one.

This explains the asymmetry precisely:

- `noteTargets` was visible in the reported view, so it went through both calls and lost its nested target.
- The sibling `*Targets` relations were not visible, so only the junction call applied and they kept theirs.
- The record side panel was unaffected because it goes through `generateDepthRecordGqlFieldsFromObject`, which already passes `sourceObjectMetadataItem`.

### Fix

Pass `sourceObjectMetadataItem` in the visible-fields call too, so both calls resolve junction relations identically.

### Tests

Added `useRelevantRecordsGqlFields.test.tsx` with two cases — a junction relation that is not visible (control) and one that is visible (the regression).

Against `main` the control passes and the regression case fails with exactly the reported shape:

```
- "note": Object {
-   "id": true,
-   "title": true,
- },
  "noteTargets": Object { "id": true }
```

With the fix both pass. I also ran the surrounding suites (junction, record-gql-fields, record-index, record-board, `useRecordIndexTableQuery`): 24 suites / 119 tests pass.

`oxlint` and `prettier --check` are clean on both files. `tsgo --noEmit` on `twenty-front` reports 23 errors, all in `src/modules/front-components/**` from the unbuilt `twenty-front-component-renderer` package — the identical 23 appear on a stashed/clean tree, so they are pre-existing and unrelated to this diff.

### Possible follow-up (not included)

`getTimelineActivityRecordGqlFields` calls `generateDepthRecordGqlFieldsFromFields` without `sourceObjectMetadataItem` in the same way. I left it out to keep this PR scoped to the reported bug, but it may deserve the same treatment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

