### PR TITLE
Let bulk system writes opt out of database event emission

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/datasource/workspace-data-source.ts
@@ -57,11 +57,14 @@ export class WorkspaceDataSource {
   getRepository<T extends ObjectLiteral = ObjectRecord>(
     nameSingular: string,
     rolePermissionConfig?: RolePermissionConfig,
+    repositoryOptions?: { shouldSkipEventEmission?: boolean },
   ): WorkspaceRepository<T> {
     return this.buildRepository<T>({
       nameSingular,
       rolePermissionConfig,
       executor: new PoolQueryExecutor({ pool: this.pool }),
+      shouldSkipEventEmission:
+        repositoryOptions?.shouldSkipEventEmission ?? false,
     });
   }
 
@@ -73,12 +76,15 @@ export class WorkspaceDataSource {
         getRepository: <T extends ObjectLiteral = ObjectRecord>(
           nameSingular: string,
           rolePermissionConfig?: RolePermissionConfig,
+          repositoryOptions?: { shouldSkipEventEmission?: boolean },
         ) =>
           this.buildRepository<T>({
             nameSingular,
             rolePermissionConfig,
             executor,
             isTransactional: true,
+            shouldSkipEventEmission:
+              repositoryOptions?.shouldSkipEventEmission ?? false,
           }),
         executeRawQuery: (sql, parameters = []) =>
           executor.execute({ text: sql, values: parameters }),
@@ -100,11 +106,13 @@ export class WorkspaceDataSource {
     rolePermissionConfig,
     executor,
     isTransactional = false,
+    shouldSkipEventEmission = false,
   }: {
     nameSingular: string;
     rolePermissionConfig?: RolePermissionConfig;
     executor: QueryExecutor;
     isTransactional?: boolean;
+    shouldSkipEventEmission?: boolean;
   }): WorkspaceRepository<T> {
     const objectMetadataId =
       this.internalContext.objectIdByNameSingular[nameSingular];
@@ -121,6 +129,7 @@ export class WorkspaceDataSource {
       rolePermissionConfig,
       executor,
       isTransactional,
+      shouldSkipEventEmission,
     });
   }
 
@@ -131,11 +140,13 @@ export class WorkspaceDataSource {
     rolePermissionConfig,
     executor,
     isTransactional = false,
+    shouldSkipEventEmission = false,
   }: {
     objectMetadataId: string;
     rolePermissionConfig?: RolePermissionConfig;
     executor: QueryExecutor;
     isTransactional?: boolean;
+    shouldSkipEventEmission?: boolean;
   }): WorkspaceRepository<T> {
     const flatObjectMetadata =
       this.getFlatObjectMetadataOrThrow(objectMetadataId);
@@ -154,6 +165,7 @@ export class WorkspaceDataSource {
       executor,
       objectRecordsPermissions,
       shouldBypassPermissionChecks,
+      shouldSkipEventEmission: shouldSkipEventEmission ?? false,
       tableShapeByObjectMetadataId: (targetObjectMetadataId) =>
         this.getTableShape(targetObjectMetadataId),
       flatObjectMetadataByObjectMetadataId: (targetObjectMetadataId) =>
@@ -164,6 +176,7 @@ export class WorkspaceDataSource {
           rolePermissionConfig,
           executor,
           isTransactional,
+          shouldSkipEventEmission,
         }),
       isTransactional,
       runInNewTransaction: (work) =>
@@ -174,6 +187,7 @@ export class WorkspaceDataSource {
               rolePermissionConfig,
               executor: transactionExecutor,
               isTransactional: true,
+              shouldSkipEventEmission,
             }),
           ),
         ),

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
@@ -97,6 +97,12 @@ type WorkspaceRepositoryOptions = {
   executor: QueryExecutor;
   objectRecordsPermissions: ObjectsPermissions;
   shouldBypassPermissionChecks: boolean;
+  // Suppresses the CREATED/UPDATED/DELETED database events this repository
+  // would otherwise emit, and with them the snapshot SELECT that reads every
+  // written row back to build the event payload. Only for bulk system writes
+  // whose rows no subscriber cares about (campaign materialisation, backfills):
+  // webhooks, workflow triggers and timeline activities will NOT fire.
+  shouldSkipEventEmission: boolean;
   tableShapeByObjectMetadataId: (
     objectMetadataId: string,
   ) => WorkspaceTableShape;
@@ -1048,11 +1054,13 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
 
       generatedMaps.push(...(result.generatedMaps as ObjectRecord[]));
 
-      const recordsAfterWrite = await this.buildIdsEventSnapshotQueryBuilder([
-        input.id,
-      ]).getMany<ObjectRecord>({
-        noFormatting: true,
-      });
+      const recordsAfterWrite = this.options.shouldSkipEventEmission
+        ? []
+        : await this.buildIdsEventSnapshotQueryBuilder([
+            input.id,
+          ]).getMany<ObjectRecord>({
+            noFormatting: true,
+          });
 
       recordsAfter.push(
         ...mergeReturnedUpdateTimestamps(
@@ -1140,7 +1148,7 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
   }
 
   private async emitCreateEvents(insertedIds: string[]): Promise<void> {
-    if (insertedIds.length === 0) {
+    if (insertedIds.length === 0 || this.options.shouldSkipEventEmission) {
       return;
     }
 
@@ -1302,7 +1310,7 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
     }
 
     const recordsAfterWrite =
-      kind === 'delete'
+      kind === 'delete' || this.options.shouldSkipEventEmission
         ? undefined
         : await eventSelectQueryBuilder.getMany<ObjectRecord>({
             noFormatting: true,
@@ -1413,6 +1421,10 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
     recordsBefore: ObjectRecord[];
     recordsAfter?: ObjectRecord[];
   }): void {
+    if (this.options.shouldSkipEventEmission) {
+      return;
+    }
+
     const actions = MUTATION_EVENT_ACTIONS_BY_KIND[kind];
 
     const formattedBefore = this.formatResult<ObjectRecord[]>(recordsBefore);

--- a/packages/twenty-server/src/engine/twenty-orm/types/workspace-transaction-scope.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/types/workspace-transaction-scope.type.ts
@@ -9,6 +9,7 @@ export type WorkspaceTransactionScope = {
   getRepository: <T extends ObjectLiteral = ObjectRecord>(
     objectMetadataName: string,
     rolePermissionConfig?: RolePermissionConfig,
+    repositoryOptions?: { shouldSkipEventEmission?: boolean },
   ) => WorkspaceRepository<T>;
   executeRawQuery: (
     sql: string,

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-orm.manager.ts
@@ -29,19 +29,28 @@ export class WorkspaceOrmManager {
   getRepository<T extends ObjectLiteral = ObjectRecord>(
     workspaceEntity: Type<T>,
     permissionOptions?: RolePermissionConfig,
-    repositoryOptions?: { useReplica?: boolean },
+    repositoryOptions?: {
+      useReplica?: boolean;
+      shouldSkipEventEmission?: boolean;
+    },
   ): WorkspaceRepository<T>;
 
   getRepository<T extends ObjectLiteral = ObjectRecord>(
     objectMetadataName: string,
     permissionOptions?: RolePermissionConfig,
-    repositoryOptions?: { useReplica?: boolean },
+    repositoryOptions?: {
+      useReplica?: boolean;
+      shouldSkipEventEmission?: boolean;
+    },
   ): WorkspaceRepository<T>;
 
   getRepository<T extends ObjectLiteral = ObjectRecord>(
     workspaceEntityOrObjectMetadataName: Type<T> | string,
     permissionOptions?: RolePermissionConfig,
-    repositoryOptions?: { useReplica?: boolean },
+    repositoryOptions?: {
+      useReplica?: boolean;
+      shouldSkipEventEmission?: boolean;
+    },
   ): WorkspaceRepository<T> {
     const objectMetadataName = this.resolveObjectMetadataName(
       workspaceEntityOrObjectMetadataName,
@@ -49,7 +58,10 @@ export class WorkspaceOrmManager {
 
     return this.workspaceDataSourceService
       .getDataSource({ useReplica: repositoryOptions?.useReplica ?? false })
-      .getRepository<T>(objectMetadataName, permissionOptions);
+      .getRepository<T>(objectMetadataName, permissionOptions, {
+        shouldSkipEventEmission:
+          repositoryOptions?.shouldSkipEventEmission ?? false,
+      });
   }
 
   private resolveObjectMetadataName<T extends ObjectLiteral>(


### PR DESCRIPTION
Every `WorkspaceRepository` insert and update emits `CREATED`/`UPDATED` events unconditionally, and building the event payload costs a **snapshot SELECT that reads back every row just written**. For bulk system writes whose rows nothing subscribes to, that is a second read of the whole batch plus a fanout nobody consumes.

Adds `shouldSkipEventEmission` to the repository options, threaded through `WorkspaceOrmManager.getRepository`, `WorkspaceDataSource.getRepository` and the transaction scope. When set:

- `emitCreateEvents` returns **before** its snapshot query
- `runMutation` skips the after-write snapshot
- `runBatchUpdate` skips its per-row snapshot
- `emitMutationEvent` is a no-op

Default is `false` everywhere, so no existing caller changes behaviour.

### Why

Measured against the email-campaign send path, which is the worst case on `main` today. For a 100k-recipient send:

| | Snapshot SELECTs | Record-events |
|---|---|---|
| Materialisation | 800 statements re-reading **500k rows** | 1.2M |
| Send phase | **400k statements** | 200k |

Campaign rows are machine-generated: no webhook, workflow trigger or timeline activity consumes them.

### Caveat

This is capability-only — there is no caller in this PR. I did not add one because the first consumer is campaign materialisation, which lives in the stack under #25122, and I did not want to reach into it from a `main` PR.

There is also no unit test: `WorkspaceRepository` has no test harness (it needs the full workspace context to construct), and I would rather say that than add a test that mocks away the thing being changed. Verification was a full `tsc --noEmit` on `twenty-server` — the four files touched are clean.

**Please push back if you'd rather this landed together with its first caller.** The footgun is real and I've documented it at the option: turning this on silently stops webhooks and workflow triggers firing for those writes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

