### PR TITLE
fix(mcp): list connected accounts from the core schema

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/tool-provider/constants/action-tool-label.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/constants/action-tool-label.constant.ts
@@ -7,6 +7,7 @@ export const ACTION_TOOL_IDS = [
   'http_request',
   'send_email',
   'draft_email',
+  'find_connected_accounts',
   'create_calendar_event',
   'search_help_center',
   'code_interpreter',
@@ -25,6 +26,9 @@ export const ACTION_TOOL_LABELS: Record<ActionToolId, ActionToolLabel> = {
   },
   draft_email: {
     label: i18nLabel(msg`Draft Email`),
+  },
+  find_connected_accounts: {
+    label: i18nLabel(msg`Find Connected Accounts`),
   },
   create_calendar_event: {
     label: i18nLabel(msg`Create Calendar Event`),

--- a/packages/twenty-server/src/engine/core-modules/tool-provider/providers/__tests__/database-tool.provider.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/providers/__tests__/database-tool.provider.spec.ts
@@ -343,4 +343,33 @@ describe('DatabaseToolProvider', () => {
       expect(descriptorNames).toContain('create_one_person');
     });
   });
+
+  it('does not advertise DATABASE_CRUD tools for leftover core-schema-backed objects', async () => {
+    const descriptorNames = await generateDescriptorNames([
+      createFlatObject({
+        nameSingular: 'connectedAccount',
+        namePlural: 'connectedAccounts',
+        isSystem: true,
+      }),
+      createFlatObject({
+        nameSingular: 'messageChannel',
+        namePlural: 'messageChannels',
+        isSystem: true,
+      }),
+      createFlatObject({
+        nameSingular: 'person',
+        namePlural: 'people',
+      }),
+    ]);
+
+    expect(descriptorNames).toContain('find_many_people');
+    expect(descriptorNames).toEqual(
+      expect.not.arrayContaining([
+        'find_many_connected_accounts',
+        'find_one_connected_account',
+        'find_many_message_channels',
+        'find_one_message_channel',
+      ]),
+    );
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/tool-provider/providers/__tests__/database-tool.provider.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/providers/__tests__/database-tool.provider.spec.ts
@@ -363,13 +363,12 @@ describe('DatabaseToolProvider', () => {
     ]);
 
     expect(descriptorNames).toContain('find_many_people');
-    expect(descriptorNames).toEqual(
-      expect.not.arrayContaining([
-        'find_many_connected_accounts',
-        'find_one_connected_account',
-        'find_many_message_channels',
-        'find_one_message_channel',
-      ]),
-    );
+    expect(
+      descriptorNames.filter(
+        (name) =>
+          name.includes('_connected_account') ||
+          name.includes('_message_channel'),
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/tool-provider/providers/action-tool.provider.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/providers/action-tool.provider.ts
@@ -24,6 +24,7 @@ import { CodeInterpreterService } from 'src/engine/core-modules/code-interpreter
 import { CreateCalendarEventTool } from 'src/engine/core-modules/tool/tools/calendar-tool/create-calendar-event-tool';
 import { CodeInterpreterTool } from 'src/engine/core-modules/tool/tools/code-interpreter-tool/code-interpreter-tool';
 import { DraftEmailTool } from 'src/engine/core-modules/tool/tools/email-tool/draft-email-tool';
+import { FindConnectedAccountsTool } from 'src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool';
 import { SendEmailTool } from 'src/engine/core-modules/tool/tools/email-tool/send-email-tool';
 import { HttpTool } from 'src/engine/core-modules/tool/tools/http-tool/http-tool';
 import { NavigateAppTool } from 'src/engine/core-modules/tool/tools/navigate-tool/navigate-app-tool';
@@ -45,6 +46,7 @@ export class ActionToolProvider implements ToolProvider {
     private readonly httpTool: HttpTool,
     private readonly sendEmailTool: SendEmailTool,
     private readonly draftEmailTool: DraftEmailTool,
+    private readonly findConnectedAccountsTool: FindConnectedAccountsTool,
     private readonly createCalendarEventTool: CreateCalendarEventTool,
     private readonly searchHelpCenterTool: SearchHelpCenterTool,
     private readonly codeInterpreterTool: CodeInterpreterTool,
@@ -60,6 +62,7 @@ export class ActionToolProvider implements ToolProvider {
       ['http_request', this.httpTool],
       ['send_email', this.sendEmailTool],
       ['draft_email', this.draftEmailTool],
+      ['find_connected_accounts', this.findConnectedAccountsTool],
       ['create_calendar_event', this.createCalendarEventTool],
       ['search_help_center', this.searchHelpCenterTool],
       ['code_interpreter', this.codeInterpreterTool],
@@ -129,6 +132,17 @@ export class ActionToolProvider implements ToolProvider {
         context.workspaceId,
         PermissionFlagType.CREATE_CALENDAR_EVENT_TOOL,
       );
+
+    if (hasEmailPermission || hasCreateCalendarEventPermission) {
+      descriptors.push(
+        this.buildDescriptor(
+          'find_connected_accounts',
+          this.findConnectedAccountsTool,
+          includeSchemas,
+          context.locale,
+        ),
+      );
+    }
 
     if (hasCreateCalendarEventPermission) {
       descriptors.push(

--- a/packages/twenty-server/src/engine/core-modules/tool-provider/providers/action-tool.provider.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/providers/action-tool.provider.ts
@@ -124,16 +124,6 @@ export class ActionToolProvider implements ToolProvider {
           context.locale,
         ),
       );
-    }
-
-    const hasCreateCalendarEventPermission =
-      await this.permissionsService.hasToolPermission(
-        context.rolePermissionConfig,
-        context.workspaceId,
-        PermissionFlagType.CREATE_CALENDAR_EVENT_TOOL,
-      );
-
-    if (hasEmailPermission || hasCreateCalendarEventPermission) {
       descriptors.push(
         this.buildDescriptor(
           'find_connected_accounts',
@@ -143,6 +133,13 @@ export class ActionToolProvider implements ToolProvider {
         ),
       );
     }
+
+    const hasCreateCalendarEventPermission =
+      await this.permissionsService.hasToolPermission(
+        context.rolePermissionConfig,
+        context.workspaceId,
+        PermissionFlagType.CREATE_CALENDAR_EVENT_TOOL,
+      );
 
     if (hasCreateCalendarEventPermission) {
       descriptors.push(

--- a/packages/twenty-server/src/engine/core-modules/tool/tool.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tool.module.ts
@@ -11,6 +11,7 @@ import { CreateCalendarEventTool } from 'src/engine/core-modules/tool/tools/cale
 import { CodeInterpreterTool } from 'src/engine/core-modules/tool/tools/code-interpreter-tool/code-interpreter-tool';
 import { DraftEmailTool } from 'src/engine/core-modules/tool/tools/email-tool/draft-email-tool';
 import { EmailComposerService } from 'src/engine/core-modules/tool/tools/email-tool/email-composer.service';
+import { FindConnectedAccountsTool } from 'src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool';
 import { SendEmailTool } from 'src/engine/core-modules/tool/tools/email-tool/send-email-tool';
 import { HttpTool } from 'src/engine/core-modules/tool/tools/http-tool/http-tool';
 import { NavigateAppTool } from 'src/engine/core-modules/tool/tools/navigate-tool/navigate-app-tool';
@@ -47,6 +48,7 @@ import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspac
     HttpTool,
     SendEmailTool,
     DraftEmailTool,
+    FindConnectedAccountsTool,
     CreateCalendarEventTool,
     EmailComposerService,
     SearchHelpCenterTool,
@@ -61,6 +63,7 @@ import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspac
     HttpTool,
     SendEmailTool,
     DraftEmailTool,
+    FindConnectedAccountsTool,
     CreateCalendarEventTool,
     EmailComposerService,
     SearchHelpCenterTool,

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/__tests__/find-connected-accounts-tool.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/__tests__/find-connected-accounts-tool.spec.ts
@@ -2,6 +2,7 @@ import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { ConnectedAccountProvider } from 'twenty-shared/types';
+import { IsNull } from 'typeorm';
 
 import { FindConnectedAccountsTool } from 'src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool';
 import { type ToolExecutionContext } from 'src/engine/core-modules/tool/types/tool-execution-context.type';
@@ -90,7 +91,10 @@ describe('FindConnectedAccountsTool', () => {
 
     expect(mockFind).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ workspaceId: WORKSPACE_ID }),
+        where: expect.objectContaining({
+          workspaceId: WORKSPACE_ID,
+          archivedAt: IsNull(),
+        }),
         select: expect.objectContaining({
           id: true,
           handle: true,

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/__tests__/find-connected-accounts-tool.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/__tests__/find-connected-accounts-tool.spec.ts
@@ -1,0 +1,182 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+import { FindConnectedAccountsTool } from 'src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool';
+import { type ToolExecutionContext } from 'src/engine/core-modules/tool/types/tool-execution-context.type';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
+
+const USER_WORKSPACE_ID = '20202020-2222-4222-8222-222222222222';
+const OTHER_USER_WORKSPACE_ID = '20202020-3333-4333-8333-333333333333';
+const WORKSPACE_ID = '20202020-1111-4111-8111-111111111111';
+
+const ownAccount = {
+  id: 'own-account-id',
+  handle: 'me@example.com',
+  handleAliases: ['me.alias@example.com'],
+  provider: ConnectedAccountProvider.GOOGLE,
+  name: 'Me',
+  visibility: 'user' as const,
+  userWorkspaceId: USER_WORKSPACE_ID,
+  accessToken: 'enc:v2:secret-token',
+};
+
+const colleagueAccount = {
+  id: 'colleague-account-id',
+  handle: 'colleague@example.com',
+  handleAliases: null,
+  provider: ConnectedAccountProvider.GOOGLE,
+  name: 'Colleague',
+  visibility: 'user' as const,
+  userWorkspaceId: OTHER_USER_WORKSPACE_ID,
+  accessToken: 'enc:v2:other-secret',
+};
+
+const sharedAccount = {
+  id: 'shared-account-id',
+  handle: 'team@example.com',
+  handleAliases: null,
+  provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+  name: 'Team',
+  visibility: 'workspace' as const,
+  userWorkspaceId: OTHER_USER_WORKSPACE_ID,
+  accessToken: 'enc:v2:shared-secret',
+};
+
+const callerContext: ToolExecutionContext = {
+  workspaceId: WORKSPACE_ID,
+  userWorkspaceId: USER_WORKSPACE_ID,
+};
+
+const apiKeyContext: ToolExecutionContext = {
+  workspaceId: WORKSPACE_ID,
+};
+
+describe('FindConnectedAccountsTool', () => {
+  let tool: FindConnectedAccountsTool;
+  let mockFind: jest.Mock;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockFind = jest.fn();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindConnectedAccountsTool,
+        {
+          provide: WorkspaceOrmManager,
+          useValue: {
+            executeInWorkspaceContext: jest.fn(
+              (callback: () => Promise<unknown>) => callback(),
+            ),
+          },
+        },
+        {
+          provide: getRepositoryToken(ConnectedAccountEntity),
+          useValue: { find: mockFind },
+        },
+      ],
+    }).compile();
+
+    tool = module.get(FindConnectedAccountsTool);
+  });
+
+  it('returns usable core-schema accounts without tokens', async () => {
+    mockFind.mockResolvedValue([ownAccount, colleagueAccount, sharedAccount]);
+
+    const output = await tool.execute({}, callerContext);
+
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ workspaceId: WORKSPACE_ID }),
+        select: expect.objectContaining({
+          id: true,
+          handle: true,
+        }),
+      }),
+    );
+    expect(mockFind.mock.calls[0][0].select.accessToken).toBeUndefined();
+    expect(mockFind.mock.calls[0][0].select.refreshToken).toBeUndefined();
+    expect(
+      mockFind.mock.calls[0][0].select.connectionParameters,
+    ).toBeUndefined();
+    expect(output.success).toBe(true);
+    expect(output.message).toBe('Found 2 connectedAccount records');
+    expect(output.result).toEqual({
+      records: [
+        {
+          id: 'own-account-id',
+          handle: 'me@example.com',
+          handleAliases: ['me.alias@example.com'],
+          provider: ConnectedAccountProvider.GOOGLE,
+          name: 'Me',
+          visibility: 'user',
+        },
+        {
+          id: 'shared-account-id',
+          handle: 'team@example.com',
+          handleAliases: null,
+          provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+          name: 'Team',
+          visibility: 'workspace',
+        },
+      ],
+      count: '2',
+    });
+    expect(JSON.stringify(output)).not.toContain('enc:v2:');
+    expect(JSON.stringify(output)).not.toContain('accessToken');
+  });
+
+  it('returns every non-archived account when the caller has no user identity', async () => {
+    mockFind.mockResolvedValue([ownAccount, colleagueAccount, sharedAccount]);
+
+    const output = await tool.execute({}, apiKeyContext);
+
+    expect(output.result).toEqual({
+      records: [
+        expect.objectContaining({ id: 'own-account-id' }),
+        expect.objectContaining({ id: 'colleague-account-id' }),
+        expect.objectContaining({ id: 'shared-account-id' }),
+      ],
+      count: '3',
+    });
+  });
+
+  it('filters by handle case-insensitively including aliases', async () => {
+    mockFind.mockResolvedValue([ownAccount, sharedAccount]);
+
+    const output = await tool.execute(
+      { handle: 'ME.ALIAS@example.com' },
+      callerContext,
+    );
+
+    expect(output.message).toBe('Found 1 connectedAccount record');
+    expect(output.result).toEqual({
+      records: [
+        {
+          id: 'own-account-id',
+          handle: 'me@example.com',
+          handleAliases: ['me.alias@example.com'],
+          provider: ConnectedAccountProvider.GOOGLE,
+          name: 'Me',
+          visibility: 'user',
+        },
+      ],
+      count: '1',
+    });
+  });
+
+  it('returns the empty MCP payload when nothing matches', async () => {
+    mockFind.mockResolvedValue([]);
+
+    const output = await tool.execute({}, callerContext);
+
+    expect(output).toEqual({
+      success: true,
+      message: 'Found 0 connectedAccount records',
+      result: { records: [], count: '0' },
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool.schema.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const FindConnectedAccountsToolInputZodSchema = z.object({
+  handle: z
+    .string()
+    .describe(
+      'Optional email handle to match against the connected account handle or aliases. Case-insensitive.',
+    )
+    .optional(),
+});
+
+export type FindConnectedAccountsToolInput = z.infer<
+  typeof FindConnectedAccountsToolInputZodSchema
+>;

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool.ts
@@ -21,7 +21,7 @@ const normalizeHandle = (handle: string): string => handle.trim().toLowerCase();
 @Injectable()
 export class FindConnectedAccountsTool implements Tool {
   description =
-    'List connected email/calendar accounts the caller can use with draft_email and send_email. Returns id, handle, provider, visibility and aliases from the core schema. Pass id as connectedAccountId. Do not guess UUIDs.';
+    'List connected email accounts the caller can use with draft_email and send_email. Returns id, handle, provider, visibility and aliases from the core schema. Pass id as connectedAccountId. Do not guess UUIDs.';
   inputSchema = FindConnectedAccountsToolInputZodSchema;
 
   constructor(

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool.ts
@@ -1,0 +1,106 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { isDefined, isNonEmptyString } from 'twenty-shared/utils';
+import { IsNull, type Repository } from 'typeorm';
+
+import {
+  FindConnectedAccountsToolInputZodSchema,
+  type FindConnectedAccountsToolInput,
+} from 'src/engine/core-modules/tool/tools/email-tool/find-connected-accounts-tool.schema';
+import { type ToolExecutionContext } from 'src/engine/core-modules/tool/types/tool-execution-context.type';
+import { type ToolOutput } from 'src/engine/core-modules/tool/types/tool-output.type';
+import { type Tool } from 'src/engine/core-modules/tool/types/tool.type';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { isConnectedAccountUsableByCaller } from 'src/engine/metadata-modules/connected-account/utils/is-connected-account-usable-by-caller.util';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
+
+const normalizeHandle = (handle: string): string => handle.trim().toLowerCase();
+
+@Injectable()
+export class FindConnectedAccountsTool implements Tool {
+  description =
+    'List connected email/calendar accounts the caller can use with draft_email and send_email. Returns id, handle, provider, visibility and aliases from the core schema. Pass id as connectedAccountId. Do not guess UUIDs.';
+  inputSchema = FindConnectedAccountsToolInputZodSchema;
+
+  constructor(
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
+    @InjectRepository(ConnectedAccountEntity)
+    private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
+  ) {}
+
+  async execute(
+    parameters: FindConnectedAccountsToolInput,
+    context: ToolExecutionContext,
+  ): Promise<ToolOutput> {
+    const authContext = buildSystemAuthContext(context.workspaceId);
+
+    const accounts = await this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        return this.connectedAccountRepository.find({
+          where: { workspaceId: context.workspaceId, archivedAt: IsNull() },
+          order: { createdAt: 'ASC', id: 'ASC' },
+          select: {
+            id: true,
+            handle: true,
+            handleAliases: true,
+            provider: true,
+            name: true,
+            visibility: true,
+            userWorkspaceId: true,
+          },
+        });
+      },
+      authContext,
+    );
+
+    const userWorkspaceId = context.userWorkspaceId;
+    const usableAccounts = isDefined(userWorkspaceId)
+      ? accounts.filter((connectedAccount) =>
+          isConnectedAccountUsableByCaller({
+            connectedAccount,
+            userWorkspaceId,
+          }),
+        )
+      : accounts;
+
+    const handleFilter = isNonEmptyString(parameters.handle)
+      ? normalizeHandle(parameters.handle)
+      : undefined;
+
+    const matchingAccounts = isDefined(handleFilter)
+      ? usableAccounts.filter((account) => {
+          if (normalizeHandle(account.handle) === handleFilter) {
+            return true;
+          }
+
+          return (account.handleAliases ?? []).some(
+            (alias) => normalizeHandle(alias) === handleFilter,
+          );
+        })
+      : usableAccounts;
+
+    // MCP JSON is not GraphQL: never spread the entity (tokens are HideField-only).
+    const records = matchingAccounts.map((account) => ({
+      id: account.id,
+      handle: account.handle,
+      handleAliases: account.handleAliases,
+      provider: account.provider,
+      name: account.name,
+      visibility: account.visibility,
+    }));
+
+    return {
+      success: true,
+      message:
+        records.length === 0
+          ? 'Found 0 connectedAccount records'
+          : `Found ${records.length} connectedAccount record${records.length === 1 ? '' : 's'}`,
+      result: {
+        records,
+        count: String(records.length),
+      },
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/__tests__/get-database-crud-tool-flat-objects.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/__tests__/get-database-crud-tool-flat-objects.util.spec.ts
@@ -1,0 +1,49 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+
+import { getDatabaseCrudToolFlatObjects } from 'src/engine/metadata-modules/ai/ai-agent/utils/get-database-crud-tool-flat-objects.util';
+
+describe('getDatabaseCrudToolFlatObjects', () => {
+  it('excludes leftover core-schema-backed objects and inactive objects', () => {
+    const objects = getDatabaseCrudToolFlatObjects({
+      person: {
+        isActive: true,
+        universalIdentifier: STANDARD_OBJECTS.person.universalIdentifier,
+        nameSingular: 'person',
+      },
+      connectedAccount: {
+        isActive: true,
+        universalIdentifier: 'connectedAccount',
+        nameSingular: 'connectedAccount',
+      },
+      messageChannel: {
+        isActive: true,
+        universalIdentifier: 'messageChannel',
+        nameSingular: 'messageChannel',
+      },
+      inactiveCompany: {
+        isActive: false,
+        universalIdentifier: STANDARD_OBJECTS.company.universalIdentifier,
+        nameSingular: 'company',
+      },
+    });
+
+    expect(objects.map((object) => object.nameSingular)).toEqual(['person']);
+  });
+
+  it('excludes workflow-related objects', () => {
+    const objects = getDatabaseCrudToolFlatObjects({
+      workflow: {
+        isActive: true,
+        universalIdentifier: STANDARD_OBJECTS.workflow.universalIdentifier,
+        nameSingular: 'workflow',
+      },
+      person: {
+        isActive: true,
+        universalIdentifier: STANDARD_OBJECTS.person.universalIdentifier,
+        nameSingular: 'person',
+      },
+    });
+
+    expect(objects.map((object) => object.nameSingular)).toEqual(['person']);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/__tests__/is-core-schema-backed-object.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/__tests__/is-core-schema-backed-object.util.spec.ts
@@ -1,0 +1,24 @@
+import { isCoreSchemaBackedObject } from 'src/engine/metadata-modules/ai/ai-agent/utils/is-core-schema-backed-object.util';
+
+describe('isCoreSchemaBackedObject', () => {
+  it('should return true for objects whose rows live in the core schema', () => {
+    expect(
+      isCoreSchemaBackedObject({ nameSingular: 'connectedAccount' }),
+    ).toBe(true);
+    expect(
+      isCoreSchemaBackedObject({ nameSingular: 'messageChannel' }),
+    ).toBe(true);
+    expect(
+      isCoreSchemaBackedObject({ nameSingular: 'calendarChannel' }),
+    ).toBe(true);
+    expect(isCoreSchemaBackedObject({ nameSingular: 'messageFolder' })).toBe(
+      true,
+    );
+  });
+
+  it('should return false for workspace-schema objects', () => {
+    expect(isCoreSchemaBackedObject({ nameSingular: 'person' })).toBe(false);
+    expect(isCoreSchemaBackedObject({ nameSingular: 'company' })).toBe(false);
+    expect(isCoreSchemaBackedObject({ nameSingular: 'workflow' })).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/get-database-crud-tool-flat-objects.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/get-database-crud-tool-flat-objects.util.ts
@@ -1,18 +1,25 @@
 import { isDefined } from 'twenty-shared/utils';
 
+import { isCoreSchemaBackedObject } from 'src/engine/metadata-modules/ai/ai-agent/utils/is-core-schema-backed-object.util';
 import { isWorkflowRelatedObject } from 'src/engine/metadata-modules/ai/ai-agent/utils/is-workflow-related-object.util';
 
-type FlatObjectWithActivityAndIdentifier = {
+type FlatObjectForDatabaseCrudTools = {
   isActive: boolean;
   universalIdentifier: string;
+  nameSingular: string;
 };
 
 export const getDatabaseCrudToolFlatObjects = <
-  T extends FlatObjectWithActivityAndIdentifier,
+  T extends FlatObjectForDatabaseCrudTools,
 >(
   byUniversalIdentifier: Partial<Record<string, T>>,
 ): T[] => {
   return Object.values(byUniversalIdentifier)
     .filter(isDefined)
-    .filter((obj) => obj.isActive && !isWorkflowRelatedObject(obj));
+    .filter(
+      (obj) =>
+        obj.isActive &&
+        !isWorkflowRelatedObject(obj) &&
+        !isCoreSchemaBackedObject(obj),
+    );
 };

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/is-core-schema-backed-object.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/is-core-schema-backed-object.util.ts
@@ -1,0 +1,16 @@
+const CORE_SCHEMA_BACKED_STANDARD_OBJECT_NAMES = [
+  'connectedAccount',
+  'messageChannel',
+  'calendarChannel',
+  'messageFolder',
+] as const;
+
+// Leftover workspace object metadata still names these after the v1.21
+// core-schema migration; DATABASE_CRUD would query empty workspace tables.
+export const isCoreSchemaBackedObject = (objectMetadata: {
+  nameSingular: string;
+}): boolean => {
+  return CORE_SCHEMA_BACKED_STANDARD_OBJECT_NAMES.includes(
+    objectMetadata.nameSingular as (typeof CORE_SCHEMA_BACKED_STANDARD_OBJECT_NAMES)[number],
+  );
+};


### PR DESCRIPTION
## Bug Description

`find_connected_accounts` (DATABASE_CRUD) always returns 0 records after the v1.21 migration moved `connectedAccount` / `messageChannel` / `calendarChannel` / `messageFolder` rows into the shared `core` schema. Leftover workspace object metadata still generated workspace-schema CRUD tools against empty tables.

`draft_email` / `send_email` already resolve accounts via TypeORM `ConnectedAccountEntity` (`schema: 'core'`), so drafts work if you already know the UUID — discovery does not.

Fixes #20407

## Root Cause

`DatabaseToolProvider` emits find tools from workspace flat-object metadata. Those four objects may still appear as active leftover metadata, but their rows live in `core.*`.

## Fix

- Exclude leftover core-schema-backed objects from DATABASE_CRUD generation (`isCoreSchemaBackedObject`, same seam as `isWorkflowRelatedObject`).
- Add ACTION tool `find_connected_accounts` that reads `core.connectedAccount`:
  - same visibility rules as email compose (`isConnectedAccountUsableByCaller`) when the caller has a `userWorkspaceId`
  - all non-archived workspace accounts when the caller is an API key (no user identity), matching `EmailComposerService` default-account fallback
  - optional `handle` filter (case-insensitive, includes aliases)
  - never returns `accessToken` / `refreshToken` / `connectionParameters`

## How to Verify

1. Connect a Gmail or IMAP account in Settings.
2. Call MCP `find_connected_accounts` (with or without `handle`).
3. Confirm the connected account `id` / `handle` are returned (not `Found 0 connectedAccount records`).
4. Pass that `id` to `draft_email` as `connectedAccountId`.

## Test Plan

- [x] Unit tests for `isCoreSchemaBackedObject` and `getDatabaseCrudToolFlatObjects`
- [x] `DatabaseToolProvider` no longer advertises leftover `connectedAccount` / `messageChannel` CRUD tools
- [x] `FindConnectedAccountsTool` tests: visibility, API-key listing, handle/alias filter, empty payload, no tokens in output
- [ ] CI on this PR

## Risk Assessment

Low — read-only listing of already-visible connected accounts; CRUD exclusion only drops tools that queried empty tables. Token fields are omitted from the TypeORM `select` and from the mapped result.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

