### PR TITLE
Order workspace cache row fetches deterministically

### DIFF
--- a/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache-rows-batch-loader.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache-rows-batch-loader.spec.ts
@@ -64,7 +64,45 @@ describe('WorkspaceCacheRowsBatchLoader', () => {
     expect(findMocksByEntity.get(ObjectMetadataEntity)).toHaveBeenCalledWith({
       where: { workspaceId: WORKSPACE_ID },
       withDeleted: true,
+      order: { createdAt: 'ASC', id: 'ASC' },
     });
+  });
+
+  // Cache providers freeze row order into their flat maps, and for ordered
+  // collections the array index carries meaning - a view's sort priority is its
+  // position in `viewSortIds`. An unordered find returns physical row order,
+  // which is not stable across recomputes, so a multi-column sort could flip on
+  // a plain restart. See twentyhq/twenty#25262.
+  it('falls back to creation order for entities without a position column', async () => {
+    const { rowsBatchLoader, findMocksByEntity } = setup();
+
+    await rowsBatchLoader.loadRows([
+      { objectMetadata: true, application: true },
+    ]);
+
+    for (const entity of [ObjectMetadataEntity, ApplicationEntity]) {
+      const findMock = findMocksByEntity.get(entity)!;
+
+      expect(findMock).toHaveBeenCalledTimes(1);
+      expect(findMock.mock.calls[0][0].order).toEqual({
+        createdAt: 'ASC',
+        id: 'ASC',
+      });
+    }
+  });
+
+  // View fields persist a user-facing order in `position`, and view filters and
+  // filter groups in `positionInViewFilterGroup`. Reading them back by creation
+  // time would revert a reordered column on the next cache recompute, so the
+  // persisted position leads and creation order only breaks ties.
+  it('reads collections that persist a position back in that order', async () => {
+    const { rowsBatchLoader, findMocksByEntity } = setup();
+
+    await rowsBatchLoader.loadRows([{ viewField: ['id'] }]);
+
+    expect(
+      findMocksByEntity.get(ViewFieldEntity)!.mock.calls[0][0].order,
+    ).toEqual({ position: 'ASC', createdAt: 'ASC', id: 'ASC' });
   });
 
   it('merges requirements into one query per entity with the union of declared columns', async () => {

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-rows-batch-loader.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-rows-batch-loader.ts
@@ -1,6 +1,7 @@
 import {
   type EntityTarget,
   type FindManyOptions,
+  type FindOptionsOrder,
   type FindOptionsWhere,
   type ObjectLiteral,
   type Repository,
@@ -24,6 +25,50 @@ import { isObjectEntityRowsRequirement } from 'src/engine/workspace-cache/utils/
 import { serializeWhereClause } from 'src/engine/workspace-cache/utils/serialize-where-clause.util';
 
 type WhereClause = FindOptionsWhere<ObjectLiteral>;
+
+// Without an ORDER BY, Postgres returns rows in physical (heap) order, which
+// changes as rows are updated and is not stable across restarts. Cache
+// providers freeze that order into their flat maps, and for the ordered
+// collections the array index carries meaning: a view's sort priority is its
+// position in `viewSortIds`, so a recompute could silently reorder a
+// multi-column sort.
+//
+// Creation order is the fallback, with `id` as a tiebreaker so equal timestamps
+// still resolve deterministically. Every entity in
+// ALL_WORKSPACE_CACHE_ENTITY_BY_NAME has both columns.
+const DEFAULT_CACHE_ROWS_ORDER = {
+  createdAt: 'ASC',
+  id: 'ASC',
+} as const satisfies FindOptionsOrder<ObjectLiteral>;
+
+// Collections that persist their own user-facing order are read back in that
+// order rather than by creation time, so reordering a column survives a cache
+// recompute. `viewSort` is deliberately absent: it has no position column, and
+// its priority is the creation order the default already gives.
+const CACHE_ROWS_ORDER_BY_ENTITY_NAME = {
+  viewField: { position: 'ASC', ...DEFAULT_CACHE_ROWS_ORDER },
+  viewFieldGroup: { position: 'ASC', ...DEFAULT_CACHE_ROWS_ORDER },
+  viewGroup: { position: 'ASC', ...DEFAULT_CACHE_ROWS_ORDER },
+  viewFilter: {
+    positionInViewFilterGroup: 'ASC',
+    ...DEFAULT_CACHE_ROWS_ORDER,
+  },
+  viewFilterGroup: {
+    positionInViewFilterGroup: 'ASC',
+    ...DEFAULT_CACHE_ROWS_ORDER,
+  },
+} as const satisfies Partial<
+  Record<CacheFetchableEntityName, FindOptionsOrder<ObjectLiteral>>
+>;
+
+const getCacheRowsOrder = (
+  entityName: CacheFetchableEntityName,
+): FindOptionsOrder<ObjectLiteral> =>
+  entityName in CACHE_ROWS_ORDER_BY_ENTITY_NAME
+    ? CACHE_ROWS_ORDER_BY_ENTITY_NAME[
+        entityName as keyof typeof CACHE_ROWS_ORDER_BY_ENTITY_NAME
+      ]
+    : DEFAULT_CACHE_ROWS_ORDER;
 
 export type WorkspaceCacheRowsSource = {
   getRepository: (
@@ -241,6 +286,7 @@ export class WorkspaceCacheRowsBatchLoader {
         workspaceId: this.workspaceId,
       },
       withDeleted: true,
+      order: getCacheRowsOrder(entityName),
     };
 
     if (columns !== null) {


### PR DESCRIPTION
Fixes #25262

### the problem

rows for the workspace cache were fetched with no ORDER BY, so postgres returns them in physical (heap) order. that order is not stable -> it shifts as rows get updated and can come back different after a plain restart.

the cache providers freeze whatever order comes back into their flat maps, and for the ordered collections the array index actually MEANS something: a view's sort priority is its position in `viewSortIds`, and the frontend maps that array positionally into `orderBy`.

so a multi column sort could silently flip, with no API write and no metadata change. in the issue @Vico92 ran 12 alternating create-and-read rounds, 2 came back reversed, and the API order always matched heap (ctid) order.

### the fix

order each cache fetch by the column that collection actually orders by:

- `viewField`, `viewFieldGroup`, `viewGroup` -> `position` first
- `viewFilter`, `viewFilterGroup` -> `positionInViewFilterGroup` first
- everything else (including `viewSort`) -> `createdAt`, then `id`

the position backed collections now keep the order a user set, so reordering a column survives a cache recompute. they were previously read in heap order, which respects `position` no more than creation order does, so that part was already arbitrary before this PR.

`viewSort` is the one with no position column, and creation order is exactly the priority it needs -> which is what #25262 is asking for, and what v2.34 already applied in `ViewSortService.findByViewId`. `getView` just doesn't read through that path.

`id` is only a tiebreaker so equal timestamps still resolve the same way. i checked every entity in `ALL_WORKSPACE_CACHE_ENTITY_BY_NAME` (32 metadata + 5 core) has both fallback columns.

### one thing changed since the issue was written

the issue points at `WorkspaceFlatViewMapCacheService` and this code:

```ts
this.viewSortRepository.find(workspaceId, { ... })
```

that doesn't exist anymore -> that service moved to the declarative `rowsRequirement` cache framework and no longer runs its own query. the missing ORDER BY is now in the shared batch loader (`workspace-cache-rows-batch-loader.ts` -> `runFetch`), so i fixed it there. same bug, one level up, and fixing it there covers every cached entity at once.

full credit to @Vico92 for the diagnosis, the repro and the suggested fix - it was correct, only the file had moved.

### review feedback already applied

- greptile flagged that a single global `createdAt` order would override view field `position` -> fixed, ordering is per entity now
- cubic flagged `viewFilterGroup` was missing from that map -> added

### testing

- updated the existing assertion in `workspace-cache-rows-batch-loader.spec.ts` (it pinned the exact find options)
- added a test that entities without a position column fall back to creation order
- added a test that position backed collections are read in position order
- verified the tests fail without the fix
- 50 tests pass across workspace-cache
- `tsc --noEmit` on twenty-server: 0 errors
- prettier clean

rebased on latest main, the earlier code generation failure was just my branch being 36 commits behind.
