### PR TITLE
Fix workflow diagram jumping 200px left when a rename forks a draft

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
@@ -333,7 +333,7 @@ export const WorkflowDiagramCanvasBase = ({
 
       const sidePanelWidth = store.get(sidePanelWidthState.atom);
 
-      if (!isInSidePanel && isSidePanelOpened) {
+      if (!isInSidePanel && isSidePanelOpened && hasViewportBeenMoved) {
         adjustedContainerWidth = baseContainerWidth - sidePanelWidth;
       } else if (!isInSidePanel && hasViewportBeenMoved) {
         adjustedContainerWidth = baseContainerWidth + sidePanelWidth;


### PR DESCRIPTION
Renaming a step on an **active** workflow forks a draft and the diagram jumps 200px to the left, clipping the leftmost node at the canvas edge. Reported by QA Scout on #24334 (https://github.com/twentyhq/twenty/pull/24334#issuecomment-5490854791); the bug predates that PR, which only made centering exact enough for the jump to be clearly visible.

`setFlowViewport` adjusts the measured container width by the side panel width when the panel is open. That adjustment is predictive: it assumes `offsetWidth` was read at the start of the panel's open animation, before the flex layout shrinks, so subtracting the panel width yields the final visible width. That holds when the recompute is a reaction to the panel opening.

It breaks when the canvas initializes in a settled layout with the panel already open. The draft fork's refetch briefly leaves `workflowWithCurrentVersion` undefined, the editable canvas returns `null`, and the remounted ReactFlow re-runs `onInit` and the viewport effect. At that point the container already excludes the panel, so the panel width is subtracted twice and the viewport lands `sidePanelWidth / 2 = 200px` left of center. Scout's measurements match exactly: correct `329.5 = 659 / 2`, broken `129.5 = (659 - 400) / 2`.

The two cases are already distinguishable in the code: a recompute reacting to a panel transition always sees a previously-set viewport (`hasViewportBeenMoved`), while a fresh init still has the default `x: 0`. The fix gates the subtraction on `hasViewportBeenMoved`, leaving the animated open/close paths untouched. It also fixes any other variant where the canvas mounts while the panel is already open.

Not covered: a canvas that mounts exactly mid panel-opening animation would still measure a transient width. No such flow exists today.

Verified by analysis against Scout's measurements, not yet in a browser. To check manually: rename a step on an active workflow (draft fork) and confirm the diagram stays centered; open/close the panel and confirm the existing recenter animation is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

