### PR TITLE
Guard side-effect handlers on isSystemSideEffect before mutating existing rows

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-search-field-metadata-on-delete-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-search-field-metadata-on-delete-side-effect-handler.service.ts
@@ -16,7 +16,7 @@ export class FieldSearchFieldMetadataOnDeleteSideEffectHandlerService extends Me
     metadataName: 'fieldMetadata',
     name: 'fieldSearchFieldMetadataOnDelete',
     description:
-      'When a field is deleted, cascade-delete every searchFieldMetadata row that indexes it. searchFieldMetadata is excluded from manifest deletion inference, so the cascade must be explicit here to cover both the API and manifest paths (the object-scoped cascade only fires on object deletion).',
+      'When a field is deleted, cascade-delete every searchFieldMetadata row that indexes it. searchFieldMetadata is excluded from manifest deletion inference, so the cascade must be explicit here to cover both the API and manifest paths (the object-scoped cascade only fires on object deletion). Only engine-owned (isSystemSideEffect) rows are deleted: caller-authored searchFieldMetadata rows are left alone.',
   },
 ) {
   buildSideEffects({
@@ -34,7 +34,10 @@ export class FieldSearchFieldMetadataOnDeleteSideEffectHandlerService extends Me
           searchFieldMetadataUniversalIdentifier
         ];
 
-      if (!isDefined(flatSearchFieldMetadata)) {
+      if (
+        !isDefined(flatSearchFieldMetadata) ||
+        flatSearchFieldMetadata.isSystemSideEffect !== true
+      ) {
         continue;
       }
 

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-unique-backing-index-on-delete-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-unique-backing-index-on-delete-side-effect-handler.service.ts
@@ -18,7 +18,7 @@ export class FieldUniqueBackingIndexOnDeleteSideEffectHandlerService extends Met
     metadataName: 'fieldMetadata',
     name: 'fieldUniqueBackingIndexOnDelete',
     description:
-      'When a unique scalar field is deleted, cascade-delete the single-field UNIQUE index that backed its uniqueness constraint.',
+      'When a unique scalar field is deleted, cascade-delete the single-field UNIQUE index that backed its uniqueness constraint. Only an engine-owned (isSystemSideEffect) index is deleted: a caller-authored index living at the derived identifier is left alone and goes through normal deletion inference.',
   },
 ) {
   buildSideEffects({
@@ -43,19 +43,21 @@ export class FieldUniqueBackingIndexOnDeleteSideEffectHandlerService extends Met
       });
     }
 
-    const flatIndexMetadataToDelete =
+    const deterministicFlatIndexMetadata =
       generateDeterministicIndexForFlatFieldMetadataOrThrow({
         flatFieldMetadata,
         flatObjectMetadata: parentFlatObjectMetadata,
       });
 
-    const indexExistsInWorkspace = isDefined(
+    const flatIndexMetadataToDelete =
       relatedFlatEntityMaps.flatIndexMaps.byUniversalIdentifier[
-        flatIndexMetadataToDelete.universalIdentifier
-      ],
-    );
+        deterministicFlatIndexMetadata.universalIdentifier
+      ];
 
-    if (!indexExistsInWorkspace) {
+    if (
+      !isDefined(flatIndexMetadataToDelete) ||
+      flatIndexMetadataToDelete.isSystemSideEffect !== true
+    ) {
       return { status: 'noop' };
     }
 

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-unique-backing-index-on-update-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-unique-backing-index-on-update-side-effect-handler.service.ts
@@ -20,7 +20,7 @@ export class FieldUniqueBackingIndexOnUpdateSideEffectHandlerService extends Met
     metadataName: 'fieldMetadata',
     name: 'fieldUniqueBackingIndexOnUpdate',
     description:
-      "Keep a unique scalar field's backing UNIQUE index in sync when its `isUnique` flag flips or the field is renamed (drop the stale index and recreate the deterministic one).",
+      "Keep a unique scalar field's backing UNIQUE index in sync when its `isUnique` flag flips or the field is renamed (drop the stale index and recreate the deterministic one). Only an engine-owned (isSystemSideEffect) stale index is dropped: a caller-authored index living at the derived identifier is left alone.",
   },
 ) {
   buildSideEffects({
@@ -97,14 +97,18 @@ export class FieldUniqueBackingIndexOnUpdateSideEffectHandlerService extends Met
           })
         : undefined;
 
-    const flatIndexMetadataToDelete =
-      isDefined(previousFlatIndexMetadata) &&
-      isDefined(
-        relatedFlatEntityMaps.flatIndexMaps.byUniversalIdentifier[
+    const existingPreviousFlatIndexMetadata = isDefined(
+      previousFlatIndexMetadata,
+    )
+      ? relatedFlatEntityMaps.flatIndexMaps.byUniversalIdentifier[
           previousFlatIndexMetadata.universalIdentifier
-        ],
-      )
-        ? previousFlatIndexMetadata
+        ]
+      : undefined;
+
+    const flatIndexMetadataToDelete =
+      isDefined(existingPreviousFlatIndexMetadata) &&
+      existingPreviousFlatIndexMetadata.isSystemSideEffect === true
+        ? existingPreviousFlatIndexMetadata
         : undefined;
 
     const flatIndexMetadataToCreate =

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-system-relations-on-update-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-system-relations-on-update-side-effect-handler.service.ts
@@ -19,7 +19,7 @@ export class ObjectSystemRelationsOnUpdateSideEffectHandlerService extends Metad
     metadataName: 'objectMetadata',
     name: 'objectSystemRelationsOnUpdate',
     description:
-      'When an object is renamed, rename the reverse MORPH_RELATION fields of its default relations to the standard objects (timelineActivity, attachment, noteTarget, taskTarget) and recompute their join-column index names. These reverse fields are isSystemSideEffect, so the engine is their sole authority on rename across both the API and manifest-sync paths (the API transpiler renames only user-authored morph relations). The reverse field universal identifier is name-free, so a rename stays a lossless update. The computed updates are emitted unconditionally; any universal identifier collision with a caller-provided operation is arbitrated by the engine merge.',
+      'When an object is renamed, rename the reverse MORPH_RELATION fields of its default relations to the standard objects (timelineActivity, attachment, noteTarget, taskTarget) and recompute their join-column index names. These reverse fields are isSystemSideEffect, so the engine is their sole authority on rename across both the API and manifest-sync paths (the API transpiler renames only user-authored morph relations). The reverse field universal identifier is name-free, so a rename stays a lossless update. Only engine-owned (isSystemSideEffect) reverse fields and indexes are touched: a caller-authored index living at a derived identifier is left alone. Any universal identifier collision with a caller-provided operation is arbitrated by the engine merge.',
   },
 ) {
   buildSideEffects({
@@ -74,9 +74,22 @@ export class ObjectSystemRelationsOnUpdateSideEffectHandlerService extends Metad
         systemSideEffectMorphFieldsOnly: true,
       });
 
+    const systemSideEffectMorphRelatedFlatIndexesToUpdate =
+      morphRelatedFlatIndexesToUpdate.filter((morphRelatedFlatIndex) => {
+        const existingFlatIndex =
+          relatedFlatEntityMaps.flatIndexMaps.byUniversalIdentifier[
+            morphRelatedFlatIndex.universalIdentifier
+          ];
+
+        return (
+          isDefined(existingFlatIndex) &&
+          existingFlatIndex.isSystemSideEffect === true
+        );
+      });
+
     if (
       morphFlatFieldMetadatasToUpdate.length === 0 &&
-      morphRelatedFlatIndexesToUpdate.length === 0
+      systemSideEffectMorphRelatedFlatIndexesToUpdate.length === 0
     ) {
       return { status: 'noop' };
     }
@@ -92,7 +105,7 @@ export class ObjectSystemRelationsOnUpdateSideEffectHandlerService extends Metad
         },
         index: {
           flatEntityToUpdate: fromArrayToUniqueKeyRecord({
-            array: morphRelatedFlatIndexesToUpdate,
+            array: systemSideEffectMorphRelatedFlatIndexesToUpdate,
             uniqueKey: 'universalIdentifier',
           }),
         },


### PR DESCRIPTION
Closes twentyhq/core-team-issues#2824

## Problem

Four side-effect handlers resolved an existing row at a derived identifier and emitted an update or delete for it without checking that the engine owned it. The engine merge only detects collisions between pending operations, not against already-synced rows, so a caller-authored row living at a derived identifier could be rewritten or deleted.

## Changes

Each handler now resolves the existing row and noops unless it has `isSystemSideEffect: true`, matching the pattern already used by the label-identifier handlers.

- `objectSystemRelationsOnUpdate`: the recomputed reverse join-column indexes are filtered through the existing index map and only engine-owned ones are emitted as updates. The reverse fields were already filtered by the rename util.
- `fieldUniqueBackingIndexOnDelete`: the index at the derived identifier is looked up and deleted only when it is engine-owned. The existing row is what gets emitted, rather than a freshly generated one.
- `fieldUniqueBackingIndexOnUpdate`: same guard on the stale backing index dropped when `isUnique` flips or the field is renamed. The recreate path is unchanged.
- `fieldSearchFieldMetadataOnDelete`: caller-authored searchFieldMetadata rows are skipped while walking the field aggregator.

Handler descriptions were extended to state the ownership rule.

## Checks

- Existing Jest suites in the side-effect handlers directory pass
- oxlint and oxfmt on the changed files: clean
- tsgo on twenty-server: no errors in the changed files

## Note

The object-level cascade in `objectSystemSideEffectsOnDelete` still deletes every searchFieldMetadata row on the object without an ownership check. It was not listed in the issue, so it is left untouched here.