### PR TITLE
fix(workflow): read core workflow versions under the caller's permissions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/services/core-workflow-version-list.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/core-workflow-version-list.service.ts
@@ -9,7 +9,6 @@ import { buildCoreWorkflowVersionLabel } from 'src/engine/core-modules/workflow/
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
-import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 
 @Injectable()
@@ -67,20 +66,14 @@ export class CoreWorkflowVersionListService {
     workspaceId: string;
     workspaceWorkflowVersionId: string;
   }): Promise<CoreWorkflowVersionDTO | null> {
-    const authContext = buildSystemAuthContext(workspaceId);
-
     const workspaceWorkflowVersion =
-      await this.workspaceOrmManager.executeInWorkspaceContext(
-        async () =>
-          this.workspaceOrmManager
-            .getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion', {
-              shouldBypassPermissionChecks: true,
-            })
-            .findOne({
-              where: { id: workspaceWorkflowVersionId },
-              select: { id: true, workflowId: true },
-            }),
-        authContext,
+      await this.workspaceOrmManager.executeInWorkspaceContext(async () =>
+        this.workspaceOrmManager
+          .getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion')
+          .findOne({
+            where: { id: workspaceWorkflowVersionId },
+            select: { id: true, workflowId: true },
+          }),
       );
 
     if (!isDefined(workspaceWorkflowVersion)) {
@@ -128,13 +121,9 @@ export class CoreWorkflowVersionListService {
       return {};
     }
 
-    const authContext = buildSystemAuthContext(workspaceId);
-
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const workspaceWorkflowVersions = await this.workspaceOrmManager
-        .getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion', {
-          shouldBypassPermissionChecks: true,
-        })
+        .getRepository<WorkflowVersionWorkspaceEntity>('workflowVersion')
         .find({
           where: {
             workflowId: workspaceWorkflowId,
@@ -155,6 +144,6 @@ export class CoreWorkflowVersionListService {
             : [],
         ),
       );
-    }, authContext);
+    });
   }
 }


### PR DESCRIPTION
The core workflow version queries (`coreWorkflowVersions`, `coreWorkflowVersion`) resolved the workspace `workflowVersion` twin under a **system** auth context with `shouldBypassPermissionChecks: true`. So a version's metadata and, for the single-version query, its full `trigger` and `steps` came back for anyone with the `WORKFLOWS` settings permission, regardless of their object-level read permission on `workflowVersion`. The workspace version page these queries replaced was object-read gated, so the move to core quietly loosened that.

## Change

`CoreWorkflowVersionListService` now resolves the workspace twin under the **caller's own** request context, with permission checks on:

- The system `buildSystemAuthContext` is dropped; `executeInWorkspaceContext` falls back to the request's `getWorkspaceAuthContext()`.
- The `workflowVersion` repository is taken without `shouldBypassPermissionChecks`, so the ORM applies the caller's role permissions.

A role that cannot read `workflowVersion` no longer resolves the twin, so the single-version query returns `null` (no `trigger`/`steps`) and the list returns versions with a null `workspaceWorkflowVersionId`. The resolver still gates the whole surface on the `WORKFLOWS` settings permission; this restores the object-level read check on top of it.

The service is only called from the request-scoped `CoreWorkflowResolver` (no jobs or crons), so the request context is always present.

## Verification

On a running instance, as an admin: the list still returns every version, the twin still resolves, and the single-version query still returns `label`, `status`, `trigger` and `steps`. So the caller context is available in the core resolver and a permitted role is unaffected.

The restricted-role path — a role without read on `workflowVersion` getting `null` — is enforced by the ORM's standard permission application when not bypassing. It is best covered by an integration test with a restricted role, which is left as a follow-up rather than asserted locally.

## Not here

The sibling `coreWorkflows` index query is on the same settings-gated surface and reads workspace data directly without object-level permission checks. This PR only tightens the version queries the review flagged; whether the index should enforce the same is a separate decision.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

