### PR TITLE
Bill every recipient of a multi-recipient send

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/utils/__tests__/count-delivered-recipients.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/utils/__tests__/count-delivered-recipients.util.spec.ts
@@ -1,0 +1,23 @@
+import { countDeliveredRecipients } from 'src/engine/core-modules/emailing-domain/utils/count-delivered-recipients.util';
+
+describe('countDeliveredRecipients', () => {
+  it('counts a single to recipient', () => {
+    expect(
+      countDeliveredRecipients({ to: ['a@example.com'], cc: [], bcc: [] }),
+    ).toBe(1);
+  });
+
+  it('counts to, cc and bcc together', () => {
+    expect(
+      countDeliveredRecipients({
+        to: ['a@example.com', 'b@example.com'],
+        cc: ['c@example.com'],
+        bcc: ['d@example.com', 'e@example.com'],
+      }),
+    ).toBe(5);
+  });
+
+  it('returns 0 when the provider delivered to nobody', () => {
+    expect(countDeliveredRecipients({ to: [], cc: [], bcc: [] })).toBe(0);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/utils/count-delivered-recipients.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/utils/count-delivered-recipients.util.ts
@@ -1,0 +1,8 @@
+import { type EmailingDomainSendEmailResult } from 'src/engine/core-modules/emailing-domain/drivers/types/emailing-domain-send-email-result.type';
+
+export const countDeliveredRecipients = ({
+  to,
+  cc,
+  bcc,
+}: EmailingDomainSendEmailResult['deliveredRecipients']): number =>
+  to.length + cc.length + bcc.length;

--- a/packages/twenty-server/src/modules/emailing/resolvers/emailing-send.resolver.ts
+++ b/packages/twenty-server/src/modules/emailing/resolvers/emailing-send.resolver.ts
@@ -25,6 +25,7 @@ import {
 } from 'src/engine/guards/feature-flag.guard';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
+import { countDeliveredRecipients } from 'src/engine/core-modules/emailing-domain/utils/count-delivered-recipients.util';
 import { EmailBillingService } from 'src/modules/emailing/services/email-billing.service';
 import { EmailingDomainSenderService } from 'src/modules/emailing/services/emailing-domain-sender.service';
 import { MessageCampaignService } from 'src/modules/emailing/services/message-campaign.service';
@@ -68,7 +69,7 @@ export class EmailingSendResolver {
 
     await this.emailBillingService.billSentEmails({
       workspaceId: currentWorkspace.id,
-      sentEmailCount: 1,
+      sentEmailCount: countDeliveredRecipients(result.deliveredRecipients),
     });
 
     return { messageId: result.messageId };


### PR DESCRIPTION
`sendEmailViaEmailingDomain` takes `to`, `cc` and `bcc` as arrays (`to` only requires `ArrayMinSize(1)`) and bills a flat `sentEmailCount: 1`. SES charges per recipient, so **every multi-recipient send through this mutation is undercharged** — a mutation addressed to twenty people is billed as one email.

The send result already carries `deliveredRecipients`, so count those instead.

`countDeliveredRecipients` is written to match the helper @neo773 added in #25125, so that stack rebases onto this cleanly — the fix is his, this just lands it on `main` now rather than at the bottom of a four-deep stack.

### Two related paths I deliberately did not touch

Both currently bill nothing on `main`, and #25125 starts billing both. Charging where nothing is charged today is a pricing decision, not a bug fix, so it should be a deliberate call rather than a side effect of a performance PR:

- `sendMessageCampaignTest` — validates credits, never calls `billSentEmails`
- `email-group-message-outbound.service.ts` — the transactional send path, never bills at all

Worth confirming these are intended before #25125 lands, since `sendKind: 'TRANSACTIONAL'` vs `'MARKETING'` arrives in that same stack and transactional sends may well be meant to stay free.

### Verified

`tsc --noEmit` clean on the touched files, and the new unit test passes:

```
PASS  src/engine/core-modules/emailing-domain/utils/__tests__/count-delivered-recipients.util.spec.ts
Tests: 3 passed, 3 total
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

