### PR TITLE
Simplify settings-shell opening in `useNavigateSettings` and add routed side-panel test

### DIFF
--- a/packages/twenty-front/src/hooks/__tests__/useNavigateSettings.test.tsx
+++ b/packages/twenty-front/src/hooks/__tests__/useNavigateSettings.test.tsx
@@ -36,6 +36,26 @@ const SidePanelWrapper = ({ children }: { children: React.ReactNode }) => (
   </MemoryRouter>
 );
 
+const RoutedSidePanelWrapper = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => (
+  <MemoryRouter>
+    <WorkspaceSurfaceContext.Provider
+      value={{
+        type: 'side-panel',
+        instanceId: 'side-panel-page',
+        ownsRouteLocation: true,
+        headerTitlePortal: null,
+        headerActionsPortal: null,
+      }}
+    >
+      {children}
+    </WorkspaceSurfaceContext.Provider>
+  </MemoryRouter>
+);
+
 describe('useNavigateSettings', () => {
   const mockNavigate = jest.fn();
 
@@ -95,18 +115,31 @@ describe('useNavigateSettings', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/settings/accounts', options);
   });
 
-  it('opens settings when a legacy side-panel page escapes to main', () => {
+  it('opens settings when a legacy side-panel page navigates to settings', () => {
     const { result } = renderHook(() => useNavigateSettings(), {
       wrapper: SidePanelWrapper,
     });
 
-    result.current(SettingsPath.NewAccount, undefined, undefined, {
-      surface: 'main',
-    });
+    result.current(SettingsPath.NewAccount);
 
     expect(openSettingsMenuMock).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith('/settings/accounts/new', {
-      surface: 'main',
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/settings/accounts/new',
+      undefined,
+    );
+  });
+
+  it('leaves settings shell handling to a routed side-panel navigator', () => {
+    const { result } = renderHook(() => useNavigateSettings(), {
+      wrapper: RoutedSidePanelWrapper,
     });
+
+    result.current(SettingsPath.NewAccount);
+
+    expect(openSettingsMenuMock).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/settings/accounts/new',
+      undefined,
+    );
   });
 });

--- a/packages/twenty-front/src/hooks/useNavigateSettings.ts
+++ b/packages/twenty-front/src/hooks/useNavigateSettings.ts
@@ -26,7 +26,7 @@ export const useNavigateSettings = () => {
 
       if (
         workspaceSurface.type === 'main' ||
-        (options?.surface === 'main' && !workspaceSurface.ownsRouteLocation)
+        !workspaceSurface.ownsRouteLocation
       ) {
         openSettingsMenu();
       }


### PR DESCRIPTION
### Motivation
- Ensure the settings shell is opened only when the current workspace surface does not own the route location, avoiding legacy-surface option handling.
- Clarify behavior for routed side-panel navigators so they can handle settings shell themselves when they own route location.
- Update tests to reflect the simplified logic and cover the routed side-panel case.

### Description
- Simplified the open-settings condition in `useNavigateSettings` by removing the `options.surface === 'main'` check and opening the settings whenever `workspaceSurface.type === 'main'` or `!workspaceSurface.ownsRouteLocation`.
- Added a new `RoutedSidePanelWrapper` test wrapper to simulate a side-panel that owns the route location.
- Updated `useNavigateSettings` tests to remove the legacy `surface` option expectation and to assert that routed side-panel navigators do not trigger `openSettingsMenu`.

### Testing
- Ran the package unit tests for `useNavigateSettings` (`jest` for `packages/twenty-front`), and the updated test file `useNavigateSettings.test.tsx` passed.
- Verified the new routed side-panel test asserts that `openSettingsMenu` is not called when `ownsRouteLocation` is `true` and that navigation still occurs as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a96eaeee534832f851189ffbb828687)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

