### PR TITLE
fix(slack): let a declined link fall through to the member's own email match

### DIFF
--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/resolve-slack-run-as-workspace-member-id.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/resolve-slack-run-as-workspace-member-id.test.ts
@@ -183,9 +183,14 @@ describe('resolveSlackRunAsWorkspaceMemberId', () => {
     expect(createSlackUserLinkMock).not.toHaveBeenCalled();
   });
 
-  it('should not run as anyone for a declined manual link, even when the email matches', async () => {
+  it('should still grant the member their own email match after a declined manual link to another member', async () => {
+    // Declining a link that lends another member's access must not cost the
+    // Slack user their own identity: once DECLINED is no longer an early
+    // return, run-as still resolves their own member by email (which is all
+    // their own permissions) and never re-creates or re-updates the link.
     findSlackUserLinkMock.mockResolvedValue({
       ...MANUAL_LINK,
+      workspaceMemberId: 'member-2',
       consentState: 'DECLINED',
     });
     findWorkspaceMemberIdByEmailMock.mockResolvedValue('member-1');
@@ -196,8 +201,31 @@ describe('resolveSlackRunAsWorkspaceMemberId', () => {
         slackClient,
         identity: IDENTITY,
       }),
+    ).toBe('member-1');
+    expect(findWorkspaceMemberIdByEmailMock).toHaveBeenCalledTimes(1);
+    expect(findWorkspaceMemberIdByEmailMock).toHaveBeenCalledWith(
+      client,
+      'ada@twenty.com',
+    );
+    expect(createSlackUserLinkMock).not.toHaveBeenCalled();
+    expect(updateSlackUserLinkMock).not.toHaveBeenCalled();
+  });
+
+  it('should not fall back to a declined manual link when the user has no own email match', async () => {
+    findSlackUserLinkMock.mockResolvedValue({
+      ...MANUAL_LINK,
+      workspaceMemberId: 'member-2',
+      consentState: 'DECLINED',
+    });
+    findWorkspaceMemberIdByEmailMock.mockResolvedValue(undefined);
+
+    expect(
+      await resolveSlackRunAsWorkspaceMemberId({
+        client,
+        slackClient,
+        identity: IDENTITY,
+      }),
     ).toBeUndefined();
-    expect(findWorkspaceMemberIdByEmailMock).not.toHaveBeenCalled();
     expect(createSlackUserLinkMock).not.toHaveBeenCalled();
     expect(updateSlackUserLinkMock).not.toHaveBeenCalled();
   });

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/resolve-slack-run-as-workspace-member-id.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/resolve-slack-run-as-workspace-member-id.ts
@@ -71,10 +71,6 @@ export const resolveSlackRunAsWorkspaceMemberId = async ({
         ? existingLink.workspaceMemberId
         : undefined;
     }
-
-    if (existingLink?.consentState === SLACK_USER_LINK_CONSENT_STATE.DECLINED) {
-      return undefined;
-    }
   }
 
   const linkableEmail = await resolveLinkableEmail({ slackClient, identity });


### PR DESCRIPTION
## Problem

When a manual Slack user link is in the `DECLINED` consent state, `resolveSlackRunAsWorkspaceMemberId` returned `undefined` before it ever reached the live email match, a link like that usually exists because someone was set up to *act as another member* (borrowed access) and declined the consent, the decline is about that borrowed access, but the early return also stripped the person of their **own** member identity: the resolver returned nothing (default agent role) until an admin removed the link

`isConsentedSlackUserLink(undefined) === true` already keeps legacy and admin set links trusted, and a `PENDING` manual link already falls through to the email match, a declined link was the only case that stopped before it

## Fix

Remove the `DECLINED` early return in `resolveSlackRunAsWorkspaceMemberId`, a manual link that was not consented now falls through to the person's own email match, exactly like a pending one does, it grants only their own permissions (their own member), and it never resurrects the declined borrowed member: if there is no own email match the resolver still returns `undefined`, and the manual branch never creates or updates a link

The change is 4 removed production lines in one file

## Reflection on the direction

This is the fall through the core team reviewer @martmull spelled out on the merged Slack consent review (#24887 / #25105, "For you to decide"): people who decline lending someone's access lose the automatic match to their own member and get nothing until an admin removes the link, and letting `DECLINED` fall through to the email match grants only permissions they already have, so this closes the loop on a gap the maintainer already flagged

## Test

- new: a member with a `DECLINED` manual link to another member still resolves to their own member by email (was `undefined`)
- new: with no own email match, a `DECLINED` link still yields `undefined` (borrowed member stays unreachable)
- updated the old case that pinned the buggy "undefined even on own email match" behaviour
- the new own match case fails without the source change (verified by reverting the 4 lines)
- `yarn test:unit` → 500 passed (72 files) · `yarn lint` → 0/0 (419 files) · `yarn typecheck` → clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

