### PR TITLE
Feature/saved responses

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client/react';
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { DragDropProvider } from '@dnd-kit/react';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
@@ -190,6 +190,14 @@ export const EmailComposerFields = ({
 
   const areCcBccFieldsVisible = composerState.showCcBcc || isDraggingRecipients;
 
+  const savedResponseSubject = useMemo(
+    () => ({
+      getCurrentSubject: () => composerState.subject,
+      setSubject: composerState.setSubject,
+    }),
+    [composerState.subject, composerState.setSubject],
+  );
+
   return (
     <StyledFieldsContainer>
       <DragDropItemDndContext.Provider value={contextValues}>
@@ -267,7 +275,7 @@ export const EmailComposerFields = ({
               <StyledComposerTextInput
                 type="text"
                 aria-label={t`Subject`}
-                defaultValue={composerState.initialSubject}
+                value={composerState.subject}
                 onChange={(event) =>
                   composerState.setSubject(event.target.value)
                 }
@@ -288,6 +296,7 @@ export const EmailComposerFields = ({
           placeholder={t`Type something or press "/" to see commands`}
           profile={INLINE_EMAIL_BODY_EDITOR_PROFILE}
           onImageUpload={uploadEmailImage}
+          savedResponseSubject={savedResponseSubject}
         />
       </StyledBody>
       {(composerState.files.length > 0 || isDefined(onAttachFiles)) && (

--- a/packages/twenty-front/src/modules/advanced-text-editor/components/FormAdvancedTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/components/FormAdvancedTextFieldInput.tsx
@@ -2,6 +2,7 @@ import { AdvancedTextEditor } from '@/advanced-text-editor/components/AdvancedTe
 import { useAdvancedTextEditor } from '@/advanced-text-editor/hooks/useAdvancedTextEditor';
 import { type AdvancedTextEditorComponentProps } from '@/advanced-text-editor/types/AdvancedTextEditorComponentProps';
 import { type AdvancedTextEditorProfile } from '@/advanced-text-editor/types/AdvancedTextEditorProfile';
+import { type AdvancedTextEditorExtensionContext } from '@/advanced-text-editor/types/AdvancedTextEditorExtensionContext';
 import { type UploadedImage } from '@/advanced-text-editor/types/UploadedImage';
 import { serializeAdvancedTextEditorDocument } from '@/advanced-text-editor/utils/serializeAdvancedTextEditorDocument';
 import { FormFieldInputContainer } from '@/ui/input/components/FormFieldInputContainer';
@@ -104,6 +105,7 @@ type FormAdvancedTextFieldInputProps = {
   enableFullScreen?: boolean;
   fullScreenBreadcrumbs?: BreadcrumbProps['links'];
   onEditorReady?: (editor: Editor | null) => void;
+  savedResponseSubject?: AdvancedTextEditorExtensionContext['savedResponseSubject'];
 };
 
 export const FormAdvancedTextFieldInput = ({
@@ -123,6 +125,7 @@ export const FormAdvancedTextFieldInput = ({
   enableFullScreen,
   fullScreenBreadcrumbs,
   onEditorReady,
+  savedResponseSubject,
 }: FormAdvancedTextFieldInputProps) => {
   const { chrome, minHeight: profileMinHeight } = profile;
 
@@ -163,6 +166,7 @@ export const FormAdvancedTextFieldInput = ({
     },
     onImageUpload,
     onImageUploadError,
+    savedResponseSubject,
   });
 
   useEffect(() => {

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/DefaultSlashCommands.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/DefaultSlashCommands.ts
@@ -1,4 +1,5 @@
 import { ADVANCED_TEXT_EDITOR_BLOCK_SLASH_COMMANDS } from '@/advanced-text-editor/constants/AdvancedTextEditorBlockSlashCommands';
+import { SavedResponsePicker } from '@/advanced-text-editor/extensions/slash-command/SavedResponsePicker';
 import { type SlashCommandConfig } from '@/advanced-text-editor/extensions/slash-command/types/SlashCommandConfig';
 import { msg } from '@lingui/core/macro';
 import {
@@ -7,6 +8,7 @@ import {
   IconH3,
   IconList,
   IconListNumbers,
+  IconMessage,
   IconPilcrow,
 } from 'twenty-ui/icon';
 
@@ -82,8 +84,21 @@ const LIST_SLASH_COMMANDS: SlashCommandConfig[] = [
   },
 ];
 
+const SAVED_RESPONSE_SLASH_COMMAND: SlashCommandConfig = {
+  id: 'savedResponse',
+  title: msg`Saved Response`,
+  description: msg`Insert a reusable response`,
+  icon: IconMessage,
+  keywords: [msg`saved`, msg`response`, msg`template`],
+  getIsActive: () => false,
+  getIsVisible: (editor) => editor.can().insertContent?.('') ?? false,
+  getOnSelect: () => () => undefined,
+  PickerComponent: SavedResponsePicker,
+};
+
 export const DEFAULT_SLASH_COMMANDS: SlashCommandConfig[] = [
   ...TEXT_SLASH_COMMANDS,
+  SAVED_RESPONSE_SLASH_COMMAND,
   ...ADVANCED_TEXT_EDITOR_BLOCK_SLASH_COMMANDS,
   ...LIST_SLASH_COMMANDS,
 ];

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SavedResponsePicker.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SavedResponsePicker.tsx
@@ -3,7 +3,10 @@ import { forwardRef } from 'react';
 import { MenuItemSuggestion } from 'twenty-ui/navigation';
 
 import { SlashCommandPicker } from '@/advanced-text-editor/extensions/slash-command/SlashCommandPicker';
-import { useSavedResponseDataSource } from '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource';
+import {
+  SavedResponseDataSourceProvider,
+  useSavedResponseDataSource,
+} from '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource';
 import {
   type SlashCommandPickerComponentProps,
   type SlashCommandPickerRef,
@@ -18,7 +21,7 @@ type SavedResponsePickerItem = {
   selectable: boolean;
 };
 
-export const SavedResponsePicker = forwardRef<
+const SavedResponsePickerContent = forwardRef<
   SlashCommandPickerRef,
   SlashCommandPickerComponentProps
 >(({ editor, range, onComplete, searchQuery, savedResponseSubject }, ref) => {
@@ -108,3 +111,12 @@ export const SavedResponsePicker = forwardRef<
     />
   );
 });
+
+export const SavedResponsePicker = forwardRef<
+  SlashCommandPickerRef,
+  SlashCommandPickerComponentProps
+>((props, ref) => (
+  <SavedResponseDataSourceProvider>
+    <SavedResponsePickerContent ref={ref} {...props} />
+  </SavedResponseDataSourceProvider>
+));

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SavedResponsePicker.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SavedResponsePicker.tsx
@@ -1,0 +1,110 @@
+import { useLingui } from '@lingui/react/macro';
+import { forwardRef } from 'react';
+import { MenuItemSuggestion } from 'twenty-ui/navigation';
+
+import { SlashCommandPicker } from '@/advanced-text-editor/extensions/slash-command/SlashCommandPicker';
+import { useSavedResponseDataSource } from '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource';
+import {
+  type SlashCommandPickerComponentProps,
+  type SlashCommandPickerRef,
+} from '@/advanced-text-editor/extensions/slash-command/types/SlashCommandPickerComponent';
+
+type SavedResponsePickerItem = {
+  id: string;
+  label: string;
+  body?: string;
+  subject?: string | null;
+  category?: string | null;
+  selectable: boolean;
+};
+
+export const SavedResponsePicker = forwardRef<
+  SlashCommandPickerRef,
+  SlashCommandPickerComponentProps
+>(({ editor, range, onComplete, searchQuery, savedResponseSubject }, ref) => {
+  const { t } = useLingui();
+  const dataSource = useSavedResponseDataSource();
+  const savedResponses = dataSource.getSavedResponses();
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+  const filteredSavedResponses = savedResponses.filter((savedResponse) =>
+    `${savedResponse.name} ${savedResponse.category ?? ''}`
+      .toLowerCase()
+      .includes(normalizedSearchQuery),
+  );
+
+  const items: SavedResponsePickerItem[] = dataSource.loading
+    ? [
+        {
+          id: 'loading',
+          label: t`Loading saved responses…`,
+          selectable: false,
+        },
+      ]
+    : savedResponses.length === 0
+      ? [
+          {
+            id: 'empty',
+            label: t`No Saved Responses yet`,
+            category: t`Create one in your workspace settings to use it here.`,
+            selectable: false,
+          },
+        ]
+      : filteredSavedResponses.length === 0
+        ? [
+            {
+              id: 'no-match',
+              label: t`No Saved Responses match your search`,
+              selectable: false,
+            },
+          ]
+        : filteredSavedResponses.map((savedResponse) => ({
+            id: savedResponse.id,
+            label: savedResponse.name,
+            body: savedResponse.body,
+            subject: savedResponse.subject,
+            category: savedResponse.category,
+            selectable: true,
+          }));
+
+  const selectItem = (item: SavedResponsePickerItem) => {
+    if (!item.selectable) {
+      return;
+    }
+
+    editor
+      .chain()
+      .focus()
+      .deleteRange(range)
+      .insertContent(item.body ?? '')
+      .run();
+
+    if (
+      savedResponseSubject?.getCurrentSubject().length === 0 &&
+      item.subject
+    ) {
+      savedResponseSubject.setSubject(item.subject);
+    }
+
+    onComplete();
+  };
+
+  return (
+    <SlashCommandPicker
+      ref={ref}
+      items={items}
+      editor={editor}
+      range={range}
+      getItemKey={(item) => item.id}
+      onEscape={onComplete}
+      onSelect={selectItem}
+      renderItem={(item, isSelected) => (
+        <MenuItemSuggestion
+          text={item.label}
+          contextualText={item.category ?? undefined}
+          selected={item.selectable && isSelected}
+          onClick={item.selectable ? () => selectItem(item) : undefined}
+        />
+      )}
+    />
+  );
+});

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SlashCommand.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SlashCommand.ts
@@ -9,6 +9,7 @@ import {
   type SlashCommandMenuProps,
 } from '@/advanced-text-editor/extensions/slash-command/SlashCommandMenu';
 import { type SlashCommandConfig } from '@/advanced-text-editor/extensions/slash-command/types/SlashCommandConfig';
+import { type SlashCommandPickerComponent } from '@/advanced-text-editor/extensions/slash-command/types/SlashCommandPickerComponent';
 import { createSuggestionRenderLifecycle } from '@/ui/suggestion/components/createSuggestionRenderLifecycle';
 
 export type SlashCommandItem = {
@@ -20,6 +21,8 @@ export type SlashCommandItem = {
   isActive?: () => boolean;
   isVisible?: () => boolean;
   command: (options: { editor: Editor; range: Range }) => void;
+  PickerComponent?: SlashCommandPickerComponent;
+  pickerQuery?: string;
 };
 
 const createSlashCommandItem = (
@@ -37,6 +40,7 @@ const createSlashCommandItem = (
     const onSelect = config.getOnSelect(ed, range);
     onSelect();
   },
+  PickerComponent: config.PickerComponent,
 });
 
 const filterVisibleItems = (items: SlashCommandItem[]): SlashCommandItem[] => {
@@ -59,16 +63,28 @@ const filterByQuery = (
   });
 };
 
-const buildItems = (editor: Editor, query: string): SlashCommandItem[] => {
+export const buildSlashCommandItems = (
+  editor: Editor,
+  query: string,
+): SlashCommandItem[] => {
+  const [commandQuery = '', ...pickerQueryParts] = query.trim().split(/\s+/);
+  const pickerQuery = pickerQueryParts.join(' ');
   const allItems = DEFAULT_SLASH_COMMANDS.map((config) =>
     createSlashCommandItem(config, editor),
   );
   const visibleItems = filterVisibleItems(allItems);
-  return filterByQuery(visibleItems, query);
+  return filterByQuery(visibleItems, commandQuery).map((item) => ({
+    ...item,
+    pickerQuery: item.PickerComponent ? pickerQuery : undefined,
+  }));
 };
 
 export type SlashCommandOptions = {
   suggestions: Omit<SuggestionOptions, 'editor'>;
+  savedResponseSubject?: {
+    getCurrentSubject: () => string;
+    setSubject: (subject: string) => void;
+  };
 };
 
 export const SlashCommand = Extension.create<SlashCommandOptions>({
@@ -88,7 +104,7 @@ export const SlashCommand = Extension.create<SlashCommandOptions>({
       Suggestion({
         editor: this.editor,
         ...this.options.suggestions,
-        items: ({ query, editor: ed }) => buildItems(ed, query),
+        items: ({ query, editor: ed }) => buildSlashCommandItems(ed, query),
         render: () =>
           createSuggestionRenderLifecycle<
             SlashCommandItem,
@@ -102,6 +118,7 @@ export const SlashCommand = Extension.create<SlashCommandOptions>({
                 editor,
                 range,
                 query,
+                savedResponseSubject: this.options.savedResponseSubject,
               }),
             },
             this.editor,

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SlashCommandMenu.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SlashCommandMenu.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useCallback, useState } from 'react';
 import { MenuItemSuggestion } from 'twenty-ui/navigation';
 
 import { type SlashCommandItem } from '@/advanced-text-editor/extensions/slash-command/SlashCommand';
+import { type SlashCommandPickerRef } from '@/advanced-text-editor/extensions/slash-command/types/SlashCommandPickerComponent';
 import { SuggestionMenu } from '@/ui/suggestion/components/SuggestionMenu';
 
 export type SlashCommandMenuProps = {
@@ -11,67 +12,111 @@ export type SlashCommandMenuProps = {
   editor: Editor;
   range: Range;
   query: string;
+  savedResponseSubject?: {
+    getCurrentSubject: () => string;
+    setSubject: (subject: string) => void;
+  };
 };
 
 const getItemKey = (item: SlashCommandItem) => item.id;
 
-export const SlashCommandMenu = forwardRef<unknown, SlashCommandMenuProps>(
-  (props, ref) => {
-    const { items, onSelect, editor, range, query } = props;
+export const SlashCommandMenu = forwardRef<
+  SlashCommandPickerRef,
+  SlashCommandMenuProps
+>((props, ref) => {
+  const { items, onSelect, editor, range, query, savedResponseSubject } = props;
 
-    const [prevSelectedIndex, setPrevSelectedIndex] = useState(0);
-    const [prevQuery, setPrevQuery] = useState('');
+  const [prevSelectedIndex, setPrevSelectedIndex] = useState(0);
+  const [prevQuery, setPrevQuery] = useState('');
+  const [activePickerItem, setActivePickerItem] = useState<SlashCommandItem>();
 
-    const handleKeyDown = useCallback(
-      (event: KeyboardEvent, selectedIndex: number) => {
-        if (event.key === 'ArrowLeft') {
-          event.preventDefault();
-          editor.chain().focus().insertContentAt(range, `/${prevQuery}`).run();
-          setTimeout(() => {
-            setPrevSelectedIndex(prevSelectedIndex);
-          }, 0);
-          return true;
-        }
+  const handleSelect = useCallback(
+    (item: SlashCommandItem) => {
+      if (item.PickerComponent) {
+        setActivePickerItem(item);
+        return;
+      }
 
-        if (event.key === 'ArrowRight') {
-          return true;
-        }
+      onSelect(item);
+    },
+    [onSelect],
+  );
 
-        if (event.key === 'Enter' && items.length > 0) {
-          setPrevQuery(query);
-          setPrevSelectedIndex(selectedIndex);
-        }
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent, selectedIndex: number) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        editor.chain().focus().insertContentAt(range, `/${prevQuery}`).run();
+        setTimeout(() => {
+          setPrevSelectedIndex(prevSelectedIndex);
+        }, 0);
+        return true;
+      }
 
-        return undefined;
-      },
-      [editor, range, prevQuery, prevSelectedIndex, items.length, query],
-    );
+      if (event.key === 'ArrowRight') {
+        return true;
+      }
 
-    const renderItem = useCallback(
-      (item: SlashCommandItem, isSelected: boolean) => (
-        <MenuItemSuggestion
-          LeftIcon={item.icon}
-          text={item.title}
-          selected={isSelected}
-          onClick={() => {
-            onSelect(item);
-          }}
-        />
-      ),
-      [onSelect],
-    );
+      if (event.key === 'Enter' && items.length > 0) {
+        setPrevQuery(query);
+        setPrevSelectedIndex(selectedIndex);
+      }
+
+      return undefined;
+    },
+    [editor, range, prevQuery, prevSelectedIndex, items.length, query],
+  );
+
+  const renderItem = useCallback(
+    (item: SlashCommandItem, isSelected: boolean) => (
+      <MenuItemSuggestion
+        LeftIcon={item.icon}
+        text={item.title}
+        selected={isSelected}
+        onClick={() => {
+          handleSelect(item);
+        }}
+      />
+    ),
+    [handleSelect],
+  );
+
+  const inlinePickerItem = items.find(
+    (item) => item.PickerComponent && item.pickerQuery,
+  );
+  const refreshedActivePickerItem = activePickerItem
+    ? (items.find((item) => item.id === activePickerItem.id) ??
+      activePickerItem)
+    : undefined;
+  const currentPickerItem = refreshedActivePickerItem ?? inlinePickerItem;
+
+  if (currentPickerItem?.PickerComponent) {
+    const PickerComponent = currentPickerItem.PickerComponent;
 
     return (
-      <SuggestionMenu
+      <PickerComponent
         ref={ref}
-        items={items}
-        onSelect={onSelect}
         editor={editor}
         range={range}
-        getItemKey={getItemKey}
-        renderItem={renderItem}
-        onKeyDown={handleKeyDown}
+        searchQuery={currentPickerItem.pickerQuery ?? ''}
+        savedResponseSubject={savedResponseSubject}
+        onComplete={() => {
+          onSelect(currentPickerItem);
+        }}
       />
     );
-  },
-);
+  }
+
+  return (
+    <SuggestionMenu
+      ref={ref}
+      items={items}
+      onSelect={handleSelect}
+      editor={editor}
+      range={range}
+      getItemKey={getItemKey}
+      renderItem={renderItem}
+      onKeyDown={handleKeyDown}
+    />
+  );
+});

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SlashCommandPicker.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/SlashCommandPicker.tsx
@@ -1,0 +1,56 @@
+import { type Editor, type Range } from '@tiptap/core';
+import { forwardRef, type ReactNode, useCallback } from 'react';
+
+import { SuggestionMenu } from '@/ui/suggestion/components/SuggestionMenu';
+import { type SlashCommandPickerRef } from '@/advanced-text-editor/extensions/slash-command/types/SlashCommandPickerComponent';
+
+export type SlashCommandPickerProps<TItem> = {
+  items: TItem[];
+  onSelect: (item: TItem) => void;
+  onEscape: () => void;
+  editor: Editor;
+  range: Range;
+  getItemKey: (item: TItem) => string;
+  renderItem: (item: TItem, isSelected: boolean) => ReactNode;
+};
+
+const SlashCommandPickerInner = <TItem,>(
+  props: SlashCommandPickerProps<TItem>,
+  ref: React.ForwardedRef<SlashCommandPickerRef>,
+) => {
+  const { items, onSelect, onEscape, editor, range, getItemKey, renderItem } =
+    props;
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return undefined;
+      }
+
+      onEscape();
+      return true;
+    },
+    [onEscape],
+  );
+
+  return (
+    <SuggestionMenu
+      ref={ref}
+      items={items}
+      onSelect={onSelect}
+      editor={editor}
+      range={range}
+      getItemKey={getItemKey}
+      renderItem={renderItem}
+      onKeyDown={handleKeyDown}
+    />
+  );
+};
+
+export const SlashCommandPicker = forwardRef(SlashCommandPickerInner) as <
+  TItem,
+>(
+  props: SlashCommandPickerProps<TItem> & {
+    ref?: React.Ref<SlashCommandPickerRef>;
+  },
+) => ReturnType<typeof SlashCommandPickerInner>;

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/DefaultSlashCommands.test.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/DefaultSlashCommands.test.ts
@@ -246,6 +246,22 @@ describe('DefaultSlashCommands', () => {
 
       expect(editor.isActive('bulletList')).toBe(true);
     });
+
+    it('should defer saved response insertion to a picker item', () => {
+      const savedResponseCommand = DEFAULT_SLASH_COMMANDS.find(
+        (command) => command.id === 'savedResponse',
+      );
+
+      editor.commands.setContent('<p>/saved</p>');
+
+      savedResponseCommand?.getOnSelect(editor, {
+        from: 1,
+        to: 7,
+      })();
+
+      expect(editor.getText()).toBe('/saved');
+      expect(savedResponseCommand?.PickerComponent).toBeDefined();
+    });
   });
 
   describe('Search keywords', () => {
@@ -273,6 +289,16 @@ describe('DefaultSlashCommands', () => {
 
       expect(bulletListCommand?.keywords.length).toBeGreaterThan(0);
       expect(orderedListCommand?.keywords.length).toBeGreaterThan(0);
+    });
+
+    it('should include all saved response aliases', () => {
+      const savedResponseCommand = DEFAULT_SLASH_COMMANDS.find(
+        (command) => command.id === 'savedResponse',
+      );
+
+      expect(
+        savedResponseCommand?.keywords.map((keyword) => keyword.message),
+      ).toEqual(['saved', 'response', 'template']);
     });
   });
 });

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/SavedResponsePicker.test.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/SavedResponsePicker.test.tsx
@@ -13,6 +13,11 @@ import { useSavedResponseDataSource } from '@/advanced-text-editor/extensions/sl
 
 jest.mock(
   '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource',
+  () => ({
+    SavedResponseDataSourceProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useSavedResponseDataSource: jest.fn(),
+  }),
 );
 
 const mockedUseSavedResponseDataSource = jest.mocked(

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/SavedResponsePicker.test.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/SavedResponsePicker.test.tsx
@@ -1,0 +1,228 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { Editor } from '@tiptap/core';
+import { Document } from '@tiptap/extension-document';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import { Text } from '@tiptap/extension-text';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
+
+import { SavedResponsePicker } from '@/advanced-text-editor/extensions/slash-command/SavedResponsePicker';
+import { useSavedResponseDataSource } from '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource';
+
+jest.mock(
+  '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource',
+);
+
+const mockedUseSavedResponseDataSource = jest.mocked(
+  useSavedResponseDataSource,
+);
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <I18nProvider i18n={i18n}>{children}</I18nProvider>
+);
+
+describe('SavedResponsePicker', () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    i18n.load('en', {});
+    i18n.activate('en');
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>/saved</p>',
+    });
+    jest.spyOn(editor.view, 'coordsAtPos').mockReturnValue({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 20,
+    });
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it('should show a loading state', () => {
+    mockedUseSavedResponseDataSource.mockReturnValue({
+      getSavedResponses: () => [],
+      loading: true,
+    });
+
+    render(
+      <SavedResponsePicker
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        onComplete={jest.fn()}
+        searchQuery=""
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText('Loading saved responses…')).toBeInTheDocument();
+  });
+
+  it('should show an empty state', () => {
+    mockedUseSavedResponseDataSource.mockReturnValue({
+      getSavedResponses: () => [],
+      loading: false,
+    });
+
+    render(
+      <SavedResponsePicker
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        onComplete={jest.fn()}
+        searchQuery=""
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText('No Saved Responses yet')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Create one in your workspace settings to use it here/),
+    ).toBeInTheDocument();
+  });
+
+  it('should insert only the selected response body', async () => {
+    const onComplete = jest.fn();
+    mockedUseSavedResponseDataSource.mockReturnValue({
+      getSavedResponses: () => [
+        {
+          id: 'response-id',
+          name: 'Marketplace Invite',
+          subject: 'An invitation',
+          body: 'Please join our marketplace.',
+          category: 'Marketplace',
+        },
+      ],
+      loading: false,
+    });
+
+    render(
+      <SavedResponsePicker
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        onComplete={onComplete}
+        searchQuery=""
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Marketplace Invite/ }),
+    );
+
+    expect(editor.getText()).toBe('Please join our marketplace.');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should populate an empty email subject', async () => {
+    const setSubject = jest.fn();
+    mockedUseSavedResponseDataSource.mockReturnValue({
+      getSavedResponses: () => [
+        {
+          id: 'response-id',
+          name: 'Marketplace Invite',
+          subject: 'An invitation',
+          body: 'Please join our marketplace.',
+          category: 'Marketplace',
+        },
+      ],
+      loading: false,
+    });
+
+    render(
+      <SavedResponsePicker
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        onComplete={jest.fn()}
+        searchQuery=""
+        savedResponseSubject={{
+          getCurrentSubject: () => '',
+          setSubject,
+        }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Marketplace Invite/ }),
+    );
+
+    expect(setSubject).toHaveBeenCalledWith('An invitation');
+  });
+
+  it('should not overwrite an existing email subject', async () => {
+    const setSubject = jest.fn();
+    mockedUseSavedResponseDataSource.mockReturnValue({
+      getSavedResponses: () => [
+        {
+          id: 'response-id',
+          name: 'Marketplace Invite',
+          subject: 'An invitation',
+          body: 'Please join our marketplace.',
+          category: 'Marketplace',
+        },
+      ],
+      loading: false,
+    });
+
+    render(
+      <SavedResponsePicker
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        onComplete={jest.fn()}
+        searchQuery=""
+        savedResponseSubject={{
+          getCurrentSubject: () => 'Existing subject',
+          setSubject,
+        }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Marketplace Invite/ }),
+    );
+
+    expect(setSubject).not.toHaveBeenCalled();
+  });
+
+  it('should filter responses by category', () => {
+    mockedUseSavedResponseDataSource.mockReturnValue({
+      getSavedResponses: () => [
+        {
+          id: 'marketplace-id',
+          name: 'Invitation',
+          subject: null,
+          body: 'Marketplace body',
+          category: 'Marketplace',
+        },
+        {
+          id: 'finance-id',
+          name: 'Instructions',
+          subject: null,
+          body: 'Finance body',
+          category: 'Finance',
+        },
+      ],
+      loading: false,
+    });
+
+    render(
+      <SavedResponsePicker
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        onComplete={jest.fn()}
+        searchQuery="market"
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText('Invitation')).toBeInTheDocument();
+    expect(screen.queryByText('Instructions')).not.toBeInTheDocument();
+  });
+});

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/SlashCommand.test.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/SlashCommand.test.ts
@@ -6,7 +6,10 @@ import { ListKit } from '@tiptap/extension-list';
 import { Paragraph } from '@tiptap/extension-paragraph';
 import { Text } from '@tiptap/extension-text';
 
-import { SlashCommand } from '@/advanced-text-editor/extensions/slash-command/SlashCommand';
+import {
+  buildSlashCommandItems,
+  SlashCommand,
+} from '@/advanced-text-editor/extensions/slash-command/SlashCommand';
 
 describe('SlashCommand', () => {
   let editor: Editor;
@@ -51,6 +54,21 @@ describe('SlashCommand', () => {
       editor.commands.insertContent('/head');
 
       expect(editor.getText()).toContain('head');
+    });
+
+    it.each([
+      ['saved market', 'market'],
+      ['template follow', 'follow'],
+      ['response pof', 'pof'],
+    ])('should pass the inline picker query from /%s', (query, pickerQuery) => {
+      const items = buildSlashCommandItems(editor, query);
+
+      expect(items).toEqual([
+        expect.objectContaining({
+          id: 'savedResponse',
+          pickerQuery,
+        }),
+      ]);
     });
   });
 

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/SlashCommandPicker.test.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/__tests__/SlashCommandPicker.test.tsx
@@ -1,0 +1,137 @@
+import { Editor } from '@tiptap/core';
+import { Document } from '@tiptap/extension-document';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import { Text } from '@tiptap/extension-text';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { MenuItemSuggestion } from 'twenty-ui/navigation';
+
+import { SlashCommandPicker } from '@/advanced-text-editor/extensions/slash-command/SlashCommandPicker';
+import { type SlashCommandPickerRef } from '@/advanced-text-editor/extensions/slash-command/types/SlashCommandPickerComponent';
+
+const PICKER_ITEMS = [
+  { code: 101, label: 'First arbitrary item' },
+  { code: 202, label: 'Second arbitrary item' },
+  { code: 303, label: 'Third arbitrary item' },
+];
+
+const getItemKey = (item: (typeof PICKER_ITEMS)[number]) =>
+  item.code.toString();
+
+const renderItem = (
+  item: (typeof PICKER_ITEMS)[number],
+  isSelected: boolean,
+) => (
+  <MenuItemSuggestion
+    text={item.label}
+    selected={isSelected}
+    onClick={() => undefined}
+  />
+);
+
+describe('SlashCommandPicker', () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text],
+      content: '<p>/saved</p>',
+    });
+    jest.spyOn(editor.view, 'coordsAtPos').mockReturnValue({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 20,
+    });
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it('should select responses with the keyboard', () => {
+    const onSelect = jest.fn();
+    const pickerRef = createRef<SlashCommandPickerRef>();
+
+    render(
+      <SlashCommandPicker
+        ref={pickerRef}
+        items={PICKER_ITEMS}
+        onSelect={onSelect}
+        onEscape={jest.fn()}
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        getItemKey={getItemKey}
+        renderItem={renderItem}
+      />,
+    );
+
+    act(() => {
+      pickerRef.current?.onKeyDown({
+        event: new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+      });
+    });
+    act(() => {
+      pickerRef.current?.onKeyDown({
+        event: new KeyboardEvent('keydown', { key: 'Enter' }),
+      });
+    });
+
+    expect(onSelect).toHaveBeenCalledWith(PICKER_ITEMS[1]);
+  });
+
+  it('should select a response with the mouse', async () => {
+    const onSelect = jest.fn();
+
+    render(
+      <SlashCommandPicker
+        items={PICKER_ITEMS}
+        onSelect={onSelect}
+        onEscape={jest.fn()}
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        getItemKey={getItemKey}
+        renderItem={(item, isSelected) => (
+          <MenuItemSuggestion
+            text={item.label}
+            selected={isSelected}
+            onClick={() => onSelect(item)}
+          />
+        )}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Third arbitrary item' }),
+    );
+
+    expect(onSelect).toHaveBeenCalledWith(PICKER_ITEMS[2]);
+  });
+
+  it('should close on Escape', () => {
+    const onEscape = jest.fn();
+    const pickerRef = createRef<SlashCommandPickerRef>();
+
+    render(
+      <SlashCommandPicker
+        ref={pickerRef}
+        items={PICKER_ITEMS}
+        onSelect={jest.fn()}
+        onEscape={onEscape}
+        editor={editor}
+        range={{ from: 1, to: 7 }}
+        getItemKey={getItemKey}
+        renderItem={renderItem}
+      />,
+    );
+
+    act(() => {
+      pickerRef.current?.onKeyDown({
+        event: new KeyboardEvent('keydown', { key: 'Escape' }),
+      });
+    });
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+
+import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
+import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+
+type SavedResponseRecord = ObjectRecord & {
+  name: string;
+  subject: string | null;
+  body: string | null;
+  category: string | null;
+};
+
+export type SavedResponse = {
+  id: string;
+  name: string;
+  subject: string | null;
+  body: string;
+  category: string | null;
+};
+
+export type SavedResponseDataSource = {
+  getSavedResponses: () => readonly SavedResponse[];
+  loading: boolean;
+};
+
+export const useSavedResponseDataSource = (): SavedResponseDataSource => {
+  const { records, loading } = useFindManyRecords<SavedResponseRecord>({
+    objectNameSingular: 'savedResponse',
+    recordGqlFields: {
+      id: true,
+      name: true,
+      subject: true,
+      body: true,
+      category: true,
+    },
+  });
+
+  const getSavedResponses = useCallback(
+    () =>
+      records.map(({ id, name, subject, body, category }) => ({
+        id,
+        name,
+        subject,
+        body: body ?? '',
+        category,
+      })),
+    [records],
+  );
+
+  return { getSavedResponses, loading };
+};

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource.ts
@@ -1,7 +1,15 @@
-import { useCallback } from 'react';
+import {
+  createContext,
+  createElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+} from 'react';
 
+import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 
 type SavedResponseRecord = ObjectRecord & {
   name: string;
@@ -23,7 +31,16 @@ export type SavedResponseDataSource = {
   loading: boolean;
 };
 
-export const useSavedResponseDataSource = (): SavedResponseDataSource => {
+const EMPTY_SAVED_RESPONSE_DATA_SOURCE: SavedResponseDataSource = {
+  getSavedResponses: () => [],
+  loading: false,
+};
+
+const SavedResponseDataSourceContext = createContext<SavedResponseDataSource>(
+  EMPTY_SAVED_RESPONSE_DATA_SOURCE,
+);
+
+const SavedResponseQueryProvider = ({ children }: { children: ReactNode }) => {
   const { records, loading } = useFindManyRecords<SavedResponseRecord>({
     objectNameSingular: 'savedResponse',
     recordGqlFields: {
@@ -47,5 +64,33 @@ export const useSavedResponseDataSource = (): SavedResponseDataSource => {
     [records],
   );
 
-  return { getSavedResponses, loading };
+  return createElement(
+    SavedResponseDataSourceContext.Provider,
+    { value: { getSavedResponses, loading } },
+    children,
+  );
 };
+
+export const SavedResponseDataSourceProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const objectMetadataItems = useAtomStateValue(objectMetadataItemsSelector);
+  const hasSavedResponseObject = objectMetadataItems.some(
+    (objectMetadataItem) => objectMetadataItem.nameSingular === 'savedResponse',
+  );
+
+  if (!hasSavedResponseObject) {
+    return createElement(
+      SavedResponseDataSourceContext.Provider,
+      { value: EMPTY_SAVED_RESPONSE_DATA_SOURCE },
+      children,
+    );
+  }
+
+  return createElement(SavedResponseQueryProvider, undefined, children);
+};
+
+export const useSavedResponseDataSource = (): SavedResponseDataSource =>
+  useContext(SavedResponseDataSourceContext);

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/data-sources/__tests__/SavedResponseDataSource.test.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/data-sources/__tests__/SavedResponseDataSource.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook } from '@testing-library/react';
+
+import { useSavedResponseDataSource } from '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource';
+import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
+
+jest.mock('@/object-record/hooks/useFindManyRecords', () => ({
+  useFindManyRecords: jest.fn(),
+}));
+
+const mockedUseFindManyRecords = jest.mocked(useFindManyRecords);
+
+describe('useSavedResponseDataSource', () => {
+  it('should request and map saved response fields', () => {
+    mockedUseFindManyRecords.mockReturnValue({
+      records: [
+        {
+          id: 'response-id',
+          name: 'Marketplace Invite',
+          subject: 'An invitation',
+          body: 'Please join our marketplace.',
+          category: 'Marketplace',
+        },
+      ],
+      loading: false,
+    } as unknown as ReturnType<typeof useFindManyRecords>);
+
+    const { result } = renderHook(() => useSavedResponseDataSource());
+
+    expect(mockedUseFindManyRecords).toHaveBeenCalledWith({
+      objectNameSingular: 'savedResponse',
+      recordGqlFields: {
+        id: true,
+        name: true,
+        subject: true,
+        body: true,
+        category: true,
+      },
+    });
+    expect(result.current.getSavedResponses()).toEqual([
+      {
+        id: 'response-id',
+        name: 'Marketplace Invite',
+        subject: 'An invitation',
+        body: 'Please join our marketplace.',
+        category: 'Marketplace',
+      },
+    ]);
+  });
+});

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/data-sources/__tests__/SavedResponseDataSource.test.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/data-sources/__tests__/SavedResponseDataSource.test.tsx
@@ -1,16 +1,36 @@
 import { renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
 
-import { useSavedResponseDataSource } from '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource';
+import {
+  SavedResponseDataSourceProvider,
+  useSavedResponseDataSource,
+} from '@/advanced-text-editor/extensions/slash-command/data-sources/SavedResponseDataSource';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 
 jest.mock('@/object-record/hooks/useFindManyRecords', () => ({
   useFindManyRecords: jest.fn(),
 }));
+jest.mock('@/ui/utilities/state/jotai/hooks/useAtomStateValue', () => ({
+  useAtomStateValue: jest.fn(),
+}));
 
 const mockedUseFindManyRecords = jest.mocked(useFindManyRecords);
+const mockedUseAtomStateValue = jest.mocked(useAtomStateValue);
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <SavedResponseDataSourceProvider>{children}</SavedResponseDataSourceProvider>
+);
 
 describe('useSavedResponseDataSource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should request and map saved response fields', () => {
+    mockedUseAtomStateValue.mockReturnValue([
+      { nameSingular: 'savedResponse' },
+    ] as ReturnType<typeof useAtomStateValue>);
     mockedUseFindManyRecords.mockReturnValue({
       records: [
         {
@@ -24,7 +44,9 @@ describe('useSavedResponseDataSource', () => {
       loading: false,
     } as unknown as ReturnType<typeof useFindManyRecords>);
 
-    const { result } = renderHook(() => useSavedResponseDataSource());
+    const { result } = renderHook(() => useSavedResponseDataSource(), {
+      wrapper: Wrapper,
+    });
 
     expect(mockedUseFindManyRecords).toHaveBeenCalledWith({
       objectNameSingular: 'savedResponse',
@@ -45,5 +67,19 @@ describe('useSavedResponseDataSource', () => {
         category: 'Marketplace',
       },
     ]);
+  });
+
+  it('should return an empty data source when the object is missing', () => {
+    mockedUseAtomStateValue.mockReturnValue([
+      { nameSingular: 'person' },
+    ] as ReturnType<typeof useAtomStateValue>);
+
+    const { result } = renderHook(() => useSavedResponseDataSource(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.getSavedResponses()).toEqual([]);
+    expect(mockedUseFindManyRecords).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/types/SlashCommandConfig.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/types/SlashCommandConfig.ts
@@ -2,6 +2,8 @@ import { type MessageDescriptor } from '@lingui/core';
 import { type Editor, type Range } from '@tiptap/core';
 import { type IconComponent } from 'twenty-ui/icon';
 
+import { type SlashCommandPickerComponent } from '@/advanced-text-editor/extensions/slash-command/types/SlashCommandPickerComponent';
+
 export type SlashCommandConfig = {
   id: string;
   title: MessageDescriptor;
@@ -11,4 +13,5 @@ export type SlashCommandConfig = {
   getIsActive: (editor: Editor) => boolean;
   getIsVisible: (editor: Editor) => boolean;
   getOnSelect: (editor: Editor, range: Range) => () => void;
+  PickerComponent?: SlashCommandPickerComponent;
 };

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/types/SlashCommandPickerComponent.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/slash-command/types/SlashCommandPickerComponent.ts
@@ -1,0 +1,21 @@
+import { type Editor, type Range } from '@tiptap/core';
+import { type ForwardRefExoticComponent, type RefAttributes } from 'react';
+
+export type SlashCommandPickerRef = {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+};
+
+export type SlashCommandPickerComponentProps = {
+  editor: Editor;
+  range: Range;
+  onComplete: () => void;
+  searchQuery: string;
+  savedResponseSubject?: {
+    getCurrentSubject: () => string;
+    setSubject: (subject: string) => void;
+  };
+};
+
+export type SlashCommandPickerComponent = ForwardRefExoticComponent<
+  SlashCommandPickerComponentProps & RefAttributes<SlashCommandPickerRef>
+>;

--- a/packages/twenty-front/src/modules/advanced-text-editor/hooks/useAdvancedTextEditor.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/hooks/useAdvancedTextEditor.ts
@@ -1,5 +1,6 @@
 import { type AdvancedTextEditorProfile } from '@/advanced-text-editor/types/AdvancedTextEditorProfile';
 import { type UploadedImage } from '@/advanced-text-editor/types/UploadedImage';
+import { type AdvancedTextEditorExtensionContext } from '@/advanced-text-editor/types/AdvancedTextEditorExtensionContext';
 import { buildAdvancedTextEditorExtensions } from '@/advanced-text-editor/utils/buildAdvancedTextEditorExtensions';
 import { deserializeAdvancedTextEditorDocument } from '@/advanced-text-editor/utils/deserializeAdvancedTextEditorDocument';
 import { type Content } from '@tiptap/core';
@@ -19,6 +20,7 @@ type UseAdvancedTextEditorProps = {
   onImageUploadError?: (error: Error, file: File) => void;
   content?: Content;
   editorProps?: EditorOptions['editorProps'];
+  savedResponseSubject?: AdvancedTextEditorExtensionContext['savedResponseSubject'];
 };
 
 export const useAdvancedTextEditor = (
@@ -34,6 +36,7 @@ export const useAdvancedTextEditor = (
     onImageUploadError,
     content,
     editorProps,
+    savedResponseSubject,
   }: UseAdvancedTextEditorProps,
   dependencies?: DependencyList,
 ) => {
@@ -44,11 +47,19 @@ export const useAdvancedTextEditor = (
         context: {
           onImageUpload,
           onImageUploadError,
+          savedResponseSubject,
         },
         placeholder,
         readonly,
       }),
-    [profile, placeholder, onImageUpload, onImageUploadError, readonly],
+    [
+      profile,
+      placeholder,
+      onImageUpload,
+      onImageUploadError,
+      savedResponseSubject,
+      readonly,
+    ],
   );
 
   const getEditorContent = (): Content | undefined => {

--- a/packages/twenty-front/src/modules/advanced-text-editor/types/AdvancedTextEditorExtensionContext.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/types/AdvancedTextEditorExtensionContext.ts
@@ -3,4 +3,8 @@ import { type UploadedImage } from '@/advanced-text-editor/types/UploadedImage';
 export type AdvancedTextEditorExtensionContext = {
   onImageUpload?: (file: File) => Promise<UploadedImage>;
   onImageUploadError?: (error: Error, file: File) => void;
+  savedResponseSubject?: {
+    getCurrentSubject: () => string;
+    setSubject: (subject: string) => void;
+  };
 };

--- a/packages/twenty-front/src/modules/advanced-text-editor/utils/buildFullRichTextExtensions.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/utils/buildFullRichTextExtensions.ts
@@ -24,7 +24,9 @@ export const buildFullRichTextExtensions = (
   Link.configure({ openOnClick: false }),
   ResizableImage,
   UploadImageExtension.configure(context),
-  SlashCommand,
+  SlashCommand.configure({
+    savedResponseSubject: context.savedResponseSubject,
+  }),
 ];
 
 export const buildFullRichTextWithVariableTagExtensions = (


### PR DESCRIPTION
Summary
Introduces the foundation for Saved Responses in the rich text editor.

Implemented
- /saved, /response, and /template slash commands
- Generic reusable slash command picker
- GraphQL-backed data source
- Email subject auto-fill when appropriate
- Graceful handling when the savedResponse object is not present
- Tests covering picker behavior and missing-object handling

Remaining work
- Saved Response object/model
- Settings management UI
- CRUD operations
- Merge field support
- Permissions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

