### PR TITLE
Move information banners above page headers

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/PageCardLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/PageCardLayout.tsx
@@ -128,16 +128,7 @@ export const PageCardLayout = ({
   const shouldShowInformationBanner =
     showInformationBanner && workspaceSurface.type === 'main';
 
-  const body = (
-    <StyledBodyContent>
-      {shouldShowInformationBanner && (
-        <StyledPrintHidden>
-          <InformationBannerWrapper />
-        </StyledPrintHidden>
-      )}
-      {children}
-    </StyledBodyContent>
-  );
+  const body = <StyledBodyContent>{children}</StyledBodyContent>;
 
   if (workspaceSurface.type === 'side-panel') {
     return (
@@ -153,6 +144,11 @@ export const PageCardLayout = ({
     <StyledRoot data-page-surface="main">
       <StyledMainCardWrapper>
         <StyledCard>
+          {shouldShowInformationBanner && (
+            <StyledPrintHidden>
+              <InformationBannerWrapper />
+            </StyledPrintHidden>
+          )}
           <StyledPrintHidden>{header}</StyledPrintHidden>
           <StyledPrintHidden>{secondaryBar}</StyledPrintHidden>
           {body}

--- a/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/PageCardLayout.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/__tests__/PageCardLayout.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+
+import { PageCardLayout } from '@/ui/layout/page/components/PageCardLayout';
+
+jest.mock('@/information-banner/components/InformationBannerWrapper', () => ({
+  InformationBannerWrapper: () => <div>Information banner</div>,
+}));
+
+describe('PageCardLayout', () => {
+  it('renders the information banner before the page bars and body', () => {
+    render(
+      <PageCardLayout
+        header={<div>Page header</div>}
+        secondaryBar={<div>Secondary bar</div>}
+      >
+        <div>Page body</div>
+      </PageCardLayout>,
+    );
+
+    const informationBanner = screen.getByText('Information banner');
+
+    expect(
+      informationBanner.compareDocumentPosition(
+        screen.getByText('Page header'),
+      ),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      informationBanner.compareDocumentPosition(
+        screen.getByText('Secondary bar'),
+      ),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      informationBanner.compareDocumentPosition(screen.getByText('Page body')),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+});


### PR DESCRIPTION
## Summary

- Render information banners before page headers and secondary bars across main page-card surfaces.
- Keep side-panel and banner-disabled behavior unchanged.
- Add a regression test for banner DOM order.

## Before/After

<img width="1720" height="720" alt="Information banner placement before and after" src="https://github.com/user-attachments/assets/3c90cd76-1c48-4bc4-a6c2-4c1942de431e" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
