### PR TITLE
fix(website): Add redirect for '/docs' to documentation site

### DIFF
--- a/packages/twenty-website/next.config.ts
+++ b/packages/twenty-website/next.config.ts
@@ -174,6 +174,11 @@ const nextConfig: LinariaConfig = {
         permanent: true,
       },
       {
+        source: '/docs',
+        destination: 'https://docs.twenty.com/',
+        permanent: true,
+      },
+      {
         source: '/resources/why-twenty',
         destination: '/why-twenty',
         permanent: true,


### PR DESCRIPTION
Micro-PR to redirect `twenty.com/docs` to `docs.twenty.com`

Small utility, I keep hitting 404 😅

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

