### PR TITLE
Stop remounting every device-session row on each render of the devices section

### DIFF
--- a/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowDropdownMenu.tsx
@@ -9,23 +9,27 @@ import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { IconDotsVertical, IconLogout } from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
 import { MenuItem } from 'twenty-ui/navigation';
-import { RevokeUserSessionDocument } from '~/generated-metadata/graphql';
+import {
+  CurrentUserSessionsDocument,
+  RevokeUserSessionDocument,
+} from '~/generated-metadata/graphql';
 
 type SettingsDeviceSessionRowDropdownMenuProps = {
   userSessionId: string;
-  onRevoked: () => void;
 };
 
 export const SettingsDeviceSessionRowDropdownMenu = ({
   userSessionId,
-  onRevoked,
 }: SettingsDeviceSessionRowDropdownMenuProps) => {
   const dropdownId = `settings-device-session-row-${userSessionId}`;
 
   const { enqueueErrorSnackBar, enqueueSuccessSnackBar } = useSnackBar();
   const { closeDropdown } = useCloseDropdown();
 
-  const [revokeUserSession] = useMutation(RevokeUserSessionDocument);
+  const [revokeUserSession] = useMutation(RevokeUserSessionDocument, {
+    refetchQueries: [CurrentUserSessionsDocument],
+    awaitRefetchQueries: true,
+  });
 
   const handleRevokeSession = async () => {
     closeDropdown(dropdownId);
@@ -33,7 +37,6 @@ export const SettingsDeviceSessionRowDropdownMenu = ({
     try {
       await revokeUserSession({ variables: { userSessionId } });
       enqueueSuccessSnackBar({ message: t`Device logged out` });
-      onRevoked();
     } catch {
       enqueueErrorSnackBar({ message: t`Failed to log out this device` });
     }

--- a/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowDropdownMenu.tsx
@@ -28,7 +28,6 @@ export const SettingsDeviceSessionRowDropdownMenu = ({
 
   const [revokeUserSession] = useMutation(RevokeUserSessionDocument, {
     refetchQueries: [CurrentUserSessionsDocument],
-    awaitRefetchQueries: true,
   });
 
   const handleRevokeSession = async () => {

--- a/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowRightComponent.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowRightComponent.tsx
@@ -7,10 +7,6 @@ import { type CurrentUserSessionsQuery } from '~/generated-metadata/graphql';
 type UserSessionListItem =
   CurrentUserSessionsQuery['currentUserSessions'][number];
 
-// SettingsListCard renders this as a component type, so it has to be a stable
-// module-level component: defining it inline in the section would give React a
-// new type on every render and remount every row -- and each row's Dropdown
-// sets state from a ref on mount.
 export const SettingsDeviceSessionRowRightComponent = ({
   item: session,
 }: {

--- a/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowRightComponent.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowRightComponent.tsx
@@ -1,0 +1,33 @@
+import { useLingui } from '@lingui/react/macro';
+
+import { SettingsDeviceSessionRowDropdownMenu } from '@/settings/profile/devices/components/SettingsDeviceSessionRowDropdownMenu';
+import { Status } from 'twenty-ui/data-display';
+import { type CurrentUserSessionsQuery } from '~/generated-metadata/graphql';
+
+type UserSessionListItem =
+  CurrentUserSessionsQuery['currentUserSessions'][number];
+
+// SettingsListCard renders this as a component type, so it has to be a stable
+// module-level component: defining it inline in the section would give React a
+// new type on every render and remount every row -- and each row's Dropdown
+// sets state from a ref on mount.
+export const SettingsDeviceSessionRowRightComponent = ({
+  item: session,
+}: {
+  item: UserSessionListItem;
+}) => {
+  const { t } = useLingui();
+
+  return (
+    <>
+      {session.isImpersonating && (
+        <Status color="orange" text={t`Impersonation`} />
+      )}
+      {session.isCurrent ? (
+        <Status color="turquoise" text={t`This device`} />
+      ) : (
+        <SettingsDeviceSessionRowDropdownMenu userSessionId={session.id} />
+      )}
+    </>
+  );
+};

--- a/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsProfileDevicesSection.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsProfileDevicesSection.tsx
@@ -5,11 +5,10 @@ import { isNonEmptyString } from '@sniptt/guards';
 
 import { useSnackBarOnQueryError } from '@/apollo/hooks/useSnackBarOnQueryError';
 import { SettingsListCard } from '@/settings/components/SettingsListCard';
-import { SettingsDeviceSessionRowDropdownMenu } from '@/settings/profile/devices/components/SettingsDeviceSessionRowDropdownMenu';
+import { SettingsDeviceSessionRowRightComponent } from '@/settings/profile/devices/components/SettingsDeviceSessionRowRightComponent';
 import { parseUserAgentDescription } from '@/settings/profile/devices/utils/parseUserAgentDescription';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { Status } from 'twenty-ui/data-display';
 import { IconDeviceDesktop, IconLogout } from 'twenty-ui/icon';
 import { Button } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
@@ -110,21 +109,7 @@ export const SettingsProfileDevicesSection = () => {
           getItemLabel={getSessionLabel}
           getItemDescription={getSessionDescription}
           RowIcon={IconDeviceDesktop}
-          RowRightComponent={({ item: session }) => (
-            <>
-              {session.isImpersonating && (
-                <Status color="orange" text={t`Impersonation`} />
-              )}
-              {session.isCurrent ? (
-                <Status color="turquoise" text={t`This device`} />
-              ) : (
-                <SettingsDeviceSessionRowDropdownMenu
-                  userSessionId={session.id}
-                  onRevoked={() => void refetch()}
-                />
-              )}
-            </>
-          )}
+          RowRightComponent={SettingsDeviceSessionRowRightComponent}
         />
         {hasOtherSessions && (
           <StyledButtonContainer>

--- a/packages/twenty-front/src/modules/settings/profile/devices/components/__tests__/SettingsProfileDevicesSection.test.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/__tests__/SettingsProfileDevicesSection.test.tsx
@@ -34,10 +34,6 @@ const Wrapper = getJestMetadataAndApolloMocksWrapper({
 });
 
 describe('SettingsProfileDevicesSection', () => {
-  // Every non-current row renders a Dropdown whose floating-ui reference ref
-  // sets state on mount. If the row component were defined inline, each render
-  // of the section would hand React a new component type and remount the row,
-  // so its DOM node would not survive a re-render.
   it('keeps a session row mounted across a re-render of the section', async () => {
     const tree = (
       <I18nProvider i18n={i18n}>
@@ -50,12 +46,12 @@ describe('SettingsProfileDevicesSection', () => {
     const { rerender } = render(tree, { wrapper: Wrapper });
 
     expect(await screen.findByText('This device')).toBeVisible();
-    // The dropdown trigger carries role="button" and wraps the icon button,
-    // so take the outermost one: it is the floating-ui reference element.
-    const [rowDropdownTrigger] = screen.getAllByRole('button');
+    const rowDropdownTrigger = screen.getByRole('button', { expanded: false });
 
     rerender(tree);
 
-    expect(screen.getAllByRole('button')[0]).toBe(rowDropdownTrigger);
+    expect(screen.getByRole('button', { expanded: false })).toBe(
+      rowDropdownTrigger,
+    );
   });
 });

--- a/packages/twenty-front/src/modules/settings/profile/devices/components/__tests__/SettingsProfileDevicesSection.test.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/__tests__/SettingsProfileDevicesSection.test.tsx
@@ -1,3 +1,5 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -37,22 +39,23 @@ describe('SettingsProfileDevicesSection', () => {
   // of the section would hand React a new component type and remount the row,
   // so its DOM node would not survive a re-render.
   it('keeps a session row mounted across a re-render of the section', async () => {
-    const { rerender } = render(
-      <MemoryRouter>
-        <SettingsProfileDevicesSection />
-      </MemoryRouter>,
-      { wrapper: Wrapper },
+    const tree = (
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter>
+          <SettingsProfileDevicesSection />
+        </MemoryRouter>
+      </I18nProvider>
     );
+
+    const { rerender } = render(tree, { wrapper: Wrapper });
 
     expect(await screen.findByText('This device')).toBeVisible();
-    const rowDropdownTrigger = screen.getByRole('button');
+    // The dropdown trigger carries role="button" and wraps the icon button,
+    // so take the outermost one: it is the floating-ui reference element.
+    const [rowDropdownTrigger] = screen.getAllByRole('button');
 
-    rerender(
-      <MemoryRouter>
-        <SettingsProfileDevicesSection />
-      </MemoryRouter>,
-    );
+    rerender(tree);
 
-    expect(screen.getByRole('button')).toBe(rowDropdownTrigger);
+    expect(screen.getAllByRole('button')[0]).toBe(rowDropdownTrigger);
   });
 });

--- a/packages/twenty-front/src/modules/settings/profile/devices/components/__tests__/SettingsProfileDevicesSection.test.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/__tests__/SettingsProfileDevicesSection.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { SettingsProfileDevicesSection } from '@/settings/profile/devices/components/SettingsProfileDevicesSection';
+import { CurrentUserSessionsDocument } from '~/generated-metadata/graphql';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+const buildSession = (id: string, isCurrent: boolean) => ({
+  __typename: 'UserSession',
+  id,
+  isCurrent,
+  isImpersonating: false,
+  userAgent: 'Mozilla/5.0 (Macintosh) Chrome/128.0',
+  ipAddress: '127.0.0.1',
+  lastActiveAt: new Date().toISOString(),
+});
+
+const Wrapper = getJestMetadataAndApolloMocksWrapper({
+  apolloMocks: [
+    {
+      request: { query: CurrentUserSessionsDocument },
+      result: {
+        data: {
+          currentUserSessions: [
+            buildSession('session-current', true),
+            buildSession('session-other', false),
+          ],
+        },
+      },
+    },
+  ],
+});
+
+describe('SettingsProfileDevicesSection', () => {
+  // Every non-current row renders a Dropdown whose floating-ui reference ref
+  // sets state on mount. If the row component were defined inline, each render
+  // of the section would hand React a new component type and remount the row,
+  // so its DOM node would not survive a re-render.
+  it('keeps a session row mounted across a re-render of the section', async () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <SettingsProfileDevicesSection />
+      </MemoryRouter>,
+      { wrapper: Wrapper },
+    );
+
+    expect(await screen.findByText('This device')).toBeVisible();
+    const rowDropdownTrigger = screen.getByRole('button');
+
+    rerender(
+      <MemoryRouter>
+        <SettingsProfileDevicesSection />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('button')).toBe(rowDropdownTrigger);
+  });
+});


### PR DESCRIPTION
### What this fixes

`SettingsProfileDevicesSection` passed `RowRightComponent` as an **inline arrow function**. `SettingsListCard` renders that prop as a component type (`<RowRightComponent item={item} />`), so every render of the section gave React a new component type and **unmounted and remounted every device row** — including each non-current row's `Dropdown`.

That matters for the React #185 crash on Profile settings ("Sorry, something went wrong" after opening Settings): `@floating-ui/react`'s `setReference` callback ref calls `setDomReference` on every mount, from the commit phase. A subtree that keeps remounting a `Dropdown` therefore trips "maximum update depth" **inside floating-ui**, which is exactly where the production stack trace points (`floating-ui.react.esm-*.js` called from the layout/ref recursion).

### Change

- The row is a module-level component (`SettingsDeviceSessionRowRightComponent`), so its type is stable across renders.
- The row's revoke mutation refetches `CurrentUserSessions` via `refetchQueries` instead of an `onRevoked` callback from the parent — that callback was the reason the row had been defined inline.

### Test

Re-renders the section and asserts a row's DOM node is the **same instance** afterwards. It fails against the inline component (the node is recreated) and passes here.

### Scope note — this does NOT fix the #185 crash

The Home → Settings crash is fixed by #25233 (a second, stale `RouteContextStoreProvider` kept alive by the app ↔ settings page transition fights the new one over the main context store). Reproducing on this PR's own preview with a single session showed this remount is not the driver. It is still a real bug: the row's dropdown was being remounted on every render of the section.

Six other settings list cards pass inline `RowRightComponent`s (`SettingsApprovedAccessDomainsListCard`, `SettingsPublicDomainsListCard`, `SettingsAgentEvalsTab`, the two admin-panel cards, the SSO card) and should get the same treatment in a follow-up; `oxlint` has no `react/no-unstable-nested-components` equivalent to guard it.
