### PR TITLE
Fix field editing in the side panel by scoping field list anchor ids

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/anchored-portal/__tests__/anchoredPortalInstanceIdAgreement.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/anchored-portal/__tests__/anchoredPortalInstanceIdAgreement.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { RecordFieldListComponentInstanceContext } from '@/object-record/record-field-list/states/contexts/RecordFieldListComponentInstanceContext';
+import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+
+const SIDE_PANEL_INSTANCE_ID = 'side-panel-page-instance';
+const BASE_INSTANCE_ID = 'fields-widget-1-record-1';
+const RECORD_ID = 'record-1';
+const FIELD_NAME = 'name';
+
+const buildWrapper =
+  (surfaceType: 'main' | 'side-panel') =>
+  ({ children }: { children: ReactNode }) => (
+    <WorkspaceSurfaceContext.Provider
+      value={{
+        type: surfaceType,
+        instanceId:
+          surfaceType === 'side-panel' ? SIDE_PANEL_INSTANCE_ID : 'main',
+        ownsRouteLocation: surfaceType === 'main',
+      }}
+    >
+      {children}
+    </WorkspaceSurfaceContext.Provider>
+  );
+
+// A field list renders its anchor elements with `prefix: instanceId`, and the
+// anchored portal later finds them with document.getElementById after resolving
+// the same context id through useAvailableComponentInstanceIdOrThrow. That
+// resolution surface-scopes the id, so a list that provides an unscoped id
+// renders anchors the portal can never find, and no editor opens.
+const renderIds = ({
+  surfaceType,
+  provideScopedId,
+}: {
+  surfaceType: 'main' | 'side-panel';
+  provideScopedId: boolean;
+}) =>
+  renderHook(
+    () => {
+      const scopedInstanceId =
+        useWorkspaceSurfaceScopedComponentInstanceId(BASE_INSTANCE_ID);
+      const providedInstanceId = provideScopedId
+        ? scopedInstanceId
+        : BASE_INSTANCE_ID;
+
+      return { providedInstanceId };
+    },
+    { wrapper: buildWrapper(surfaceType) },
+  );
+
+const renderResolvedId = ({
+  surfaceType,
+  providedInstanceId,
+}: {
+  surfaceType: 'main' | 'side-panel';
+  providedInstanceId: string;
+}) =>
+  renderHook(
+    () =>
+      useAvailableComponentInstanceIdOrThrow(
+        RecordFieldListComponentInstanceContext,
+      ),
+    {
+      wrapper: ({ children }: { children: ReactNode }) => {
+        const Surface = buildWrapper(surfaceType);
+
+        return (
+          <Surface>
+            <RecordFieldListComponentInstanceContext.Provider
+              value={{ instanceId: providedInstanceId }}
+            >
+              {children}
+            </RecordFieldListComponentInstanceContext.Provider>
+          </Surface>
+        );
+      },
+    },
+  );
+
+const anchorIdFor = (prefix: string) =>
+  getRecordFieldInputInstanceId({
+    recordId: RECORD_ID,
+    fieldName: FIELD_NAME,
+    prefix,
+  });
+
+describe('field list anchor ids and anchored portal lookups', () => {
+  it.each(['main', 'side-panel'] as const)(
+    'agree on %s when the list provides a surface-scoped instance id',
+    (surfaceType) => {
+      const { result: provided } = renderIds({
+        surfaceType,
+        provideScopedId: true,
+      });
+      const providedInstanceId = provided.current.providedInstanceId;
+
+      const { result: resolved } = renderResolvedId({
+        surfaceType,
+        providedInstanceId,
+      });
+
+      expect(anchorIdFor(resolved.current)).toBe(
+        anchorIdFor(providedInstanceId),
+      );
+    },
+  );
+
+  it('disagree in a side panel when the list provides an unscoped instance id', () => {
+    const { result: provided } = renderIds({
+      surfaceType: 'side-panel',
+      provideScopedId: false,
+    });
+    const providedInstanceId = provided.current.providedInstanceId;
+
+    const { result: resolved } = renderResolvedId({
+      surfaceType: 'side-panel',
+      providedInstanceId,
+    });
+
+    // This is the regression: document.getElementById(portal id) misses the
+    // anchor the list rendered, so RecordInlineCellAnchoredPortal renders null.
+    expect(anchorIdFor(resolved.current)).not.toBe(
+      anchorIdFor(providedInstanceId),
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field-list/components/RecordFieldList.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/components/RecordFieldList.tsx
@@ -22,6 +22,7 @@ import { useRecordShowContainerActions } from '@/object-record/record-show/hooks
 import { useRecordShowContainerData } from '@/object-record/record-show/hooks/useRecordShowContainerData';
 import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
 import { getObjectPermissionsFromMapByObjectMetadataId } from '@/settings/roles/role-permissions/objects-permissions/utils/getObjectPermissionsFromMapByObjectMetadataId';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { FieldMetadataType } from 'twenty-shared/types';
 
@@ -36,7 +37,7 @@ type RecordFieldListProps = {
 };
 
 export const RecordFieldList = ({
-  instanceId,
+  instanceId: instanceIdFromProps,
   objectNameSingular,
   objectRecordId,
   showDuplicatesSection = true,
@@ -44,6 +45,12 @@ export const RecordFieldList = ({
   excludeFieldMetadataIds = [],
   excludeCreatedAtAndUpdatedAt = true,
 }: RecordFieldListProps) => {
+  // Anchored portals look this id up in the DOM after resolving it through
+  // useAvailableComponentInstanceIdOrThrow, which surface-scopes it. Scoping it
+  // here keeps the rendered anchor ids and that lookup on the same string.
+  const instanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId(instanceIdFromProps);
+
   const { recordLoading } = useRecordShowContainerData({
     objectRecordId,
   });

--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsWidget.tsx
@@ -11,6 +11,7 @@ import { useFieldsWidgetGroupsForDisplay } from '@/page-layout/widgets/fields/ho
 import { useFieldsWidgetHiddenFieldsForDisplay } from '@/page-layout/widgets/fields/hooks/useFieldsWidgetHiddenFieldsForDisplay';
 import { useTargetRecord } from '@/ui/layout/contexts/useTargetRecord';
 import { useWorkspaceSurface } from '@/ui/layout/hooks/useWorkspaceSurface';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { SidePanelProvider } from '@/ui/layout/side-panel/contexts/SidePanelContext';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
@@ -55,7 +56,12 @@ export const FieldsWidget = ({ widget }: FieldsWidgetProps) => {
   const targetRecord = useTargetRecord();
   const isInSidePanel = useWorkspaceSurface().type === 'side-panel';
 
-  const instanceId = `fields-${widget.id}-${targetRecord.id}${isInSidePanel ? '-side-panel' : ''}`;
+  // Anchored portals look this id up in the DOM after resolving it through
+  // useAvailableComponentInstanceIdOrThrow, which surface-scopes it. Scoping it
+  // here keeps the rendered anchor ids and that lookup on the same string.
+  const instanceId = useWorkspaceSurfaceScopedComponentInstanceId(
+    `fields-${widget.id}-${targetRecord.id}`,
+  );
 
   const { objectMetadataItem } = useObjectMetadataItem({
     objectNameSingular: targetRecord.targetObjectNameSingular,

--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/__stories__/FieldsWidget.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/__stories__/FieldsWidget.stories.tsx
@@ -2,7 +2,7 @@ import { type ApolloClient } from '@apollo/client';
 import { useApolloClient } from '@apollo/client/react';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { MemoryRouter } from 'react-router-dom';
-import { expect, waitFor, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { isMinimalMetadataReadyState } from '@/metadata-store/states/isMinimalMetadataReadyState';
 import { ApolloCoreClientContext } from '@/object-metadata/contexts/ApolloCoreClientContext';
@@ -20,6 +20,7 @@ import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { FieldsWidget } from '@/page-layout/widgets/fields/components/FieldsWidget';
 import { WidgetComponentInstanceContext } from '@/page-layout/widgets/states/contexts/WidgetComponentInstanceContext';
 import { LayoutRenderingProvider } from '@/ui/layout/contexts/LayoutRenderingContext';
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
 import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { type ViewWithRelations } from '@/views/types/ViewWithRelations';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
@@ -247,7 +248,15 @@ const createViewFieldGroup = (
   viewFields,
 });
 
-const FieldsWidgetStoryRenderer = ({ view }: { view: ViewWithRelations }) => {
+const SIDE_PANEL_SURFACE_INSTANCE_ID = 'fields-widget-story-side-panel';
+
+const FieldsWidgetStoryRenderer = ({
+  view,
+  surfaceType = 'main',
+}: {
+  view: ViewWithRelations;
+  surfaceType?: 'main' | 'side-panel';
+}) => {
   const widget = createFieldsWidget(FIELDS_VIEW_ID);
 
   const pageLayoutData = createPageLayoutWithWidget(
@@ -300,7 +309,18 @@ const FieldsWidgetStoryRenderer = ({ view }: { view: ViewWithRelations }) => {
                 <WidgetComponentInstanceContext.Provider
                   value={{ instanceId: widget.id }}
                 >
-                  <FieldsWidget widget={widget} />
+                  <WorkspaceSurfaceContext.Provider
+                    value={{
+                      type: surfaceType,
+                      instanceId:
+                        surfaceType === 'side-panel'
+                          ? SIDE_PANEL_SURFACE_INSTANCE_ID
+                          : 'main',
+                      ownsRouteLocation: surfaceType === 'main',
+                    }}
+                  >
+                    <FieldsWidget widget={widget} />
+                  </WorkspaceSurfaceContext.Provider>
                 </WidgetComponentInstanceContext.Provider>
               </PageLayoutContentProvider>
             </LayoutRenderingProvider>
@@ -457,4 +477,63 @@ export const Empty: Story = {
       ).toBeVisible();
     });
   },
+};
+
+// Hovering a field mounts an interactive copy of the cell through
+// RecordInlineCellAnchoredPortal, which finds its anchor with
+// document.getElementById after resolving the list instance id through
+// useAvailableComponentInstanceIdOrThrow -- and that resolution surface-scopes
+// the id. If the list rendered its anchors from an unscoped id, the lookup
+// misses, nothing interactive mounts, and the click lands on the inert display
+// underneath: the cell highlights but no editor ever opens.
+const openEditModeOnEmployees = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  const canvas = within(canvasElement);
+
+  const [employeesValue] = await canvas.findAllByText('250');
+  await userEvent.hover(employeesValue);
+
+  const hoveredValues = await canvas.findAllByText('250');
+  await userEvent.click(hoveredValues[hoveredValues.length - 1]);
+
+  await waitFor(() => {
+    expect(canvasElement.querySelector('input')).not.toBeNull();
+  });
+};
+
+const singleGroupView = () => {
+  const contactInfoFields = [
+    createViewField('vf-name', nameField.id, 0, 'group-contact-info'),
+    createViewField('vf-employees', employeesField.id, 1, 'group-contact-info'),
+  ];
+
+  return createView({
+    viewFields: contactInfoFields,
+    viewFieldGroups: [
+      createViewFieldGroup(
+        'group-contact-info',
+        'Contact Info',
+        0,
+        contactInfoFields,
+      ),
+    ],
+  });
+};
+
+export const OpensEditModeOnMainSurface: Story = {
+  render: () => <FieldsWidgetStoryRenderer view={singleGroupView()} />,
+  play: openEditModeOnEmployees,
+};
+
+export const OpensEditModeInSidePanel: Story = {
+  render: () => (
+    <FieldsWidgetStoryRenderer
+      view={singleGroupView()}
+      surfaceType="side-panel"
+    />
+  ),
+  play: openEditModeOnEmployees,
 };


### PR DESCRIPTION
Fixes the QA Scout regression on #25164: records were only editable from the index table — clicking a field in the Fields panel highlighted the cell but never opened an editor.

### Root cause

#25164 made `useAvailableComponentInstanceIdOrThrow` surface-scope every instance id it resolves. `FieldsWidget` and `RecordFieldList` still rendered their **anchor elements** from an unscoped id, while the anchored portals resolved the **scoped** one. In a side panel the two diverge:

```
anchors rendered as: fields-<widget>-<record>-side-panel
portal looked up:    fields-<widget>-<record>-<surfaceInstanceId>
```

`RecordInlineCellAnchoredPortal` does `document.getElementById(...)` on that id and returns `null` when it misses. So hovering a field mounted no interactive cell, and the click landed on the inert display underneath — the cell highlighted, no editor opened, nothing could be typed. The edit-mode portal missed for the same reason.

`FieldsWidget` had also hand-rolled its own `-side-panel` suffix, which is what made the two ids differ rather than merely both being unscoped.

### Fix

Both components scope their instance id **once**, where it is created, so the ids they render anchors from and the ids the portals resolve are the same string. Scoping is idempotent (`getWorkspaceSurfaceScopedComponentInstanceId` returns early when the id already ends with the surface id), so consumers re-scoping it is a no-op. The redundant `-side-panel` suffix is dropped.

### Tests

The existing `FieldsWidget` stories only rendered on the main surface and never opened an editor, which is why CI stayed green through the regression. This adds:

- `OpensEditModeOnMainSurface` and `OpensEditModeInSidePanel` — hover a field, click it, assert an input mounts. The side-panel one is the regression guard.
- A unit test pinning the id agreement the portals depend on, including the side-panel case that used to diverge.

### Verification

`twenty-front` typecheck, lint and oxfmt are clean locally. The two new stories were built into storybook successfully but I have **not** run them in a browser locally — CI is the check on those. I have also not verified this against a running app, so the fix is reasoned from the code path rather than observed end to end.

### Scope note

This addresses the **side-panel** path, which is where the scoped/unscoped ids provably diverge. The QA Scout report also mentions the full record page (`/object/company/<id>`); on a `main` surface `getWorkspaceSurfaceScopedComponentInstanceId` returns the id unchanged, so that half of the report is not explained by this bug and may be a separate issue or a mis-attribution. Worth re-running QA Scout after this lands to confirm.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

