### PR TITLE
fix(messaging): register blocklist delete listener on DELETED, not CREATED

### DIFF
--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/listeners/messaging-blocklist.listener.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/listeners/messaging-blocklist.listener.ts
@@ -41,7 +41,7 @@ export class MessagingBlocklistListener {
     );
   }
 
-  @OnDatabaseBatchEvent('blocklist', DatabaseEventAction.CREATED)
+  @OnDatabaseBatchEvent('blocklist', DatabaseEventAction.DELETED)
   async handleDeletedEvent(
     payload: WorkspaceEventBatch<
       ObjectRecordDeleteEvent<BlocklistWorkspaceEntity>


### PR DESCRIPTION
## Summary
Blocklist listener registered `handleDeletedEvent` on `DatabaseEventAction.CREATED` instead of `DELETED`, so adding a blocklist entry fired the delete-reimport job with a create payload (no `properties.before`), crashing with `TypeError: Cannot read properties of undefined (reading 'workspaceMemberId')`. Flagged by QA scout on #24988.

## Test plan
- [x] Diff lint (`nx lint:diff-with-main twenty-server`) passes
- [x] Matches the working sibling pattern in `calendar-blocklist.listener.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

