### PR TITLE
Host the main surface's route context store once, above the page transition

### DIFF
--- a/packages/twenty-front/src/modules/app/routing/utils/__tests__/getWorkspaceRouteObjectsForSurface.test.tsx
+++ b/packages/twenty-front/src/modules/app/routing/utils/__tests__/getWorkspaceRouteObjectsForSurface.test.tsx
@@ -1,0 +1,58 @@
+import { Children, isValidElement, type ReactNode } from 'react';
+
+import { type WorkspaceRouteObject } from '@/app/routing/types/WorkspaceRouteObject';
+import { getWorkspaceRouteObjectsForSurface } from '@/app/routing/utils/getWorkspaceRouteObjectsForSurface';
+import { RouteContextStoreProvider } from '@/context-store/components/RouteContextStoreProvider';
+
+const containsRouteContextStoreProvider = (node: ReactNode): boolean =>
+  Children.toArray(node).some(
+    (child) =>
+      isValidElement(child) &&
+      (child.type === RouteContextStoreProvider ||
+        containsRouteContextStoreProvider(
+          (child.props as { children?: ReactNode }).children,
+        )),
+  );
+
+const routeObjects: WorkspaceRouteObject[] = [
+  {
+    path: '/objects/:objectNamePlural',
+    element: <div>index</div>,
+    handle: { workspaceSurfaces: ['main', 'side-panel'] },
+  },
+  {
+    path: '/settings/*',
+    element: <div>settings</div>,
+    handle: { workspaceSurfaces: ['main', 'side-panel'] },
+  },
+];
+
+describe('getWorkspaceRouteObjectsForSurface', () => {
+  it('leaves main-surface route elements without a route context store provider', () => {
+    const mainRouteObjects = getWorkspaceRouteObjectsForSurface(
+      routeObjects,
+      'main',
+    );
+
+    expect(mainRouteObjects).toHaveLength(2);
+    expect(
+      mainRouteObjects.some((routeObject) =>
+        containsRouteContextStoreProvider(routeObject.element),
+      ),
+    ).toBe(false);
+  });
+
+  it('wraps side-panel route elements with a route context store provider', () => {
+    const sidePanelRouteObjects = getWorkspaceRouteObjectsForSurface(
+      routeObjects,
+      'side-panel',
+    );
+
+    expect(sidePanelRouteObjects).toHaveLength(2);
+    expect(
+      sidePanelRouteObjects.every((routeObject) =>
+        containsRouteContextStoreProvider(routeObject.element),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/twenty-front/src/modules/app/routing/utils/getWorkspaceRouteObjectsForSurface.tsx
+++ b/packages/twenty-front/src/modules/app/routing/utils/getWorkspaceRouteObjectsForSurface.tsx
@@ -43,7 +43,14 @@ const getWorkspaceRouteObjects = (
     ];
   });
 
+// The main surface hosts its route context store once, above the page
+// transition, in MainAppLayoutWithSidePanel: the transition keeps the page
+// being left mounted while the next one enters, and a provider inside each
+// page would leave two of them writing the same store from different routes.
+// The side panel renders its routes against its own location, which only the
+// routed tree can read, and it remounts per location, so its provider lives
+// inside the tree.
 export const getWorkspaceRouteObjectsForSurface = (
   routeObjects: WorkspaceRouteObject[],
   surface: WorkspaceSurfaceType,
-) => getWorkspaceRouteObjects(routeObjects, surface, true);
+) => getWorkspaceRouteObjects(routeObjects, surface, surface === 'side-panel');

--- a/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
@@ -1,4 +1,5 @@
 import { CommandMenuForMobile } from '@/command-menu/components/CommandMenuForMobile';
+import { RouteContextStoreProvider } from '@/context-store/components/RouteContextStoreProvider';
 import { useCommandMenuHotKeys } from '@/command-menu/hooks/useCommandMenuHotKeys';
 import { SidePanelForDesktop } from '@/side-panel/components/SidePanelForDesktop';
 import { SidePanelPathUrlSyncEffect } from '@/side-panel/routing/components/SidePanelPathUrlSyncEffect';
@@ -129,6 +130,7 @@ export const MainAppLayoutWithSidePanel = () => {
 
   return (
     <StyledRow>
+      <RouteContextStoreProvider />
       <SidePanelPathUrlSyncEffect />
       <StyledContent>
         <MainAppLayoutOutlet />

--- a/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
@@ -1,6 +1,6 @@
 import { CommandMenuForMobile } from '@/command-menu/components/CommandMenuForMobile';
-import { RouteContextStoreProvider } from '@/context-store/components/RouteContextStoreProvider';
 import { useCommandMenuHotKeys } from '@/command-menu/hooks/useCommandMenuHotKeys';
+import { RouteContextStoreProvider } from '@/context-store/components/RouteContextStoreProvider';
 import { SidePanelForDesktop } from '@/side-panel/components/SidePanelForDesktop';
 import { SidePanelPathUrlSyncEffect } from '@/side-panel/routing/components/SidePanelPathUrlSyncEffect';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';

--- a/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
@@ -11,25 +11,32 @@ import { type WorkspaceRouteObject } from '@/app/routing/types/WorkspaceRouteObj
 import { getWorkspaceRouteObjectsForSurface } from '@/app/routing/utils/getWorkspaceRouteObjectsForSurface';
 import { MainAppLayoutWithSidePanel } from '@/ui/layout/page/components/MainAppLayoutWithSidePanel';
 
-const mountedProviders = { current: 0, max: 0 };
+const mockProviderStats = { current: 0, max: 0 };
+const mockSeenParams: Record<string, string | undefined>[] = [];
 
-jest.mock('@/context-store/components/RouteContextStoreProvider', () => ({
-  RouteContextStoreProvider: () => {
-    useEffect(() => {
-      mountedProviders.current += 1;
-      mountedProviders.max = Math.max(
-        mountedProviders.max,
-        mountedProviders.current,
-      );
+jest.mock('@/context-store/components/RouteContextStoreProvider', () => {
+  const { useParams } = jest.requireActual('react-router-dom');
 
-      return () => {
-        mountedProviders.current -= 1;
-      };
-    }, []);
+  return {
+    RouteContextStoreProvider: () => {
+      mockSeenParams.push(useParams());
 
-    return null;
-  },
-}));
+      useEffect(() => {
+        mockProviderStats.current += 1;
+        mockProviderStats.max = Math.max(
+          mockProviderStats.max,
+          mockProviderStats.current,
+        );
+
+        return () => {
+          mockProviderStats.current -= 1;
+        };
+      }, []);
+
+      return null;
+    },
+  };
+});
 
 jest.mock('@/side-panel/components/SidePanelForDesktop', () => ({
   SidePanelForDesktop: () => null,
@@ -90,6 +97,9 @@ describe('MainAppLayoutWithSidePanel', () => {
     );
 
     expect(await screen.findByText('record index page')).toBeInTheDocument();
+    // Hosted above the routes, the provider still reads the matched leaf's
+    // params: react-router shares one params object across a matched branch.
+    expect(mockSeenParams.at(-1)?.objectNamePlural).toBe('companies');
 
     act(() => {
       navigateRef.current?.('/settings/profile');
@@ -99,6 +109,7 @@ describe('MainAppLayoutWithSidePanel', () => {
       expect(screen.getByText('settings page')).toBeInTheDocument();
     });
 
-    expect(mountedProviders.max).toBe(1);
+    expect(mockSeenParams.at(-1)?.objectNamePlural).toBeUndefined();
+    expect(mockProviderStats.max).toBe(1);
   });
 });

--- a/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
@@ -69,7 +69,7 @@ const routeObjects: WorkspaceRouteObject[] = [
 
 const navigateRef: { current: NavigateFunction | null } = { current: null };
 
-const NavigateProbe = () => {
+const NavigateProbeEffect = () => {
   navigateRef.current = useNavigate();
 
   return null;
@@ -91,7 +91,7 @@ describe('MainAppLayoutWithSidePanel', () => {
   it('keeps a single route context store provider on the main surface across a section switch', async () => {
     render(
       <MemoryRouter initialEntries={['/objects/companies']}>
-        <NavigateProbe />
+        <NavigateProbeEffect />
         <MainSurfaceRoutes />
       </MemoryRouter>,
     );

--- a/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
@@ -1,6 +1,11 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import {
+  MemoryRouter,
+  type NavigateFunction,
+  useNavigate,
+  useRoutes,
+} from 'react-router-dom';
 
 import { type WorkspaceRouteObject } from '@/app/routing/types/WorkspaceRouteObject';
 import { getWorkspaceRouteObjectsForSurface } from '@/app/routing/utils/getWorkspaceRouteObjectsForSurface';
@@ -55,28 +60,39 @@ const routeObjects: WorkspaceRouteObject[] = [
   },
 ];
 
+const navigateRef: { current: NavigateFunction | null } = { current: null };
+
+const NavigateProbe = () => {
+  navigateRef.current = useNavigate();
+
+  return null;
+};
+
+const MainSurfaceRoutes = () =>
+  useRoutes([
+    {
+      element: <MainAppLayoutWithSidePanel />,
+      children: getWorkspaceRouteObjectsForSurface(routeObjects, 'main'),
+    },
+  ]);
+
 describe('MainAppLayoutWithSidePanel', () => {
   // Switching between the app and settings sections keeps the page being left
   // mounted while the next one animates in. If each page carried its own route
   // context store provider, the stale one would keep writing the main store
   // from a route that no longer matches the location, fighting the new one.
   it('keeps a single route context store provider on the main surface across a section switch', async () => {
-    const router = createMemoryRouter(
-      [
-        {
-          element: <MainAppLayoutWithSidePanel />,
-          children: getWorkspaceRouteObjectsForSurface(routeObjects, 'main'),
-        },
-      ],
-      { initialEntries: ['/objects/companies'] },
+    render(
+      <MemoryRouter initialEntries={['/objects/companies']}>
+        <NavigateProbe />
+        <MainSurfaceRoutes />
+      </MemoryRouter>,
     );
-
-    render(<RouterProvider router={router} />);
 
     expect(await screen.findByText('record index page')).toBeInTheDocument();
 
-    await act(async () => {
-      await router.navigate('/settings/profile');
+    act(() => {
+      navigateRef.current?.('/settings/profile');
     });
 
     await waitFor(() => {

--- a/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
@@ -1,0 +1,88 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+
+import { type WorkspaceRouteObject } from '@/app/routing/types/WorkspaceRouteObject';
+import { getWorkspaceRouteObjectsForSurface } from '@/app/routing/utils/getWorkspaceRouteObjectsForSurface';
+import { MainAppLayoutWithSidePanel } from '@/ui/layout/page/components/MainAppLayoutWithSidePanel';
+
+const mountedProviders = { current: 0, max: 0 };
+
+jest.mock('@/context-store/components/RouteContextStoreProvider', () => ({
+  RouteContextStoreProvider: () => {
+    useEffect(() => {
+      mountedProviders.current += 1;
+      mountedProviders.max = Math.max(
+        mountedProviders.max,
+        mountedProviders.current,
+      );
+
+      return () => {
+        mountedProviders.current -= 1;
+      };
+    }, []);
+
+    return null;
+  },
+}));
+
+jest.mock('@/side-panel/components/SidePanelForDesktop', () => ({
+  SidePanelForDesktop: () => null,
+}));
+
+jest.mock('@/command-menu/components/CommandMenuForMobile', () => ({
+  CommandMenuForMobile: () => null,
+}));
+
+jest.mock('@/side-panel/routing/components/SidePanelPathUrlSyncEffect', () => ({
+  SidePanelPathUrlSyncEffect: () => null,
+}));
+
+jest.mock('@/command-menu/hooks/useCommandMenuHotKeys', () => ({
+  useCommandMenuHotKeys: () => {},
+}));
+
+const routeObjects: WorkspaceRouteObject[] = [
+  {
+    path: '/objects/:objectNamePlural',
+    element: <div>record index page</div>,
+    handle: { workspaceSurfaces: ['main'] },
+  },
+  {
+    path: '/settings/*',
+    element: <div>settings page</div>,
+    handle: { workspaceSurfaces: ['main'] },
+  },
+];
+
+describe('MainAppLayoutWithSidePanel', () => {
+  // Switching between the app and settings sections keeps the page being left
+  // mounted while the next one animates in. If each page carried its own route
+  // context store provider, the stale one would keep writing the main store
+  // from a route that no longer matches the location, fighting the new one.
+  it('keeps a single route context store provider on the main surface across a section switch', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          element: <MainAppLayoutWithSidePanel />,
+          children: getWorkspaceRouteObjectsForSurface(routeObjects, 'main'),
+        },
+      ],
+      { initialEntries: ['/objects/companies'] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByText('record index page')).toBeInTheDocument();
+
+    await act(async () => {
+      await router.navigate('/settings/profile');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('settings page')).toBeInTheDocument();
+    });
+
+    expect(mountedProviders.max).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes the React #185 crash ("Sorry, something went wrong" on `/settings/profile`) when opening Settings from the Home page.

### How it was found

Reproduced on a preview environment (single session, seeded workspace) and instrumented the page before the click:

- **History**: exactly one navigation (`push /settings/profile` from `switchNavigationDrawerMode`). No route ping-pong.
- **DOM (ordered MutationObserver)**: after the new `[settings]` transition page mounts, the still-mounted, exiting `[app]` page has its Companies content torn down and rebuilt ~25 times, alternating between the loaded page root and the `RecordIndexSkeletonLoader` root — i.e. the stale page flips between "object known" and "object unknown".
- **Stack (300 frames)**: the throw happens in `dispatchSetState` ← floating-ui `useFloating`'s `setReference` callback ref ← `commitAttachRef` ← the layout-effect recursion. Every remount of the Companies page mounts its Filter/Sort/Options dropdowns, each of which attaches that ref and sets state from the commit phase. floating-ui is where the 51st nested update lands — the last straw, not the driver.

### Root cause

`RecordIndexPage` renders the skeleton whenever `contextStoreCurrentObjectMetadataItemId` is undefined, and the only effect that writes that atom is `RouteContextStoreProviderEffect`.

#25141 replaced the single `MainContextStoreProvider` (mounted once in `WorkspaceAppProviders`) with a `RouteContextStoreProvider` injected into **every top-level route element of a surface** (`getWorkspaceRouteObjectsForSurface`). `MainAppLayoutOutlet` cross-fades app ↔ settings with `AnimatePresence`, which keeps the page being left mounted for 300ms. During that window the main surface has **two live providers**: the stale one's `useParams()` still says `companies` (its route context is frozen in the element `AnimatePresence` stored) while `useLocation()` already says `/settings/profile`, so it writes the companies object id; the new one writes `undefined`. Both list the atom in their effect deps, so each write re-triggers the other, synchronously, until React's nested-update limit.

That also explains why QA Scout's settings visit passed: it never crossed the app → settings transition from a record page.

### Fix

- The main surface hosts **one** `RouteContextStoreProvider`, in `MainAppLayoutWithSidePanel` above the transition — the same ownership the pre-#25141 provider had. A layout-level `useParams()` sees the branch's params (`matchRouteBranch` shares one params object across the branch; the old provider relied on this too).
- `getWorkspaceRouteObjectsForSurface` injects the in-tree provider only for the **side panel**, which renders its routes against its own location (readable only inside the routed tree) and remounts per location, so it never keeps a stale page alive.

### Tests

- `getWorkspaceRouteObjectsForSurface.test.tsx` — main-surface route elements carry no provider; side-panel ones do.
- `MainAppLayoutWithSidePanel.test.tsx` — renders the real layout with fixture routes, navigates `/objects/companies` → `/settings/profile`, and asserts the main surface never has two providers mounted at once. This fails against the per-page injection.

### Verification

Typecheck, lint and oxfmt clean locally; the tests run in CI. The decisive check is the same reproduction on this PR's preview environment, which I'll run once it's up.

### Related

- #25232 (device-row remount) and #25225 (instance-id scoping) are real fixes but neither addresses this crash — confirmed by reproducing it on #25232's own preview.
- The `useNavigateApp`-in-effect pattern I called out earlier is a separate latent issue, not this crash; #25225's description will be corrected.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Verification on the preview environment

- Home → Settings (the click that throws `Minified React error #185` on main): `/settings/profile` renders, no error boundary, no console error, exactly one main page surface once the cross-fade ends.
- `/objects/companies` renders the full record table with the provider hosted above the routes, so the layout-level `useParams()` does resolve the leaf route's `objectNamePlural` (react-router shares one params object across a matched branch; the pre-#25141 `MainContextStoreProvider` relied on the same thing from the same position). Pinned by the layout test.
- Settings → Home restores the object context; a second round trip stays clean.
