### PR TITLE
Fix workflow side panel state sharing

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useWorkflowCommandMenu.test.tsx
+++ b/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useWorkflowCommandMenu.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { SIDE_PANEL_COMPONENT_INSTANCE_ID } from '@/side-panel/constants/SidePanelComponentInstanceId';
 import { useSidePanelWorkflowNavigation } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation';
 import { sidePanelWorkflowIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowIdComponentState';
+import { sidePanelWorkflowVisualizerComponentInstanceIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowVisualizerComponentInstanceIdComponentState';
 import { sidePanelWorkflowVersionIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowVersionIdComponentState';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
 import { contextStoreCurrentViewTypeComponentState } from '@/context-store/states/contextStoreCurrentViewTypeComponentState';
@@ -90,6 +91,11 @@ const renderHooks = () => {
         sidePanelWorkflowVersionIdComponentState,
         'mocked-uuid',
       );
+      const sidePanelWorkflowVisualizerComponentInstanceId =
+        useAtomComponentStateValue(
+          sidePanelWorkflowVisualizerComponentInstanceIdComponentState,
+          'mocked-uuid',
+        );
       const { getIcon } = useIcons();
 
       return {
@@ -100,6 +106,7 @@ const renderHooks = () => {
         openWorkflowViewStepInSidePanel,
         sidePanelWorkflowId,
         sidePanelWorkflowVersionId,
+        sidePanelWorkflowVisualizerComponentInstanceId,
         contextStoreCurrentObjectMetadataItemId,
         contextStoreTargetedRecordsRule,
         contextStoreNumberOfSelectedRecords,
@@ -127,6 +134,9 @@ describe('useSidePanelWorkflowNavigation', () => {
     });
 
     expect(result.current.sidePanelWorkflowId).toBe('test-workflow-id');
+    expect(result.current.sidePanelWorkflowVisualizerComponentInstanceId).toBe(
+      'test-workflow-id',
+    );
 
     expect(mockNavigateCommandMenu).toHaveBeenCalledWith({
       page: SidePanelPages.WorkflowTriggerSelectType,
@@ -205,6 +215,9 @@ describe('useSidePanelWorkflowNavigation', () => {
 
     expect(result.current.sidePanelWorkflowId).toBe('test-workflow-id');
     expect(result.current.sidePanelWorkflowVersionId).toBe(
+      'test-workflow-version-id',
+    );
+    expect(result.current.sidePanelWorkflowVisualizerComponentInstanceId).toBe(
       'test-workflow-version-id',
     );
 

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope.tsx
@@ -1,0 +1,23 @@
+import { useSidePanelWorkflowVisualizerComponentInstanceIdOrThrow } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowVisualizerComponentInstanceIdOrThrow';
+import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
+import { type ReactNode } from 'react';
+
+export const SidePanelWorkflowVisualizerScope = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const workflowVisualizerComponentInstanceId =
+    useSidePanelWorkflowVisualizerComponentInstanceIdOrThrow();
+
+  return (
+    <WorkflowVisualizerComponentInstanceContext.Provider
+      value={{
+        instanceId: workflowVisualizerComponentInstanceId,
+        shouldScopeToWorkspaceSurface: false,
+      }}
+    >
+      {children}
+    </WorkflowVisualizerComponentInstanceContext.Provider>
+  );
+};

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/components/__tests__/SidePanelWorkflowVisualizerScope.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/components/__tests__/SidePanelWorkflowVisualizerScope.test.tsx
@@ -1,0 +1,76 @@
+import { SidePanelWorkflowVisualizerScope } from '@/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope';
+import { sidePanelWorkflowVisualizerComponentInstanceIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowVisualizerComponentInstanceIdComponentState';
+import { SidePanelPageComponentInstanceContext } from '@/side-panel/states/contexts/SidePanelPageComponentInstanceContext';
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { useAvailableComponentInstanceId } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId';
+import { useFlowOrThrow } from '@/workflow/hooks/useFlowOrThrow';
+import { flowComponentState } from '@/workflow/states/flowComponentState';
+import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
+import { render, screen } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+
+const SIDE_PANEL_PAGE_ID = 'side-panel-page-id';
+const WORKFLOW_VISUALIZER_COMPONENT_INSTANCE_ID =
+  'workflow-id-source-surface-id';
+
+const FlowVersionId = () => {
+  const flow = useFlowOrThrow();
+  const workflowVisualizerComponentInstanceId = useAvailableComponentInstanceId(
+    WorkflowVisualizerComponentInstanceContext,
+  );
+
+  return (
+    <>
+      <div>{flow.workflowVersionId}</div>
+      <div>{workflowVisualizerComponentInstanceId}</div>
+    </>
+  );
+};
+
+describe('SidePanelWorkflowVisualizerScope', () => {
+  it('reads workflow state from the visualizer that opened the side panel', () => {
+    const store = createStore();
+
+    store.set(
+      sidePanelWorkflowVisualizerComponentInstanceIdComponentState.atomFamily({
+        instanceId: SIDE_PANEL_PAGE_ID,
+      }),
+      WORKFLOW_VISUALIZER_COMPONENT_INSTANCE_ID,
+    );
+    store.set(
+      flowComponentState.atomFamily({
+        instanceId: WORKFLOW_VISUALIZER_COMPONENT_INSTANCE_ID,
+      }),
+      {
+        workflowVersionId: 'workflow-version-id',
+        trigger: null,
+        steps: null,
+      },
+    );
+
+    render(
+      <Provider store={store}>
+        <SidePanelPageComponentInstanceContext.Provider
+          value={{ instanceId: SIDE_PANEL_PAGE_ID }}
+        >
+          <WorkspaceSurfaceContext.Provider
+            value={{
+              type: 'side-panel',
+              instanceId: SIDE_PANEL_PAGE_ID,
+              ownsRouteLocation: false,
+            }}
+          >
+            <SidePanelWorkflowVisualizerScope>
+              <FlowVersionId />
+            </SidePanelWorkflowVisualizerScope>
+          </WorkspaceSurfaceContext.Provider>
+        </SidePanelPageComponentInstanceContext.Provider>
+      </Provider>,
+    );
+
+    expect(screen.getByText('workflow-version-id')).toBeVisible();
+    expect(
+      screen.getByText(WORKFLOW_VISUALIZER_COMPONENT_INSTANCE_ID),
+    ).toBeVisible();
+  });
+});

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation.ts
@@ -2,9 +2,14 @@ import { useNavigateSidePanel } from '@/side-panel/hooks/useNavigateSidePanel';
 import { sidePanelWorkflowIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowIdComponentState';
 import { sidePanelWorkflowRunIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowRunIdComponentState';
 import { sidePanelWorkflowStepIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowStepIdComponentState';
+import { sidePanelWorkflowVisualizerComponentInstanceIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowVisualizerComponentInstanceIdComponentState';
 import { sidePanelWorkflowVersionIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowVersionIdComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceIdResolver } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { useAvailableComponentInstanceId } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId';
 import { type WorkflowRunStepStatus } from '@/workflow/types/Workflow';
+import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
 import { useSetInitialWorkflowRunSidePanelTab } from '@/workflow/workflow-diagram/hooks/useSetInitialWorkflowRunSidePanelTab';
+import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
 import { workflowSelectedNodeComponentState } from '@/workflow/workflow-diagram/states/workflowSelectedNodeComponentState';
 import { t } from '@lingui/core/macro';
 import { useCallback } from 'react';
@@ -23,10 +28,43 @@ export const useSidePanelWorkflowNavigation = () => {
   const { navigateSidePanel } = useNavigateSidePanel();
   const { setInitialWorkflowRunSidePanelTab } =
     useSetInitialWorkflowRunSidePanelTab();
+  const inheritedWorkflowVisualizerComponentInstanceId =
+    useAvailableComponentInstanceId(WorkflowVisualizerComponentInstanceContext);
+  const resolveWorkspaceSurfaceScopedComponentInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceIdResolver();
+
+  const setWorkflowVisualizerComponentInstanceIdForSidePanelPage = useCallback(
+    ({ pageId, recordId }: { pageId: string; recordId: string }) => {
+      const workflowVisualizerComponentInstanceId =
+        inheritedWorkflowVisualizerComponentInstanceId ??
+        resolveWorkspaceSurfaceScopedComponentInstanceId(
+          getWorkflowVisualizerComponentInstanceId({ recordId }),
+        );
+
+      store.set(
+        sidePanelWorkflowVisualizerComponentInstanceIdComponentState.atomFamily(
+          { instanceId: pageId },
+        ),
+        workflowVisualizerComponentInstanceId,
+      );
+
+      return workflowVisualizerComponentInstanceId;
+    },
+    [
+      inheritedWorkflowVisualizerComponentInstanceId,
+      resolveWorkspaceSurfaceScopedComponentInstanceId,
+      store,
+    ],
+  );
 
   const openWorkflowTriggerTypeInSidePanel = useCallback(
     (workflowId: string) => {
       const pageId = v4();
+
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage({
+        pageId,
+        recordId: workflowId,
+      });
 
       store.set(
         sidePanelWorkflowIdComponentState.atomFamily({
@@ -42,12 +80,21 @@ export const useSidePanelWorkflowNavigation = () => {
         pageId,
       });
     },
-    [navigateSidePanel, store],
+    [
+      navigateSidePanel,
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage,
+      store,
+    ],
   );
 
   const openWorkflowCreateStepInSidePanel = useCallback(
     (workflowId: string) => {
       const pageId = v4();
+
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage({
+        pageId,
+        recordId: workflowId,
+      });
 
       store.set(
         sidePanelWorkflowIdComponentState.atomFamily({
@@ -63,7 +110,11 @@ export const useSidePanelWorkflowNavigation = () => {
         pageId,
       });
     },
-    [navigateSidePanel, store],
+    [
+      navigateSidePanel,
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage,
+      store,
+    ],
   );
 
   const openWorkflowEditStepInSidePanel = useCallback(
@@ -74,6 +125,12 @@ export const useSidePanelWorkflowNavigation = () => {
       stepId?: string,
     ) => {
       const pageId = v4();
+
+      const workflowVisualizerComponentInstanceId =
+        setWorkflowVisualizerComponentInstanceIdForSidePanelPage({
+          pageId,
+          recordId: workflowId,
+        });
 
       store.set(
         sidePanelWorkflowIdComponentState.atomFamily({
@@ -92,7 +149,7 @@ export const useSidePanelWorkflowNavigation = () => {
 
         store.set(
           workflowSelectedNodeComponentState.atomFamily({
-            instanceId: workflowId,
+            instanceId: workflowVisualizerComponentInstanceId,
           }),
           stepId,
         );
@@ -105,12 +162,21 @@ export const useSidePanelWorkflowNavigation = () => {
         pageId,
       });
     },
-    [navigateSidePanel, store],
+    [
+      navigateSidePanel,
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage,
+      store,
+    ],
   );
 
   const openWorkflowEditStepTypeInSidePanel = useCallback(
     (workflowId: string) => {
       const pageId = v4();
+
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage({
+        pageId,
+        recordId: workflowId,
+      });
 
       store.set(
         sidePanelWorkflowIdComponentState.atomFamily({
@@ -126,7 +192,11 @@ export const useSidePanelWorkflowNavigation = () => {
         pageId,
       });
     },
-    [navigateSidePanel, store],
+    [
+      navigateSidePanel,
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage,
+      store,
+    ],
   );
 
   const openWorkflowViewStepInSidePanel = useCallback(
@@ -144,6 +214,12 @@ export const useSidePanelWorkflowNavigation = () => {
       stepId?: string;
     }) => {
       const pageId = v4();
+
+      const workflowVisualizerComponentInstanceId =
+        setWorkflowVisualizerComponentInstanceIdForSidePanelPage({
+          pageId,
+          recordId: workflowVersionId,
+        });
 
       store.set(
         sidePanelWorkflowIdComponentState.atomFamily({
@@ -168,7 +244,7 @@ export const useSidePanelWorkflowNavigation = () => {
 
         store.set(
           workflowSelectedNodeComponentState.atomFamily({
-            instanceId: workflowVersionId,
+            instanceId: workflowVisualizerComponentInstanceId,
           }),
           stepId,
         );
@@ -181,7 +257,11 @@ export const useSidePanelWorkflowNavigation = () => {
         pageId,
       });
     },
-    [navigateSidePanel, store],
+    [
+      navigateSidePanel,
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage,
+      store,
+    ],
   );
 
   const openWorkflowRunViewStepInSidePanel = useCallback(
@@ -201,6 +281,12 @@ export const useSidePanelWorkflowNavigation = () => {
       stepExecutionStatus: WorkflowRunStepStatus;
     }) => {
       const pageId = v4();
+
+      const workflowVisualizerComponentInstanceId =
+        setWorkflowVisualizerComponentInstanceIdForSidePanelPage({
+          pageId,
+          recordId: workflowRunId,
+        });
 
       store.set(
         sidePanelWorkflowIdComponentState.atomFamily({
@@ -223,7 +309,7 @@ export const useSidePanelWorkflowNavigation = () => {
 
       store.set(
         workflowSelectedNodeComponentState.atomFamily({
-          instanceId: workflowRunId,
+          instanceId: workflowVisualizerComponentInstanceId,
         }),
         workflowSelectedNode,
       );
@@ -240,7 +326,12 @@ export const useSidePanelWorkflowNavigation = () => {
         stepExecutionStatus,
       });
     },
-    [navigateSidePanel, setInitialWorkflowRunSidePanelTab, store],
+    [
+      navigateSidePanel,
+      setInitialWorkflowRunSidePanelTab,
+      setWorkflowVisualizerComponentInstanceIdForSidePanelPage,
+      store,
+    ],
   );
 
   return {

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/hooks/useSidePanelWorkflowVisualizerComponentInstanceIdOrThrow.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/hooks/useSidePanelWorkflowVisualizerComponentInstanceIdOrThrow.ts
@@ -1,0 +1,18 @@
+import { sidePanelWorkflowVisualizerComponentInstanceIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowVisualizerComponentInstanceIdComponentState';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { isDefined } from 'twenty-shared/utils';
+
+export const useSidePanelWorkflowVisualizerComponentInstanceIdOrThrow = () => {
+  const sidePanelWorkflowVisualizerComponentInstanceId =
+    useAtomComponentStateValue(
+      sidePanelWorkflowVisualizerComponentInstanceIdComponentState,
+    );
+
+  if (!isDefined(sidePanelWorkflowVisualizerComponentInstanceId)) {
+    throw new Error(
+      'Expected the workflow visualizer component instance ID to be defined',
+    );
+  }
+
+  return sidePanelWorkflowVisualizerComponentInstanceId;
+};

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/states/sidePanelWorkflowVisualizerComponentInstanceIdComponentState.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/states/sidePanelWorkflowVisualizerComponentInstanceIdComponentState.ts
@@ -1,0 +1,9 @@
+import { SidePanelPageComponentInstanceContext } from '@/side-panel/states/contexts/SidePanelPageComponentInstanceContext';
+import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
+
+export const sidePanelWorkflowVisualizerComponentInstanceIdComponentState =
+  createAtomComponentState<string | undefined>({
+    key: 'side-panel/workflow-visualizer-component-instance-id',
+    defaultValue: undefined,
+    componentInstanceContext: SidePanelPageComponentInstanceContext,
+  });

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/step/create/components/SidePanelWorkflowCreateStep.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/step/create/components/SidePanelWorkflowCreateStep.tsx
@@ -1,20 +1,10 @@
-import { useSidePanelWorkflowIdOrThrow } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowIdOrThrow';
+import { SidePanelWorkflowVisualizerScope } from '@/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope';
 import { SidePanelWorkflowCreateStepContent } from '@/side-panel/pages/workflow/step/create/components/SidePanelWorkflowCreateStepContent';
-import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
-import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
 
 export const SidePanelWorkflowCreateStep = () => {
-  const workflowId = useSidePanelWorkflowIdOrThrow();
-
   return (
-    <WorkflowVisualizerComponentInstanceContext.Provider
-      value={{
-        instanceId: getWorkflowVisualizerComponentInstanceId({
-          recordId: workflowId,
-        }),
-      }}
-    >
+    <SidePanelWorkflowVisualizerScope>
       <SidePanelWorkflowCreateStepContent />
-    </WorkflowVisualizerComponentInstanceContext.Provider>
+    </SidePanelWorkflowVisualizerScope>
   );
 };

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStep.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStep.tsx
@@ -1,21 +1,10 @@
-import { useSidePanelWorkflowIdOrThrow } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowIdOrThrow';
+import { SidePanelWorkflowVisualizerScope } from '@/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope';
 import { SidePanelWorkflowEditStepContent } from '@/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStepContent';
-import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
-import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
 
 export const SidePanelWorkflowEditStep = () => {
-  const workflowId = useSidePanelWorkflowIdOrThrow();
-  const instanceId = getWorkflowVisualizerComponentInstanceId({
-    recordId: workflowId,
-  });
-
   return (
-    <WorkflowVisualizerComponentInstanceContext.Provider
-      value={{
-        instanceId,
-      }}
-    >
+    <SidePanelWorkflowVisualizerScope>
       <SidePanelWorkflowEditStepContent />
-    </WorkflowVisualizerComponentInstanceContext.Provider>
+    </SidePanelWorkflowVisualizerScope>
   );
 };

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStepType.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStepType.tsx
@@ -1,20 +1,10 @@
-import { useSidePanelWorkflowIdOrThrow } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowIdOrThrow';
+import { SidePanelWorkflowVisualizerScope } from '@/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope';
 import { SidePanelWorkflowEditStepTypeContent } from '@/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStepTypeContent';
-import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
-import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
 
 export const SidePanelWorkflowEditStepType = () => {
-  const workflowId = useSidePanelWorkflowIdOrThrow();
-
   return (
-    <WorkflowVisualizerComponentInstanceContext.Provider
-      value={{
-        instanceId: getWorkflowVisualizerComponentInstanceId({
-          recordId: workflowId,
-        }),
-      }}
-    >
+    <SidePanelWorkflowVisualizerScope>
       <SidePanelWorkflowEditStepTypeContent />
-    </WorkflowVisualizerComponentInstanceContext.Provider>
+    </SidePanelWorkflowVisualizerScope>
   );
 };

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/step/view-run/components/SidePanelWorkflowRunViewStep.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/step/view-run/components/SidePanelWorkflowRunViewStep.tsx
@@ -1,19 +1,10 @@
+import { SidePanelWorkflowVisualizerScope } from '@/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope';
 import { SidePanelWorkflowRunViewStepContent } from '@/side-panel/pages/workflow/step/view-run/components/SidePanelWorkflowRunViewStepContent';
-import { useSidePanelWorkflowRunIdOrThrow } from '@/side-panel/pages/workflow/step/view-run/hooks/useSidePanelWorkflowRunIdOrThrow';
-import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
-import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
 
 export const SidePanelWorkflowRunViewStep = () => {
-  const workflowRunId = useSidePanelWorkflowRunIdOrThrow();
   return (
-    <WorkflowVisualizerComponentInstanceContext.Provider
-      value={{
-        instanceId: getWorkflowVisualizerComponentInstanceId({
-          recordId: workflowRunId,
-        }),
-      }}
-    >
+    <SidePanelWorkflowVisualizerScope>
       <SidePanelWorkflowRunViewStepContent />
-    </WorkflowVisualizerComponentInstanceContext.Provider>
+    </SidePanelWorkflowVisualizerScope>
   );
 };

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/step/view/components/SidePanelWorkflowViewStep.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/step/view/components/SidePanelWorkflowViewStep.tsx
@@ -1,20 +1,10 @@
-import { useSidePanelWorkflowVersionIdOrThrow } from '@/side-panel/pages/workflow/step/view/hooks/useSidePanelWorkflowVersionIdOrThrow';
+import { SidePanelWorkflowVisualizerScope } from '@/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope';
 import { SidePanelWorkflowViewStepContent } from '@/side-panel/pages/workflow/step/view/components/SidePanelWorkflowViewStepContent';
-import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
-import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
 
 export const SidePanelWorkflowViewStep = () => {
-  const workflowVersionId = useSidePanelWorkflowVersionIdOrThrow();
-
   return (
-    <WorkflowVisualizerComponentInstanceContext.Provider
-      value={{
-        instanceId: getWorkflowVisualizerComponentInstanceId({
-          recordId: workflowVersionId,
-        }),
-      }}
-    >
+    <SidePanelWorkflowVisualizerScope>
       <SidePanelWorkflowViewStepContent />
-    </WorkflowVisualizerComponentInstanceContext.Provider>
+    </SidePanelWorkflowVisualizerScope>
   );
 };

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/trigger-type/components/SidePanelWorkflowSelectTriggerType.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/trigger-type/components/SidePanelWorkflowSelectTriggerType.tsx
@@ -1,20 +1,10 @@
-import { useSidePanelWorkflowIdOrThrow } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowIdOrThrow';
+import { SidePanelWorkflowVisualizerScope } from '@/side-panel/pages/workflow/components/SidePanelWorkflowVisualizerScope';
 import { SidePanelWorkflowSelectTriggerTypeContent } from '@/side-panel/pages/workflow/trigger-type/components/SidePanelWorkflowSelectTriggerTypeContent';
-import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
-import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
 
 export const SidePanelWorkflowSelectTriggerType = () => {
-  const workflowId = useSidePanelWorkflowIdOrThrow();
-
   return (
-    <WorkflowVisualizerComponentInstanceContext.Provider
-      value={{
-        instanceId: getWorkflowVisualizerComponentInstanceId({
-          recordId: workflowId,
-        }),
-      }}
-    >
+    <SidePanelWorkflowVisualizerScope>
       <SidePanelWorkflowSelectTriggerTypeContent />
-    </WorkflowVisualizerComponentInstanceContext.Provider>
+    </SidePanelWorkflowVisualizerScope>
   );
 };

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId.ts
@@ -1,19 +1,21 @@
 import { useComponentInstanceStateContext } from '@/ui/utilities/state/component-state/hooks/useComponentInstanceStateContext';
 import { type ComponentInstanceStateContext } from '@/ui/utilities/state/component-state/types/ComponentInstanceStateContext';
+import { type ComponentStateKey } from '@/ui/utilities/state/component-state/types/ComponentStateKey';
 import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { isNonEmptyString } from '@sniptt/guards';
 
-export const useAvailableComponentInstanceId = <
-  T extends { instanceId: string },
->(
+export const useAvailableComponentInstanceId = <T extends ComponentStateKey>(
   Context: ComponentInstanceStateContext<T>,
 ): string | null => {
   const instanceStateContext = useComponentInstanceStateContext(Context);
 
   const instanceIdFromContext = instanceStateContext?.instanceId;
-  const scopedInstanceId = useWorkspaceSurfaceScopedComponentInstanceId(
-    instanceIdFromContext ?? '',
-  );
+  const workspaceSurfaceScopedInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId(instanceIdFromContext ?? '');
+  const availableInstanceId =
+    instanceStateContext?.shouldScopeToWorkspaceSurface === false
+      ? (instanceIdFromContext ?? '')
+      : workspaceSurfaceScopedInstanceId;
 
-  return isNonEmptyString(scopedInstanceId) ? scopedInstanceId : null;
+  return isNonEmptyString(availableInstanceId) ? availableInstanceId : null;
 };

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow.ts
@@ -1,10 +1,11 @@
 import { useComponentInstanceStateContext } from '@/ui/utilities/state/component-state/hooks/useComponentInstanceStateContext';
 import { type ComponentInstanceStateContext } from '@/ui/utilities/state/component-state/types/ComponentInstanceStateContext';
+import { type ComponentStateKey } from '@/ui/utilities/state/component-state/types/ComponentStateKey';
 import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { isNonEmptyString } from '@sniptt/guards';
 
 export const useAvailableComponentInstanceIdOrThrow = <
-  T extends { instanceId: string },
+  T extends ComponentStateKey,
 >(
   Context: ComponentInstanceStateContext<T>,
   instanceIdFromProps?: string,
@@ -15,11 +16,15 @@ export const useAvailableComponentInstanceIdOrThrow = <
   const availableInstanceId = isNonEmptyString(instanceIdFromProps)
     ? instanceIdFromProps
     : (instanceIdFromContext ?? '');
-  const scopedInstanceId =
+  const workspaceSurfaceScopedInstanceId =
     useWorkspaceSurfaceScopedComponentInstanceId(availableInstanceId);
+  const resolvedInstanceId =
+    instanceStateContext?.shouldScopeToWorkspaceSurface === false
+      ? availableInstanceId
+      : workspaceSurfaceScopedInstanceId;
 
-  if (isNonEmptyString(scopedInstanceId)) {
-    return scopedInstanceId;
+  if (isNonEmptyString(resolvedInstanceId)) {
+    return resolvedInstanceId;
   }
 
   throw new Error(

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useComponentInstanceStateContext.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useComponentInstanceStateContext.ts
@@ -1,9 +1,8 @@
 import { type ComponentInstanceStateContext } from '@/ui/utilities/state/component-state/types/ComponentInstanceStateContext';
+import { type ComponentStateKey } from '@/ui/utilities/state/component-state/types/ComponentStateKey';
 import { useContext } from 'react';
 
-export const useComponentInstanceStateContext = <
-  T extends { instanceId: string },
->(
+export const useComponentInstanceStateContext = <T extends ComponentStateKey>(
   Context: ComponentInstanceStateContext<T>,
 ) => {
   const context = useContext(Context);

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/types/ComponentInstanceStateContext.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/types/ComponentInstanceStateContext.ts
@@ -1,4 +1,5 @@
+import { type ComponentStateKey } from '@/ui/utilities/state/component-state/types/ComponentStateKey';
 import { type Context } from 'react';
 
-export type ComponentInstanceStateContext<T extends { instanceId: string }> =
+export type ComponentInstanceStateContext<T extends ComponentStateKey> =
   Context<T | null>;

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/types/ComponentStateKey.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/types/ComponentStateKey.ts
@@ -1,3 +1,4 @@
 export type ComponentStateKey = {
   instanceId: string;
+  shouldScopeToWorkspaceSurface?: boolean;
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext.tsx
@@ -1,6 +1,7 @@
+import { type ComponentStateKey } from '@/ui/utilities/state/component-state/types/ComponentStateKey';
 import { createComponentInstanceContext } from '@/ui/utilities/state/component-state/utils/createComponentInstanceContext';
 
 export const WorkflowVisualizerComponentInstanceContext =
-  createComponentInstanceContext({
+  createComponentInstanceContext<ComponentStateKey>({
     instanceId: '',
   });


### PR DESCRIPTION
## Summary

- Preserve the originating workflow visualizer state when opening workflow side panels.
- Keep workflow panels connected to the correct surface-scoped flow while retaining normal surface isolation.
- Cover workflow panel navigation and cross-surface state reuse.

## Before/After

Before: opening a workflow trigger or action could crash because the panel looked up an empty side-panel-scoped flow.

After: triggers and actions open their side panels using the originating workflow visualizer state.


<img width="500" height="272" alt="workflow-side-panel-fixed-pr" src="https://github.com/user-attachments/assets/8676b30b-2de5-42a8-9e17-e7670494a029" />
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

