### PR TITLE
Drop the app-to-settings cross-fade

### DIFF
--- a/packages/twenty-front/src/modules/app/routing/utils/getWorkspaceRouteObjectsForSurface.tsx
+++ b/packages/twenty-front/src/modules/app/routing/utils/getWorkspaceRouteObjectsForSurface.tsx
@@ -43,13 +43,10 @@ const getWorkspaceRouteObjects = (
     ];
   });
 
-// The main surface hosts its route context store once, above the page
-// transition, in MainAppLayoutWithSidePanel: the transition keeps the page
-// being left mounted while the next one enters, and a provider inside each
-// page would leave two of them writing the same store from different routes.
-// The side panel renders its routes against its own location, which only the
-// routed tree can read, and it remounts per location, so its provider lives
-// inside the tree.
+// Each surface has exactly one route context store provider. The main surface
+// hosts it in MainAppLayoutWithSidePanel, above its routes. The side panel
+// renders its routes against its own location, which only the routed tree can
+// read, and it remounts per location, so its provider lives inside the tree.
 export const getWorkspaceRouteObjectsForSurface = (
   routeObjects: WorkspaceRouteObject[],
   surface: WorkspaceSurfaceType,

--- a/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
@@ -5,18 +5,7 @@ import { SidePanelForDesktop } from '@/side-panel/components/SidePanelForDesktop
 import { SidePanelPathUrlSyncEffect } from '@/side-panel/routing/components/SidePanelPathUrlSyncEffect';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { styled } from '@linaria/react';
-import { AnimatePresence, motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
-import { useLocation, useOutlet } from 'react-router-dom';
-import { isDefined } from 'twenty-shared/utils';
-import { isSettingsPath } from '~/utils/isSettingsPath';
-
-const ROUTE_SECTION_DATA_ATTRIBUTE = 'data-main-app-route-section';
-
-const APP_TO_SETTINGS_TRANSITION_DURATION_IN_SECONDS = 0.3;
-
-const getMainAppLayoutRouteSection = (pathname: string) =>
-  isSettingsPath(pathname) ? 'settings' : 'app';
+import { Outlet } from 'react-router-dom';
 
 const StyledRow = styled.div`
   display: flex;
@@ -53,76 +42,6 @@ const StyledContent = styled.div`
   }
 `;
 
-const StyledContentTransitionContainer = styled.div`
-  display: grid;
-  flex: 1 1 0;
-  min-height: 0;
-  min-width: 0;
-  overflow: hidden;
-
-  @media print {
-    display: block;
-    min-height: auto;
-    min-width: auto;
-    overflow: visible;
-  }
-`;
-
-const StyledContentTransitionPage = styled(motion.div)`
-  display: flex;
-  grid-area: 1 / 1;
-  min-height: 0;
-  min-width: 0;
-  width: 100%;
-
-  @media print {
-    display: block;
-    min-height: auto;
-    min-width: auto;
-  }
-`;
-
-const MainAppLayoutOutlet = () => {
-  const { pathname } = useLocation();
-  const outlet = useOutlet();
-  const routeSection = getMainAppLayoutRouteSection(pathname);
-  const [containerElement, setContainerElement] =
-    useState<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!isDefined(containerElement)) {
-      return;
-    }
-
-    Array.from(containerElement.children).forEach((child) => {
-      if (child instanceof HTMLElement) {
-        child.inert =
-          child.getAttribute(ROUTE_SECTION_DATA_ATTRIBUTE) !== routeSection;
-      }
-    });
-  }, [containerElement, routeSection]);
-
-  return (
-    <StyledContentTransitionContainer ref={setContainerElement}>
-      <AnimatePresence initial={false}>
-        <StyledContentTransitionPage
-          key={routeSection}
-          {...{ [ROUTE_SECTION_DATA_ATTRIBUTE]: routeSection }}
-          initial={{ opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -4, pointerEvents: 'none' }}
-          transition={{
-            duration: APP_TO_SETTINGS_TRANSITION_DURATION_IN_SECONDS,
-            ease: 'easeInOut',
-          }}
-        >
-          {outlet}
-        </StyledContentTransitionPage>
-      </AnimatePresence>
-    </StyledContentTransitionContainer>
-  );
-};
-
 export const MainAppLayoutWithSidePanel = () => {
   const isMobile = useIsMobile();
 
@@ -133,7 +52,7 @@ export const MainAppLayoutWithSidePanel = () => {
       <RouteContextStoreProvider />
       <SidePanelPathUrlSyncEffect />
       <StyledContent>
-        <MainAppLayoutOutlet />
+        <Outlet />
       </StyledContent>
       {isMobile ? <CommandMenuForMobile /> : <SidePanelForDesktop />}
     </StyledRow>

--- a/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/MainAppLayoutWithSidePanel.test.tsx
@@ -84,11 +84,7 @@ const MainSurfaceRoutes = () =>
   ]);
 
 describe('MainAppLayoutWithSidePanel', () => {
-  // Switching between the app and settings sections keeps the page being left
-  // mounted while the next one animates in. If each page carried its own route
-  // context store provider, the stale one would keep writing the main store
-  // from a route that no longer matches the location, fighting the new one.
-  it('keeps a single route context store provider on the main surface across a section switch', async () => {
+  it('hosts one route context store provider that reads the matched leaf params', async () => {
     render(
       <MemoryRouter initialEntries={['/objects/companies']}>
         <NavigateProbeEffect />


### PR DESCRIPTION
## What

Removes the app ↔ settings cross-fade in `MainAppLayoutWithSidePanel`: the `AnimatePresence` outlet, the `inert` toggling of the exiting page, the transition styles and constants. The layout renders `<Outlet />` directly, as it did before #21523.

## Why

The fade kept the page being left **mounted and live** for 0.3 s. That is the mechanism behind #25233's React #185 crash (two route context store providers writing the main store from different routes during the overlap), and even with that fixed, the exiting record index rendered as a skeleton during the fade because the store had already switched to the new route. Any future page-level effect that writes shared state would reintroduce the same class of bug.

Dropping the transition removes the class: pages swap in one commit, nothing stale runs.

## Product change

No 300 ms fade between the app and settings sections. If the fade is wanted back, the right way is a snapshot-based transition (View Transitions API, or React Router's `unstable_viewTransition`), which animates pixels after the old page has unmounted; that is a separate PR and would not bring the hazard back.

## Also

- `getWorkspaceRouteObjectsForSurface`: the comment no longer justifies the one-provider-per-surface rule by the transition.
- The layout test keeps the two invariants that still matter: one provider on the main surface, and that provider reading the matched leaf's params from above the routes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

