### PR TITLE
Support legacy activity target columns during upgrade

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788425677783-enforce-activity-target-uniqueness.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788425677783-enforce-activity-target-uniqueness.command.ts
@@ -11,8 +11,8 @@ import { rebindFlatIndexToWorkspaceColumns } from 'src/database/commands/upgrade
 import { resolveActivityTargetColumns } from 'src/database/commands/upgrade-version-command/2-38/utils/resolve-activity-target-columns.util';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { findManyFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-many-flat-entity-by-id-in-flat-entity-maps.util';
 import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
@@ -191,13 +191,10 @@ export class EnforceActivityTargetUniquenessCommand extends ProvisionedWorkspace
         return rebindFlatIndexToWorkspaceColumns({
           flatIndexMetadata: standardFlatIndexMetadata,
           flatObjectMetadata,
-          objectFlatFieldMetadatas: Object.values(
-            flatFieldMetadataMaps.byUniversalIdentifier,
-          ).filter(
-            (flatFieldMetadata): flatFieldMetadata is FlatFieldMetadata =>
-              isDefined(flatFieldMetadata) &&
-              flatFieldMetadata.objectMetadataId === flatObjectMetadata.id,
-          ),
+          objectFlatFieldMetadatas: findManyFlatEntityByIdInFlatEntityMaps({
+            flatEntityMaps: flatFieldMetadataMaps,
+            flatEntityIds: flatObjectMetadata.fieldIds,
+          }),
           columnNames,
         });
       },

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788425677783-enforce-activity-target-uniqueness.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/2-38-workspace-command-1788425677783-enforce-activity-target-uniqueness.command.ts
@@ -7,8 +7,12 @@ import { WorkspaceIteratorService } from 'src/database/commands/command-runners/
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
 import { getStandardFlatEntitiesToCreateOrThrow } from 'src/database/commands/upgrade-version-command/2-10/utils/get-standard-flat-entities-to-create-or-throw.util';
 import { buildDuplicateActivityTargetQuery } from 'src/database/commands/upgrade-version-command/2-38/utils/build-duplicate-activity-target-query.util';
+import { rebindFlatIndexToWorkspaceColumns } from 'src/database/commands/upgrade-version-command/2-38/utils/rebind-flat-index-to-workspace-columns.util';
+import { resolveActivityTargetColumns } from 'src/database/commands/upgrade-version-command/2-38/utils/resolve-activity-target-columns.util';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
@@ -17,22 +21,31 @@ import { WorkspaceMigrationBuilderException } from 'src/engine/workspace-manager
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
 
 const ACTIVITY_TARGET_CONFIGS = [
-  { tableName: 'taskTarget', parentColumnName: 'taskId' },
-  { tableName: 'noteTarget', parentColumnName: 'noteId' },
+  {
+    tableName: 'taskTarget',
+    parentColumnName: 'taskId',
+    uniqueIndexUniversalIdentifiers: [
+      STANDARD_OBJECTS.taskTarget.indexes.taskPersonUniqueIndex
+        .universalIdentifier,
+      STANDARD_OBJECTS.taskTarget.indexes.taskCompanyUniqueIndex
+        .universalIdentifier,
+      STANDARD_OBJECTS.taskTarget.indexes.taskOpportunityUniqueIndex
+        .universalIdentifier,
+    ],
+  },
+  {
+    tableName: 'noteTarget',
+    parentColumnName: 'noteId',
+    uniqueIndexUniversalIdentifiers: [
+      STANDARD_OBJECTS.noteTarget.indexes.notePersonUniqueIndex
+        .universalIdentifier,
+      STANDARD_OBJECTS.noteTarget.indexes.noteCompanyUniqueIndex
+        .universalIdentifier,
+      STANDARD_OBJECTS.noteTarget.indexes.noteOpportunityUniqueIndex
+        .universalIdentifier,
+    ],
+  },
 ] as const;
-
-const ACTIVITY_TARGET_UNIQUE_INDEX_UNIVERSAL_IDENTIFIERS = [
-  STANDARD_OBJECTS.taskTarget.indexes.taskPersonUniqueIndex.universalIdentifier,
-  STANDARD_OBJECTS.taskTarget.indexes.taskCompanyUniqueIndex
-    .universalIdentifier,
-  STANDARD_OBJECTS.taskTarget.indexes.taskOpportunityUniqueIndex
-    .universalIdentifier,
-  STANDARD_OBJECTS.noteTarget.indexes.notePersonUniqueIndex.universalIdentifier,
-  STANDARD_OBJECTS.noteTarget.indexes.noteCompanyUniqueIndex
-    .universalIdentifier,
-  STANDARD_OBJECTS.noteTarget.indexes.noteOpportunityUniqueIndex
-    .universalIdentifier,
-];
 
 @RegisteredWorkspaceCommand('2.38.0', 1788425677783)
 @Command({
@@ -85,23 +98,63 @@ export class EnforceActivityTargetUniquenessCommand extends ProvisionedWorkspace
     }
 
     let duplicateCount = 0;
+    const uniqueIndexUniversalIdentifiers: string[] = [];
+    const columnNamesByIndexUniversalIdentifier = new Map<string, string[]>();
 
     for (const targetConfig of ACTIVITY_TARGET_CONFIGS) {
+      const rows = await dataSource.query<Array<{ column_name: string }>>(
+        `SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2`,
+        [schemaName, targetConfig.tableName],
+      );
+      const targetColumns = resolveActivityTargetColumns(
+        new Set(rows.map(({ column_name }) => column_name)),
+      );
+
+      if (!isDefined(targetColumns)) {
+        this.logger.error(
+          `MANUAL REPAIR REQUIRED: skipping activity target uniqueness for ${targetConfig.tableName} in workspace ${workspaceId}: expected target columns are incomplete`,
+        );
+
+        continue;
+      }
+
       const [result] = await dataSource.query<Array<{ count: number }>>(
         buildDuplicateActivityTargetQuery({
           schemaName,
-          ...targetConfig,
+          tableName: targetConfig.tableName,
+          parentColumnName: targetConfig.parentColumnName,
+          targetColumns,
           deleteDuplicates: !options.dryRun,
         }),
       );
 
       duplicateCount += result?.count ?? 0;
+      uniqueIndexUniversalIdentifiers.push(
+        ...targetConfig.uniqueIndexUniversalIdentifiers,
+      );
+      targetColumns.forEach((targetColumn, index) => {
+        const uniqueIndexUniversalIdentifier =
+          targetConfig.uniqueIndexUniversalIdentifiers[index];
+
+        if (!isDefined(uniqueIndexUniversalIdentifier)) {
+          throw new Error(
+            `Could not resolve activity target index at position ${index}`,
+          );
+        }
+
+        columnNamesByIndexUniversalIdentifier.set(
+          uniqueIndexUniversalIdentifier,
+          [targetConfig.parentColumnName, targetColumn.columnName],
+        );
+      });
     }
 
-    const { flatIndexMaps } = await this.workspaceCacheService.getOrRecompute(
-      workspaceId,
-      ['flatIndexMaps'],
-    );
+    const { flatIndexMaps, flatFieldMetadataMaps, flatObjectMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatIndexMaps',
+        'flatFieldMetadataMaps',
+        'flatObjectMetadataMaps',
+      ]);
     const { twentyStandardFlatApplication } =
       await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
         { workspaceId },
@@ -112,13 +165,43 @@ export class EnforceActivityTargetUniquenessCommand extends ProvisionedWorkspace
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,
       });
-    const indexesToCreate =
+    const standardIndexesToCreate =
       getStandardFlatEntitiesToCreateOrThrow<FlatIndexMetadata>({
         standardFlatEntityMaps: standardAllFlatEntityMaps.flatIndexMaps,
         existingFlatEntityMaps: flatIndexMaps,
-        universalIdentifiers:
-          ACTIVITY_TARGET_UNIQUE_INDEX_UNIVERSAL_IDENTIFIERS,
+        universalIdentifiers: uniqueIndexUniversalIdentifiers,
       });
+    const indexesToCreate = standardIndexesToCreate.map(
+      (standardFlatIndexMetadata) => {
+        const flatObjectMetadata = findFlatEntityByUniversalIdentifierOrThrow({
+          universalIdentifier:
+            standardFlatIndexMetadata.objectMetadataUniversalIdentifier,
+          flatEntityMaps: flatObjectMetadataMaps,
+        });
+        const columnNames = columnNamesByIndexUniversalIdentifier.get(
+          standardFlatIndexMetadata.universalIdentifier,
+        );
+
+        if (!isDefined(columnNames)) {
+          throw new Error(
+            `Could not resolve columns for activity target index ${standardFlatIndexMetadata.universalIdentifier}`,
+          );
+        }
+
+        return rebindFlatIndexToWorkspaceColumns({
+          flatIndexMetadata: standardFlatIndexMetadata,
+          flatObjectMetadata,
+          objectFlatFieldMetadatas: Object.values(
+            flatFieldMetadataMaps.byUniversalIdentifier,
+          ).filter(
+            (flatFieldMetadata): flatFieldMetadata is FlatFieldMetadata =>
+              isDefined(flatFieldMetadata) &&
+              flatFieldMetadata.objectMetadataId === flatObjectMetadata.id,
+          ),
+          columnNames,
+        });
+      },
+    );
 
     this.logger.log(
       `${options.dryRun ? '[DRY RUN] Would remove' : 'Removed'} ${duplicateCount} duplicate activity target(s) and ${options.dryRun ? 'would create' : 'will create'} ${indexesToCreate.length} unique index(es) for workspace ${workspaceId}`,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-duplicate-activity-target-query.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/build-duplicate-activity-target-query.util.spec.ts
@@ -4,7 +4,15 @@ const QUERY_ARGS = {
   schemaName: 'workspace_123',
   tableName: 'taskTarget',
   parentColumnName: 'taskId',
-};
+  targetColumns: [
+    { type: 'person', columnName: 'targetPersonId' },
+    { type: 'company', columnName: 'targetCompanyId' },
+    { type: 'opportunity', columnName: 'targetOpportunityId' },
+  ],
+} satisfies Omit<
+  Parameters<typeof buildDuplicateActivityTargetQuery>[0],
+  'deleteDuplicates'
+>;
 
 describe('buildDuplicateActivityTargetQuery', () => {
   it('partitions each morph target type independently and deletes duplicates', () => {
@@ -22,8 +30,24 @@ describe('buildDuplicateActivityTargetQuery', () => {
     expect(query).toContain(
       'ORDER BY\n          ("activityTarget"."deletedAt" IS NULL) DESC',
     );
+    expect(query).toContain('DELETE FROM "workspace_123"."taskTarget"');
+  });
+
+  it('supports legacy activity target column names', () => {
+    const query = buildDuplicateActivityTargetQuery({
+      ...QUERY_ARGS,
+      targetColumns: [
+        { type: 'person', columnName: 'personId' },
+        { type: 'company', columnName: 'companyId' },
+        { type: 'opportunity', columnName: 'opportunityId' },
+      ],
+      deleteDuplicates: true,
+    });
+
+    expect(query).toContain(`('person', "activityTarget"."personId")`);
+    expect(query).toContain(`('company', "activityTarget"."companyId")`);
     expect(query).toContain(
-      'DELETE FROM "workspace_123"."taskTarget"',
+      `('opportunity', "activityTarget"."opportunityId")`,
     );
   });
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/rebind-flat-index-to-workspace-columns.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/rebind-flat-index-to-workspace-columns.util.spec.ts
@@ -1,0 +1,116 @@
+import {
+  FieldMetadataType,
+  IndexType,
+  RelationType,
+} from 'twenty-shared/types';
+
+import { rebindFlatIndexToWorkspaceColumns } from 'src/database/commands/upgrade-version-command/2-38/utils/rebind-flat-index-to-workspace-columns.util';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { getFlatIndexMetadataMock } from 'src/engine/metadata-modules/flat-index-metadata/__mocks__/get-flat-index-metadata.mock';
+import { TASK_TARGET_FLAT_OBJECT_MOCK } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/task-target-flat-object.mock';
+
+const CREATED_AT = '2026-09-04T00:00:00.000Z';
+const INDEX_ID = 'index-id';
+const INDEX_UNIVERSAL_IDENTIFIER = '4adf4d5a-ad69-4c5c-bc62-2807816b3aa8';
+
+const taskField = getFlatFieldMetadataMock({
+  id: 'legacy-task-field-id',
+  universalIdentifier: 'legacy-task-field-universal-identifier',
+  objectMetadataId: TASK_TARGET_FLAT_OBJECT_MOCK.id,
+  type: FieldMetadataType.RELATION,
+  name: 'task',
+  settings: {
+    relationType: RelationType.MANY_TO_ONE,
+    joinColumnName: 'taskId',
+  },
+  universalSettings: {
+    relationType: RelationType.MANY_TO_ONE,
+    joinColumnName: 'taskId',
+  },
+});
+const personField = getFlatFieldMetadataMock({
+  id: 'legacy-person-field-id',
+  universalIdentifier: 'legacy-person-field-universal-identifier',
+  objectMetadataId: TASK_TARGET_FLAT_OBJECT_MOCK.id,
+  type: FieldMetadataType.RELATION,
+  name: 'person',
+  settings: {
+    relationType: RelationType.MANY_TO_ONE,
+    joinColumnName: 'personId',
+  },
+  universalSettings: {
+    relationType: RelationType.MANY_TO_ONE,
+    joinColumnName: 'personId',
+  },
+});
+const flatIndexMetadata = getFlatIndexMetadataMock({
+  id: INDEX_ID,
+  universalIdentifier: INDEX_UNIVERSAL_IDENTIFIER,
+  objectMetadataId: 'standard-task-target-object-id',
+  objectMetadataUniversalIdentifier:
+    TASK_TARGET_FLAT_OBJECT_MOCK.universalIdentifier,
+  applicationUniversalIdentifier:
+    TASK_TARGET_FLAT_OBJECT_MOCK.applicationUniversalIdentifier,
+  indexType: IndexType.BTREE,
+  indexWhereClause: '"deletedAt" IS NULL',
+  isUnique: true,
+  name: 'standard-index-name',
+  flatIndexFieldMetadatas: [taskField, personField].map(
+    (fieldMetadata, order) => ({
+      id: `index-field-${order}`,
+      workspaceId: TASK_TARGET_FLAT_OBJECT_MOCK.workspaceId,
+      indexMetadataId: INDEX_ID,
+      fieldMetadataId: `standard-field-${order}`,
+      order,
+      subFieldName: null,
+      createdAt: CREATED_AT,
+      updatedAt: CREATED_AT,
+    }),
+  ),
+  universalFlatIndexFieldMetadatas: [taskField, personField].map(
+    (_, order) => ({
+      indexMetadataUniversalIdentifier: INDEX_UNIVERSAL_IDENTIFIER,
+      fieldMetadataUniversalIdentifier: `standard-field-${order}`,
+      order,
+      subFieldName: null,
+      createdAt: CREATED_AT,
+      updatedAt: CREATED_AT,
+    }),
+  ),
+});
+
+describe('rebindFlatIndexToWorkspaceColumns', () => {
+  it('binds index fields and its name to legacy workspace relations', () => {
+    const result = rebindFlatIndexToWorkspaceColumns({
+      flatIndexMetadata,
+      flatObjectMetadata: TASK_TARGET_FLAT_OBJECT_MOCK,
+      objectFlatFieldMetadatas: [taskField, personField],
+      columnNames: ['taskId', 'personId'],
+    });
+
+    expect(result.objectMetadataId).toBe(TASK_TARGET_FLAT_OBJECT_MOCK.id);
+    expect(
+      result.flatIndexFieldMetadatas.map(
+        ({ fieldMetadataId }) => fieldMetadataId,
+      ),
+    ).toEqual([taskField.id, personField.id]);
+    expect(
+      result.universalFlatIndexFieldMetadatas.map(
+        ({ fieldMetadataUniversalIdentifier }) =>
+          fieldMetadataUniversalIdentifier,
+      ),
+    ).toEqual([taskField.universalIdentifier, personField.universalIdentifier]);
+    expect(result.name).not.toBe(flatIndexMetadata.name);
+  });
+
+  it('throws when a workspace relation column cannot be resolved', () => {
+    expect(() =>
+      rebindFlatIndexToWorkspaceColumns({
+        flatIndexMetadata,
+        flatObjectMetadata: TASK_TARGET_FLAT_OBJECT_MOCK,
+        objectFlatFieldMetadatas: [taskField],
+        columnNames: ['taskId', 'personId'],
+      }),
+    ).toThrow('Could not find relation field for column personId');
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/resolve-activity-target-columns.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/__tests__/resolve-activity-target-columns.util.spec.ts
@@ -1,0 +1,40 @@
+import { resolveActivityTargetColumns } from 'src/database/commands/upgrade-version-command/2-38/utils/resolve-activity-target-columns.util';
+
+describe('resolveActivityTargetColumns', () => {
+  it('prefers the current column names', () => {
+    expect(
+      resolveActivityTargetColumns(
+        new Set([
+          'targetPersonId',
+          'personId',
+          'targetCompanyId',
+          'companyId',
+          'targetOpportunityId',
+          'opportunityId',
+        ]),
+      ),
+    ).toEqual([
+      { type: 'person', columnName: 'targetPersonId' },
+      { type: 'company', columnName: 'targetCompanyId' },
+      { type: 'opportunity', columnName: 'targetOpportunityId' },
+    ]);
+  });
+
+  it('falls back to the legacy column names', () => {
+    expect(
+      resolveActivityTargetColumns(
+        new Set(['personId', 'companyId', 'opportunityId']),
+      ),
+    ).toEqual([
+      { type: 'person', columnName: 'personId' },
+      { type: 'company', columnName: 'companyId' },
+      { type: 'opportunity', columnName: 'opportunityId' },
+    ]);
+  });
+
+  it('returns undefined when a target column is missing', () => {
+    expect(
+      resolveActivityTargetColumns(new Set(['personId', 'companyId'])),
+    ).toBeUndefined();
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-duplicate-activity-target-query.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/build-duplicate-activity-target-query.util.ts
@@ -1,12 +1,16 @@
+import { type ActivityTargetColumn } from 'src/database/commands/upgrade-version-command/2-38/utils/resolve-activity-target-columns.util';
+
 export const buildDuplicateActivityTargetQuery = ({
   schemaName,
   tableName,
   parentColumnName,
+  targetColumns,
   deleteDuplicates,
 }: {
   schemaName: string;
   tableName: string;
   parentColumnName: string;
+  targetColumns: ActivityTargetColumn[];
   deleteDuplicates: boolean;
 }) => `
   WITH "rankedTargets" AS (
@@ -25,9 +29,12 @@ export const buildDuplicateActivityTargetQuery = ({
     FROM "${schemaName}"."${tableName}" "activityTarget"
     CROSS JOIN LATERAL (
       VALUES
-        ('person', "activityTarget"."targetPersonId"),
-        ('company', "activityTarget"."targetCompanyId"),
-        ('opportunity', "activityTarget"."targetOpportunityId")
+${targetColumns
+  .map(
+    ({ type, columnName }) =>
+      `        ('${type}', "activityTarget"."${columnName}")`,
+  )
+  .join(',\n')}
     ) AS "target"("type", "id")
     WHERE "target"."id" IS NOT NULL
   ),

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/rebind-flat-index-to-workspace-columns.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/rebind-flat-index-to-workspace-columns.util.ts
@@ -1,0 +1,90 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { getJoinColumnNameForRelationField } from 'src/engine/metadata-modules/field-metadata/utils/get-join-column-name-for-relation-field.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
+import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { computeFlatIndexNameOrThrow } from 'src/engine/metadata-modules/index-metadata/utils/compute-flat-index-name.util';
+
+export const rebindFlatIndexToWorkspaceColumns = ({
+  flatIndexMetadata,
+  flatObjectMetadata,
+  objectFlatFieldMetadatas,
+  columnNames,
+}: {
+  flatIndexMetadata: FlatIndexMetadata;
+  flatObjectMetadata: FlatObjectMetadata;
+  objectFlatFieldMetadatas: FlatFieldMetadata[];
+  columnNames: string[];
+}): FlatIndexMetadata => {
+  const flatFieldMetadatas = columnNames.map((columnName) => {
+    const flatFieldMetadata = objectFlatFieldMetadatas.find(
+      (candidateFlatFieldMetadata) =>
+        isMorphOrRelationFlatFieldMetadata(candidateFlatFieldMetadata) &&
+        getJoinColumnNameForRelationField(candidateFlatFieldMetadata) ===
+          columnName,
+    );
+
+    if (!isDefined(flatFieldMetadata)) {
+      throw new Error(
+        `Could not find relation field for column ${columnName} on object ${flatObjectMetadata.nameSingular}`,
+      );
+    }
+
+    return flatFieldMetadata;
+  });
+
+  const flatIndexFieldMetadatas = flatFieldMetadatas.map(
+    (flatFieldMetadata, order) => {
+      const templateFlatIndexFieldMetadata =
+        flatIndexMetadata.flatIndexFieldMetadatas.find(
+          (flatIndexFieldMetadata) => flatIndexFieldMetadata.order === order,
+        );
+
+      if (!isDefined(templateFlatIndexFieldMetadata)) {
+        throw new Error(
+          `Could not find index field at order ${order} for index ${flatIndexMetadata.universalIdentifier}`,
+        );
+      }
+
+      return {
+        ...templateFlatIndexFieldMetadata,
+        fieldMetadataId: flatFieldMetadata.id,
+      };
+    },
+  );
+  const universalFlatIndexFieldMetadatas = flatFieldMetadatas.map(
+    (flatFieldMetadata, order) => {
+      const templateUniversalFlatIndexFieldMetadata =
+        flatIndexMetadata.universalFlatIndexFieldMetadatas.find(
+          (flatIndexFieldMetadata) => flatIndexFieldMetadata.order === order,
+        );
+
+      if (!isDefined(templateUniversalFlatIndexFieldMetadata)) {
+        throw new Error(
+          `Could not find universal index field at order ${order} for index ${flatIndexMetadata.universalIdentifier}`,
+        );
+      }
+
+      return {
+        ...templateUniversalFlatIndexFieldMetadata,
+        fieldMetadataUniversalIdentifier: flatFieldMetadata.universalIdentifier,
+      };
+    },
+  );
+
+  return {
+    ...flatIndexMetadata,
+    name: computeFlatIndexNameOrThrow({
+      flatObjectMetadata,
+      objectFlatFieldMetadatas,
+      indexFields: universalFlatIndexFieldMetadatas,
+      isUnique: flatIndexMetadata.isUnique,
+      indexWhereClause: flatIndexMetadata.indexWhereClause,
+    }),
+    objectMetadataId: flatObjectMetadata.id,
+    flatIndexFieldMetadatas,
+    universalFlatIndexFieldMetadatas,
+  };
+};

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/resolve-activity-target-columns.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/resolve-activity-target-columns.util.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 export const ACTIVITY_TARGET_COLUMN_CANDIDATES = [
   {
     type: 'person',
@@ -13,10 +15,15 @@ export const ACTIVITY_TARGET_COLUMN_CANDIDATES = [
   },
 ] as const;
 
+type ActivityTargetColumnCandidate =
+  (typeof ACTIVITY_TARGET_COLUMN_CANDIDATES)[number];
+
 export type ActivityTargetColumn = {
-  type: (typeof ACTIVITY_TARGET_COLUMN_CANDIDATES)[number]['type'];
-  columnName: (typeof ACTIVITY_TARGET_COLUMN_CANDIDATES)[number]['columnNames'][number];
-};
+  [TCandidate in ActivityTargetColumnCandidate as TCandidate['type']]: {
+    type: TCandidate['type'];
+    columnName: TCandidate['columnNames'][number];
+  };
+}[ActivityTargetColumnCandidate['type']];
 
 export const resolveActivityTargetColumns = (
   existingColumnNames: Set<string>,
@@ -27,13 +34,13 @@ export const resolveActivityTargetColumns = (
         existingColumnNames.has(candidateColumnName),
       );
 
-      return columnName === undefined ? undefined : { type, columnName };
+      return isDefined(columnName) ? { type, columnName } : undefined;
     },
   );
 
   return targetColumns.every(
     (targetColumn): targetColumn is ActivityTargetColumn =>
-      targetColumn !== undefined,
+      isDefined(targetColumn),
   )
     ? targetColumns
     : undefined;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/resolve-activity-target-columns.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-38/utils/resolve-activity-target-columns.util.ts
@@ -1,0 +1,40 @@
+export const ACTIVITY_TARGET_COLUMN_CANDIDATES = [
+  {
+    type: 'person',
+    columnNames: ['targetPersonId', 'personId'],
+  },
+  {
+    type: 'company',
+    columnNames: ['targetCompanyId', 'companyId'],
+  },
+  {
+    type: 'opportunity',
+    columnNames: ['targetOpportunityId', 'opportunityId'],
+  },
+] as const;
+
+export type ActivityTargetColumn = {
+  type: (typeof ACTIVITY_TARGET_COLUMN_CANDIDATES)[number]['type'];
+  columnName: (typeof ACTIVITY_TARGET_COLUMN_CANDIDATES)[number]['columnNames'][number];
+};
+
+export const resolveActivityTargetColumns = (
+  existingColumnNames: Set<string>,
+): ActivityTargetColumn[] | undefined => {
+  const targetColumns = ACTIVITY_TARGET_COLUMN_CANDIDATES.map(
+    ({ type, columnNames }) => {
+      const columnName = columnNames.find((candidateColumnName) =>
+        existingColumnNames.has(candidateColumnName),
+      );
+
+      return columnName === undefined ? undefined : { type, columnName };
+    },
+  );
+
+  return targetColumns.every(
+    (targetColumn): targetColumn is ActivityTargetColumn =>
+      targetColumn !== undefined,
+  )
+    ? targetColumns
+    : undefined;
+};


### PR DESCRIPTION
## Summary
- resolve activity-target columns from the physical workspace schema
- prefer current target-prefixed columns while supporting legacy person/company/opportunity columns
- skip incomplete target tables and their indexes with an explicit manual-repair log

## Why
The 2.38.0 main upgrade reached 64 successful workspaces but failed on 9 legacy workspaces because their taskTarget/noteTarget metadata and physical schema still use personId, companyId, and opportunityId. The cleanup query assumed targetPersonId, targetCompanyId, and targetOpportunityId.

## Verification
- focused Jest: 2 suites, 6 tests passed
- Prettier check passed
- diff lint completed with no errors (one unrelated existing warning)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

