### PR TITLE
Resolve morph member IDs in grouped metadata

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/__tests__/doesFieldMetadataItemMatchFieldMetadataId.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/__tests__/doesFieldMetadataItemMatchFieldMetadataId.test.ts
@@ -1,0 +1,61 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type FieldMetadataItemRelation } from '@/object-metadata/types/FieldMetadataItemRelation';
+import { doesFieldMetadataItemMatchFieldMetadataId } from '@/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId';
+import { RelationType } from '~/generated-metadata/graphql';
+
+const createRelation = (
+  sourceFieldMetadataId: string,
+): FieldMetadataItemRelation => ({
+  type: RelationType.MANY_TO_ONE,
+  sourceFieldMetadata: {
+    id: sourceFieldMetadataId,
+    name: 'sourceField',
+  },
+  targetFieldMetadata: {
+    id: 'target-field-id',
+    name: 'targetField',
+  },
+  sourceObjectMetadata: {
+    id: 'source-object-id',
+    nameSingular: 'sourceObject',
+    namePlural: 'sourceObjects',
+  },
+  targetObjectMetadata: {
+    id: 'target-object-id',
+    nameSingular: 'targetObject',
+    namePlural: 'targetObjects',
+  },
+});
+
+const fieldMetadataItem = {
+  id: 'field-id',
+  relation: createRelation('relation-source-field-id'),
+  morphRelations: [createRelation('morph-member-field-id')],
+} satisfies Pick<FieldMetadataItem, 'id' | 'relation' | 'morphRelations'>;
+
+describe('doesFieldMetadataItemMatchFieldMetadataId', () => {
+  it.each([
+    ['its own ID', fieldMetadataItem, 'field-id', true],
+    [
+      'its relation source ID',
+      fieldMetadataItem,
+      'relation-source-field-id',
+      true,
+    ],
+    ['a morph member ID', fieldMetadataItem, 'morph-member-field-id', true],
+    ['an unknown ID', fieldMetadataItem, 'unknown-field-id', false],
+    [
+      'an unknown ID when relations are absent',
+      { id: 'field-id', relation: null, morphRelations: null },
+      'unknown-field-id',
+      false,
+    ],
+  ])('returns whether the field matches %s', (_, field, id, expected) => {
+    expect(
+      doesFieldMetadataItemMatchFieldMetadataId({
+        fieldMetadataItem: field,
+        fieldMetadataId: id,
+      }),
+    ).toBe(expected);
+  });
+});

--- a/packages/twenty-front/src/modules/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId.ts
@@ -4,10 +4,14 @@ export const doesFieldMetadataItemMatchFieldMetadataId = ({
   fieldMetadataItem,
   fieldMetadataId,
 }: {
-  fieldMetadataItem: FieldMetadataItem;
+  fieldMetadataItem: Pick<
+    FieldMetadataItem,
+    'id' | 'relation' | 'morphRelations'
+  >;
   fieldMetadataId: string;
 }): boolean =>
   fieldMetadataItem.id === fieldMetadataId ||
+  fieldMetadataItem.relation?.sourceFieldMetadata.id === fieldMetadataId ||
   (fieldMetadataItem.morphRelations ?? []).some(
     ({ sourceFieldMetadata }) => sourceFieldMetadata.id === fieldMetadataId,
   );

--- a/packages/twenty-front/src/modules/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId.ts
@@ -8,7 +8,6 @@ export const doesFieldMetadataItemMatchFieldMetadataId = ({
   fieldMetadataId: string;
 }): boolean =>
   fieldMetadataItem.id === fieldMetadataId ||
-  fieldMetadataItem.relation?.sourceFieldMetadata.id === fieldMetadataId ||
   (fieldMetadataItem.morphRelations ?? []).some(
     ({ sourceFieldMetadata }) => sourceFieldMetadata.id === fieldMetadataId,
   );

--- a/packages/twenty-front/src/modules/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId.ts
@@ -8,6 +8,7 @@ export const doesFieldMetadataItemMatchFieldMetadataId = ({
   fieldMetadataId: string;
 }): boolean =>
   fieldMetadataItem.id === fieldMetadataId ||
+  fieldMetadataItem.relation?.sourceFieldMetadata.id === fieldMetadataId ||
   (fieldMetadataItem.morphRelations ?? []).some(
     ({ sourceFieldMetadata }) => sourceFieldMetadata.id === fieldMetadataId,
   );

--- a/packages/twenty-front/src/modules/object-metadata/utils/findFieldMetadataItemByFieldMetadataId.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/findFieldMetadataItemByFieldMetadataId.ts
@@ -1,0 +1,16 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { doesFieldMetadataItemMatchFieldMetadataId } from '@/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId';
+
+export const findFieldMetadataItemByFieldMetadataId = ({
+  fieldMetadataItems,
+  fieldMetadataId,
+}: {
+  fieldMetadataItems: FieldMetadataItem[] | undefined;
+  fieldMetadataId: string;
+}): FieldMetadataItem | undefined =>
+  fieldMetadataItems?.find((fieldMetadataItem) =>
+    doesFieldMetadataItemMatchFieldMetadataId({
+      fieldMetadataItem,
+      fieldMetadataId,
+    }),
+  );

--- a/packages/twenty-front/src/modules/object-metadata/utils/getFieldMetadataItemByIdOrThrow.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/getFieldMetadataItemByIdOrThrow.ts
@@ -1,5 +1,5 @@
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
-import { doesFieldMetadataItemMatchFieldMetadataId } from '@/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId';
+import { findFieldMetadataItemByFieldMetadataId } from '@/object-metadata/utils/findFieldMetadataItemByFieldMetadataId';
 import { CustomError, isDefined } from 'twenty-shared/utils';
 
 type GetFieldMetadataItemByIdParams = {
@@ -15,12 +15,10 @@ export const getFieldMetadataItemByIdOrThrow = ({
   objectMetadataItems,
 }: GetFieldMetadataItemByIdParams) => {
   for (const objectMetadataItem of objectMetadataItems) {
-    const fieldMetadataItem = objectMetadataItem.fields.find((field) =>
-      doesFieldMetadataItemMatchFieldMetadataId({
-        fieldMetadataItem: field,
-        fieldMetadataId,
-      }),
-    );
+    const fieldMetadataItem = findFieldMetadataItemByFieldMetadataId({
+      fieldMetadataItems: objectMetadataItem.fields,
+      fieldMetadataId,
+    });
 
     if (isDefined(fieldMetadataItem)) {
       return {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJunctionConfig.ts
@@ -1,5 +1,5 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
-import { doesFieldMetadataItemMatchFieldMetadataId } from '@/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId';
+import { findFieldMetadataItemByFieldMetadataId } from '@/object-metadata/utils/findFieldMetadataItemByFieldMetadataId';
 import { type JunctionConfig } from '@/object-record/record-field/ui/utils/junction/types/JunctionConfig';
 import { type JunctionObjectMetadataItem } from '@/object-record/record-field/ui/utils/junction/types/JunctionObjectMetadataItem';
 import { FieldMetadataType } from 'twenty-shared/types';
@@ -29,14 +29,6 @@ export const getJunctionConfig = ({
   if (!isDefined(junctionObjectMetadata)) {
     return null;
   }
-
-  const findFieldById = (fieldMetadataId: string) =>
-    junctionObjectMetadata.fields.find((fieldMetadataItem) =>
-      doesFieldMetadataItemMatchFieldMetadataId({
-        fieldMetadataItem,
-        fieldMetadataId,
-      }),
-    );
 
   const findSourceField = (
     excludeFieldId?: string,
@@ -69,10 +61,16 @@ export const getJunctionConfig = ({
 
   const hasConfiguredTargetField = hasJunctionTargetFieldId(settings);
   const configuredTargetField = hasConfiguredTargetField
-    ? findFieldById(settings.junctionTargetFieldId)
+    ? findFieldMetadataItemByFieldMetadataId({
+        fieldMetadataItems: junctionObjectMetadata.fields,
+        fieldMetadataId: settings.junctionTargetFieldId,
+      })
     : undefined;
   const relationSourceField = isDefined(relationTargetFieldMetadataId)
-    ? findFieldById(relationTargetFieldMetadataId)
+    ? findFieldMetadataItemByFieldMetadataId({
+        fieldMetadataItems: junctionObjectMetadata.fields,
+        fieldMetadataId: relationTargetFieldMetadataId,
+      })
     : undefined;
   const sourceField =
     relationSourceField ?? findSourceField(configuredTargetField?.id);

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationJunctionForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationJunctionForm.tsx
@@ -7,7 +7,7 @@ import { IconLink } from 'twenty-ui/icon';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetadataItemById';
-import { doesFieldMetadataItemMatchFieldMetadataId } from '@/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId';
+import { findFieldMetadataItemByFieldMetadataId } from '@/object-metadata/utils/findFieldMetadataItemByFieldMetadataId';
 import { isValidJunctionTargetField } from '@/object-record/record-field/ui/utils/junction/isValidJunctionTargetField';
 import { SettingsOptionCardContentSelect } from '@/settings/components/SettingsOptions/SettingsOptionCardContentSelect';
 import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
@@ -103,12 +103,10 @@ export const SettingsDataModelFieldRelationJunctionForm = ({
 
   const isJunctionConfigEnabled = isDefined(junctionTargetFieldId);
   const selectedJunctionTargetFieldId = isDefined(junctionTargetFieldId)
-    ? (junctionObjectMetadataItem.fields.find((fieldMetadataItem) =>
-        doesFieldMetadataItemMatchFieldMetadataId({
-          fieldMetadataItem,
-          fieldMetadataId: junctionTargetFieldId,
-        }),
-      )?.id ?? junctionTargetFieldId)
+    ? (findFieldMetadataItemByFieldMetadataId({
+        fieldMetadataItems: junctionObjectMetadataItem.fields,
+        fieldMetadataId: junctionTargetFieldId,
+      })?.id ?? junctionTargetFieldId)
     : undefined;
   const isConfiguredTargetValid = junctionFieldOptions.some(
     ({ value }) => value === selectedJunctionTargetFieldId,

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/hooks/useChartSettingsValues.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/hooks/useChartSettingsValues.ts
@@ -1,4 +1,4 @@
-import { doesFieldMetadataItemMatchFieldMetadataId } from '@/object-metadata/utils/doesFieldMetadataItemMatchFieldMetadataId';
+import { findFieldMetadataItemByFieldMetadataId } from '@/object-metadata/utils/findFieldMetadataItemByFieldMetadataId';
 import { CHART_NUMBER_FORMAT_DEFAULT } from '@/page-layout/widgets/graph/constants/ChartNumberFormatDefault';
 import { useGraphGroupBySortOptionLabels } from '@/side-panel/pages/page-layout/hooks/useGraphGroupBySortOptionLabels';
 import { useGraphXSortOptionLabels } from '@/side-panel/pages/page-layout/hooks/useGraphXSortOptionLabels';
@@ -54,14 +54,6 @@ export const useChartSettingsValues = ({
 
   const isPieChart = configuration.__typename === 'PieChartConfiguration';
 
-  const findGroupByField = (fieldMetadataId: string) =>
-    objectMetadataItem?.fields.find((fieldMetadataItem) =>
-      doesFieldMetadataItemMatchFieldMetadataId({
-        fieldMetadataItem,
-        fieldMetadataId,
-      }),
-    );
-
   let groupByFieldXId: string | undefined;
   let groupByFieldYId: string | undefined;
   let groupBySubFieldNameX: CompositeFieldSubFieldName | undefined;
@@ -85,11 +77,17 @@ export const useChartSettingsValues = ({
   }
 
   const groupByFieldX = isDefined(groupByFieldXId)
-    ? findGroupByField(groupByFieldXId)
+    ? findFieldMetadataItemByFieldMetadataId({
+        fieldMetadataItems: objectMetadataItem?.fields,
+        fieldMetadataId: groupByFieldXId,
+      })
     : undefined;
 
   const groupByFieldY = isDefined(groupByFieldYId)
-    ? findGroupByField(groupByFieldYId)
+    ? findFieldMetadataItemByFieldMetadataId({
+        fieldMetadataItems: objectMetadataItem?.fields,
+        fieldMetadataId: groupByFieldYId,
+      })
     : undefined;
 
   const groupBySubFieldNameXLabel =
@@ -210,7 +208,10 @@ export const useChartSettingsValues = ({
       }
       case CHART_CONFIGURATION_SETTING_IDS.DATA_ON_DISPLAY_PIE_CHART: {
         const pieChartGroupByField = isDefined(finalGroupByFieldYId)
-          ? findGroupByField(finalGroupByFieldYId)
+          ? findFieldMetadataItemByFieldMetadataId({
+              fieldMetadataItems: objectMetadataItem?.fields,
+              fieldMetadataId: finalGroupByFieldYId,
+            })
           : undefined;
         const pieChartGroupBySubFieldNameLabel =
           isDefined(finalGroupBySubFieldNameY) &&


### PR DESCRIPTION
## Context

`junctionTargetFieldId` can store the ID of a physical morph member. Frontend metadata collapses that morph group to one representative field, whose top-level ID can belong to a different member; the remaining physical IDs live in `morphRelations[].sourceFieldMetadata.id`.

After #25108 correctly stopped inferring over explicit invalid settings, a valid Task/Note junction whose configured member was not the chosen representative could appear invalid. This caused `Cannot resolve morph junction metadata for task`, and downstream surfaces treated the relation as forbidden.

## Fix

- Let shared field identity match the representative ID, a regular relation source ID, or any represented morph-member source ID.
- Extract one `findFieldMetadataItemByFieldMetadataId` utility and reuse it in generic metadata lookup, junction resolution, Junction settings, and chart settings.
- Keep fail-closed behavior for IDs that genuinely match no field; no inference fallback is restored.
- Add direct predicate coverage for representative, relation-source, morph-member, unknown, and relationless cases.

After rebasing on merged #25113, the PR is 7 files / +114 / -38. Non-test production code is +53 / -38; the rest is focused coverage.

## Validation

- 5 focused frontend suites / 59 tests pass after the rebase.
- Frontend typecheck passes after the rebase.
- Type-aware lint, formatting, and `git diff --check` pass.

This is the urgent independent crash fix and should merge before deploying the current `main` containing #25113.



Fixes #25103
