### PR TITLE
Fix upgrade resume after instance command segment

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
@@ -19,6 +19,7 @@ import {
 } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
 import { WorkspaceCommandRunnerService } from 'src/engine/core-modules/upgrade/services/workspace-command-runner.service';
 import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
+import { isUpgradeWorkspaceCursorValidForSegment } from 'src/engine/core-modules/upgrade/utils/is-upgrade-workspace-cursor-valid-for-segment.util';
 import { UpgradeAwareEntityMetadataAdapter } from 'src/engine/twenty-orm/upgrade-aware/upgrade-aware-entity-metadata.adapter';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
 import { assertUnreachable, isDefined } from 'twenty-shared/utils';
@@ -279,9 +280,6 @@ export class UpgradeSequenceRunnerService {
       await this.upgradeMigrationService.getWorkspaceLastAttemptedCommandNameOrThrow(
         allProvisionedWorkspaceIds,
       );
-    const precedingStep =
-      startCursor > 0 ? sequence[startCursor - 1] : undefined;
-
     const invalidWorkspaces: Array<{
       workspaceId: string;
       cursorName: string;
@@ -295,16 +293,15 @@ export class UpgradeSequenceRunnerService {
           stepName: workspaceCursor.name,
         });
 
-      const isWithinSegment =
-        cursorPosition >= startCursor && cursorPosition <= endCursor;
+      const isWorkspaceCursorValid = isUpgradeWorkspaceCursorValidForSegment({
+        sequence,
+        cursorPosition,
+        workspaceCursorStatus: workspaceCursor.status,
+        startCursor,
+        endCursor,
+      });
 
-      const isAtPrecedingInstanceCommandCompleted =
-        isDefined(precedingStep) &&
-        precedingStep.kind !== 'workspace' &&
-        cursorPosition === startCursor - 1 &&
-        workspaceCursor.status === 'completed';
-
-      if (!isWithinSegment && !isAtPrecedingInstanceCommandCompleted) {
+      if (!isWorkspaceCursorValid) {
         invalidWorkspaces.push({
           workspaceId,
           cursorName: workspaceCursor.name,

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/is-upgrade-workspace-cursor-valid-for-segment.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/is-upgrade-workspace-cursor-valid-for-segment.util.spec.ts
@@ -1,0 +1,61 @@
+import { type UpgradeStepKind } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
+import { isUpgradeWorkspaceCursorValidForSegment } from 'src/engine/core-modules/upgrade/utils/is-upgrade-workspace-cursor-valid-for-segment.util';
+
+const SEQUENCE: Array<{ kind: UpgradeStepKind }> = [
+  { kind: 'workspace' },
+  { kind: 'fast-instance' },
+  { kind: 'fast-instance' },
+  { kind: 'slow-instance' },
+  { kind: 'workspace' },
+  { kind: 'workspace' },
+];
+
+describe('isUpgradeWorkspaceCursorValidForSegment', () => {
+  it('accepts a cursor within the workspace segment', () => {
+    expect(
+      isUpgradeWorkspaceCursorValidForSegment({
+        sequence: SEQUENCE,
+        cursorPosition: 5,
+        workspaceCursorStatus: 'failed',
+        startCursor: 4,
+        endCursor: 5,
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts a completed cursor anywhere in the preceding instance segment', () => {
+    expect(
+      isUpgradeWorkspaceCursorValidForSegment({
+        sequence: SEQUENCE,
+        cursorPosition: 1,
+        workspaceCursorStatus: 'completed',
+        startCursor: 4,
+        endCursor: 5,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a failed cursor in the preceding instance segment', () => {
+    expect(
+      isUpgradeWorkspaceCursorValidForSegment({
+        sequence: SEQUENCE,
+        cursorPosition: 1,
+        workspaceCursorStatus: 'failed',
+        startCursor: 4,
+        endCursor: 5,
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects a completed cursor before the preceding instance segment', () => {
+    expect(
+      isUpgradeWorkspaceCursorValidForSegment({
+        sequence: SEQUENCE,
+        cursorPosition: 0,
+        workspaceCursorStatus: 'completed',
+        startCursor: 4,
+        endCursor: 5,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/is-upgrade-workspace-cursor-valid-for-segment.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/is-upgrade-workspace-cursor-valid-for-segment.util.ts
@@ -1,0 +1,40 @@
+import { type UpgradeStepKind } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
+import { type UpgradeMigrationStatus } from 'src/engine/core-modules/upgrade/upgrade-migration.entity';
+
+export const isUpgradeWorkspaceCursorValidForSegment = ({
+  sequence,
+  cursorPosition,
+  workspaceCursorStatus,
+  startCursor,
+  endCursor,
+}: {
+  sequence: Array<{ kind: UpgradeStepKind }>;
+  cursorPosition: number;
+  workspaceCursorStatus: UpgradeMigrationStatus;
+  startCursor: number;
+  endCursor: number;
+}): boolean => {
+  if (cursorPosition >= startCursor && cursorPosition <= endCursor) {
+    return true;
+  }
+
+  if (workspaceCursorStatus !== 'completed') {
+    return false;
+  }
+
+  let precedingInstanceSegmentStartCursor = startCursor;
+
+  while (
+    precedingInstanceSegmentStartCursor > 0 &&
+    sequence[precedingInstanceSegmentStartCursor - 1].kind !== 'workspace'
+  ) {
+    precedingInstanceSegmentStartCursor--;
+  }
+
+  // Later instance commands can already be globally complete without a
+  // workspace-specific cursor when the workspace was provisioned later.
+  return (
+    cursorPosition >= precedingInstanceSegmentStartCursor &&
+    cursorPosition < startCursor
+  );
+};


### PR DESCRIPTION
## Summary
- accept completed workspace cursors anywhere in the contiguous instance-command segment immediately preceding workspace commands
- preserve rejection of failed or older-segment cursors
- add regression coverage for interrupted upgrades

## Release context
The 2.38.0 main-environment upgrade was interrupted by a command-runner pod replacement after 62/73 workspaces. On resume, seven workspaces still pointed at the penultimate completed instance command, and the validator aborted before resuming them.

## Verification
- focused Jest suite: 3 tests passed
- Prettier check passed
- full server typecheck was attempted but did not complete locally within six minutes and was stopped without output

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

