### PR TITLE
fix(sdk): make remote:add --test write only to the test config

### DIFF
--- a/packages/twenty-sdk/src/cli/commands/dev/dev.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/dev.ts
@@ -37,7 +37,9 @@ export class AppDevCommand {
     const { serverUp, authValid } = await apiService.validateAuth();
 
     if (serverUp && !authValid) {
-      await promptForReauthentication(ConfigService.getActiveRemote());
+      await promptForReauthentication({
+        remoteName: ConfigService.getActiveRemote(),
+      });
     }
   }
 

--- a/packages/twenty-sdk/src/cli/commands/remote/index.ts
+++ b/packages/twenty-sdk/src/cli/commands/remote/index.ts
@@ -15,9 +15,10 @@ type AuthMethod = 'OAuth' | 'API key';
 const authenticate = async (
   apiUrl: string,
   apiKey?: string,
+  configPath?: string,
 ): Promise<AuthMethod> => {
   if (apiKey) {
-    const result = await authLogin({ apiKey, apiUrl });
+    const result = await authLogin({ apiKey, apiUrl, configPath });
 
     if (!result.success) {
       console.error(chalk.red('✗ Authentication failed.'));
@@ -27,15 +28,16 @@ const authenticate = async (
     return 'API key';
   }
 
-  return runOAuthWithApiKeyFallback(apiUrl);
+  return runOAuthWithApiKeyFallback(apiUrl, configPath);
 };
 
 const runOAuthWithApiKeyFallback = async (
   apiUrl: string,
+  configPath?: string,
 ): Promise<AuthMethod> => {
   console.log(chalk.gray('Opening browser for authentication...'));
 
-  const oauthResult = await authLoginOAuth({ apiUrl });
+  const oauthResult = await authLoginOAuth({ apiUrl, configPath });
 
   if (oauthResult.success) {
     return 'OAuth';
@@ -56,6 +58,7 @@ const runOAuthWithApiKeyFallback = async (
   const fallbackResult = await authLogin({
     apiKey: keyAnswer.apiKey,
     apiUrl,
+    configPath,
   });
 
   if (!fallbackResult.success) {
@@ -85,9 +88,11 @@ const addAction = async (options: {
 
   if (options.as !== undefined && existingRemotes.includes(options.as)) {
     const config = await configService.getConfigForRemote(options.as);
+    const overrideUrl = options.url ?? options.apiUrl;
+    const apiUrl = overrideUrl ? normalizeUrl(overrideUrl) : config.apiUrl;
 
     ConfigService.setActiveRemote(options.as);
-    const method = await authenticate(config.apiUrl, options.apiKey);
+    const method = await authenticate(apiUrl, options.apiKey, configPath);
 
     console.log(
       chalk.green(`✓ Re-authenticated "${options.as}" via ${method}.`),
@@ -146,7 +151,7 @@ const addAction = async (options: {
   const name = options.as ?? deriveRemoteName(serverUrl);
 
   ConfigService.setActiveRemote(name);
-  const method = await authenticate(serverUrl, options.apiKey);
+  const method = await authenticate(serverUrl, options.apiKey, configPath);
 
   console.log(
     chalk.green(`✓ Remote "${name}" added (${serverUrl}) via ${method}.`),

--- a/packages/twenty-sdk/src/cli/commands/remote/index.ts
+++ b/packages/twenty-sdk/src/cli/commands/remote/index.ts
@@ -5,6 +5,7 @@ import { ApiService } from '@/cli/utilities/api/api-service';
 import { ConfigService } from '@/cli/utilities/config/config-service';
 import { getConfigPath } from '@/cli/utilities/config/get-config-path';
 import { detectLocalServer } from '@/cli/utilities/server/detect-local-server';
+import { isNonEmptyString } from '@sniptt/guards';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import inquirer from 'inquirer';
@@ -12,11 +13,17 @@ import { normalizeUrl } from 'twenty-shared/utils';
 
 type AuthMethod = 'OAuth' | 'API key';
 
-const authenticate = async (
-  apiUrl: string,
-  apiKey?: string,
-  configPath?: string,
-): Promise<AuthMethod> => {
+type AuthenticateOptions = {
+  apiUrl: string;
+  apiKey?: string;
+  configPath?: string;
+};
+
+const authenticate = async ({
+  apiUrl,
+  apiKey,
+  configPath,
+}: AuthenticateOptions): Promise<AuthMethod> => {
   if (apiKey) {
     const result = await authLogin({ apiKey, apiUrl, configPath });
 
@@ -28,13 +35,13 @@ const authenticate = async (
     return 'API key';
   }
 
-  return runOAuthWithApiKeyFallback(apiUrl, configPath);
+  return runOAuthWithApiKeyFallback({ apiUrl, configPath });
 };
 
-const runOAuthWithApiKeyFallback = async (
-  apiUrl: string,
-  configPath?: string,
-): Promise<AuthMethod> => {
+const runOAuthWithApiKeyFallback = async ({
+  apiUrl,
+  configPath,
+}: Omit<AuthenticateOptions, 'apiKey'>): Promise<AuthMethod> => {
   console.log(chalk.gray('Opening browser for authentication...'));
 
   const oauthResult = await authLoginOAuth({ apiUrl, configPath });
@@ -81,18 +88,22 @@ const addAction = async (options: {
     console.warn(chalk.yellow('⚠ --api-url is deprecated. Use --url instead.'));
   }
   const configPath = options.test ? getConfigPath(true) : undefined;
-  const configService = new ConfigService(
-    configPath ? { configPath } : undefined,
-  );
+  const configService = new ConfigService({ configPath });
   const existingRemotes = await configService.getRemotes();
 
   if (options.as !== undefined && existingRemotes.includes(options.as)) {
     const config = await configService.getConfigForRemote(options.as);
     const overrideUrl = options.url ?? options.apiUrl;
-    const apiUrl = overrideUrl ? normalizeUrl(overrideUrl) : config.apiUrl;
+    const apiUrl = isNonEmptyString(overrideUrl)
+      ? normalizeUrl(overrideUrl)
+      : config.apiUrl;
 
     ConfigService.setActiveRemote(options.as);
-    const method = await authenticate(apiUrl, options.apiKey, configPath);
+    const method = await authenticate({
+      apiUrl,
+      apiKey: options.apiKey,
+      configPath,
+    });
 
     console.log(
       chalk.green(`✓ Re-authenticated "${options.as}" via ${method}.`),
@@ -151,7 +162,11 @@ const addAction = async (options: {
   const name = options.as ?? deriveRemoteName(serverUrl);
 
   ConfigService.setActiveRemote(name);
-  const method = await authenticate(serverUrl, options.apiKey, configPath);
+  const method = await authenticate({
+    apiUrl: serverUrl,
+    apiKey: options.apiKey,
+    configPath,
+  });
 
   console.log(
     chalk.green(`✓ Remote "${name}" added (${serverUrl}) via ${method}.`),

--- a/packages/twenty-sdk/src/cli/operations/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/operations/dev-once.ts
@@ -142,9 +142,9 @@ const innerAppDevOnce = async (
   }
 
   if (!validateAuth.authValid) {
-    const outcome = await promptForReauthentication(
-      ConfigService.getActiveRemote(),
-    );
+    const outcome = await promptForReauthentication({
+      remoteName: ConfigService.getActiveRemote(),
+    });
 
     if (outcome !== 'reauthenticated') {
       return {

--- a/packages/twenty-sdk/src/cli/operations/login-oauth.ts
+++ b/packages/twenty-sdk/src/cli/operations/login-oauth.ts
@@ -12,6 +12,7 @@ export type AuthLoginOAuthOptions = {
   apiUrl: string;
   remote?: string;
   timeoutMs?: number;
+  configPath?: string;
 };
 
 export type OAuthDiscoveryResponse = {
@@ -23,13 +24,15 @@ export type OAuthDiscoveryResponse = {
 const innerAuthLoginOAuth = async (
   options: AuthLoginOAuthOptions,
 ): Promise<CommandResult> => {
-  const { apiUrl, remote, timeoutMs } = options;
+  const { apiUrl, remote, timeoutMs, configPath } = options;
 
   if (remote) {
     ConfigService.setActiveRemote(remote);
   }
 
-  const configService = new ConfigService();
+  const configService = new ConfigService(
+    configPath ? { configPath } : undefined,
+  );
 
   const discoveryUrl = `${apiUrl}/.well-known/oauth-authorization-server`;
 

--- a/packages/twenty-sdk/src/cli/operations/login-oauth.ts
+++ b/packages/twenty-sdk/src/cli/operations/login-oauth.ts
@@ -30,9 +30,7 @@ const innerAuthLoginOAuth = async (
     ConfigService.setActiveRemote(remote);
   }
 
-  const configService = new ConfigService(
-    configPath ? { configPath } : undefined,
-  );
+  const configService = new ConfigService({ configPath });
 
   const discoveryUrl = `${apiUrl}/.well-known/oauth-authorization-server`;
 
@@ -117,6 +115,7 @@ const innerAuthLoginOAuth = async (
     const apiService = new ApiService({
       serverUrl: apiUrl,
       token: accessToken,
+      configPath,
     });
 
     const validateAuth = await apiService.validateAuth();

--- a/packages/twenty-sdk/src/cli/operations/login.ts
+++ b/packages/twenty-sdk/src/cli/operations/login.ts
@@ -7,18 +7,21 @@ export type AuthLoginOptions = {
   apiKey: string;
   apiUrl: string;
   remote?: string;
+  configPath?: string;
 };
 
 const innerAuthLogin = async (
   options: AuthLoginOptions,
 ): Promise<CommandResult> => {
-  const { apiKey, apiUrl, remote } = options;
+  const { apiKey, apiUrl, remote, configPath } = options;
 
   if (remote) {
     ConfigService.setActiveRemote(remote);
   }
 
-  const configService = new ConfigService();
+  const configService = new ConfigService(
+    configPath ? { configPath } : undefined,
+  );
 
   await configService.setConfig({
     apiUrl,
@@ -28,7 +31,7 @@ const innerAuthLogin = async (
     twentyCLIRegistrationClientId: undefined,
   });
 
-  const apiService = new ApiService();
+  const apiService = new ApiService({ serverUrl: apiUrl, token: apiKey });
   const validateAuth = await apiService.validateAuth();
 
   if (!validateAuth.authValid) {

--- a/packages/twenty-sdk/src/cli/operations/login.ts
+++ b/packages/twenty-sdk/src/cli/operations/login.ts
@@ -19,9 +19,7 @@ const innerAuthLogin = async (
     ConfigService.setActiveRemote(remote);
   }
 
-  const configService = new ConfigService(
-    configPath ? { configPath } : undefined,
-  );
+  const configService = new ConfigService({ configPath });
 
   await configService.setConfig({
     apiUrl,
@@ -31,7 +29,11 @@ const innerAuthLogin = async (
     twentyCLIRegistrationClientId: undefined,
   });
 
-  const apiService = new ApiService({ serverUrl: apiUrl, token: apiKey });
+  const apiService = new ApiService({
+    serverUrl: apiUrl,
+    token: apiKey,
+    configPath,
+  });
   const validateAuth = await apiService.validateAuth();
 
   if (!validateAuth.authValid) {

--- a/packages/twenty-sdk/src/cli/utilities/api/api-client.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/api-client.ts
@@ -14,6 +14,7 @@ export class ApiClient {
   readonly client: AxiosInstance;
   readonly configService: ConfigService;
   private readonly tokenOverride?: string;
+  private readonly configPath?: string;
   readonly serverUrlOverride?: string;
   private reauthAttempted: boolean = false;
 
@@ -22,14 +23,17 @@ export class ApiClient {
     serverUrl?: string;
     token?: string;
     skipAuth?: boolean;
+    configPath?: string;
   }) {
     const {
       disableInterceptors = false,
       serverUrl,
       token,
       skipAuth = false,
+      configPath,
     } = options || {};
-    this.configService = new ConfigService();
+    this.configService = new ConfigService({ configPath });
+    this.configPath = configPath;
     this.tokenOverride = token;
     this.serverUrlOverride = serverUrl;
     this.client = axios.create();
@@ -125,7 +129,10 @@ export class ApiClient {
     const remoteName = ConfigService.getActiveRemote();
     console.error(`Authentication failed on remote "${remoteName}"`);
 
-    const outcome = await promptForReauthentication(remoteName);
+    const outcome = await promptForReauthentication({
+      remoteName,
+      configPath: this.configPath,
+    });
 
     if (outcome === 'reauthenticated') {
       const authToken = await this.resolveAuthToken();

--- a/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
@@ -15,6 +15,7 @@ type ApiServiceOptions = {
   serverUrl?: string;
   token?: string;
   skipAuth?: boolean;
+  configPath?: string;
 };
 
 export class ApiService {

--- a/packages/twenty-sdk/src/cli/utilities/auth/reauth-helper.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/reauth-helper.ts
@@ -5,9 +5,15 @@ import { ConfigService } from '@/cli/utilities/config/config-service';
 
 export type ReauthOutcome = 'reauthenticated' | 'declined' | 'non-interactive';
 
-export const promptForReauthentication = async (
-  remoteName: string,
-): Promise<ReauthOutcome> => {
+export type PromptForReauthenticationOptions = {
+  remoteName: string;
+  configPath?: string;
+};
+
+export const promptForReauthentication = async ({
+  remoteName,
+  configPath,
+}: PromptForReauthenticationOptions): Promise<ReauthOutcome> => {
   if (!process.stdout.isTTY) {
     return 'non-interactive';
   }
@@ -25,10 +31,14 @@ export const promptForReauthentication = async (
     return 'declined';
   }
 
-  const configService = new ConfigService();
+  const configService = new ConfigService({ configPath });
   const { apiUrl } = await configService.getConfig();
 
-  const result = await authLoginOAuth({ apiUrl, remote: remoteName });
+  const result = await authLoginOAuth({
+    apiUrl,
+    remote: remoteName,
+    configPath,
+  });
 
   if (result.success) {
     console.log(chalk.green(`✓ Re-authenticated "${remoteName}".`));


### PR DESCRIPTION
The re-authenticate branch of remote:add went through authLogin with a default ConfigService, so credentials landed in ~/.twenty/config.json even when --test selected config.test.json. It also ignored --url and reused the stored apiUrl.

Thread the selected config path through authLogin and authLoginOAuth, and honor --url when re-authenticating an existing remote.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

