### PR TITLE
Update Ask AI command icon and migrate legacy sparkle icon in 2.38

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1787938100000-pin-ask-ai-command-menu-item.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1787938100000-pin-ask-ai-command-menu-item.command.ts
@@ -16,7 +16,7 @@ import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspa
 @Command({
   name: 'upgrade:2-38:pin-ask-ai-command-menu-item',
   description:
-    'Pin the Ask AI command to page headers as an icon-only action across the app',
+    'Pin the Ask AI command to page headers with its updated icon as an icon-only action across the app',
 })
 export class PinAskAiCommandMenuItemCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
@@ -49,7 +49,9 @@ export class PinAskAiCommandMenuItemCommand extends ProvisionedWorkspaceCommandR
     }
 
     if (options.dryRun) {
-      this.logger.log(`Would pin the Ask AI command for workspace ${workspaceId}`);
+      this.logger.log(
+        `Would pin the Ask AI command and update its icon for workspace ${workspaceId}`,
+      );
 
       return;
     }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-pin-ask-ai-command-menu-item-update.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-pin-ask-ai-command-menu-item-update.util.spec.ts
@@ -17,10 +17,11 @@ const LEGACY_COMMAND_MENU_ITEM: FlatCommandMenuItem = Object.freeze({
   }),
   isPinned: false,
   shortLabel: 'Ask AI',
+  icon: 'IconSparkles',
 });
 
 describe('buildPinAskAiCommandMenuItemUpdate', () => {
-  it('pins the command and drops its short label without changing other fields', () => {
+  it('pins the command, drops its short label, and updates its icon', () => {
     expect(
       buildPinAskAiCommandMenuItemUpdate({
         existingCommandMenuItem: LEGACY_COMMAND_MENU_ITEM,
@@ -30,6 +31,7 @@ describe('buildPinAskAiCommandMenuItemUpdate', () => {
       ...LEGACY_COMMAND_MENU_ITEM,
       isPinned: true,
       shortLabel: null,
+      icon: 'IconMessageCirclePlus',
       updatedAt: NOW,
     });
   });
@@ -51,6 +53,13 @@ describe('buildPinAskAiCommandMenuItemUpdate', () => {
       },
     },
     {
+      name: 'custom icon',
+      existingCommandMenuItem: {
+        ...LEGACY_COMMAND_MENU_ITEM,
+        icon: 'IconRobot',
+      },
+    },
+    {
       name: 'workspace pinning override',
       existingCommandMenuItem: {
         ...LEGACY_COMMAND_MENU_ITEM,
@@ -62,6 +71,13 @@ describe('buildPinAskAiCommandMenuItemUpdate', () => {
       existingCommandMenuItem: {
         ...LEGACY_COMMAND_MENU_ITEM,
         overrides: { shortLabel: 'Ask AI' },
+      },
+    },
+    {
+      name: 'workspace icon override',
+      existingCommandMenuItem: {
+        ...LEGACY_COMMAND_MENU_ITEM,
+        overrides: { icon: 'IconSparkles' },
       },
     },
   ])('skips $name', ({ existingCommandMenuItem }) => {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-pin-ask-ai-command-menu-item-update.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-pin-ask-ai-command-menu-item-update.util.ts
@@ -4,6 +4,7 @@ import { type FlatCommandMenuItem } from 'src/engine/metadata-modules/flat-comma
 import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
 
 const LEGACY_ASK_AI_SHORT_LABEL = 'Ask AI';
+const LEGACY_ASK_AI_ICON = 'IconSparkles';
 
 export const buildPinAskAiCommandMenuItemUpdate = ({
   existingCommandMenuItem,
@@ -16,16 +17,18 @@ export const buildPinAskAiCommandMenuItemUpdate = ({
     return undefined;
   }
 
-  // Pinning and short labels are workspace-editable, so an override means the
+  // These properties are workspace-editable, so an override means the
   // workspace already made its own choice for this command.
   const hasWorkspaceOverride =
     isDefined(existingCommandMenuItem.overrides?.isPinned) ||
-    isDefined(existingCommandMenuItem.overrides?.shortLabel);
+    isDefined(existingCommandMenuItem.overrides?.shortLabel) ||
+    isDefined(existingCommandMenuItem.overrides?.icon);
 
   if (
     hasWorkspaceOverride ||
     existingCommandMenuItem.isPinned !== false ||
-    existingCommandMenuItem.shortLabel !== LEGACY_ASK_AI_SHORT_LABEL
+    existingCommandMenuItem.shortLabel !== LEGACY_ASK_AI_SHORT_LABEL ||
+    existingCommandMenuItem.icon !== LEGACY_ASK_AI_ICON
   ) {
     return undefined;
   }
@@ -34,6 +37,7 @@ export const buildPinAskAiCommandMenuItemUpdate = ({
     ...existingCommandMenuItem,
     isPinned: STANDARD_COMMAND_MENU_ITEMS.askAi.isPinned,
     shortLabel: STANDARD_COMMAND_MENU_ITEMS.askAi.shortLabel,
+    icon: STANDARD_COMMAND_MENU_ITEMS.askAi.icon,
     updatedAt: now,
   };
 };

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
@@ -872,7 +872,7 @@ export const STANDARD_COMMAND_MENU_ITEMS = {
     label: i18nLabel(
       msg({ message: `Ask AI`, context: 'commandMenuItem.label' }),
     ),
-    icon: 'IconSparkles',
+    icon: 'IconMessageCirclePlus',
     isPinned: true,
     position: 43,
     shortLabel: null,


### PR DESCRIPTION
### Motivation
- Replace the Ask AI command-menu sparkle icon with the new design-provided icon and ensure the unshipped 2.38 workspace upgrade migrates existing workspaces to the new icon.
- Preserve any workspace-level customizations and avoid overwriting custom icons or overrides when migrating the default.

### Description
- Change the standard default for the Ask AI command icon from `IconSparkles` to `IconMessageCirclePlus` in `standard-command-menu-item.constant.ts`.
- Extend `buildPinAskAiCommandMenuItemUpdate` to treat `icon` like other workspace-editable properties by adding `LEGACY_ASK_AI_ICON`, checking `overrides?.icon`, comparing the existing `icon` against the legacy, and including `icon: STANDARD_COMMAND_MENU_ITEMS.askAi.icon` in the produced update.
- Update unit tests in `__tests__/build-pin-ask-ai-command-menu-item-update.util.spec.ts` to assert the icon swap and add cases to guard against custom or overridden icons being changed.
- Update the 2.38 workspace command description and its dry-run log to reflect that the command will also update the Ask AI icon.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues, which succeeded.
- Attempted to run the unit spec via `npx jest packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-pin-ask-ai-command-menu-item-update.util.spec.ts --config=packages/twenty-server/jest.config.mjs --runInBand`, but Jest could not start because repository dependencies are not installed in the environment (missing `file-type`), so tests were not executed here.
- The updated unit test file was added to cover the new icon behavior and the new guard cases, but CI or a local dev environment with dependencies installed should be used to run the tests to verify green status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97d4155398832fb49feb8c3d0f043a)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

