### PR TITLE
Use published /images/halftone environment image for glass environment texture

### DIFF
--- a/packages/twenty-website/src/platform/visuals/halftone-studio/engine/materials.ts
+++ b/packages/twenty-website/src/platform/visuals/halftone-studio/engine/materials.ts
@@ -445,9 +445,8 @@ const GLASS_ENVIRONMENT_INTENSITY_BASE = 0.18;
 const GLASS_ENVIRONMENT_INTENSITY_MULTIPLIER = 0.12;
 const GLASS_ENVIRONMENT_ZOOM = 1.55;
 const GLASS_TRANSMISSION_BACKGROUND = new THREE.Color(0x030303);
-const GLASS_TEXTURE_URLS = {
-  environment: '/halftone/materials/glass/environment.webp',
-} as const;
+// The images prefix bypasses the locale catch-all that owns the /halftone route.
+const GLASS_ENVIRONMENT_URL = '/images/halftone/environment.jpg';
 const MAX_TEXTURE_ANISOTROPY = 8;
 
 function setTextureSampling(
@@ -626,7 +625,7 @@ function loadTexture(
 
 async function loadGlassEnvironmentAssets(renderer: THREE.WebGLRenderer) {
   const sourceBackgroundTexture = await loadTexture(
-    GLASS_TEXTURE_URLS.environment,
+    GLASS_ENVIRONMENT_URL,
     renderer,
     THREE.SRGBColorSpace,
   );


### PR DESCRIPTION
### Motivation
- Avoid the locale catch-all on the `/halftone` route by pointing the glass environment texture to the published images prefix so the environment asset can be reliably loaded at runtime.

### Description
- Replace the `GLASS_TEXTURE_URLS` object with a single `GLASS_ENVIRONMENT_URL` constant set to `/images/halftone/environment.jpg` and update `loadGlassEnvironmentAssets` to use `GLASS_ENVIRONMENT_URL`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a996831c9f0832f8e0c8de6fdd17ed1)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

