### PR TITLE
chore(slack): bump app version to 0.6.1

### DIFF
--- a/packages/twenty-apps/public/slack/package.json
+++ b/packages/twenty-apps/public/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/slack",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Slack assistant and workflow steps for Twenty",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Bumps `@twentyhq/slack` from 0.6.0 to 0.6.1 in `packages/twenty-apps/public/slack/package.json`.

The version string only lives in that file, so nothing else needed updating.

Patch bump covering #25237 (removing the "Answered in" duration footer from assistant replies).