### PR TITLE
Fix record navigation from dashboard side panels

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/components/NavigateToNextRecordSingleRecordCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/components/NavigateToNextRecordSingleRecordCommand.tsx
@@ -1,22 +1,13 @@
 import { HeadlessEngineCommandWrapperEffect } from '@/command-menu-item/engine-command/components/HeadlessEngineCommandWrapperEffect';
-import { useHeadlessCommandContextApi } from '@/command-menu-item/engine-command/hooks/useHeadlessCommandContextApi';
+import { useRecordShowPagePaginationCommandContext } from '@/command-menu-item/engine-command/record/single-record/hooks/useRecordShowPagePaginationCommandContext';
 import { useRecordShowPagePagination } from '@/object-record/record-show/hooks/useRecordShowPagePagination';
-import { isDefined } from 'twenty-shared/utils';
 
 export const NavigateToNextRecordSingleRecordCommand = () => {
-  const { objectMetadataItem, selectedRecords } =
-    useHeadlessCommandContextApi();
-
-  const recordId = selectedRecords[0]?.id;
-
-  if (!isDefined(recordId) || !isDefined(objectMetadataItem)) {
-    throw new Error(
-      'Record ID and object metadata are required to navigate to next record',
-    );
-  }
+  const { objectNameSingular, recordId } =
+    useRecordShowPagePaginationCommandContext();
 
   const { navigateToNextRecord, isLoadingPagination } =
-    useRecordShowPagePagination(objectMetadataItem.nameSingular, recordId);
+    useRecordShowPagePagination(objectNameSingular, recordId);
 
   return (
     <HeadlessEngineCommandWrapperEffect

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/components/NavigateToPreviousRecordSingleRecordCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/components/NavigateToPreviousRecordSingleRecordCommand.tsx
@@ -1,22 +1,13 @@
 import { HeadlessEngineCommandWrapperEffect } from '@/command-menu-item/engine-command/components/HeadlessEngineCommandWrapperEffect';
-import { useHeadlessCommandContextApi } from '@/command-menu-item/engine-command/hooks/useHeadlessCommandContextApi';
+import { useRecordShowPagePaginationCommandContext } from '@/command-menu-item/engine-command/record/single-record/hooks/useRecordShowPagePaginationCommandContext';
 import { useRecordShowPagePagination } from '@/object-record/record-show/hooks/useRecordShowPagePagination';
-import { isDefined } from 'twenty-shared/utils';
 
 export const NavigateToPreviousRecordSingleRecordCommand = () => {
-  const { objectMetadataItem, selectedRecords } =
-    useHeadlessCommandContextApi();
-
-  const recordId = selectedRecords[0]?.id;
-
-  if (!isDefined(recordId) || !isDefined(objectMetadataItem)) {
-    throw new Error(
-      'Record ID and object metadata are required to navigate to previous record',
-    );
-  }
+  const { objectNameSingular, recordId } =
+    useRecordShowPagePaginationCommandContext();
 
   const { navigateToPreviousRecord, isLoadingPagination } =
-    useRecordShowPagePagination(objectMetadataItem.nameSingular, recordId);
+    useRecordShowPagePagination(objectNameSingular, recordId);
 
   return (
     <HeadlessEngineCommandWrapperEffect

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/hooks/__tests__/useRecordShowPagePaginationCommandContext.test.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/hooks/__tests__/useRecordShowPagePaginationCommandContext.test.tsx
@@ -1,0 +1,85 @@
+import { useHeadlessCommandContextApi } from '@/command-menu-item/engine-command/hooks/useHeadlessCommandContextApi';
+import { type HeadlessEngineCommandContextApi } from '@/command-menu-item/engine-command/types/HeadlessCommandContextApi';
+import { contextStoreRecordShowParentViewComponentState } from '@/context-store/states/contextStoreRecordShowParentViewComponentState';
+import { useRecordShowPagePaginationCommandContext } from '@/command-menu-item/engine-command/record/single-record/hooks/useRecordShowPagePaginationCommandContext';
+import { sidePanelNavigationStackState } from '@/side-panel/states/sidePanelNavigationStackState';
+import { renderHook } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+import { SidePanelPages } from 'twenty-shared/types';
+
+jest.mock(
+  '@/command-menu-item/engine-command/hooks/useHeadlessCommandContextApi',
+);
+
+const mockedUseHeadlessCommandContextApi = jest.mocked(
+  useHeadlessCommandContextApi,
+);
+
+const RECORD_ID = 'b1c2d3e4-0000-4000-8000-000000000000';
+const MAIN_CONTEXT_STORE_INSTANCE_ID = 'main-context-store';
+const SIDE_PANEL_PAGE_INSTANCE_ID = 'side-panel-page';
+
+const getWrapper = (store: ReturnType<typeof createStore>) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <JotaiProvider store={store}>{children}</JotaiProvider>;
+  };
+
+describe('useRecordShowPagePaginationCommandContext', () => {
+  beforeEach(() => {
+    mockedUseHeadlessCommandContextApi.mockReturnValue({
+      contextStoreInstanceId: MAIN_CONTEXT_STORE_INSTANCE_ID,
+      isInSidePanel: true,
+      objectMetadataItem: { nameSingular: 'dashboard' },
+      selectedRecords: [{ id: RECORD_ID }],
+    } as HeadlessEngineCommandContextApi);
+  });
+
+  it('uses the active side panel parent view object for record pagination', () => {
+    const store = createStore();
+
+    store.set(sidePanelNavigationStackState.atom, [
+      {
+        page: SidePanelPages.RoutedPage,
+        pageId: SIDE_PANEL_PAGE_INSTANCE_ID,
+        pageTitle: 'Follow ups',
+      },
+    ] as never);
+    store.set(
+      contextStoreRecordShowParentViewComponentState.atomFamily({
+        instanceId: SIDE_PANEL_PAGE_INSTANCE_ID,
+      }),
+      {
+        parentViewComponentId: 'follow-ups-view',
+        parentViewObjectNameSingular: 'followUp',
+        parentViewFilterGroups: [],
+        parentViewFilters: [],
+        parentViewSorts: [],
+      },
+    );
+
+    const { result } = renderHook(
+      () => useRecordShowPagePaginationCommandContext(),
+      { wrapper: getWrapper(store) },
+    );
+
+    expect(result.current).toEqual({
+      objectNameSingular: 'followUp',
+      recordId: RECORD_ID,
+    });
+  });
+
+  it('falls back to the command object outside a parent view', () => {
+    const store = createStore();
+
+    const { result } = renderHook(
+      () => useRecordShowPagePaginationCommandContext(),
+      { wrapper: getWrapper(store) },
+    );
+
+    expect(result.current).toEqual({
+      objectNameSingular: 'dashboard',
+      recordId: RECORD_ID,
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/hooks/useRecordShowPagePaginationCommandContext.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/hooks/useRecordShowPagePaginationCommandContext.ts
@@ -1,0 +1,44 @@
+import { useHeadlessCommandContextApi } from '@/command-menu-item/engine-command/hooks/useHeadlessCommandContextApi';
+import { contextStoreRecordShowParentViewComponentState } from '@/context-store/states/contextStoreRecordShowParentViewComponentState';
+import { sidePanelNavigationStackState } from '@/side-panel/states/sidePanelNavigationStackState';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { isDefined } from 'twenty-shared/utils';
+
+export const useRecordShowPagePaginationCommandContext = () => {
+  const {
+    contextStoreInstanceId,
+    isInSidePanel,
+    objectMetadataItem,
+    selectedRecords,
+  } = useHeadlessCommandContextApi();
+
+  const sidePanelNavigationStack = useAtomStateValue(
+    sidePanelNavigationStackState,
+  );
+
+  const activeSidePanelPageInstanceId = sidePanelNavigationStack.at(-1)?.pageId;
+
+  const parentViewContextStoreInstanceId =
+    isInSidePanel && isDefined(activeSidePanelPageInstanceId)
+      ? activeSidePanelPageInstanceId
+      : contextStoreInstanceId;
+
+  const parentView = useAtomComponentStateValue(
+    contextStoreRecordShowParentViewComponentState,
+    parentViewContextStoreInstanceId,
+  );
+
+  const recordId = selectedRecords[0]?.id;
+  const objectNameSingular =
+    parentView?.parentViewObjectNameSingular ??
+    objectMetadataItem?.nameSingular;
+
+  if (!isDefined(recordId) || !isDefined(objectNameSingular)) {
+    throw new Error(
+      'Record ID and object name are required to navigate between records',
+    );
+  }
+
+  return { objectNameSingular, recordId };
+};


### PR DESCRIPTION
## Context

Opening a record from a filtered `RECORD_TABLE` dashboard widget preserves the widget view's filters for previous/next record navigation. The side panel command menu remains bound to the dashboard's main context, so those commands used the `dashboard` object with filters belonging to the widget's target object.

The server correctly rejected the mismatched filters. The record still opened, but users received repeated `Invalid filter` toasts and record pagination could resolve to `0/0`.

Fixes #23064.

## What changed

- Added a shared pagination command context resolver for previous/next record commands.
- When a command runs in the side panel, pagination now reads the target object from the active panel page's saved parent-view context.
- When no parent view exists, pagination keeps using the command context object, preserving direct record-page behavior.
- Added regression coverage for both the dashboard side-panel mismatch and the fallback path.

## Why this approach

The record index already stores the widget's object, filters, groups, and sorts on the destination side-panel page. Using that parent-view object keeps the pagination object aligned with the filters from the same view.

This avoids changing the broader side-panel command-menu context, which is intentionally synchronized with the main page and is shared by unrelated commands.

## Safety

- Frontend-only change, no API, schema, migration, or persisted-data changes.
- Scoped to resolving the object used by previous/next record pagination commands.
- Direct record opens and contexts without saved parent-view state retain the existing fallback.

## Expected impact

Filtered record-table widgets can open records without querying `dashboard` with widget-specific fields. Previous/next navigation uses the widget target object and its saved view filters, removing the invalid-filter toasts and restoring the correct pagination set.

## Limitations

This does not change general side-panel command-menu context ownership. It only corrects record pagination when parent-view state is available, otherwise existing behavior is preserved.

## Validation

- `npx jest packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/hooks/__tests__/useRecordShowPagePaginationCommandContext.test.tsx --config=packages/twenty-front/jest.config.mjs --runInBand`
- `npx nx lint:diff-with-main twenty-front`
- `npx tsgo -p tsconfig.json --noEmit` from `packages/twenty-front`
- `git diff --check`
