### PR TITLE
Include Note/Task rich-text body in field lists and add unit test

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/hooks/__tests__/useFieldListFieldMetadataItems.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/hooks/__tests__/useFieldListFieldMetadataItems.test.tsx
@@ -1,0 +1,52 @@
+import { useLabelIdentifierFieldMetadataItem } from '@/object-metadata/hooks/useLabelIdentifierFieldMetadataItem';
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { useFieldListFieldMetadataItems } from '@/object-record/record-field-list/hooks/useFieldListFieldMetadataItems';
+import { renderHook } from '@testing-library/react';
+import { CoreObjectNameSingular, FieldMetadataType } from 'twenty-shared/types';
+
+jest.mock('@/object-metadata/hooks/useLabelIdentifierFieldMetadataItem');
+jest.mock('@/object-metadata/hooks/useObjectMetadataItem');
+jest.mock('@/object-metadata/hooks/useObjectMetadataItems');
+jest.mock('@/object-record/hooks/useObjectPermissions');
+
+const activityBodyField = {
+  id: 'activity-body-field-id',
+  name: 'bodyV2',
+  type: FieldMetadataType.RICH_TEXT,
+  isActive: true,
+} as FieldMetadataItem;
+
+describe('useFieldListFieldMetadataItems', () => {
+  beforeEach(() => {
+    jest.mocked(useLabelIdentifierFieldMetadataItem).mockReturnValue({
+      labelIdentifierFieldMetadataItem: undefined,
+    });
+    jest.mocked(useObjectMetadataItem).mockReturnValue({
+      objectMetadataItem: {
+        readableFields: [activityBodyField],
+      } as ReturnType<typeof useObjectMetadataItem>['objectMetadataItem'],
+    });
+    jest.mocked(useObjectMetadataItems).mockReturnValue({
+      objectMetadataItems: [],
+    });
+    jest.mocked(useObjectPermissions).mockReturnValue({
+      objectPermissionsByObjectMetadataId: {},
+    });
+  });
+
+  it.each([CoreObjectNameSingular.Note, CoreObjectNameSingular.Task])(
+    'includes the %s body in field lists',
+    (objectNameSingular) => {
+      const { result } = renderHook(() =>
+        useFieldListFieldMetadataItems({ objectNameSingular }),
+      );
+
+      expect(result.current.inlineFieldMetadataItems).toEqual([
+        activityBodyField,
+      ]);
+    },
+  );
+});

--- a/packages/twenty-front/src/modules/object-record/record-field-list/hooks/useFieldListFieldMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/hooks/useFieldListFieldMetadataItems.ts
@@ -5,7 +5,7 @@ import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions
 import { categorizeRelationFields } from '@/object-record/record-field-list/utils/categorizeRelationFields';
 import { isFieldCellSupported } from '@/object-record/utils/isFieldCellSupported';
 import groupBy from 'lodash.groupby';
-import { CoreObjectNameSingular, FieldMetadataType } from 'twenty-shared/types';
+import { FieldMetadataType } from 'twenty-shared/types';
 
 type UseFieldListFieldMetadataItemsProps = {
   objectNameSingular: string;
@@ -55,21 +55,11 @@ export const useFieldListFieldMetadataItems = ({
     );
 
   const { inlineFieldMetadataItems, relationFieldMetadataItems } = groupBy(
-    availableFieldMetadataItems
-      .filter(
-        (fieldMetadataItem) =>
-          fieldMetadataItem.name !== 'createdAt' &&
-          fieldMetadataItem.name !== 'deletedAt',
-      )
-      .filter(
-        (fieldMetadataItem) =>
-          !(
-            fieldMetadataItem.type === FieldMetadataType.RICH_TEXT &&
-            fieldMetadataItem.name === 'bodyV2' &&
-            (objectNameSingular === CoreObjectNameSingular.Note ||
-              objectNameSingular === CoreObjectNameSingular.Task)
-          ),
-      ),
+    availableFieldMetadataItems.filter(
+      (fieldMetadataItem) =>
+        fieldMetadataItem.name !== 'createdAt' &&
+        fieldMetadataItem.name !== 'deletedAt',
+    ),
     (fieldMetadataItem) =>
       fieldMetadataItem.type === FieldMetadataType.RELATION ||
       fieldMetadataItem.type === FieldMetadataType.MORPH_RELATION


### PR DESCRIPTION
### Motivation

- Remove a special-case exclusion so the rich-text `bodyV2` field for Note and Task objects appears in inline field lists.

### Description

- Stop filtering out `bodyV2` rich-text fields for Note and Task in `useFieldListFieldMetadataItems`, so `availableFieldMetadataItems` no longer excludes that case.
- Simplify the grouping filter to only exclude `createdAt` and `deletedAt` before categorizing fields and remove the now-unused `CoreObjectNameSingular` import.
- Add `useFieldListFieldMetadataItems.test.tsx` which mocks metadata hooks and asserts that the `bodyV2` field is included for `CoreObjectNameSingular.Note` and `CoreObjectNameSingular.Task`.

### Testing

- Added unit test `useFieldListFieldMetadataItems.test.tsx` under `packages/twenty-front/.../__tests__` which runs the hook and verifies inclusion of `bodyV2`. 
- Ran the package tests with `yarn test packages/twenty-front` and the new test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a973a3b4644832f855aabbcec894b9f)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

