### PR TITLE
Bound the jotai selector atom caches

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-store/states/selectors/recordStoreFieldValueSelector.ts
+++ b/packages/twenty-front/src/modules/object-record/record-store/states/selectors/recordStoreFieldValueSelector.ts
@@ -11,6 +11,7 @@ import {
 import { isFieldMorphRelation } from '@/object-record/record-field/ui/types/guards/isFieldMorphRelation';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { createAtomFamilySelector } from '@/ui/utilities/state/jotai/utils/createAtomFamilySelector';
+import { createBoundedAtomCache } from '@/ui/utilities/state/jotai/utils/createBoundedAtomCache';
 import { RelationType } from 'twenty-shared/types';
 import {
   computeMorphRelationGqlFieldName,
@@ -28,7 +29,7 @@ const simpleFieldValueSelector = createAtomFamilySelector<
       get(recordStoreFamilyState, recordId)?.[fieldName],
 });
 
-const morphAtomCache = new Map<string, Atom<unknown>>();
+const morphAtomCache = createBoundedAtomCache<Atom<unknown>>();
 
 const getMorphRelationFieldValueAtom = (
   recordId: string,

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createBoundedAtomCache.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createBoundedAtomCache.test.ts
@@ -54,7 +54,7 @@ describe('createBoundedAtomCache', () => {
 
     const sizeBeforePromotion = cache.size();
 
-    cache.get('key-0');
+    expect(cache.get('key-0')).toBeDefined();
 
     expect(cache.size()).toBe(sizeBeforePromotion);
   });

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createBoundedAtomCache.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createBoundedAtomCache.test.ts
@@ -42,6 +42,23 @@ describe('createBoundedAtomCache', () => {
     expect(cache.get('key-99')).toBeDefined();
   });
 
+  it('does not count an atom twice when reading it promotes it', () => {
+    const maxCachedAtomsPerGeneration = 10;
+    const cache = createBoundedAtomCache<ReturnType<typeof atom<number>>>(
+      maxCachedAtomsPerGeneration,
+    );
+
+    for (let index = 0; index <= maxCachedAtomsPerGeneration; index++) {
+      cache.set(`key-${index}`, atom(index));
+    }
+
+    const sizeBeforePromotion = cache.size();
+
+    cache.get('key-0');
+
+    expect(cache.size()).toBe(sizeBeforePromotion);
+  });
+
   it('keeps an atom that is read again before its generation rotates out', () => {
     const cache = createBoundedAtomCache<ReturnType<typeof atom<number>>>(10);
     const survivingAtom = atom(0);

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createBoundedAtomCache.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createBoundedAtomCache.test.ts
@@ -1,0 +1,60 @@
+import { atom } from 'jotai';
+
+import { createBoundedAtomCache } from '@/ui/utilities/state/jotai/utils/createBoundedAtomCache';
+
+describe('createBoundedAtomCache', () => {
+  it('returns the cached atom for a known key', () => {
+    const cache = createBoundedAtomCache<ReturnType<typeof atom<number>>>();
+    const cachedAtom = atom(1);
+
+    cache.set('a', cachedAtom);
+
+    expect(cache.get('a')).toBe(cachedAtom);
+  });
+
+  it('returns undefined for an unknown key', () => {
+    const cache = createBoundedAtomCache<ReturnType<typeof atom<number>>>();
+
+    expect(cache.get('missing')).toBeUndefined();
+  });
+
+  it('stops growing once far more keys than the bound are inserted', () => {
+    const maxCachedAtomsPerGeneration = 10;
+    const cache = createBoundedAtomCache<ReturnType<typeof atom<number>>>(
+      maxCachedAtomsPerGeneration,
+    );
+
+    for (let index = 0; index < 1000; index++) {
+      cache.set(`key-${index}`, atom(index));
+    }
+
+    expect(cache.size()).toBeLessThanOrEqual(
+      2 * (maxCachedAtomsPerGeneration + 1),
+    );
+  });
+
+  it('drops the coldest keys and keeps the most recently written ones', () => {
+    const cache = createBoundedAtomCache<ReturnType<typeof atom<number>>>(10);
+
+    for (let index = 0; index < 100; index++) {
+      cache.set(`key-${index}`, atom(index));
+    }
+
+    expect(cache.get('key-0')).toBeUndefined();
+    expect(cache.get('key-99')).toBeDefined();
+  });
+
+  it('keeps an atom that is read again before its generation rotates out', () => {
+    const cache = createBoundedAtomCache<ReturnType<typeof atom<number>>>(10);
+    const survivingAtom = atom(0);
+
+    cache.set('survivor', survivingAtom);
+
+    for (let index = 0; index < 100; index++) {
+      cache.set(`key-${index}`, atom(index));
+      cache.get('survivor');
+    }
+
+    expect(cache.get('survivor')).toBe(survivingAtom);
+  });
+});

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createBoundedAtomCache.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createBoundedAtomCache.test.ts
@@ -28,9 +28,7 @@ describe('createBoundedAtomCache', () => {
       cache.set(`key-${index}`, atom(index));
     }
 
-    expect(cache.size()).toBeLessThanOrEqual(
-      2 * (maxCachedAtomsPerGeneration + 1),
-    );
+    expect(cache.size()).toBeLessThanOrEqual(2 * maxCachedAtomsPerGeneration);
   });
 
   it('drops the coldest keys and keeps the most recently written ones', () => {

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomComponentFamilySelector.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomComponentFamilySelector.ts
@@ -7,6 +7,7 @@ import { type ComponentFamilySelector } from '@/ui/utilities/state/jotai/types/C
 import { type ComponentFamilyStateKey } from '@/ui/utilities/state/jotai/types/ComponentFamilyState';
 import { type SelectorGetter } from '@/ui/utilities/state/jotai/types/SelectorCallbacks';
 import { buildGetHelper } from '@/ui/utilities/state/jotai/utils/buildGetHelper';
+import { createBoundedAtomCache } from '@/ui/utilities/state/jotai/utils/createBoundedAtomCache';
 import { isDefined } from 'twenty-shared/utils';
 
 export const createAtomComponentFamilySelector = <ValueType, FamilyKey>({
@@ -26,7 +27,7 @@ export const createAtomComponentFamilySelector = <ValueType, FamilyKey>({
     globalComponentInstanceContextMap.set(key, componentInstanceContext);
   }
 
-  const atomCache = new Map<string, Atom<ValueType>>();
+  const atomCache = createBoundedAtomCache<Atom<ValueType>>();
 
   const selectorFamily = (
     componentFamilyStateKey: ComponentFamilyStateKey<FamilyKey>,

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomFamilySelector.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomFamilySelector.ts
@@ -4,6 +4,7 @@ import { selectAtom } from 'jotai/utils';
 import { type FamilySelector } from '@/ui/utilities/state/jotai/types/FamilySelector';
 import { type SelectorGetter } from '@/ui/utilities/state/jotai/types/SelectorCallbacks';
 import { buildGetHelper } from '@/ui/utilities/state/jotai/utils/buildGetHelper';
+import { createBoundedAtomCache } from '@/ui/utilities/state/jotai/utils/createBoundedAtomCache';
 import { isDefined } from 'twenty-shared/utils';
 
 export const createAtomFamilySelector = <ValueType, FamilyKey>({
@@ -15,7 +16,7 @@ export const createAtomFamilySelector = <ValueType, FamilyKey>({
   get: (familyKey: FamilyKey) => (callbacks: SelectorGetter) => ValueType;
   areEqual?: (previous: ValueType, next: ValueType) => boolean;
 }): FamilySelector<ValueType, FamilyKey> => {
-  const atomCache = new Map<string, Atom<ValueType>>();
+  const atomCache = createBoundedAtomCache<Atom<ValueType>>();
 
   const selectorFamily = (familyKey: FamilyKey): Atom<ValueType> => {
     const cacheKey =

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomWritableFamilySelector.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomWritableFamilySelector.ts
@@ -6,6 +6,7 @@ import {
 } from '@/ui/utilities/state/jotai/types/SelectorCallbacks';
 import { type WritableFamilySelector } from '@/ui/utilities/state/jotai/types/WritableFamilySelector';
 import { buildGetHelper } from '@/ui/utilities/state/jotai/utils/buildGetHelper';
+import { createBoundedAtomCache } from '@/ui/utilities/state/jotai/utils/createBoundedAtomCache';
 import { buildSetHelper } from '@/ui/utilities/state/jotai/utils/buildSetHelper';
 
 export const createAtomWritableFamilySelector = <ValueType, FamilyKey>({
@@ -19,14 +20,14 @@ export const createAtomWritableFamilySelector = <ValueType, FamilyKey>({
     familyKey: FamilyKey,
   ) => (callbacks: SelectorSetter, newValue: ValueType) => void;
 }): WritableFamilySelector<ValueType, FamilyKey> => {
-  const atomCache = new Map<
-    string,
-    WritableAtom<
-      ValueType,
-      [ValueType | ((prev: ValueType) => ValueType)],
-      void
-    >
-  >();
+  const atomCache =
+    createBoundedAtomCache<
+      WritableAtom<
+        ValueType,
+        [ValueType | ((prev: ValueType) => ValueType)],
+        void
+      >
+    >();
 
   const selectorFamily = (
     familyKey: FamilyKey,

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createBoundedAtomCache.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createBoundedAtomCache.ts
@@ -1,0 +1,51 @@
+export type BoundedAtomCache<TAtom> = {
+  get: (cacheKey: string) => TAtom | undefined;
+  set: (cacheKey: string, atomToCache: TAtom) => void;
+  size: () => number;
+};
+
+// A record table renders at most a few hundred rows at a time but caches one selector
+// atom per cell it has ever rendered, so scrolling grew the cache without bound. Two
+// generations of this size can be retained at once.
+export const DEFAULT_MAX_CACHED_ATOMS_PER_GENERATION = 20000;
+
+// Selector atoms are pure projections of the atoms they read, so dropping one costs a
+// recompute on the next read and never loses state: a component still holding an
+// evicted atom keeps reading the same source through it.
+export const createBoundedAtomCache = <TAtom>(
+  maxCachedAtomsPerGeneration = DEFAULT_MAX_CACHED_ATOMS_PER_GENERATION,
+): BoundedAtomCache<TAtom> => {
+  let currentGeneration = new Map<string, TAtom>();
+  let previousGeneration = new Map<string, TAtom>();
+
+  // Rotating whole generations keeps a cache hit a single Map lookup. An LRU would have
+  // to delete and re-insert on every hit, which measured 4x slower on the cell path.
+  const setInCurrentGeneration = (cacheKey: string, atomToCache: TAtom) => {
+    currentGeneration.set(cacheKey, atomToCache);
+
+    if (currentGeneration.size > maxCachedAtomsPerGeneration) {
+      previousGeneration = currentGeneration;
+      currentGeneration = new Map();
+    }
+  };
+
+  return {
+    get: (cacheKey) => {
+      const atomFromCurrentGeneration = currentGeneration.get(cacheKey);
+
+      if (atomFromCurrentGeneration !== undefined) {
+        return atomFromCurrentGeneration;
+      }
+
+      const atomFromPreviousGeneration = previousGeneration.get(cacheKey);
+
+      if (atomFromPreviousGeneration !== undefined) {
+        setInCurrentGeneration(cacheKey, atomFromPreviousGeneration);
+      }
+
+      return atomFromPreviousGeneration;
+    },
+    set: setInCurrentGeneration,
+    size: () => currentGeneration.size + previousGeneration.size,
+  };
+};

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createBoundedAtomCache.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createBoundedAtomCache.ts
@@ -21,12 +21,12 @@ export const createBoundedAtomCache = <TAtom>(
   // Rotating whole generations keeps a cache hit a single Map lookup. An LRU would have
   // to delete and re-insert on every hit, which measured 4x slower on the cell path.
   const setInCurrentGeneration = (cacheKey: string, atomToCache: TAtom) => {
-    currentGeneration.set(cacheKey, atomToCache);
-
-    if (currentGeneration.size > maxCachedAtomsPerGeneration) {
+    if (currentGeneration.size >= maxCachedAtomsPerGeneration) {
       previousGeneration = currentGeneration;
       currentGeneration = new Map();
     }
+
+    currentGeneration.set(cacheKey, atomToCache);
   };
 
   return {

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createBoundedAtomCache.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createBoundedAtomCache.ts
@@ -40,6 +40,7 @@ export const createBoundedAtomCache = <TAtom>(
       const atomFromPreviousGeneration = previousGeneration.get(cacheKey);
 
       if (atomFromPreviousGeneration !== undefined) {
+        previousGeneration.delete(cacheKey);
         setInCurrentGeneration(cacheKey, atomFromPreviousGeneration);
       }
 


### PR DESCRIPTION
## What

Selector families (`createAtomFamilySelector`, `createAtomWritableFamilySelector`, `createAtomComponentFamilySelector`) each cached one derived atom per key in a module-level `Map` that was never evicted. The only eviction anywhere in the jotai layer today is the `routed-flow` scope in `createAtomFamilyState`.

`recordStoreFieldValueSelector` creates one such atom per `(recordId, fieldName)`, and `useRecordFieldValue` is called by every field display hook. So the record table allocated an atom for **every cell it ever rendered** and kept it for the life of the tab. The caches are module singletons, so they also survive view switches, object switches and client-side navigation.

The asymmetry that makes this matter: the table renders at most `NUMBER_OF_VIRTUALIZED_ROWS` (240) rows, but the cache grows with every row ever scrolled past. The DOM is bounded, the cache was not.

## Why it is safe to evict

All three creators produce purely derived atoms: read-only, or writes passing through to the base atoms. They hold no state of their own, so dropping one costs a recompute on the next read and loses nothing. A component still holding an evicted atom keeps reading the same source through it, and a write through a newer atom for the same key still lands on the same base atom, so both see the update. Base-atom families (`createAtomFamilyState`, `createAtomComponentFamilyState`) hold real state and are deliberately left alone.

## Approach

Two generations rather than an LRU. An LRU has to delete and re-insert on every cache hit, which measured **74 ns/read vs 17.6 ns** for a plain `Map` lookup on this path. Generation rotation keeps a hit to a single lookup (23 ns) while still bounding retention.

The bound is per generation, with at most two generations live, so an atom survives at least a full generation past its last read. At 240 rows you would have to scroll past roughly a thousand fresh rows before a still-mounted cell's atom could be dropped, and dropping it is harmless anyway.

## Measurements

Numbers below are the pattern reproduced in isolation against jotai 2.17.1 under `--expose-gc`, not the real app profiled. Overhead per cell is ~561 B, about 4x the record data it projects.

| scrolled | before | after |
|---|---|---|
| 20k records x 20 fields | 265 MB | 114 MB (-57%) |
| 5k records x 25 fields | 79 MB | 46 MB (-42%) |

## Not included

- The cache key is still `JSON.stringify({ recordId, fieldName })` (152 ns vs 12 ns for a concatenated key). That is ~0.7 ms per full table render, and changing how keys are derived risks collisions across the ~103 families, so it is not worth bundling with a memory fix.
- What remains after this change is mostly `recordStoreFamilyState` retaining every record ever fetched. That one holds real state and needs its own design.

## Testing

- `npx jest --config=packages/twenty-front/jest.config.mjs` — 1190 suites, 7035 tests pass
- `npx tsgo -p tsconfig.json --noEmit` in `packages/twenty-front` — clean
- `oxlint --type-aware` and `oxfmt --check` on the changed files — clean
- New unit tests cover the hit/miss path, that the cache stops growing, that cold keys are dropped, and that a key read again survives rotation

---
_Generated by [Claude Code](https://claude.ai/code/session_015tamy1dfsMxQLNEwNN56Qz)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

