### PR TITLE
feat(server): record the S3 agent pool state when a request times out

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 
 import fs from 'fs';
+import { type Agent } from 'http';
 import { readdir, readFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { Readable } from 'stream';
@@ -35,6 +36,7 @@ import {
   FileStorageExceptionCode,
 } from 'src/engine/core-modules/file-storage/interfaces/file-storage-exception';
 import { type ByteRange } from 'src/engine/core-modules/file-storage/types/byte-range.type';
+import { describeHttpAgents } from 'src/engine/core-modules/file-storage/utils/describe-http-agents.util';
 import { buildAwsRequestHandlerOptions } from 'src/utils/aws-request-handler.util';
 
 export interface S3DriverOptions extends S3ClientConfig {
@@ -90,6 +92,32 @@ export class S3Driver implements StorageDriver {
     return this.s3Client;
   }
 
+  private async runWithAgentDiagnostics<TResult>(
+    operation: string,
+    run: () => Promise<TResult>,
+  ): Promise<TResult> {
+    try {
+      return await run();
+    } catch (error) {
+      if (error instanceof Error && error.name === 'TimeoutError') {
+        const requestHandler = this.s3Client.config.requestHandler as
+          | { config?: { httpAgent?: Agent; httpsAgent?: Agent } }
+          | undefined;
+
+        this.logger.error(
+          `S3 ${operation} timed out; agent pool: ${JSON.stringify(
+            describeHttpAgents([
+              requestHandler?.config?.httpAgent,
+              requestHandler?.config?.httpsAgent,
+            ]),
+          )}`,
+        );
+      }
+
+      throw error;
+    }
+  }
+
   async readFile(params: {
     filePath: string;
     byteRange?: ByteRange;
@@ -103,7 +131,9 @@ export class S3Driver implements StorageDriver {
     });
 
     try {
-      const file = await this.s3Client.send(command);
+      const file = await this.runWithAgentDiagnostics('GetObject', () =>
+        this.s3Client.send(command),
+      );
 
       if (!file || !file.Body || !(file.Body instanceof Readable)) {
         throw new Error('Unable to get file stream');
@@ -134,7 +164,9 @@ export class S3Driver implements StorageDriver {
       Bucket: this.bucketName,
     });
 
-    await this.s3Client.send(command);
+    await this.runWithAgentDiagnostics('PutObject', () =>
+      this.s3Client.send(command),
+    );
   }
 
   async writeFileStream(params: {
@@ -161,11 +193,13 @@ export class S3Driver implements StorageDriver {
     filePath: string;
   }): Promise<{ size: number } | null> {
     try {
-      const head = await this.s3Client.send(
-        new HeadObjectCommand({
-          Bucket: this.bucketName,
-          Key: params.filePath,
-        }),
+      const head = await this.runWithAgentDiagnostics('HeadObject', () =>
+        this.s3Client.send(
+          new HeadObjectCommand({
+            Bucket: this.bucketName,
+            Key: params.filePath,
+          }),
+        ),
       );
 
       return { size: head.ContentLength ?? 0 };

--- a/packages/twenty-server/src/engine/core-modules/file-storage/utils/__tests__/describe-http-agents.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/utils/__tests__/describe-http-agents.util.spec.ts
@@ -1,0 +1,69 @@
+import { type Agent } from 'http';
+
+import { describeHttpAgents } from 'src/engine/core-modules/file-storage/utils/describe-http-agents.util';
+
+const buildAgent = ({
+  sockets = {},
+  freeSockets = {},
+  requests = {},
+  maxSockets = 200,
+}: {
+  sockets?: Record<string, unknown[]>;
+  freeSockets?: Record<string, unknown[]>;
+  requests?: Record<string, unknown[]>;
+  maxSockets?: number;
+}) => ({ sockets, freeSockets, requests, maxSockets }) as unknown as Agent;
+
+describe('describeHttpAgents', () => {
+  it('returns undefined when no agent has been initialized', () => {
+    expect(describeHttpAgents([undefined, undefined])).toBeUndefined();
+  });
+
+  it('reports a saturated pool with its queued requests', () => {
+    const agent = buildAgent({
+      sockets: {
+        's3.eu-central-1.amazonaws.com:443:': new Array(200).fill({}),
+      },
+      requests: { 's3.eu-central-1.amazonaws.com:443:': new Array(7).fill({}) },
+      maxSockets: 200,
+    });
+
+    expect(describeHttpAgents([agent])).toEqual({
+      origins: [
+        {
+          origin: 's3.eu-central-1.amazonaws.com:443:',
+          busySockets: 200,
+          freeSockets: 0,
+          queuedRequests: 7,
+        },
+      ],
+      totalBusySockets: 200,
+      totalFreeSockets: 0,
+      totalQueuedRequests: 7,
+      maxSockets: 200,
+    });
+  });
+
+  it('reports an idle pool so a timeout can be distinguished from saturation', () => {
+    const agent = buildAgent({
+      sockets: { 'host:443:': [{}, {}] },
+      freeSockets: { 'host:443:': [{}] },
+    });
+
+    const snapshot = describeHttpAgents([agent]);
+
+    expect(snapshot?.totalBusySockets).toBe(2);
+    expect(snapshot?.totalFreeSockets).toBe(1);
+    expect(snapshot?.totalQueuedRequests).toBe(0);
+  });
+
+  it('aggregates the http and https agents together', () => {
+    const snapshot = describeHttpAgents([
+      buildAgent({ sockets: { 'a:443:': [{}] } }),
+      buildAgent({ sockets: { 'b:443:': [{}, {}] } }),
+    ]);
+
+    expect(snapshot?.origins).toHaveLength(2);
+    expect(snapshot?.totalBusySockets).toBe(3);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/file-storage/utils/describe-http-agents.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/utils/describe-http-agents.util.ts
@@ -1,0 +1,68 @@
+import { type Agent } from 'http';
+
+export type HttpAgentSnapshot = {
+  origins: {
+    origin: string;
+    busySockets: number;
+    freeSockets: number;
+    queuedRequests: number;
+  }[];
+  totalBusySockets: number;
+  totalFreeSockets: number;
+  totalQueuedRequests: number;
+  maxSockets: number;
+};
+
+const countByOrigin = (pool: Record<string, unknown[]> | undefined) =>
+  Object.entries(pool ?? {}).reduce<Record<string, number>>(
+    (counts, [origin, entries]) => ({
+      ...counts,
+      [origin]: entries?.length ?? 0,
+    }),
+    {},
+  );
+
+export const describeHttpAgents = (
+  agents: (Agent | undefined)[],
+): HttpAgentSnapshot | undefined => {
+  const definedAgents = agents.filter((agent): agent is Agent =>
+    Boolean(agent),
+  );
+
+  if (definedAgents.length === 0) {
+    return undefined;
+  }
+
+  const origins = definedAgents.flatMap((agent) => {
+    const busy = countByOrigin(
+      agent.sockets as unknown as Record<string, unknown[]>,
+    );
+    const free = countByOrigin(
+      agent.freeSockets as unknown as Record<string, unknown[]>,
+    );
+    const queued = countByOrigin(
+      agent.requests as unknown as Record<string, unknown[]>,
+    );
+
+    return Array.from(
+      new Set([
+        ...Object.keys(busy),
+        ...Object.keys(free),
+        ...Object.keys(queued),
+      ]),
+    ).map((origin) => ({
+      origin,
+      busySockets: busy[origin] ?? 0,
+      freeSockets: free[origin] ?? 0,
+      queuedRequests: queued[origin] ?? 0,
+    }));
+  });
+
+  return {
+    origins,
+    totalBusySockets: origins.reduce((sum, o) => sum + o.busySockets, 0),
+    totalFreeSockets: origins.reduce((sum, o) => sum + o.freeSockets, 0),
+    totalQueuedRequests: origins.reduce((sum, o) => sum + o.queuedRequests, 0),
+    maxSockets: definedAgents[0].maxSockets,
+  };
+};


### PR DESCRIPTION
## Why

`TWENTY-SERVER-JVT` (`@smithy/node-http-handler - the request socket did not establish a connection within 30000 ms`) has taken down workspace creation repeatedly. The error means one thing only: **the HTTPS agent could not hand out a socket in time.** It does not say why, and the difference matters enormously:

- pool saturated, requests queued behind it → a socket/slot leak
- pool idle → the stall is somewhere else entirely and the leak hunt is wasted

That state lives inside the process. It is invisible to `kubectl`, invisible to `/proc/net/tcp` (a wedged prod pod showed only 3 ESTABLISHED sockets), and it is destroyed the moment the pod restarts — which is exactly what happens, because these pods OOM-cycle on their own. Every occurrence so far has erased its own evidence before anyone could attach a debugger.

## What this does

When a timeout surfaces from `GetObject`, `PutObject` or `HeadObject`, log the agent's own bookkeeping next to it:

```
S3 GetObject timed out; agent pool: {"origins":[{"origin":"s3.eu-central-1.amazonaws.com:443:",
"busySockets":200,"freeSockets":0,"queuedRequests":7}],"totalBusySockets":200,
"totalFreeSockets":0,"totalQueuedRequests":7,"maxSockets":200}
```

All S3 operations share one agent, so whichever times out first records the state for the whole client. Zero cost when healthy — nothing runs unless a `TimeoutError` is thrown.

Reading the next occurrence:

| log line | meaning |
|---|---|
| `totalBusySockets` at `maxSockets`, `totalQueuedRequests` > 0 | pool saturated — slots are being leaked, hunt the holder |
| `totalBusySockets` low, `totalQueuedRequests` 0 | pool is fine — the stall is before the socket (DNS, event loop, threadpool) |

Those two have opposite fixes, and today we cannot tell them apart.

## Verification

Wedged a real `@aws-sdk/client-s3` (unconsumed response bodies until the pool filled), then ran the exact snapshot code this PR adds:

```
S3 HeadObject timed out; agent pool: {"origins":[{"origin":"127.0.0.1:58355:","busySockets":10,
"freeSockets":0,"queuedRequests":2}],"totalBusySockets":10,"totalFreeSockets":0,
"totalQueuedRequests":2,"maxSockets":10}
```

Unit tests cover the saturated case, the idle case, undefined agents before first use, and http+https aggregation.

## Scope

Diagnostic only — no behaviour change, no control flow change, errors propagate exactly as before. It is deliberately not a fix: it is what tells us which fix to write.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

