### PR TITLE
Keep task and note junction relations consistent

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useCreateManyRecords.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useCreateManyRecords.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { v4 } from 'uuid';
 
 import { CoreObjectNameSingular } from 'twenty-shared/types';
+import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
 import {
   query,
   response,
@@ -17,6 +18,9 @@ jest.mock('uuid', () => ({
 }));
 
 jest.mock('@/object-record/hooks/useRefetchAggregateQueries');
+jest.mock(
+  '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect',
+);
 const mockRefetchAggregateQueries = jest.fn();
 jest.mocked(useRefetchAggregateQueries).mockReturnValue({
   refetchAggregateQueries: mockRefetchAggregateQueries,
@@ -113,6 +117,13 @@ describe('useCreateManyRecords', () => {
     mocks[1].request.variables.data.forEach((record: any) => {
       expect(record).not.toHaveProperty('id');
     });
+    expect(triggerCreateRecordsOptimisticEffect).toHaveBeenCalledTimes(1);
+    expect(triggerCreateRecordsOptimisticEffect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordsToCreate: response,
+        checkForRecordInCache: false,
+      }),
+    );
     expect(mockRefetchAggregateQueries).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
@@ -98,10 +98,10 @@ export const useCreateManyRecords = <
   }: createManyRecordsProps) => {
     const sanitizedCreateManyRecordsInput: PartialObjectRecordWithOptionalId[] =
       [];
-    const shouldPerformOptimisticEffect = upsert !== true;
+    const shouldPerformPreOptimisticEffect = upsert !== true;
     const recordOptimisticRecordsInput: PartialObjectRecordWithId[] = [];
     recordsToCreate.forEach((recordToCreate) => {
-      const idForCreation = shouldPerformOptimisticEffect
+      const idForCreation = shouldPerformPreOptimisticEffect
         ? (recordToCreate?.id ?? v4())
         : undefined;
       const sanitizedRecord = {
@@ -124,7 +124,7 @@ export const useCreateManyRecords = <
 
       sanitizedCreateManyRecordsInput.push(sanitizedRecord);
 
-      if (shouldPerformOptimisticEffect) {
+      if (shouldPerformPreOptimisticEffect) {
         const optimisticRecordInput = {
           ...computeOptimisticRecordFromInput({
             cache: apolloCoreClient.cache,
@@ -200,12 +200,7 @@ export const useCreateManyRecords = <
             mutationResponseField
           ];
 
-          if (
-            !isDefined(records?.length) ||
-            skipPostOptimisticEffect ||
-            !shouldPerformOptimisticEffect
-          )
-            return;
+          if (!isDefined(records?.length) || skipPostOptimisticEffect) return;
 
           triggerCreateRecordsOptimisticEffect({
             cache,
@@ -213,7 +208,7 @@ export const useCreateManyRecords = <
             recordsToCreate: records,
             objectMetadataItems,
             shouldMatchRootQueryFilter,
-            checkForRecordInCache: true,
+            checkForRecordInCache: shouldPerformPreOptimisticEffect,
             objectPermissionsByObjectMetadataId,
             upsertRecordsInStore,
           });

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/__tests__/useUpdateJunctionRelationFromCell.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/__tests__/useUpdateJunctionRelationFromCell.test.tsx
@@ -9,7 +9,6 @@ import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
 import { useUpdateJunctionRelationFromCell } from '@/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
-import { searchRecordStoreFamilyState } from '@/object-record/record-picker/multiple-record-picker/states/searchRecordStoreComponentFamilyState';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { getMockFieldMetadataItemOrThrow } from '~/testing/utils/getMockFieldMetadataItemOrThrow';
 import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
@@ -67,19 +66,6 @@ describe('useUpdateJunctionRelationFromCell', () => {
       id: sourceRecordId,
       __typename: 'Rocket',
       taskTargets: [],
-    });
-    store.set(searchRecordStoreFamilyState.atomFamily(targetRecordId), {
-      recordId: targetRecordId,
-      label: 'Prepare launch',
-      objectLabelSingular: 'Task',
-      objectNameSingular: 'task',
-      tsRank: 1,
-      tsRankCD: 1,
-      record: {
-        id: targetRecordId,
-        __typename: 'Task',
-        title: 'Prepare launch',
-      },
     });
     mockCreateManyRecords.mockResolvedValue([
       {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -1,12 +1,9 @@
 import { useCallback } from 'react';
 import { useStore } from 'jotai';
 import { isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
-import { getObjectTypename } from '@/object-record/cache/utils/getObjectTypename';
-import { getRecordFromRecordNode } from '@/object-record/cache/utils/getRecordFromRecordNode';
 import { useCreateManyRecords } from '@/object-record/hooks/useCreateManyRecords';
 import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
@@ -15,16 +12,13 @@ import {
   type FieldRelationMetadata,
   type FieldRelationValue,
 } from '@/object-record/record-field/ui/types/FieldMetadata';
-import { upsertJunctionRecordInSourceRecordStore } from '@/object-record/record-field/ui/utils/junction/upsertJunctionRecordInSourceRecordStore';
 import { findJunctionRecordByTargetId } from '@/object-record/record-field/ui/utils/junction/findJunctionRecordByTargetId';
 import { findTargetFieldInfo } from '@/object-record/record-field/ui/utils/junction/findTargetFieldInfo';
 import { getSourceJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getSourceJoinColumnName';
 import { isUsableJunctionConfig } from '@/object-record/record-field/ui/utils/junction/isUsableJunctionConfig';
 import { resolveJunctionConfig } from '@/object-record/record-field/ui/utils/junction/resolveJunctionConfig';
-import { searchRecordStoreFamilyState } from '@/object-record/record-picker/multiple-record-picker/states/searchRecordStoreComponentFamilyState';
 import { type RecordPickerPickableMorphItem } from '@/object-record/record-picker/types/RecordPickerPickableMorphItem';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
-import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 
 type UseUpdateJunctionRelationFromCellArgs = {
   fieldMetadataItem: FieldMetadataItem;
@@ -94,7 +88,6 @@ export const useUpdateJunctionRelationFromCell = ({
       });
 
       const fieldName = fieldDefinition.metadata.fieldName;
-      const junctionObjectName = junctionObjectMetadata.nameSingular;
 
       const targetFieldInfo = findTargetFieldInfo(
         targetFields,
@@ -137,90 +130,8 @@ export const useUpdateJunctionRelationFromCell = ({
         }
 
         await deleteJunctionRecord(junctionRecordToDelete.id);
-
-        const recordFromStoreForDelete = store.get(
-          recordStoreFamilyState.atomFamily(recordId),
-        );
-        const currentFieldValue = recordFromStoreForDelete?.[fieldName] as
-          | FieldRelationValue<FieldRelationFromManyValue>
-          | undefined;
-
-        if (
-          !isDefined(currentFieldValue) ||
-          !Array.isArray(currentFieldValue)
-        ) {
-          return;
-        }
-
-        const updatedJunctionRecords = currentFieldValue.filter(
-          (record) => record.id !== junctionRecordToDelete.id,
-        );
-
-        store.set(
-          recordStoreFamilyState.atomFamily(recordId),
-          (currentRecord: Record<string, unknown> | null | undefined) => {
-            if (!isDefined(currentRecord)) {
-              return currentRecord;
-            }
-            return {
-              ...currentRecord,
-              [fieldName]: updatedJunctionRecords,
-            } as ObjectRecord;
-          },
-        );
       } else {
-        const searchRecord = store.get(
-          searchRecordStoreFamilyState.atomFamily(morphItem.recordId),
-        );
-
-        if (!isDefined(searchRecord?.record)) {
-          return;
-        }
-
-        const targetRecord = searchRecord.record;
-        const optimisticJunctionId = v4();
-        const now = new Date().toISOString();
-
-        const junctionRecordForStore = {
-          id: optimisticJunctionId,
-          createdAt: now,
-          updatedAt: now,
-          __typename: getObjectTypename(junctionObjectName),
-          [sourceJoinColumnName]: recordId,
-          [targetJoinColumnName]: morphItem.recordId,
-          [targetFieldName]: targetRecord,
-        };
-
-        upsertJunctionRecordInSourceRecordStore({
-          store,
-          sourceRecordId: recordId,
-          sourceFieldName: fieldName,
-          junctionRecord: junctionRecordForStore,
-        });
-
-        const removeOptimisticJunctionRecord = () =>
-          store.set(
-            recordStoreFamilyState.atomFamily(recordId),
-            (currentRecord: Record<string, unknown> | null | undefined) => {
-              if (!isDefined(currentRecord)) {
-                return currentRecord;
-              }
-
-              const currentFieldValue = currentRecord[fieldName];
-
-              return {
-                ...currentRecord,
-                [fieldName]: Array.isArray(currentFieldValue)
-                  ? currentFieldValue.filter(
-                      (junctionRecord) =>
-                        junctionRecord.id !== optimisticJunctionId,
-                    )
-                  : currentFieldValue,
-              } as ObjectRecord;
-            },
-          );
-
-        const persistedJunctionRecordNode = await createJunctionRecords({
+        await createJunctionRecords({
           recordsToCreate: [
             {
               [sourceJoinColumnName]: recordId,
@@ -228,33 +139,6 @@ export const useUpdateJunctionRelationFromCell = ({
             },
           ],
           upsert: true,
-        })
-          .then(([createdJunctionRecordNode]) => createdJunctionRecordNode)
-          .catch((error: Error) => {
-            removeOptimisticJunctionRecord();
-
-            throw error;
-          });
-
-        if (!isDefined(persistedJunctionRecordNode)) {
-          removeOptimisticJunctionRecord();
-
-          return;
-        }
-
-        const persistedJunctionRecord = getRecordFromRecordNode({
-          recordNode: persistedJunctionRecordNode,
-        });
-
-        removeOptimisticJunctionRecord();
-        upsertJunctionRecordInSourceRecordStore({
-          store,
-          sourceRecordId: recordId,
-          sourceFieldName: fieldName,
-          junctionRecord: {
-            ...junctionRecordForStore,
-            ...persistedJunctionRecord,
-          },
         });
       }
     },

--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/hooks/useOpenObjectRecordsSpreadsheetImportDialog.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/hooks/useOpenObjectRecordsSpreadsheetImportDialog.ts
@@ -43,6 +43,7 @@ export const useOpenObjectRecordsSpreadsheetImportDialog = (
     mutationBatchSize: SPREADSHEET_IMPORT_CREATE_RECORDS_BATCH_SIZE,
     setBatchedRecordsCount: setSpreadsheetImportCreatedRecordsProgress,
     abortController,
+    skipPostOptimisticEffect: true,
   });
 
   const openObjectRecordsSpreadsheetImportDialog = (

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-upgrade-version-command.module.ts
@@ -18,6 +18,7 @@ import { SimplifyStandardTaskNoteLayoutsCommand } from 'src/database/commands/up
 import { ProvisionMissingObjectSystemRelationsCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788266912940-provision-missing-object-system-relations.command';
 import { HideAskAiInSidePanelCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788266562942-hide-ask-ai-in-side-panel.command';
 import { GateWorkflowVersionNavigationByCoreIndexFlagCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788340845000-gate-workflow-version-navigation-by-core-index-flag.command';
+import { EnforceActivityTargetUniquenessCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788425677783-enforce-activity-target-uniqueness.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { CommandMenuItemEntity } from 'src/engine/metadata-modules/command-menu-item/entities/command-menu-item.entity';
 import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
@@ -52,6 +53,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     ProvisionMissingObjectSystemRelationsCommand,
     HideAskAiInSidePanelCommand,
     GateWorkflowVersionNavigationByCoreIndexFlagCommand,
+    EnforceActivityTargetUniquenessCommand,
   ],
 })
 export class V2_38_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788425677783-enforce-activity-target-uniqueness.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788425677783-enforce-activity-target-uniqueness.command.ts
@@ -1,0 +1,152 @@
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { getStandardFlatEntitiesToCreateOrThrow } from 'src/database/commands/upgrade-version-command/2-10/utils/get-standard-flat-entities-to-create-or-throw.util';
+import { buildDuplicateActivityTargetQuery } from 'src/database/commands/upgrade-version-command/2-38/utils/build-duplicate-activity-target-query.util';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceMigrationBuilderException } from 'src/engine/workspace-manager/workspace-migration/exceptions/workspace-migration-builder-exception';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const ACTIVITY_TARGET_CONFIGS = [
+  { tableName: 'taskTarget', parentColumnName: 'taskId' },
+  { tableName: 'noteTarget', parentColumnName: 'noteId' },
+] as const;
+
+const ACTIVITY_TARGET_UNIQUE_INDEX_UNIVERSAL_IDENTIFIERS = [
+  STANDARD_OBJECTS.taskTarget.indexes.taskPersonUniqueIndex.universalIdentifier,
+  STANDARD_OBJECTS.taskTarget.indexes.taskCompanyUniqueIndex
+    .universalIdentifier,
+  STANDARD_OBJECTS.taskTarget.indexes.taskOpportunityUniqueIndex
+    .universalIdentifier,
+  STANDARD_OBJECTS.noteTarget.indexes.notePersonUniqueIndex.universalIdentifier,
+  STANDARD_OBJECTS.noteTarget.indexes.noteCompanyUniqueIndex
+    .universalIdentifier,
+  STANDARD_OBJECTS.noteTarget.indexes.noteOpportunityUniqueIndex
+    .universalIdentifier,
+];
+
+@RegisteredWorkspaceCommand('2.38.0', 1788425677783)
+@Command({
+  name: 'upgrade:2-38:enforce-activity-target-uniqueness',
+  description:
+    'Remove duplicate task/note targets and add their missing unique indexes',
+})
+export class EnforceActivityTargetUniquenessCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+    dataSource,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    if (!isDefined(dataSource)) {
+      this.logger.warn(
+        `Skipping activity target uniqueness for workspace ${workspaceId}: no workspace data source`,
+      );
+
+      return;
+    }
+
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+    const [provisionedTables] = await dataSource.query<
+      Array<{ taskTarget: string | null; noteTarget: string | null }>
+    >(
+      `SELECT
+        to_regclass($1) AS "taskTarget",
+        to_regclass($2) AS "noteTarget"`,
+      [`"${schemaName}"."taskTarget"`, `"${schemaName}"."noteTarget"`],
+    );
+
+    if (
+      !isDefined(provisionedTables?.taskTarget) ||
+      !isDefined(provisionedTables.noteTarget)
+    ) {
+      this.logger.warn(
+        `Skipping activity target uniqueness for workspace ${workspaceId}: target tables are not provisioned`,
+      );
+
+      return;
+    }
+
+    let duplicateCount = 0;
+
+    for (const targetConfig of ACTIVITY_TARGET_CONFIGS) {
+      const [result] = await dataSource.query<Array<{ count: number }>>(
+        buildDuplicateActivityTargetQuery({
+          schemaName,
+          ...targetConfig,
+          deleteDuplicates: !options.dryRun,
+        }),
+      );
+
+      duplicateCount += result?.count ?? 0;
+    }
+
+    const { flatIndexMaps } = await this.workspaceCacheService.getOrRecompute(
+      workspaceId,
+      ['flatIndexMaps'],
+    );
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        now: new Date().toISOString(),
+        workspaceId,
+        twentyStandardApplicationId: twentyStandardFlatApplication.id,
+      });
+    const indexesToCreate =
+      getStandardFlatEntitiesToCreateOrThrow<FlatIndexMetadata>({
+        standardFlatEntityMaps: standardAllFlatEntityMaps.flatIndexMaps,
+        existingFlatEntityMaps: flatIndexMaps,
+        universalIdentifiers:
+          ACTIVITY_TARGET_UNIQUE_INDEX_UNIVERSAL_IDENTIFIERS,
+      });
+
+    this.logger.log(
+      `${options.dryRun ? '[DRY RUN] Would remove' : 'Removed'} ${duplicateCount} duplicate activity target(s) and ${options.dryRun ? 'would create' : 'will create'} ${indexesToCreate.length} unique index(es) for workspace ${workspaceId}`,
+    );
+
+    if (options.dryRun || indexesToCreate.length === 0) {
+      return;
+    }
+
+    const result =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+          workspaceId,
+          allFlatEntityOperationByMetadataName: {
+            index: {
+              flatEntityToCreate: indexesToCreate,
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+        },
+      );
+
+    if (result.status === 'fail') {
+      throw new WorkspaceMigrationBuilderException(result);
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-duplicate-activity-target-query.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-duplicate-activity-target-query.util.spec.ts
@@ -1,0 +1,41 @@
+import { buildDuplicateActivityTargetQuery } from 'src/database/commands/upgrade-version-command/2-38/utils/build-duplicate-activity-target-query.util';
+
+const QUERY_ARGS = {
+  schemaName: 'workspace_123',
+  tableName: 'taskTarget',
+  parentColumnName: 'taskId',
+};
+
+describe('buildDuplicateActivityTargetQuery', () => {
+  it('partitions each morph target type independently and deletes duplicates', () => {
+    const query = buildDuplicateActivityTargetQuery({
+      ...QUERY_ARGS,
+      deleteDuplicates: true,
+    });
+
+    expect(query).toContain('"activityTarget"."taskId"');
+    expect(query).toContain(`('person', "activityTarget"."targetPersonId")`);
+    expect(query).toContain(`('company', "activityTarget"."targetCompanyId")`);
+    expect(query).toContain(
+      `('opportunity', "activityTarget"."targetOpportunityId")`,
+    );
+    expect(query).toContain(
+      'ORDER BY\n          ("activityTarget"."deletedAt" IS NULL) DESC',
+    );
+    expect(query).toContain(
+      'DELETE FROM "workspace_123"."taskTarget"',
+    );
+  });
+
+  it('only counts duplicates on a dry run', () => {
+    const query = buildDuplicateActivityTargetQuery({
+      ...QUERY_ARGS,
+      deleteDuplicates: false,
+    });
+
+    expect(query).not.toContain('DELETE FROM');
+    expect(query).toContain(
+      'SELECT COUNT(*)::integer AS "count" FROM "duplicateTargets"',
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-duplicate-activity-target-query.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-duplicate-activity-target-query.util.ts
@@ -1,0 +1,48 @@
+export const buildDuplicateActivityTargetQuery = ({
+  schemaName,
+  tableName,
+  parentColumnName,
+  deleteDuplicates,
+}: {
+  schemaName: string;
+  tableName: string;
+  parentColumnName: string;
+  deleteDuplicates: boolean;
+}) => `
+  WITH "rankedTargets" AS (
+    SELECT
+      "activityTarget"."id",
+      ROW_NUMBER() OVER (
+        PARTITION BY
+          "activityTarget"."${parentColumnName}",
+          "target"."type",
+          "target"."id"
+        ORDER BY
+          ("activityTarget"."deletedAt" IS NULL) DESC,
+          "activityTarget"."createdAt",
+          "activityTarget"."id"
+      ) AS "duplicateRank"
+    FROM "${schemaName}"."${tableName}" "activityTarget"
+    CROSS JOIN LATERAL (
+      VALUES
+        ('person', "activityTarget"."targetPersonId"),
+        ('company', "activityTarget"."targetCompanyId"),
+        ('opportunity', "activityTarget"."targetOpportunityId")
+    ) AS "target"("type", "id")
+    WHERE "target"."id" IS NOT NULL
+  ),
+  "duplicateTargets" AS (
+    SELECT DISTINCT "id"
+    FROM "rankedTargets"
+    WHERE "duplicateRank" > 1
+  )${
+    deleteDuplicates
+      ? `,
+  "deletedTargets" AS (
+    DELETE FROM "${schemaName}"."${tableName}"
+    WHERE "id" IN (SELECT "id" FROM "duplicateTargets")
+    RETURNING "id"
+  )
+  SELECT COUNT(*)::integer AS "count" FROM "deletedTargets"`
+      : '\n  SELECT COUNT(*)::integer AS "count" FROM "duplicateTargets"'
+  }`;

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/__tests__/compute-activity-target-standard-metadata.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/__tests__/compute-activity-target-standard-metadata.spec.ts
@@ -1,5 +1,6 @@
 import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 
+import { validateAndReturnIndexWhereClause } from 'src/engine/workspace-manager/workspace-migration/utils/validate-index-where-clause.util';
 import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
 
 const WORKSPACE_ID = '20202020-1111-4111-8111-111111111111';
@@ -47,4 +48,39 @@ describe('Activity target standard metadata build', () => {
 
     expect(fieldMetadata?.isUIEditable).toBe(true);
   });
+
+  it.each([
+    {
+      objectName: 'taskTarget',
+      indexes: [
+        STANDARD_OBJECTS.taskTarget.indexes.taskPersonUniqueIndex,
+        STANDARD_OBJECTS.taskTarget.indexes.taskCompanyUniqueIndex,
+        STANDARD_OBJECTS.taskTarget.indexes.taskOpportunityUniqueIndex,
+      ],
+    },
+    {
+      objectName: 'noteTarget',
+      indexes: [
+        STANDARD_OBJECTS.noteTarget.indexes.notePersonUniqueIndex,
+        STANDARD_OBJECTS.noteTarget.indexes.noteCompanyUniqueIndex,
+        STANDARD_OBJECTS.noteTarget.indexes.noteOpportunityUniqueIndex,
+      ],
+    },
+  ] as const)(
+    'allows only one live $objectName row per target',
+    ({ indexes }) => {
+      for (const { universalIdentifier } of indexes) {
+        const indexMetadata =
+          allFlatEntityMaps.flatIndexMaps.byUniversalIdentifier[
+            universalIdentifier
+          ];
+
+        expect(indexMetadata).toMatchObject({ isUnique: true });
+        expect(indexMetadata?.indexWhereClause).toBe('"deletedAt" IS NULL');
+        expect(
+          validateAndReturnIndexWhereClause(indexMetadata?.indexWhereClause),
+        ).toBe('"deletedAt" IS NULL');
+      }
+    },
+  );
 });

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/build-standard-target-flat-index-metadatas.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/build-standard-target-flat-index-metadatas.util.ts
@@ -6,7 +6,11 @@ import {
   createStandardIndexFlatMetadata,
 } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/create-standard-index-flat-metadata.util';
 
-type StandardTargetObjectName = 'calendarEventTarget' | 'messageThreadTarget';
+type StandardTargetObjectName =
+  | 'calendarEventTarget'
+  | 'messageThreadTarget'
+  | 'noteTarget'
+  | 'taskTarget';
 
 type TargetIndexNames<T extends StandardTargetObjectName> = {
   parentIdIndex: AllStandardObjectIndexName<T>;

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-note-target-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-note-target-standard-flat-index-metadata.util.ts
@@ -1,67 +1,37 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
-import {
-  type CreateStandardIndexArgs,
-  createStandardIndexFlatMetadata,
-} from 'src/engine/workspace-manager/twenty-standard-application/utils/index/create-standard-index-flat-metadata.util';
+import { type CreateStandardIndexArgs } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/create-standard-index-flat-metadata.util';
+import { buildStandardTargetFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/build-standard-target-flat-index-metadatas.util';
 
-export const buildNoteTargetStandardFlatIndexMetadatas = ({
-  now,
-  objectName,
-  workspaceId,
-  standardObjectMetadataRelatedEntityIds,
-  dependencyFlatEntityMaps,
-  twentyStandardApplicationId,
-}: Omit<CreateStandardIndexArgs<'noteTarget'>, 'context'>): Record<
-  AllStandardObjectIndexName<'noteTarget'>,
-  FlatIndexMetadata
-> => ({
-  noteIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'noteIdIndex',
-      relatedFieldNames: ['note'],
+export const buildNoteTargetStandardFlatIndexMetadatas = (
+  args: Omit<CreateStandardIndexArgs<'noteTarget'>, 'context'>,
+): Record<AllStandardObjectIndexName<'noteTarget'>, FlatIndexMetadata> => {
+  const indexes = buildStandardTargetFlatIndexMetadatas({
+    args,
+    fieldNames: {
+      parent: 'note',
+      person: 'targetPerson',
+      company: 'targetCompany',
+      opportunity: 'targetOpportunity',
     },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
-  personIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'personIdIndex',
-      relatedFieldNames: ['targetPerson'],
+    indexNames: {
+      parentIdIndex: 'noteIdIndex',
+      personIdIndex: 'personIdIndex',
+      companyIdIndex: 'companyIdIndex',
+      opportunityIdIndex: 'opportunityIdIndex',
+      personUniqueIndex: 'notePersonUniqueIndex',
+      companyUniqueIndex: 'noteCompanyUniqueIndex',
+      opportunityUniqueIndex: 'noteOpportunityUniqueIndex',
     },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
-  companyIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'companyIdIndex',
-      relatedFieldNames: ['targetCompany'],
-    },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
-  opportunityIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'opportunityIdIndex',
-      relatedFieldNames: ['targetOpportunity'],
-    },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
-});
+  });
+
+  return {
+    noteIdIndex: indexes.parentIdIndex,
+    personIdIndex: indexes.personIdIndex,
+    companyIdIndex: indexes.companyIdIndex,
+    opportunityIdIndex: indexes.opportunityIdIndex,
+    notePersonUniqueIndex: indexes.personUniqueIndex,
+    noteCompanyUniqueIndex: indexes.companyUniqueIndex,
+    noteOpportunityUniqueIndex: indexes.opportunityUniqueIndex,
+  };
+};

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-task-target-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-task-target-standard-flat-index-metadata.util.ts
@@ -1,67 +1,37 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
-import {
-  type CreateStandardIndexArgs,
-  createStandardIndexFlatMetadata,
-} from 'src/engine/workspace-manager/twenty-standard-application/utils/index/create-standard-index-flat-metadata.util';
+import { type CreateStandardIndexArgs } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/create-standard-index-flat-metadata.util';
+import { buildStandardTargetFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/build-standard-target-flat-index-metadatas.util';
 
-export const buildTaskTargetStandardFlatIndexMetadatas = ({
-  now,
-  objectName,
-  workspaceId,
-  standardObjectMetadataRelatedEntityIds,
-  dependencyFlatEntityMaps,
-  twentyStandardApplicationId,
-}: Omit<CreateStandardIndexArgs<'taskTarget'>, 'context'>): Record<
-  AllStandardObjectIndexName<'taskTarget'>,
-  FlatIndexMetadata
-> => ({
-  taskIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'taskIdIndex',
-      relatedFieldNames: ['task'],
+export const buildTaskTargetStandardFlatIndexMetadatas = (
+  args: Omit<CreateStandardIndexArgs<'taskTarget'>, 'context'>,
+): Record<AllStandardObjectIndexName<'taskTarget'>, FlatIndexMetadata> => {
+  const indexes = buildStandardTargetFlatIndexMetadatas({
+    args,
+    fieldNames: {
+      parent: 'task',
+      person: 'targetPerson',
+      company: 'targetCompany',
+      opportunity: 'targetOpportunity',
     },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
-  personIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'personIdIndex',
-      relatedFieldNames: ['targetPerson'],
+    indexNames: {
+      parentIdIndex: 'taskIdIndex',
+      personIdIndex: 'personIdIndex',
+      companyIdIndex: 'companyIdIndex',
+      opportunityIdIndex: 'opportunityIdIndex',
+      personUniqueIndex: 'taskPersonUniqueIndex',
+      companyUniqueIndex: 'taskCompanyUniqueIndex',
+      opportunityUniqueIndex: 'taskOpportunityUniqueIndex',
     },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
-  companyIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'companyIdIndex',
-      relatedFieldNames: ['targetCompany'],
-    },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
-  opportunityIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'opportunityIdIndex',
-      relatedFieldNames: ['targetOpportunity'],
-    },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
-});
+  });
+
+  return {
+    taskIdIndex: indexes.parentIdIndex,
+    personIdIndex: indexes.personIdIndex,
+    companyIdIndex: indexes.companyIdIndex,
+    opportunityIdIndex: indexes.opportunityIdIndex,
+    taskPersonUniqueIndex: indexes.personUniqueIndex,
+    taskCompanyUniqueIndex: indexes.companyUniqueIndex,
+    taskOpportunityUniqueIndex: indexes.opportunityUniqueIndex,
+  };
+};

--- a/packages/twenty-server/test/integration/ai/suites/mcp-tool-execution.integration-spec.ts
+++ b/packages/twenty-server/test/integration/ai/suites/mcp-tool-execution.integration-spec.ts
@@ -236,7 +236,7 @@ describe('MCP tool execution (integration)', () => {
   describe('group_by_note_targets (morph relation column)', () => {
     let createdCompanyAId: string | undefined;
     let createdCompanyBId: string | undefined;
-    let createdNoteId: string | undefined;
+    const createdNoteIds: string[] = [];
     const createdNoteTargetIds: string[] = [];
 
     beforeAll(async () => {
@@ -254,13 +254,6 @@ describe('MCP tool execution (integration)', () => {
 
       createdCompanyBId = companyB.id;
 
-      const note = await executeWorkspaceTool<CreatedRecord>(
-        TOOL_NAMES.createNote,
-        { title: `mcp-group-by-note-${randomUUID()}` },
-      );
-
-      createdNoteId = note.id;
-
       // Two targets on company A, one on company B — the grouped counts
       // we'll assert against later.
       const targetCompanyIds = [
@@ -270,9 +263,16 @@ describe('MCP tool execution (integration)', () => {
       ];
 
       for (const targetCompanyId of targetCompanyIds) {
+        const note = await executeWorkspaceTool<CreatedRecord>(
+          TOOL_NAMES.createNote,
+          { title: `mcp-group-by-note-${randomUUID()}` },
+        );
+
+        createdNoteIds.push(note.id);
+
         const noteTarget = await executeWorkspaceTool<CreatedRecord>(
           TOOL_NAMES.createNoteTarget,
-          { noteId: createdNoteId, targetCompanyId },
+          { noteId: note.id, targetCompanyId },
         );
 
         createdNoteTargetIds.push(noteTarget.id);
@@ -283,8 +283,8 @@ describe('MCP tool execution (integration)', () => {
       if (createdNoteTargetIds.length > 0) {
         await deleteRecordsByIds('noteTarget', createdNoteTargetIds);
       }
-      if (createdNoteId) {
-        await deleteRecordsByIds('note', [createdNoteId]);
+      if (createdNoteIds.length > 0) {
+        await deleteRecordsByIds('note', createdNoteIds);
       }
 
       const companyIds = [createdCompanyAId, createdCompanyBId].filter(
@@ -354,7 +354,7 @@ describe('MCP tool execution (integration)', () => {
           aggregateOperation: 'COUNT',
           // Scope to the noteTargets we created so other seeded rows don't
           // leak into the counts.
-          noteId: { eq: createdNoteId },
+          noteId: { in: createdNoteIds },
         },
       );
 

--- a/packages/twenty-server/test/integration/graphql/suites/upsert/activity-target-upsert.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/upsert/activity-target-upsert.integration-spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { isDefined } from 'twenty-shared/utils';
 
 import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
 import { createOneOperation } from 'test/integration/graphql/utils/create-one-operation.util';
@@ -79,7 +80,7 @@ describe('activity target upsert', () => {
 
       expect(findResponse.body.data.taskTargets.edges).toHaveLength(1);
     } finally {
-      if (taskTargetId) {
+      if (isDefined(taskTargetId)) {
         await makeGraphqlAPIRequest(
           destroyOneOperationFactory({
             objectMetadataSingularName: 'taskTarget',

--- a/packages/twenty-server/test/integration/graphql/suites/upsert/activity-target-upsert.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/upsert/activity-target-upsert.integration-spec.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from 'crypto';
+
+import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
+import { createOneOperation } from 'test/integration/graphql/utils/create-one-operation.util';
+import { deleteOneOperationFactory } from 'test/integration/graphql/utils/delete-one-operation-factory.util';
+import { destroyOneOperationFactory } from 'test/integration/graphql/utils/destroy-one-operation-factory.util';
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+
+describe('activity target upsert', () => {
+  it('keeps one live task target and restores it after deletion', async () => {
+    const taskId = randomUUID();
+    const personId = randomUUID();
+    let taskTargetId: string | undefined;
+
+    try {
+      await createOneOperation({
+        objectMetadataSingularName: 'task',
+        gqlFields: 'id',
+        input: { id: taskId, title: 'Activity target upsert task' },
+      });
+      await createOneOperation({
+        objectMetadataSingularName: 'person',
+        gqlFields: 'id',
+        input: {
+          id: personId,
+          name: { firstName: 'Activity target', lastName: 'upsert' },
+        },
+      });
+
+      const createTaskTarget = () =>
+        makeGraphqlAPIRequest(
+          createManyOperationFactory({
+            objectMetadataSingularName: 'taskTarget',
+            objectMetadataPluralName: 'taskTargets',
+            gqlFields: 'id deletedAt taskId targetPersonId',
+            data: [{ taskId, targetPersonId: personId }],
+            upsert: true,
+          }),
+        );
+
+      const firstCreateResponse = await createTaskTarget();
+      const createdTaskTargetId =
+        firstCreateResponse.body.data.createTaskTargets[0].id;
+
+      taskTargetId = createdTaskTargetId;
+
+      const repeatedCreateResponse = await createTaskTarget();
+
+      expect(repeatedCreateResponse.body.data.createTaskTargets[0]).toEqual(
+        expect.objectContaining({ id: createdTaskTargetId, deletedAt: null }),
+      );
+
+      await makeGraphqlAPIRequest(
+        deleteOneOperationFactory({
+          objectMetadataSingularName: 'taskTarget',
+          gqlFields: 'id',
+          recordId: createdTaskTargetId,
+        }),
+      );
+
+      const restoreResponse = await createTaskTarget();
+
+      expect(restoreResponse.body.data.createTaskTargets[0]).toEqual(
+        expect.objectContaining({ id: createdTaskTargetId, deletedAt: null }),
+      );
+
+      const findResponse = await makeGraphqlAPIRequest(
+        findManyOperationFactory({
+          objectMetadataSingularName: 'taskTarget',
+          objectMetadataPluralName: 'taskTargets',
+          gqlFields: 'id',
+          filter: {
+            taskId: { eq: taskId },
+            targetPersonId: { eq: personId },
+          },
+        }),
+      );
+
+      expect(findResponse.body.data.taskTargets.edges).toHaveLength(1);
+    } finally {
+      if (taskTargetId) {
+        await makeGraphqlAPIRequest(
+          destroyOneOperationFactory({
+            objectMetadataSingularName: 'taskTarget',
+            gqlFields: 'id',
+            recordId: taskTargetId,
+          }),
+        );
+      }
+
+      await makeGraphqlAPIRequest(
+        destroyOneOperationFactory({
+          objectMetadataSingularName: 'task',
+          gqlFields: 'id',
+          recordId: taskId,
+        }),
+      );
+      await makeGraphqlAPIRequest(
+        destroyOneOperationFactory({
+          objectMetadataSingularName: 'person',
+          gqlFields: 'id',
+          recordId: personId,
+        }),
+      );
+    }
+  });
+});

--- a/packages/twenty-shared/src/metadata/__tests__/__snapshots__/standardObjectUniversalIdentifiers.test.ts.snap
+++ b/packages/twenty-shared/src/metadata/__tests__/__snapshots__/standardObjectUniversalIdentifiers.test.ts.snap
@@ -2020,8 +2020,17 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       "companyIdIndex": {
         "universalIdentifier": "2d83909a-a383-4e82-b00a-8b7739f3f906",
       },
+      "noteCompanyUniqueIndex": {
+        "universalIdentifier": "e3b92659-04cf-4496-8fd4-4f32c747c26a",
+      },
       "noteIdIndex": {
         "universalIdentifier": "9294d9e3-0225-4c7f-9d6e-23b4c25b6b24",
+      },
+      "noteOpportunityUniqueIndex": {
+        "universalIdentifier": "58002741-8aa7-4812-b7af-f4cf98dd2433",
+      },
+      "notePersonUniqueIndex": {
+        "universalIdentifier": "29be76d1-ff4f-4f0f-b05c-f679a234e90a",
       },
       "opportunityIdIndex": {
         "universalIdentifier": "0d1a59b4-cc87-4b7d-804a-656e8504f371",
@@ -2707,8 +2716,17 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       "personIdIndex": {
         "universalIdentifier": "b7d305d1-6fae-4ed6-9bdc-354fe9032c0e",
       },
+      "taskCompanyUniqueIndex": {
+        "universalIdentifier": "637dce5e-f609-49f4-89e3-c0ef9e330d3a",
+      },
       "taskIdIndex": {
         "universalIdentifier": "c882f7a4-b025-4d32-aa26-5ef2595bdbf9",
+      },
+      "taskOpportunityUniqueIndex": {
+        "universalIdentifier": "eb5422ff-7a41-48d2-a2df-3de1cbf7bced",
+      },
+      "taskPersonUniqueIndex": {
+        "universalIdentifier": "4adf4d5a-ad69-4c5c-bc62-2807816b3aa8",
       },
     },
     "morphIds": {

--- a/packages/twenty-shared/src/metadata/constants/standard-object.constant.ts
+++ b/packages/twenty-shared/src/metadata/constants/standard-object.constant.ts
@@ -750,6 +750,15 @@ export const STANDARD_OBJECTS = {
       opportunityIdIndex: {
         universalIdentifier: '0d1a59b4-cc87-4b7d-804a-656e8504f371',
       },
+      notePersonUniqueIndex: {
+        universalIdentifier: '29be76d1-ff4f-4f0f-b05c-f679a234e90a',
+      },
+      noteCompanyUniqueIndex: {
+        universalIdentifier: 'e3b92659-04cf-4496-8fd4-4f32c747c26a',
+      },
+      noteOpportunityUniqueIndex: {
+        universalIdentifier: '58002741-8aa7-4812-b7af-f4cf98dd2433',
+      },
     },
     views: {
       allNoteTargets: buildStandardObjectIndexView({
@@ -1063,6 +1072,15 @@ export const STANDARD_OBJECTS = {
       },
       opportunityIdIndex: {
         universalIdentifier: '6942e0ba-90f6-4c33-bf40-7f00b1ec35ab',
+      },
+      taskPersonUniqueIndex: {
+        universalIdentifier: '4adf4d5a-ad69-4c5c-bc62-2807816b3aa8',
+      },
+      taskCompanyUniqueIndex: {
+        universalIdentifier: '637dce5e-f609-49f4-89e3-c0ef9e330d3a',
+      },
+      taskOpportunityUniqueIndex: {
+        universalIdentifier: 'eb5422ff-7a41-48d2-a2df-3de1cbf7bced',
       },
     },
     views: {


### PR DESCRIPTION
## Summary

- enforce one live `TaskTarget` or `NoteTarget` row per parent and morph target
- reconcile successful junction upserts through the shared Apollo/Jotai record effects
- delete the junction editor's bespoke optimistic pivot bookkeeping
- keep spreadsheet imports' intentional no-cache-reconciliation behavior explicit at that caller
- remove historical duplicate pivots before adding the missing indexes to upgraded workspaces

## Root causes

There were two independent consistency problems:

1. `TaskTarget` and `NoteTarget` had no composite unique indexes. `createMany(..., upsert: true)` derives conflict keys from schema indexes, so repeated selections inserted duplicate pivots instead of upserting.
2. `useCreateManyRecords` skipped its successful post-mutation cache effect whenever `upsert` was enabled. The junction editor compensated by writing pivots directly to the Jotai record store, leaving Apollo's source relation stale. A subsequent generic delete reconciled from that stale Apollo record and overwrote the manually added relations. This produced the reported sequence: start with one relation, add several, remove one, and fall back to the original relation.

Historical inspection confirms the uniqueness issue predates the morph conversion: the target indexes were already non-unique before #17476, and that migration only renamed the target relations.

## Fix and simplification

Successful upserts now run the same shared relation/cache reconciliation as successful creates. Upserts still skip the pre-request optimistic create because their resulting ID is unknown; the server result is the authoritative record used for reconciliation. Spreadsheet import opts out explicitly to preserve its bulk-import optimization.

With the shared effect owning both Apollo and Jotai updates, `useUpdateJunctionRelationFromCell` only creates or deletes the pivot. This removes 118 lines of temporary IDs, search-store reads, rollback code, and manual record-store mutation. No picker mutation queue is used.

`TaskTarget` and `NoteTarget` now use the shared target-index builder already used by `CalendarEventTarget` and `MessageThreadTarget`, removing duplicated index construction.

## Upgrade safety

Existing workspaces may already contain duplicates. The 2.38 workspace upgrade keeps one canonical row per parent, target type, and target id, preferring a live row. It hard-deletes redundant pivots before creating the six partial unique indexes.

## Tests

- frontend regression coverage asserts that successful upserts invoke shared cache reconciliation
- junction hook coverage verifies create/delete pivot delegation without private cache state
- full frontend suite: 1,151 suites and 6,829 tests passed
- frontend typecheck, lint, and formatting passed
- standard metadata asserts partial unique indexes for `TaskTarget` and `NoteTarget`
- pure query tests cover destructive cleanup and dry-run counting
- GraphQL integration covers repeated upsert, delete, and restore while keeping exactly one live pivot
- the MCP grouping fixture uses valid unique Note–Company pairs
