### PR TITLE
chore(server): add worker memory diagnostics logging

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -210,8 +210,9 @@ export class BullMQDriver
 
           // TODO: Correctly support for job.id
           const timeStart = performance.now();
-          // Diagnostic: attribute heap growth to job types to tell whether
-          // per-job allocations (e.g. thread reconciliation) drive the OOM loop.
+          // TODO: diagnostic only — remove once the worker OOM root cause is
+          // confirmed. Attribute heap growth to job types, including jobs that
+          // throw under memory pressure (logged from the finally below).
           const heapUsedBeforeBytes = process.memoryUsage().heapUsed;
           const workspaceId = job.data?.workspaceId;
           const workspaceSuffix = workspaceId
@@ -221,24 +222,30 @@ export class BullMQDriver
           this.logger.log(
             `Processing job ${job.id} with name ${job.name} on queue ${queueName}${workspaceSuffix}`,
           );
-          await handler({
-            data: job.data,
-            id: job.id ?? '',
-            name: job.name,
-            retryLimit: Math.max(0, (job.opts.attempts ?? 1) - 1),
-            updateData: (data) => job.updateData(data),
-            abortSignal,
-          });
-          const timeEnd = performance.now();
-          const executionTime = timeEnd - timeStart;
-          const heapUsedAfterBytes = process.memoryUsage().heapUsed;
-          const heapDeltaMegabytes =
-            (heapUsedAfterBytes - heapUsedBeforeBytes) / BYTES_PER_MEGABYTE;
-          const heapUsedMegabytes = heapUsedAfterBytes / BYTES_PER_MEGABYTE;
 
-          this.logger.log(
-            `Job ${job.id} with name ${job.name} processed on queue ${queueName} in ${executionTime.toFixed(2)}ms${workspaceSuffix} heapDeltaMB=${heapDeltaMegabytes.toFixed(1)} heapUsedMB=${heapUsedMegabytes.toFixed(0)}`,
-          );
+          let jobSucceeded = false;
+
+          try {
+            await handler({
+              data: job.data,
+              id: job.id ?? '',
+              name: job.name,
+              retryLimit: Math.max(0, (job.opts.attempts ?? 1) - 1),
+              updateData: (data) => job.updateData(data),
+              abortSignal,
+            });
+            jobSucceeded = true;
+          } finally {
+            const executionTime = performance.now() - timeStart;
+            const heapUsedAfterBytes = process.memoryUsage().heapUsed;
+            const heapDeltaMegabytes =
+              (heapUsedAfterBytes - heapUsedBeforeBytes) / BYTES_PER_MEGABYTE;
+            const heapUsedMegabytes = heapUsedAfterBytes / BYTES_PER_MEGABYTE;
+
+            this.logger.log(
+              `Job ${job.id} with name ${job.name} ${jobSucceeded ? 'processed' : 'failed'} on queue ${queueName} in ${executionTime.toFixed(2)}ms${workspaceSuffix} heapDeltaMB=${heapDeltaMegabytes.toFixed(1)} heapUsedMB=${heapUsedMegabytes.toFixed(0)}`,
+            );
+          }
         }),
       workerOptions,
     );

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -4,6 +4,8 @@ import {
   type OnModuleInit,
 } from '@nestjs/common';
 
+import v8 from 'v8';
+
 import * as Sentry from '@sentry/node';
 import {
   type JobsOptions,
@@ -213,7 +215,7 @@ export class BullMQDriver
           // TODO: diagnostic only — remove once the worker OOM root cause is
           // confirmed. Attribute heap growth to job types, including jobs that
           // throw under memory pressure (logged from the finally below).
-          const heapUsedBeforeBytes = process.memoryUsage().heapUsed;
+          const heapUsedBeforeBytes = v8.getHeapStatistics().used_heap_size;
           const workspaceId = job.data?.workspaceId;
           const workspaceSuffix = workspaceId
             ? ` [workspace=${workspaceId}]`
@@ -237,7 +239,7 @@ export class BullMQDriver
             jobSucceeded = true;
           } finally {
             const executionTime = performance.now() - timeStart;
-            const heapUsedAfterBytes = process.memoryUsage().heapUsed;
+            const heapUsedAfterBytes = v8.getHeapStatistics().used_heap_size;
             const heapDeltaMegabytes =
               (heapUsedAfterBytes - heapUsedBeforeBytes) / BYTES_PER_MEGABYTE;
             const heapUsedMegabytes = heapUsedAfterBytes / BYTES_PER_MEGABYTE;

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -41,6 +41,7 @@ import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/
 export type BullMQDriverOptions = QueueOptions;
 
 const V4_LENGTH = 36;
+const BYTES_PER_MEGABYTE = 1024 * 1024;
 
 export class BullMQDriver
   implements MessageQueueDriver, OnModuleDestroy, OnModuleInit
@@ -209,6 +210,9 @@ export class BullMQDriver
 
           // TODO: Correctly support for job.id
           const timeStart = performance.now();
+          // Diagnostic: attribute heap growth to job types to tell whether
+          // per-job allocations (e.g. thread reconciliation) drive the OOM loop.
+          const heapUsedBeforeBytes = process.memoryUsage().heapUsed;
           const workspaceId = job.data?.workspaceId;
           const workspaceSuffix = workspaceId
             ? ` [workspace=${workspaceId}]`
@@ -227,9 +231,13 @@ export class BullMQDriver
           });
           const timeEnd = performance.now();
           const executionTime = timeEnd - timeStart;
+          const heapUsedAfterBytes = process.memoryUsage().heapUsed;
+          const heapDeltaMegabytes =
+            (heapUsedAfterBytes - heapUsedBeforeBytes) / BYTES_PER_MEGABYTE;
+          const heapUsedMegabytes = heapUsedAfterBytes / BYTES_PER_MEGABYTE;
 
           this.logger.log(
-            `Job ${job.id} with name ${job.name} processed on queue ${queueName} in ${executionTime.toFixed(2)}ms${workspaceSuffix}`,
+            `Job ${job.id} with name ${job.name} processed on queue ${queueName} in ${executionTime.toFixed(2)}ms${workspaceSuffix} heapDeltaMB=${heapDeltaMegabytes.toFixed(1)} heapUsedMB=${heapUsedMegabytes.toFixed(0)}`,
           );
         }),
       workerOptions,

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-metrics.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-metrics.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import v8 from 'v8';
+
 import { type Histogram } from '@opentelemetry/api';
 
 import { isDefined } from 'twenty-shared/utils';
@@ -29,8 +31,17 @@ const CACHE_DURATION_BUCKETS_SECONDS = [
 const STATS_TTL_MS = 5_000;
 const SIZE_REFRESH_MS = 5 * 60 * 1000;
 const SIZE_STARTUP_DELAY_MS = 30 * 1000;
-const SIZE_SAMPLE_PER_PROVIDER = 3;
+// Sized off the hot path every SIZE_REFRESH_MS. 50 keeps the extrapolated byte
+// estimate accurate enough to tell a cache-dominated heap from one that is not;
+// the byte-heavy providers are entry-capped well under this, so they get sized
+// in full.
+const SIZE_SAMPLE_PER_PROVIDER = 50;
 const SIZE_WALK_NODE_CAP = 300_000;
+const MEMORY_REPORT_INTERVAL_MS = 60 * 1000;
+const BYTES_PER_MEGABYTE = 1024 * 1024;
+
+const toMegabytes = (bytes: number): number =>
+  Math.round(bytes / BYTES_PER_MEGABYTE);
 
 // Cache observability, split from WorkspaceCacheService (which drives it via start()/stop()).
 @Injectable()
@@ -46,6 +57,7 @@ export class WorkspaceCacheMetricsService {
   private cacheSizeTotalBytes = 0;
   private sizeSampler?: ReturnType<typeof setInterval>;
   private sizeStartupTimer?: ReturnType<typeof setTimeout>;
+  private memoryReportTimer?: ReturnType<typeof setInterval>;
   private statsCache?: { computedAt: number } & LocalCacheStats;
   private sizeSampleInFlight = false;
   private packingBacklog = 0;
@@ -94,6 +106,7 @@ export class WorkspaceCacheMetricsService {
     this.localCache = localCache;
     this.registerGauges();
     this.scheduleSizeSampler();
+    this.scheduleMemoryReport();
   }
 
   stop(): void {
@@ -103,6 +116,46 @@ export class WorkspaceCacheMetricsService {
     if (isDefined(this.sizeSampler)) {
       clearInterval(this.sizeSampler);
     }
+    if (isDefined(this.memoryReportTimer)) {
+      clearInterval(this.memoryReportTimer);
+    }
+  }
+
+  // Diagnostic: correlate process/V8 memory with the cache's own size in one log
+  // line so we can tell whether the metadata cache tracks the heap climb to OOM
+  // (retained, old-space) versus per-job allocation spikes (transient, new-space).
+  private scheduleMemoryReport(): void {
+    const report = (): void => {
+      const memoryUsage = process.memoryUsage();
+      const heapSpaces = v8.getHeapSpaceStatistics();
+      const oldSpaceUsedBytes =
+        heapSpaces.find((space) => space.space_name === 'old_space')
+          ?.space_used_size ?? 0;
+      const newSpaceUsedBytes =
+        heapSpaces.find((space) => space.space_name === 'new_space')
+          ?.space_used_size ?? 0;
+
+      const topProviders = Object.entries(this.cacheSizeByKeyName)
+        .sort(([, bytesA], [, bytesB]) => bytesB - bytesA)
+        .slice(0, 3)
+        .map(([keyName, bytes]) => `${keyName}:${toMegabytes(bytes)}MB`)
+        .join(',');
+
+      this.logger.log(
+        `[WorkspaceCacheMemReport] ` +
+          `heapUsedMB=${toMegabytes(memoryUsage.heapUsed)} ` +
+          `rssMB=${toMegabytes(memoryUsage.rss)} ` +
+          `externalMB=${toMegabytes(memoryUsage.external)} ` +
+          `oldSpaceMB=${toMegabytes(oldSpaceUsedBytes)} ` +
+          `newSpaceMB=${toMegabytes(newSpaceUsedBytes)} ` +
+          `cacheEntries=${this.getStats().entries} ` +
+          `cacheBytesEstimateMB=${toMegabytes(this.cacheSizeTotalBytes)} ` +
+          `top=${topProviders}`,
+      );
+    };
+
+    this.memoryReportTimer = setInterval(report, MEMORY_REPORT_INTERVAL_MS);
+    this.memoryReportTimer.unref();
   }
 
   recordRecompute(seconds: number, cacheKey: WorkspaceCacheKeyName): void {

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-metrics.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-metrics.service.ts
@@ -31,11 +31,20 @@ const CACHE_DURATION_BUCKETS_SECONDS = [
 const STATS_TTL_MS = 5_000;
 const SIZE_REFRESH_MS = 5 * 60 * 1000;
 const SIZE_STARTUP_DELAY_MS = 30 * 1000;
-// Sized off the hot path every SIZE_REFRESH_MS. 50 keeps the extrapolated byte
-// estimate accurate enough to tell a cache-dominated heap from one that is not;
-// the byte-heavy providers are entry-capped well under this, so they get sized
-// in full.
+// Sampled off the hot path every SIZE_REFRESH_MS. 50 bounds the walk for
+// high-count, low-byte providers; the byte-heavy providers are sized in full via
+// SIZE_IN_FULL_PROVIDERS so the estimate is exact where it dominates the heap.
 const SIZE_SAMPLE_PER_PROVIDER = 50;
+// Byte-heavy providers (ORM / field-metadata graphs, ~MB each) are entry-capped
+// in WorkspaceCacheService, so every entry is sized rather than extrapolated from
+// a sample — extrapolating the largest, highest-variance entries is what made the
+// estimate untrustworthy. Their caps (<=512) bound the walk and packed versions
+// are sized for free, so the added cost stays small and off the hot path.
+const SIZE_IN_FULL_PROVIDERS = new Set([
+  'ORMEntityMetadatas',
+  'flatFieldMetadataMaps',
+  'flatFieldMetadataMapsOrm',
+]);
 const SIZE_WALK_NODE_CAP = 300_000;
 const MEMORY_REPORT_INTERVAL_MS = 60 * 1000;
 const BYTES_PER_MEGABYTE = 1024 * 1024;
@@ -121,9 +130,10 @@ export class WorkspaceCacheMetricsService {
     }
   }
 
-  // Diagnostic: correlate process/V8 memory with the cache's own size in one log
-  // line so we can tell whether the metadata cache tracks the heap climb to OOM
-  // (retained, old-space) versus per-job allocation spikes (transient, new-space).
+  // TODO: diagnostic only — remove once the worker OOM root cause is confirmed.
+  // Correlates process/V8 memory with the cache's own size in one log line so we
+  // can tell whether the metadata cache tracks the heap climb to OOM (retained,
+  // old-space) versus per-job allocation spikes (transient, new-space).
   private scheduleMemoryReport(): void {
     const report = (): void => {
       const memoryUsage = process.memoryUsage();
@@ -148,7 +158,7 @@ export class WorkspaceCacheMetricsService {
           `externalMB=${toMegabytes(memoryUsage.external)} ` +
           `oldSpaceMB=${toMegabytes(oldSpaceUsedBytes)} ` +
           `newSpaceMB=${toMegabytes(newSpaceUsedBytes)} ` +
-          `cacheEntries=${this.getStats().entries} ` +
+          `cacheEntries=${this.localCache?.size ?? 0} ` +
           `cacheBytesEstimateMB=${toMegabytes(this.cacheSizeTotalBytes)} ` +
           `top=${topProviders}`,
       );
@@ -262,7 +272,12 @@ export class WorkspaceCacheMetricsService {
 
       stats.count += 1;
 
-      if (stats.sampled < SIZE_SAMPLE_PER_PROVIDER && entry.versions.size > 0) {
+      const sizeEveryEntry = SIZE_IN_FULL_PROVIDERS.has(keyName);
+
+      if (
+        (sizeEveryEntry || stats.sampled < SIZE_SAMPLE_PER_PROVIDER) &&
+        entry.versions.size > 0
+      ) {
         // Size every retained version, not just the latest — stale versions still occupy heap.
         let entryBytes = 0;
 

--- a/packages/twenty-server/src/modules/match-participant/participant-target-reconciliation.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/participant-target-reconciliation.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import v8 from 'v8';
+
 import chunk from 'lodash.chunk';
 import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
@@ -164,7 +166,7 @@ export class ParticipantTargetReconciliationService {
     // TODO: diagnostic only — remove once the worker OOM root cause is confirmed.
     // Size what one reconcile loads and how much heap it retains, to confirm
     // whether this path (added in #24778) drives worker memory.
-    const heapUsedBeforeBytes = process.memoryUsage().heapUsed;
+    const heapUsedBeforeBytes = v8.getHeapStatistics().used_heap_size;
     let messagesLoaded = 0;
     let participantsLoaded = 0;
 
@@ -223,7 +225,7 @@ export class ParticipantTargetReconciliationService {
     }
 
     const heapDeltaMegabytes =
-      (process.memoryUsage().heapUsed - heapUsedBeforeBytes) /
+      (v8.getHeapStatistics().used_heap_size - heapUsedBeforeBytes) /
       BYTES_PER_MEGABYTE;
 
     this.logger.log(

--- a/packages/twenty-server/src/modules/match-participant/participant-target-reconciliation.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/participant-target-reconciliation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import chunk from 'lodash.chunk';
 import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
@@ -29,8 +29,14 @@ type TargetWorkspaceEntity = Omit<ExistingTarget, 'parentId' | 'deletedAt'> & {
   deletedAt: string | null;
 };
 
+const BYTES_PER_MEGABYTE = 1024 * 1024;
+
 @Injectable()
 export class ParticipantTargetReconciliationService {
+  private readonly logger = new Logger(
+    ParticipantTargetReconciliationService.name,
+  );
+
   constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
 
   public async reconcileParticipantTargets({
@@ -144,19 +150,34 @@ export class ParticipantTargetReconciliationService {
     messageThreadIds: string[];
     transactionScope?: WorkspaceTransactionScope;
   }): Promise<void> {
+    const uniqueMessageThreadIds = [...new Set(messageThreadIds)];
+
+    if (uniqueMessageThreadIds.length === 0) {
+      return;
+    }
+
     const messageRepository = await this.getRepository<MessageWorkspaceEntity>(
       'message',
       transactionScope,
     );
 
+    // Diagnostic: size what one reconcile loads and how much heap it retains,
+    // to confirm whether this path (added in #24778) drives worker memory.
+    const heapUsedBeforeBytes = process.memoryUsage().heapUsed;
+    let messagesLoaded = 0;
+    let participantsLoaded = 0;
+
     for (const messageThreadIdChunk of chunk(
-      [...new Set(messageThreadIds)],
+      uniqueMessageThreadIds,
       QUERY_MAX_RECORDS,
     )) {
       const threadMessages = await messageRepository.find({
         where: { messageThreadId: In(messageThreadIdChunk) },
         select: { id: true, messageThreadId: true },
       });
+
+      messagesLoaded += threadMessages.length;
+
       const messageThreadIdByMessageId = new Map<string, string>();
 
       for (const { id, messageThreadId } of threadMessages) {
@@ -185,6 +206,8 @@ export class ParticipantTargetReconciliationService {
         );
       }
 
+      participantsLoaded += participants.length;
+
       await this.reconcileTargets({
         parentIds: messageThreadIdChunk,
         parentFieldName: 'messageThreadId',
@@ -197,6 +220,14 @@ export class ParticipantTargetReconciliationService {
         transactionScope,
       });
     }
+
+    const heapDeltaMegabytes =
+      (process.memoryUsage().heapUsed - heapUsedBeforeBytes) /
+      BYTES_PER_MEGABYTE;
+
+    this.logger.log(
+      `[ReconcileMem] messageThreadTarget threads=${uniqueMessageThreadIds.length} messagesLoaded=${messagesLoaded} participantsLoaded=${participantsLoaded} heapDeltaMB=${heapDeltaMegabytes.toFixed(1)}`,
+    );
   }
 
   private async reconcileTargets({

--- a/packages/twenty-server/src/modules/match-participant/participant-target-reconciliation.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/participant-target-reconciliation.service.ts
@@ -161,8 +161,9 @@ export class ParticipantTargetReconciliationService {
       transactionScope,
     );
 
-    // Diagnostic: size what one reconcile loads and how much heap it retains,
-    // to confirm whether this path (added in #24778) drives worker memory.
+    // TODO: diagnostic only — remove once the worker OOM root cause is confirmed.
+    // Size what one reconcile loads and how much heap it retains, to confirm
+    // whether this path (added in #24778) drives worker memory.
     const heapUsedBeforeBytes = process.memoryUsage().heapUsed;
     let messagesLoaded = 0;
     let participantsLoaded = 0;


### PR DESCRIPTION
## Problem

`twenty-server-worker-default` pods OOM-restart continuously (~10/hr on v2.37.4), sawtoothing up to the 4 GiB cgroup / ~3.6 GiB V8 ceiling. There are two candidate drivers for the heap growth and we can't yet tell which dominates:

1. The in-process workspace metadata cache — capped by entry count and per-provider counts, not bytes (`workspace-cache.service.ts`), so its byte footprint is unbounded and workload-dependent.
2. Per-job transient allocations — notably the message-thread target reconciliation added in #24778, which loads whole threads (messages + participants) per import chunk.

A V8 heap snapshot would settle it, but generating one in-place reliably OOMs the pod (the generator's overhead is roughly the size of the heap, exceeding the headroom under the 4 GiB limit), so we can't pull retained-size-by-type from prod.

## What this adds

Read-only instrumentation (no behavior change) so the two paths can be separated from `kubectl logs` alone:

1. **Per-job heap attribution** (`bullmq.driver.ts`): the existing `… processed on queue …` line now carries `heapDeltaMB` and `heapUsedMB`, so heap growth is attributable by job type.
2. **Cache vs heap correlation** (`workspace-cache-metrics.service.ts`): a periodic (60s) `[WorkspaceCacheMemReport]` line — `heapUsedMB / rssMB / externalMB / oldSpaceMB / newSpaceMB / cacheEntries / cacheBytesEstimateMB / top=<top-3 providers>`. The size sampler is raised from 3 to 50 entries per provider (still off the hot path, run every 5 min with a yield between entries) so the byte estimate is accurate enough to tell a cache-dominated heap from one that is not. The byte-heavy providers are entry-capped well under 50, so they are sized in full.
3. **Reconciliation load sizing** (`participant-target-reconciliation.service.ts`): `[ReconcileMem] messageThreadTarget threads=… messagesLoaded=… participantsLoaded=… heapDeltaMB=…` per message-thread reconcile (the #24778 path).

## How to read it

- **Cache is the driver** if `oldSpaceMB` and `cacheBytesEstimateMB` climb with `heapUsedMB` over a pod's life and don't recede.
- **Per-job / reconciliation is the driver** if the largest `heapDeltaMB` values land on reconcile/import jobs and heap spikes track them; `[ReconcileMem]` shows how much each call loads.
- old-space drift = retained; new-space churn that recedes = transient.

## Interpretation caveats

These logs narrow the cause; they observe correlation, not causation. Read them accordingly:

- `heapDelta` mixes uncollected garbage with retained memory (GC timing), and jobs also populate the shared cache, so a large per-job delta is not proof the job retained that memory. Trust the baseline/old-space trend for retention, and the exact counts (`messagesLoaded`, `participantsLoaded`, `cacheEntries`) over the deltas.
- Concurrency > 1 queues (not `worker-default`) cross-attribute per-job deltas.
- If the result is ambiguous (cache is only part of the heap), confirm causally by tightening the cache on staging and checking whether the OOM loop stops.

## Notes

- Diagnostic and temporary — revert once the root cause is confirmed.
- `process.memoryUsage()` runs twice per job (negligible, but on the job hot path, so worth removing after the investigation).
- No new PII; log volume is unchanged for #1 (fields appended to an existing line), +1 line/60s for #2, +1 line/reconcile for #3.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

