### PR TITLE
docs: clarify that the app key-value store is persistent (Postgres-backed)

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/logic/key-value-store.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/key-value-store.mdx
@@ -8,7 +8,7 @@ Logic functions run sandboxed in short-lived Node.js processes — once a run fi
 
 Every application gets its own isolated namespace: entries are keyed by the authenticated app, so your keys can never collide with — or be read by — another application.
 
-The store is **persistent**: entries are stored in the instance's PostgreSQL database — not in an in-memory cache like Redis — so they survive server restarts, deployments, and app updates, and stay around until you delete them. This makes it safe for durable state like API keys, sync cursors, or per-user configuration, not just short-lived caches.
+The store is **persistent**: entries are stored in the instance's PostgreSQL database — not in an in-memory cache like Redis — so they survive server restarts, deployments, and app updates, and stay around until you delete them. This makes it reliable for durable state like sync cursors or per-user configuration, not just short-lived caches. Values are stored as plain JSON without application-level encryption, so don't put secrets in it — keep API keys and other credentials in secret [application or server variables](/developers/extend/apps/config/application), which are encrypted at rest.
 
 ```text
   ┌─────────────────┐   kv.set(key, value)   ┌──────────────────────────┐

--- a/packages/twenty-docs/developers/extend/apps/logic/key-value-store.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/key-value-store.mdx
@@ -8,6 +8,8 @@ Logic functions run sandboxed in short-lived Node.js processes — once a run fi
 
 Every application gets its own isolated namespace: entries are keyed by the authenticated app, so your keys can never collide with — or be read by — another application.
 
+The store is **persistent**: entries are stored in the instance's PostgreSQL database — not in an in-memory cache like Redis — so they survive server restarts, deployments, and app updates, and stay around until you delete them. This makes it safe for durable state like API keys, sync cursors, or per-user configuration, not just short-lived caches.
+
 ```text
   ┌─────────────────┐   kv.set(key, value)   ┌──────────────────────────┐
   │ Logic function  │ ─────────────────────▶ │ Application KV store     │
@@ -96,7 +98,7 @@ export default defineLogicFunction({
 - **Namespacing.** Prefix keys to keep different concerns apart — `sync-cursor:linear`, `cache:exchange-rate:USD:EUR`, `lock:nightly-report`.
 - **Expiry (TTL).** The store has no built-in expiration. Store a timestamp inside the value (as in the cache example) and check it on read, or clear stale keys from a [cron-triggered function](/developers/extend/apps/logic/logic-functions).
 - **What to store.** Any JSON-serializable value — numbers, strings, arrays, objects. Keep entries small; this is for coordination and caching, not large blobs or files. For files, use a `FILES` field and [`uploadFile`](/developers/extend/apps/logic/logic-functions#uploading-files).
-- **Visibility.** Entries live in the instance database, not as workspace records — they never show up in the workspace UI, aren't part of your app's data model, and need no role or object permissions.
+- **Visibility.** Entries live in the instance's Postgres database, not as workspace records — they never show up in the workspace UI, aren't part of your app's data model, and need no role or object permissions.
 
 ## Alternative: a queryable store object
 


### PR DESCRIPTION
The [Key-Value Store docs page](https://docs.twenty.com/developers/extend/apps/logic/key-value-store) never states that the store is persistent, and users have assumed it is Redis-backed and ephemeral (which came up in a community conversation, where someone ruled out the KV store for storing an API key for that reason).

This adds an explicit note in the intro that entries are stored in the instance's PostgreSQL database (not an in-memory cache like Redis), survive restarts and deployments, and are suitable for durable state like API keys, sync cursors, and per-user configuration. Also tweaks the Visibility tip to name Postgres.

Only the English source page is touched; localized copies are left to the translation pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZtLDjZNKkmvcUAXtBbtAg)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

