### PR TITLE
fix(ai-chat) - fix AI chat drop zone flickering while dragging over its own content

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AiChatTab.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatTab.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@linaria/react';
-import { useState } from 'react';
+import { type DragEvent, useState } from 'react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { DropZone } from '@/activities/files/components/DropZone';
@@ -40,11 +40,21 @@ export const AiChatTab = () => {
 
   const { uploadFiles } = useAiChatFileUpload();
 
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return;
+    }
+
+    setIsDraggingFile(false);
+  };
+
   return (
     <StyledContainer
       isDraggingFile={isDraggingFile}
       onDragEnter={() => setIsDraggingFile(true)}
-      onDragLeave={() => setIsDraggingFile(false)}
+      onDragLeave={handleDragLeave}
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={(event) => event.preventDefault()}
     >
       <AgentChatHasBeenOpenedEffect />
       <AgentChatStreamingPartsDiffSyncEffect />

--- a/packages/twenty-front/src/modules/ai/components/AiChatTab.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatTab.tsx
@@ -41,10 +41,18 @@ export const AiChatTab = () => {
   const { uploadFiles } = useAiChatFileUpload();
 
   const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
-    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+    if (
+      event.relatedTarget instanceof Node &&
+      event.currentTarget.contains(event.relatedTarget)
+    ) {
       return;
     }
 
+    setIsDraggingFile(false);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
     setIsDraggingFile(false);
   };
 
@@ -54,7 +62,7 @@ export const AiChatTab = () => {
       onDragEnter={() => setIsDraggingFile(true)}
       onDragLeave={handleDragLeave}
       onDragOver={(event) => event.preventDefault()}
-      onDrop={(event) => event.preventDefault()}
+      onDrop={handleDrop}
     >
       <AgentChatHasBeenOpenedEffect />
       <AgentChatStreamingPartsDiffSyncEffect />


### PR DESCRIPTION
## Problem

Dropping a file in the AI chat fails often, and when it fails the browser opens the file in the tab.

The chat container resets `isDraggingFile` on every `dragleave`. `dragleave` bubbles, so moving the cursor from the drop zone's dashed area onto its own children (icon, "Upload files", "Drag and Drop Here") counts as a leave: the drop zone unmounts, the thread remounts, the next drag tick mounts the drop zone again, and so on while the pointer sits over the centre text. A release during an unmounted phase lands on nothing, and with no `dragover` preventDefault the browser navigates to the file.

Reproduced on prod and on main with a synthetic drag sequence, identical behaviour on both. Heavier threads widen the unmounted window, which is why prod feels worse.

## Fix

- Only reset `isDraggingFile` when the leave target is outside the container, so moving between the drop zone's children keeps it mounted. This keeps the reset from #19794 for dragging out of the chat without dropping.
- Prevent default on `dragover` and `drop` at the container so a stray drop is ignored instead of navigating the tab away.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


