### PR TITLE
fix(ai): apply store:false on every provider call site

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -468,6 +468,7 @@ export class AgentAsyncExecutorService {
             inputSchema,
             error,
             model: registeredModel.model,
+            sdkPackage: registeredModel.sdkPackage,
           });
         },
       });

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-monitor/services/agent-turn-grader.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-monitor/services/agent-turn-grader.service.ts
@@ -7,6 +7,7 @@ import { NotFoundError } from 'src/engine/core-modules/graphql/utils/graphql-err
 import { AgentMessageEntity } from 'src/engine/metadata-modules/ai/ai-agent-execution/entities/agent-message.entity';
 import { AgentTurnEntity } from 'src/engine/metadata-modules/ai/ai-agent-execution/entities/agent-turn.entity';
 import { AgentTurnEvaluationEntity } from 'src/engine/metadata-modules/ai/ai-agent-monitor/entities/agent-turn-evaluation.entity';
+import { getCallLevelProviderOptions } from 'src/engine/metadata-modules/ai/ai-chat/utils/provider-options.util';
 import { buildAiTelemetry } from 'src/engine/metadata-modules/ai/ai-models/utils/build-ai-telemetry.util';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
@@ -91,6 +92,9 @@ Respond ONLY with valid JSON in this exact format:
           agentId: turn.agentId,
           threadId: turn.threadId,
           turnId: turn.id,
+        }),
+        providerOptions: getCallLevelProviderOptions({
+          sdkPackage: defaultModel.sdkPackage,
         }),
       });
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/repair-tool-call.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/repair-tool-call.util.ts
@@ -7,11 +7,13 @@ import {
   type ToolSet,
   generateText,
 } from 'ai';
+import { type AiSdkPackage } from 'twenty-shared/ai';
 import { type z } from 'zod';
 
 import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-operation-type.enum';
 import { AiBillingService } from 'src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service';
 import { extractCacheCreationTokensFromSteps } from 'src/engine/metadata-modules/ai/ai-billing/utils/extract-cache-creation-tokens.util';
+import { getCallLevelProviderOptions } from 'src/engine/metadata-modules/ai/ai-chat/utils/provider-options.util';
 import { buildAiTelemetry } from 'src/engine/metadata-modules/ai/ai-models/utils/build-ai-telemetry.util';
 
 type ToolCall = {
@@ -35,6 +37,7 @@ export const repairToolCall = async ({
   inputSchema,
   error,
   model,
+  sdkPackage,
   billingContext,
 }: {
   toolCall: ToolCall;
@@ -42,6 +45,7 @@ export const repairToolCall = async ({
   inputSchema: (toolCall: { toolName: string }) => unknown;
   error: Error;
   model: LanguageModel;
+  sdkPackage: AiSdkPackage;
   billingContext?: RepairToolCallBillingContext;
 }): Promise<ToolCall | null> => {
   // Don't attempt to fix invalid tool names
@@ -88,6 +92,7 @@ export const repairToolCall = async ({
         workspaceId: billingContext?.workspaceId,
         userWorkspaceId: billingContext?.userWorkspaceId,
       }),
+      providerOptions: getCallLevelProviderOptions({ sdkPackage }),
     });
 
     usage = result.usage;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-title-generation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-title-generation.service.ts
@@ -11,6 +11,7 @@ import { BillingUsageService } from 'src/engine/core-modules/billing/services/bi
 import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-operation-type.enum';
 import { AiBillingService } from 'src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service';
 import { extractCacheCreationTokensFromSteps } from 'src/engine/metadata-modules/ai/ai-billing/utils/extract-cache-creation-tokens.util';
+import { getCallLevelProviderOptions } from 'src/engine/metadata-modules/ai/ai-chat/utils/provider-options.util';
 import { buildAiTelemetry } from 'src/engine/metadata-modules/ai/ai-models/utils/build-ai-telemetry.util';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
 
@@ -50,6 +51,9 @@ export class AgentTitleGenerationService {
           functionId: 'agent-title-generation',
           workspaceId,
           userWorkspaceId,
+        }),
+        providerOptions: getCallLevelProviderOptions({
+          sdkPackage: defaultModel.sdkPackage,
         }),
       });
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -630,6 +630,7 @@ export class ChatExecutionService {
           inputSchema,
           error,
           model: registeredModel.model,
+          sdkPackage: registeredModel.sdkPackage,
           billingContext: {
             aiBillingService: this.aiBillingService,
             modelId: registeredModel.modelId,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-generate-text/controllers/ai-generate-text.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-generate-text/controllers/ai-generate-text.controller.ts
@@ -18,6 +18,7 @@ import {
   AiExceptionCode,
 } from 'src/engine/metadata-modules/ai/ai.exception';
 import { AiBillingService } from 'src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service';
+import { getCallLevelProviderOptions } from 'src/engine/metadata-modules/ai/ai-chat/utils/provider-options.util';
 import { AiRestApiExceptionFilter } from 'src/engine/metadata-modules/ai/filters/ai-api-exception.filter';
 import { GenerateTextInput } from 'src/engine/metadata-modules/ai/ai-generate-text/dtos/generate-text.input';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
@@ -79,6 +80,9 @@ export class AiGenerateTextController {
             functionId: 'ai-generate-text',
             workspaceId: workspace.id,
             userWorkspaceId,
+          }),
+          providerOptions: getCallLevelProviderOptions({
+            sdkPackage: registeredModel.sdkPackage,
           }),
         }),
       );


### PR DESCRIPTION
## Problem

`getCallLevelProviderOptions` sets `store: false` for OpenAI and Azure, opting out of provider-side response retention. It was only wired into `chat-execution.service.ts` and `agent-async-executor.service.ts`.

Four other call sites reach the provider with no `providerOptions` at all, so `store: false` was never sent:

| Call site | What it sends |
|---|---|
| `agent-title-generation.service.ts` | the user's chat message, interpolated into the prompt |
| `agent-turn-grader.service.ts` | the full turn: user request, agent response, tool outputs |
| `repair-tool-call.util.ts` | `JSON.stringify(toolCall.input)`, i.e. record data |
| `ai-generate-text.controller.ts` | arbitrary system and user prompts |

A single chat message fans out to several of these, so retention behaviour differed between calls carrying the same customer data. The main completion opted out of retention while the title generation and turn grading calls derived from it did not.

## Change

Routes all four through `getCallLevelProviderOptions`. `repairToolCall` gains an `sdkPackage` param since it previously only received `model`; both of its callers already have `registeredModel.sdkPackage` in scope.

No behaviour change for Anthropic, Google or Bedrock, which have no `store` equivalent and fall through to the existing default.

## Notes

`store: false` is a retention control, not a no-training commitment. Those are separate guarantees and the latter lives in the provider contracts.

Worth considering as a follow-up: a lint rule or test that fails when a new `generateText`/`streamText` call site omits `providerOptions`, since this gap opened by addition rather than by anyone changing the util.

## Test

- `provider-options.util.spec.ts` passes (9 tests)
- `tsgo --noEmit` clean for all touched files
- `nx lint:diff-with-main twenty-server` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

