### PR TITLE
Batch repeated per-item queries across email and calendar sync

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
@@ -1,6 +1,8 @@
 import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import chunk from 'lodash.chunk';
+import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { In, Repository } from 'typeorm';
 
@@ -51,80 +53,91 @@ export class CalendarEventsImportCronJob {
       },
     });
 
-    for (const activeWorkspace of activeWorkspaces) {
-      try {
-        const pendingCalendarChannels =
-          await this.calendarChannelRepository.find({
-            where: {
-              workspaceId: activeWorkspace.id,
-              isSyncEnabled: true,
-              syncStage:
-                CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
-            },
-          });
+    const activeWorkspaceIds = activeWorkspaces.map(
+      (workspace) => workspace.id,
+    );
 
-        const calendarChannelsToSchedule = pendingCalendarChannels.filter(
-          (calendarChannel) =>
-            !isThrottled(
-              toIsoStringOrNull(calendarChannel.syncStageStartedAt),
-              calendarChannel.throttleFailureCount,
-            ),
-        );
+    if (activeWorkspaceIds.length === 0) {
+      return;
+    }
 
-        const throttledCount =
-          pendingCalendarChannels.length - calendarChannelsToSchedule.length;
+    const pendingCalendarChannels = await this.calendarChannelRepository
+      .find({
+        where: {
+          workspaceId: In(activeWorkspaceIds),
+          isSyncEnabled: true,
+          syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
+        },
+      })
+      .catch((error): CalendarChannelEntity[] => {
+        this.exceptionHandlerService.captureExceptions([error]);
 
-        if (throttledCount > 0) {
-          this.logger.log(
-            `Skipped ${throttledCount} throttled calendar channels for workspace ${activeWorkspace.id}`,
-          );
-        }
+        return [];
+      });
 
-        if (calendarChannelsToSchedule.length === 0) {
-          continue;
-        }
+    const calendarChannelsToSchedule = pendingCalendarChannels.filter(
+      (calendarChannel) =>
+        !isThrottled(
+          toIsoStringOrNull(calendarChannel.syncStageStartedAt),
+          calendarChannel.throttleFailureCount,
+        ),
+    );
 
-        const calendarChannelIds = calendarChannelsToSchedule.map(
-          (calendarChannel) => calendarChannel.id,
-        );
+    const throttledCount =
+      pendingCalendarChannels.length - calendarChannelsToSchedule.length;
 
-        const updateResult = await this.calendarChannelRepository
-          .createQueryBuilder()
-          .update()
-          .set({
-            syncStage:
-              CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED,
-            syncStageStartedAt: new Date(),
-          })
-          .where({
-            id: In(calendarChannelIds),
-            workspaceId: activeWorkspace.id,
-            isSyncEnabled: true,
-            syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
-          })
-          .returning('id')
-          .execute();
+    if (throttledCount > 0) {
+      this.logger.log(`Skipped ${throttledCount} throttled calendar channels`);
+    }
 
-        const updatedIds = updateResult.raw.map(
-          (row: { id: string }) => row.id,
-        );
+    if (calendarChannelsToSchedule.length === 0) {
+      return;
+    }
 
-        for (const calendarChannelId of updatedIds) {
-          await this.messageQueueService.add<CalendarEventsImportJobData>(
-            CalendarEventsImportJob.name,
-            {
-              calendarChannelId,
-              workspaceId: activeWorkspace.id,
-            },
-          );
-        }
-      } catch (error) {
-        this.exceptionHandlerService.captureExceptions([error], {
-          workspace: {
-            id: activeWorkspace.id,
-          },
+    for (const calendarChannelsBatch of chunk(
+      calendarChannelsToSchedule,
+      QUERY_MAX_RECORDS,
+    )) {
+      const updateResult = await this.calendarChannelRepository
+        .createQueryBuilder()
+        .update()
+        .set({
+          syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED,
+          syncStageStartedAt: new Date(),
+        })
+        .where({
+          id: In(calendarChannelsBatch.map(({ id }) => id)),
+          isSyncEnabled: true,
+          syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
+        })
+        .returning('id')
+        .execute()
+        .catch((error): { raw: { id: string }[] } => {
+          this.exceptionHandlerService.captureExceptions([error]);
+
+          return { raw: [] };
         });
+
+      const updatedIds = updateResult.raw.map((row: { id: string }) => row.id);
+      const jobs = calendarChannelsBatch
+        .filter(({ id }) => updatedIds.includes(id))
+        .map(({ id: calendarChannelId, workspaceId }) => ({
+          calendarChannelId,
+          workspaceId,
+        }));
+
+      if (jobs.length === 0) {
+        continue;
       }
+
+      await this.messageQueueService
+        .bulkAdd<CalendarEventsImportJobData>(
+          CalendarEventsImportJob.name,
+          jobs,
+        )
+        .catch((error) => {
+          this.exceptionHandlerService.captureExceptions([error]);
+        });
     }
   }
 }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -70,6 +70,21 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
           calendarChannelsFromCore.map((channel) => [channel.id, channel]),
         );
 
+        const hasRestrictedCalendarChannel = calendarChannelsFromCore.some(
+          (calendarChannel) =>
+            calendarChannel.visibility !==
+            CalendarChannelVisibility.SHARE_EVERYTHING,
+        );
+
+        const accessibleCalendarChannelIds =
+          isDefined(userId) && hasRestrictedCalendarChannel
+            ? await this.getAccessibleCalendarChannelIds({
+                userId,
+                workspaceId,
+                calendarChannelIds,
+              })
+            : new Set<string>();
+
         for (let i = calendarEvents.length - 1; i >= 0; i--) {
           const associations = calendarChannelCalendarEventsAssociations.filter(
             (association) =>
@@ -95,28 +110,12 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
             continue;
           }
 
-          if (isDefined(userId)) {
-            const userWorkspace = await this.userWorkspaceRepository.findOne({
-              where: { userId, workspaceId },
-              select: ['id'],
-            });
-
-            if (userWorkspace) {
-              const connectedAccounts =
-                await this.connectedAccountRepository.find({
-                  where: {
-                    calendarChannels: {
-                      id: In(calendarChannels.map((channel) => channel.id)),
-                    },
-                    userWorkspaceId: userWorkspace.id,
-                    workspaceId,
-                  },
-                });
-
-              if (connectedAccounts.length > 0) {
-                continue;
-              }
-            }
+          if (
+            calendarChannels.some((calendarChannel) =>
+              accessibleCalendarChannelIds.has(calendarChannel.id),
+            )
+          ) {
+            continue;
           }
 
           if (
@@ -138,6 +137,42 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
       },
       authContext,
       { lite: true },
+    );
+  }
+
+  private async getAccessibleCalendarChannelIds({
+    userId,
+    workspaceId,
+    calendarChannelIds,
+  }: {
+    userId: string;
+    workspaceId: string;
+    calendarChannelIds: string[];
+  }): Promise<Set<string>> {
+    const userWorkspace = await this.userWorkspaceRepository.findOne({
+      where: { userId, workspaceId },
+      select: ['id'],
+    });
+
+    if (!isDefined(userWorkspace)) {
+      return new Set<string>();
+    }
+
+    const connectedAccounts = await this.connectedAccountRepository.find({
+      where: {
+        calendarChannels: { id: In(calendarChannelIds) },
+        userWorkspaceId: userWorkspace.id,
+        workspaceId,
+      },
+      relations: { calendarChannels: true },
+    });
+
+    return new Set(
+      connectedAccounts.flatMap((connectedAccount) =>
+        (connectedAccount.calendarChannels ?? []).map(
+          (calendarChannel) => calendarChannel.id,
+        ),
+      ),
     );
   }
 }

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
@@ -56,13 +56,23 @@ export class CreateCompanyAndPersonService {
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
   ) {}
 
-  async createCompaniesAndPeople(
-    connectedAccount: ConnectedAccountEntity,
-    contactsToCreate: Contact[],
-    workspaceId: string,
-    source: FieldActorSource,
-    accountOwner: WorkspaceMemberWorkspaceEntity | null,
-  ): Promise<DeepPartial<PersonWorkspaceEntity>[]> {
+  async createCompaniesAndPeople({
+    connectedAccount,
+    contactsToCreate,
+    workspaceId,
+    source,
+    accountOwner,
+    workspaceMembers,
+    isInternalMessagesImportEnabled,
+  }: {
+    connectedAccount: ConnectedAccountEntity;
+    contactsToCreate: Contact[];
+    workspaceId: string;
+    source: FieldActorSource;
+    accountOwner: WorkspaceMemberWorkspaceEntity | null;
+    workspaceMembers: WorkspaceMemberWorkspaceEntity[];
+    isInternalMessagesImportEnabled: boolean;
+  }): Promise<DeepPartial<PersonWorkspaceEntity>[]> {
     if (!contactsToCreate || contactsToCreate.length === 0) {
       return [];
     }
@@ -77,24 +87,12 @@ export class CreateCompanyAndPersonService {
         },
       );
 
-      const workspaceMemberRepository = this.workspaceOrmManager.getRepository(
-        WorkspaceMemberWorkspaceEntity,
-        { shouldBypassPermissionChecks: true },
-      );
-
-      const workspaceMembers = await workspaceMemberRepository.find();
-
-      const workspace = await this.workspaceRepository.findOne({
-        where: { id: workspaceId },
-        select: ['id', 'isInternalMessagesImportEnabled'],
-      });
-
       const peopleToCreateFromOtherCompanies =
         filterOutContactsThatBelongToSelfOrWorkspaceMembers(
           contactsToCreate,
           connectedAccount,
           workspaceMembers,
-          workspace?.isInternalMessagesImportEnabled ?? false,
+          isInternalMessagesImportEnabled,
         );
 
       const { uniqueContacts, uniqueHandles } = getUniqueContactsAndHandles(
@@ -184,8 +182,6 @@ export class CreateCompanyAndPersonService {
       CONTACTS_CREATION_BATCH_SIZE,
     );
 
-    const authContext = buildSystemAuthContext(workspaceId);
-
     const userWorkspace = await this.userWorkspaceRepository.findOne({
       where: { id: connectedAccount.userWorkspaceId },
     });
@@ -198,28 +194,29 @@ export class CreateCompanyAndPersonService {
       return;
     }
 
-    const accountOwner =
-      await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
-        const workspaceMemberRepository =
-          this.workspaceOrmManager.getRepository(
-            WorkspaceMemberWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
+    const contactCreationContext = await this.getContactCreationContext({
+      workspaceId,
+      userId: userWorkspace.userId,
+    });
 
-        return workspaceMemberRepository.findOne({
-          where: { userId: userWorkspace.userId },
-        });
-      }, authContext);
+    if (!isDefined(contactCreationContext)) {
+      return;
+    }
+
+    const { accountOwner, workspaceMembers, isInternalMessagesImportEnabled } =
+      contactCreationContext;
 
     for (const contactsBatch of contactsBatches) {
       try {
-        await this.createCompaniesAndPeople(
+        await this.createCompaniesAndPeople({
           connectedAccount,
-          contactsBatch,
+          contactsToCreate: contactsBatch,
           workspaceId,
           source,
           accountOwner,
-        );
+          workspaceMembers,
+          isInternalMessagesImportEnabled,
+        });
       } catch (error) {
         // Concurrent imports for the same workspace can insert the same company
         // domain or person email, and the loser hits the unique index. The
@@ -234,6 +231,57 @@ export class CreateCompanyAndPersonService {
           },
         });
       }
+    }
+  }
+
+  private async getContactCreationContext({
+    workspaceId,
+    userId,
+  }: {
+    workspaceId: string;
+    userId: string;
+  }): Promise<
+    | {
+        accountOwner: WorkspaceMemberWorkspaceEntity | null;
+        workspaceMembers: WorkspaceMemberWorkspaceEntity[];
+        isInternalMessagesImportEnabled: boolean;
+      }
+    | undefined
+  > {
+    try {
+      const workspace = await this.workspaceRepository.findOne({
+        where: { id: workspaceId },
+        select: ['id', 'isInternalMessagesImportEnabled'],
+      });
+      const authContext = buildSystemAuthContext(workspaceId);
+      const { accountOwner, workspaceMembers } =
+        await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+          const workspaceMemberRepository =
+            this.workspaceOrmManager.getRepository(
+              WorkspaceMemberWorkspaceEntity,
+              { shouldBypassPermissionChecks: true },
+            );
+
+          const accountOwner = await workspaceMemberRepository.findOne({
+            where: { userId },
+          });
+          const workspaceMembers = await workspaceMemberRepository.find();
+
+          return { accountOwner, workspaceMembers };
+        }, authContext);
+
+      return {
+        accountOwner,
+        workspaceMembers,
+        isInternalMessagesImportEnabled:
+          workspace?.isInternalMessagesImportEnabled ?? false,
+      };
+    } catch (error) {
+      this.exceptionHandlerService.captureExceptions([error], {
+        workspace: { id: workspaceId },
+      });
+
+      return undefined;
     }
   }
 

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -69,11 +69,20 @@ export class ApplyMessagesVisibilityRestrictionsService {
           messageChannelsFromCore.map((ch) => [ch.id, ch]),
         );
 
-        const workspaceMemberRepository =
-          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+        const hasRestrictedMessageChannel = messageChannelsFromCore.some(
+          (messageChannel) =>
+            messageChannel.visibility !==
+            MessageChannelVisibility.SHARE_EVERYTHING,
+        );
+
+        const accessibleMessageChannelIds =
+          isDefined(userId) && hasRestrictedMessageChannel
+            ? await this.getAccessibleMessageChannelIds({
+                userId,
+                workspaceId,
+                messageChannelIds,
+              })
+            : new Set<string>();
 
         for (let i = messages.length - 1; i >= 0; i--) {
           const associations = messageChannelMessagesAssociations.filter(
@@ -104,33 +113,12 @@ export class ApplyMessagesVisibilityRestrictionsService {
             continue;
           }
 
-          if (isDefined(userId)) {
-            const workspaceMember =
-              await workspaceMemberRepository.findOneByOrFail({
-                userId,
-              });
-
-            const userWorkspace = await this.userWorkspaceRepository.findOne({
-              where: { userId: workspaceMember.userId, workspaceId },
-            });
-
-            if (userWorkspace) {
-              const connectedAccounts =
-                await this.connectedAccountRepository.find({
-                  where: {
-                    userWorkspaceId: userWorkspace.id,
-                    workspaceId,
-                    messageChannels: {
-                      id: In(messageChannels.map((channel) => channel.id)),
-                    },
-                  },
-                  relations: { messageChannels: true },
-                });
-
-              if (connectedAccounts.length > 0) {
-                continue;
-              }
-            }
+          if (
+            messageChannels.some((messageChannel) =>
+              accessibleMessageChannelIds.has(messageChannel.id),
+            )
+          ) {
+            continue;
           }
 
           if (
@@ -156,6 +144,51 @@ export class ApplyMessagesVisibilityRestrictionsService {
       },
       authContext,
       { lite: true },
+    );
+  }
+
+  private async getAccessibleMessageChannelIds({
+    userId,
+    workspaceId,
+    messageChannelIds,
+  }: {
+    userId: string;
+    workspaceId: string;
+    messageChannelIds: string[];
+  }): Promise<Set<string>> {
+    const workspaceMemberRepository =
+      this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        'workspaceMember',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const workspaceMember = await workspaceMemberRepository.findOneByOrFail({
+      userId,
+    });
+
+    const userWorkspace = await this.userWorkspaceRepository.findOne({
+      where: { userId: workspaceMember.userId, workspaceId },
+    });
+
+    if (!isDefined(userWorkspace)) {
+      return new Set<string>();
+    }
+
+    const connectedAccounts = await this.connectedAccountRepository.find({
+      where: {
+        userWorkspaceId: userWorkspace.id,
+        workspaceId,
+        messageChannels: { id: In(messageChannelIds) },
+      },
+      relations: { messageChannels: true },
+    });
+
+    return new Set(
+      connectedAccounts.flatMap((connectedAccount) =>
+        (connectedAccount.messageChannels ?? []).map(
+          (messageChannel) => messageChannel.id,
+        ),
+      ),
     );
   }
 }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
@@ -1,7 +1,8 @@
 import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { isDefined } from 'twenty-shared/utils';
+import chunk from 'lodash.chunk';
+import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { In, Not, Repository } from 'typeorm';
 
@@ -53,101 +54,105 @@ export class MessagingMessagesImportCronJob {
       },
     });
 
-    for (const activeWorkspace of activeWorkspaces) {
-      try {
-        const pendingMessageChannels = await this.messageChannelRepository.find(
-          {
-            where: {
-              workspaceId: activeWorkspace.id,
-              isSyncEnabled: true,
-              syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
-              type: Not(MessageChannelType.EMAIL_GROUP),
-            },
-          },
-        );
+    const activeWorkspaceIds = activeWorkspaces.map(
+      (workspace) => workspace.id,
+    );
 
-        const messageChannelsToSchedule = pendingMessageChannels.filter(
-          (messageChannel) =>
-            !isThrottled(
-              toIsoStringOrNull(messageChannel.syncStageStartedAt),
-              messageChannel.throttleFailureCount,
-              toIsoStringOrNull(messageChannel.throttleRetryAfter),
-            ),
-        );
+    if (activeWorkspaceIds.length === 0) {
+      return;
+    }
 
-        const throttledCount =
-          pendingMessageChannels.length - messageChannelsToSchedule.length;
+    const pendingMessageChannels = await this.messageChannelRepository
+      .find({
+        where: {
+          workspaceId: In(activeWorkspaceIds),
+          isSyncEnabled: true,
+          syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+          type: Not(MessageChannelType.EMAIL_GROUP),
+        },
+      })
+      .catch((error): MessageChannelEntity[] => {
+        this.exceptionHandlerService.captureExceptions([error]);
 
-        if (throttledCount > 0) {
-          this.logger.log(
-            `Skipped ${throttledCount} throttled message channels for workspace ${activeWorkspace.id}`,
-          );
-        }
-
-        if (messageChannelsToSchedule.length === 0) {
-          continue;
-        }
-
-        const messageChannelIdsToSchedule = messageChannelsToSchedule.map(
-          (messageChannel) => messageChannel.id,
-        );
-
-        const updateResult = await this.messageChannelRepository
-          .createQueryBuilder()
-          .update()
-          .set({
-            syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
-            syncStageStartedAt: new Date(),
-          })
-          .where({
-            id: In(messageChannelIdsToSchedule),
-            workspaceId: activeWorkspace.id,
-            isSyncEnabled: true,
-            syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
-          })
-          .returning('id')
-          .execute();
-
-        const updatedIds = updateResult.raw.map(
-          (row: { id: string }) => row.id,
-        );
-
-        for (const messageChannelId of updatedIds) {
-          await this.messageQueueService.add<MessagingMessagesImportJobData>(
-            MessagingMessagesImportJob.name,
-            {
-              workspaceId: activeWorkspace.id,
-              messageChannelId,
-            },
-          );
-        }
-      } catch (error) {
         if (
           error.code === '42P01' &&
           error.message.includes('messageChannel" does not exist')
         ) {
-          const refetchedWorkspace = await this.workspaceRepository.findOneBy({
-            id: activeWorkspace.id,
-          });
-
-          if (isDefined(refetchedWorkspace)) {
-            this.exceptionHandlerService.captureExceptions([error], {
-              workspace: {
-                id: activeWorkspace.id,
-              },
-            });
-            throw new Error(
+          throw Object.assign(
+            new Error(
               'Workspace schema not found while the workspace is still active',
-            );
-          }
-        } else {
-          this.exceptionHandlerService.captureExceptions([error], {
-            workspace: {
-              id: activeWorkspace.id,
-            },
-          });
+            ),
+            { cause: error },
+          );
         }
+
+        return [];
+      });
+
+    const messageChannelsToSchedule = pendingMessageChannels.filter(
+      (messageChannel) =>
+        !isThrottled(
+          toIsoStringOrNull(messageChannel.syncStageStartedAt),
+          messageChannel.throttleFailureCount,
+          toIsoStringOrNull(messageChannel.throttleRetryAfter),
+        ),
+    );
+
+    const throttledCount =
+      pendingMessageChannels.length - messageChannelsToSchedule.length;
+
+    if (throttledCount > 0) {
+      this.logger.log(`Skipped ${throttledCount} throttled message channels`);
+    }
+
+    if (messageChannelsToSchedule.length === 0) {
+      return;
+    }
+
+    for (const messageChannelsBatch of chunk(
+      messageChannelsToSchedule,
+      QUERY_MAX_RECORDS,
+    )) {
+      const updateResult = await this.messageChannelRepository
+        .createQueryBuilder()
+        .update()
+        .set({
+          syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
+          syncStageStartedAt: new Date(),
+        })
+        .where({
+          id: In(messageChannelsBatch.map(({ id }) => id)),
+          isSyncEnabled: true,
+          syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+        })
+        .returning('id')
+        .execute()
+        .catch((error): { raw: { id: string }[] } => {
+          this.exceptionHandlerService.captureExceptions([error]);
+
+          return { raw: [] };
+        });
+
+      const updatedIds = updateResult.raw.map((row: { id: string }) => row.id);
+      const jobs = messageChannelsBatch
+        .filter(({ id }) => updatedIds.includes(id))
+        .map(({ id: messageChannelId, workspaceId }) => ({
+          workspaceId,
+          messageChannelId,
+        }));
+
+      if (jobs.length === 0) {
+        continue;
       }
+
+      await this.messageQueueService
+        .bulkAdd<MessagingMessagesImportJobData>(
+          MessagingMessagesImportJob.name,
+          jobs,
+        )
+        .catch((error) => {
+          this.exceptionHandlerService.captureExceptions([error]);
+        });
     }
   }
 }

--- a/packages/twenty-server/test/integration/google/calendar/channel-visibility-multiple-events.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/calendar/channel-visibility-multiple-events.integration-spec.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  CalendarChannelVisibility,
+  ConnectedAccountProvider,
+} from 'twenty-shared/types';
+
+import { FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED } from 'twenty-shared/constants';
+
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { makeGraphqlAPIRequestWithMemberRole } from 'test/integration/graphql/utils/make-graphql-api-request-with-member-role.util';
+import { googleCalendarEvent } from 'test/integration/google/mocks/google-calendar-event.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import { runCalendarChannelEventsImport } from 'test/integration/utils/run-calendar-channel-events-import.util';
+import { runCalendarChannelListFetch } from 'test/integration/utils/run-calendar-channel-list-fetch.util';
+
+const HANDLE = 'google-calendar-visibility-multi@apple.dev';
+
+const RESTRICTED = FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED;
+
+const EVENT_TOKEN = 'visibility-multi';
+
+describe('Calendar channel visibility across a multi-event page (integration)', () => {
+  const eventTitles = [
+    `Calendar event ${EVENT_TOKEN} ${randomUUID()}`,
+    `Calendar event ${EVENT_TOKEN} ${randomUUID()}`,
+    `Calendar event ${EVENT_TOKEN} ${randomUUID()}`,
+  ];
+
+  const gmail = setupGoogleMock({ handle: HANDLE });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  const readEventsAs = async (
+    makeRequest:
+      | typeof makeGraphqlAPIRequest
+      | typeof makeGraphqlAPIRequestWithMemberRole,
+  ) => {
+    const response = await makeRequest(
+      findManyOperationFactory({
+        objectMetadataSingularName: 'calendarEvent',
+        objectMetadataPluralName: 'calendarEvents',
+        gqlFields: 'title description',
+        filter: { title: { in: eventTitles } },
+      }),
+    );
+
+    expect(response.body.errors).toBeUndefined();
+
+    return response.body.data.calendarEvents.edges.map(
+      (edge: { node: { title: string; description: string } }) => edge.node,
+    );
+  };
+
+  const setVisibility = async (visibility: CalendarChannelVisibility) => {
+    await getCoreRepository<CalendarChannelEntity>(
+      CalendarChannelEntity,
+    ).update({ id: channel.calendarChannelId }, { visibility });
+  };
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    gmail.serveCalendarEvents(
+      eventTitles.map((title) =>
+        googleCalendarEvent({
+          summary: title,
+          description: `Agenda for ${title}`,
+        }),
+      ),
+    );
+
+    await runCalendarChannelListFetch(channel.calendarChannelId);
+    await runCalendarChannelEventsImport(channel.calendarChannelId);
+  }, 120000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('returns every event on the page unmasked to another member when the channel shares everything', async () => {
+    await setVisibility(CalendarChannelVisibility.SHARE_EVERYTHING);
+
+    const events = await readEventsAs(makeGraphqlAPIRequestWithMemberRole);
+
+    expect(events).toHaveLength(eventTitles.length);
+    expect(
+      events.map((event: { title: string }) => event.title).sort(),
+    ).toEqual([...eventTitles].sort());
+    for (const event of events) {
+      expect(event.description).not.toBe(RESTRICTED);
+    }
+  }, 60000);
+
+  it('masks the title and description of every event on the page under metadata visibility', async () => {
+    await setVisibility(CalendarChannelVisibility.METADATA);
+
+    const events = await readEventsAs(makeGraphqlAPIRequestWithMemberRole);
+
+    expect(events).toHaveLength(eventTitles.length);
+    for (const event of events) {
+      expect(event.title).toBe(RESTRICTED);
+      expect(event.description).toBe(RESTRICTED);
+    }
+  }, 60000);
+
+  it('returns every event on the page unmasked to the connected account owner under metadata visibility', async () => {
+    await setVisibility(CalendarChannelVisibility.METADATA);
+
+    const events = await readEventsAs(makeGraphqlAPIRequest);
+
+    expect(events).toHaveLength(eventTitles.length);
+    expect(
+      events.map((event: { title: string }) => event.title).sort(),
+    ).toEqual([...eventTitles].sort());
+    for (const event of events) {
+      expect(event.description).not.toBe(RESTRICTED);
+    }
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/google/calendar/import-cron-scheduling.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/calendar/import-cron-scheduling.integration-spec.ts
@@ -1,0 +1,89 @@
+import {
+  CalendarChannelSyncStage,
+  CalendarChannelSyncStatus,
+  ConnectedAccountProvider,
+} from 'twenty-shared/types';
+
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { CalendarEventsImportCronJob } from 'src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job';
+
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import { queryCalendarChannel } from 'test/integration/utils/query-messaging.util';
+import { runSyncCron } from 'test/integration/utils/run-sync-cron.util';
+
+const PENDING_HANDLE = 'calendar-import-cron-pending@apple.dev';
+const THROTTLED_HANDLE = 'calendar-import-cron-throttled@apple.dev';
+
+describe('Calendar events import cron scheduling (integration)', () => {
+  const gmail = setupGoogleMock({ handle: PENDING_HANDLE });
+
+  let pendingChannel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let throttledChannel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  beforeAll(async () => {
+    pendingChannel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: PENDING_HANDLE,
+    });
+
+    gmail.actAsAccount(THROTTLED_HANDLE);
+
+    throttledChannel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: THROTTLED_HANDLE,
+    });
+
+    const calendarChannelRepository = getCoreRepository<CalendarChannelEntity>(
+      CalendarChannelEntity,
+    );
+
+    await calendarChannelRepository.update(
+      { id: pendingChannel.calendarChannelId },
+      {
+        syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
+        syncStageStartedAt: null,
+        throttleFailureCount: 0,
+      },
+    );
+
+    await calendarChannelRepository.update(
+      { id: throttledChannel.calendarChannelId },
+      {
+        syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
+        syncStageStartedAt: new Date().toISOString(),
+        throttleFailureCount: 1,
+      },
+    );
+  }, 120000);
+
+  afterAll(async () => {
+    await pendingChannel?.cleanup().catch(() => undefined);
+    await throttledChannel?.cleanup().catch(() => undefined);
+  });
+
+  it('schedules a pending calendar channel for import and skips a throttled one', async () => {
+    await runSyncCron(CalendarEventsImportCronJob);
+
+    const pendingChannelAfter = await queryCalendarChannel(pendingChannel);
+
+    expect(pendingChannelAfter.syncStage).not.toBe(
+      CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
+    );
+    expect(pendingChannelAfter.syncStageStartedAt).not.toBeNull();
+    expect(pendingChannelAfter.syncStatus).not.toBe(
+      CalendarChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
+    );
+    expect(pendingChannelAfter.syncStatus).not.toBe(
+      CalendarChannelSyncStatus.FAILED_UNKNOWN,
+    );
+
+    const throttledChannelAfter = await queryCalendarChannel(throttledChannel);
+
+    expect(throttledChannelAfter.syncStage).toBe(
+      CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
+    );
+    expect(throttledChannelAfter.throttleFailureCount).toBe(1);
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/google/calendar/participant-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/calendar/participant-creation.integration-spec.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from 'node:crypto';
+
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { googleCalendarEvent } from 'test/integration/google/mocks/google-calendar-event.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { findRecordNodesByFilter } from 'test/integration/utils/find-records-by-filter.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import { runCalendarChannelEventsImport } from 'test/integration/utils/run-calendar-channel-events-import.util';
+import { runCalendarChannelListFetch } from 'test/integration/utils/run-calendar-channel-list-fetch.util';
+import { waitForAllJobsToFinish } from 'test/integration/utils/wait-for-all-jobs-to-finish.util';
+
+const HANDLE = 'google-calendar-participant-creation@apple.dev';
+
+const FIRST_EVENT_TITLE = `Calendar event first ${randomUUID()}`;
+const SECOND_EVENT_TITLE = `Calendar event second ${randomUUID()}`;
+
+const FIRST_EVENT_ATTENDEES = [
+  `attendee-a1-${randomUUID()}@acme.com`,
+  `attendee-a2-${randomUUID()}@acme.com`,
+];
+const MATCHED_ATTENDEE = `attendee-b1-${randomUUID()}@acme.com`;
+
+const createPerson = async (primaryEmail: string) => {
+  const response = await makeGraphqlAPIRequest(
+    createOneOperationFactory({
+      objectMetadataSingularName: 'person',
+      gqlFields: 'id',
+      data: { emails: { primaryEmail } },
+    }),
+  );
+
+  expect(response.body.errors).toBeUndefined();
+
+  return response.body.data.createPerson.id as string;
+};
+
+describe('Calendar event participant creation (integration)', () => {
+  const gmail = setupGoogleMock({ handle: HANDLE });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let matchedPersonId: string;
+
+  beforeAll(async () => {
+    matchedPersonId = await createPerson(MATCHED_ATTENDEE);
+
+    await waitForAllJobsToFinish();
+
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    await getCoreRepository<CalendarChannelEntity>(
+      CalendarChannelEntity,
+    ).update(
+      { id: channel.calendarChannelId },
+      { isContactAutoCreationEnabled: false },
+    );
+
+    gmail.serveCalendarEvents([
+      googleCalendarEvent({
+        summary: FIRST_EVENT_TITLE,
+        attendees: FIRST_EVENT_ATTENDEES.map((email) => ({ email })),
+      }),
+      googleCalendarEvent({
+        summary: SECOND_EVENT_TITLE,
+        attendees: [{ email: MATCHED_ATTENDEE }],
+      }),
+    ]);
+
+    await runCalendarChannelListFetch(channel.calendarChannelId);
+    await runCalendarChannelEventsImport(channel.calendarChannelId);
+  }, 120000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('links every imported participant to the calendar event it was fetched for', async () => {
+    const [firstEvent] = await findRecordNodesByFilter<{ id: string }>(
+      'calendarEvent',
+      'calendarEvents',
+      'id',
+      { title: { eq: FIRST_EVENT_TITLE } },
+    );
+    const [secondEvent] = await findRecordNodesByFilter<{ id: string }>(
+      'calendarEvent',
+      'calendarEvents',
+      'id',
+      { title: { eq: SECOND_EVENT_TITLE } },
+    );
+
+    expect(firstEvent).toBeDefined();
+    expect(secondEvent).toBeDefined();
+
+    const firstEventParticipants = await findRecordNodesByFilter<{
+      handle: string;
+      calendarEventId: string;
+    }>(
+      'calendarEventParticipant',
+      'calendarEventParticipants',
+      'handle calendarEventId',
+      { calendarEventId: { eq: firstEvent.id } },
+    );
+
+    expect(
+      firstEventParticipants.map((participant) => participant.handle).sort(),
+    ).toEqual([...FIRST_EVENT_ATTENDEES].sort());
+    for (const participant of firstEventParticipants) {
+      expect(participant.calendarEventId).toBe(firstEvent.id);
+    }
+
+    const secondEventParticipants = await findRecordNodesByFilter<{
+      handle: string;
+      calendarEventId: string;
+    }>(
+      'calendarEventParticipant',
+      'calendarEventParticipants',
+      'handle calendarEventId',
+      { calendarEventId: { eq: secondEvent.id } },
+    );
+
+    expect(secondEventParticipants).toHaveLength(1);
+    expect(secondEventParticipants[0].handle).toBe(MATCHED_ATTENDEE);
+    expect(secondEventParticipants[0].calendarEventId).toBe(secondEvent.id);
+  }, 60000);
+
+  it('assigns the matching person to the correct participant without mismatching the insert batch', async () => {
+    const matchedParticipants = await findRecordNodesByFilter<{
+      handle: string;
+      personId: string | null;
+    }>(
+      'calendarEventParticipant',
+      'calendarEventParticipants',
+      'handle personId',
+      { handle: { eq: MATCHED_ATTENDEE } },
+    );
+
+    expect(matchedParticipants).toHaveLength(1);
+    expect(matchedParticipants[0].personId).toBe(matchedPersonId);
+
+    const unmatchedParticipants = await findRecordNodesByFilter<{
+      handle: string;
+      personId: string | null;
+    }>(
+      'calendarEventParticipant',
+      'calendarEventParticipants',
+      'handle personId',
+      { handle: { in: FIRST_EVENT_ATTENDEES } },
+    );
+
+    expect(unmatchedParticipants).toHaveLength(FIRST_EVENT_ATTENDEES.length);
+    for (const participant of unmatchedParticipants) {
+      expect(participant.personId).toBeNull();
+    }
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/google/messaging/blocklist-cleanup-multiple-handles.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/blocklist-cleanup-multiple-handles.integration-spec.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from 'node:crypto';
+
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { getGmailMessageSubject } from 'test/integration/google/mocks/gmail-message-subject.util';
+import { gmailMessage } from 'test/integration/google/mocks/gmail-message.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { findImportedMessageSubjects } from 'test/integration/utils/find-imported-records.util';
+import { runMessageChannelSync } from 'test/integration/utils/run-message-channel-sync.util';
+import { waitForAllJobsToFinish } from 'test/integration/utils/wait-for-all-jobs-to-finish.util';
+
+const HANDLE_1 = 'gmail-blocklist-multi-1@apple.dev';
+const HANDLE_2 = 'gmail-blocklist-multi-2@apple.dev';
+
+const BLOCKED_A = `blocked-a-${randomUUID()}@acme.com`;
+const BLOCKED_B = `blocked-b-${randomUUID()}@acme.com`;
+const KEPT_1 = `kept-1-${randomUUID()}@acme.com`;
+const KEPT_2 = `kept-2-${randomUUID()}@acme.com`;
+
+describe('Blocklist cleanup with multiple handles across multiple channels (integration)', () => {
+  const messageFromAToChannel1 = gmailMessage({
+    from: BLOCKED_A,
+    to: HANDLE_1,
+  });
+  const messageFromBToChannel1 = gmailMessage({
+    from: BLOCKED_B,
+    to: HANDLE_1,
+  });
+  const keptMessageChannel1 = gmailMessage({ from: KEPT_1, to: HANDLE_1 });
+
+  const messageFromAToChannel2 = gmailMessage({
+    from: BLOCKED_A,
+    to: HANDLE_2,
+  });
+  const messageFromBToChannel2 = gmailMessage({
+    from: BLOCKED_B,
+    to: HANDLE_2,
+  });
+  const keptMessageChannel2 = gmailMessage({ from: KEPT_2, to: HANDLE_2 });
+
+  const subjectAChannel1 = getGmailMessageSubject(messageFromAToChannel1);
+  const subjectBChannel1 = getGmailMessageSubject(messageFromBToChannel1);
+  const keptSubjectChannel1 = getGmailMessageSubject(keptMessageChannel1);
+
+  const subjectAChannel2 = getGmailMessageSubject(messageFromAToChannel2);
+  const subjectBChannel2 = getGmailMessageSubject(messageFromBToChannel2);
+  const keptSubjectChannel2 = getGmailMessageSubject(keptMessageChannel2);
+
+  const allSubjects = [
+    subjectAChannel1,
+    subjectBChannel1,
+    keptSubjectChannel1,
+    subjectAChannel2,
+    subjectBChannel2,
+    keptSubjectChannel2,
+  ];
+
+  const inbox = [
+    messageFromAToChannel1,
+    messageFromBToChannel1,
+    keptMessageChannel1,
+  ];
+
+  const gmail = setupGoogleMock({ handle: HANDLE_1, inbox });
+
+  let channel1: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let channel2: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  beforeAll(async () => {
+    channel1 = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE_1,
+    });
+
+    await runMessageChannelSync(channel1.channelId);
+
+    gmail.actAsAccount(HANDLE_2);
+
+    const channel2Messages = [
+      messageFromAToChannel2,
+      messageFromBToChannel2,
+      keptMessageChannel2,
+    ];
+
+    // The detail/batch fetch handlers resolve against the shared inbox
+    // reference, so channel 2's messages must be added to it as well as
+    // served through the list endpoint.
+    inbox.push(...channel2Messages);
+    gmail.serveMessageList(channel2Messages);
+
+    channel2 = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE_2,
+    });
+
+    await runMessageChannelSync(channel2.channelId);
+  }, 180000);
+
+  afterAll(async () => {
+    await channel1?.cleanup().catch(() => undefined);
+    await channel2?.cleanup().catch(() => undefined);
+  });
+
+  it('imports every blocked and kept message on both channels before anything is blocked', async () => {
+    expect(await findImportedMessageSubjects(allSubjects)).toEqual(
+      [...allSubjects].sort(),
+    );
+  }, 60000);
+
+  it('blocking multiple handles at once deletes their messages from every channel and keeps everything else', async () => {
+    const response = await makeGraphqlAPIRequest(
+      createManyOperationFactory({
+        objectMetadataSingularName: 'blocklist',
+        objectMetadataPluralName: 'blocklists',
+        gqlFields: 'id handle',
+        data: [
+          {
+            handle: BLOCKED_A,
+            workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JANE,
+          },
+          {
+            handle: BLOCKED_B,
+            workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JANE,
+          },
+        ],
+      }),
+    );
+
+    expect(response.body.errors).toBeUndefined();
+
+    await waitForAllJobsToFinish();
+
+    expect(await findImportedMessageSubjects(allSubjects)).toEqual(
+      [keptSubjectChannel1, keptSubjectChannel2].sort(),
+    );
+  }, 120000);
+});

--- a/packages/twenty-server/test/integration/google/messaging/channel-visibility-multiple-messages.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/channel-visibility-multiple-messages.integration-spec.ts
@@ -1,0 +1,130 @@
+import {
+  ConnectedAccountProvider,
+  MessageChannelVisibility,
+} from 'twenty-shared/types';
+
+import { FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED } from 'twenty-shared/constants';
+
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { makeGraphqlAPIRequestWithMemberRole } from 'test/integration/graphql/utils/make-graphql-api-request-with-member-role.util';
+import { getGmailMessageSubject } from 'test/integration/google/mocks/gmail-message-subject.util';
+import { gmailMessage } from 'test/integration/google/mocks/gmail-message.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import { runMessageChannelSync } from 'test/integration/utils/run-message-channel-sync.util';
+
+const HANDLE = 'gmail-visibility-multi@apple.dev';
+
+const RESTRICTED = FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED;
+
+const THREAD_TOKEN = 'visibility-multi';
+
+describe('Message channel visibility across a multi message page (integration)', () => {
+  const inbox = [
+    gmailMessage({ from: `first-${THREAD_TOKEN}@example.com` }),
+    gmailMessage({ from: `second-${THREAD_TOKEN}@example.com` }),
+    gmailMessage({ from: `third-${THREAD_TOKEN}@example.com` }),
+  ];
+  const subjects = inbox.map(getGmailMessageSubject);
+
+  setupGoogleMock({ handle: HANDLE, inbox });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  const readMessagesAs = async (
+    makeRequest:
+      | typeof makeGraphqlAPIRequest
+      | typeof makeGraphqlAPIRequestWithMemberRole,
+  ) => {
+    const response = await makeRequest(
+      findManyOperationFactory({
+        objectMetadataSingularName: 'message',
+        objectMetadataPluralName: 'messages',
+        gqlFields: 'subject text',
+        filter: { subject: { in: subjects } },
+      }),
+    );
+
+    expect(response.body.errors).toBeUndefined();
+
+    return response.body.data.messages.edges.map(
+      (edge: { node: { subject: string; text: string } }) => edge.node,
+    );
+  };
+
+  const setVisibility = async (visibility: MessageChannelVisibility) => {
+    await getCoreRepository<MessageChannelEntity>(MessageChannelEntity).update(
+      { id: channel.channelId },
+      { visibility },
+    );
+  };
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    await runMessageChannelSync(channel.channelId);
+  }, 120000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('returns every message unmasked to another member when the channel shares everything', async () => {
+    await setVisibility(MessageChannelVisibility.SHARE_EVERYTHING);
+
+    const messages = await readMessagesAs(makeGraphqlAPIRequestWithMemberRole);
+
+    expect(messages).toHaveLength(subjects.length);
+    expect(
+      messages.map((message: { subject: string }) => message.subject).sort(),
+    ).toEqual([...subjects].sort());
+    for (const message of messages) {
+      expect(message.text).not.toBe(RESTRICTED);
+    }
+  });
+
+  it('masks the body of every message on the page under subject visibility', async () => {
+    await setVisibility(MessageChannelVisibility.SUBJECT);
+
+    const messages = await readMessagesAs(makeGraphqlAPIRequestWithMemberRole);
+
+    expect(messages).toHaveLength(subjects.length);
+    for (const message of messages) {
+      expect(subjects).toContain(message.subject);
+      expect(message.text).toBe(RESTRICTED);
+    }
+  });
+
+  it('masks the subject and body of every message on the page under metadata visibility', async () => {
+    await setVisibility(MessageChannelVisibility.METADATA);
+
+    const messages = await readMessagesAs(makeGraphqlAPIRequestWithMemberRole);
+
+    expect(messages).toHaveLength(subjects.length);
+    for (const message of messages) {
+      expect(message.subject).toBe(RESTRICTED);
+      expect(message.text).toBe(RESTRICTED);
+    }
+  });
+
+  it('returns every message unmasked to the connected account owner under metadata visibility', async () => {
+    await setVisibility(MessageChannelVisibility.METADATA);
+
+    const messages = await readMessagesAs(makeGraphqlAPIRequest);
+
+    expect(messages).toHaveLength(subjects.length);
+    expect(
+      messages.map((message: { subject: string }) => message.subject).sort(),
+    ).toEqual([...subjects].sort());
+    for (const message of messages) {
+      expect(message.text).not.toBe(RESTRICTED);
+    }
+  });
+});

--- a/packages/twenty-server/test/integration/google/messaging/folder-discovery.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/folder-discovery.integration-spec.ts
@@ -1,6 +1,7 @@
 import {
   ConnectedAccountProvider,
   MessageFolderImportPolicy,
+  MessageFolderPendingSyncAction,
 } from 'twenty-shared/types';
 
 import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
@@ -75,5 +76,42 @@ describe('Gmail folder discovery (integration)', () => {
       Work: true,
       Archive: false,
     });
+  }, 60000);
+
+  it('updates a renamed folder in place by id and marks a removed folder for deletion', async () => {
+    const foldersBeforeChange = await queryMessageFolders(channel.channelId);
+    const workFolderId = foldersBeforeChange.find(
+      (folder) => folder.name === 'Work',
+    )?.id;
+    const sentFolderId = foldersBeforeChange.find(
+      (folder) => folder.name === 'SENT',
+    )?.id;
+
+    if (!workFolderId || !sentFolderId) {
+      throw new Error(
+        'Expected the Work and SENT folders to already be synced from earlier in this suite',
+      );
+    }
+
+    gmail.labels.remove('Label_Work');
+    gmail.labels.add({ id: 'Label_Work', name: 'Engineering' });
+    gmail.labels.remove('SENT');
+
+    await runMessageChannelSync(channel.channelId);
+
+    const foldersAfterChange = await queryMessageFolders(channel.channelId);
+
+    const renamedFolder = foldersAfterChange.find(
+      (folder) => folder.id === workFolderId,
+    );
+    const deletedFolder = foldersAfterChange.find(
+      (folder) => folder.id === sentFolderId,
+    );
+
+    expect(renamedFolder?.name).toBe('Engineering');
+    expect(renamedFolder?.isSynced).toBe(true);
+    expect(deletedFolder?.pendingSyncAction).toBe(
+      MessageFolderPendingSyncAction.FOLDER_DELETION,
+    );
   }, 60000);
 });

--- a/packages/twenty-server/test/integration/google/messaging/message-participant-volume.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/message-participant-volume.integration-spec.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  ConnectedAccountProvider,
+  MessageParticipantRole,
+} from 'twenty-shared/types';
+
+import { gmailMessage } from 'test/integration/google/mocks/gmail-message.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { findRecordNodesByFilter } from 'test/integration/utils/find-records-by-filter.util';
+import { runMessageChannelSync } from 'test/integration/utils/run-message-channel-sync.util';
+
+const HANDLE = 'gmail-participant-volume@apple.dev';
+
+const MESSAGE_COUNT = 30;
+
+const senderHandles = Array.from(
+  { length: MESSAGE_COUNT },
+  () => `sender-${randomUUID()}@acme.dev`,
+);
+
+const inbox = senderHandles.map((from) => gmailMessage({ from, to: HANDLE }));
+
+describe('Message participant saving at volume (integration)', () => {
+  setupGoogleMock({ handle: HANDLE, inbox });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    await runMessageChannelSync(channel.channelId);
+  }, 180000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('persists a distinct sender participant for every imported message with the right handle and role', async () => {
+    const fromParticipants = await findRecordNodesByFilter<{
+      handle: string;
+      role: string;
+      messageId: string;
+    }>('messageParticipant', 'messageParticipants', 'handle role messageId', {
+      handle: { in: senderHandles },
+    });
+
+    expect(fromParticipants).toHaveLength(MESSAGE_COUNT);
+    expect(
+      fromParticipants.every(
+        (participant) => participant.role === MessageParticipantRole.FROM,
+      ),
+    ).toBe(true);
+    expect(
+      new Set(fromParticipants.map((participant) => participant.handle)).size,
+    ).toBe(MESSAGE_COUNT);
+    expect(
+      new Set(fromParticipants.map((participant) => participant.messageId))
+        .size,
+    ).toBe(MESSAGE_COUNT);
+  }, 120000);
+
+  it('links every message to its own recipient participant row instead of collapsing on the shared handle', async () => {
+    const toParticipants = await findRecordNodesByFilter<{
+      role: string;
+      messageId: string;
+    }>('messageParticipant', 'messageParticipants', 'role messageId', {
+      handle: { eq: HANDLE },
+      role: { eq: MessageParticipantRole.TO },
+    });
+
+    expect(toParticipants).toHaveLength(MESSAGE_COUNT);
+    expect(
+      new Set(toParticipants.map((participant) => participant.messageId)).size,
+    ).toBe(MESSAGE_COUNT);
+  }, 120000);
+});

--- a/packages/twenty-server/test/integration/google/messaging/stale-sync.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/stale-sync.integration-spec.ts
@@ -14,6 +14,10 @@ import { runSyncCron } from 'test/integration/utils/run-sync-cron.util';
 
 const STALE_HANDLE = 'messaging-stale-sync@apple.dev';
 const RECENT_HANDLE = 'messaging-recent-sync@apple.dev';
+const SECOND_STALE_LIST_FETCH_HANDLE =
+  'messaging-stale-sync-second-list-fetch@apple.dev';
+const STALE_IMPORT_HANDLE_A = 'messaging-stale-sync-import-a@apple.dev';
+const STALE_IMPORT_HANDLE_B = 'messaging-stale-sync-import-b@apple.dev';
 
 const STALE_STARTED_AT = new Date(Date.now() - 31 * 60 * 1000);
 const RECENT_STARTED_AT = new Date(Date.now() - 60 * 1000);
@@ -23,6 +27,11 @@ describe('Messaging stale-sync recovery (integration)', () => {
 
   let staleChannel: Awaited<ReturnType<typeof connectMessagingAccount>>;
   let recentChannel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let secondStaleListFetchChannel: Awaited<
+    ReturnType<typeof connectMessagingAccount>
+  >;
+  let staleImportChannelA: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let staleImportChannelB: Awaited<ReturnType<typeof connectMessagingAccount>>;
 
   beforeAll(async () => {
     staleChannel = await connectMessagingAccount({
@@ -37,18 +46,48 @@ describe('Messaging stale-sync recovery (integration)', () => {
       handle: RECENT_HANDLE,
     });
 
-    for (const connectedChannel of [staleChannel, recentChannel]) {
+    gmail.actAsAccount(SECOND_STALE_LIST_FETCH_HANDLE);
+
+    secondStaleListFetchChannel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: SECOND_STALE_LIST_FETCH_HANDLE,
+    });
+
+    gmail.actAsAccount(STALE_IMPORT_HANDLE_A);
+
+    staleImportChannelA = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: STALE_IMPORT_HANDLE_A,
+    });
+
+    gmail.actAsAccount(STALE_IMPORT_HANDLE_B);
+
+    staleImportChannelB = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: STALE_IMPORT_HANDLE_B,
+    });
+
+    for (const connectedChannel of [
+      staleChannel,
+      recentChannel,
+      secondStaleListFetchChannel,
+      staleImportChannelA,
+      staleImportChannelB,
+    ]) {
       const channelState = await queryMessageChannel(connectedChannel);
 
       expect(channelState.syncStage).toBe(
         MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
       );
     }
-  }, 120000);
+  }, 180000);
 
   afterAll(async () => {
     await staleChannel?.cleanup().catch(() => undefined);
     await recentChannel?.cleanup().catch(() => undefined);
+    await secondStaleListFetchChannel?.cleanup().catch(() => undefined);
+    await staleImportChannelA?.cleanup().catch(() => undefined);
+    await staleImportChannelB?.cleanup().catch(() => undefined);
   });
 
   it('resets a stale ongoing channel to pending and leaves a recent one running', async () => {
@@ -85,5 +124,87 @@ describe('Messaging stale-sync recovery (integration)', () => {
     expect(recentChannelAfter.syncStage).toBe(
       MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
     );
+  }, 60000);
+
+  it('resets several stale channels to their own correct pending stage in one run and leaves the recent one untouched', async () => {
+    const messageChannelRepository =
+      getCoreRepository<MessageChannelEntity>(MessageChannelEntity);
+
+    await messageChannelRepository.update(
+      { id: staleChannel.channelId },
+      {
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
+        syncStageStartedAt: STALE_STARTED_AT,
+      },
+    );
+
+    await messageChannelRepository.update(
+      { id: secondStaleListFetchChannel.channelId },
+      {
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
+        syncStageStartedAt: STALE_STARTED_AT,
+      },
+    );
+
+    await messageChannelRepository.update(
+      { id: staleImportChannelA.channelId },
+      {
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING,
+        syncStageStartedAt: STALE_STARTED_AT,
+      },
+    );
+
+    await messageChannelRepository.update(
+      { id: staleImportChannelB.channelId },
+      {
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING,
+        syncStageStartedAt: STALE_STARTED_AT,
+      },
+    );
+
+    await messageChannelRepository.update(
+      { id: recentChannel.channelId },
+      {
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
+        syncStageStartedAt: RECENT_STARTED_AT,
+      },
+    );
+
+    await runSyncCron(MessagingOngoingStaleCronJob);
+
+    const [
+      staleChannelAfter,
+      secondStaleListFetchChannelAfter,
+      staleImportChannelAAfter,
+      staleImportChannelBAfter,
+      recentChannelAfter,
+    ] = await Promise.all([
+      queryMessageChannel(staleChannel),
+      queryMessageChannel(secondStaleListFetchChannel),
+      queryMessageChannel(staleImportChannelA),
+      queryMessageChannel(staleImportChannelB),
+      queryMessageChannel(recentChannel),
+    ]);
+
+    expect(staleChannelAfter.syncStage).toBe(
+      MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+    );
+    expect(staleChannelAfter.syncStageStartedAt).toBeNull();
+    expect(secondStaleListFetchChannelAfter.syncStage).toBe(
+      MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+    );
+    expect(secondStaleListFetchChannelAfter.syncStageStartedAt).toBeNull();
+    expect(staleImportChannelAAfter.syncStage).toBe(
+      MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+    );
+    expect(staleImportChannelAAfter.syncStageStartedAt).toBeNull();
+    expect(staleImportChannelBAfter.syncStage).toBe(
+      MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+    );
+    expect(staleImportChannelBAfter.syncStageStartedAt).toBeNull();
+    expect(recentChannelAfter.syncStage).toBe(
+      MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
+    );
+    expect(recentChannelAfter.syncStageStartedAt).not.toBeNull();
   }, 60000);
 });


### PR DESCRIPTION
## Summary

- Schedule pending message and calendar imports across active workspaces in bounded batches, instead of querying and updating once per workspace.
- Resolve message and calendar visibility access once per page instead of once per record.
- Reuse workspace members and the internal-message-import setting across contact-creation batches.

## Performance

Query-count reduction derived from the diff. N is the number of records in a read page, W is the number of active workspaces, C is the number of pending channels, and B is the number of contact-creation batches.

| Area | Before | After |
|---|---|---|
| Message/calendar visibility resolution | O(N) repeated access lookups | O(1) access lookups per page |
| Pending import scheduling (every minute) | O(W) channel selects and updates | One channel select, then bounded 200-channel update and enqueue batches |
| Contact creation context | O(B) workspace-member/config reads | One read of each per job |