### PR TITLE
Scope component instance ids at the provider, not in the resolving primitive

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/recipients/components/EmailRecipientsFieldInput.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/recipients/components/EmailRecipientsFieldInput.tsx
@@ -53,6 +53,7 @@ import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentTyp
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 const SUGGESTIONS_SEARCH_DEBOUNCE_MS = 300;
 
@@ -127,7 +128,9 @@ export const EmailRecipientsFieldInput = ({
 }: EmailRecipientsFieldInputProps) => {
   const instanceId = useId();
   const focusId = `email-recipients-field-${instanceId}`;
-  const suggestionsDropdownId = `${focusId}-suggestions`;
+  const suggestionsDropdownId = useWorkspaceSurfaceScopedComponentInstanceId(
+    `${focusId}-suggestions`,
+  );
 
   const inputRef = useRef<HTMLInputElement>(null);
 

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenuDropdown.tsx
@@ -15,6 +15,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
 import { useContext } from 'react';
@@ -63,9 +64,12 @@ export const RecordIndexCommandMenuDropdown = () => {
     ...(shouldShowMoreActions ? ['more-actions'] : []),
   ];
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   return (

--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterCompositeSubFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterCompositeSubFieldSelectMenu.tsx
@@ -21,6 +21,7 @@ import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import { IconChevronLeft, useIcons } from 'twenty-ui/icon';
@@ -79,9 +80,14 @@ export const AdvancedFilterCompositeSubFieldSelectMenu = ({
   const { advancedFilterFieldSelectDropdownId } =
     useAdvancedFilterFieldSelectDropdown(recordFilterId);
 
+  const scopedAdvancedFilterFieldSelectDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      advancedFilterFieldSelectDropdownId,
+    );
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    advancedFilterFieldSelectDropdownId,
+    scopedAdvancedFilterFieldSelectDropdownId,
   );
 
   if (!isDefined(objectFilterDropdownSubMenuFieldType)) {

--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterRecordFilterOperandSelectContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterRecordFilterOperandSelectContent.tsx
@@ -18,6 +18,7 @@ import { SelectableList } from '@/ui/layout/selectable-list/components/Selectabl
 import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
 import { type ViewFilterOperand } from 'twenty-shared/types';
@@ -56,9 +57,12 @@ export const AdvancedFilterRecordFilterOperandSelectContent = ({
     setRecordFilterUsedInAdvancedFilterDropdownRow(filter);
   };
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { userTimeZoneAbbreviation } =

--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterRelationTargetFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterRelationTargetFieldSelectMenu.tsx
@@ -20,6 +20,7 @@ import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { IconChevronLeft, IconUserCircle, useIcons } from 'twenty-ui/icon';
@@ -60,9 +61,14 @@ export const AdvancedFilterRelationTargetFieldSelectMenu = ({
   const { advancedFilterFieldSelectDropdownId } =
     useAdvancedFilterFieldSelectDropdown(recordFilterId);
 
+  const scopedAdvancedFilterFieldSelectDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      advancedFilterFieldSelectDropdownId,
+    );
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    advancedFilterFieldSelectDropdownId,
+    scopedAdvancedFilterFieldSelectDropdownId,
   );
 
   const { objectMetadataItem: workspaceMemberObjectMetadataItem } =

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOptionSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOptionSelect.tsx
@@ -21,6 +21,7 @@ import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/com
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { MAX_OPTIONS_TO_DISPLAY } from 'twenty-shared/constants';
@@ -73,9 +74,12 @@ export const ObjectFilterDropdownOptionSelect = ({
 
   const { resetSelectedItem } = useSelectableList(componentInstanceId);
 
+  const scopedComponentInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId(componentInstanceId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    componentInstanceId,
+    scopedComponentInstanceId,
   );
 
   const { foundFieldMetadataItem: relationTargetFieldMetadataItem } =

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
@@ -11,6 +11,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useUpdateCurrentView } from '@/views/hooks/useUpdateCurrentView';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { Pill } from 'twenty-ui/data-display';
 import {
@@ -35,9 +36,12 @@ export const ObjectOptionsDropdownCalendarViewContent = () => {
   );
   const { updateCurrentView } = useUpdateCurrentView();
 
+  const scopedObjectOptionsDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(OBJECT_OPTIONS_DROPDOWN_ID);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    OBJECT_OPTIONS_DROPDOWN_ID,
+    scopedObjectOptionsDropdownId,
   );
 
   const { closeDropdown } = useObjectOptionsDropdown();

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCustomView.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCustomView.tsx
@@ -25,6 +25,7 @@ import {
 import { useDestroyViewFromCurrentState } from '@/views/view-picker/hooks/useDestroyViewFromCurrentState';
 import { viewPickerReferenceViewIdComponentState } from '@/views/view-picker/states/viewPickerReferenceViewIdComponentState';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
 import {
@@ -120,9 +121,12 @@ export const ObjectOptionsDropdownCustomView = ({
     'Delete view',
   ];
 
+  const scopedObjectOptionsDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(OBJECT_OPTIONS_DROPDOWN_ID);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    OBJECT_OPTIONS_DROPDOWN_ID,
+    scopedObjectOptionsDropdownId,
   );
 
   if (!customViewData) {

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownDefaultView.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownDefaultView.tsx
@@ -12,6 +12,7 @@ import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { useOpenCreateViewDropdown } from '@/views/hooks/useOpenCreateViewDropown';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useLingui } from '@lingui/react/macro';
 import {
   IconCopy,
@@ -42,9 +43,12 @@ export const ObjectOptionsDropdownDefaultView = () => {
     'Create custom view',
   ];
 
+  const scopedObjectOptionsDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(OBJECT_OPTIONS_DROPDOWN_ID);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    OBJECT_OPTIONS_DROPDOWN_ID,
+    scopedObjectOptionsDropdownId,
   );
 
   const { openCreateViewDropdown } = useOpenCreateViewDropdown(recordIndexId);

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/views/types/ViewType';
 import { useGetAvailableFieldsForCalendar } from '@/views/view-picker/hooks/useGetAvailableFieldsForCalendar';
 import { useGetAvailableFieldsToGroupRecordsBy } from '@/views/view-picker/hooks/useGetAvailableFieldsToGroupRecordsBy';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useLingui } from '@lingui/react/macro';
 import { useCallback } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -125,9 +126,12 @@ export const ObjectOptionsDropdownLayoutContent = () => {
       : []),
   ];
 
+  const scopedObjectOptionsDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(OBJECT_OPTIONS_DROPDOWN_ID);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    OBJECT_OPTIONS_DROPDOWN_ID,
+    scopedObjectOptionsDropdownId,
   );
 
   return (

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupSortContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupSortContent.tsx
@@ -17,6 +17,7 @@ import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import {
@@ -49,9 +50,12 @@ export const ObjectOptionsDropdownRecordGroupSortContent = () => {
     setRecordIndexRecordGroupSort(sort);
   };
 
+  const scopedObjectOptionsDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(OBJECT_OPTIONS_DROPDOWN_ID);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    OBJECT_OPTIONS_DROPDOWN_ID,
+    scopedObjectOptionsDropdownId,
   );
 
   useEffect(() => {

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupsContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupsContent.tsx
@@ -24,6 +24,7 @@ import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { useGetAvailableFieldsToGroupRecordsBy } from '@/views/view-picker/hooks/useGetAvailableFieldsToGroupRecordsBy';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
 import {
@@ -103,9 +104,12 @@ export const ObjectOptionsDropdownRecordGroupsContent = () => {
     }
   }, [hiddenRecordGroupIds, currentContentId, onContentChange]);
 
+  const scopedObjectOptionsDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(OBJECT_OPTIONS_DROPDOWN_ID);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    OBJECT_OPTIONS_DROPDOWN_ID,
+    scopedObjectOptionsDropdownId,
   );
 
   const selectableItemIdArray = [

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownVisibilityContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownVisibilityContent.tsx
@@ -14,6 +14,7 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import { useCanPersistViewChanges } from '@/views/hooks/useCanPersistViewChanges';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { useUpdateCurrentView } from '@/views/hooks/useUpdateCurrentView';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useLingui } from '@lingui/react/macro';
 import { createPortal } from 'react-dom';
 import { createPath, useLocation } from 'react-router-dom';
@@ -41,9 +42,12 @@ export const ObjectOptionsDropdownVisibilityContent = () => {
   const hasViewsPermission = useHasPermissionFlag(PermissionFlagType.VIEWS);
   const { canPersistChanges } = useCanPersistViewChanges();
 
+  const scopedObjectOptionsDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(OBJECT_OPTIONS_DROPDOWN_ID);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    OBJECT_OPTIONS_DROPDOWN_ID,
+    scopedObjectOptionsDropdownId,
   );
 
   const selectableItemIdArray = [

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -30,6 +30,7 @@ import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomC
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { findByProperty } from 'twenty-shared/utils';
 import { IconX, useIcons } from 'twenty-ui/icon';
@@ -152,14 +153,17 @@ export const ObjectSortDropdownButton = () => {
     ...hiddenFieldMetadataItemsSorted.map((item) => item.id),
   ];
 
+  const scopedObjectSortDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(OBJECT_SORT_DROPDOWN_ID);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    OBJECT_SORT_DROPDOWN_ID,
+    scopedObjectSortDropdownId,
   );
 
   const setSelectedItemId = useSetAtomComponentState(
     selectedItemIdComponentState,
-    OBJECT_SORT_DROPDOWN_ID,
+    scopedObjectSortDropdownId,
   );
 
   const shouldShowHiddenFields = hiddenFieldMetadataItemsSorted.length > 0;

--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItemContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItemContent.tsx
@@ -17,6 +17,7 @@ import { Avatar } from 'twenty-ui/data-display';
 import { MenuItemMultiSelectAvatar } from 'twenty-ui/navigation';
 
 import { multipleRecordPickerSearchableObjectMetadataItemsComponentState } from '@/object-record/record-picker/multiple-record-picker/states/multipleRecordPickerSearchableObjectMetadataItemsComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { type SearchRecord } from '~/generated/graphql';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
 
@@ -36,7 +37,9 @@ export const MultipleRecordPickerMenuItemContent = ({
   );
 
   const selectableListComponentInstanceId =
-    getMultipleRecordPickerSelectableListId(componentInstanceId);
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      getMultipleRecordPickerSelectableListId(componentInstanceId),
+    );
 
   const isSelectedItemId = useAtomComponentFamilyStateValue(
     isSelectedItemIdComponentFamilyState,

--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItem.tsx
@@ -13,6 +13,7 @@ import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/com
 import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { capitalize, isDefined } from 'twenty-shared/utils';
 import { Avatar } from 'twenty-ui/data-display';
 import { MenuItemSelectAvatar } from 'twenty-ui/navigation';
@@ -35,7 +36,9 @@ export const SingleRecordPickerMenuItem = ({
     );
 
   const selectableListComponentInstanceId =
-    getSingleRecordPickerSelectableListId(recordPickerComponentInstanceId);
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      getSingleRecordPickerSelectableListId(recordPickerComponentInstanceId),
+    );
 
   const isSelectedItemId = useAtomComponentFamilyStateValue(
     isSelectedItemIdComponentFamilyState,

--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItems.tsx
@@ -21,6 +21,7 @@ import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/com
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { type IconComponent } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 
@@ -47,7 +48,9 @@ export const SingleRecordPickerMenuItems = ({
     );
 
   const selectableListComponentInstanceId =
-    getSingleRecordPickerSelectableListId(recordPickerComponentInstanceId);
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      getSingleRecordPickerSelectableListId(recordPickerComponentInstanceId),
+    );
 
   const { resetSelectedItem } = useSelectableList(
     selectableListComponentInstanceId,

--- a/packages/twenty-front/src/modules/object-record/record-table-widget/components/RecordTableWidgetNestedRelationPickerMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table-widget/components/RecordTableWidgetNestedRelationPickerMenuItem.tsx
@@ -4,6 +4,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { isSelectedItemIdComponentFamilyState } from '@/ui/layout/selectable-list/states/isSelectedItemIdComponentFamilyState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { Avatar } from 'twenty-ui/data-display';
 import { MenuItemSelectAvatar } from 'twenty-ui/navigation';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
@@ -21,10 +22,13 @@ export const RecordTableWidgetNestedRelationPickerMenuItem = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const isSelectedItemId = useAtomComponentFamilyStateValue(
     isSelectedItemIdComponentFamilyState,
     relationRecord.id,
-    dropdownId,
+    scopedDropdownId,
   );
 
   return (

--- a/packages/twenty-front/src/modules/object-record/select/components/MultipleSelectDropdown.tsx
+++ b/packages/twenty-front/src/modules/object-record/select/components/MultipleSelectDropdown.tsx
@@ -10,6 +10,7 @@ import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectab
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
 import { t } from '@lingui/core/macro';
 import { Avatar } from 'twenty-ui/data-display';
@@ -40,9 +41,12 @@ export const MultipleSelectDropdown = ({
 
   const { resetSelectedItem } = useSelectableList(selectableListId);
 
+  const scopedSelectableListId =
+    useWorkspaceSurfaceScopedComponentInstanceId(selectableListId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    selectableListId,
+    scopedSelectableListId,
   );
 
   const handleItemSelectChange = (

--- a/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabListEffect.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabListEffect.test.tsx
@@ -2,7 +2,6 @@ import { PageLayoutTabListEffect } from '@/page-layout/components/PageLayoutTabL
 import { makeTab } from '@/page-layout/testing/pageLayoutDraftFixtures';
 import { LayoutRenderingProvider } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
-import { getWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { TabListFromUrlOptionalEffect } from '@/ui/layout/tab-list/components/TabListFromUrlOptionalEffect';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { TabListComponentInstanceContext } from '@/ui/layout/tab-list/states/contexts/TabListComponentInstanceContext';
@@ -121,11 +120,7 @@ describe('PageLayoutTabListEffect', () => {
       const store = createStore();
       const surfaceInstanceId = isInSidePanel ? 'side-panel-page-1' : 'main';
       const activeTabAtom = activeTabIdComponentState.atomFamily({
-        instanceId: getWorkspaceSurfaceScopedComponentInstanceId({
-          componentInstanceId: TAB_LIST_INSTANCE_ID,
-          surfaceType: isInSidePanel ? 'side-panel' : 'main',
-          surfaceInstanceId,
-        }),
+        instanceId: TAB_LIST_INSTANCE_ID,
       });
       store.set(activeTabAtom, activeTabId);
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/__stories__/WidgetRenderer.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/__stories__/WidgetRenderer.stories.tsx
@@ -34,7 +34,6 @@ import { WidgetComponentInstanceContext } from '@/page-layout/widgets/states/con
 import { widgetCardHoveredComponentFamilyState } from '@/page-layout/widgets/states/widgetCardHoveredComponentFamilyState';
 import { LayoutRenderingProvider } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
-import { getWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import {
   AggregateOperations,
   AxisNameDisplay,
@@ -87,12 +86,6 @@ const WIDGET_ID_ONE_TO_MANY_RELATION = 'widget-one-to-many-relation-field';
 const WIDGET_ID_CATALOG = 'catalog-widget';
 const TAB_ID_OVERVIEW = 'tab-overview';
 const SIDE_PANEL_INSTANCE_ID = 'widget-side-panel';
-const SIDE_PANEL_PAGE_LAYOUT_INSTANCE_ID =
-  getWorkspaceSurfaceScopedComponentInstanceId({
-    componentInstanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
-    surfaceType: 'side-panel',
-    surfaceInstanceId: SIDE_PANEL_INSTANCE_ID,
-  });
 
 const mockPersonRecord: ObjectRecord = {
   __typename: 'Person',
@@ -1492,13 +1485,13 @@ export const InSidePanel: Story = {
     );
     jotaiStore.set(
       pageLayoutPersistedComponentState.atomFamily({
-        instanceId: SIDE_PANEL_PAGE_LAYOUT_INSTANCE_ID,
+        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
       }),
       sidePanelPageLayoutData,
     );
     jotaiStore.set(
       pageLayoutDraftComponentState.atomFamily({
-        instanceId: SIDE_PANEL_PAGE_LAYOUT_INSTANCE_ID,
+        instanceId: PAGE_LAYOUT_TEST_INSTANCE_ID,
       }),
       sidePanelPageLayoutData,
     );

--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/__stories__/FieldsWidget.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/__stories__/FieldsWidget.stories.tsx
@@ -2,7 +2,7 @@ import { type ApolloClient } from '@apollo/client';
 import { useApolloClient } from '@apollo/client/react';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { MemoryRouter } from 'react-router-dom';
-import { expect, waitFor, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { isMinimalMetadataReadyState } from '@/metadata-store/states/isMinimalMetadataReadyState';
 import { ApolloCoreClientContext } from '@/object-metadata/contexts/ApolloCoreClientContext';
@@ -20,6 +20,7 @@ import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { FieldsWidget } from '@/page-layout/widgets/fields/components/FieldsWidget';
 import { WidgetComponentInstanceContext } from '@/page-layout/widgets/states/contexts/WidgetComponentInstanceContext';
 import { LayoutRenderingProvider } from '@/ui/layout/contexts/LayoutRenderingContext';
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
 import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { type ViewWithRelations } from '@/views/types/ViewWithRelations';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
@@ -247,7 +248,15 @@ const createViewFieldGroup = (
   viewFields,
 });
 
-const FieldsWidgetStoryRenderer = ({ view }: { view: ViewWithRelations }) => {
+const SIDE_PANEL_SURFACE_INSTANCE_ID = 'fields-widget-story-side-panel';
+
+const FieldsWidgetStoryRenderer = ({
+  view,
+  surfaceType = 'main',
+}: {
+  view: ViewWithRelations;
+  surfaceType?: 'main' | 'side-panel';
+}) => {
   const widget = createFieldsWidget(FIELDS_VIEW_ID);
 
   const pageLayoutData = createPageLayoutWithWidget(
@@ -300,7 +309,18 @@ const FieldsWidgetStoryRenderer = ({ view }: { view: ViewWithRelations }) => {
                 <WidgetComponentInstanceContext.Provider
                   value={{ instanceId: widget.id }}
                 >
-                  <FieldsWidget widget={widget} />
+                  <WorkspaceSurfaceContext.Provider
+                    value={{
+                      type: surfaceType,
+                      instanceId:
+                        surfaceType === 'side-panel'
+                          ? SIDE_PANEL_SURFACE_INSTANCE_ID
+                          : 'main',
+                      ownsRouteLocation: surfaceType === 'main',
+                    }}
+                  >
+                    <FieldsWidget widget={widget} />
+                  </WorkspaceSurfaceContext.Provider>
                 </WidgetComponentInstanceContext.Provider>
               </PageLayoutContentProvider>
             </LayoutRenderingProvider>
@@ -457,4 +477,63 @@ export const Empty: Story = {
       ).toBeVisible();
     });
   },
+};
+
+// Hovering a field mounts an interactive copy of the cell through
+// RecordInlineCellAnchoredPortal, which finds its anchor with
+// document.getElementById after resolving the list instance id through
+// useAvailableComponentInstanceIdOrThrow -- and that resolution surface-scopes
+// the id. If the list rendered its anchors from an unscoped id, the lookup
+// misses, nothing interactive mounts, and the click lands on the inert display
+// underneath: the cell highlights but no editor ever opens.
+const openEditModeOnEmployees = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  const canvas = within(canvasElement);
+
+  const [employeesValue] = await canvas.findAllByText('250');
+  await userEvent.hover(employeesValue);
+
+  const hoveredValues = await canvas.findAllByText('250');
+  await userEvent.click(hoveredValues[hoveredValues.length - 1]);
+
+  await waitFor(() => {
+    expect(canvasElement.querySelector('input')).not.toBeNull();
+  });
+};
+
+const singleGroupView = () => {
+  const contactInfoFields = [
+    createViewField('vf-name', nameField.id, 0, 'group-contact-info'),
+    createViewField('vf-employees', employeesField.id, 1, 'group-contact-info'),
+  ];
+
+  return createView({
+    viewFields: contactInfoFields,
+    viewFieldGroups: [
+      createViewFieldGroup(
+        'group-contact-info',
+        'Contact Info',
+        0,
+        contactInfoFields,
+      ),
+    ],
+  });
+};
+
+export const OpensEditModeOnMainSurface: Story = {
+  render: () => <FieldsWidgetStoryRenderer view={singleGroupView()} />,
+  play: openEditModeOnEmployees,
+};
+
+export const OpensEditModeInSidePanel: Story = {
+  render: () => (
+    <FieldsWidgetStoryRenderer
+      view={singleGroupView()}
+      surfaceType="side-panel"
+    />
+  ),
+  play: openEditModeOnEmployees,
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/__stories__/FieldsWidget.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/__stories__/FieldsWidget.stories.tsx
@@ -4,6 +4,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { MemoryRouter } from 'react-router-dom';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { isMinimalMetadataReadyState } from '@/metadata-store/states/isMinimalMetadataReadyState';
 import { ApolloCoreClientContext } from '@/object-metadata/contexts/ApolloCoreClientContext';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
@@ -315,7 +316,7 @@ const FieldsWidgetStoryRenderer = ({
                       instanceId:
                         surfaceType === 'side-panel'
                           ? SIDE_PANEL_SURFACE_INSTANCE_ID
-                          : 'main',
+                          : MAIN_CONTEXT_STORE_INSTANCE_ID,
                       ownsRouteLocation: surfaceType === 'main',
                     }}
                   >

--- a/packages/twenty-front/src/modules/settings/components/__tests__/SettingsRoutedFlowStateScope.test.tsx
+++ b/packages/twenty-front/src/modules/settings/components/__tests__/SettingsRoutedFlowStateScope.test.tsx
@@ -41,6 +41,8 @@ const ScopedStateProbe = ({
 }: {
   name: 'main' | 'panel' | 'panel-second';
 }) => {
+  const modalId = useWorkspaceSurfaceScopedComponentInstanceId(MODAL_ID);
+  const dropdownId = useWorkspaceSurfaceScopedComponentInstanceId(DROPDOWN_ID);
   const tableId = useWorkspaceSurfaceScopedComponentInstanceId('role-table');
   const settingsDraftRole = useAtomFamilyStateValue(
     settingsDraftRoleFamilyState,
@@ -60,12 +62,12 @@ const ScopedStateProbe = ({
   );
   const isModalOpened = useAtomComponentStateValue(
     isModalOpenedComponentState,
-    MODAL_ID,
+    modalId,
   );
   const { openModal, toggleModal } = useModal();
   const isDropdownOpen = useAtomComponentStateValue(
     isDropdownOpenComponentState,
-    DROPDOWN_ID,
+    dropdownId,
   );
   const { openDropdown } = useOpenDropdown();
   const sortedFieldByTable = useAtomFamilyStateValue(

--- a/packages/twenty-front/src/modules/settings/components/layout/useSettingsActiveTabId.ts
+++ b/packages/twenty-front/src/modules/settings/components/layout/useSettingsActiveTabId.ts
@@ -1,4 +1,5 @@
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useLocation } from 'react-router-dom';
 import { isDefined } from 'twenty-shared/utils';
@@ -10,9 +11,11 @@ export const useSettingsActiveTabId = (
   componentInstanceId: string,
   tabIds: string[],
 ): string | null => {
+  const scopedComponentInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId(componentInstanceId);
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
-    componentInstanceId,
+    scopedComponentInstanceId,
   );
   const { hash } = useLocation();
 

--- a/packages/twenty-front/src/modules/settings/developers/components/WebhookEntitySelect.tsx
+++ b/packages/twenty-front/src/modules/settings/developers/components/WebhookEntitySelect.tsx
@@ -13,6 +13,7 @@ import { SelectableList } from '@/ui/layout/selectable-list/components/Selectabl
 import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -48,9 +49,12 @@ export const WebhookEntitySelect = ({
   const { objectMetadataItems } = useObjectMetadataItems();
   const { closeDropdown } = useCloseDropdown();
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const metadataOptions: SelectOption<string>[] = [

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelPermissionFieldSelectSubFieldMenu.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelPermissionFieldSelectSubFieldMenu.tsx
@@ -30,6 +30,7 @@ import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type SettingsRolePermissionsObjectLevelRecordLevelPermissionFieldSelectSubFieldMenuProps =
   {
@@ -89,9 +90,14 @@ export const SettingsRolePermissionsObjectLevelRecordLevelPermissionFieldSelectS
     const { advancedFilterFieldSelectDropdownId } =
       useAdvancedFilterFieldSelectDropdown(recordFilterId);
 
+    const scopedAdvancedFilterFieldSelectDropdownId =
+      useWorkspaceSurfaceScopedComponentInstanceId(
+        advancedFilterFieldSelectDropdownId,
+      );
+
     const selectedItemId = useAtomComponentStateValue(
       selectedItemIdComponentState,
-      advancedFilterFieldSelectDropdownId,
+      scopedAdvancedFilterFieldSelectDropdownId,
     );
 
     if (!isDefined(objectFilterDropdownSubMenuFieldType)) {

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelDefaultSelectionEffect.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelDefaultSelectionEffect.tsx
@@ -2,6 +2,7 @@ import { SIDE_PANEL_SELECTABLE_LIST_ID } from '@/side-panel/constants/SidePanelS
 import { hasUserSelectedSidePanelListItemState } from '@/side-panel/states/hasUserSelectedSidePanelListItemState';
 import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectableList';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useEffect } from 'react';
@@ -15,9 +16,13 @@ export const SidePanelDefaultSelectionEffect = ({
   const { setSelectedItemId } = useSelectableList(
     SIDE_PANEL_SELECTABLE_LIST_ID,
   );
+  const scopedSelectableListId = useWorkspaceSurfaceScopedComponentInstanceId(
+    SIDE_PANEL_SELECTABLE_LIST_ID,
+  );
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    SIDE_PANEL_SELECTABLE_LIST_ID,
+    scopedSelectableListId,
   );
 
   const hasUserSelectedSidePanelListItem = useAtomStateValue(

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/WidgetSettingsFooter.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/WidgetSettingsFooter.tsx
@@ -7,6 +7,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { SidePanelFooter } from '@/ui/layout/side-panel/components/SidePanelFooter';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useLingui } from '@lingui/react/macro';
 import { useId } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -42,9 +43,12 @@ export const WidgetSettingsFooter = ({
     closeDropdown(dropdownId);
   };
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   return (

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartAggregateOperationSelectableListItem.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartAggregateOperationSelectableListItem.tsx
@@ -12,6 +12,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { isDefined } from 'twenty-shared/utils';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 
@@ -40,9 +41,12 @@ export const ChartAggregateOperationSelectableListItem = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const configuration = widgetInEditMode?.configuration;

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartAxisNameSelectionDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartAxisNameSelectionDropdownContent.tsx
@@ -11,6 +11,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 import { AxisNameDisplay } from '~/generated-metadata/graphql';
 
@@ -34,9 +35,12 @@ export const ChartAxisNameSelectionDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const axisOptions: AxisNameDisplay[] = [

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartColorSelectionDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartColorSelectionDropdownContent.tsx
@@ -14,6 +14,7 @@ import { SelectableList } from '@/ui/layout/selectable-list/components/Selectabl
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
 import { capitalize, isDefined } from 'twenty-shared/utils';
@@ -35,9 +36,12 @@ export const ChartColorSelectionDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { updateCurrentWidgetConfig } =

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartDataSourceDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartDataSourceDropdownContent.tsx
@@ -19,6 +19,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useMemo, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -41,9 +42,12 @@ export const ChartDataSourceDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const searchableObjects = useMemo(() => {

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartDateGranularitySelectionDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartDateGranularitySelectionDropdownContent.tsx
@@ -13,6 +13,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { ObjectRecordGroupByDateGranularity } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { MenuItemSelect } from 'twenty-ui/navigation';
@@ -108,9 +109,12 @@ export const ChartDateGranularitySelectionDropdownContent = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const dateGranularityOptions: ObjectRecordGroupByDateGranularity[] = [

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartFieldSelectionForAggregateOperationDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartFieldSelectionForAggregateOperationDropdownContent.tsx
@@ -14,6 +14,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
 import { useIcons } from 'twenty-ui/icon';
@@ -60,9 +61,12 @@ export const ChartFieldSelectionForAggregateOperationDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const availableFieldMetadataItems = filterBySearchQuery({

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionCompositeFieldView.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionCompositeFieldView.tsx
@@ -12,6 +12,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { IconChevronLeft, useIcons } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 
@@ -34,9 +35,12 @@ export const ChartGroupByFieldSelectionCompositeFieldView = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const compositeFieldType = compositeField.type as CompositeFieldType;

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionDropdownContentBase.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionDropdownContentBase.tsx
@@ -22,6 +22,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useMemo, useState } from 'react';
 import {
@@ -80,9 +81,12 @@ export const ChartGroupByFieldSelectionDropdownContentBase = <
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const availableFieldMetadataItems = useMemo(

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionMorphRelationFieldView.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionMorphRelationFieldView.tsx
@@ -11,6 +11,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useMemo, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -56,9 +57,12 @@ export const ChartGroupByFieldSelectionMorphRelationFieldView = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
   const availableTargets = useMemo<MorphRelationTarget[]>(() => {
     return (morphField.morphRelations ?? [])

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionTargetObjectFieldsView.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionTargetObjectFieldsView.tsx
@@ -14,6 +14,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useMemo, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -54,9 +55,12 @@ export const ChartGroupByFieldSelectionTargetObjectFieldsView = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { objectMetadataItems } = useObjectMetadataItems();

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartNumberFormatSelectionDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartNumberFormatSelectionDropdownContent.tsx
@@ -12,6 +12,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 import { ChartNumberFormat } from '~/generated-metadata/graphql';
 
@@ -41,9 +42,12 @@ export const ChartNumberFormatSelectionDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const numberFormatOptions: ChartNumberFormat[] = [

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartRatioAggregateOperationSelectableListItem.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartRatioAggregateOperationSelectableListItem.tsx
@@ -7,6 +7,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { isDefined } from 'twenty-shared/utils';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 
@@ -24,9 +25,12 @@ export const ChartRatioAggregateOperationSelectableListItem = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const isCurrentlyRatio =

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartRatioOptionBooleanSelectableListItem.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartRatioOptionBooleanSelectableListItem.tsx
@@ -8,6 +8,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { IconCheck, IconX } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 import { AggregateOperations } from '~/generated-metadata/graphql';
@@ -31,9 +32,12 @@ export const ChartRatioOptionBooleanSelectableListItem = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const currentRatioConfig = isWidgetConfigurationOfType(

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartRatioOptionSelectSelectableListItem.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartRatioOptionSelectSelectableListItem.tsx
@@ -8,6 +8,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { MenuItemSelectTag } from 'twenty-ui/navigation';
 import { type ThemeColor } from 'twenty-ui/theme';
 import { AggregateOperations } from '~/generated-metadata/graphql';
@@ -33,9 +34,12 @@ export const ChartRatioOptionSelectSelectableListItem = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const currentRatioConfig = isWidgetConfigurationOfType(

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartSortByGroupByFieldDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartSortByGroupByFieldDropdownContent.tsx
@@ -19,6 +19,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { isDefined } from 'twenty-shared/utils';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 import {
@@ -53,9 +54,12 @@ export const ChartSortByGroupByFieldDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const objectMetadataItem = objectMetadataItems.find(

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartSortBySelectionDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartSortBySelectionDropdownContent.tsx
@@ -19,6 +19,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { type CompositeFieldSubFieldName } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { MenuItemSelect } from 'twenty-ui/navigation';
@@ -41,9 +42,12 @@ export const ChartSortBySelectionDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const configuration = widgetInEditMode?.configuration;

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetFieldDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetFieldDropdownContent.tsx
@@ -30,6 +30,7 @@ import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectab
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useMemo, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -93,9 +94,12 @@ export const FieldWidgetFieldDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { updateCurrentWidgetConfig } =

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetLayoutDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetLayoutDropdownContent.tsx
@@ -30,6 +30,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
 import {
@@ -162,9 +163,12 @@ export const FieldWidgetLayoutDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { updateCurrentWidgetConfig } =

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetNestedFieldDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetNestedFieldDropdownContent.tsx
@@ -12,6 +12,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { IconChevronLeft, useIcons } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 
@@ -39,9 +40,12 @@ export const FieldWidgetNestedFieldDropdownContent = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { getIcon } = useIcons();

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/WidgetVisibilityOptionsList.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/WidgetVisibilityOptionsList.tsx
@@ -7,6 +7,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 
 type WidgetVisibilityOptionsListProps = {
@@ -22,9 +23,12 @@ export const WidgetVisibilityOptionsList = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const visibilityLabels = useVisibilityLabels();

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent.tsx
@@ -9,6 +9,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useIcons } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 
@@ -37,9 +38,12 @@ export const RecordTableCalendarFieldDropdownContent = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { closeDropdown } = useCloseDropdown();

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarLayoutDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarLayoutDropdownContent.tsx
@@ -7,6 +7,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import {
   IconCalendarEvent,
@@ -31,9 +32,12 @@ export const RecordTableCalendarLayoutDropdownContent = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { closeDropdown } = useCloseDropdown();

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableDataSourceDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableDataSourceDropdownContent.tsx
@@ -18,6 +18,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -39,9 +40,12 @@ export const RecordTableDataSourceDropdownContent = () => {
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { updateCurrentWidgetConfig } =

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableGroupByDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableGroupByDropdownContent.tsx
@@ -11,6 +11,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -48,9 +49,12 @@ export const RecordTableGroupByDropdownContent = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { closeDropdown } = useCloseDropdown();

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
@@ -14,6 +14,7 @@ import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states
 import { DropdownComponentInstanceContext } from '@/ui/layout/dropdown/contexts/DropdownComponentInstanceContext';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type RecordTableLayoutDropdownContentProps = {
   pageLayoutId: string;
@@ -38,9 +39,12 @@ export const RecordTableLayoutDropdownContent = ({
     DropdownComponentInstanceContext,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { closeDropdown } = useCloseDropdown();

--- a/packages/twenty-front/src/modules/ui/field/input/components/MultiSelectInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/MultiSelectInput.tsx
@@ -16,6 +16,7 @@ import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import { type SelectOption } from 'twenty-ui/input';
@@ -48,9 +49,14 @@ export const MultiSelectInput = ({
     selectableListComponentInstanceId,
   );
 
+  const scopedSelectableListComponentInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      selectableListComponentInstanceId,
+    );
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    selectableListComponentInstanceId,
+    scopedSelectableListComponentInstanceId,
   );
 
   const [searchFilter, setSearchFilter] = useState('');

--- a/packages/twenty-front/src/modules/ui/input/components/IconPicker.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/IconPicker.tsx
@@ -42,6 +42,7 @@ import { ClickOutsideListenerContext } from '@/ui/utilities/pointer-event/contex
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { arrayToChunks } from '~/utils/array/arrayToChunks';
 
 export type IconPickerProps = {
@@ -412,7 +413,8 @@ export const IconPicker = ({
 
   const iconColorPickerDropdownId = `${dropdownId}-icon-color-picker`;
 
-  const selectableListInstanceId = 'icon-list';
+  const selectableListInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId('icon-list');
 
   const focusedIconKey =
     useAtomComponentStateValue(

--- a/packages/twenty-front/src/modules/ui/input/components/Select.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/Select.tsx
@@ -18,6 +18,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectableList';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { isNonEmptyArray, isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
 import { type IconComponent } from 'twenty-ui/icon';
@@ -161,9 +162,12 @@ export const Select = <Value extends SelectValue>({
 
   const selectableItemIdArray = filteredOptions.map((option) => option.label);
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const { setSelectedItemId } = useSelectableList(dropdownId);

--- a/packages/twenty-front/src/modules/ui/layout/selectable-list/hooks/__tests__/useSelectableList.surfaceScope.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/selectable-list/hooks/__tests__/useSelectableList.surfaceScope.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectableList';
+import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+
+const DROPDOWN_ID = 'sort-dropdown';
+const SIDE_PANEL_INSTANCE_ID = 'side-panel-page';
+
+const buildWrapper =
+  (store: ReturnType<typeof createStore>) =>
+  ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={store}>
+      <WorkspaceSurfaceContext.Provider
+        value={{
+          type: 'side-panel',
+          instanceId: SIDE_PANEL_INSTANCE_ID,
+          ownsRouteLocation: false,
+        }}
+      >
+        {children}
+      </WorkspaceSurfaceContext.Provider>
+    </JotaiProvider>
+  );
+
+// useSelectableList scopes the id it is handed to the current surface before
+// writing. A component that reads selectedItemIdComponentState directly with
+// the raw id it passed in would look at a different atom inside a side panel,
+// so such readers scope the id the same way first.
+describe('useSelectableList surface scoping', () => {
+  it('writes under the surface-scoped id, which a scoped reader sees and a raw reader does not', () => {
+    const store = createStore();
+    const wrapper = buildWrapper(store);
+
+    const { result: list } = renderHook(() => useSelectableList(DROPDOWN_ID), {
+      wrapper,
+    });
+
+    act(() => {
+      list.current.setSelectedItemId('option-b');
+    });
+
+    const { result: scopedRead } = renderHook(
+      () => {
+        const scopedDropdownId =
+          useWorkspaceSurfaceScopedComponentInstanceId(DROPDOWN_ID);
+
+        return useAtomComponentStateValue(
+          selectedItemIdComponentState,
+          scopedDropdownId,
+        );
+      },
+      { wrapper },
+    );
+
+    const { result: rawRead } = renderHook(
+      () =>
+        useAtomComponentStateValue(selectedItemIdComponentState, DROPDOWN_ID),
+      { wrapper },
+    );
+
+    expect(scopedRead.current).toBe('option-b');
+    expect(rawRead.current).toBeNull();
+  });
+});

--- a/packages/twenty-front/src/modules/ui/layout/selectable-list/hooks/useSelectableList.ts
+++ b/packages/twenty-front/src/modules/ui/layout/selectable-list/hooks/useSelectableList.ts
@@ -4,13 +4,18 @@ import { useStore } from 'jotai';
 import { SelectableListComponentInstanceContext } from '@/ui/layout/selectable-list/states/contexts/SelectableListComponentInstanceContext';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { isSelectedItemIdComponentFamilyState } from '@/ui/layout/selectable-list/states/isSelectedItemIdComponentFamilyState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { isDefined } from 'twenty-shared/utils';
 
 export const useSelectableList = (instanceId?: string) => {
-  const selectableListInstanceId = useAvailableComponentInstanceIdOrThrow(
-    SelectableListComponentInstanceContext,
-    instanceId,
+  const unscopedSelectableListInstanceId =
+    useAvailableComponentInstanceIdOrThrow(
+      SelectableListComponentInstanceContext,
+      instanceId,
+    );
+  const selectableListInstanceId = useWorkspaceSurfaceScopedComponentInstanceId(
+    unscopedSelectableListInstanceId,
   );
 
   const store = useStore();

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/__tests__/useAvailableComponentInstanceIdOrThrow.test.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/__tests__/useAvailableComponentInstanceIdOrThrow.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { type ReactNode } from 'react';
 
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { RecordFieldListComponentInstanceContext } from '@/object-record/record-field-list/states/contexts/RecordFieldListComponentInstanceContext';
 import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
 import { useAvailableComponentInstanceId } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId';
@@ -21,7 +22,10 @@ const buildWrapper =
     <WorkspaceSurfaceContext.Provider
       value={{
         type: surfaceType,
-        instanceId: surfaceType === 'side-panel' ? 'side-panel-page' : 'main',
+        instanceId:
+          surfaceType === 'side-panel'
+            ? 'side-panel-page'
+            : MAIN_CONTEXT_STORE_INSTANCE_ID,
         ownsRouteLocation: surfaceType === 'main',
       }}
     >

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/__tests__/useAvailableComponentInstanceIdOrThrow.test.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/__tests__/useAvailableComponentInstanceIdOrThrow.test.tsx
@@ -1,0 +1,124 @@
+import { renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { RecordFieldListComponentInstanceContext } from '@/object-record/record-field-list/states/contexts/RecordFieldListComponentInstanceContext';
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { useAvailableComponentInstanceId } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId';
+import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+
+const CONTEXT_INSTANCE_ID = 'record-field-list-from-context';
+const PROPS_INSTANCE_ID = 'record-field-list-from-props';
+
+const buildWrapper =
+  ({
+    surfaceType,
+    provideContext,
+  }: {
+    surfaceType: 'main' | 'side-panel';
+    provideContext: boolean;
+  }) =>
+  ({ children }: { children: ReactNode }) => (
+    <WorkspaceSurfaceContext.Provider
+      value={{
+        type: surfaceType,
+        instanceId: surfaceType === 'side-panel' ? 'side-panel-page' : 'main',
+        ownsRouteLocation: surfaceType === 'main',
+      }}
+    >
+      {provideContext ? (
+        <RecordFieldListComponentInstanceContext.Provider
+          value={{ instanceId: CONTEXT_INSTANCE_ID }}
+        >
+          {children}
+        </RecordFieldListComponentInstanceContext.Provider>
+      ) : (
+        children
+      )}
+    </WorkspaceSurfaceContext.Provider>
+  );
+
+// Surface isolation is opted into where an id is created, at the provider.
+// These hooks must hand back exactly what they were given on every surface:
+// a side panel may deliberately provide the same id as the main surface to
+// share state with it, and ids are also rendered into DOM anchors that get
+// looked up by the exact string the provider used.
+describe('useAvailableComponentInstanceIdOrThrow', () => {
+  it.each(['main', 'side-panel'] as const)(
+    'returns the context id verbatim on a %s surface',
+    (surfaceType) => {
+      const { result } = renderHook(
+        () =>
+          useAvailableComponentInstanceIdOrThrow(
+            RecordFieldListComponentInstanceContext,
+          ),
+        { wrapper: buildWrapper({ surfaceType, provideContext: true }) },
+      );
+
+      expect(result.current).toBe(CONTEXT_INSTANCE_ID);
+    },
+  );
+
+  it.each(['main', 'side-panel'] as const)(
+    'returns an explicit id verbatim on a %s surface',
+    (surfaceType) => {
+      const { result } = renderHook(
+        () =>
+          useAvailableComponentInstanceIdOrThrow(
+            RecordFieldListComponentInstanceContext,
+            PROPS_INSTANCE_ID,
+          ),
+        { wrapper: buildWrapper({ surfaceType, provideContext: true }) },
+      );
+
+      expect(result.current).toBe(PROPS_INSTANCE_ID);
+    },
+  );
+
+  it('throws when no id is provided or in context', () => {
+    expect(() =>
+      renderHook(
+        () =>
+          useAvailableComponentInstanceIdOrThrow(
+            RecordFieldListComponentInstanceContext,
+          ),
+        {
+          wrapper: buildWrapper({ surfaceType: 'main', provideContext: false }),
+        },
+      ),
+    ).toThrow('Instance id is not provided and cannot be found in context.');
+  });
+});
+
+describe('useAvailableComponentInstanceId', () => {
+  it.each(['main', 'side-panel'] as const)(
+    'returns the context id verbatim on a %s surface',
+    (surfaceType) => {
+      const { result } = renderHook(
+        () =>
+          useAvailableComponentInstanceId(
+            RecordFieldListComponentInstanceContext,
+          ),
+        { wrapper: buildWrapper({ surfaceType, provideContext: true }) },
+      );
+
+      expect(result.current).toBe(CONTEXT_INSTANCE_ID);
+    },
+  );
+
+  it('returns null when there is no context', () => {
+    const { result } = renderHook(
+      () =>
+        useAvailableComponentInstanceId(
+          RecordFieldListComponentInstanceContext,
+        ),
+      {
+        wrapper: buildWrapper({
+          surfaceType: 'side-panel',
+          provideContext: false,
+        }),
+      },
+    );
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId.ts
@@ -15,7 +15,7 @@ export const useAvailableComponentInstanceId = <
 
   if (isNonEmptyString(instanceIdFromContext)) {
     return instanceIdFromContext;
-  } else {
-    return null;
   }
+
+  return null;
 };

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId.ts
@@ -1,8 +1,9 @@
 import { useComponentInstanceStateContext } from '@/ui/utilities/state/component-state/hooks/useComponentInstanceStateContext';
 import { type ComponentInstanceStateContext } from '@/ui/utilities/state/component-state/types/ComponentInstanceStateContext';
-import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { isNonEmptyString } from '@sniptt/guards';
 
+// Returns the id exactly as provided; see useAvailableComponentInstanceIdOrThrow
+// for why surface scoping belongs at the provider, not here.
 export const useAvailableComponentInstanceId = <
   T extends { instanceId: string },
 >(
@@ -11,9 +12,10 @@ export const useAvailableComponentInstanceId = <
   const instanceStateContext = useComponentInstanceStateContext(Context);
 
   const instanceIdFromContext = instanceStateContext?.instanceId;
-  const scopedInstanceId = useWorkspaceSurfaceScopedComponentInstanceId(
-    instanceIdFromContext ?? '',
-  );
 
-  return isNonEmptyString(scopedInstanceId) ? scopedInstanceId : null;
+  if (isNonEmptyString(instanceIdFromContext)) {
+    return instanceIdFromContext;
+  } else {
+    return null;
+  }
 };

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow.ts
@@ -20,11 +20,13 @@ export const useAvailableComponentInstanceIdOrThrow = <
 
   if (isNonEmptyString(instanceIdFromProps)) {
     return instanceIdFromProps;
-  } else if (isNonEmptyString(instanceIdFromContext)) {
-    return instanceIdFromContext;
-  } else {
-    throw new Error(
-      'Instance id is not provided and cannot be found in context.',
-    );
   }
+
+  if (isNonEmptyString(instanceIdFromContext)) {
+    return instanceIdFromContext;
+  }
+
+  throw new Error(
+    'Instance id is not provided and cannot be found in context.',
+  );
 };

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow.ts
@@ -1,8 +1,13 @@
 import { useComponentInstanceStateContext } from '@/ui/utilities/state/component-state/hooks/useComponentInstanceStateContext';
 import { type ComponentInstanceStateContext } from '@/ui/utilities/state/component-state/types/ComponentInstanceStateContext';
-import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { isNonEmptyString } from '@sniptt/guards';
 
+// Returns the id exactly as provided. Surface isolation is opted into where an
+// id is created (useWorkspaceSurfaceScopedComponentInstanceId at the provider),
+// never here: this hook cannot tell state meant to be shared across surfaces
+// (a side panel reading the main diagram's flow) from state that must be
+// isolated, and ids also escape into DOM anchors that are looked up by the
+// exact string a provider rendered.
 export const useAvailableComponentInstanceIdOrThrow = <
   T extends { instanceId: string },
 >(
@@ -12,17 +17,14 @@ export const useAvailableComponentInstanceIdOrThrow = <
   const instanceStateContext = useComponentInstanceStateContext(Context);
 
   const instanceIdFromContext = instanceStateContext?.instanceId;
-  const availableInstanceId = isNonEmptyString(instanceIdFromProps)
-    ? instanceIdFromProps
-    : (instanceIdFromContext ?? '');
-  const scopedInstanceId =
-    useWorkspaceSurfaceScopedComponentInstanceId(availableInstanceId);
 
-  if (isNonEmptyString(scopedInstanceId)) {
-    return scopedInstanceId;
+  if (isNonEmptyString(instanceIdFromProps)) {
+    return instanceIdFromProps;
+  } else if (isNonEmptyString(instanceIdFromContext)) {
+    return instanceIdFromContext;
+  } else {
+    throw new Error(
+      'Instance id is not provided and cannot be found in context.',
+    );
   }
-
-  throw new Error(
-    'Instance id is not provided and cannot be found in context.',
-  );
 };

--- a/packages/twenty-front/src/modules/workflow/hooks/__tests__/useFlowOrThrow.test.tsx
+++ b/packages/twenty-front/src/modules/workflow/hooks/__tests__/useFlowOrThrow.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { createStore, Provider as JotaiProvider } from 'jotai';
 import { type ReactNode } from 'react';
 
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useFlowOrThrow } from '@/workflow/hooks/useFlowOrThrow';
@@ -23,7 +24,10 @@ const buildWrapper =
       <WorkspaceSurfaceContext.Provider
         value={{
           type: surfaceType,
-          instanceId: surfaceType === 'side-panel' ? 'side-panel-page' : 'main',
+          instanceId:
+            surfaceType === 'side-panel'
+              ? 'side-panel-page'
+              : MAIN_CONTEXT_STORE_INSTANCE_ID,
           ownsRouteLocation: surfaceType === 'main',
         }}
       >

--- a/packages/twenty-front/src/modules/workflow/hooks/__tests__/useFlowOrThrow.test.tsx
+++ b/packages/twenty-front/src/modules/workflow/hooks/__tests__/useFlowOrThrow.test.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
+import { useFlowOrThrow } from '@/workflow/hooks/useFlowOrThrow';
+import { flowComponentState } from '@/workflow/states/flowComponentState';
+import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
+
+const VISUALIZER_INSTANCE_ID = 'workflow-visualizer-workflow-1';
+
+const buildWrapper =
+  ({
+    store,
+    surfaceType,
+  }: {
+    store: ReturnType<typeof createStore>;
+    surfaceType: 'main' | 'side-panel';
+  }) =>
+  ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={store}>
+      <WorkspaceSurfaceContext.Provider
+        value={{
+          type: surfaceType,
+          instanceId: surfaceType === 'side-panel' ? 'side-panel-page' : 'main',
+          ownsRouteLocation: surfaceType === 'main',
+        }}
+      >
+        <WorkflowVisualizerComponentInstanceContext.Provider
+          value={{ instanceId: VISUALIZER_INSTANCE_ID }}
+        >
+          {children}
+        </WorkflowVisualizerComponentInstanceContext.Provider>
+      </WorkspaceSurfaceContext.Provider>
+    </JotaiProvider>
+  );
+
+describe('useFlowOrThrow', () => {
+  // The workflow diagram on the main surface writes the flow, and the side
+  // panel step editor deliberately provides the same visualizer instance id to
+  // read it. If component ids were rewritten per surface, the side panel would
+  // read a different atom and every step click would crash.
+  it('reads a flow written on the main surface from a side panel sharing the instance id', () => {
+    const store = createStore();
+    const flow = {
+      workflowVersionId: 'workflow-version-1',
+      trigger: null,
+      steps: [],
+    };
+
+    const { result: writer } = renderHook(
+      () => useSetAtomComponentState(flowComponentState),
+      { wrapper: buildWrapper({ store, surfaceType: 'main' }) },
+    );
+
+    act(() => {
+      writer.current(flow);
+    });
+
+    const { result: reader } = renderHook(() => useFlowOrThrow(), {
+      wrapper: buildWrapper({ store, surfaceType: 'side-panel' }),
+    });
+
+    expect(reader.current).toEqual(flow);
+  });
+
+  it('throws when the flow has not been written', () => {
+    expect(() =>
+      renderHook(() => useFlowOrThrow(), {
+        wrapper: buildWrapper({
+          store: createStore(),
+          surfaceType: 'side-panel',
+        }),
+      }),
+    ).toThrow('Expected the flow to be defined');
+  });
+});

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeOptionsDropdown.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeOptionsDropdown.tsx
@@ -6,6 +6,7 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import { WORKFLOW_DIAGRAM_STEP_NODE_BASE_CLICK_OUTSIDE_ID } from '@/workflow/workflow-diagram/constants/WorkflowDiagramStepNodeClickOutsideId';
 import { WorkflowStepOptionsMenuItems } from '@/workflow/workflow-steps/components/WorkflowStepOptionsMenuItems';
 import { WORKFLOW_STEP_OPTIONS_MENU_ITEM_IDS } from '@/workflow/workflow-steps/constants/WorkflowStepOptionsMenuItemIds';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
 import { useId } from 'react';
@@ -45,9 +46,12 @@ export const WorkflowDiagramStepNodeOptionsDropdown = ({
     WORKFLOW_STEP_OPTIONS_MENU_ITEM_IDS.deleteNode,
   ];
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const closeDropdownThen = (action: () => void) => () => {

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepFooter.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepFooter.tsx
@@ -12,6 +12,7 @@ import { useDeleteStep } from '@/workflow/workflow-steps/hooks/useDeleteStep';
 import { useDuplicateStep } from '@/workflow/workflow-steps/hooks/useDuplicateStep';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { workflowAiAgentActionAgentState } from '@/workflow/workflow-steps/workflow-actions/ai-agent-action/states/workflowAiAgentActionAgentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useLingui } from '@lingui/react/macro';
 import { useId } from 'react';
 import { SettingsPath } from 'twenty-shared/types';
@@ -98,9 +99,12 @@ export const WorkflowStepFooter = ({
     }
   };
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const OptionsDropdown = (

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowObjectDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowObjectDropdownContent.tsx
@@ -9,6 +9,7 @@ import { SelectableList } from '@/ui/layout/selectable-list/components/Selectabl
 import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useState } from 'react';
 import { MenuItem } from 'twenty-ui/navigation';
 
@@ -73,9 +74,12 @@ export const WorkflowObjectDropdownContent = ({
     (objectMetadataItem) => objectMetadataItem.nameSingular,
   );
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const handleSearchInputChange = (

--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerDatabaseEventForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerDatabaseEventForm.tsx
@@ -20,6 +20,7 @@ import { WorkflowStepBody } from '@/workflow/workflow-steps/components/WorkflowS
 import { WorkflowStepFooter } from '@/workflow/workflow-steps/components/WorkflowStepFooter';
 import { WorkflowStepFilterBuilder } from '@/workflow/workflow-steps/filters/components/WorkflowStepFilterBuilder';
 import { type FilterSettings } from '@/workflow/workflow-steps/filters/types/FilterSettings';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
 import { useMemo, useState } from 'react';
@@ -147,9 +148,12 @@ export const WorkflowEditTriggerDatabaseEventForm = ({
 
   const selectableItemIdArray = filteredObjects.map((option) => option.value);
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
-    dropdownId,
+    scopedDropdownId,
   );
 
   const handleOptionClick = (value: string) => {


### PR DESCRIPTION
Root-cause fix for the three regressions QA Scout found on `main` after #25164: records not editable from the Fields panel (side panel), every workflow step click crashing with `Expected the flow to be defined`, and — the same mechanism — anything else that shares or anchors component state across surfaces.

### Root cause

#25164 moved workspace-surface scoping **into** `useAvailableComponentInstanceIdOrThrow` / `useAvailableComponentInstanceId`. Those sit under all 12 jotai component-state hooks (156 call sites), so every id read through them was silently rewritten to `<id>-<surfaceInstanceId>` inside a side panel.

That primitive cannot know which state is meant to be shared and which must be isolated, and it breaks two things it cannot distinguish:

1. **State shared across surfaces by design.** `SidePanelWorkflowEditStep` deliberately provides the *same* `WorkflowVisualizerComponentInstanceContext` id as the main diagram so the step editor reads the diagram's `flowComponentState`. The diagram writes under `X` (scoping is identity on `main`); the side panel now reads under `X-<sidePanel>` → `undefined` → `useFlowOrThrow` throws on every step click.
2. **Ids that escape into the DOM.** `FieldsWidget` / `RecordFieldList` render anchor elements from their instance id; `RecordInlineCellAnchoredPortal` finds them with `document.getElementById` after resolving the id through the primitive. In a side panel the rendered id and the looked-up id differ, the lookup misses, the portal renders `null`, and the click lands on the inert display underneath — the cell highlights, no editor opens.

The codebase's existing convention is the correct one: **isolation is opted into at the provider, where an id is created**, with `useWorkspaceSurfaceScopedComponentInstanceId`. The page-layout module already does exactly this (`PageLayoutRenderer`, `PageLayoutTabsRenderer`, `PageLayoutLeftPanel`), so #25164's primitive scoping was redundant there and harmful everywhere else.

### Fix

- Restore both primitives to their pre-#25164 form — return the id exactly as provided — with a comment pinning that contract and why.
- Restore the three explicit provider-side scopings #25164 removed (`useSelectableList`, `SidePanelDefaultSelectionEffect`, `useSettingsActiveTabId`).
- Re-seed the two test/story files #25164 changed to assume implicit scoping (`PageLayoutTabListEffect.test.tsx`, `WidgetRenderer.stories.tsx`) under the raw ids their components actually use.
- Keep everything else in #25164 — header-portal split, route validation, SDK allowlist, URL/history — untouched.

Nothing on `main` since #25164 touched these hooks, so this is collision-free with the open PRs.

### Also: selectable-list readers (from review)

Review caught a real gap: `useSelectableList` scopes the id it is handed before **writing**, but ~50 components **read** `selectedItemIdComponentState` / `isSelectedItemIdComponentFamilyState` directly with the raw id they passed in (`dropdownId`, `OBJECT_SORT_DROPDOWN_ID`, `OBJECT_OPTIONS_DROPDOWN_ID`, the record-picker list ids, …). In a side panel that's a different atom, so the current option lost its focused state. The mismatch pre-dates #25164 — its primitive scoping had been papering over it — and restoring the primitive re-exposed it, so it's fixed here rather than deferred.

Every such reader now resolves the same surface-scoped id the writer uses. The set was established by parsing every call of the two atoms with a formatting-agnostic enumeration (77 reads), not by grep — the first pass missed the page-layout side-panel setting dropdowns and the workflow step-editor dropdowns because their calls were laid out differently; the quality review caught that and the second pass covers them. Readers scope right before the read; the record pickers and `IconPicker` scope where the list id is *created*, so write, provider and reads all agree. `SettingsMorphRelationMultiSelect` and `MultipleRecordPickerCreateTargetSelect` already did exactly this — the rest is now consistent with them.

### Tests

- `useAvailableComponentInstanceIdOrThrow.test.tsx` — contract test: both primitives return the provided id verbatim on `main` and `side-panel`, from context and from props.
- `useSelectableList.surfaceScope.test.tsx` — writes through `useSelectableList` in a side panel and shows a scoped read sees the value while a raw read does not.
- `useFlowOrThrow.test.tsx` — the workflow crash: a flow written on the main surface is readable from a side panel providing the same instance id.
- `FieldsWidget.stories.tsx` — `OpensEditModeOnMainSurface` / `OpensEditModeInSidePanel`: hover a field, click it, assert an input mounts, in a real browser. The existing stories only rendered on `main` and never opened an editor, which is why CI stayed green through the regression.

### Verification

`twenty-front` typecheck, lint and oxfmt are clean locally. Tests and storybook were **not** run locally by request — CI is the check.

### Supersedes

Closes #25221, which patched only the field-list symptom. Its side-panel stories are carried here as the browser-level guard.

### Caveat

Reverting the primitive could re-expose cross-surface state leaks that #25164's blanket scoping fixed *beyond* the three explicit sites restored here (a hover position bleeding between surfaces, that kind of thing). Those should be fixed the same way — scope at the provider — as they surface. They are cosmetic next to "no workflow can be edited".
