### PR TITLE
fix(billing) - fix stale seat count billed on plan and interval subscription updates

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription-update.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription-update.service.ts
@@ -37,8 +37,11 @@ import { getCurrentLicensedBillingSubscriptionItemOrThrow } from 'src/engine/cor
 import { getCurrentResourceCreditSubscriptionItemOrThrow } from 'src/engine/core-modules/billing/utils/get-resource-credit-subscription-item-or-throw.util';
 import { normalizePriceRef } from 'src/engine/core-modules/billing/utils/normalize-price-ref.utils';
 import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
+import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 export type SubscriptionStripePrices = {
   licensedPriceId: string;
   seats: number;
@@ -61,6 +64,7 @@ export class BillingSubscriptionUpdateService {
     private readonly stripeSubscriptionScheduleService: StripeSubscriptionScheduleService,
     private readonly billingSubscriptionPhaseService: BillingSubscriptionPhaseService,
     private readonly billingSubscriptionService: BillingSubscriptionService,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
   async changeResourceCreditPrice(
@@ -203,12 +207,17 @@ export class BillingSubscriptionUpdateService {
     const resourceCreditItem =
       getCurrentResourceCreditSubscriptionItemOrThrow(subscription);
 
+    const workspaceMembersCount = await this.countWorkspaceMembers(workspaceId);
+
     const toUpdateCurrentPrices = await this.computeSubscriptionPricesUpdate(
       subscriptionUpdate,
       {
         licensedPriceId: licensedItem.stripePriceId,
         resourceCreditPriceId: resourceCreditItem.stripePriceId,
-        seats: licensedItem.quantity,
+        seats:
+          workspaceMembersCount > 0
+            ? workspaceMembersCount
+            : licensedItem.quantity,
       },
     );
 
@@ -332,6 +341,23 @@ export class BillingSubscriptionUpdateService {
     await this.billingSubscriptionService.syncSubscriptionToDatabase(
       subscription.workspaceId,
       subscription.stripeSubscriptionId,
+    );
+  }
+
+  private async countWorkspaceMembers(workspaceId: string): Promise<number> {
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    return await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const workspaceMemberRepository =
+          this.workspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
+
+        return await workspaceMemberRepository.count();
+      },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription-update.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription-update.service.ts
@@ -207,17 +207,17 @@ export class BillingSubscriptionUpdateService {
     const resourceCreditItem =
       getCurrentResourceCreditSubscriptionItemOrThrow(subscription);
 
-    const workspaceMembersCount = await this.countWorkspaceMembers(workspaceId);
+    const seats =
+      subscriptionUpdate.type === SubscriptionUpdateType.SEATS
+        ? subscriptionUpdate.newSeats
+        : await this.countWorkspaceMembers(workspaceId);
 
     const toUpdateCurrentPrices = await this.computeSubscriptionPricesUpdate(
       subscriptionUpdate,
       {
         licensedPriceId: licensedItem.stripePriceId,
         resourceCreditPriceId: resourceCreditItem.stripePriceId,
-        seats:
-          workspaceMembersCount > 0
-            ? workspaceMembersCount
-            : licensedItem.quantity,
+        seats: seats > 0 ? seats : licensedItem.quantity,
       },
     );
 


### PR DESCRIPTION
## Problem

Stripe's licensed seat quantity only tracks workspace member changes through `UpdateSubscriptionQuantityJob`, which is enqueued with a 24h settling delay. A plan or interval update inside that window reuses the quantity stored on the Stripe subscription item, so the resulting invoice can bill seats for members that no longer exist. Concretely: removing a member and then switching from monthly to yearly a few minutes later invoices the old seat count for a full year, and the later seat decrease only produces a proration credit applied to the next yearly invoice.

## Fix

`updateSubscription` now counts the workspace's members and uses that as the licensed quantity, falling back to the stored Stripe quantity when the count is unavailable. Seat updates from the sync job are unchanged, since `newSeats` still overrides the computed context. Deferred downgrades benefit too: the scheduled next phase is built with the live count instead of the stale one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

