### PR TITLE
Stabilise the record table cell context values

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableContextProvider.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableContextProvider.tsx
@@ -1,8 +1,11 @@
-import { type ReactNode, useCallback } from 'react';
+import { type ReactNode, useCallback, useMemo } from 'react';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { RecordTableContextProvider as RecordTableContextInternalProvider } from '@/object-record/record-table/contexts/RecordTableContext';
+import {
+  RecordTableContextProvider as RecordTableContextInternalProvider,
+  type RecordTableContextValue,
+} from '@/object-record/record-table/contexts/RecordTableContext';
 
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
@@ -16,6 +19,10 @@ import { RecordTableUpdateContext } from '@/object-record/record-table/contexts/
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useIsTouchDevice } from 'twenty-ui/utilities';
 import { OpenRecordIn } from 'twenty-shared/types';
+
+const RECORD_FIELDS_SCOPE_CONTEXT_VALUE = {
+  scopeInstanceId: RECORD_TABLE_CELL_INPUT_ID_PREFIX,
+};
 
 type RecordTableContextProviderProps = {
   viewBarId: string;
@@ -46,6 +53,15 @@ export const RecordTableContextProvider = ({
     visibleRecordFieldsComponentSelector,
   );
 
+  const visibleRecordFieldsWithMinWidth = useMemo(
+    () =>
+      visibleRecordFields.map((field) => ({
+        ...field,
+        size: Math.max(field.size, RECORD_TABLE_COLUMN_MIN_WIDTH),
+      })),
+    [visibleRecordFields],
+  );
+
   const { updateOneRecord } = useUpdateOneRecord();
 
   const updateRecord = useCallback(
@@ -70,26 +86,34 @@ export const RecordTableContextProvider = ({
       ? 'CLICK'
       : 'MOUSE_DOWN';
 
+  const recordTableContextValue: RecordTableContextValue = useMemo(
+    () => ({
+      viewBarId,
+      objectMetadataItem,
+      objectMetadataItems,
+      recordTableId,
+      objectNameSingular,
+      objectPermissions,
+      visibleRecordFields: visibleRecordFieldsWithMinWidth,
+      onRecordIdentifierClick,
+      triggerEvent,
+    }),
+    [
+      viewBarId,
+      objectMetadataItem,
+      objectMetadataItems,
+      recordTableId,
+      objectNameSingular,
+      objectPermissions,
+      visibleRecordFieldsWithMinWidth,
+      onRecordIdentifierClick,
+      triggerEvent,
+    ],
+  );
+
   return (
-    <RecordFieldsScopeContextProvider
-      value={{ scopeInstanceId: RECORD_TABLE_CELL_INPUT_ID_PREFIX }}
-    >
-      <RecordTableContextInternalProvider
-        value={{
-          viewBarId,
-          objectMetadataItem,
-          objectMetadataItems,
-          recordTableId,
-          objectNameSingular,
-          objectPermissions,
-          visibleRecordFields: visibleRecordFields.map((field) => ({
-            ...field,
-            size: Math.max(field.size, RECORD_TABLE_COLUMN_MIN_WIDTH),
-          })),
-          onRecordIdentifierClick,
-          triggerEvent,
-        }}
-      >
+    <RecordFieldsScopeContextProvider value={RECORD_FIELDS_SCOPE_CONTEXT_VALUE}>
+      <RecordTableContextInternalProvider value={recordTableContextValue}>
         <RecordTableUpdateContext.Provider value={updateRecord}>
           {children}
         </RecordTableUpdateContext.Provider>

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWithWrappers.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWithWrappers.tsx
@@ -12,6 +12,7 @@ import { PageFocusId } from '@/types/PageFocusId';
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { styled } from '@linaria/react';
+import { useCallback } from 'react';
 
 const StyledRecordTablePrintBoundary = styled.div`
   display: contents;
@@ -60,11 +61,14 @@ export const RecordTableWithWrappers = ({
   const { unfocusRecordTableRow } = useFocusedRecordTableRow(recordTableId);
   const { openRecordFromIndexView } = useOpenRecordFromIndexView();
 
-  const handleRecordIdentifierClick = (rowIndex: number, recordId: string) => {
-    activateRecordTableRow(rowIndex);
-    unfocusRecordTableRow();
-    openRecordFromIndexView({ recordId });
-  };
+  const handleRecordIdentifierClick = useCallback(
+    (rowIndex: number, recordId: string) => {
+      activateRecordTableRow(rowIndex);
+      unfocusRecordTableRow();
+      openRecordFromIndexView({ recordId });
+    },
+    [activateRecordTableRow, unfocusRecordTableRow, openRecordFromIndexView],
+  );
 
   const { deleteOneRecord } = useDeleteOneRecord({ objectNameSingular });
 

--- a/packages/twenty-front/src/modules/object-record/record-table/contexts/RecordTableContext.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/contexts/RecordTableContext.ts
@@ -3,7 +3,7 @@ import { type RecordField } from '@/object-record/record-field/types/RecordField
 import { type ObjectPermission } from '~/generated-metadata/graphql';
 import { createRequiredContext } from '~/utils/createRequiredContext';
 
-type RecordTableContextValue = {
+export type RecordTableContextValue = {
   recordTableId: string;
   viewBarId: string;
   objectNameSingular: string;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextWrapper.tsx
@@ -6,7 +6,7 @@ import { useRecordTableRowContextOrThrow } from '@/object-record/record-table/co
 import { RecordTableCellFieldContextGeneric } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextGeneric';
 import { RecordTableCellFieldContextLabelIdentifier } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextLabelIdentifier';
 import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 
 type RecordTableCellFieldContextWrapperProps = {
   children: ReactNode;
@@ -36,8 +36,15 @@ export const RecordTableCellFieldContextWrapper = ({
   const isLabelIdentifier =
     labelIdentifierFieldMetadataItem?.id === recordField.fieldMetadataItemId;
 
+  const fieldComponentInstanceContextValue = useMemo(
+    () => ({ instanceId }),
+    [instanceId],
+  );
+
   return (
-    <RecordFieldComponentInstanceContext.Provider value={{ instanceId }}>
+    <RecordFieldComponentInstanceContext.Provider
+      value={fieldComponentInstanceContextValue}
+    >
       {isLabelIdentifier ? (
         <RecordTableCellFieldContextLabelIdentifier key={instanceId}>
           {children}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellWrapper.tsx
@@ -1,8 +1,10 @@
 import { type RecordField } from '@/object-record/record-field/types/RecordField';
-import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
+import {
+  RecordTableCellContext,
+  type RecordTableCellContextValue,
+} from '@/object-record/record-table/contexts/RecordTableCellContext';
 import { useRecordTableRowContextOrThrow } from '@/object-record/record-table/contexts/RecordTableRowContext';
 import { RecordTableCellFieldContextWrapper } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextWrapper';
-import { type TableCellPosition } from '@/object-record/record-table/types/TableCellPosition';
 import { useMemo } from 'react';
 
 export const RecordTableCellWrapper = ({
@@ -16,20 +18,20 @@ export const RecordTableCellWrapper = ({
 }) => {
   const { rowIndex } = useRecordTableRowContextOrThrow();
 
-  const currentTableCellPosition: TableCellPosition = useMemo(
+  const cellContextValue: RecordTableCellContextValue = useMemo(
     () => ({
-      column: recordFieldIndex,
-      row: rowIndex,
+      recordField,
+      cellPosition: {
+        column: recordFieldIndex,
+        row: rowIndex,
+      },
     }),
-    [recordFieldIndex, rowIndex],
+    [recordField, recordFieldIndex, rowIndex],
   );
 
   return (
     <RecordTableCellContext.Provider
-      value={{
-        recordField,
-        cellPosition: currentTableCellPosition,
-      }}
+      value={cellContextValue}
       key={recordField.fieldMetadataItemId}
     >
       <RecordTableCellFieldContextWrapper recordField={recordField}>


### PR DESCRIPTION
## What

Three providers in the record table cell render path built their context value as a fresh object literal on every render, so every consumer re-rendered whenever the provider did.

The one that actually drives the others is `RecordTableContextProvider`: besides passing a fresh `value` object, it rebuilt `visibleRecordFields` with `.map()` on each render, minting **new `recordField` objects every time**. That is why memoizing `RecordTableCellWrapper` alone would have been a no-op: its `useMemo` depends on `recordField`, whose identity changed on every render of the table provider. The existing `useMemo` on `currentTableCellPosition` was already dead weight for the same reason, since the surrounding object literal was rebuilt regardless.

With ~240 virtualized rows this fans out across every mounted cell.

## Changes

- `RecordTableContextProvider`: memoize the min-width-mapped `visibleRecordFields` and the context value; hoist the constant `RecordFieldsScopeContextProvider` value to a module constant
- `RecordTableCellWrapper`: memoize the whole context value instead of just the position inside it
- `RecordTableCellFieldContextWrapper`: memoize the `{ instanceId }` value
- Export `RecordTableContextValue` so the memo keeps the contextual type. Without it `triggerEvent` widens from `'CLICK' | 'MOUSE_DOWN'` to `string`, because the JSX prop was previously supplying that contextual type

Ordering matters here: the provider fix is what makes the two cell-level memos hold.

## Scope

Render cost only, no behaviour change and no memory effect. I have not profiled the real app, so this is reasoning from the render path rather than a measured frame-time win.

## Testing

- `npx jest --config=packages/twenty-front/jest.config.mjs` — 1189 suites, 7030 tests pass
- `npx tsgo -p tsconfig.json --noEmit` in `packages/twenty-front` — clean
- `oxlint --type-aware` and `oxfmt --check` on the changed files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_015tamy1dfsMxQLNEwNN56Qz)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

