### PR TITLE
Hide Ask AI command when in side panel

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-upgrade-version-command.module.ts
@@ -12,6 +12,7 @@ import { PinAskAiCommandMenuItemCommand } from 'src/database/commands/upgrade-ve
 import { ReownObjectNavigationCommandMenuItemsCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788166853000-reown-object-navigation-command-menu-items.command';
 import { ProvisionMissingObjectNavigationCommandMenuItemsCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788181550000-provision-missing-object-navigation-command-menu-items.command';
 import { EnableStandardActivityTargetFieldsCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788197000000-enable-standard-activity-target-fields.command';
+import { HideAskAiInSidePanelCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788266562942-hide-ask-ai-in-side-panel.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { CommandMenuItemEntity } from 'src/engine/metadata-modules/command-menu-item/entities/command-menu-item.entity';
 import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
@@ -40,6 +41,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     ReownObjectNavigationCommandMenuItemsCommand,
     ProvisionMissingObjectNavigationCommandMenuItemsCommand,
     EnableStandardActivityTargetFieldsCommand,
+    HideAskAiInSidePanelCommand,
   ],
 })
 export class V2_38_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788266562942-hide-ask-ai-in-side-panel.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788266562942-hide-ask-ai-in-side-panel.command.ts
@@ -1,0 +1,80 @@
+import { Command } from 'nest-commander';
+import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { buildHideAskAiInSidePanelCommandMenuItemUpdate } from 'src/database/commands/upgrade-version-command/2-38/utils/build-hide-ask-ai-in-side-panel-command-menu-item-update.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+import { WorkspaceMigrationBuilderException } from 'src/engine/workspace-manager/workspace-migration/exceptions/workspace-migration-builder-exception';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+@RegisteredWorkspaceCommand('2.38.0', 1788266562942)
+@Command({
+  name: 'upgrade:2-38:hide-ask-ai-in-side-panel',
+  description: 'Hide the Ask AI command in side panels',
+})
+export class HideAskAiInSidePanelCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const { flatCommandMenuItemMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatCommandMenuItemMaps',
+      ]);
+
+    const commandMenuItemToUpdate =
+      buildHideAskAiInSidePanelCommandMenuItemUpdate({
+        existingCommandMenuItem:
+          flatCommandMenuItemMaps.byUniversalIdentifier[
+            STANDARD_COMMAND_MENU_ITEMS.askAi.universalIdentifier
+          ],
+        now: new Date().toISOString(),
+      });
+
+    if (!isDefined(commandMenuItemToUpdate)) {
+      return;
+    }
+
+    if (options.dryRun) {
+      this.logger.log(
+        `Would hide the Ask AI command in side panels for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            commandMenuItem: {
+              flatEntityToCreate: [],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [commandMenuItemToUpdate],
+            },
+          },
+          workspaceId,
+          isSystemBuild: true,
+          applicationUniversalIdentifier:
+            TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      throw new WorkspaceMigrationBuilderException(validateAndBuildResult);
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-hide-ask-ai-in-side-panel-command-menu-item-update.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-hide-ask-ai-in-side-panel-command-menu-item-update.util.spec.ts
@@ -1,0 +1,69 @@
+import { buildHideAskAiInSidePanelCommandMenuItemUpdate } from 'src/database/commands/upgrade-version-command/2-38/utils/build-hide-ask-ai-in-side-panel-command-menu-item-update.util';
+import { type FlatCommandMenuItem } from 'src/engine/metadata-modules/flat-command-menu-item/types/flat-command-menu-item.type';
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+import { createStandardCommandMenuItemFlatMetadata } from 'src/engine/workspace-manager/twenty-standard-application/utils/command-menu-item/create-standard-command-menu-item-flat-metadata.util';
+
+const NOW = '2026-09-01T12:00:00.000Z';
+const LEGACY_COMMAND_MENU_ITEM: FlatCommandMenuItem = Object.freeze({
+  ...createStandardCommandMenuItemFlatMetadata({
+    commandMenuItemName: 'askAi',
+    commandMenuItemId: 'ask-ai-command-id',
+    workspaceId: 'workspace-id',
+    twentyStandardApplicationId: 'application-id',
+    dependencyFlatEntityMaps: {
+      flatObjectMetadataMaps: createEmptyFlatEntityMaps(),
+    },
+    now: '2026-08-01T00:00:00.000Z',
+  }),
+  conditionalAvailabilityExpression: 'permissionFlags.AI',
+});
+
+describe('buildHideAskAiInSidePanelCommandMenuItemUpdate', () => {
+  it('updates the legacy availability expression to the standard definition', () => {
+    expect(
+      buildHideAskAiInSidePanelCommandMenuItemUpdate({
+        existingCommandMenuItem: LEGACY_COMMAND_MENU_ITEM,
+        now: NOW,
+      }),
+    ).toEqual({
+      ...LEGACY_COMMAND_MENU_ITEM,
+      conditionalAvailabilityExpression:
+        STANDARD_COMMAND_MENU_ITEMS.askAi.conditionalAvailabilityExpression,
+      updatedAt: NOW,
+    });
+  });
+
+  it('keeps the migrated expression synchronized with the standard definition', () => {
+    expect(
+      STANDARD_COMMAND_MENU_ITEMS.askAi.conditionalAvailabilityExpression,
+    ).toBe('permissionFlags.AI and not isInSidePanel');
+  });
+
+  it.each([
+    { name: 'missing command', existingCommandMenuItem: undefined },
+    {
+      name: 'custom availability expression',
+      existingCommandMenuItem: {
+        ...LEGACY_COMMAND_MENU_ITEM,
+        conditionalAvailabilityExpression:
+          'permissionFlags.AI and objectPermissions.canReadObjectRecords',
+      },
+    },
+    {
+      name: 'already migrated command',
+      existingCommandMenuItem: {
+        ...LEGACY_COMMAND_MENU_ITEM,
+        conditionalAvailabilityExpression:
+          STANDARD_COMMAND_MENU_ITEMS.askAi.conditionalAvailabilityExpression,
+      },
+    },
+  ])('skips $name', ({ existingCommandMenuItem }) => {
+    expect(
+      buildHideAskAiInSidePanelCommandMenuItemUpdate({
+        existingCommandMenuItem,
+        now: NOW,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-hide-ask-ai-in-side-panel-command-menu-item-update.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-hide-ask-ai-in-side-panel-command-menu-item-update.util.ts
@@ -1,0 +1,29 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type FlatCommandMenuItem } from 'src/engine/metadata-modules/flat-command-menu-item/types/flat-command-menu-item.type';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+
+const LEGACY_ASK_AI_AVAILABILITY_EXPRESSION = 'permissionFlags.AI';
+
+export const buildHideAskAiInSidePanelCommandMenuItemUpdate = ({
+  existingCommandMenuItem,
+  now,
+}: {
+  existingCommandMenuItem: FlatCommandMenuItem | undefined;
+  now: string;
+}): FlatCommandMenuItem | undefined => {
+  if (
+    !isDefined(existingCommandMenuItem) ||
+    existingCommandMenuItem.conditionalAvailabilityExpression !==
+      LEGACY_ASK_AI_AVAILABILITY_EXPRESSION
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...existingCommandMenuItem,
+    conditionalAvailabilityExpression:
+      STANDARD_COMMAND_MENU_ITEMS.askAi.conditionalAvailabilityExpression,
+    updatedAt: now,
+  };
+};

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
@@ -877,7 +877,8 @@ export const STANDARD_COMMAND_MENU_ITEMS = {
     position: 43,
     shortLabel: null,
     availabilityType: CommandMenuItemAvailabilityType.GLOBAL,
-    conditionalAvailabilityExpression: 'permissionFlags.AI',
+    conditionalAvailabilityExpression:
+      'permissionFlags.AI and not isInSidePanel',
     availabilityObjectMetadataUniversalIdentifier: null,
     frontComponentUniversalIdentifier: null,
     engineComponentKey: EngineComponentKey.ASK_AI,


### PR DESCRIPTION
### Motivation
- Prevent the `Ask AI` command from appearing in side panels so it is only available in main/global contexts when AI permission is granted.

### Description
- Update `askAi` command's `conditionalAvailabilityExpression` from `permissionFlags.AI` to `permissionFlags.AI and not isInSidePanel` in `standard-command-menu-item.constant.ts` so the item is hidden inside side panels.

### Testing
- Ran the project test and lint workflows with `yarn test` and `yarn lint`, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a96c17ec31c832fa82dd318377e1385)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

