### PR TITLE
Expose Note/Task body in field lists and FieldWidget selector, add tests

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/hooks/__tests__/useFieldListFieldMetadataItems.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/hooks/__tests__/useFieldListFieldMetadataItems.test.tsx
@@ -1,0 +1,60 @@
+import { useLabelIdentifierFieldMetadataItem } from '@/object-metadata/hooks/useLabelIdentifierFieldMetadataItem';
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { useFieldListFieldMetadataItems } from '@/object-record/record-field-list/hooks/useFieldListFieldMetadataItems';
+import { renderHook } from '@testing-library/react';
+import { CoreObjectNameSingular, FieldMetadataType } from 'twenty-shared/types';
+
+jest.mock('@/object-metadata/hooks/useLabelIdentifierFieldMetadataItem');
+jest.mock('@/object-metadata/hooks/useObjectMetadataItem');
+jest.mock('@/object-metadata/hooks/useObjectMetadataItems');
+jest.mock('@/object-record/hooks/useObjectPermissions');
+
+const noteBodyField = {
+  id: 'note-body-field-id',
+  name: 'bodyV2',
+  type: FieldMetadataType.RICH_TEXT,
+  isActive: true,
+} as FieldMetadataItem;
+
+describe('useFieldListFieldMetadataItems', () => {
+  beforeEach(() => {
+    jest.mocked(useLabelIdentifierFieldMetadataItem).mockReturnValue({
+      labelIdentifierFieldMetadataItem: undefined,
+    });
+    jest.mocked(useObjectMetadataItem).mockReturnValue({
+      objectMetadataItem: {
+        readableFields: [noteBodyField],
+      } as ReturnType<typeof useObjectMetadataItem>['objectMetadataItem'],
+    });
+    jest.mocked(useObjectMetadataItems).mockReturnValue({
+      objectMetadataItems: [],
+    });
+    jest.mocked(useObjectPermissions).mockReturnValue({
+      objectPermissionsByObjectMetadataId: {},
+    });
+  });
+
+  it('excludes the note body from regular field lists', () => {
+    const { result } = renderHook(() =>
+      useFieldListFieldMetadataItems({
+        objectNameSingular: CoreObjectNameSingular.Note,
+      }),
+    );
+
+    expect(result.current.inlineFieldMetadataItems).toEqual([]);
+  });
+
+  it('includes the note body when requested by the field widget selector', () => {
+    const { result } = renderHook(() =>
+      useFieldListFieldMetadataItems({
+        objectNameSingular: CoreObjectNameSingular.Note,
+        includeNoteAndTaskBody: true,
+      }),
+    );
+
+    expect(result.current.inlineFieldMetadataItems).toEqual([noteBodyField]);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field-list/hooks/useFieldListFieldMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/hooks/useFieldListFieldMetadataItems.ts
@@ -13,6 +13,7 @@ type UseFieldListFieldMetadataItemsProps = {
   excludeCreatedAtAndUpdatedAt?: boolean;
   showRelationSections?: boolean;
   includeSystemObjectRelations?: boolean;
+  includeNoteAndTaskBody?: boolean;
 };
 
 export const useFieldListFieldMetadataItems = ({
@@ -21,6 +22,7 @@ export const useFieldListFieldMetadataItems = ({
   showRelationSections = true,
   excludeCreatedAtAndUpdatedAt = true,
   includeSystemObjectRelations = false,
+  includeNoteAndTaskBody = false,
 }: UseFieldListFieldMetadataItemsProps) => {
   const { labelIdentifierFieldMetadataItem } =
     useLabelIdentifierFieldMetadataItem({
@@ -64,6 +66,7 @@ export const useFieldListFieldMetadataItems = ({
       .filter(
         (fieldMetadataItem) =>
           !(
+            !includeNoteAndTaskBody &&
             fieldMetadataItem.type === FieldMetadataType.RICH_TEXT &&
             fieldMetadataItem.name === 'bodyV2' &&
             (objectNameSingular === CoreObjectNameSingular.Note ||

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields.ts
@@ -11,6 +11,7 @@ export const useFieldWidgetEligibleFields = (objectNameSingular: string) => {
     // Allow advanced relation fields targeting system objects (e.g. calendarEventParticipants)
     // to appear in the FieldWidget selector — the widget can render them as boxed relations.
     includeSystemObjectRelations: true,
+    includeNoteAndTaskBody: true,
   });
 
   return useMemo(() => {


### PR DESCRIPTION
### Motivation
- Make the rich-text `bodyV2` field for `Note` and `Task` available to the FieldWidget selector while keeping it excluded from regular field lists by default.

### Description
- Add an `includeNoteAndTaskBody` option to `useFieldListFieldMetadataItems` with a default of `false` and use it to control whether the `bodyV2` `RICH_TEXT` field on `Note`/`Task` is filtered out.
- Update `useFieldWidgetEligibleFields` to call `useFieldListFieldMetadataItems` with `includeNoteAndTaskBody: true` so the widget selector can include note/task bodies (rendered as boxed relations where applicable).
- Add unit tests in `useFieldListFieldMetadataItems.test.tsx` to verify that `bodyV2` is excluded by default and included when `includeNoteAndTaskBody` is set to `true`.

### Testing
- Added `useFieldListFieldMetadataItems` unit tests in `packages/twenty-front/src/modules/object-record/record-field-list/hooks/__tests__/useFieldListFieldMetadataItems.test.tsx`; the tests assert exclusion by default and inclusion when `includeNoteAndTaskBody` is enabled, and they passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a973a3b4644832f855aabbcec894b9f)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

