### PR TITLE
fix(exception-handler): guard Sentry driver against non-object exceptions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/exception-handler/drivers/sentry.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/drivers/sentry.driver.ts
@@ -48,7 +48,10 @@ export class ExceptionHandlerSentryDriver implements ExceptionHandlerDriverInter
       }
 
       for (const exception of exceptions) {
-        const errorPath = (exception.path ?? [])
+        const isObjectException =
+          typeof exception === 'object' && exception !== null;
+
+        const errorPath = (isObjectException ? (exception.path ?? []) : [])
           .map((v: string | number) => (typeof v === 'number' ? '$index' : v))
           .join(' > ');
 
@@ -60,13 +63,13 @@ export class ExceptionHandlerSentryDriver implements ExceptionHandlerDriverInter
           });
         }
 
-        if ('context' in exception && exception.context) {
+        if (isObjectException && 'context' in exception && exception.context) {
           Object.entries(exception.context).forEach(([key, value]) => {
             scope.setExtra(key, value);
           });
         }
 
-        if ('cause' in exception && exception.cause) {
+        if (isObjectException && 'cause' in exception && exception.cause) {
           scope.setContext('cause', {
             name: exception.cause.name,
             message: exception.cause.message,

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/drivers/sentry.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/drivers/sentry.driver.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node';
+import { isObject } from '@sniptt/guards';
 import {
   getGenericOperationName,
   getHumanReadableNameFromCode,
@@ -48,8 +49,7 @@ export class ExceptionHandlerSentryDriver implements ExceptionHandlerDriverInter
       }
 
       for (const exception of exceptions) {
-        const isObjectException =
-          typeof exception === 'object' && exception !== null;
+        const isObjectException = isObject(exception);
 
         const errorPath = (isObjectException ? (exception.path ?? []) : [])
           .map((v: string | number) => (typeof v === 'number' ? '$index' : v))


### PR DESCRIPTION
## Problem

Errors surfaced in the `ai-stream-queue` processor as:

```
Cannot use 'in' operator to search for 'context' in Invalid input for tool execute_tool: Type validation failed: ...
```

The underlying trigger is benign: the model occasionally calls `execute_tool` with the wrong payload shape (e.g. `parameters` instead of the required `arguments`). The AI SDK rejects it and hands the failure back as a **string**, not an `Error`. That string propagates up through the stream job and into `captureExceptions`.

`ExceptionHandlerSentryDriver` then runs `'context' in exception` (and `'cause' in exception`) directly on the value. The `in` operator only works on objects, so when `exception` is a string it throws, turning a routine bad tool-call into an unhandled crash in the exception pipeline and burying the real error.

## Fix

Guard the object-only accesses in the Sentry driver with a `typeof exception === 'object' && exception !== null` check before using the `in` operator or reading `.path`. Non-object exceptions (strings) now capture cleanly instead of crashing the handler.

## Scope

Minimal, defensive fix in the exception handler only. The model-side tool-call mistake is a separate, harmless concern and is out of scope here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

