### PR TITLE
Fix chat reference chip Storybook assertion

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/__stories__/ChatReferenceChip.stories.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__stories__/ChatReferenceChip.stories.tsx
@@ -98,7 +98,7 @@ export const ExistingMetadata: Story = {
 
     expect((await canvas.findByText('Companies')).closest('a')).toHaveAttribute(
       'href',
-      `/objects/${companyObjectMetadataItem.namePlural}`,
+      `/settings/objects/${companyObjectMetadataItem.namePlural}`,
     );
     expect((await canvas.findByText('Employees')).closest('a')).toHaveAttribute(
       'href',


### PR DESCRIPTION
## Summary
- update the existing object chat reference story to expect the data model settings route
- align the Storybook assertion with `ObjectMetadataLink` and its unit test

## Testing
- `prettier --check packages/twenty-front/src/modules/ai/components/__stories__/ChatReferenceChip.stories.tsx`
- `git diff --check`
- full Storybook browser test deferred to CI because the local dependency install exceeded available disk space

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

