### PR TITLE
Keep the raw junction target id out of a relation field's universal settings

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-field-metadata-entity-to-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-field-metadata-entity-to-flat-field-metadata.util.ts
@@ -1,4 +1,7 @@
-import { FieldMetadataType } from 'twenty-shared/types';
+import {
+  type FieldMetadataSettings,
+  FieldMetadataType,
+} from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { isFieldMetadataSettingsOfType } from 'src/engine/metadata-modules/field-metadata/utils/is-field-metadata-settings-of-type.util';
@@ -6,6 +9,26 @@ import { fromEntityToScalarEntity } from 'src/engine/metadata-modules/flat-entit
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FromEntityToFlatEntityArgs } from 'src/engine/workspace-cache/types/from-entity-to-flat-entity-args.type';
 import { resolveManyToOneRelationIdsToUniversalIdentifiers } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-many-to-one-relation-ids-to-universal-identifiers.util';
+
+const toRelationUniversalSettings = ({
+  settings,
+  fieldMetadataIdToUniversalIdentifierMap,
+}: {
+  settings: FieldMetadataSettings<
+    FieldMetadataType.RELATION | FieldMetadataType.MORPH_RELATION
+  >;
+  fieldMetadataIdToUniversalIdentifierMap: Map<string, string>;
+}) => {
+  const { junctionTargetFieldId, ...universalSettings } = settings;
+
+  return {
+    ...universalSettings,
+    ...(isDefined(junctionTargetFieldId) && {
+      junctionTargetFieldUniversalIdentifier:
+        fieldMetadataIdToUniversalIdentifierMap.get(junctionTargetFieldId),
+    }),
+  };
+};
 
 export const fromFieldMetadataEntityToFlatFieldMetadata = (
   args: FromEntityToFlatEntityArgs<'fieldMetadata'>,
@@ -32,15 +55,10 @@ export const fromFieldMetadataEntityToFlatFieldMetadata = (
     isFieldMetadataSettingsOfType(settings, FieldMetadataType.MORPH_RELATION);
 
   const settingsWithUniversalIdentifiers = isRelationSettings
-    ? {
-        ...settings,
-        ...(isDefined(settings.junctionTargetFieldId) && {
-          junctionTargetFieldUniversalIdentifier:
-            fieldMetadataIdToUniversalIdentifierMap.get(
-              settings.junctionTargetFieldId,
-            ),
-        }),
-      }
+    ? toRelationUniversalSettings({
+        settings,
+        fieldMetadataIdToUniversalIdentifierMap,
+      })
     : settings;
 
   return {


### PR DESCRIPTION
## Context
When a relation field has a junction target, the flat field built from the entity kept the workspace-local junctionTargetFieldId inside universalSettings next to the universal identifier it resolves to. A manifest never carries that id, and universalSettings is a compared property, so every sync of such a field produced an update action. The universal settings now hold only the universal identifier, as the manifest path already does.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

