### PR TITLE
Add the missing im:write scope to the Slack app manifest

### DIFF
--- a/packages/twenty-apps/public/slack/SETUP.md
+++ b/packages/twenty-apps/public/slack/SETUP.md
@@ -18,6 +18,7 @@ Two parts: a **Slack app** you create, and the **Twenty side** where you paste i
    | `chat:write` | post, update, delete, ephemeral |
    | `chat:write.public` | post to public channels without the bot joining |
    | `groups:read` | list private channels the bot is in |
+   | `im:write` | open a DM with a member to ask for their consent to a manual link |
    | `reactions:write` | add reactions |
    | `app_mentions:read` | assistant: mentions of the bot |
    | `channels:history` | assistant: thread follow-ups in public channels |

--- a/packages/twenty-apps/public/slack/slack-app-manifest.json
+++ b/packages/twenty-apps/public/slack/slack-app-manifest.json
@@ -25,6 +25,7 @@
         "chat:write",
         "chat:write.public",
         "groups:read",
+        "im:write",
         "reactions:write",
         "app_mentions:read",
         "channels:history",


### PR DESCRIPTION
`im:write` is requested at connect time by the Slack connection provider (`slack-connection.ts:28`) but was absent from both `slack-app-manifest.json` and the scopes table in `SETUP.md`.

Slack validates that every scope requested at authorize time appears under the app's Bot Token Scopes, so a Slack app created from this manifest fails OAuth. The setup guide warns about exactly this failure mode a few lines above the table it was missing from.

## Scope

Affects **newly created Slack apps only**. The scope itself already shipped in 0.5.0, and the README has told people to reconnect for it since then, so existing installs need no action.

## Why this is its own PR

Split out of [#25214](https://github.com/twentyhq/twenty/pull/25214) so a live OAuth breakage isn't queued behind a documentation review. That PR now carries only the vetted-marketplace flag and the version bump.

## Test plan

- [ ] A Slack app created from the updated manifest completes the OAuth connect flow

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVj51vPJYMhvfkRoppynJW)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

