### PR TITLE
Restore purpose-built side panel page state

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/hooks/__tests__/useWorkspaceSurfaceScopedComponentInstanceId.test.ts
+++ b/packages/twenty-front/src/modules/ui/layout/hooks/__tests__/useWorkspaceSurfaceScopedComponentInstanceId.test.ts
@@ -1,0 +1,53 @@
+import { getWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+
+describe('getWorkspaceSurfaceScopedComponentInstanceId', () => {
+  it('keeps main-surface component IDs unchanged', () => {
+    expect(
+      getWorkspaceSurfaceScopedComponentInstanceId({
+        componentInstanceId: 'table',
+        surfaceType: 'main',
+        surfaceInstanceId: 'main',
+      }),
+    ).toBe('table');
+  });
+
+  it('scopes reusable component IDs once per side-panel instance', () => {
+    const args = {
+      surfaceType: 'side-panel' as const,
+      surfaceInstanceId: 'panel-1',
+    };
+
+    expect(
+      getWorkspaceSurfaceScopedComponentInstanceId({
+        ...args,
+        componentInstanceId: 'table',
+      }),
+    ).toBe('table-panel-1');
+    expect(
+      getWorkspaceSurfaceScopedComponentInstanceId({
+        ...args,
+        componentInstanceId: 'table-panel-1',
+      }),
+    ).toBe('table-panel-1');
+  });
+
+  it('preserves a component ID that is already the side-panel instance ID', () => {
+    expect(
+      getWorkspaceSurfaceScopedComponentInstanceId({
+        componentInstanceId: 'panel-1',
+        surfaceType: 'side-panel',
+        surfaceInstanceId: 'panel-1',
+      }),
+    ).toBe('panel-1');
+  });
+
+  it('preserves a missing component ID', () => {
+    expect(
+      getWorkspaceSurfaceScopedComponentInstanceId({
+        componentInstanceId: '',
+        surfaceType: 'side-panel',
+        surfaceInstanceId: 'panel-1',
+      }),
+    ).toBe('');
+  });
+});

--- a/packages/twenty-front/src/modules/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId.ts
+++ b/packages/twenty-front/src/modules/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId.ts
@@ -13,6 +13,8 @@ export const getWorkspaceSurfaceScopedComponentInstanceId = ({
   if (
     surfaceType !== 'side-panel' ||
     surfaceInstanceId.length === 0 ||
+    componentInstanceId.length === 0 ||
+    componentInstanceId === surfaceInstanceId ||
     componentInstanceId.endsWith(`-${surfaceInstanceId}`)
   ) {
     return componentInstanceId;

--- a/packages/twenty-front/src/modules/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId.ts
+++ b/packages/twenty-front/src/modules/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId.ts
@@ -1,4 +1,5 @@
 import { useWorkspaceSurface } from '@/ui/layout/hooks/useWorkspaceSurface';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useCallback } from 'react';
 
 export const getWorkspaceSurfaceScopedComponentInstanceId = ({
@@ -12,8 +13,8 @@ export const getWorkspaceSurfaceScopedComponentInstanceId = ({
 }) => {
   if (
     surfaceType !== 'side-panel' ||
-    surfaceInstanceId.length === 0 ||
-    componentInstanceId.length === 0 ||
+    !isNonEmptyString(surfaceInstanceId) ||
+    !isNonEmptyString(componentInstanceId) ||
     componentInstanceId === surfaceInstanceId ||
     componentInstanceId.endsWith(`-${surfaceInstanceId}`)
   ) {


### PR DESCRIPTION
## Summary

- preserve purpose-built side-panel page state when its component instance ID is already the panel instance ID
- continue suffix-scoping reusable inner component IDs per panel entry
- preserve empty component IDs instead of manufacturing an invalid scoped ID
- add regression coverage for main, reusable side-panel, already-scoped, page-instance, and empty IDs

## Root cause

Purpose-built pages seed their state with their unique `pageId`. Automatic workspace-surface scoping then treated that already-unique ID like a reusable inner component ID and transformed it to `pageId-pageId`. Readers consequently saw default/null state, leaving pages such as Create Related, Compose Email/Calendar Event, workflow panels, campaign test, and front-component panels with a visible shell but blank body.

The surface instance is itself a valid isolated component instance. Only reusable IDs need the suffix.

## Validation

- focused Jest suite: 4 tests passed
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

