### PR TITLE
Fix dashboard record table settings context

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dashboard/SidePanelDashboardRecordTableSettings.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dashboard/SidePanelDashboardRecordTableSettings.tsx
@@ -3,7 +3,7 @@ import { CommandMenuItemDropdown } from '@/command-menu/components/CommandMenuIt
 import { CommandMenuItemNumberInput } from '@/command-menu/components/CommandMenuItemNumberInput';
 import { CommandMenuItemToggle } from '@/command-menu/components/CommandMenuItemToggle';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { useCurrentPageLayoutOrThrow } from '@/page-layout/hooks/useCurrentPageLayoutOrThrow';
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
 import { useRecordTableWidgetFieldCallbacks } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetFieldCallbacks';
 import { useRecordTableWidgetLayoutCallbacks } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks';
 import { useRecordTableWidgetViewForDisplay } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetViewForDisplay';
@@ -31,6 +31,7 @@ import { useWidgetInEditMode } from '@/side-panel/pages/page-layout/hooks/useWid
 import { SidePanelSubPages } from '@/side-panel/types/SidePanelSubPages';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
@@ -69,7 +70,10 @@ export const SidePanelDashboardRecordTableSettings = () => {
   const { t } = useLingui();
 
   const { pageLayoutId } = usePageLayoutIdFromContextStore();
-  const { currentPageLayout } = useCurrentPageLayoutOrThrow();
+  const pageLayoutDraft = useAtomComponentStateValue(
+    pageLayoutDraftComponentState,
+    pageLayoutId,
+  );
   const { widgetInEditMode } = useWidgetInEditMode(pageLayoutId);
   const { navigateToSidePanelSubPage } = useSidePanelSubPageHistory();
 
@@ -95,7 +99,7 @@ export const SidePanelDashboardRecordTableSettings = () => {
 
   const isUIEditable = getRecordTableWidgetIsUIEditable(
     configuration,
-    currentPageLayout.type,
+    pageLayoutDraft.type,
   );
 
   const {

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dashboard/__tests__/SidePanelDashboardRecordTableSettings.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dashboard/__tests__/SidePanelDashboardRecordTableSettings.test.tsx
@@ -1,0 +1,106 @@
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
+import { SidePanelDashboardRecordTableSettings } from '@/side-panel/pages/page-layout/components/dashboard/SidePanelDashboardRecordTableSettings';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { PageLayoutType } from '~/generated-metadata/graphql';
+
+const PAGE_LAYOUT_ID = 'dashboard-page-layout-id';
+
+jest.mock('@/object-metadata/hooks/useObjectMetadataItems', () => ({
+  useObjectMetadataItems: () => ({ objectMetadataItems: [] }),
+}));
+
+jest.mock(
+  '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetFieldCallbacks',
+  () => ({
+    useRecordTableWidgetFieldCallbacks: () => ({
+      handleFieldUpdated: jest.fn(),
+      handleFieldCreated: jest.fn(),
+    }),
+  }),
+);
+
+jest.mock(
+  '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks',
+  () => ({
+    useRecordTableWidgetLayoutCallbacks: () => ({
+      handleShouldHideEmptyGroupsChange: jest.fn(),
+    }),
+  }),
+);
+
+jest.mock(
+  '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetViewForDisplay',
+  () => ({
+    useRecordTableWidgetViewForDisplay: () => ({ view: undefined }),
+  }),
+);
+
+jest.mock('@/side-panel/hooks/useSidePanelSubPageHistory', () => ({
+  useSidePanelSubPageHistory: () => ({
+    navigateToSidePanelSubPage: jest.fn(),
+  }),
+}));
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/usePageLayoutIdFromContextStore',
+  () => ({
+    usePageLayoutIdFromContextStore: () => ({ pageLayoutId: PAGE_LAYOUT_ID }),
+  }),
+);
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/useRecordTableSettingsDescriptions',
+  () => ({
+    useRecordTableSettingsDescriptions: () => ({
+      sourceDescription: '',
+      fieldsDescription: '',
+      filterDescription: '',
+      sortDescription: '',
+    }),
+  }),
+);
+
+jest.mock(
+  '@/side-panel/pages/page-layout/hooks/useUpdateCurrentWidgetConfig',
+  () => ({
+    useUpdateCurrentWidgetConfig: () => ({
+      updateCurrentWidgetConfig: jest.fn(),
+    }),
+  }),
+);
+
+jest.mock('@/side-panel/pages/page-layout/hooks/useWidgetInEditMode', () => ({
+  useWidgetInEditMode: () => ({ widgetInEditMode: undefined }),
+}));
+
+describe('SidePanelDashboardRecordTableSettings', () => {
+  it('reads the dashboard draft without a page layout component context', () => {
+    const store = createStore();
+
+    store.set(
+      pageLayoutDraftComponentState.atomFamily({ instanceId: PAGE_LAYOUT_ID }),
+      {
+        id: PAGE_LAYOUT_ID,
+        name: 'Dashboard layout',
+        type: PageLayoutType.DASHBOARD,
+        objectMetadataId: null,
+        tabs: [],
+        defaultTabToFocusOnMobileAndSidePanelId: null,
+        isFirstTabPinned: true,
+      },
+    );
+
+    const { container } = render(
+      <JotaiProvider store={store}>
+        <I18nProvider i18n={i18n}>
+          <SidePanelDashboardRecordTableSettings />
+        </I18nProvider>
+      </JotaiProvider>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## Context

On a dashboard in edit mode, selecting **Add widget > View** opens the record-table settings in the side panel. `SidePanelDashboardRecordTableSettings` then called `useCurrentPageLayoutOrThrow()`, which resolves component state through `PageLayoutComponentInstanceContext`.

That context belongs to the main page-layout renderer and is not available in the side-panel page tree, so the settings page crashed with:

```
Instance id is not provided and cannot be found in context.
```

## What changed

- Read `pageLayoutDraftComponentState` with the explicit `pageLayoutId` already resolved from the dashboard context store.
- Use the draft layout type when determining whether record-table content is editable.
- Add a regression test rendering the settings page without `PageLayoutComponentInstanceContext`, matching the side-panel topology.

## Why this approach

Other dashboard widget settings already access page-layout component state with the explicit layout ID. The record-table settings page is only available while editing a draft, so the draft is also the state source used by its widget update hooks.

This keeps page-layout context scoped to the renderer and avoids adding a broad provider around unrelated side-panel pages.

## Safety

- Frontend-only, no API, schema, migration, or persisted-data changes.
- Scoped to the dashboard record-table settings page.
- Existing widget configuration and update behavior are unchanged.
