### PR TITLE
fix(workflow): blank step-editor tabs in the side panel

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useWorkflowCommandMenu.test.tsx
+++ b/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useWorkflowCommandMenu.test.tsx
@@ -174,11 +174,11 @@ describe('useSidePanelWorkflowNavigation', () => {
     const { result } = renderHooks();
 
     act(() => {
-      result.current.openWorkflowEditStepInSidePanel(
-        'test-workflow-id',
-        'Edit Step',
-        IconSettingsAutomation,
-      );
+      result.current.openWorkflowEditStepInSidePanel({
+        workflowId: 'test-workflow-id',
+        title: 'Edit Step',
+        icon: IconSettingsAutomation,
+      });
     });
 
     expect(result.current.sidePanelWorkflowId).toBe('test-workflow-id');

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation.ts
@@ -1,4 +1,6 @@
 import { useNavigateSidePanel } from '@/side-panel/hooks/useNavigateSidePanel';
+import { getWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { sidePanelWorkflowIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowIdComponentState';
 import { sidePanelWorkflowRunIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowRunIdComponentState';
 import { sidePanelWorkflowStepIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowStepIdComponentState';
@@ -72,8 +74,22 @@ export const useSidePanelWorkflowNavigation = () => {
       title: string,
       icon: IconComponent,
       stepId?: string,
+      initialStepTab?: { tabListComponentId: string; tabId: string },
     ) => {
       const pageId = v4();
+
+      if (isDefined(initialStepTab)) {
+        store.set(
+          activeTabIdComponentState.atomFamily({
+            instanceId: getWorkspaceSurfaceScopedComponentInstanceId({
+              componentInstanceId: initialStepTab.tabListComponentId,
+              surfaceType: 'side-panel',
+              surfaceInstanceId: pageId,
+            }),
+          }),
+          initialStepTab.tabId,
+        );
+      }
 
       store.set(
         sidePanelWorkflowIdComponentState.atomFamily({

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation.ts
@@ -69,13 +69,19 @@ export const useSidePanelWorkflowNavigation = () => {
   );
 
   const openWorkflowEditStepInSidePanel = useCallback(
-    (
-      workflowId: string,
-      title: string,
-      icon: IconComponent,
-      stepId?: string,
-      initialStepTab?: { tabListComponentId: string; tabId: string },
-    ) => {
+    ({
+      workflowId,
+      title,
+      icon,
+      stepId,
+      initialStepTab,
+    }: {
+      workflowId: string;
+      title: string;
+      icon: IconComponent;
+      stepId?: string;
+      initialStepTab?: { tabListComponentId: string; tabId: string };
+    }) => {
       const pageId = v4();
 
       if (isDefined(initialStepTab)) {

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/step/create/components/SidePanelWorkflowCreateStepContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/step/create/components/SidePanelWorkflowCreateStepContent.tsx
@@ -105,12 +105,12 @@ export const SidePanelWorkflowCreateStepContent = () => {
 
     setSidePanelNavigationStack([]);
 
-    openWorkflowEditStepInSidePanel(
-      workflowVisualizerWorkflowId,
-      createdStep.name,
-      getIcon(getActionIcon(createdStep.type as WorkflowActionType)),
-      createdStep.id,
-    );
+    openWorkflowEditStepInSidePanel({
+      workflowId: workflowVisualizerWorkflowId,
+      title: createdStep.name,
+      icon: getIcon(getActionIcon(createdStep.type as WorkflowActionType)),
+      stepId: createdStep.id,
+    });
   };
 
   return <SidePanelWorkflowSelectAction onActionSelected={handleCreateStep} />;

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStepTypeContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStepTypeContent.tsx
@@ -68,12 +68,12 @@ export const SidePanelWorkflowEditStepTypeContent = () => {
 
     setSidePanelNavigationStack([]);
 
-    openWorkflowEditStepInSidePanel(
-      workflowVisualizerWorkflowId,
-      updatedStep.name,
-      getIcon(getActionIcon(updatedStep.type as WorkflowActionType)),
-      updatedStep.id,
-    );
+    openWorkflowEditStepInSidePanel({
+      workflowId: workflowVisualizerWorkflowId,
+      title: updatedStep.name,
+      icon: getIcon(getActionIcon(updatedStep.type as WorkflowActionType)),
+      stepId: updatedStep.id,
+    });
   };
 
   return (

--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/trigger-type/components/SidePanelWorkflowSelectTriggerTypeContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/trigger-type/components/SidePanelWorkflowSelectTriggerTypeContent.tsx
@@ -65,12 +65,12 @@ export const SidePanelWorkflowSelectTriggerTypeContent = () => {
 
       setWorkflowSelectedNode(TRIGGER_STEP_ID);
 
-      openWorkflowEditStepInSidePanel(
+      openWorkflowEditStepInSidePanel({
         workflowId,
-        defaultLabel,
-        getIcon(icon),
-        TRIGGER_STEP_ID,
-      );
+        title: defaultLabel,
+        icon: getIcon(icon),
+        stepId: TRIGGER_STEP_ID,
+      });
     };
   };
 

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramStepNodeEditable.tsx
@@ -62,12 +62,12 @@ export const WorkflowDiagramStepNodeEditable = ({
     setWorkflowSelectedNode(id);
 
     if (isDefined(workflowVisualizerWorkflowId)) {
-      openWorkflowEditStepInSidePanel(
-        workflowVisualizerWorkflowId,
-        data.name,
-        getIcon(getWorkflowNodeIconKey(data)),
-        id,
-      );
+      openWorkflowEditStepInSidePanel({
+        workflowId: workflowVisualizerWorkflowId,
+        title: data.name,
+        icon: getIcon(getWorkflowNodeIconKey(data)),
+        stepId: id,
+      });
     }
   };
 

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowEditActionAiAgent.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowEditActionAiAgent.tsx
@@ -1,5 +1,6 @@
 import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { type SingleTabProps } from '@/ui/layout/tab-list/types/SingleTabProps';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
@@ -113,7 +114,7 @@ export const WorkflowEditActionAiAgent = ({
 
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
-    componentInstanceId,
+    useWorkspaceSurfaceScopedComponentInstanceId(componentInstanceId),
   );
   const currentTabId =
     (activeTabId as WorkflowAiAgentTabId) ?? WORKFLOW_AI_AGENT_TABS.PROMPT;

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/code-action/components/WorkflowEditActionCode.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/code-action/components/WorkflowEditActionCode.tsx
@@ -13,6 +13,7 @@ import { LogicFunctionLogs } from '@/logic-functions/components/LogicFunctionLog
 import { InputLabel, CodeEditor } from 'twenty-ui/input';
 import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
@@ -93,7 +94,9 @@ export const WorkflowEditActionCode = ({
   const fullScreenFocusId = `code-editor-fullscreen-${logicFunctionId}`;
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
-    WORKFLOW_LOGIC_FUNCTION_TAB_LIST_COMPONENT_ID,
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      WORKFLOW_LOGIC_FUNCTION_TAB_LIST_COMPONENT_ID,
+    ),
   );
   const { getUpdatableWorkflowVersion } =
     useGetUpdatableWorkflowVersionOrThrow();

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/WorkflowEditActionHttpRequest.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/WorkflowEditActionHttpRequest.tsx
@@ -8,6 +8,7 @@ import { WorkflowStepCmdEnterButton } from '@/workflow/workflow-steps/components
 import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
 import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { WorkflowStepFooter } from '@/workflow/workflow-steps/components/WorkflowStepFooter';
 import { getBodyTypeFromHeaders } from '@/workflow/workflow-steps/workflow-actions/http-request-action/utils/getBodyTypeFromHeaders';
@@ -91,7 +92,9 @@ export const WorkflowEditActionHttpRequest = ({
   const { theme } = useContext(ThemeContext);
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
-    WORKFLOW_HTTP_REQUEST_TAB_LIST_COMPONENT_ID,
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      WORKFLOW_HTTP_REQUEST_TAB_LIST_COMPONENT_ID,
+    ),
   );
 
   const { formData, handleFieldChange, saveAction } = useHttpRequestForm({

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
@@ -7,6 +7,7 @@ import { useGetOneLogicFunction } from '@/logic-functions/hooks/useGetOneLogicFu
 import { InputLabel } from 'twenty-ui/input';
 import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { type WorkflowLogicFunctionAction } from '@/workflow/types/Workflow';
 import { WorkflowExpectedOutputBodyInput } from '@/workflow/workflow-steps/components/WorkflowExpectedOutputBodyInput';
@@ -80,7 +81,9 @@ export const WorkflowEditActionLogicFunction = ({
 
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
-    WORKFLOW_LOGIC_FUNCTION_ACTION_TAB_LIST_COMPONENT_ID,
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      WORKFLOW_LOGIC_FUNCTION_ACTION_TAB_LIST_COMPONENT_ID,
+    ),
   );
 
   const functionInput = useMemo(() => {

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useVariableDropdown.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useVariableDropdown.ts
@@ -2,6 +2,8 @@ import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadat
 import { useSidePanelWorkflowNavigation } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation';
 import { sidePanelNavigationStackState } from '@/side-panel/states/sidePanelNavigationStackState';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { WORKFLOW_LOGIC_FUNCTION_TAB_LIST_COMPONENT_ID } from '@/workflow/workflow-steps/workflow-actions/code-action/constants/WorkflowLogicFunctionTabListComponentId';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { workflowVisualizerWorkflowIdComponentState } from '@/workflow/states/workflowVisualizerWorkflowIdComponentState';
@@ -84,7 +86,9 @@ export const useVariableDropdown = ({
   );
   const setActiveTabId = useSetAtomComponentState(
     activeTabIdComponentState,
-    'workflow-logic-function-tab-list-component-id',
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      WORKFLOW_LOGIC_FUNCTION_TAB_LIST_COMPONENT_ID,
+    ),
   );
   const setWorkflowDiagram = useSetAtomComponentState(
     workflowDiagramComponentState,

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useVariableDropdown.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useVariableDropdown.ts
@@ -149,18 +149,18 @@ export const useVariableDropdown = ({
 
       setSidePanelNavigationStack([]);
 
-      openWorkflowEditStepInSidePanel(
-        workflowVisualizerWorkflowId,
-        step.name,
-        getIcon(step.icon),
-        step.id,
-        isDefined(linkOutputSchema.link.tab)
+      openWorkflowEditStepInSidePanel({
+        workflowId: workflowVisualizerWorkflowId,
+        title: step.name,
+        icon: getIcon(step.icon),
+        stepId: step.id,
+        initialStepTab: isDefined(linkOutputSchema.link.tab)
           ? {
               tabListComponentId: WORKFLOW_LOGIC_FUNCTION_TAB_LIST_COMPONENT_ID,
               tabId: linkOutputSchema.link.tab,
             }
           : undefined,
-      );
+      });
     };
 
     if (isLinkOutputSchema(currentSubStep)) {

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useVariableDropdown.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useVariableDropdown.ts
@@ -1,8 +1,6 @@
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useSidePanelWorkflowNavigation } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowNavigation';
 import { sidePanelNavigationStackState } from '@/side-panel/states/sidePanelNavigationStackState';
-import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
-import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { WORKFLOW_LOGIC_FUNCTION_TAB_LIST_COMPONENT_ID } from '@/workflow/workflow-steps/workflow-actions/code-action/constants/WorkflowLogicFunctionTabListComponentId';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
@@ -84,12 +82,6 @@ export const useVariableDropdown = ({
   const setWorkflowSelectedNode = useSetAtomComponentState(
     workflowSelectedNodeComponentState,
   );
-  const setActiveTabId = useSetAtomComponentState(
-    activeTabIdComponentState,
-    useWorkspaceSurfaceScopedComponentInstanceId(
-      WORKFLOW_LOGIC_FUNCTION_TAB_LIST_COMPONENT_ID,
-    ),
-  );
   const setWorkflowDiagram = useSetAtomComponentState(
     workflowDiagramComponentState,
   );
@@ -162,11 +154,13 @@ export const useVariableDropdown = ({
         step.name,
         getIcon(step.icon),
         step.id,
+        isDefined(linkOutputSchema.link.tab)
+          ? {
+              tabListComponentId: WORKFLOW_LOGIC_FUNCTION_TAB_LIST_COMPONENT_ID,
+              tabId: linkOutputSchema.link.tab,
+            }
+          : undefined,
       );
-
-      if (isDefined(linkOutputSchema.link.tab)) {
-        setActiveTabId(linkOutputSchema.link.tab);
-      }
     };
 
     if (isLinkOutputSchema(currentSubStep)) {


### PR DESCRIPTION
## What happened

Since #25141 ("Unify workspace routes across main and side panel"), the Configuration/Test tab content of the workflow step editors renders blank in the side panel. No error anywhere: the tabs display and highlight on click, but the panel below stays empty.

## Root cause

#25141 made `TabList` store `activeTabIdComponentState` under the **workspace-surface-scoped** instance id (`useWorkspaceSurfaceScopedComponentInstanceId`), but did not update the components that read that state with their **raw** component ids. On the side-panel surface the two ids differ, so those readers see `activeTabId === undefined` forever, and since each tab's content renders conditionally on it, nothing appears. Clicking a tab writes the scoped id, which the raw readers never see.

Main-surface readers (settings pages, admin panel) are unaffected: the scoping helper returns the raw id outside the side panel. The run-view step page is also unaffected because its instance id equals the surface id, which the helper leaves untouched.

## The fix

Wrap the read (or write) in `useWorkspaceSurfaceScopedComponentInstanceId`, matching what `TabList` does, at the five affected sites:

- `WorkflowEditActionHttpRequest` — blank Configuration/Test tabs
- `WorkflowEditActionCode` — same
- `WorkflowEditActionLogicFunction` — same
- `WorkflowEditActionAiAgent` — same, with its per-step instance id
- `useVariableDropdown` — its write that opens a linked code step on a specific tab landed on the raw id, so it silently did nothing. Scoping it in place would still miss: the dropdown navigates to a *new* side panel page, and the surface id is per page. The requested tab now travels through `openWorkflowEditStepInSidePanel` as an optional `initialStepTab` and is written under the target page's scoped id at navigation time (same pattern as the run view's initial tab); the inlined string literal is replaced with the existing constant

## Verified

On a dev instance running this branch: the HTTP Request step's Configuration tab shows its full form (URL, method, headers, expected response body) and switching to Test renders the response panel — both blank before the fix. Bisect confirmed blank on pristine `origin/main` and working with only this change applied.