### PR TITLE
Emit restored events when upsert revives records

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-repository.ts
@@ -86,7 +86,11 @@ const MUTATION_EVENT_ACTIONS_BY_KIND: Record<
   delete: [DatabaseEventAction.DESTROYED],
   restore: [DatabaseEventAction.RESTORED],
   'soft-delete': [DatabaseEventAction.DELETED],
-  update: [DatabaseEventAction.UPDATED, DatabaseEventAction.UPSERTED],
+  update: [
+    DatabaseEventAction.UPDATED,
+    DatabaseEventAction.RESTORED,
+    DatabaseEventAction.UPSERTED,
+  ],
 };
 
 type WorkspaceRepositoryOptions<TEntity extends ObjectLiteral> = {
@@ -985,15 +989,19 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
       this.options.tableShape,
     );
 
-    const rawBeforeByInputIndex: ObjectRecord[][] = [];
+    const rawBeforeById = new Map<string, ObjectRecord[]>();
     const existingRecordsMapById: Record<string, ObjectRecord> = {};
 
     for (const input of inputs) {
+      if (rawBeforeById.has(input.id)) {
+        continue;
+      }
+
       const rawBefore = await this.buildIdsEventSnapshotQueryBuilder([
         input.id,
       ]).getMany<ObjectRecord>({ noFormatting: true });
 
-      rawBeforeByInputIndex.push(rawBefore);
+      rawBeforeById.set(input.id, rawBefore);
 
       for (const formattedRecord of this.formatResult<ObjectRecord[]>(
         rawBefore,
@@ -1037,7 +1045,7 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
         updatedColumns: Object.keys(setColumns),
       });
 
-      const rawBeforeForInput = rawBeforeByInputIndex[index];
+      const rawBeforeForInput = rawBeforeById.get(input.id) ?? [];
 
       recordsBefore.push(...rawBeforeForInput);
 
@@ -1070,15 +1078,16 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
             noFormatting: true,
           });
 
-      recordsAfter.push(
-        ...mergeReturnedUpdateTimestamps(
-          mergeRecordsWithUpdateValues(
-            getUpdateEventRecords(rawBeforeForInput, recordsAfterWrite),
-            setColumns,
-          ),
-          result.generatedMaps as ObjectRecord[],
+      const recordsAfterForInput = mergeReturnedUpdateTimestamps(
+        mergeRecordsWithUpdateValues(
+          getUpdateEventRecords(rawBeforeForInput, recordsAfterWrite),
+          setColumns,
         ),
+        result.generatedMaps as ObjectRecord[],
       );
+
+      recordsAfter.push(...recordsAfterForInput);
+      rawBeforeById.set(input.id, recordsAfterForInput);
     }
 
     if (isDefined(filesFieldFileIds)) {
@@ -1439,16 +1448,36 @@ export class WorkspaceRepository<TEntity extends ObjectLiteral = ObjectRecord> {
     const formattedAfter = isDefined(recordsAfter)
       ? this.formatResult<ObjectRecord[]>(recordsAfter)
       : undefined;
+    const isRestoredAtIndex = (index: number) =>
+      isDefined(formattedBefore[index]?.deletedAt) &&
+      !isDefined(formattedAfter?.[index]?.deletedAt);
 
     for (const action of actions) {
+      const shouldIncludeAllRecords =
+        kind !== 'update' || action === DatabaseEventAction.UPSERTED;
+      const shouldIncludeRecordAtIndex = (index: number) =>
+        action === DatabaseEventAction.RESTORED
+          ? isRestoredAtIndex(index)
+          : !isRestoredAtIndex(index);
+      const recordsBeforeForAction = shouldIncludeAllRecords
+        ? formattedBefore
+        : formattedBefore.filter((_, index) =>
+            shouldIncludeRecordAtIndex(index),
+          );
+      const recordsAfterForAction = shouldIncludeAllRecords
+        ? formattedAfter
+        : formattedAfter?.filter((_, index) =>
+            shouldIncludeRecordAtIndex(index),
+          );
+
       const event = formatTwentyOrmEventToDatabaseBatchEvent({
         action,
         objectMetadataItem: this.options.flatObjectMetadata,
         flatFieldMetadataMaps:
           this.options.internalContext.flatFieldMetadataMaps,
         workspaceId: this.options.internalContext.workspaceId,
-        recordsBefore: formattedBefore,
-        recordsAfter: formattedAfter,
+        recordsBefore: recordsBeforeForAction,
+        recordsAfter: recordsAfterForAction,
         authContext: this.options.authContext,
       });
 

--- a/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/timeline/timeline-activity-write-path.integration-spec.ts
@@ -1,4 +1,5 @@
 import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
 import { destroyOneOperationFactory } from 'test/integration/graphql/utils/destroy-one-operation-factory.util';
 import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
 import { updateManyOperationFactory } from 'test/integration/graphql/utils/update-many-operation-factory.util';
@@ -563,7 +564,7 @@ describe('timeline activity write path (integration)', () => {
       });
     });
 
-    it('should write a linked entry on the company when the note target is deleted', async () => {
+    it('should write one re-link entry when a deleted note target is upserted twice', async () => {
       await makeGraphqlAPIRequest(
         deleteOneOperationFactory({
           objectMetadataSingularName: 'noteTarget',
@@ -584,6 +585,60 @@ describe('timeline activity write path (integration)', () => {
 
       expect(timelineActivities).toHaveLength(1);
       expect(timelineActivities[0].linkedRecordId).toBe(NOTE_ID);
+
+      const linkedTimelineActivitiesBeforeRestore =
+        await findTimelineActivities({
+          targetCompanyId: { eq: NOTE_COMPANY_ID },
+          timelineActivityTypeId: {
+            eq: timelineActivityTypeIdForOrThrow(
+              'linked',
+              NOTE_UNIVERSAL_IDENTIFIER,
+            ),
+          },
+        });
+
+      expect(linkedTimelineActivitiesBeforeRestore).toHaveLength(1);
+
+      // Keep the original link outside the deliberate activity merge window,
+      // so the final count detects both missing and duplicate restore events.
+      await global.testDataSource.query(
+        `UPDATE "${TEST_SCHEMA_NAME}"."timelineActivity" SET "createdAt" = NOW() - INTERVAL '11 minutes' WHERE "id" = $1`,
+        [linkedTimelineActivitiesBeforeRestore[0].id],
+      );
+
+      const restoreResponse = await makeGraphqlAPIRequest(
+        createManyOperationFactory({
+          objectMetadataSingularName: 'noteTarget',
+          objectMetadataPluralName: 'noteTargets',
+          gqlFields: 'id',
+          data: [
+            {
+              noteId: NOTE_ID,
+              targetCompanyId: NOTE_COMPANY_ID,
+            },
+            {
+              noteId: NOTE_ID,
+              targetCompanyId: NOTE_COMPANY_ID,
+            },
+          ],
+          upsert: true,
+        }),
+      );
+
+      expect(restoreResponse.body.errors).toBeUndefined();
+
+      const linkedTimelineActivities = await findTimelineActivities({
+        targetCompanyId: { eq: NOTE_COMPANY_ID },
+        timelineActivityTypeId: {
+          eq: timelineActivityTypeIdForOrThrow(
+            'linked',
+            NOTE_UNIVERSAL_IDENTIFIER,
+          ),
+        },
+      });
+
+      expect(linkedTimelineActivities).toHaveLength(2);
+      expect(linkedTimelineActivities[1].linkedRecordId).toBe(NOTE_ID);
     });
   });
 


### PR DESCRIPTION
## Problem

After #25200, re-adding a previously removed task or note relation correctly revives its soft-deleted junction row, but no linked timeline activity or restored webhook is emitted. The upsert update path emits UPDATED and UPSERTED; consumers deliberately do not subscribe to UPSERTED because every insert/update also emits it.

## Fix

Classify soft-deleted-to-live transitions at the shared workspace repository event boundary. Restored rows emit RESTORED (plus the existing UPSERTED compatibility event), while ordinary rows in the same batch continue to emit UPDATED. No junction-specific listener or metadata path is added.

Add an integration regression covering note target delete then upsert: the original link, unlink, and re-link timeline entries must all be present.

## Validation

- Server typecheck
- Event formatting unit tests
- Timeline action routing unit tests
- Prettier and diff checks
- The focused integration suite requires the provisioned test database and will run in CI

Follow-up to #25200 and its QA Scout finding.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

