### PR TITLE
Restore the GraphQL documents the metadata codegen still needs

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/common/graphql/queries/findOneNavigationMenuItem.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/graphql/queries/findOneNavigationMenuItem.ts
@@ -1,0 +1,11 @@
+import { NAVIGATION_MENU_ITEM_QUERY_FRAGMENT } from '@/navigation-menu-item/common/graphql/fragments/navigationMenuItemQueryFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_ONE_NAVIGATION_MENU_ITEM = gql`
+  ${NAVIGATION_MENU_ITEM_QUERY_FRAGMENT}
+  query FindOneNavigationMenuItem($id: UUID!) {
+    navigationMenuItem(id: $id) {
+      ...NavigationMenuItemQueryFields
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/page-layout/graphql/queries/findAllPageLayouts.ts
+++ b/packages/twenty-front/src/modules/page-layout/graphql/queries/findAllPageLayouts.ts
@@ -1,0 +1,11 @@
+import { PAGE_LAYOUT_FRAGMENT } from '@/dashboards/graphql/fragments/pageLayoutFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_ALL_PAGE_LAYOUTS = gql`
+  ${PAGE_LAYOUT_FRAGMENT}
+  query FindAllPageLayouts {
+    getPageLayouts {
+      ...PageLayoutFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/accounts/graphql/mutations/updateMessageFolder.ts
+++ b/packages/twenty-front/src/modules/settings/accounts/graphql/mutations/updateMessageFolder.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const UPDATE_MESSAGE_FOLDER = gql`
+  mutation UpdateMessageFolder($input: UpdateMessageFolderInput!) {
+    updateMessageFolder(input: $input) {
+      id
+      isSynced
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/emailing-domains/graphql/mutations/deleteEmailingDomain.ts
+++ b/packages/twenty-front/src/modules/settings/emailing-domains/graphql/mutations/deleteEmailingDomain.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client';
+
+export const DELETE_EMAILING_DOMAIN = gql`
+  mutation DeleteEmailingDomain($id: String!) {
+    deleteEmailingDomain(id: $id)
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/security/graphql/mutations/createOIDCSSOIdentityProvider.ts
+++ b/packages/twenty-front/src/modules/settings/security/graphql/mutations/createOIDCSSOIdentityProvider.ts
@@ -1,0 +1,15 @@
+/* @license Enterprise */
+
+import { gql } from '@apollo/client';
+
+export const CREATE_OIDC_SSO_IDENTITY_PROVIDER = gql`
+  mutation CreateOIDCIdentityProvider($input: SetupOIDCSsoInput!) {
+    createOIDCIdentityProvider(input: $input) {
+      id
+      type
+      issuer
+      name
+      status
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/security/graphql/mutations/createSAMLSSOIdentityProvider.ts
+++ b/packages/twenty-front/src/modules/settings/security/graphql/mutations/createSAMLSSOIdentityProvider.ts
@@ -1,0 +1,15 @@
+/* @license Enterprise */
+
+import { gql } from '@apollo/client';
+
+export const CREATE_SAML_SSO_IDENTITY_PROVIDER = gql`
+  mutation CreateSAMLIdentityProvider($input: SetupSAMLSsoInput!) {
+    createSAMLIdentityProvider(input: $input) {
+      id
+      type
+      issuer
+      name
+      status
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/security/graphql/mutations/deleteSSOIdentityProvider.ts
+++ b/packages/twenty-front/src/modules/settings/security/graphql/mutations/deleteSSOIdentityProvider.ts
@@ -1,0 +1,11 @@
+/* @license Enterprise */
+
+import { gql } from '@apollo/client';
+
+export const DELETE_SSO_IDENTITY_PROVIDER = gql`
+  mutation DeleteSSOIdentityProvider($input: DeleteSsoInput!) {
+    deleteSSOIdentityProvider(input: $input) {
+      identityProviderId
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/security/graphql/mutations/editSSOIdentityProvider.ts
+++ b/packages/twenty-front/src/modules/settings/security/graphql/mutations/editSSOIdentityProvider.ts
@@ -1,0 +1,15 @@
+/* @license Enterprise */
+
+import { gql } from '@apollo/client';
+
+export const EDIT_SSO_IDENTITY_PROVIDER = gql`
+  mutation EditSSOIdentityProvider($input: EditSsoInput!) {
+    editSSOIdentityProvider(input: $input) {
+      id
+      type
+      issuer
+      name
+      status
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/security/graphql/queries/getWorkspaceSSOIdentitiesProviders.ts
+++ b/packages/twenty-front/src/modules/settings/security/graphql/queries/getWorkspaceSSOIdentitiesProviders.ts
@@ -1,0 +1,15 @@
+/* @license Enterprise */
+
+import { gql } from '@apollo/client';
+
+export const GET_SSO_IDENTITY_PROVIDERS = gql`
+  query GetSSOIdentityProviders {
+    getSSOIdentityProviders {
+      type
+      id
+      name
+      issuer
+      status
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/mutations/createViewField.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/createViewField.ts
@@ -1,0 +1,11 @@
+import { VIEW_FIELD_FRAGMENT } from '@/views/graphql/fragments/viewFieldFragment';
+import { gql } from '@apollo/client';
+
+export const CREATE_VIEW_FIELD = gql`
+  ${VIEW_FIELD_FRAGMENT}
+  mutation CreateViewField($input: CreateViewFieldInput!) {
+    createViewField(input: $input) {
+      ...ViewFieldFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/mutations/createViewFieldGroup.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/createViewFieldGroup.ts
@@ -1,0 +1,11 @@
+import { VIEW_FIELD_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewFieldGroupFragment';
+import { gql } from '@apollo/client';
+
+export const CREATE_VIEW_FIELD_GROUP = gql`
+  ${VIEW_FIELD_GROUP_FRAGMENT}
+  mutation CreateViewFieldGroup($input: CreateViewFieldGroupInput!) {
+    createViewFieldGroup(input: $input) {
+      ...ViewFieldGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/mutations/createViewGroup.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/createViewGroup.ts
@@ -1,0 +1,11 @@
+import { VIEW_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewGroupFragment';
+import { gql } from '@apollo/client';
+
+export const CREATE_VIEW_GROUP = gql`
+  ${VIEW_GROUP_FRAGMENT}
+  mutation CreateViewGroup($input: CreateViewGroupInput!) {
+    createViewGroup(input: $input) {
+      ...ViewGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/mutations/deleteView.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/deleteView.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client';
+
+export const DELETE_VIEW = gql`
+  mutation DeleteView($id: String!) {
+    deleteView(id: $id)
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/mutations/deleteViewFilterGroup.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/deleteViewFilterGroup.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client';
+
+export const DELETE_VIEW_FILTER_GROUP = gql`
+  mutation DeleteViewFilterGroup($id: String!) {
+    deleteViewFilterGroup(id: $id)
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/mutations/deleteViewGroup.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/deleteViewGroup.ts
@@ -1,0 +1,11 @@
+import { VIEW_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewGroupFragment';
+import { gql } from '@apollo/client';
+
+export const DELETE_VIEW_GROUP = gql`
+  ${VIEW_GROUP_FRAGMENT}
+  mutation DeleteViewGroup($input: DeleteViewGroupInput!) {
+    deleteViewGroup(input: $input) {
+      ...ViewGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/mutations/destroyViewGroup.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/destroyViewGroup.ts
@@ -1,0 +1,11 @@
+import { VIEW_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewGroupFragment';
+import { gql } from '@apollo/client';
+
+export const DESTROY_VIEW_GROUP = gql`
+  ${VIEW_GROUP_FRAGMENT}
+  mutation DestroyViewGroup($input: DestroyViewGroupInput!) {
+    destroyViewGroup(input: $input) {
+      ...ViewGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/mutations/updateViewGroup.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/updateViewGroup.ts
@@ -1,0 +1,11 @@
+import { VIEW_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewGroupFragment';
+import { gql } from '@apollo/client';
+
+export const UPDATE_VIEW_GROUP = gql`
+  ${VIEW_GROUP_FRAGMENT}
+  mutation UpdateViewGroup($input: UpdateViewGroupInput!) {
+    updateViewGroup(input: $input) {
+      ...ViewGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findManyViewFields.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findManyViewFields.ts
@@ -1,0 +1,11 @@
+import { VIEW_FIELD_FRAGMENT } from '@/views/graphql/fragments/viewFieldFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_MANY_VIEW_FIELDS = gql`
+  ${VIEW_FIELD_FRAGMENT}
+  query FindManyViewFields($viewId: String!) {
+    getViewFields(viewId: $viewId) {
+      ...ViewFieldFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findManyViewFilterGroups.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findManyViewFilterGroups.ts
@@ -1,0 +1,11 @@
+import { VIEW_FILTER_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewFilterGroupFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_MANY_VIEW_FILTER_GROUPS = gql`
+  ${VIEW_FILTER_GROUP_FRAGMENT}
+  query FindManyViewFilterGroups($viewId: String) {
+    getViewFilterGroups(viewId: $viewId) {
+      ...ViewFilterGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findManyViewFilters.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findManyViewFilters.ts
@@ -1,0 +1,11 @@
+import { VIEW_FILTER_FRAGMENT } from '@/views/graphql/fragments/viewFilterFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_MANY_VIEW_FILTERS = gql`
+  ${VIEW_FILTER_FRAGMENT}
+  query FindManyViewFilters($viewId: String) {
+    getViewFilters(viewId: $viewId) {
+      ...ViewFilterFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findManyViewGroups.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findManyViewGroups.ts
@@ -1,0 +1,11 @@
+import { VIEW_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewGroupFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_MANY_VIEW_GROUPS = gql`
+  ${VIEW_GROUP_FRAGMENT}
+  query FindManyViewGroups($viewId: String) {
+    getViewGroups(viewId: $viewId) {
+      ...ViewGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findManyViewSorts.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findManyViewSorts.ts
@@ -1,0 +1,11 @@
+import { VIEW_SORT_FRAGMENT } from '@/views/graphql/fragments/viewSortFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_MANY_VIEW_SORTS = gql`
+  ${VIEW_SORT_FRAGMENT}
+  query FindManyViewSorts($viewId: String) {
+    getViewSorts(viewId: $viewId) {
+      ...ViewSortFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findOneView.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findOneView.ts
@@ -1,0 +1,11 @@
+import { VIEW_FRAGMENT } from '@/views/graphql/fragments/viewFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_ONE_VIEW = gql`
+  ${VIEW_FRAGMENT}
+  query FindOneView($id: String!) {
+    getView(id: $id) {
+      ...ViewFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findOneViewField.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findOneViewField.ts
@@ -1,0 +1,11 @@
+import { VIEW_FIELD_FRAGMENT } from '@/views/graphql/fragments/viewFieldFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_ONE_VIEW_FIELD = gql`
+  ${VIEW_FIELD_FRAGMENT}
+  query FindOneViewField($id: String!) {
+    getViewField(id: $id) {
+      ...ViewFieldFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findOneViewFilter.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findOneViewFilter.ts
@@ -1,0 +1,11 @@
+import { VIEW_FILTER_FRAGMENT } from '@/views/graphql/fragments/viewFilterFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_ONE_VIEW_FILTER = gql`
+  ${VIEW_FILTER_FRAGMENT}
+  query FindOneViewFilter($id: String!) {
+    getViewFilter(id: $id) {
+      ...ViewFilterFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findOneViewFilterGroup.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findOneViewFilterGroup.ts
@@ -1,0 +1,11 @@
+import { VIEW_FILTER_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewFilterGroupFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_ONE_VIEW_FILTER_GROUP = gql`
+  ${VIEW_FILTER_GROUP_FRAGMENT}
+  query FindOneViewFilterGroup($id: String!) {
+    getViewFilterGroup(id: $id) {
+      ...ViewFilterGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findOneViewGroup.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findOneViewGroup.ts
@@ -1,0 +1,11 @@
+import { VIEW_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewGroupFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_ONE_VIEW_GROUP = gql`
+  ${VIEW_GROUP_FRAGMENT}
+  query FindOneViewGroup($id: String!) {
+    getViewGroup(id: $id) {
+      ...ViewGroupFragment
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/views/graphql/queries/findOneViewSort.ts
+++ b/packages/twenty-front/src/modules/views/graphql/queries/findOneViewSort.ts
@@ -1,0 +1,11 @@
+import { VIEW_SORT_FRAGMENT } from '@/views/graphql/fragments/viewSortFragment';
+import { gql } from '@apollo/client';
+
+export const FIND_ONE_VIEW_SORT = gql`
+  ${VIEW_SORT_FRAGMENT}
+  query FindOneViewSort($id: String!) {
+    getViewSort(id: $id) {
+      ...ViewSortFragment
+    }
+  }
+`;


### PR DESCRIPTION
The cleanup of unused frontend files removed 28 GraphQL document files that nothing imports directly, but the metadata codegen reads them by glob and the SSO, view, navigation and emailing-domain hooks import the Document constants it generates from them. Since then the committed generated types only typecheck because they are stale: regenerating drops those operations and breaks the front build, and the codegen drift check fails on every server change. Restoring the documents makes the generated file reproducible again.

Introduced in https://github.com/twentyhq/twenty/pull/25253

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

