### PR TITLE
fix(server): propagate stream destroy to the socket behind the SDK checksum wrapper

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -179,6 +179,7 @@
     "@nestjs/cli": "^11.0.16",
     "@nestjs/schematics": "^11.0.9",
     "@nestjs/testing": "11.2.1",
+    "@smithy/util-stream": "4.5.16",
     "@swc/cli": "^0.8.1",
     "@swc/core": "^1.15.11",
     "@swc/jest": "^0.2.39",

--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
@@ -36,6 +36,7 @@ import {
 } from 'src/engine/core-modules/file-storage/interfaces/file-storage-exception';
 import { type ByteRange } from 'src/engine/core-modules/file-storage/types/byte-range.type';
 import { buildAwsRequestHandlerOptions } from 'src/utils/aws-request-handler.util';
+import { propagateDestroyToSource } from 'src/utils/propagate-destroy-to-source.util';
 
 export interface S3DriverOptions extends S3ClientConfig {
   bucketName: string;
@@ -109,7 +110,7 @@ export class S3Driver implements StorageDriver {
         throw new Error('Unable to get file stream');
       }
 
-      return file.Body;
+      return propagateDestroyToSource(file.Body);
     } catch (error) {
       if (error.name === 'NoSuchKey') {
         throw new FileStorageException(

--- a/packages/twenty-server/src/utils/__tests__/propagate-destroy-to-source.util.spec.ts
+++ b/packages/twenty-server/src/utils/__tests__/propagate-destroy-to-source.util.spec.ts
@@ -1,0 +1,70 @@
+import { once } from 'events';
+import { PassThrough, Readable } from 'stream';
+
+import { ChecksumStream } from '@smithy/util-stream';
+
+import { propagateDestroyToSource } from 'src/utils/propagate-destroy-to-source.util';
+
+describe('propagateDestroyToSource', () => {
+  it('returns the same stream instance', () => {
+    const stream = new PassThrough();
+
+    expect(propagateDestroyToSource(stream)).toBe(stream);
+  });
+
+  it('destroys the wrapped source when the wrapper is destroyed unread', async () => {
+    const source = new PassThrough();
+    const wrapper = new PassThrough() as PassThrough & { source: Readable };
+
+    wrapper.source = source;
+
+    propagateDestroyToSource(wrapper).destroy();
+    await once(source, 'close');
+
+    expect(source.destroyed).toBe(true);
+  });
+
+  it('leaves a fully consumed source alone so its socket stays reusable', async () => {
+    const source = new PassThrough({ autoDestroy: false });
+    const wrapper = new PassThrough() as PassThrough & { source: Readable };
+
+    wrapper.source = source;
+    source.resume();
+    source.end();
+    await once(source, 'end');
+
+    propagateDestroyToSource(wrapper).destroy();
+    await once(wrapper, 'close');
+
+    expect(source.readableEnded).toBe(true);
+    expect(source.destroyed).toBe(false);
+  });
+
+  it('tolerates a stream with no source', async () => {
+    const stream = new PassThrough();
+
+    propagateDestroyToSource(stream).destroy();
+    await once(stream, 'close');
+
+    expect(stream.destroyed).toBe(true);
+  });
+
+  it('reaches the response stream behind a real SDK ChecksumStream', async () => {
+    const source = new PassThrough();
+    const wrapper = new ChecksumStream({
+      source,
+      checksum: {
+        update: () => {},
+        digest: async () => new Uint8Array(),
+        reset: () => {},
+      },
+      checksumSourceLocation: 'x-amz-checksum-crc32',
+      expectedChecksum: 'AA==',
+    });
+
+    propagateDestroyToSource(wrapper).destroy();
+    await once(source, 'close');
+
+    expect(source.destroyed).toBe(true);
+  });
+});

--- a/packages/twenty-server/src/utils/__tests__/propagate-destroy-to-source.util.spec.ts
+++ b/packages/twenty-server/src/utils/__tests__/propagate-destroy-to-source.util.spec.ts
@@ -5,6 +5,19 @@ import { ChecksumStream } from '@smithy/util-stream';
 
 import { propagateDestroyToSource } from 'src/utils/propagate-destroy-to-source.util';
 
+jest.useRealTimers();
+
+const onceWithin = (stream: Readable, event: string) =>
+  Promise.race([
+    once(stream, event),
+    new Promise((_resolve, reject) =>
+      setTimeout(
+        () => reject(new Error(`${event} not emitted within 1s`)),
+        1000,
+      ).unref(),
+    ),
+  ]);
+
 describe('propagateDestroyToSource', () => {
   it('returns the same stream instance', () => {
     const stream = new PassThrough();
@@ -19,7 +32,7 @@ describe('propagateDestroyToSource', () => {
     wrapper.source = source;
 
     propagateDestroyToSource(wrapper).destroy();
-    await once(source, 'close');
+    await onceWithin(source, 'close');
 
     expect(source.destroyed).toBe(true);
   });
@@ -31,10 +44,10 @@ describe('propagateDestroyToSource', () => {
     wrapper.source = source;
     source.resume();
     source.end();
-    await once(source, 'end');
+    await onceWithin(source, 'end');
 
     propagateDestroyToSource(wrapper).destroy();
-    await once(wrapper, 'close');
+    await onceWithin(wrapper, 'close');
 
     expect(source.readableEnded).toBe(true);
     expect(source.destroyed).toBe(false);
@@ -44,7 +57,7 @@ describe('propagateDestroyToSource', () => {
     const stream = new PassThrough();
 
     propagateDestroyToSource(stream).destroy();
-    await once(stream, 'close');
+    await onceWithin(stream, 'close');
 
     expect(stream.destroyed).toBe(true);
   });
@@ -63,7 +76,7 @@ describe('propagateDestroyToSource', () => {
     });
 
     propagateDestroyToSource(wrapper).destroy();
-    await once(source, 'close');
+    await onceWithin(source, 'close');
 
     expect(source.destroyed).toBe(true);
   });

--- a/packages/twenty-server/src/utils/propagate-destroy-to-source.util.ts
+++ b/packages/twenty-server/src/utils/propagate-destroy-to-source.util.ts
@@ -11,6 +11,7 @@ export const propagateDestroyToSource = <TStream extends Readable>(
     const source = (stream as ReadableWithSource).source;
 
     if (isDefined(source) && !source.destroyed && !source.readableEnded) {
+      source.on('error', () => {});
       source.destroy();
     }
   });

--- a/packages/twenty-server/src/utils/propagate-destroy-to-source.util.ts
+++ b/packages/twenty-server/src/utils/propagate-destroy-to-source.util.ts
@@ -1,0 +1,19 @@
+import { type Readable } from 'stream';
+
+import { isDefined } from 'twenty-shared/utils';
+
+type ReadableWithSource = Readable & { source?: Readable };
+
+export const propagateDestroyToSource = <TStream extends Readable>(
+  stream: TStream,
+): TStream => {
+  stream.once('close', () => {
+    const source = (stream as ReadableWithSource).source;
+
+    if (isDefined(source) && !source.destroyed && !source.readableEnded) {
+      source.destroy();
+    }
+  });
+
+  return stream;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -18262,17 +18262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^4.5.10":
-  version: 4.6.3
-  resolution: "@smithy/util-stream@npm:4.6.3"
-  dependencies:
-    "@smithy/core": "npm:^3.24.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/7a0ab21330e6bc8a8ff85747c860fd917df4696735e19a858fa00550068af3f0b9705c429e46db56e8ec14b80f741f4efb64a178980d8f6312985920902c402d
-  languageName: node
-  linkType: hard
-
-"@smithy/util-stream@npm:^4.5.16":
+"@smithy/util-stream@npm:4.5.16, @smithy/util-stream@npm:^4.5.16":
   version: 4.5.16
   resolution: "@smithy/util-stream@npm:4.5.16"
   dependencies:
@@ -18285,6 +18275,16 @@ __metadata:
     "@smithy/util-utf8": "npm:^4.2.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/266fbed834b0d6d1daccaf89eb24cab93feb6d2ee904689ceaf5cd15c9e9170f4f46632ab5dc630bc09dd8a3465d7e72aeda43f4b4150f4eebf21f00027ed015
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.5.10":
+  version: 4.6.3
+  resolution: "@smithy/util-stream@npm:4.6.3"
+  dependencies:
+    "@smithy/core": "npm:^3.24.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7a0ab21330e6bc8a8ff85747c860fd917df4696735e19a858fa00550068af3f0b9705c429e46db56e8ec14b80f741f4efb64a178980d8f6312985920902c402d
   languageName: node
   linkType: hard
 
@@ -49804,6 +49804,7 @@ __metadata:
     "@sentry/nestjs": "npm:^10.59.0"
     "@sentry/node": "npm:^10.59.0"
     "@sentry/profiling-node": "npm:^10.59.0"
+    "@smithy/util-stream": "npm:4.5.16"
     "@sniptt/guards": "npm:0.2.0"
     "@swc/cli": "npm:^0.8.1"
     "@swc/core": "npm:^1.15.11"


### PR DESCRIPTION
## Problem

`TWENTY-SERVER-JVT` keeps taking down workspace creation: an affected pod fails every S3 call with the 30s connection timeout for hours and only recovers on restart.

## Root cause — reproduced

**The SDK wraps every GetObject body in a `ChecksumStream` by default, and that wrapper does not implement `_destroy`.**

- `responseChecksumValidation` defaults to `WHEN_SUPPORTED`, so the middleware sets `ChecksumMode=ENABLED` on every GetObject; S3 auto-attaches checksum headers to all objects, so in production every downloaded body is the wrapper, not the socket stream.
- Destroying the wrapper — what the upload mime sniff does after its 64KB prefix on every completed upload, and what the streaming controllers do on client aborts — detaches it and leaves the real response socket **paused**. A paused socket is unpolled: when S3 later resets the connection, no `close` ever fires, and `close` is the only event that removes a socket from the agent's pool. One of the 200 slots gone, permanently, invisible to `netstat`.
- Enough of those and every S3 call queues behind a pool that will never free a slot, dying at the 30s connect timer until the pod restarts.

This also explains why the earlier stream-cleanup fix (#25107) didn't stop the outage: its `destroy()` calls were correct in intent and hit the wrapper.

## Fix

One line at the single point every body passes through: the driver attaches destroy propagation to each body it returns. When the returned stream closes without its underlying source having ended, the source is destroyed too, releasing the socket.

- **Checksum validation stays enabled** — no SDK defaults are changed. (An earlier revision of this PR disabled `responseChecksumValidation`; review pushed back on losing the integrity check and it also silently altered presigned-URL query strings via the unrelated `requestChecksumCalculation`. This approach keeps both defaults intact.)
- The acquisition point covers **every** consumer, present and future, including ones that call plain `.destroy()` — the streaming controllers, `readReadablePrefix`, and `streamToBuffer`'s max-size guard alike — so no call-site changes and nothing to forget on the next consumer.
- The `readableEnded` guard means a fully consumed body is left alone and its socket returns to the keep-alive pool.
- A no-op error handler is attached to the source before destroying it, so a reset surfacing during teardown is absorbed rather than becoming an uncaught exception.

## Verification

Against the installed `@aws-sdk/client-s3` + `@smithy/node-http-handler`, with a server that sends checksum headers like S3 does (validation active — a wrong checksum fails the read, proving the default is on):

| | pool slots pinned | next call |
|---|---|---|
| before | 5 of 5 after five aborted downloads, permanent, survives peer RST | fails with the production error |
| after | 0 | socket in 2ms |
| full consumption, after | 0 — socket back in the keep-alive pool | reuses it |

The spec constructs a **real `ChecksumStream`**, so an SDK-internal rename of the wrapped-source property fails the build instead of silently disabling the fix. That import is why `@smithy/util-stream` is declared as a devDependency (pinned to the version the SDK already resolves — the yarn.lock delta is only that descriptor).

## Notes

- The wrapper's missing destroy propagation looks unreported upstream (smithy-typescript); worth filing separately.
- The inbound-email S3 client fully drains its bodies and is unaffected today; it would inherit the same latent hazard only if a consumer there starts destroying streams early — deliberately untouched here.
- Post-deploy: `TWENTY-SERVER-JVT` should flatline; any recurrence after 72h of normal traffic means a second, SDK-internal feeder and the pre-designed leak-attribution probe is the next step.
