### PR TITLE
Create and delete the enqueue-job spec's logic functions one at a time

### DIFF
--- a/packages/twenty-server/test/integration/metadata/suites/application/enqueue-job.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/enqueue-job.integration-spec.ts
@@ -215,27 +215,21 @@ describe('enqueueJob (e2e)', () => {
     standardApplicationToken =
       standardTokenData.generateApplicationToken.applicationAccessToken.token;
 
-    const [
-      { data: createData },
-      { data: retryableCreateData },
-      { data: appendingCreateData },
-    ] = await Promise.all([
-      createOneLogicFunction({
-        input: { name: `enqueue-job-target-${uuidv4()}` },
-        gqlFields: 'id universalIdentifier',
-        expectToFail: false,
-      }),
-      createOneLogicFunction({
-        input: { name: `enqueue-job-retryable-target-${uuidv4()}` },
-        gqlFields: 'id universalIdentifier',
-        expectToFail: false,
-      }),
-      createOneLogicFunction({
-        input: { name: `enqueue-job-appending-target-${uuidv4()}` },
-        gqlFields: 'id universalIdentifier',
-        expectToFail: false,
-      }),
-    ]);
+    const { data: createData } = await createOneLogicFunction({
+      input: { name: `enqueue-job-target-${uuidv4()}` },
+      gqlFields: 'id universalIdentifier',
+      expectToFail: false,
+    });
+    const { data: retryableCreateData } = await createOneLogicFunction({
+      input: { name: `enqueue-job-retryable-target-${uuidv4()}` },
+      gqlFields: 'id universalIdentifier',
+      expectToFail: false,
+    });
+    const { data: appendingCreateData } = await createOneLogicFunction({
+      input: { name: `enqueue-job-appending-target-${uuidv4()}` },
+      gqlFields: 'id universalIdentifier',
+      expectToFail: false,
+    });
 
     expect(createData.createOneLogicFunction.universalIdentifier).toBeDefined();
     expect(
@@ -298,20 +292,18 @@ describe('enqueueJob (e2e)', () => {
   });
 
   afterAll(async () => {
-    await Promise.all([
-      deleteLogicFunction({
-        input: { id: logicFunctionId },
-        expectToFail: false,
-      }),
-      deleteLogicFunction({
-        input: { id: retryableLogicFunctionId },
-        expectToFail: false,
-      }),
-      deleteLogicFunction({
-        input: { id: appendingLogicFunctionId },
-        expectToFail: false,
-      }),
-    ]);
+    await deleteLogicFunction({
+      input: { id: logicFunctionId },
+      expectToFail: false,
+    });
+    await deleteLogicFunction({
+      input: { id: retryableLogicFunctionId },
+      expectToFail: false,
+    });
+    await deleteLogicFunction({
+      input: { id: appendingLogicFunctionId },
+      expectToFail: false,
+    });
 
     if (isDefined(otherWorkspaceUserAccessToken)) {
       await deleteUser({ accessToken: otherWorkspaceUserAccessToken });

--- a/packages/twenty-server/test/integration/metadata/suites/application/enqueue-job.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/enqueue-job.integration-spec.ts
@@ -292,18 +292,23 @@ describe('enqueueJob (e2e)', () => {
   });
 
   afterAll(async () => {
-    await deleteLogicFunction({
-      input: { id: logicFunctionId },
-      expectToFail: false,
-    });
-    await deleteLogicFunction({
-      input: { id: retryableLogicFunctionId },
-      expectToFail: false,
-    });
-    await deleteLogicFunction({
-      input: { id: appendingLogicFunctionId },
-      expectToFail: false,
-    });
+    const teardownErrors: unknown[] = [];
+
+    for (const id of [
+      logicFunctionId,
+      retryableLogicFunctionId,
+      appendingLogicFunctionId,
+    ]) {
+      try {
+        await deleteLogicFunction({ input: { id }, expectToFail: false });
+      } catch (error) {
+        teardownErrors.push(error);
+      }
+    }
+
+    if (teardownErrors.length > 0) {
+      throw teardownErrors[0];
+    }
 
     if (isDefined(otherWorkspaceUserAccessToken)) {
       await deleteUser({ accessToken: otherWorkspaceUserAccessToken });


### PR DESCRIPTION
The spec created its three target logic functions with Promise.all and deleted them the same way. Three metadata mutations on the same workspace racing each other made the suite fail in three of five recent CI runs with "Could not find flat entity in maps", each time on a different creation. The mutations now run sequentially.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

