### PR TITLE
fix(ai): send x-opencode-session header on inference requests

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service.ts
@@ -141,7 +141,11 @@ export class SdkProviderFactoryService {
 
   private buildStandardProvider(
     config: AiProviderConfig,
-    factory: (opts: { apiKey?: string; baseURL?: string }) => CallableFunction,
+    factory: (opts: {
+      apiKey?: string;
+      baseURL?: string;
+      headers?: Record<string, string>;
+    }) => CallableFunction,
     options?: { middleware?: LanguageModelMiddleware },
   ): AiSdkProviderInstance {
     const provider = factory({

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/sdk-provider-factory.service.ts
@@ -93,6 +93,10 @@ export class SdkProviderFactoryService {
     this.providerInstances.clear();
   }
 
+  private createOpencodeHeaders(): Record<string, string> {
+    return { 'x-opencode-session': crypto.randomUUID() };
+  }
+
   private toProviderInstance(
     provider: unknown,
     sdkPackage: AiSdkPackage,
@@ -143,6 +147,7 @@ export class SdkProviderFactoryService {
     const provider = factory({
       ...(config.apiKey && { apiKey: config.apiKey }),
       ...(config.baseUrl && { baseURL: config.baseUrl }),
+      headers: this.createOpencodeHeaders(),
     });
 
     return this.toProviderInstance(provider, config.npm, (modelId: string) => {
@@ -158,6 +163,7 @@ export class SdkProviderFactoryService {
     const provider = createXai({
       ...(config.apiKey && { apiKey: config.apiKey }),
       ...(config.baseUrl && { baseURL: config.baseUrl }),
+      headers: this.createOpencodeHeaders(),
     });
 
     return this.toProviderInstance(provider, AI_SDK_XAI, (modelId: string) =>
@@ -214,6 +220,7 @@ export class SdkProviderFactoryService {
       name: config.name ?? 'openai-compatible',
       baseURL: config.baseUrl,
       ...(config.apiKey && { apiKey: config.apiKey }),
+      headers: this.createOpencodeHeaders(),
     });
 
     return this.toProviderInstance(
@@ -231,6 +238,7 @@ export class SdkProviderFactoryService {
     const provider = createAzure({
       baseURL: config.baseUrl,
       ...(config.apiKey && { apiKey: config.apiKey }),
+      headers: this.createOpencodeHeaders(),
     });
 
     return this.toProviderInstance(provider, AI_SDK_AZURE, (modelId: string) =>


### PR DESCRIPTION
Fixes #25286

Twenty uses the Vercel AI SDK for AI features via the OpenCode Go managed inference API. Requests via `ai-sdk/openai-compatible` (and other providers) did not include an `x-opencode-session` header. Starting 09/05 the proxy requires a stable per-conversation ID and will error without it.

This adds the header to all SDK providers (OpenAI, Anthropic, Google, Mistral, xAI, OpenAI-Compatible, Azure) at provider creation via a per-provider stable UUID (`crypto.randomUUID()`). The header is then sent on every outbound inference HTTP request from that provider instance.

Implementation: `SdkProviderFactoryService.createOpencodeHeaders()` returns `{ 'x-opencode-session': crypto.randomUUID() }` and is passed as `headers` to each `create*` factory. Bedrock is excluded as it uses AWS SigV4.

Verification: after merge, outbound inference requests show `x-opencode-session` in proxy logs. Locally, `headers` is present on the provider instance.

Closes #25286

Related upstream: https://github.com/vercel/ai/issues/20271

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

