### PR TITLE
Show the Stripe billing date in self-hosted enterprise settings

### DIFF
--- a/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
+++ b/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -223,12 +223,13 @@ export const SettingsEnterprise = ({
     stripeStatus === 'incomplete' || stripeStatus === 'incomplete_expired';
 
   const licensee = subscriptionStatus?.licensee ?? null;
-  const expiresAt = subscriptionStatus?.expiresAt
-    ? new Date(subscriptionStatus.expiresAt)
-    : null;
 
   const cancelAt = isDefined(subscriptionStatus?.cancelAt)
     ? new Date(subscriptionStatus.cancelAt)
+    : null;
+
+  const currentPeriodEnd = isDefined(subscriptionStatus?.currentPeriodEnd)
+    ? new Date(subscriptionStatus.currentPeriodEnd)
     : null;
 
   const cancelAtDate =
@@ -240,6 +241,13 @@ export const SettingsEnterprise = ({
     isCancelScheduled && isDefined(cancelAt)
       ? t`Your enterprise features will remain active until ${cancelAtDate}.`
       : null;
+
+  // expiresAt is the validity token lease renewed daily by the instance, not a
+  // billing date, so the subscription rows read the Stripe period instead.
+  const subscriptionDate = isCancelScheduled ? cancelAt : currentPeriodEnd;
+  const subscriptionDateLabel = isCancelScheduled
+    ? t`Cancels on`
+    : t`Renews on`;
 
   const handleActivate = useCallback(async () => {
     if (!enterpriseKey.trim()) return;
@@ -694,11 +702,11 @@ export const SettingsEnterprise = ({
                   currentValue={licensee}
                 />
               )}
-              {expiresAt && (
+              {isDefined(subscriptionDate) && (
                 <SubscriptionInfoRowContainer
-                  label={t`Valid until`}
+                  label={subscriptionDateLabel}
                   Icon={IconCalendarRepeat}
-                  currentValue={new Date(expiresAt).toLocaleDateString()}
+                  currentValue={subscriptionDate.toLocaleDateString()}
                 />
               )}
             </SubscriptionInfoContainer>
@@ -756,11 +764,11 @@ export const SettingsEnterprise = ({
                   currentValue={licensee}
                 />
               )}
-              {expiresAt && (
+              {isDefined(subscriptionDate) && (
                 <SubscriptionInfoRowContainer
-                  label={isCancelScheduled ? t`Cancels on` : t`Valid until`}
+                  label={subscriptionDateLabel}
                   Icon={IconCalendarRepeat}
-                  currentValue={new Date(expiresAt).toLocaleDateString()}
+                  currentValue={subscriptionDate.toLocaleDateString()}
                 />
               )}
             </SubscriptionInfoContainer>

--- a/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
+++ b/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -242,10 +242,10 @@ export const SettingsEnterprise = ({
       ? t`Your enterprise features will remain active until ${cancelAtDate}.`
       : null;
 
-  // expiresAt is the validity token lease renewed daily by the instance, not a
-  // billing date, so the subscription rows read the Stripe period instead.
-  const subscriptionDate = isCancelScheduled ? cancelAt : currentPeriodEnd;
-  const subscriptionDateLabel = isCancelScheduled
+  const cancellationOrPeriodEndDate = isCancelScheduled
+    ? cancelAt
+    : currentPeriodEnd;
+  const cancellationOrPeriodEndDateLabel = isCancelScheduled
     ? t`Cancels on`
     : t`Renews on`;
 
@@ -702,11 +702,11 @@ export const SettingsEnterprise = ({
                   currentValue={licensee}
                 />
               )}
-              {isDefined(subscriptionDate) && (
+              {isDefined(cancellationOrPeriodEndDate) && (
                 <SubscriptionInfoRowContainer
-                  label={subscriptionDateLabel}
+                  label={cancellationOrPeriodEndDateLabel}
                   Icon={IconCalendarRepeat}
-                  currentValue={subscriptionDate.toLocaleDateString()}
+                  currentValue={cancellationOrPeriodEndDate.toLocaleDateString()}
                 />
               )}
             </SubscriptionInfoContainer>
@@ -764,11 +764,11 @@ export const SettingsEnterprise = ({
                   currentValue={licensee}
                 />
               )}
-              {isDefined(subscriptionDate) && (
+              {isDefined(cancellationOrPeriodEndDate) && (
                 <SubscriptionInfoRowContainer
-                  label={subscriptionDateLabel}
+                  label={cancellationOrPeriodEndDateLabel}
                   Icon={IconCalendarRepeat}
-                  currentValue={subscriptionDate.toLocaleDateString()}
+                  currentValue={cancellationOrPeriodEndDate.toLocaleDateString()}
                 />
               )}
             </SubscriptionInfoContainer>


### PR DESCRIPTION
Self-hosted admins reported that the date in Settings > Enterprise never matches the renewal date in Stripe (e.g. the app said 04.09 while Stripe said 24.09).

The subscription rows were rendering `expiresAt`, which is not a billing date. `getSubscriptionStatus` fills it from `getLicenseInfo()`, i.e. the `exp` claim of the enterprise validity token. That token is a short-lived license lease that `EnterpriseKeyValidationCronJob` renews every night at 4 AM UTC, so the value always sits a few days out and creeps forward daily. Labelled "Valid until" next to the billing portal link, it reads as a renewal date.

`currentPeriodEnd` (the real Stripe period end) was already fetched by the query and exposed on `EnterpriseSubscriptionStatusDTO`, but never rendered.

Separately, when a cancellation is scheduled the row switched its label to "Cancels on" while still showing `expiresAt`. `cancelAt` is in the same payload and was only used for the prose notice below, so the row could claim the subscription ends in three days when it actually ends weeks later.

## Changes

- Render `currentPeriodEnd` under a "Renews on" label.
- Use `cancelAt` for the "Cancels on" label.
- Drop the `expiresAt` row. The lease is an implementation detail of the offline grace window, and the case where it matters is already covered by the dedicated "your validity token is invalid or has expired" branch.

## Test

Self-hosted instance with an active enterprise key: the date shown now matches the period end in the Stripe customer portal. With a cancellation scheduled, "Cancels on" matches the cancellation date in Stripe.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

