### PR TITLE
fix - fail AI chat sends fast when the stream job cannot be enqueued

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-worker-config.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-worker-config.constant.ts
@@ -22,15 +22,6 @@ export const MESSAGE_QUEUE_WORKER_CONFIG: Record<
   MessageQueue,
   MessageQueueWorkerConfig
 > = {
-  [MessageQueue.taskAssignedQueue]: {
-    priority: 4,
-    workerOptions: {
-      concurrency: 1,
-      lockDuration: 30_000,
-      maxStalledCount: 1,
-      boundedShutdownDrain: false,
-    },
-  },
   [MessageQueue.messagingQueue]: {
     priority: 2,
     workerOptions: {

--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.constants.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.constants.ts
@@ -3,7 +3,6 @@ export const PROCESS_METADATA = Symbol('message-queue:process_metadata');
 export const QUEUE_DRIVER = Symbol('message-queue:queue_driver');
 
 export enum MessageQueue {
-  taskAssignedQueue = 'task-assigned-queue',
   messagingQueue = 'messaging-queue',
   webhookQueue = 'webhook-queue',
   cronQueue = 'cron-queue',

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/stream-enqueue-timeout-ms.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/stream-enqueue-timeout-ms.constant.ts
@@ -1,0 +1,1 @@
+export const STREAM_ENQUEUE_TIMEOUT_MS = 15_000;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/__tests__/agent-chat-streaming.service.claim.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/__tests__/agent-chat-streaming.service.claim.spec.ts
@@ -1,5 +1,7 @@
 import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AiExceptionCode } from 'src/engine/metadata-modules/ai/ai.exception';
+import { STREAM_ENQUEUE_TIMEOUT_MS } from 'src/engine/metadata-modules/ai/ai-chat/constants/stream-enqueue-timeout-ms.constant';
+import { STREAM_AGENT_CHAT_JOB_NAME } from 'src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat-job-name.constant';
 import { AgentChatStreamingService } from 'src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service';
 
 describe('AgentChatStreamingService claim & reap', () => {
@@ -174,9 +176,74 @@ describe('AgentChatStreamingService claim & reap', () => {
       expect(threadRepository.update).toHaveBeenLastCalledWith(
         'workspace-id',
         { id: 'thread-id', activeStreamId: expect.any(String) },
-        { activeStreamId: null },
+        {
+          activeStreamId: null,
+          lastStreamError: expect.objectContaining({
+            failedAt: expect.any(String),
+          }),
+        },
       );
       expect(streamHeartbeatService.clear).toHaveBeenCalled();
+    });
+
+    it('converts a never-resolving enqueue into a timeout and releases the claim', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const {
+          service,
+          threadRepository,
+          messageQueueService,
+          streamHeartbeatService,
+        } = buildService();
+
+        messageQueueService.add.mockReturnValue(new Promise(() => {}));
+
+        const streamPromise = service.streamAgentChat(sendArguments);
+        const assertion = expect(streamPromise).rejects.toMatchObject({
+          code: AiExceptionCode.STREAM_ENQUEUE_TIMEOUT,
+        });
+
+        await jest.advanceTimersByTimeAsync(STREAM_ENQUEUE_TIMEOUT_MS);
+        await assertion;
+
+        expect(threadRepository.update).toHaveBeenLastCalledWith(
+          'workspace-id',
+          { id: 'thread-id', activeStreamId: expect.any(String) },
+          {
+            activeStreamId: null,
+            lastStreamError: expect.objectContaining({
+              code: AiExceptionCode.STREAM_ENQUEUE_TIMEOUT,
+              failedAt: expect.any(String),
+            }),
+          },
+        );
+        expect(streamHeartbeatService.clear).toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not let the thread-activity broadcast block or fail the enqueue', async () => {
+      const { service, agentChatService, messageQueueService } = buildService();
+
+      agentChatService.notifyThreadActivityUpdated.mockReturnValue(
+        new Promise(() => {}),
+      );
+
+      const result = await service.streamAgentChat(sendArguments);
+
+      expect(result.queued).toBe(false);
+      expect(messageQueueService.add).toHaveBeenCalledTimes(1);
+      expect(messageQueueService.add).toHaveBeenCalledWith(
+        STREAM_AGENT_CHAT_JOB_NAME,
+        expect.objectContaining({
+          threadId: 'thread-id',
+          userWorkspaceId: 'user-workspace-id',
+          streamId: expect.any(String),
+          existingTurnId: 'turn-id',
+        }),
+      );
     });
   });
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
@@ -25,6 +25,7 @@ import {
 } from 'src/engine/metadata-modules/ai/ai-agent-execution/entities/agent-message.entity';
 import { mapDBPartsToUIMessageParts } from 'src/engine/metadata-modules/ai/ai-agent-execution/utils/mapDBPartsToUIMessageParts';
 import { type BrowsingContextType } from 'src/engine/metadata-modules/ai/ai-agent/types/browsingContext.type';
+import { STREAM_ENQUEUE_TIMEOUT_MS } from 'src/engine/metadata-modules/ai/ai-chat/constants/stream-enqueue-timeout-ms.constant';
 import { AgentChatThreadEntity } from 'src/engine/metadata-modules/ai/ai-chat/entities/agent-chat-thread.entity';
 import { type AgentChatThreadLastStreamError } from 'src/engine/metadata-modules/ai/ai-chat/types/agent-chat-thread-last-stream-error.type';
 import { STREAM_AGENT_CHAT_JOB_NAME } from 'src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat-job-name.constant';
@@ -244,11 +245,13 @@ export class AgentChatStreamingService {
         workspaceId: workspace.id,
       });
 
-      await this.agentChatService.notifyThreadActivityUpdated({
-        threadId,
-        userWorkspaceId,
-        workspaceId: workspace.id,
-      });
+      this.agentChatService
+        .notifyThreadActivityUpdated({
+          threadId,
+          userWorkspaceId,
+          workspaceId: workspace.id,
+        })
+        .catch(() => {});
 
       const previousMessages = await this.loadMessagesFromDB(
         threadId,
@@ -256,23 +259,20 @@ export class AgentChatStreamingService {
         workspace.id,
       );
 
-      await this.messageQueueService.add<StreamAgentChatJobData>(
-        STREAM_AGENT_CHAT_JOB_NAME,
-        {
-          threadId: thread.id,
-          streamId,
-          userWorkspaceId,
-          workspaceId: workspace.id,
-          messages: previousMessages,
-          browsingContext,
-          modelId,
-          lastUserMessageText: text,
-          lastUserMessageParts: userMessageParts,
-          hasTitle: !!thread.title,
-          conversationSizeTokens: thread.conversationSize,
-          existingTurnId: savedUserMessage.turnId ?? undefined,
-        },
-      );
+      await this.enqueueStreamJob({
+        threadId: thread.id,
+        streamId,
+        userWorkspaceId,
+        workspaceId: workspace.id,
+        messages: previousMessages,
+        browsingContext,
+        modelId,
+        lastUserMessageText: text,
+        lastUserMessageParts: userMessageParts,
+        hasTitle: !!thread.title,
+        conversationSizeTokens: thread.conversationSize,
+        existingTurnId: savedUserMessage.turnId ?? undefined,
+      });
 
       return {
         queued: false,
@@ -281,8 +281,11 @@ export class AgentChatStreamingService {
         turnId: savedUserMessage.turnId,
       };
     } catch (error) {
-      await this.releaseStreamClaim(threadId, workspace.id, streamId);
       const streamError = mapErrorToStreamError(error);
+
+      await this.releaseStreamClaim(threadId, workspace.id, streamId, {
+        lastStreamError: { ...streamError, failedAt: new Date().toISOString() },
+      });
 
       this.metricsService.incrementCounterBy({
         key: MetricsKeys.AiChatTurnFailed,
@@ -365,23 +368,20 @@ export class AgentChatStreamingService {
         );
       }
 
-      await this.messageQueueService.add<StreamAgentChatJobData>(
-        STREAM_AGENT_CHAT_JOB_NAME,
-        {
-          threadId,
-          streamId,
-          userWorkspaceId,
-          workspaceId: workspace.id,
-          messages,
-          browsingContext: null,
-          modelId,
-          lastUserMessageText: text,
-          lastUserMessageParts: [{ type: 'text' as const, text }],
-          hasTitle: !!thread.title,
-          conversationSizeTokens: thread.conversationSize,
-          existingTurnId: turnId,
-        },
-      );
+      await this.enqueueStreamJob({
+        threadId,
+        streamId,
+        userWorkspaceId,
+        workspaceId: workspace.id,
+        messages,
+        browsingContext: null,
+        modelId,
+        lastUserMessageText: text,
+        lastUserMessageParts: [{ type: 'text' as const, text }],
+        hasTitle: !!thread.title,
+        conversationSizeTokens: thread.conversationSize,
+        existingTurnId: turnId,
+      });
 
       return { streamId, messageId, turnId };
     } catch (error) {
@@ -487,23 +487,20 @@ export class AgentChatStreamingService {
         (part) => part.type === 'text',
       );
 
-      await this.messageQueueService.add<StreamAgentChatJobData>(
-        STREAM_AGENT_CHAT_JOB_NAME,
-        {
-          threadId,
-          streamId,
-          userWorkspaceId,
-          workspaceId: workspace.id,
-          messages,
-          browsingContext: null,
-          modelId,
-          lastUserMessageText: textPart?.text ?? '',
-          lastUserMessageParts: retriedMessage.parts,
-          hasTitle: !!thread.title,
-          conversationSizeTokens: thread.conversationSize,
-          existingTurnId: lastUserMessage.turnId,
-        },
-      );
+      await this.enqueueStreamJob({
+        threadId,
+        streamId,
+        userWorkspaceId,
+        workspaceId: workspace.id,
+        messages,
+        browsingContext: null,
+        modelId,
+        lastUserMessageText: textPart?.text ?? '',
+        lastUserMessageParts: retriedMessage.parts,
+        hasTitle: !!thread.title,
+        conversationSizeTokens: thread.conversationSize,
+        existingTurnId: lastUserMessage.turnId,
+      });
 
       return {
         streamId,
@@ -654,24 +651,21 @@ export class AgentChatStreamingService {
       workspace.id,
     );
 
-    await this.messageQueueService.add<StreamAgentChatJobData>(
-      STREAM_AGENT_CHAT_JOB_NAME,
-      {
-        threadId,
-        streamId,
-        userWorkspaceId,
-        workspaceId: workspace.id,
-        messages,
-        browsingContext: null,
-        modelId,
-        lastUserMessageText: '',
-        lastUserMessageParts: [],
-        hasTitle: !!thread.title,
-        conversationSizeTokens: thread.conversationSize,
-        existingTurnId: turnId ?? undefined,
-        isResume: true,
-      },
-    );
+    await this.enqueueStreamJob({
+      threadId,
+      streamId,
+      userWorkspaceId,
+      workspaceId: workspace.id,
+      messages,
+      browsingContext: null,
+      modelId,
+      lastUserMessageText: '',
+      lastUserMessageParts: [],
+      hasTitle: !!thread.title,
+      conversationSizeTokens: thread.conversationSize,
+      existingTurnId: turnId ?? undefined,
+      isResume: true,
+    });
   }
 
   async flushNextQueuedMessage(
@@ -753,17 +747,21 @@ export class AgentChatStreamingService {
         return;
       }
 
-      await this.eventPublisherService.publish({
-        threadId,
-        workspaceId,
-        event: { type: 'queue-updated' },
-      });
+      this.eventPublisherService
+        .publish({
+          threadId,
+          workspaceId,
+          event: { type: 'queue-updated' },
+        })
+        .catch(() => {});
 
-      await this.eventPublisherService.publish({
-        threadId,
-        workspaceId,
-        event: { type: 'message-persisted', messageId: nextQueued.id },
-      });
+      this.eventPublisherService
+        .publish({
+          threadId,
+          workspaceId,
+          event: { type: 'message-persisted', messageId: nextQueued.id },
+        })
+        .catch(() => {});
 
       const [uiMessages, thread] = await Promise.all([
         this.loadMessagesFromDB(threadId, userWorkspaceId, workspaceId),
@@ -779,25 +777,25 @@ export class AgentChatStreamingService {
         ...fileParts,
       ];
 
-      await this.messageQueueService.add<StreamAgentChatJobData>(
-        STREAM_AGENT_CHAT_JOB_NAME,
-        {
-          threadId,
-          streamId,
-          userWorkspaceId,
-          workspaceId,
-          messages: uiMessages,
-          browsingContext: null,
-          lastUserMessageText: messageText,
-          lastUserMessageParts,
-          hasTitle,
-          conversationSizeTokens: thread.conversationSize,
-          existingTurnId: turnId,
-        },
-      );
+      await this.enqueueStreamJob({
+        threadId,
+        streamId,
+        userWorkspaceId,
+        workspaceId,
+        messages: uiMessages,
+        browsingContext: null,
+        lastUserMessageText: messageText,
+        lastUserMessageParts,
+        hasTitle,
+        conversationSizeTokens: thread.conversationSize,
+        existingTurnId: turnId,
+      });
     } catch (error) {
-      await this.releaseStreamClaim(threadId, workspaceId, streamId);
       const streamError = mapErrorToStreamError(error);
+
+      await this.releaseStreamClaim(threadId, workspaceId, streamId, {
+        lastStreamError: { ...streamError, failedAt: new Date().toISOString() },
+      });
 
       this.metricsService.incrementCounterBy({
         key: MetricsKeys.AiChatTurnFailed,
@@ -809,6 +807,35 @@ export class AgentChatStreamingService {
         },
       });
       throw error;
+    }
+  }
+
+  private async enqueueStreamJob(
+    jobData: StreamAgentChatJobData,
+  ): Promise<void> {
+    let timeoutHandle: NodeJS.Timeout | undefined;
+
+    try {
+      await Promise.race([
+        this.messageQueueService.add<StreamAgentChatJobData>(
+          STREAM_AGENT_CHAT_JOB_NAME,
+          jobData,
+        ),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(() => {
+            reject(
+              new AiException(
+                `Could not enqueue the chat stream job within ${STREAM_ENQUEUE_TIMEOUT_MS}ms`,
+                AiExceptionCode.STREAM_ENQUEUE_TIMEOUT,
+              ),
+            );
+          }, STREAM_ENQUEUE_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (isDefined(timeoutHandle)) {
+        clearTimeout(timeoutHandle);
+      }
     }
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai.exception.ts
@@ -26,6 +26,7 @@ export enum AiExceptionCode {
   RUN_AGENT_NOT_ALLOWED = 'RUN_AGENT_NOT_ALLOWED',
   NO_FAILED_TURN_TO_RETRY = 'NO_FAILED_TURN_TO_RETRY',
   STREAM_INTERRUPTED = 'STREAM_INTERRUPTED',
+  STREAM_ENQUEUE_TIMEOUT = 'STREAM_ENQUEUE_TIMEOUT',
 }
 
 const getAiExceptionUserFriendlyMessage = (code: AiExceptionCode) => {
@@ -72,6 +73,8 @@ const getAiExceptionUserFriendlyMessage = (code: AiExceptionCode) => {
       return msg`There is no failed message to retry.`;
     case AiExceptionCode.STREAM_INTERRUPTED:
       return msg`The response was interrupted before it could finish.`;
+    case AiExceptionCode.STREAM_ENQUEUE_TIMEOUT:
+      return msg`Your message could not be handed off for processing. Please try again.`;
     default:
       assertUnreachable(code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/ai/utils/ai-graphql-api-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/utils/ai-graphql-api-exception-handler.util.ts
@@ -46,6 +46,7 @@ export const aiGraphqlApiExceptionHandler = (error: Error) => {
       case AiExceptionCode.API_KEY_NOT_CONFIGURED:
       case AiExceptionCode.USER_WORKSPACE_ID_NOT_FOUND:
       case AiExceptionCode.STREAM_INTERRUPTED:
+      case AiExceptionCode.STREAM_ENQUEUE_TIMEOUT:
         throw new InternalServerError(error);
       default: {
         return assertUnreachable(error.code);


### PR DESCRIPTION
## Context

Fixes #25165. On some self-hosted instances the AI chat hangs with no reply and no error, and only recovers ~10 minutes later as a `STREAM_INTERRUPTED` turn with 0 tokens.

## Root cause

The stream job is never enqueued. When the server's queue Redis connection never reaches `ready`, BullMQ's `add()` awaits its internal ready promise forever with nothing on the wire. By then the user message is saved and the stream claim is taken, so the thread sits locked until the 600s claim TTL reaps it. Nothing times out, nothing is logged.

The same unbounded pattern also sits on the UI broadcast (Redis pub/sub) just before the enqueue.

## Changes

- Bound the stream-job enqueue with a 15s timeout via a shared `enqueueStreamJob` helper covering all five enqueue paths. On timeout the claim is released and a new `STREAM_ENQUEUE_TIMEOUT` error is surfaced instead of a silent 10-minute lockout.
- Move the thread-activity and queue pub/sub broadcasts off the enqueue critical path (best effort) so a stalled broadcast can't block the turn from starting.
- Remove the dead `task-assigned-queue` enum + worker-config entry: no processor has ever consumed it, so every deployment shows a permanently workerless queue that keeps getting read as a worker outage.

## Not fixed here

The environment trigger (why a given instance's queue Redis never connects, e.g. an eviction policy other than `noeviction`) is out of scope. This PR makes that failure fast and named so the instance's own logs point at the cause.

## Test

- New unit tests: never-resolving enqueue converts to a timeout and releases the claim; a stalled thread-activity broadcast does not block the enqueue.
- Typecheck, lint:diff-with-main, and the ai-chat + admin-panel suites pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

