### PR TITLE
fix(auth): preserve connected account scopes on SSO login

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -1160,7 +1160,7 @@ export class AuthService {
       case ConnectedAccountProvider.GOOGLE:
         return ['email', 'profile'];
       case ConnectedAccountProvider.MICROSOFT:
-        return ['user.read'];
+        return ['User.Read'];
       case ConnectedAccountProvider.OIDC:
         return ['openid', 'email', 'profile'];
       case ConnectedAccountProvider.SAML:

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-sso-connected-account.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-sso-connected-account.service.spec.ts
@@ -62,13 +62,14 @@ describe('CreateSsoConnectedAccountService', () => {
       userId: 'user-id',
       handle: 'user@example.com',
       provider: ConnectedAccountProvider.MICROSOFT,
-      scopes: ['user.read'],
+      scopes: ['User.Read'],
     });
 
+    expect(connectedAccountRepository.update).toHaveBeenCalledTimes(1);
     expect(connectedAccountRepository.update).toHaveBeenCalledWith(
       'connected-account-id',
       expect.objectContaining({
-        scopes: [...existingScopes, 'user.read'],
+        scopes: existingScopes,
       }),
     );
   });

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-sso-connected-account.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-sso-connected-account.service.spec.ts
@@ -1,0 +1,75 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+import { type Repository } from 'typeorm';
+
+import { CreateSsoConnectedAccountService } from 'src/engine/core-modules/auth/services/create-sso-connected-account.service';
+import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+
+describe('CreateSsoConnectedAccountService', () => {
+  let createSsoConnectedAccountService: CreateSsoConnectedAccountService;
+  let connectedAccountRepository: Repository<ConnectedAccountEntity>;
+  let userWorkspaceRepository: Repository<UserWorkspaceEntity>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateSsoConnectedAccountService,
+        {
+          provide: getRepositoryToken(ConnectedAccountEntity),
+          useValue: {
+            findOneBy: jest.fn(),
+            save: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(UserWorkspaceEntity),
+          useValue: {
+            findOneBy: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    createSsoConnectedAccountService =
+      module.get<CreateSsoConnectedAccountService>(
+        CreateSsoConnectedAccountService,
+      );
+    connectedAccountRepository = module.get<Repository<ConnectedAccountEntity>>(
+      getRepositoryToken(ConnectedAccountEntity),
+    );
+    userWorkspaceRepository = module.get<Repository<UserWorkspaceEntity>>(
+      getRepositoryToken(UserWorkspaceEntity),
+    );
+  });
+
+  it('should preserve mailbox scopes when updating an SSO connected account', async () => {
+    const existingScopes = ['Mail.ReadWrite', 'Mail.Send', 'User.Read'];
+
+    jest.spyOn(userWorkspaceRepository, 'findOneBy').mockResolvedValue({
+      id: 'user-workspace-id',
+    } as UserWorkspaceEntity);
+    jest.spyOn(connectedAccountRepository, 'findOneBy').mockResolvedValue({
+      id: 'connected-account-id',
+      scopes: existingScopes,
+    } as ConnectedAccountEntity);
+
+    await createSsoConnectedAccountService.createOrUpdateSsoConnectedAccount({
+      workspaceId: 'workspace-id',
+      userId: 'user-id',
+      handle: 'user@example.com',
+      provider: ConnectedAccountProvider.MICROSOFT,
+      scopes: ['user.read'],
+    });
+
+    expect(connectedAccountRepository.update).toHaveBeenCalledWith(
+      'connected-account-id',
+      expect.objectContaining({
+        scopes: [...existingScopes, 'user.read'],
+      }),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-sso-connected-account.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-sso-connected-account.service.ts
@@ -54,10 +54,14 @@ export class CreateSsoConnectedAccountService {
     });
 
     if (existing) {
+      const mergedScopes = Array.from(
+        new Set([...(existing.scopes ?? []), ...scopes]),
+      );
+
       await this.connectedAccountRepository.update(existing.id, {
         lastSignedInAt: new Date(),
         provider,
-        scopes,
+        scopes: mergedScopes,
         ...(oidcTokenClaims !== undefined
           ? { oidcTokenClaims: oidcTokenClaims as object }
           : {}),

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
@@ -42,7 +42,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy, 'microsoft') {
       clientSecret: twentyConfigService.get('AUTH_MICROSOFT_CLIENT_SECRET'),
       callbackURL: twentyConfigService.get('AUTH_MICROSOFT_CALLBACK_URL'),
       tenant: 'common',
-      scope: ['user.read'],
+      scope: ['User.Read'],
       passReqToCallback: true,
     });
   }


### PR DESCRIPTION
## Summary
- merge SSO login scopes with scopes already stored on a connected account
- preserve mailbox permissions such as Microsoft Mail.Send across subsequent SSO sign-ins
- add regression coverage for the Microsoft mailbox scenario

## Testing
- focused Jest service test
- type-aware oxlint on both changed files
- oxfmt check on both changed files
- git diff --check

Closes #25227

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

