### PR TITLE
fix: include workspace-shared accounts in findByUserWorkspaceId (#25226)

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/__tests__/connected-account-metadata.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/__tests__/connected-account-metadata.service.spec.ts
@@ -8,6 +8,7 @@ import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/con
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
+import { In } from 'typeorm';
 
 describe('ConnectedAccountMetadataService', () => {
   let service: ConnectedAccountMetadataService;
@@ -71,6 +72,14 @@ describe('ConnectedAccountMetadataService', () => {
       });
 
       expect(result).toEqual([ownAccount]);
+      expect(connectedAccountRepository.find).toHaveBeenCalledTimes(2);
+      expect(connectedAccountRepository.find).toHaveBeenNthCalledWith(1, {
+        where: { userWorkspaceId, workspaceId },
+      });
+      expect(connectedAccountRepository.find).toHaveBeenNthCalledWith(2, {
+        where: { workspaceId, visibility: 'workspace' },
+        select: ['id'],
+      });
     });
 
     it('includes workspace-shared accounts alongside the own accounts', async () => {
@@ -85,9 +94,17 @@ describe('ConnectedAccountMetadataService', () => {
       });
 
       expect(result).toEqual([ownAccount, sharedAccount]);
+      expect(connectedAccountRepository.find).toHaveBeenCalledTimes(3);
+      expect(connectedAccountRepository.find).toHaveBeenNthCalledWith(3, {
+        where: {
+          id: In([sharedAccount.id]),
+          workspaceId,
+          visibility: 'workspace',
+        },
+      });
     });
 
-    it('does not duplicate an account that is both own and shared', async () => {
+    it('does not duplicate an account that is both own and shared, and skips the third query', async () => {
       connectedAccountRepository.find
         .mockResolvedValueOnce([ownAccount])
         .mockResolvedValueOnce([{ id: ownAccount.id }]);
@@ -98,6 +115,7 @@ describe('ConnectedAccountMetadataService', () => {
       });
 
       expect(result).toEqual([ownAccount]);
+      expect(connectedAccountRepository.find).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/__tests__/connected-account-metadata.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/__tests__/connected-account-metadata.service.spec.ts
@@ -1,0 +1,103 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ConnectionProviderLifecycleHookService } from 'src/engine/core-modules/application/connection-provider/connection-provider-lifecycle-hook.service';
+import { AppOAuthRevokeService } from 'src/engine/core-modules/application/connection-provider/refresh/services/app-oauth-revoke.service';
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
+
+describe('ConnectedAccountMetadataService', () => {
+  let service: ConnectedAccountMetadataService;
+  let connectedAccountRepository: {
+    find: jest.Mock;
+  };
+
+  const workspaceId = 'workspace-1';
+  const userWorkspaceId = 'user-workspace-1';
+
+  const ownAccount = {
+    id: 'own-account-1',
+    userWorkspaceId,
+    workspaceId,
+    visibility: 'user',
+  } as ConnectedAccountEntity;
+
+  const sharedAccount = {
+    id: 'shared-account-1',
+    userWorkspaceId: 'someone-else',
+    workspaceId,
+    visibility: 'workspace',
+  } as ConnectedAccountEntity;
+
+  beforeEach(async () => {
+    connectedAccountRepository = { find: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConnectedAccountMetadataService,
+        {
+          provide: getRepositoryToken(ConnectedAccountEntity),
+          useValue: connectedAccountRepository,
+        },
+        {
+          provide: getRepositoryToken(CalendarChannelEntity),
+          useValue: { find: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(MessageChannelEntity),
+          useValue: { find: jest.fn() },
+        },
+        { provide: AppOAuthRevokeService, useValue: {} },
+        { provide: ConnectionProviderLifecycleHookService, useValue: {} },
+        { provide: WorkspaceEventEmitter, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get(ConnectedAccountMetadataService);
+  });
+
+  describe('findByUserWorkspaceId', () => {
+    it("returns only the caller's own accounts when there are no shared accounts", async () => {
+      connectedAccountRepository.find
+        .mockResolvedValueOnce([ownAccount])
+        .mockResolvedValueOnce([]);
+
+      const result = await service.findByUserWorkspaceId({
+        userWorkspaceId,
+        workspaceId,
+      });
+
+      expect(result).toEqual([ownAccount]);
+    });
+
+    it('includes workspace-shared accounts alongside the own accounts', async () => {
+      connectedAccountRepository.find
+        .mockResolvedValueOnce([ownAccount])
+        .mockResolvedValueOnce([{ id: sharedAccount.id }])
+        .mockResolvedValueOnce([sharedAccount]);
+
+      const result = await service.findByUserWorkspaceId({
+        userWorkspaceId,
+        workspaceId,
+      });
+
+      expect(result).toEqual([ownAccount, sharedAccount]);
+    });
+
+    it('does not duplicate an account that is both own and shared', async () => {
+      connectedAccountRepository.find
+        .mockResolvedValueOnce([ownAccount])
+        .mockResolvedValueOnce([{ id: ownAccount.id }]);
+
+      const result = await service.findByUserWorkspaceId({
+        userWorkspaceId,
+        workspaceId,
+      });
+
+      expect(result).toEqual([ownAccount]);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/connected-account-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/connected-account-metadata.service.ts
@@ -10,11 +10,11 @@ import { AppOAuthRevokeService } from 'src/engine/core-modules/application/conne
 import { CALENDAR_CHANNEL_DELETED_EVENT } from 'src/engine/metadata-modules/calendar-channel/constants/calendar-channel-deleted.constant';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { type CalendarChannelDeletedEvent } from 'src/engine/metadata-modules/calendar-channel/types/calendar-channel-deleted.type';
-import { CONNECTED_ACCOUNT_DELETED_EVENT } from 'src/engine/metadata-modules/connected-account/constants/connected-account-deleted.constant';
 import {
   ConnectedAccountException,
   ConnectedAccountExceptionCode,
 } from 'src/engine/metadata-modules/connected-account/connected-account.exception';
+import { CONNECTED_ACCOUNT_DELETED_EVENT } from 'src/engine/metadata-modules/connected-account/constants/connected-account-deleted.constant';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { type ConnectedAccountDeletedEvent } from 'src/engine/metadata-modules/connected-account/types/connected-account-deleted.type';
 import { isConnectedAccountUsableByCaller } from 'src/engine/metadata-modules/connected-account/utils/is-connected-account-usable-by-caller.util';
@@ -46,9 +46,30 @@ export class ConnectedAccountMetadataService {
     userWorkspaceId: string;
     workspaceId: string;
   }): Promise<ConnectedAccountEntity[]> {
-    return this.repository.find({
+    const ownConnectedAccounts = await this.repository.find({
       where: { userWorkspaceId, workspaceId },
     });
+
+    const sharedConnectedAccountIds =
+      await this.getWorkspaceSharedConnectedAccountIds({ workspaceId });
+
+    const ownConnectedAccountIds = new Set(
+      ownConnectedAccounts.map((connectedAccount) => connectedAccount.id),
+    );
+
+    const additionalSharedAccountIds = sharedConnectedAccountIds.filter(
+      (id) => !ownConnectedAccountIds.has(id),
+    );
+
+    if (additionalSharedAccountIds.length === 0) {
+      return ownConnectedAccounts;
+    }
+
+    const sharedConnectedAccounts = await this.repository.find({
+      where: { id: In(additionalSharedAccountIds), workspaceId },
+    });
+
+    return [...ownConnectedAccounts, ...sharedConnectedAccounts];
   }
 
   async findById({

--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/connected-account-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/connected-account-metadata.service.ts
@@ -66,7 +66,11 @@ export class ConnectedAccountMetadataService {
     }
 
     const sharedConnectedAccounts = await this.repository.find({
-      where: { id: In(additionalSharedAccountIds), workspaceId },
+      where: {
+        id: In(additionalSharedAccountIds),
+        workspaceId,
+        visibility: 'workspace',
+      },
     });
 
     return [...ownConnectedAccounts, ...sharedConnectedAccounts];


### PR DESCRIPTION
Fixes #25226 

myConnectedAccounts filtered strictly by userWorkspaceId, while myMessageChannels unioned own accounts with workspace-shared ones.
This asymmetry meant a mailbox shared with the workspace (visibility: 'workspace') was visible in shared threads but absent
from myConnectedAccounts, so the Reply button never rendered even though the backend would have permitted the send.

This updates findByUserWorkspaceId in connected-account-metadata.service.ts to also include workspace-shared accounts, mirroring the existing pattern already used in message-channel-metadata.service.ts (getWorkspaceSharedConnectedAccountIds), de-duplicating so an account that is both the caller's own and shared isn't returned twice.

Added unit tests covering: own-accounts-only, own+shared combined, and no duplication when an account is both.

Scope note: the issue also flagged two related sharp edges (deleteConnectedAccount accepting the same shared-account bypass and no ownership filter in Settings → Accounts). 
Left those out of this PR to keep it focused — happy to pick those up separately if useful.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

