### PR TITLE
Remove the automatic snackbar when a front component copies to the clipboard

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/front-components/my-profile/markdown-editor.tsx
+++ b/packages/twenty-apps/internal/twenty-partners/src/modules/partner/self-service/front-components/my-profile/markdown-editor.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { copyToClipboard } from 'twenty-sdk/front-component';
+import { copyToClipboard, enqueueSnackbar } from 'twenty-sdk/front-component';
 
 import { COLORS, FONT } from 'src/modules/shared/front-components/palette';
 import { MarkdownContent } from './markdown-render';
@@ -52,8 +52,11 @@ const buildPrompt = (value: string): string =>
   ].join('\n');
 
 // The front-component runs in a Web Worker with no clipboard API; copyToClipboard is a host
-// action that copies on the main thread and shows its own confirmation snackbar.
-const copyPrompt = (value: string): Promise<void> => copyToClipboard(buildPrompt(value));
+// action that copies on the main thread, silently — the confirmation is ours to show.
+const copyPrompt = async (value: string): Promise<void> => {
+  await copyToClipboard(buildPrompt(value));
+  await enqueueSnackbar({ message: 'Prompt copied to clipboard', variant: 'success' });
+};
 
 const EDITOR_HEIGHT = 280;
 

--- a/packages/twenty-front/src/hooks/__tests__/useCopyToClipboard.test.tsx
+++ b/packages/twenty-front/src/hooks/__tests__/useCopyToClipboard.test.tsx
@@ -1,0 +1,112 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { act, renderHook } from '@testing-library/react';
+
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
+
+const mockEnqueueSuccessSnackBar = jest.fn();
+const mockEnqueueErrorSnackBar = jest.fn();
+
+jest.mock('@/ui/feedback/snack-bar-manager/hooks/useSnackBar', () => ({
+  useSnackBar: () => ({
+    enqueueSuccessSnackBar: mockEnqueueSuccessSnackBar,
+    enqueueErrorSnackBar: mockEnqueueErrorSnackBar,
+  }),
+}));
+
+const mockWriteText = jest.fn();
+
+const setIsSecureContext = (isSecureContext: boolean) => {
+  Object.defineProperty(window, 'isSecureContext', {
+    configurable: true,
+    value: isSecureContext,
+  });
+};
+
+const renderUseCopyToClipboard = () =>
+  renderHook(() => useCopyToClipboard(), {
+    wrapper: ({ children }) => I18nProvider({ i18n, children }),
+  });
+
+describe('useCopyToClipboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWriteText.mockResolvedValue(undefined);
+    // jsdom ships no clipboard implementation
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: mockWriteText },
+    });
+    setIsSecureContext(true);
+  });
+
+  describe('copyToClipboard', () => {
+    it('should copy the text and enqueue the default success snack bar', async () => {
+      const { result } = renderUseCopyToClipboard();
+
+      await act(async () => {
+        await result.current.copyToClipboard('hello clipboard');
+      });
+
+      expect(mockWriteText).toHaveBeenCalledWith('hello clipboard');
+      expect(mockEnqueueSuccessSnackBar).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Copied to clipboard' }),
+      );
+    });
+
+    it('should enqueue the provided message instead of the default one', async () => {
+      const { result } = renderUseCopyToClipboard();
+
+      await act(async () => {
+        await result.current.copyToClipboard('hello', 'Email copied');
+      });
+
+      expect(mockEnqueueSuccessSnackBar).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Email copied' }),
+      );
+    });
+  });
+
+  describe('copyToClipboardWithoutSuccessSnackBar', () => {
+    it('should copy the text without enqueuing any snack bar', async () => {
+      const { result } = renderUseCopyToClipboard();
+
+      await act(async () => {
+        await result.current.copyToClipboardWithoutSuccessSnackBar(
+          'hello clipboard',
+        );
+      });
+
+      expect(mockWriteText).toHaveBeenCalledWith('hello clipboard');
+      expect(mockEnqueueSuccessSnackBar).not.toHaveBeenCalled();
+      expect(mockEnqueueErrorSnackBar).not.toHaveBeenCalled();
+    });
+
+    it('should enqueue an error snack bar when the write fails', async () => {
+      mockWriteText.mockRejectedValue(new Error('denied'));
+
+      const { result } = renderUseCopyToClipboard();
+
+      await act(async () => {
+        await result.current.copyToClipboardWithoutSuccessSnackBar('hello');
+      });
+
+      expect(mockEnqueueErrorSnackBar).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Couldn't copy to clipboard" }),
+      );
+    });
+
+    it('should not write to the clipboard outside a secure context', async () => {
+      setIsSecureContext(false);
+
+      const { result } = renderUseCopyToClipboard();
+
+      await act(async () => {
+        await result.current.copyToClipboardWithoutSuccessSnackBar('hello');
+      });
+
+      expect(mockWriteText).not.toHaveBeenCalled();
+      expect(mockEnqueueErrorSnackBar).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
+++ b/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
@@ -1,5 +1,6 @@
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useLingui } from '@lingui/react/macro';
+import { isDefined } from 'twenty-shared/utils';
 import { IconCopy, IconExclamationCircle } from 'twenty-ui/icon';
 import { useContext } from 'react';
 import { ThemeContext } from 'twenty-ui/theme-constants';
@@ -27,7 +28,7 @@ export const useCopyToClipboard = () => {
     try {
       await navigator.clipboard.writeText(valueAsString);
 
-      if (successMessage === null) {
+      if (!isDefined(successMessage)) {
         return;
       }
 

--- a/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
+++ b/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
@@ -8,7 +8,10 @@ export const useCopyToClipboard = () => {
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
   const { t } = useLingui();
 
-  const copyToClipboard = async (valueAsString: string, message?: string) => {
+  const writeToClipboard = async (
+    valueAsString: string,
+    successMessage: string | null,
+  ) => {
     if (!window.isSecureContext) {
       enqueueErrorSnackBar({
         message: t`Clipboard requires a secure connection (HTTPS). Please access this app over HTTPS to enable copying.`,
@@ -24,8 +27,12 @@ export const useCopyToClipboard = () => {
     try {
       await navigator.clipboard.writeText(valueAsString);
 
+      if (successMessage === null) {
+        return;
+      }
+
       enqueueSuccessSnackBar({
-        message: message || t`Copied to clipboard`,
+        message: successMessage,
         options: {
           icon: <IconCopy size={theme.icon.size.md} />,
           duration: 2000,
@@ -42,5 +49,11 @@ export const useCopyToClipboard = () => {
     }
   };
 
-  return { copyToClipboard };
+  const copyToClipboard = async (valueAsString: string, message?: string) =>
+    await writeToClipboard(valueAsString, message || t`Copied to clipboard`);
+
+  const copyToClipboardWithoutSuccessSnackBar = async (valueAsString: string) =>
+    await writeToClipboard(valueAsString, null);
+
+  return { copyToClipboard, copyToClipboardWithoutSuccessSnackBar };
 };

--- a/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
+++ b/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
@@ -47,7 +47,7 @@ const mockEnqueueInfoSnackBar = jest.fn();
 const mockEnqueueWarningSnackBar = jest.fn();
 const mockCloseSidePanelMenu = jest.fn();
 const mockSetCommandMenuItemProgress = jest.fn();
-const mockCopyToClipboard = jest.fn();
+const mockCopyToClipboardWithoutSuccessSnackBar = jest.fn();
 const mockDirectUploadFile = jest.fn();
 const mockSetRecordPageActiveTabId = jest.fn();
 const mockStorageSet = jest.fn();
@@ -158,7 +158,8 @@ jest.mock('@/ui/utilities/state/jotai/hooks/useSetAtomFamilyState', () => ({
 
 jest.mock('~/hooks/useCopyToClipboard', () => ({
   useCopyToClipboard: () => ({
-    copyToClipboard: mockCopyToClipboard,
+    copyToClipboardWithoutSuccessSnackBar:
+      mockCopyToClipboardWithoutSuccessSnackBar,
   }),
 }));
 
@@ -1090,7 +1091,7 @@ describe('useFrontComponentExecutionContext', () => {
   });
 
   describe('copyToClipboard', () => {
-    it('should call useCopyToClipboard with the provided text and a preview message', async () => {
+    it('should copy the provided text without enqueuing a success snack bar', async () => {
       const { result } = renderUseFrontComponentExecutionContext({
         frontComponentId: FRONT_COMPONENT_ID,
       });
@@ -1101,29 +1102,10 @@ describe('useFrontComponentExecutionContext', () => {
         );
       });
 
-      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledWith(
         'hello clipboard',
-        'Application copied "hello clipboard" to your clipboard',
       );
-    });
-
-    it('should truncate the preview when the text is longer than the preview length', async () => {
-      const { result } = renderUseFrontComponentExecutionContext({
-        frontComponentId: FRONT_COMPONENT_ID,
-      });
-
-      const longText = 'a'.repeat(50);
-
-      await act(async () => {
-        await result.current.frontComponentHostCommunicationApi.copyToClipboard(
-          longText,
-        );
-      });
-
-      expect(mockCopyToClipboard).toHaveBeenCalledWith(
-        longText,
-        `Application copied "${'a'.repeat(30)}…" to your clipboard`,
-      );
+      expect(mockEnqueueSuccessSnackBar).not.toHaveBeenCalled();
     });
 
     it.each([
@@ -1143,7 +1125,7 @@ describe('useFrontComponentExecutionContext', () => {
         );
       });
 
-      expect(mockCopyToClipboard).not.toHaveBeenCalled();
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).not.toHaveBeenCalled();
     });
 
     it('should silently drop payloads exceeding the maximum length', async () => {
@@ -1159,7 +1141,7 @@ describe('useFrontComponentExecutionContext', () => {
         );
       });
 
-      expect(mockCopyToClipboard).not.toHaveBeenCalled();
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).not.toHaveBeenCalled();
     });
 
     it('should rate-limit consecutive calls within one second', async () => {
@@ -1176,10 +1158,9 @@ describe('useFrontComponentExecutionContext', () => {
         );
       });
 
-      expect(mockCopyToClipboard).toHaveBeenCalledTimes(1);
-      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledTimes(1);
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledWith(
         'first',
-        expect.stringContaining('first'),
       );
     });
 
@@ -1207,16 +1188,14 @@ describe('useFrontComponentExecutionContext', () => {
         );
       });
 
-      expect(mockCopyToClipboard).toHaveBeenCalledTimes(2);
-      expect(mockCopyToClipboard).toHaveBeenNthCalledWith(
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledTimes(2);
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenNthCalledWith(
         1,
         'first',
-        expect.stringContaining('first'),
       );
-      expect(mockCopyToClipboard).toHaveBeenNthCalledWith(
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenNthCalledWith(
         2,
         'second',
-        expect.stringContaining('second'),
       );
 
       dateNowSpy.mockRestore();

--- a/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
+++ b/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
@@ -1091,7 +1091,7 @@ describe('useFrontComponentExecutionContext', () => {
   });
 
   describe('copyToClipboard', () => {
-    it('should copy the provided text without enqueuing a success snack bar', async () => {
+    it('should copy the provided text through the silent clipboard helper', async () => {
       const { result } = renderUseFrontComponentExecutionContext({
         frontComponentId: FRONT_COMPONENT_ID,
       });
@@ -1105,7 +1105,6 @@ describe('useFrontComponentExecutionContext', () => {
       expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledWith(
         'hello clipboard',
       );
-      expect(mockEnqueueSuccessSnackBar).not.toHaveBeenCalled();
     });
 
     it.each([

--- a/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
+++ b/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
@@ -1158,7 +1158,9 @@ describe('useFrontComponentExecutionContext', () => {
         );
       });
 
-      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledTimes(1);
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledTimes(
+        1,
+      );
       expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledWith(
         'first',
       );
@@ -1188,7 +1190,9 @@ describe('useFrontComponentExecutionContext', () => {
         );
       });
 
-      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledTimes(2);
+      expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenCalledTimes(
+        2,
+      );
       expect(mockCopyToClipboardWithoutSuccessSnackBar).toHaveBeenNthCalledWith(
         1,
         'first',

--- a/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
+++ b/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
@@ -60,7 +60,6 @@ import { FileFolder } from '~/generated-metadata/graphql';
 
 const FRONT_COMPONENT_CLIPBOARD_MAX_LENGTH = 64 * 1024;
 const FRONT_COMPONENT_CLIPBOARD_RATE_LIMIT_MS = 1000;
-const FRONT_COMPONENT_CLIPBOARD_PREVIEW_LENGTH = 30;
 
 const FRONT_COMPONENT_UPLOAD_FILE_NAME_MAX_LENGTH = 200;
 
@@ -159,9 +158,9 @@ export const useFrontComponentExecutionContext = ({
     enqueueWarningSnackBar,
   } = useSnackBar();
   const { closeSidePanelMenu } = useSidePanelMenu();
-  const { copyToClipboard: copyToClipboardWithSnackbar } = useCopyToClipboard();
+  const { copyToClipboardWithoutSuccessSnackBar } = useCopyToClipboard();
   const { uploadFile: uploadFileToFilesField } = useDirectFileUpload();
-  const { t, i18n } = useLingui();
+  const { i18n } = useLingui();
   // oxlint-disable-next-line twenty/no-state-useref
   const lastCopyToClipboardCallAtRef = useRef<number>(Number.NEGATIVE_INFINITY);
   const setCommandMenuItemProgress = useSetAtomFamilyState(
@@ -488,15 +487,9 @@ export const useFrontComponentExecutionContext = ({
       }
       lastCopyToClipboardCallAtRef.current = now;
 
-      const preview =
-        text.length > FRONT_COMPONENT_CLIPBOARD_PREVIEW_LENGTH
-          ? `${text.slice(0, FRONT_COMPONENT_CLIPBOARD_PREVIEW_LENGTH)}…`
-          : text;
-
-      await copyToClipboardWithSnackbar(
-        text,
-        t`Application copied "${preview}" to your clipboard`,
-      );
+      // Front components notify their own users, so a host success snackbar
+      // would show up on top of theirs.
+      await copyToClipboardWithoutSuccessSnackBar(text);
     };
 
   const hostUploadFile: FrontComponentHostCommunicationApi['uploadFile'] =


### PR DESCRIPTION
Closes twentyhq/core-team-issues#2648

### Problem

When a front component calls `copyToClipboard` from the SDK, the host enqueued its own success snackbar (`Application copied "…" to your clipboard`). Applications already notify their users after a copy, so two notifications stacked up.

### Fix

- `useCopyToClipboard` now exposes `copyToClipboardWithoutSuccessSnackBar` alongside `copyToClipboard`; both share the same clipboard write and error handling, only the success snackbar differs.
- `useFrontComponentExecutionContext` uses that variant, so the host no longer notifies on a successful copy. The preview/truncation logic that only existed to build that message is gone.
- The secure-context and copy-failure snackbars are kept: `copyToClipboard` resolves to `void`, so an application has no way to detect and report those itself.

Everything else is unchanged — the host API signature, the size limit and the 1s rate limit still apply.

### The one app that relied on the host snackbar

`twenty-partners`' markdown editor had no local feedback of its own — no state, no `enqueueSnackbar`, and a comment documenting that its **Copy prompt** button leaned on the host confirmation. It would have gone silent, so it now enqueues its own snackbar.

Auditing the rest: `copyToClipboard` has exactly one caller across `packages/twenty-apps/` (this one), no app reaches for `navigator.clipboard` directly, and the apps that need feedback — discord, fireflies — already call `enqueueSnackbar` themselves.

### Tests

- New `useCopyToClipboard.test.tsx` exercises the real hook with `navigator.clipboard` and `window.isSecureContext` stubbed: the default and custom success messages, silence on a successful silent copy, and the error snackbar on both a rejected write and a non-secure context.
- `useFrontComponentExecutionContext.test.tsx` mocks the clipboard hook wholesale, so it now only asserts what it can at that boundary — that the host delegates to the silent variant. The preview-truncation test is dropped along with the preview.

https://claude.ai/code/session_01U8czApmCbTRTznKCExsXSW