### PR TITLE
Treat Google policy_enforced as a permanent OAuth error

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/google/constants/google-permanent-oauth-error-codes.constant.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/google/constants/google-permanent-oauth-error-codes.constant.ts
@@ -8,4 +8,5 @@ export const GOOGLE_PERMANENT_OAUTH_ERROR_CODES = new Set([
   'unsupported_grant_type',
   'invalid_scope',
   'admin_policy_enforced',
+  'policy_enforced',
 ]);


### PR DESCRIPTION
Accounts enrolled in Advanced Protection return policy_enforced on refresh, which can never succeed for a non-Google app. It was falling through to TEMPORARY_NETWORK_ERROR, so the channel retried five times before failing as FAILED_UNKNOWN. Mark the channel as needing a reconnect instead.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

