### PR TITLE
Add --no-delete to apply, plan and dev for additive application sync

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -3926,7 +3926,7 @@ type Mutation {
   deletePublicDomain(domain: String!): Boolean!
   checkPublicDomainValidRecords(domain: String!): DomainValidRecords
   createDevelopmentApplication(universalIdentifier: String!, name: String!): DevelopmentApplication!
-  syncApplication(manifest: JSON!, dryRun: Boolean): WorkspaceMigration!
+  syncApplication(manifest: JSON!, dryRun: Boolean, inferDeletionFromMissingEntities: Boolean): WorkspaceMigration!
   uploadApplicationFile(file: Upload!, applicationUniversalIdentifier: String!, fileFolder: FileFolder!, filePath: String!): File!
   createApplicationFileUploads(applicationUniversalIdentifier: String!, files: [ApplicationFileUploadRequestInput!]!): CreateApplicationFileUploadsResult!
   completeApplicationFileUploads(applicationUniversalIdentifier: String!, fileIds: [UUID!]!): CompleteApplicationFileUploadsResult!

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -6957,7 +6957,7 @@ export interface MutationGenqlSelection{
     deletePublicDomain?: { __args: {domain: Scalars['String']} }
     checkPublicDomainValidRecords?: (DomainValidRecordsGenqlSelection & { __args: {domain: Scalars['String']} })
     createDevelopmentApplication?: (DevelopmentApplicationGenqlSelection & { __args: {universalIdentifier: Scalars['String'], name: Scalars['String']} })
-    syncApplication?: (WorkspaceMigrationGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null)} })
+    syncApplication?: (WorkspaceMigrationGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), inferDeletionFromMissingEntities?: (Scalars['Boolean'] | null)} })
     uploadApplicationFile?: (FileGenqlSelection & { __args: {file: Scalars['Upload'], applicationUniversalIdentifier: Scalars['String'], fileFolder: FileFolder, filePath: Scalars['String']} })
     createApplicationFileUploads?: (CreateApplicationFileUploadsResultGenqlSelection & { __args: {applicationUniversalIdentifier: Scalars['String'], files: ApplicationFileUploadRequestInput[]} })
     completeApplicationFileUploads?: (CompleteApplicationFileUploadsResultGenqlSelection & { __args: {applicationUniversalIdentifier: Scalars['String'], fileIds: Scalars['UUID'][]} })

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -10256,6 +10256,9 @@ export default {
                     ],
                     "dryRun": [
                         8
+                    ],
+                    "inferDeletionFromMissingEntities": [
+                        8
                     ]
                 }
             ],

--- a/packages/twenty-docs/developers/extend/apps/getting-started/quick-start.mdx
+++ b/packages/twenty-docs/developers/extend/apps/getting-started/quick-start.mdx
@@ -127,6 +127,7 @@ All modes need an authenticated remote. See [Syncing & recovery](/developers/ext
 | Flag | Description |
 |------|-------------|
 | `--force` | Apply destructive changes (deletes) without confirmation. |
+| `--no-delete` | Keep entities that are missing from your source instead of deleting them. Also accepted by `plan` and `apply`. |
 | `--debounceMs <ms>` | Set the file-change debounce delay in milliseconds (default: `1000`). |
 | `--verbose` / `--debug` | Show detailed build logs, sync requests, and error traces. |
 

--- a/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
+++ b/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
@@ -17,6 +17,7 @@ For day-to-day local iteration you almost always want `yarn twenty dev`. Deployi
 | Iterate locally with live sync | `yarn twenty dev` | Watches your files and syncs on every change. |
 | Sync once and exit (CI, scripts, hooks) | `yarn twenty apply` | One build + sync, then exits. Add `--force` to skip the destructive-change confirmation. |
 | Preview changes **without applying them** | `yarn twenty plan` | Computes and prints the diff; writes nothing. |
+| Sync without deleting anything | `yarn twenty apply --no-delete` | Creates and updates only: entities that exist in the workspace but not in your source are left alone. Also accepted by `plan` and `dev`. |
 | Remove the app from the workspace | `yarn twenty app:uninstall` | Add `--yes` to skip the prompt. |
 | Ship a tarball to a server | `yarn twenty app:publish --private` | Requires a **strictly higher** `package.json` version — see [Publishing](/developers/extend/apps/operations/publishing). |
 | Publish to the marketplace (npm) | `yarn twenty app:publish` | — |
@@ -53,6 +54,8 @@ This is your first diagnostic: it tells you exactly which objects, fields, and l
 
 Destructive changes (`to destroy`) are listed with what they drop (e.g. `objectMetadata "auditNote" — drops the table and all its rows`) and require interactive confirmation, or `--force` in scripts.
 
+A sync deletes every entity your app owns that your source no longer declares. When a plan contains destroys it says so and points at `--no-delete`, which makes the sync additive: creates and updates are applied, nothing missing from your source is deleted. Use it when your source is intentionally partial, for example while adopting an app that was built in the UI.
+
 When a sync fails on a single entity, the error names the offending entity and its `universalIdentifier`, for example:
 
 ```text
@@ -88,7 +91,7 @@ A plan:
 - Is useful before a risky change, when reviewing an AI-generated change, or in a script that should fail if an unexpected change is about to land.
 
 <Note>
-A plan only previews **metadata** changes, and it requires the app to have been synced at least once (so the workspace knows about it). If you run it against an app that was never synced, the server reports that the app is not installed — run `yarn twenty dev` once first.
+A plan only previews **metadata** changes. It also works for an app that was never synced: the server evaluates the manifest against an empty application, so the plan lists everything your source would create.
 </Note>
 
 ## Recovery ladder

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -3881,6 +3881,7 @@ export type MutationStopAgentChatStreamArgs = {
 
 export type MutationSyncApplicationArgs = {
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
+  inferDeletionFromMissingEntities?: InputMaybe<Scalars['Boolean']['input']>;
   manifest: Scalars['JSON']['input'];
 };
 

--- a/packages/twenty-sdk/src/cli/commands/dev/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/dev-once.ts
@@ -11,6 +11,7 @@ export type AppDevOnceCommandOptions = {
   verbose?: boolean;
   apply?: boolean;
   force?: boolean;
+  inferDeletionFromMissingEntities?: boolean;
 };
 
 export class AppDevOnceCommand {
@@ -34,6 +35,8 @@ export class AppDevOnceCommand {
       verbose: options.verbose,
       apply,
       force: options.force,
+      inferDeletionFromMissingEntities:
+        options.inferDeletionFromMissingEntities,
       onProgress: (message) => console.log(chalk.gray(message)),
       onPlan: (text) => console.log(`\n${text}\n`),
       confirmApply: (deleteCount) =>

--- a/packages/twenty-sdk/src/cli/commands/dev/dev.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/dev.ts
@@ -17,6 +17,7 @@ export type AppDevOptions = {
   verbose?: boolean;
   debounceMs?: number;
   force?: boolean;
+  inferDeletionFromMissingEntities?: boolean;
 };
 
 export class AppDevCommand {
@@ -75,6 +76,8 @@ export class AppDevCommand {
       verbose: options.verbose,
       debounceMs: options.debounceMs,
       force: options.force,
+      inferDeletionFromMissingEntities:
+        options.inferDeletionFromMissingEntities,
       interactive: !options.headless && process.stdout.isTTY === true,
       onExit: ({ code, message }) => {
         if (options.headless) {

--- a/packages/twenty-sdk/src/cli/commands/dev/index.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/index.ts
@@ -29,6 +29,7 @@ export const registerDevCommands = (program: Command): void => {
       debounceMs?: string;
       dryRun?: boolean;
       force?: boolean;
+      delete: boolean;
     },
   ) => {
     if (options.dryRun && !options.once) {
@@ -55,6 +56,7 @@ export const registerDevCommands = (program: Command): void => {
         verbose,
         apply: !options.dryRun,
         force: options.force,
+        inferDeletionFromMissingEntities: options.delete,
       });
 
       return;
@@ -67,6 +69,7 @@ export const registerDevCommands = (program: Command): void => {
         ? parseInt(options.debounceMs, 10)
         : undefined,
       force: options.force,
+      inferDeletionFromMissingEntities: options.delete,
     });
   };
 
@@ -85,6 +88,10 @@ export const registerDevCommands = (program: Command): void => {
       '-f, --force',
       'Apply destructive changes (deletes) without confirmation',
     )
+    .option(
+      '--no-delete',
+      'Keep entities that are missing from your source instead of deleting them',
+    )
     .option('--debounceMs <ms>', 'Debounce in ms (default: 1 000)')
     .option('-v, --verbose', 'Show detailed logs')
     .option('-d, --debug', 'Show detailed logs (alias for --verbose)')
@@ -93,13 +100,21 @@ export const registerDevCommands = (program: Command): void => {
   program
     .command('plan [appPath]')
     .description('Preview metadata changes without applying them')
+    .option(
+      '--no-delete',
+      'Keep entities that are missing from your source instead of deleting them',
+    )
     .option('-v, --verbose', 'Show detailed logs')
     .action(
-      async (appPath: string | undefined, options: { verbose?: boolean }) => {
+      async (
+        appPath: string | undefined,
+        options: { delete: boolean; verbose?: boolean },
+      ) => {
         await devOnceCommand.execute({
           appPath: formatPath(appPath),
           verbose: options.verbose,
           apply: false,
+          inferDeletionFromMissingEntities: options.delete,
         });
       },
     );
@@ -111,17 +126,22 @@ export const registerDevCommands = (program: Command): void => {
       '-f, --force',
       'Apply destructive changes (deletes) without confirmation',
     )
+    .option(
+      '--no-delete',
+      'Keep entities that are missing from your source instead of deleting them',
+    )
     .option('-v, --verbose', 'Show detailed logs')
     .action(
       async (
         appPath: string | undefined,
-        options: { force?: boolean; verbose?: boolean },
+        options: { force?: boolean; delete: boolean; verbose?: boolean },
       ) => {
         await devOnceCommand.execute({
           appPath: formatPath(appPath),
           verbose: options.verbose,
           apply: true,
           force: options.force,
+          inferDeletionFromMissingEntities: options.delete,
         });
       },
     );

--- a/packages/twenty-sdk/src/cli/operations/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/operations/dev-once.ts
@@ -40,6 +40,7 @@ export type AppDevOnceOptions = {
   verbose?: boolean;
   apply?: boolean;
   force?: boolean;
+  inferDeletionFromMissingEntities?: boolean;
   onProgress?: (message: string) => void;
   onPlan?: (text: string) => void;
   confirmApply?: (deleteCount: number) => Promise<boolean>;
@@ -119,6 +120,7 @@ const innerAppDevOnce = async (
     verbose = false,
     apply = true,
     force = false,
+    inferDeletionFromMissingEntities = true,
   } = options;
 
   onProgress?.('Checking server...');
@@ -230,13 +232,18 @@ const innerAppDevOnce = async (
 
     const planResult = await apiService.syncApplication(manifest, {
       dryRun: true,
+      inferDeletionFromMissingEntities,
     });
 
     if (!planResult.success) {
       return { success: false, error: buildSyncError(planResult, verbose) };
     }
 
-    onPlan?.(formatSyncActionsPlan(planResult.data.actions));
+    onPlan?.(
+      formatSyncActionsPlan(planResult.data.actions, {
+        showNoDeleteHint: inferDeletionFromMissingEntities,
+      }),
+    );
 
     return { success: true, data: makeData() };
   }
@@ -248,10 +255,15 @@ const innerAppDevOnce = async (
 
     const planResult = await apiService.syncApplication(manifest, {
       dryRun: true,
+      inferDeletionFromMissingEntities,
     });
 
     if (planResult.success) {
-      onPlan?.(formatSyncActionsPlan(planResult.data.actions));
+      onPlan?.(
+        formatSyncActionsPlan(planResult.data.actions, {
+          showNoDeleteHint: inferDeletionFromMissingEntities,
+        }),
+      );
       planRendered = true;
 
       if (hasDestructiveActions(planResult.data.actions)) {
@@ -335,7 +347,9 @@ const innerAppDevOnce = async (
 
   onProgress?.('Syncing manifest...');
 
-  const syncResult = await apiService.syncApplication(manifest);
+  const syncResult = await apiService.syncApplication(manifest, {
+    inferDeletionFromMissingEntities,
+  });
 
   if (!syncResult.success) {
     return { success: false, error: buildSyncError(syncResult, verbose) };

--- a/packages/twenty-sdk/src/cli/utilities/api/__tests__/application-api.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/__tests__/application-api.spec.ts
@@ -1,0 +1,99 @@
+import { ApplicationApi } from '@/cli/utilities/api/application-api';
+import { type AxiosInstance } from 'axios';
+import { type Manifest } from 'twenty-shared/application';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const MANIFEST = {
+  application: { universalIdentifier: 'app', displayName: 'App' },
+} as unknown as Manifest;
+
+describe('ApplicationApi.syncApplication', () => {
+  const post = vi.fn();
+  const api = new ApplicationApi({ post } as unknown as AxiosInstance);
+
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue({
+      data: {
+        data: {
+          syncApplication: {
+            applicationUniversalIdentifier: 'app',
+            actions: [],
+          },
+        },
+      },
+    });
+  });
+
+  const sentOperation = () =>
+    post.mock.calls[0][1] as {
+      query: string;
+      variables: Record<string, unknown>;
+    };
+
+  it('sends only the manifest by default', async () => {
+    await api.syncApplication(MANIFEST);
+
+    const { query, variables } = sentOperation();
+
+    expect(query).toContain('mutation SyncApplication($manifest: JSON!)');
+    expect(query).toContain('syncApplication(manifest: $manifest)');
+    expect(variables).toEqual({ manifest: MANIFEST });
+  });
+
+  it('declares dryRun only when requested', async () => {
+    await api.syncApplication(MANIFEST, { dryRun: true });
+
+    const { query, variables } = sentOperation();
+
+    expect(query).toContain('$dryRun: Boolean');
+    expect(query).toContain('dryRun: $dryRun');
+    expect(query).not.toContain('inferDeletionFromMissingEntities');
+    expect(variables).toEqual({ manifest: MANIFEST, dryRun: true });
+  });
+
+  it('declares inferDeletionFromMissingEntities only when deletions are turned off', async () => {
+    await api.syncApplication(MANIFEST, {
+      inferDeletionFromMissingEntities: false,
+    });
+
+    const { query, variables } = sentOperation();
+
+    expect(query).toContain('$inferDeletionFromMissingEntities: Boolean');
+    expect(query).toContain(
+      'inferDeletionFromMissingEntities: $inferDeletionFromMissingEntities',
+    );
+    expect(query).not.toContain('dryRun');
+    expect(variables).toEqual({
+      manifest: MANIFEST,
+      inferDeletionFromMissingEntities: false,
+    });
+  });
+
+  it('leaves the default deletion behaviour implicit', async () => {
+    await api.syncApplication(MANIFEST, {
+      dryRun: true,
+      inferDeletionFromMissingEntities: true,
+    });
+
+    const { query, variables } = sentOperation();
+
+    expect(query).not.toContain('inferDeletionFromMissingEntities');
+    expect(variables).toEqual({ manifest: MANIFEST, dryRun: true });
+  });
+
+  it('declares both arguments for an additive plan', async () => {
+    await api.syncApplication(MANIFEST, {
+      dryRun: true,
+      inferDeletionFromMissingEntities: false,
+    });
+
+    const { variables } = sentOperation();
+
+    expect(variables).toEqual({
+      manifest: MANIFEST,
+      dryRun: true,
+      inferDeletionFromMissingEntities: false,
+    });
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
@@ -84,7 +84,7 @@ export class ApiService {
 
   syncApplication(
     manifest: Manifest,
-    options?: { dryRun?: boolean },
+    options?: { dryRun?: boolean; inferDeletionFromMissingEntities?: boolean },
   ): Promise<
     ApiResponse<
       {

--- a/packages/twenty-sdk/src/cli/utilities/api/application-api.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/application-api.ts
@@ -6,6 +6,7 @@ import {
   type MetadataValidationErrorResponse,
   type SyncAction,
 } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
 
 export class ApplicationApi {
   constructor(private readonly client: AxiosInstance) {}
@@ -313,7 +314,7 @@ export class ApplicationApi {
 
   async syncApplication(
     manifest: Manifest,
-    options?: { dryRun?: boolean },
+    options?: { dryRun?: boolean; inferDeletionFromMissingEntities?: boolean },
   ): Promise<
     ApiResponse<
       {
@@ -324,27 +325,38 @@ export class ApplicationApi {
     >
   > {
     try {
-      const isDryRun = options?.dryRun ?? false;
+      const optionalArguments = [
+        options?.dryRun === true ? 'dryRun' : null,
+        options?.inferDeletionFromMissingEntities === false
+          ? 'inferDeletionFromMissingEntities'
+          : null,
+      ].filter(isDefined);
 
-      const mutation = isDryRun
-        ? `
-        mutation SyncApplication($manifest: JSON!, $dryRun: Boolean) {
-          syncApplication(manifest: $manifest, dryRun: $dryRun) {
-            applicationUniversalIdentifier
-            actions
-          }
-        }
-      `
-        : `
-        mutation SyncApplication($manifest: JSON!) {
-          syncApplication(manifest: $manifest) {
+      const variableDeclarations = [
+        '$manifest: JSON!',
+        ...optionalArguments.map((argument) => `$${argument}: Boolean`),
+      ].join(', ');
+      const argumentAssignments = [
+        'manifest: $manifest',
+        ...optionalArguments.map((argument) => `${argument}: $${argument}`),
+      ].join(', ');
+
+      const mutation = `
+        mutation SyncApplication(${variableDeclarations}) {
+          syncApplication(${argumentAssignments}) {
             applicationUniversalIdentifier
             actions
           }
         }
       `;
 
-      const variables = isDryRun ? { manifest, dryRun: true } : { manifest };
+      const variables = {
+        manifest,
+        ...(options?.dryRun === true ? { dryRun: true } : {}),
+        ...(options?.inferDeletionFromMissingEntities === false
+          ? { inferDeletionFromMissingEntities: false }
+          : {}),
+      };
 
       const response = await this.client.post(
         '/metadata',

--- a/packages/twenty-sdk/src/cli/utilities/api/application-api.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/application-api.ts
@@ -326,7 +326,7 @@ export class ApplicationApi {
   > {
     try {
       const optionalArguments = [
-        options?.dryRun === true ? 'dryRun' : null,
+        options?.dryRun ? 'dryRun' : null,
         options?.inferDeletionFromMissingEntities === false
           ? 'inferDeletionFromMissingEntities'
           : null,
@@ -352,7 +352,7 @@ export class ApplicationApi {
 
       const variables = {
         manifest,
-        ...(options?.dryRun === true ? { dryRun: true } : {}),
+        ...(options?.dryRun ? { dryRun: true } : {}),
         ...(options?.inferDeletionFromMissingEntities === false
           ? { inferDeletionFromMissingEntities: false }
           : {}),

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator.ts
@@ -24,6 +24,7 @@ export type DevModeOrchestratorOptions = {
   debounceMs?: number;
   verbose?: boolean;
   force?: boolean;
+  inferDeletionFromMissingEntities?: boolean;
   interactive?: boolean;
   onExit?: (params: { code: number; message: string }) => void;
 };
@@ -83,6 +84,8 @@ export class DevModeOrchestrator {
       apiService,
       verbose: this.verbose,
       force: options.force ?? false,
+      inferDeletionFromMissingEntities:
+        options.inferDeletionFromMissingEntities ?? true,
       interactive: options.interactive ?? false,
       onExit: options.onExit,
     });

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/__tests__/format-sync-actions-plan.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/__tests__/format-sync-actions-plan.spec.ts
@@ -185,6 +185,50 @@ describe('formatSyncActionsPlan', () => {
     expect(plan).not.toContain('Warning:');
   });
 
+  it('should suggest --no-delete when the plan destroys entities and deletions are inferred', () => {
+    const plan = formatSyncActionsPlan(
+      [
+        {
+          type: 'delete',
+          metadataName: 'view',
+          universalIdentifier: 'v',
+          flatEntity: { name: 'My view' },
+        },
+      ],
+      { showNoDeleteHint: true },
+    );
+
+    expect(plan).toContain('Re-run with --no-delete to keep them.');
+  });
+
+  it('should not suggest --no-delete without the option', () => {
+    const plan = formatSyncActionsPlan([
+      {
+        type: 'delete',
+        metadataName: 'view',
+        universalIdentifier: 'v',
+        flatEntity: { name: 'My view' },
+      },
+    ]);
+
+    expect(plan).not.toContain('--no-delete');
+  });
+
+  it('should not suggest --no-delete when nothing is destroyed', () => {
+    const plan = formatSyncActionsPlan(
+      [
+        {
+          type: 'create',
+          metadataName: 'fieldMetadata',
+          flatEntity: { name: 'name' },
+        },
+      ],
+      { showNoDeleteHint: true },
+    );
+
+    expect(plan).not.toContain('--no-delete');
+  });
+
   it('should group by type ordered by first appearance, create before delete within a group', () => {
     const plan = formatSyncActionsPlan([
       {

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/format-sync-actions-plan.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/format-sync-actions-plan.ts
@@ -233,6 +233,9 @@ const formatFooter = (counts: {
     `${counts.update} to change`,
   )}, ${chalk.red(`${counts.delete} to destroy`)}.`;
 
+export const NO_DELETE_HINT =
+  'Entities missing from your source are destroyed by default. Re-run with --no-delete to keep them.';
+
 const formatDestructiveWarning = (actions: SyncAction[]): string => {
   const deletes = actions.filter(isDestructiveAction);
 
@@ -266,6 +269,7 @@ const formatDestructiveWarning = (actions: SyncAction[]): string => {
 
 export const formatSyncActionsPlan = (
   actions: SyncAction[] | undefined,
+  options?: { showNoDeleteHint?: boolean },
 ): string => {
   if (!isNonEmptyArray(actions)) {
     return 'No changes. Twenty metadata matches your manifest.';
@@ -288,6 +292,10 @@ export const formatSyncActionsPlan = (
     '',
     formatFooter(counts),
   ];
+
+  if (counts.delete > 0 && options?.showNoDeleteHint === true) {
+    sections.push(chalk.dim(NO_DELETE_HINT));
+  }
 
   if (hasDestructiveActions(actions)) {
     sections.push('', formatDestructiveWarning(actions));

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/format-sync-actions-plan.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/format-sync-actions-plan.ts
@@ -236,6 +236,16 @@ const formatFooter = (counts: {
 export const NO_DELETE_HINT =
   'Entities missing from your source are destroyed by default. Re-run with --no-delete to keep them.';
 
+export const shouldShowNoDeleteHint = ({
+  actions,
+  inferDeletionFromMissingEntities,
+}: {
+  actions: SyncAction[] | undefined;
+  inferDeletionFromMissingEntities: boolean;
+}): boolean =>
+  inferDeletionFromMissingEntities &&
+  (actions ?? []).some((action) => action.type === 'delete');
+
 const formatDestructiveWarning = (actions: SyncAction[]): string => {
   const deletes = actions.filter(isDestructiveAction);
 
@@ -293,7 +303,12 @@ export const formatSyncActionsPlan = (
     formatFooter(counts),
   ];
 
-  if (counts.delete > 0 && options?.showNoDeleteHint === true) {
+  if (
+    shouldShowNoDeleteHint({
+      actions,
+      inferDeletionFromMissingEntities: options?.showNoDeleteHint ?? false,
+    })
+  ) {
     sections.push(chalk.dim(NO_DELETE_HINT));
   }
 

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
@@ -12,6 +12,7 @@ import {
   countDestructiveActions,
   hasDestructiveActions,
   NO_DELETE_HINT,
+  shouldShowNoDeleteHint,
 } from '@/cli/utilities/dev/orchestrator/steps/format-sync-actions-plan';
 import { formatSyncActionsSummary } from '@/cli/utilities/dev/orchestrator/steps/format-sync-actions-summary';
 import { formatManifestValidationErrors } from '@/cli/utilities/error/format-manifest-validation-errors';
@@ -108,8 +109,11 @@ export class SyncApplicationOrchestratorStep {
       }
 
       if (
-        this.inferDeletionFromMissingEntities &&
-        planResult.data.actions.some((action) => action.type === 'delete')
+        shouldShowNoDeleteHint({
+          actions: planResult.data.actions,
+          inferDeletionFromMissingEntities:
+            this.inferDeletionFromMissingEntities,
+        })
       ) {
         events.push({ message: NO_DELETE_HINT, status: 'info' });
       }

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
@@ -11,6 +11,7 @@ import {
 import {
   countDestructiveActions,
   hasDestructiveActions,
+  NO_DELETE_HINT,
 } from '@/cli/utilities/dev/orchestrator/steps/format-sync-actions-plan';
 import { formatSyncActionsSummary } from '@/cli/utilities/dev/orchestrator/steps/format-sync-actions-summary';
 import { formatManifestValidationErrors } from '@/cli/utilities/error/format-manifest-validation-errors';
@@ -29,6 +30,7 @@ export class SyncApplicationOrchestratorStep {
   private notify: () => void;
   private verbose: boolean;
   private force: boolean;
+  private inferDeletionFromMissingEntities: boolean;
   private interactive: boolean;
   private onExit?: (params: { code: number; message: string }) => void;
 
@@ -38,6 +40,7 @@ export class SyncApplicationOrchestratorStep {
     notify,
     verbose,
     force,
+    inferDeletionFromMissingEntities,
     interactive,
     onExit,
   }: {
@@ -46,6 +49,7 @@ export class SyncApplicationOrchestratorStep {
     notify: () => void;
     verbose?: boolean;
     force?: boolean;
+    inferDeletionFromMissingEntities?: boolean;
     interactive?: boolean;
     onExit?: (params: { code: number; message: string }) => void;
   }) {
@@ -54,6 +58,8 @@ export class SyncApplicationOrchestratorStep {
     this.notify = notify;
     this.verbose = verbose ?? false;
     this.force = force ?? false;
+    this.inferDeletionFromMissingEntities =
+      inferDeletionFromMissingEntities ?? true;
     this.interactive = interactive ?? false;
     this.onExit = onExit;
   }
@@ -92,12 +98,20 @@ export class SyncApplicationOrchestratorStep {
 
       const planResult = await this.apiService.syncApplication(manifest, {
         dryRun: true,
+        inferDeletionFromMissingEntities: this.inferDeletionFromMissingEntities,
       });
 
       if (!planResult.success) {
         this.applyFailure(planResult, events);
 
         return;
+      }
+
+      if (
+        this.inferDeletionFromMissingEntities &&
+        planResult.data.actions.some((action) => action.type === 'delete')
+      ) {
+        events.push({ message: NO_DELETE_HINT, status: 'info' });
       }
 
       if (hasDestructiveActions(planResult.data.actions)) {
@@ -114,7 +128,9 @@ export class SyncApplicationOrchestratorStep {
 
     events.push({ message: 'Syncing manifest', status: 'info' });
 
-    const syncResult = await this.apiService.syncApplication(manifest);
+    const syncResult = await this.apiService.syncApplication(manifest, {
+      inferDeletionFromMissingEntities: this.inferDeletionFromMissingEntities,
+    });
 
     if (syncResult.success) {
       events.push(...formatSyncActionsSummary(syncResult.data.actions));

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
@@ -61,12 +61,14 @@ export class ApplicationDevelopmentResolver {
 
   @Mutation(() => WorkspaceMigrationDTO)
   async syncApplication(
-    @Args() { manifest, dryRun }: ApplicationInput,
+    @Args()
+    { manifest, dryRun, inferDeletionFromMissingEntities }: ApplicationInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
   ): Promise<WorkspaceMigrationDTO> {
     return this.applicationDevelopmentService.syncApplication({
       manifest,
       dryRun,
+      inferDeletionFromMissingEntities,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.service.ts
@@ -92,12 +92,17 @@ export class ApplicationDevelopmentService {
   async syncApplication({
     manifest,
     dryRun,
+    inferDeletionFromMissingEntities,
     workspaceId,
   }: {
     manifest: ApplicationInput['manifest'];
     dryRun?: boolean;
+    inferDeletionFromMissingEntities?: boolean | null;
     workspaceId: string;
   }): Promise<WorkspaceMigrationDTO> {
+    const shouldInferDeletionFromMissingEntities =
+      inferDeletionFromMissingEntities !== false;
+
     await this.throttlePerApplication(
       manifest.application.universalIdentifier,
       workspaceId,
@@ -125,6 +130,8 @@ export class ApplicationDevelopmentService {
           workspaceId,
           manifest,
           dryRun: true,
+          inferDeletionFromMissingEntities:
+            shouldInferDeletionFromMissingEntities,
         });
 
       return {
@@ -135,7 +142,12 @@ export class ApplicationDevelopmentService {
     }
 
     return this.cacheLockService.withLock(
-      () => this.applyManifestSync(manifest, workspaceId),
+      () =>
+        this.applyManifestSync(
+          manifest,
+          workspaceId,
+          shouldInferDeletionFromMissingEntities,
+        ),
       `app-sync:${workspaceId}`,
       APP_SYNC_LOCK_OPTIONS,
     );
@@ -206,6 +218,7 @@ export class ApplicationDevelopmentService {
   private async applyManifestSync(
     manifest: ApplicationInput['manifest'],
     workspaceId: string,
+    inferDeletionFromMissingEntities: boolean,
   ): Promise<WorkspaceMigrationDTO> {
     const applicationRegistrationId = await this.findApplicationRegistrationId(
       manifest.application.universalIdentifier,
@@ -231,6 +244,7 @@ export class ApplicationDevelopmentService {
         manifest,
         applicationRegistrationId,
         application,
+        inferDeletionFromMissingEntities,
       });
 
     await this.syncRegistrationMetadata(

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application.input.ts
@@ -10,4 +10,7 @@ export class ApplicationInput {
 
   @Field(() => Boolean, { nullable: true })
   dryRun?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  inferDeletionFromMissingEntities?: boolean;
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-apply.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-apply.service.ts
@@ -26,6 +26,7 @@ export class ApplicationManifestApplyService {
     applicationRegistrationId,
     application,
     forceSdkClientGeneration = false,
+    inferDeletionFromMissingEntities = true,
   }: {
     workspaceId: string;
     manifest: Manifest;
@@ -34,6 +35,7 @@ export class ApplicationManifestApplyService {
       ApplicationEntity,
       'id' | 'universalIdentifier' | 'version'
     >;
+    inferDeletionFromMissingEntities?: boolean;
     // Installs and upgrades force regeneration so function-only upgrades pick
     // up SDK-level changes; dev sync relies on first-apply/schema-change to
     // avoid regenerating on every save.
@@ -52,6 +54,7 @@ export class ApplicationManifestApplyService {
         workspaceId,
         manifest,
         applicationRegistrationId,
+        inferDeletionFromMissingEntities,
       });
 
     if (forceSdkClientGeneration || isFirstApply || hasSchemaMetadataChanged) {

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -170,11 +170,13 @@ export class ApplicationManifestMigrationService {
     workspaceId,
     ownerFlatApplication,
     dryRun = false,
+    inferDeletionFromMissingEntities = true,
   }: {
     manifest: Manifest;
     workspaceId: string;
     ownerFlatApplication: FlatApplication;
     dryRun?: boolean;
+    inferDeletionFromMissingEntities?: boolean;
   }): Promise<{
     workspaceMigration: WorkspaceMigration;
     hasSchemaMetadataChanged: boolean;
@@ -222,7 +224,9 @@ export class ApplicationManifestMigrationService {
         toAllUniversalFlatEntityMaps,
         buildOptions: {
           isSystemBuild: false,
-          inferDeletionFromMissingEntities: true,
+          inferDeletionFromMissingEntities: inferDeletionFromMissingEntities
+            ? true
+            : undefined,
           applicationUniversalIdentifier:
             ownerFlatApplication.universalIdentifier,
         },

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-sync.service.ts
@@ -61,11 +61,13 @@ export class ApplicationSyncService {
     manifest,
     applicationRegistrationId,
     dryRun = false,
+    inferDeletionFromMissingEntities = true,
   }: {
     workspaceId: string;
     manifest: Manifest;
     applicationRegistrationId?: string;
     dryRun?: boolean;
+    inferDeletionFromMissingEntities?: boolean;
   }): Promise<{
     workspaceMigration: WorkspaceMigration;
     hasSchemaMetadataChanged: boolean;
@@ -91,6 +93,7 @@ export class ApplicationSyncService {
             workspaceId,
             ownerFlatApplication,
             dryRun,
+            inferDeletionFromMissingEntities,
           },
         );
     } catch (error) {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/workspace-owned-properties-by-metadata-name.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/workspace-owned-properties-by-metadata-name.constant.ts
@@ -9,4 +9,6 @@ export const WORKSPACE_OWNED_PROPERTIES_BY_METADATA_NAME: Partial<{
   [P in AllMetadataName]: MetadataEntityComparablePropertyName<P>[];
 }> = {
   pageLayout: ['isFirstTabPinned'],
+  skill: ['isActive'],
+  view: ['createdByUserWorkspaceId'],
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/keep-workspace-owned-properties.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/keep-workspace-owned-properties.util.spec.ts
@@ -90,9 +90,10 @@ describe('keepWorkspaceOwnedProperties', () => {
       },
     });
 
-    expect(result.byUniversalIdentifier['skill-universal-identifier']).toEqual(
-      { ...shippedSkill, isActive: false },
-    );
+    expect(result.byUniversalIdentifier['skill-universal-identifier']).toEqual({
+      ...shippedSkill,
+      isActive: false,
+    });
   });
 
   it('should keep the creator of a view the workspace already has', () => {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/keep-workspace-owned-properties.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/keep-workspace-owned-properties.util.spec.ts
@@ -69,18 +69,74 @@ describe('keepWorkspaceOwnedProperties', () => {
     ).toEqual(standardPageLayout);
   });
 
-  it('should return the standard entities untouched for a metadata without workspace-owned properties', () => {
-    const toFlatEntityMaps = {
-      byUniversalIdentifier: {
-        'view-universal-identifier': { name: 'All Companies' },
+  it('should keep a skill deactivated by the workspace', () => {
+    const shippedSkill = {
+      universalIdentifier: 'skill-universal-identifier',
+      name: 'summarize',
+      isActive: true,
+    };
+
+    const result = keepWorkspaceOwnedProperties({
+      metadataName: 'skill',
+      fromFlatEntityMaps: {
+        byUniversalIdentifier: {
+          'skill-universal-identifier': { ...shippedSkill, isActive: false },
+        },
       },
+      toFlatEntityMaps: {
+        byUniversalIdentifier: {
+          'skill-universal-identifier': shippedSkill,
+        },
+      },
+    });
+
+    expect(result.byUniversalIdentifier['skill-universal-identifier']).toEqual(
+      { ...shippedSkill, isActive: false },
+    );
+  });
+
+  it('should keep the creator of a view the workspace already has', () => {
+    const shippedView = {
+      universalIdentifier: 'view-universal-identifier',
+      name: 'All Companies',
+      createdByUserWorkspaceId: null,
     };
 
     const result = keepWorkspaceOwnedProperties({
       metadataName: 'view',
       fromFlatEntityMaps: {
         byUniversalIdentifier: {
-          'view-universal-identifier': { name: 'Renamed by the workspace' },
+          'view-universal-identifier': {
+            ...shippedView,
+            createdByUserWorkspaceId: 'user-workspace-id',
+          },
+        },
+      },
+      toFlatEntityMaps: {
+        byUniversalIdentifier: {
+          'view-universal-identifier': shippedView,
+        },
+      },
+    });
+
+    expect(result.byUniversalIdentifier['view-universal-identifier']).toEqual({
+      ...shippedView,
+      createdByUserWorkspaceId: 'user-workspace-id',
+    });
+  });
+
+  it('should return the standard entities untouched for a metadata without workspace-owned properties', () => {
+    const toFlatEntityMaps = {
+      byUniversalIdentifier: {
+        'role-universal-identifier': { label: 'Manager' },
+      },
+    };
+
+    const result = keepWorkspaceOwnedProperties({
+      metadataName: 'role',
+      fromFlatEntityMaps: {
+        byUniversalIdentifier: {
+          'role-universal-identifier': { label: 'Renamed by the workspace' },
         },
       },
       toFlatEntityMaps,

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-additive-mode.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-additive-mode.integration-spec.ts
@@ -1,0 +1,162 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { buildDefaultObjectManifest } from 'test/integration/metadata/suites/application/utils/build-default-object-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
+import { deactivateSkill } from 'test/integration/metadata/suites/skill/utils/deactivate-skill.util';
+import { findSkills } from 'test/integration/metadata/suites/skill/utils/find-skills.util';
+import { type Manifest, type SkillManifest } from 'twenty-shared/application';
+import { isDefined } from 'twenty-shared/utils';
+import { v4 as uuidv4 } from 'uuid';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+const SKILL_NAME = 'additiveModeSkill';
+
+const skill: SkillManifest = {
+  universalIdentifier: uuidv4(),
+  name: SKILL_NAME,
+  label: 'Additive Mode Skill',
+  content: 'Summarize the record in one sentence.',
+};
+
+const ticketObject = buildDefaultObjectManifest({
+  applicationUniversalIdentifier: TEST_APP_ID,
+  nameSingular: 'additiveTicket',
+  namePlural: 'additiveTickets',
+  labelSingular: 'Additive Ticket',
+  labelPlural: 'Additive Tickets',
+  description: 'A support ticket',
+});
+
+const invoiceObject = buildDefaultObjectManifest({
+  applicationUniversalIdentifier: TEST_APP_ID,
+  nameSingular: 'additiveInvoice',
+  namePlural: 'additiveInvoices',
+  labelSingular: 'Additive Invoice',
+  labelPlural: 'Additive Invoices',
+  description: 'A billing invoice',
+});
+
+const buildManifest = (
+  overrides?: Partial<Pick<Manifest, 'objects' | 'skills'>>,
+) =>
+  buildBaseManifest({
+    appId: TEST_APP_ID,
+    roleId: TEST_ROLE_ID,
+    overrides: { skills: [skill], ...overrides },
+  });
+
+const findObjectNames = async (): Promise<string[]> => {
+  const { objects } = await findManyObjectMetadata({
+    input: { filter: {}, paging: { first: 100 } },
+    gqlFields: 'id nameSingular',
+    expectToFail: false,
+  });
+
+  return objects.map((object) => object.nameSingular);
+};
+
+const findTestSkill = async () => {
+  const { data } = await findSkills({
+    input: undefined,
+    gqlFields: 'id name isActive',
+    expectToFail: false,
+  });
+
+  const found = data.skills.find(
+    (candidate: { name: string }) => candidate.name === SKILL_NAME,
+  );
+
+  expect(isDefined(found)).toBe(true);
+
+  return found as { id: string; name: string; isActive: boolean };
+};
+
+describe('Manifest sync - additive mode', () => {
+  beforeEach(async () => {
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      name: 'Additive Mode Test Application',
+      description: 'App for testing additive manifest sync',
+      sourcePath: 'additive-mode-manifest-sync',
+    });
+
+    await syncApplication({
+      manifest: buildManifest({ objects: [ticketObject, invoiceObject] }),
+      expectToFail: false,
+    });
+  }, 60000);
+
+  afterEach(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+  });
+
+  it('keeps entities missing from the manifest when deletions are turned off', async () => {
+    const manifestWithoutInvoice = buildManifest({ objects: [ticketObject] });
+
+    const additivePlan = await syncApplication({
+      manifest: manifestWithoutInvoice,
+      dryRun: true,
+      inferDeletionFromMissingEntities: false,
+      expectToFail: false,
+    });
+
+    expect(additivePlan.errors).toBeUndefined();
+    expect(
+      additivePlan.data.syncApplication.actions.filter(
+        (action) => (action as { type: string }).type === 'delete',
+      ),
+    ).toHaveLength(0);
+
+    const pruningPlan = await syncApplication({
+      manifest: manifestWithoutInvoice,
+      dryRun: true,
+      expectToFail: false,
+    });
+
+    expect(
+      pruningPlan.data.syncApplication.actions.filter(
+        (action) => (action as { type: string }).type === 'delete',
+      ).length,
+    ).toBeGreaterThan(0);
+
+    const additiveSync = await syncApplication({
+      manifest: manifestWithoutInvoice,
+      inferDeletionFromMissingEntities: false,
+      expectToFail: false,
+    });
+
+    expect(additiveSync.errors).toBeUndefined();
+
+    const objectNames = await findObjectNames();
+
+    expect(objectNames).toContain('additiveTicket');
+    expect(objectNames).toContain('additiveInvoice');
+  }, 60000);
+
+  it('keeps a skill deactivated by the workspace across a sync', async () => {
+    const skillBefore = await findTestSkill();
+
+    expect(skillBefore.isActive).toBe(true);
+
+    const deactivation = await deactivateSkill({
+      input: { id: skillBefore.id },
+      expectToFail: false,
+    });
+
+    expect(deactivation.errors).toBeUndefined();
+
+    await syncApplication({
+      manifest: buildManifest({ objects: [ticketObject, invoiceObject] }),
+      expectToFail: false,
+    });
+
+    const skillAfter = await findTestSkill();
+
+    expect(skillAfter.isActive).toBe(false);
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application-query-factory.util.ts
@@ -4,13 +4,23 @@ import { type Manifest } from 'twenty-shared/application';
 export const syncApplicationQueryFactory = ({
   manifest,
   dryRun,
+  inferDeletionFromMissingEntities,
 }: {
   manifest: Manifest;
   dryRun?: boolean;
+  inferDeletionFromMissingEntities?: boolean;
 }) => ({
   query: gql`
-    mutation SyncApplication($manifest: JSON!, $dryRun: Boolean) {
-      syncApplication(manifest: $manifest, dryRun: $dryRun) {
+    mutation SyncApplication(
+      $manifest: JSON!
+      $dryRun: Boolean
+      $inferDeletionFromMissingEntities: Boolean
+    ) {
+      syncApplication(
+        manifest: $manifest
+        dryRun: $dryRun
+        inferDeletionFromMissingEntities: $inferDeletionFromMissingEntities
+      ) {
         applicationUniversalIdentifier
         actions
       }
@@ -19,5 +29,6 @@ export const syncApplicationQueryFactory = ({
   variables: {
     manifest,
     dryRun,
+    inferDeletionFromMissingEntities,
   },
 });

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application.util.ts
@@ -15,17 +15,20 @@ export const syncApplication = async ({
   expectToFail = false,
   token,
   dryRun,
+  inferDeletionFromMissingEntities,
 }: {
   manifest: Manifest;
   expectToFail?: boolean;
   token?: string;
   dryRun?: boolean;
+  inferDeletionFromMissingEntities?: boolean;
 }): CommonResponseBody<{
   syncApplication: WorkspaceMigration;
 }> => {
   const graphqlOperation = syncApplicationQueryFactory({
     manifest,
     dryRun,
+    inferDeletionFromMissingEntities,
   });
 
   const response = await makeMetadataAPIRequest(graphqlOperation, token);


### PR DESCRIPTION
By default syncApplication infers deletions from entities missing in the manifest, which makes it impossible to push a partial source tree without destroying what the workspace already has. This adds an opt-out.

Server: new nullable inferDeletionFromMissingEntities argument on the syncApplication mutation (default true), threaded through the dev service, the apply service and the manifest migration builder. pageLayout isFirstTabPinned, skill isActive and view createdByUserWorkspaceId are workspace-owned so a sync does not reset them. Note that this second change applies to every sync, not only to --no-delete: keepWorkspaceOwnedProperties runs unconditionally, so a workspace that deactivated an app skill or pinned a layout tab keeps that state when the app is re-applied.

SDK: --no-delete option on apply, plan and dev. Plans that would destroy entities print a hint pointing at the flag. The mutation only declares the arguments that are actually set.

Docs: sync-and-recovery page describes the flag.

Tests: unit specs for the workspace-owned properties, the plan formatter and the mutation builder, plus an integration spec covering the additive sync and a deactivated skill surviving a sync.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


