### PR TITLE
Fix main's red typecheck: drop removed portal fields from the settings test wrapper

### DIFF
--- a/packages/twenty-front/src/hooks/__tests__/useNavigateSettings.test.tsx
+++ b/packages/twenty-front/src/hooks/__tests__/useNavigateSettings.test.tsx
@@ -45,8 +45,6 @@ const RoutedSidePanelWrapper = ({
         type: 'side-panel',
         instanceId: 'side-panel-page',
         ownsRouteLocation: true,
-        headerTitlePortal: null,
-        headerActionsPortal: null,
       }}
     >
       {children}
@@ -139,5 +137,35 @@ describe('useNavigateSettings', () => {
       '/settings/accounts/new',
       undefined,
     );
+  });
+
+  it('opens settings when a legacy side-panel page escapes to main', () => {
+    const { result } = renderHook(() => useNavigateSettings(), {
+      wrapper: SidePanelWrapper,
+    });
+
+    result.current(SettingsPath.NewAccount, undefined, undefined, {
+      surface: 'main',
+    });
+
+    expect(openSettingsMenuMock).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/settings/accounts/new', {
+      surface: 'main',
+    });
+  });
+
+  it('leaves the shell to the navigator when a routed page escapes to main', () => {
+    const { result } = renderHook(() => useNavigateSettings(), {
+      wrapper: RoutedSidePanelWrapper,
+    });
+
+    result.current(SettingsPath.NewAccount, undefined, undefined, {
+      surface: 'main',
+    });
+
+    expect(openSettingsMenuMock).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/settings/accounts/new', {
+      surface: 'main',
+    });
   });
 });

--- a/packages/twenty-front/src/hooks/useNavigateSettings.ts
+++ b/packages/twenty-front/src/hooks/useNavigateSettings.ts
@@ -24,6 +24,9 @@ export const useNavigateSettings = () => {
     ) => {
       const path = getSettingsPath(to, params, queryParams, hash);
 
+      // A routed side-panel owns its location, and its navigator already opens
+      // the settings shell when a path escapes to main. Every other surface
+      // navigates the main router directly, so the shell has to be opened here.
       if (
         workspaceSurface.type === 'main' ||
         !workspaceSurface.ownsRouteLocation


### PR DESCRIPTION
### This unblocks `main`

`main` is currently **red on `front-task (typecheck)`**, and this PR fixes it.

```
src/hooks/__tests__/useNavigateSettings.test.tsx(48,9): error TS2353:
Object literal may only specify known properties, and 'headerTitlePortal'
does not exist in type 'WorkspaceSurfaceContextValue'.
```

**Cause — a semantic conflict, not a textual one.** #25164 removed `headerTitlePortal` / `headerActionsPortal` from `WorkspaceSurfaceContextValue` and updated `SidePanelWrapper` in this test file. In parallel, #25187 added `RoutedSidePanelWrapper` to the same file, setting both fields. Each PR typechecked against its own base; merged together they do not. Git merged them cleanly because the two wrappers are different hunks.

Verified: `npx nx typecheck twenty-front` is green with this change and red without it.

### Also in this PR

- Comments the `useNavigateSettings` condition with why the settings-shell decision splits on **route ownership** rather than the caller passing `surface: 'main'`: only `SidePanelRoutedPage` sets `ownsRouteLocation: true`, and it is also the only surface installing `SidePanelRouteNavigatorProvider`, whose navigator already opens the shell for `/settings` paths escaping to main. Every other surface reaches the main router directly.
- Adds the two `surface: 'main'` cases #25187's tests did not cover, so all four surface/option combinations are pinned.

The behaviour change this branch originally carried already shipped via #25187; only the comment and the extra coverage remain from it.

### Testing

`useNavigateSettings`: 8/8 pass. `twenty-front` typecheck, lint and oxfmt all clean.

### Notes — dropped from earlier revisions of this branch

- The no-op guard added to `SidePanelPathUrlSyncEffect.replaceSearchParams` was removed as unreachable: every path reaching `replaceSearchParams` necessarily changes the search string, instrumenting it across 63 suites / 681 tests produced zero hits, and its test passed unchanged against pre-PR source.
- **Correction (post-merge):** the React #185 crash on Home → Settings is *not* the `useNavigateApp` pattern described in an earlier revision of this note. Its root cause is a second, stale `RouteContextStoreProvider` kept alive by the app ↔ settings page transition, fixed in #25233. `useNavigateApp` returning a new function every render (with ten effects listing it in their deps) remains a latent re-navigation pattern worth its own cleanup.

