### PR TITLE
test(server): cover field read permission for group-by records selection

### DIFF
--- a/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/fields-permissions/read-permissions.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/fields-permissions/read-permissions.integration-spec.ts
@@ -537,7 +537,8 @@ describe('Field permissions restrictions', () => {
       gqlFields: 'edges { node { id jobTitle } }',
     });
 
-    const response = await makeGraphqlAPIRequest(graphqlOperation);
+    const response =
+      await makeGraphqlAPIRequestWithMemberRole(graphqlOperation);
 
     expectNoGraphQLErrors(response);
 

--- a/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/fields-permissions/read-permissions.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/fields-permissions/read-permissions.integration-spec.ts
@@ -528,6 +528,54 @@ describe('Field permissions restrictions', () => {
     expectNoGraphQLErrors(response);
   });
 
+  it('should return record field values in a group by records selection when the field is readable', async () => {
+    const graphqlOperation = groupByOperationFactory({
+      objectMetadataSingularName: 'person',
+      objectMetadataPluralName: 'people',
+      groupBy: [{ companyId: true }],
+      filter: { id: { eq: personId } },
+      gqlFields: 'edges { node { id jobTitle } }',
+    });
+
+    const response = await makeGraphqlAPIRequest(graphqlOperation);
+
+    expectNoGraphQLErrors(response);
+
+    const jobTitles = response.body.data.peopleGroupBy
+      .flatMap(
+        (group: { edges: { node: { jobTitle: string } }[] }) => group.edges,
+      )
+      .map((edge: { node: { jobTitle: string } }) => edge.node.jobTitle);
+
+    expect(jobTitles).toContain('Paris');
+  });
+
+  it('should reject reading a record field without read permission in a group by records selection', async () => {
+    await upsertFieldPermissions({
+      roleId: customRoleId,
+      fieldPermissions: [
+        {
+          objectMetadataId: personObjectId,
+          fieldMetadataId: restrictedPersonFieldId,
+          canReadFieldValue: false,
+          canUpdateFieldValue: null,
+        },
+      ],
+    });
+
+    const graphqlOperation = groupByOperationFactory({
+      objectMetadataSingularName: 'person',
+      objectMetadataPluralName: 'people',
+      groupBy: [{ companyId: true }],
+      gqlFields: 'edges { node { id jobTitle } }',
+    });
+
+    const response =
+      await makeGraphqlAPIRequestWithMemberRole(graphqlOperation);
+
+    expectPermissionDeniedError(response);
+  });
+
   describe('Aggregate operations', () => {
     it('1. should allow aggregate over a restricted field', async () => {
       await restrictAccessToCompanyEmployee(


### PR DESCRIPTION
Adds integration test coverage for the group-by records selection path:

- asserts record field values are returned when the field is readable
- asserts a role without field read permission is denied on the same query

Test-only, no product code changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

