### PR TITLE
feat(slack): log Slack event retry deliveries

### DIFF
--- a/packages/twenty-apps/public/slack/src/logic-functions/slack-events-resolver.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/slack-events-resolver.ts
@@ -15,6 +15,7 @@ import {
 import { type SlackEventsRequestBody } from 'src/logic-functions/types/slack-events-request-body.type';
 import { findClaimedWorkspaceId } from 'src/logic-functions/utils/find-claimed-workspace-id';
 import { resolveTargetWorkspaceId } from 'src/logic-functions/utils/resolve-target-workspace-id';
+import { logSlackRetryDelivery } from 'src/logic-functions/utils/log-slack-retry-delivery';
 import { verifySlackWebhookRequestOrThrow } from 'src/logic-functions/utils/verify-slack-webhook-request-or-throw';
 
 type SlackEventsResolverResult =
@@ -29,6 +30,8 @@ export const slackEventsResolverHandler = async (
   routePayload: RoutePayload<SlackEventsRequestBody>,
 ): Promise<SlackEventsResolverResult> => {
   verifySlackWebhookRequestOrThrow(routePayload);
+
+  logSlackRetryDelivery({ headers: routePayload.headers, source: 'events' });
 
   const body = routePayload.body;
 
@@ -104,6 +107,11 @@ export default defineLogicFunction({
   timeoutSeconds: 15,
   handler: slackEventsResolverHandler,
   serverRouteTriggerSettings: {
-    forwardedRequestHeaders: ['x-slack-signature', 'x-slack-request-timestamp'],
+    forwardedRequestHeaders: [
+      'x-slack-signature',
+      'x-slack-request-timestamp',
+      'x-slack-retry-num',
+      'x-slack-retry-reason',
+    ],
   },
 });

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/log-slack-retry-delivery.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/log-slack-retry-delivery.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { logSlackRetryDelivery } from 'src/logic-functions/utils/log-slack-retry-delivery';
+
+describe('logSlackRetryDelivery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should not log when the request is a first delivery', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    logSlackRetryDelivery({
+      headers: { 'x-slack-signature': 'v0=abc' },
+      source: 'events',
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('should log the attempt and reason when the request is a retry', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    logSlackRetryDelivery({
+      headers: {
+        'x-slack-retry-num': '2',
+        'x-slack-retry-reason': 'http_timeout',
+      },
+      source: 'events',
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      '[slack] events retry delivery: attempt 2, reason http_timeout',
+    );
+  });
+
+  it('should fall back to an unknown reason when Slack omits it', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    logSlackRetryDelivery({
+      headers: { 'x-slack-retry-num': '1' },
+      source: 'events',
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      '[slack] events retry delivery: attempt 1, reason unknown',
+    );
+  });
+
+  it('should fall back to an unknown reason when Slack sends an empty one', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    logSlackRetryDelivery({
+      headers: { 'x-slack-retry-num': '1', 'x-slack-retry-reason': '' },
+      source: 'events',
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      '[slack] events retry delivery: attempt 1, reason unknown',
+    );
+  });
+});

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/log-slack-retry-delivery.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/log-slack-retry-delivery.ts
@@ -1,0 +1,23 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
+export const logSlackRetryDelivery = ({
+  headers,
+  source,
+}: {
+  headers: Record<string, string | undefined>;
+  source: string;
+}): void => {
+  const retryNum = headers['x-slack-retry-num'];
+
+  if (!isNonEmptyString(retryNum)) {
+    return;
+  }
+
+  const retryReason = isNonEmptyString(headers['x-slack-retry-reason'])
+    ? headers['x-slack-retry-reason']
+    : 'unknown';
+
+  console.warn(
+    `[slack] ${source} retry delivery: attempt ${retryNum}, reason ${retryReason}`,
+  );
+};


### PR DESCRIPTION
## Why

Slack re-delivers an Events API event when it does not receive a 200 within 3 seconds, up to three times. The resolver's own work is cheap (an HMAC check and a KV read before it queues the job), but a cold logic-function sandbox can push the ack past 3s, and `timeoutSeconds` on the resolver is 15.

Two costs follow from a retry, neither previously visible:

- each re-delivery is a billed logic-function invocation
- sustained retries get event delivery disabled for the app by Slack

Correctness was never at risk: the unique index on `(slackChannelId, slackMessageTimestamp)` dedupes the re-deliveries, so the bot answers once. But the retry rate was unobservable, because `x-slack-retry-num` was not in the resolver's `forwardedRequestHeaders`, so a retry reached the handler looking identical to a first delivery.

## What

- Forward `x-slack-retry-num` and `x-slack-retry-reason` on the events resolver.
- Log a line when a retry arrives (`logSlackRetryDelivery`), after signature verification so only genuine Slack requests are counted.

No behavior change: this only surfaces a number. It does not try to reduce retries; that is a separate question (measure resolver p95 cold vs warm) this change makes answerable.

Only the Events API uses this retry mechanism, so the interactivity resolver is deliberately left untouched rather than carrying a header that never arrives.

## Test plan

- 3 unit tests on the logger: first delivery is silent, a retry logs its attempt and reason, a missing reason falls back to `unknown`
- `yarn typecheck`, `yarn lint`, `yarn test:unit` all clean (599 tests, 86 files)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

