### PR TITLE
feat(slack): auto-link the installer on connect and clear ghost links

### DIFF
--- a/packages/twenty-apps/public/slack/README.md
+++ b/packages/twenty-apps/public/slack/README.md
@@ -14,7 +14,7 @@ Mention the bot in a channel or DM it. It replies in the thread with your CRM da
 
 Out of the box the bot runs with the **Slack Assistant** role, which can read, create, update and soft-delete people, companies, opportunities, notes and tasks. Workspace members stay read-only and hard delete is off. Tighten the role in **Settings → Roles** if you want a narrower bot.
 
-**It acts as whoever tagged it.** The first time someone mentions the bot, their Slack profile email is matched against workspace members and the pair is stored as a **Slack User Link** record. From then on the bot runs with that member's own permissions, so it can never do more than the person asking. Someone with no link gets the **Slack Assistant** role instead, exactly as before.
+**It acts as whoever tagged it.** The first time someone mentions the bot, their Slack profile email is matched against workspace members and the pair is stored as a **Slack User Link** record. The person who connects the Slack workspace is matched the same way right at connection time, so the installer is linked before anyone messages the bot. From then on the bot runs with that member's own permissions, so it can never do more than the person asking. Someone with no link gets the **Slack Assistant** role instead, exactly as before.
 
 A link matched on email is re-verified on every request: the bot rechecks that the Slack account's current verified email still points at the same member, and follows the live match rather than the stored record if they disagree. The record is an audit trail, not the source of truth.
 

--- a/packages/twenty-apps/public/slack/src/logic-functions/data/find-deleted-slack-user-link-id.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/data/find-deleted-slack-user-link-id.ts
@@ -1,0 +1,29 @@
+import { isNonEmptyString } from '@sniptt/guards';
+import { type CoreApiClient } from 'twenty-client-sdk/core';
+
+export const findDeletedSlackUserLinkId = async (
+  client: CoreApiClient,
+  { slackTeamId, slackUserId }: { slackTeamId: string; slackUserId: string },
+): Promise<string | undefined> => {
+  const queryResult = await client.query({
+    slackUserLinks: {
+      __args: {
+        filter: {
+          slackTeamId: { eq: slackTeamId },
+          slackUserId: { eq: slackUserId },
+          deletedAt: { is: 'NOT_NULL' },
+        },
+        first: 1,
+      },
+      edges: {
+        node: {
+          id: true,
+        },
+      },
+    },
+  });
+
+  const id = queryResult.slackUserLinks?.edges?.[0]?.node?.id;
+
+  return isNonEmptyString(id) ? id : undefined;
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/handlers/__tests__/slack-set-user-link-handler.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/handlers/__tests__/slack-set-user-link-handler.test.ts
@@ -9,6 +9,7 @@ const {
   authTestMock,
   doesWorkspaceMemberExistMock,
   findSlackUserLinkMock,
+  findDeletedSlackUserLinkIdMock,
   createSlackUserLinkMock,
   updateSlackUserLinkMock,
   destroySlackUserLinkMock,
@@ -24,6 +25,7 @@ const {
   authTestMock: vi.fn(),
   doesWorkspaceMemberExistMock: vi.fn(),
   findSlackUserLinkMock: vi.fn(),
+  findDeletedSlackUserLinkIdMock: vi.fn(),
   createSlackUserLinkMock: vi.fn(),
   updateSlackUserLinkMock: vi.fn(),
   destroySlackUserLinkMock: vi.fn(),
@@ -60,6 +62,10 @@ vi.mock('src/logic-functions/data/does-workspace-member-exist', () => ({
 
 vi.mock('src/logic-functions/data/find-slack-user-link', () => ({
   findSlackUserLink: findSlackUserLinkMock,
+}));
+
+vi.mock('src/logic-functions/data/find-deleted-slack-user-link-id', () => ({
+  findDeletedSlackUserLinkId: findDeletedSlackUserLinkIdMock,
 }));
 
 vi.mock('src/logic-functions/data/create-slack-user-link', () => ({
@@ -104,6 +110,7 @@ describe('slackSetUserLinkHandler', () => {
     authTestMock.mockResolvedValue({ team_id: INSTALLED_TEAM_ID });
     doesWorkspaceMemberExistMock.mockResolvedValue(true);
     findSlackUserLinkMock.mockResolvedValue(undefined);
+    findDeletedSlackUserLinkIdMock.mockResolvedValue(undefined);
     createSlackUserLinkMock.mockResolvedValue('link-new');
     fetchSlackUserIdentityMock.mockResolvedValue({
       slackUserId: INPUT.slackUserId,
@@ -123,6 +130,18 @@ describe('slackSetUserLinkHandler', () => {
     expect(result.success).toBe(false);
     expect(createSlackUserLinkMock).not.toHaveBeenCalled();
     expect(updateSlackUserLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('should destroy a soft-deleted ghost link before creating the same tuple', async () => {
+    findDeletedSlackUserLinkIdMock.mockResolvedValue('link-ghost');
+
+    const result = await slackSetUserLinkHandler(INPUT);
+
+    expect(result.success).toBe(true);
+    expect(destroySlackUserLinkMock).toHaveBeenCalledWith(expect.anything(), {
+      id: 'link-ghost',
+    });
+    expect(createSlackUserLinkMock).toHaveBeenCalledTimes(1);
   });
 
   it('should refuse a member id the workspace cannot confirm', async () => {

--- a/packages/twenty-apps/public/slack/src/logic-functions/handlers/__tests__/slack-set-user-link-handler.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/handlers/__tests__/slack-set-user-link-handler.test.ts
@@ -142,6 +142,9 @@ describe('slackSetUserLinkHandler', () => {
       id: 'link-ghost',
     });
     expect(createSlackUserLinkMock).toHaveBeenCalledTimes(1);
+    expect(destroySlackUserLinkMock.mock.invocationCallOrder[0]).toBeLessThan(
+      createSlackUserLinkMock.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
   it('should refuse a member id the workspace cannot confirm', async () => {

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/auto-link-slack-installer.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/auto-link-slack-installer.test.ts
@@ -1,0 +1,171 @@
+import { type WebClient } from '@slack/web-api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { autoLinkSlackInstaller } from 'src/logic-functions/utils/auto-link-slack-installer';
+
+const {
+  coreApiClientMock,
+  findWorkspaceMemberEmailByIdMock,
+  resolveSlackUserByEmailMock,
+  findSlackUserLinkMock,
+  persistSlackUserLinkMock,
+} = vi.hoisted(() => ({
+  coreApiClientMock: vi.fn(),
+  findWorkspaceMemberEmailByIdMock: vi.fn(),
+  resolveSlackUserByEmailMock: vi.fn(),
+  findSlackUserLinkMock: vi.fn(),
+  persistSlackUserLinkMock: vi.fn(),
+}));
+
+vi.mock('twenty-client-sdk/core', () => ({
+  CoreApiClient: coreApiClientMock,
+}));
+
+vi.mock('src/logic-functions/data/find-workspace-member-email-by-id', () => ({
+  findWorkspaceMemberEmailById: findWorkspaceMemberEmailByIdMock,
+}));
+
+vi.mock('src/logic-functions/utils/resolve-slack-user-by-email', () => ({
+  resolveSlackUserByEmail: resolveSlackUserByEmailMock,
+}));
+
+vi.mock('src/logic-functions/data/find-slack-user-link', () => ({
+  findSlackUserLink: findSlackUserLinkMock,
+}));
+
+vi.mock('src/logic-functions/utils/persist-slack-user-link', () => ({
+  persistSlackUserLink: persistSlackUserLinkMock,
+}));
+
+const slackClient = {} as WebClient;
+
+const INSTALLED_TEAM_ID = 'T-installed';
+const MEMBER_ID = 'member-1';
+
+describe('autoLinkSlackInstaller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findWorkspaceMemberEmailByIdMock.mockResolvedValue('ada@twenty.com');
+    resolveSlackUserByEmailMock.mockResolvedValue({
+      slackUserId: 'U-installer',
+      slackTeamId: INSTALLED_TEAM_ID,
+      displayName: 'Ada',
+      isRegularUserAccount: true,
+    });
+    findSlackUserLinkMock.mockResolvedValue(undefined);
+    persistSlackUserLinkMock.mockResolvedValue('link-new');
+  });
+
+  it('should do nothing without a connecting workspace member', async () => {
+    await autoLinkSlackInstaller({
+      slackClient,
+      slackTeamId: INSTALLED_TEAM_ID,
+      workspaceMemberId: null,
+    });
+
+    expect(findWorkspaceMemberEmailByIdMock).not.toHaveBeenCalled();
+    expect(persistSlackUserLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when the member has no readable email', async () => {
+    findWorkspaceMemberEmailByIdMock.mockResolvedValue(undefined);
+
+    await autoLinkSlackInstaller({
+      slackClient,
+      slackTeamId: INSTALLED_TEAM_ID,
+      workspaceMemberId: MEMBER_ID,
+    });
+
+    expect(resolveSlackUserByEmailMock).not.toHaveBeenCalled();
+    expect(persistSlackUserLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when no Slack account matches the email', async () => {
+    resolveSlackUserByEmailMock.mockResolvedValue(undefined);
+
+    await autoLinkSlackInstaller({
+      slackClient,
+      slackTeamId: INSTALLED_TEAM_ID,
+      workspaceMemberId: MEMBER_ID,
+    });
+
+    expect(persistSlackUserLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('should not link a restricted account', async () => {
+    resolveSlackUserByEmailMock.mockResolvedValue({
+      slackUserId: 'U-guest',
+      slackTeamId: INSTALLED_TEAM_ID,
+      displayName: 'Guest',
+      isRegularUserAccount: false,
+    });
+
+    await autoLinkSlackInstaller({
+      slackClient,
+      slackTeamId: INSTALLED_TEAM_ID,
+      workspaceMemberId: MEMBER_ID,
+    });
+
+    expect(persistSlackUserLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('should leave an existing link for the account untouched', async () => {
+    findSlackUserLinkMock.mockResolvedValue({
+      id: 'link-existing',
+      workspaceMemberId: 'member-other',
+      source: 'MANUAL',
+      consentState: 'DECLINED',
+    });
+
+    await autoLinkSlackInstaller({
+      slackClient,
+      slackTeamId: INSTALLED_TEAM_ID,
+      workspaceMemberId: MEMBER_ID,
+    });
+
+    expect(persistSlackUserLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('should create an active auto link for the installer', async () => {
+    await autoLinkSlackInstaller({
+      slackClient,
+      slackTeamId: INSTALLED_TEAM_ID,
+      workspaceMemberId: MEMBER_ID,
+    });
+
+    expect(persistSlackUserLinkMock).toHaveBeenCalledWith(expect.anything(), {
+      existingLink: undefined,
+      isSameMemberRelink: false,
+      slackTeamId: INSTALLED_TEAM_ID,
+      slackUserId: 'U-installer',
+      workspaceMemberId: MEMBER_ID,
+      name: 'Ada',
+      source: 'AUTO',
+      consentState: 'ACTIVE',
+    });
+  });
+
+  it('should keep the lookup team when it differs from the connection team', async () => {
+    resolveSlackUserByEmailMock.mockResolvedValue({
+      slackUserId: 'U-installer',
+      slackTeamId: 'T-enterprise-leaf',
+      displayName: 'Ada',
+      isRegularUserAccount: true,
+    });
+
+    await autoLinkSlackInstaller({
+      slackClient,
+      slackTeamId: INSTALLED_TEAM_ID,
+      workspaceMemberId: MEMBER_ID,
+    });
+
+    expect(findSlackUserLinkMock).toHaveBeenCalledWith(expect.anything(), {
+      slackTeamId: 'T-enterprise-leaf',
+      slackUserId: 'U-installer',
+    });
+    expect(persistSlackUserLinkMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slackTeamId: 'T-enterprise-leaf' }),
+    );
+  });
+});

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/persist-slack-user-link.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/persist-slack-user-link.test.ts
@@ -8,10 +8,12 @@ const {
   createSlackUserLinkMock,
   destroySlackUserLinkMock,
   updateSlackUserLinkMock,
+  findDeletedSlackUserLinkIdMock,
 } = vi.hoisted(() => ({
   createSlackUserLinkMock: vi.fn(),
   destroySlackUserLinkMock: vi.fn(),
   updateSlackUserLinkMock: vi.fn(),
+  findDeletedSlackUserLinkIdMock: vi.fn(),
 }));
 
 vi.mock('src/logic-functions/data/create-slack-user-link', () => ({
@@ -24,6 +26,10 @@ vi.mock('src/logic-functions/data/destroy-slack-user-link', () => ({
 
 vi.mock('src/logic-functions/data/update-slack-user-link', () => ({
   updateSlackUserLink: updateSlackUserLinkMock,
+}));
+
+vi.mock('src/logic-functions/data/find-deleted-slack-user-link-id', () => ({
+  findDeletedSlackUserLinkId: findDeletedSlackUserLinkIdMock,
 }));
 
 const SLACK_TEAM_ID = 'T0INSTALLED';
@@ -60,6 +66,27 @@ describe('persistSlackUserLink', () => {
     createSlackUserLinkMock.mockResolvedValue('link-new');
     destroySlackUserLinkMock.mockResolvedValue(undefined);
     updateSlackUserLinkMock.mockResolvedValue(undefined);
+    findDeletedSlackUserLinkIdMock.mockResolvedValue(undefined);
+  });
+
+  it('should destroy a soft-deleted ghost holding the tuple before creating', async () => {
+    findDeletedSlackUserLinkIdMock.mockResolvedValue('link-ghost');
+
+    expect(await persist()).toBe('link-new');
+
+    expect(destroySlackUserLinkMock).toHaveBeenCalledWith(client, {
+      id: 'link-ghost',
+    });
+    expect(createSlackUserLinkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not look for a ghost when replacing a live link', async () => {
+    expect(await persist({ existingLink })).toBe('link-new');
+
+    expect(findDeletedSlackUserLinkIdMock).not.toHaveBeenCalled();
+    expect(destroySlackUserLinkMock).toHaveBeenCalledWith(client, {
+      id: existingLink.id,
+    });
   });
 
   it('should create a link when the Slack account has none', async () => {

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/persist-slack-user-link.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/persist-slack-user-link.test.ts
@@ -78,6 +78,9 @@ describe('persistSlackUserLink', () => {
       id: 'link-ghost',
     });
     expect(createSlackUserLinkMock).toHaveBeenCalledTimes(1);
+    expect(destroySlackUserLinkMock.mock.invocationCallOrder[0]).toBeLessThan(
+      createSlackUserLinkMock.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
   it('should not look for a ghost when replacing a live link', async () => {

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/auto-link-slack-installer.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/auto-link-slack-installer.ts
@@ -1,0 +1,63 @@
+import { type WebClient } from '@slack/web-api';
+import { isNonEmptyString } from '@sniptt/guards';
+import { CoreApiClient } from 'twenty-client-sdk/core';
+import { isDefined } from 'twenty-sdk/utils';
+
+import { SLACK_USER_LINK_CONSENT_STATE } from 'src/logic-functions/constants/slack-user-link-consent-state';
+import { SLACK_USER_LINK_SOURCE } from 'src/logic-functions/constants/slack-user-link-source';
+import { findSlackUserLink } from 'src/logic-functions/data/find-slack-user-link';
+import { findWorkspaceMemberEmailById } from 'src/logic-functions/data/find-workspace-member-email-by-id';
+import { persistSlackUserLink } from 'src/logic-functions/utils/persist-slack-user-link';
+import { resolveSlackUserByEmail } from 'src/logic-functions/utils/resolve-slack-user-by-email';
+
+export const autoLinkSlackInstaller = async ({
+  slackClient,
+  slackTeamId,
+  workspaceMemberId,
+}: {
+  slackClient: WebClient;
+  slackTeamId: string;
+  workspaceMemberId: string | null;
+}): Promise<void> => {
+  if (!isNonEmptyString(workspaceMemberId)) {
+    return;
+  }
+
+  const client = new CoreApiClient({ runAs: 'application' });
+
+  const email = await findWorkspaceMemberEmailById(client, workspaceMemberId);
+
+  if (!isNonEmptyString(email)) {
+    return;
+  }
+
+  const resolvedUser = await resolveSlackUserByEmail(slackClient, email);
+
+  if (!isDefined(resolvedUser) || !resolvedUser.isRegularUserAccount) {
+    return;
+  }
+
+  const linkTeamId = isNonEmptyString(resolvedUser.slackTeamId)
+    ? resolvedUser.slackTeamId
+    : slackTeamId;
+
+  const existingLink = await findSlackUserLink(client, {
+    slackTeamId: linkTeamId,
+    slackUserId: resolvedUser.slackUserId,
+  });
+
+  if (isDefined(existingLink)) {
+    return;
+  }
+
+  await persistSlackUserLink(client, {
+    existingLink: undefined,
+    isSameMemberRelink: false,
+    slackTeamId: linkTeamId,
+    slackUserId: resolvedUser.slackUserId,
+    workspaceMemberId,
+    name: resolvedUser.displayName,
+    source: SLACK_USER_LINK_SOURCE.AUTO,
+    consentState: SLACK_USER_LINK_CONSENT_STATE.ACTIVE,
+  });
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/persist-slack-user-link.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/persist-slack-user-link.ts
@@ -4,6 +4,7 @@ import { isDefined } from 'twenty-sdk/utils';
 
 import { createSlackUserLink } from 'src/logic-functions/data/create-slack-user-link';
 import { destroySlackUserLink } from 'src/logic-functions/data/destroy-slack-user-link';
+import { findDeletedSlackUserLinkId } from 'src/logic-functions/data/find-deleted-slack-user-link-id';
 import { updateSlackUserLink } from 'src/logic-functions/data/update-slack-user-link';
 import { type SlackUserLink } from 'src/logic-functions/types/slack-user-link.type';
 import { type SlackUserLinkConsentState } from 'src/logic-functions/types/slack-user-link-consent-state.type';
@@ -51,6 +52,15 @@ export const persistSlackUserLink = async (
 
   if (isDefined(existingLink)) {
     await destroySlackUserLink(client, { id: existingLink.id });
+  } else {
+    const deletedLinkId = await findDeletedSlackUserLinkId(client, {
+      slackTeamId,
+      slackUserId,
+    });
+
+    if (isDefined(deletedLinkId)) {
+      await destroySlackUserLink(client, { id: deletedLinkId });
+    }
   }
 
   return createSlackUserLink(client, {

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/register-slack-connection.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/register-slack-connection.ts
@@ -2,9 +2,11 @@ import { WebClient } from '@slack/web-api';
 import { isNonEmptyString } from '@sniptt/guards';
 import { getConnection, kv } from 'twenty-sdk/logic-function';
 
+import { autoLinkSlackInstaller } from 'src/logic-functions/utils/auto-link-slack-installer';
 import { cacheSlackBotUserId } from 'src/logic-functions/utils/cache-slack-bot-user-id';
 import { getSlackConnectedAccountTeamKvKey } from 'src/logic-functions/utils/get-slack-connected-account-team-kv-key';
 import { getSlackTeamKvKey } from 'src/logic-functions/utils/get-slack-team-kv-key';
+import { toErrorMessage } from 'src/logic-functions/utils/to-error-message.util';
 
 type RegisterSlackConnectionArgs = {
   connectedAccountId: string;
@@ -40,6 +42,18 @@ export const registerSlackConnection = async ({
   await kv.set(getSlackTeamKvKey(teamId), null, { scope: 'SERVER' });
 
   await cacheSlackBotUserId(botUserId);
+
+  try {
+    await autoLinkSlackInstaller({
+      slackClient: client,
+      slackTeamId: teamId,
+      workspaceMemberId: connection.workspaceMemberId,
+    });
+  } catch (error) {
+    console.warn(
+      `[slack] installer auto-link skipped: ${toErrorMessage(error)}`,
+    );
+  }
 
   return { ok: true, teamId };
 };


### PR DESCRIPTION
## Why

First follow-up to #24887, from the review discussion: the person who installs the Slack app should not have to message the bot before being linked, and the app should automate as much of the matching as possible starting with the connection itself. This PR handles the installer; the roster-wide bulk match and the unmatched-users listing come in the next PR.

It also fixes a latent bug the settings work exposed: app-defined unique indexes count soft-deleted rows, and deleting a workspace member cascade-soft-deletes their links, so a ghost row could permanently block relinking that Slack account.

## What it does

- **Installer auto-link on connect**: the connection payload now exposes the connecting member (`workspaceMemberId` on `AppConnection`, added server-side). After registering the connection, the onConnect hook reads that member's email, resolves it through `users.lookupByEmail` with the same trust gates as the lazy match (regular, confirmed accounts only), and stores an active AUTO link. Best effort: any failure is logged and never fails the connection. An existing link for that Slack account, whatever its state, is left untouched. The server does not store Slack's `authed_user`, so this is an email match; an installer whose Slack email differs still links manually.
- **Ghost link cleanup**: creating a link now destroys a soft-deleted row still holding the (team, user) unique tuple. Without this, a cascade from a deleted workspace member leaves a ghost no admin can see or clear, and that Slack account can never be linked again.

## Tests

The installer auto-link decision table (no member, no email, no match, restricted account, existing link untouched, happy path, enterprise team pass-through) and the ghost cleanup paths (destroyed before create, skipped when replacing a live link), plus the full app suite: `yarn lint`, `yarn typecheck`, `yarn test:unit` (407 tests) and `yarn twenty dev:build` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9jAuSxYo7kjeX5Nz6T5DP)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

