### PR TITLE
Fix webhook trigger variables resolving to undefined

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Param,
   Post,
+  type RawBodyRequest,
   Req,
   UseFilters,
   UseGuards,
@@ -15,6 +16,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
 import { WorkflowTriggerRestApiExceptionFilter } from 'src/engine/core-modules/workflow/filters/workflow-trigger-rest-api-exception.filter';
+import { parseWebhookTriggerPayload } from 'src/engine/core-modules/workflow/utils/parse-webhook-trigger-payload.util';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
 import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
@@ -55,11 +57,11 @@ export class WorkflowTriggerController {
   async runWorkflowByPostRequest(
     @Param('workspaceId') workspaceId: string,
     @Param('workflowId') workflowId: string,
-    @Req() request: Request,
+    @Req() request: RawBodyRequest<Request>,
   ) {
     return await this.runWorkflow({
       workflowId,
-      payload: request.body || {},
+      payload: parseWebhookTriggerPayload(request),
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/core-modules/workflow/utils/__tests__/parse-webhook-trigger-payload.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/utils/__tests__/parse-webhook-trigger-payload.util.spec.ts
@@ -1,0 +1,85 @@
+import { type RawBodyRequest } from '@nestjs/common';
+
+import { type Request } from 'express';
+
+import { parseWebhookTriggerPayload } from 'src/engine/core-modules/workflow/utils/parse-webhook-trigger-payload.util';
+
+const buildRequest = ({
+  body,
+  rawBody,
+}: {
+  body?: unknown;
+  rawBody?: string;
+}) =>
+  ({
+    body,
+    rawBody: rawBody === undefined ? undefined : Buffer.from(rawBody),
+  }) as RawBodyRequest<Request>;
+
+describe('parseWebhookTriggerPayload', () => {
+  it('returns the parsed body of an application/json request', () => {
+    const request = buildRequest({
+      body: { companyName: 'Twenty' },
+      rawBody: '{"companyName":"Twenty"}',
+    });
+
+    expect(parseWebhookTriggerPayload(request)).toEqual({
+      companyName: 'Twenty',
+    });
+  });
+
+  it('recovers a JSON document sent under a form content type', () => {
+    const request = buildRequest({
+      body: { '{"companyName":"Twenty"}': '' },
+      rawBody: '{"companyName":"Twenty"}',
+    });
+
+    expect(parseWebhookTriggerPayload(request)).toEqual({
+      companyName: 'Twenty',
+    });
+  });
+
+  it('recovers a JSON document sent under a text content type', () => {
+    const request = buildRequest({
+      body: '{"companyName":"Twenty"}',
+      rawBody: '{"companyName":"Twenty"}',
+    });
+
+    expect(parseWebhookTriggerPayload(request)).toEqual({
+      companyName: 'Twenty',
+    });
+  });
+
+  it('keeps a genuinely form-encoded body', () => {
+    const request = buildRequest({
+      body: { companyName: 'Twenty', need: 'a b' },
+      rawBody: 'companyName=Twenty&need=a+b',
+    });
+
+    expect(parseWebhookTriggerPayload(request)).toEqual({
+      companyName: 'Twenty',
+      need: 'a b',
+    });
+  });
+
+  it('keeps a JSON array payload', () => {
+    const request = buildRequest({
+      body: [{ companyName: 'Twenty' }],
+      rawBody: '[{"companyName":"Twenty"}]',
+    });
+
+    expect(parseWebhookTriggerPayload(request)).toEqual([
+      { companyName: 'Twenty' },
+    ]);
+  });
+
+  it('ignores a raw body that parses to a scalar', () => {
+    const request = buildRequest({ body: {}, rawBody: '42' });
+
+    expect(parseWebhookTriggerPayload(request)).toEqual({});
+  });
+
+  it('falls back to an empty payload when there is no body', () => {
+    expect(parseWebhookTriggerPayload(buildRequest({}))).toEqual({});
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/workflow/utils/parse-webhook-trigger-payload.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/utils/parse-webhook-trigger-payload.util.ts
@@ -1,0 +1,26 @@
+import { type RawBodyRequest } from '@nestjs/common';
+
+import { type Request } from 'express';
+import { isPlainObject, parseJson } from 'twenty-shared/utils';
+
+const isJsonDocument = (value: unknown): value is object =>
+  isPlainObject(value) || Array.isArray(value);
+
+// Senders routinely POST a JSON document under a form or text content type.
+// Express then hands us the whole document as a single urlencoded key, or as a
+// raw string, and every {{trigger.<field>}} reference resolves to undefined.
+// A genuinely form-encoded body is percent-encoded, so it can never parse back
+// as JSON and keeps going through the regular body parser.
+export const parseWebhookTriggerPayload = (
+  request: RawBodyRequest<Request>,
+): object => {
+  const payloadFromRawBody = parseJson<unknown>(
+    request.rawBody?.toString('utf8'),
+  );
+
+  if (isJsonDocument(payloadFromRawBody)) {
+    return payloadFromRawBody;
+  }
+
+  return request.body || {};
+};

--- a/packages/twenty-shared/src/utils/__tests__/variable-resolver.test.ts
+++ b/packages/twenty-shared/src/utils/__tests__/variable-resolver.test.ts
@@ -53,6 +53,16 @@ describe('resolveInput', () => {
     expect(resolveInput('{{user.email}}', context)).toBe(undefined);
   });
 
+  it('should resolve a non-existent variable embedded in a string to nothing', () => {
+    expect(resolveInput('Email: {{user.email}}!', context)).toBe('Email: !');
+  });
+
+  it('should keep null variables embedded in a string', () => {
+    expect(resolveInput('{ "a": {{specialValues.nullValue}} }', context)).toBe(
+      '{ "a": null }',
+    );
+  });
+
   it('should resolve variables in an array', () => {
     const input = ['{{user.name}}', '{{settings.theme}}', 'static'];
     const expected = ['John Doe', 'dark', 'static'];

--- a/packages/twenty-shared/src/utils/variable-resolver.ts
+++ b/packages/twenty-shared/src/utils/variable-resolver.ts
@@ -81,6 +81,13 @@ const resolveString = (
   return input.replace(VARIABLE_PATTERN, (matchedToken, _) => {
     const processedToken = evalFromContext(matchedToken, context);
 
+    // A variable that cannot be resolved must vanish rather than print the
+    // string "undefined" into user content. null is kept as-is so that a
+    // variable used as a JSON value still produces valid JSON.
+    if (processedToken === undefined) {
+      return '';
+    }
+
     if (typeof processedToken === 'object' && processedToken !== null) {
       return JSON.stringify(processedToken);
     }


### PR DESCRIPTION
## Problem

In a workflow triggered by a webhook, `{{trigger.<field>}}` references resolve to nothing. Embedded in text (a Create Record title, a rich text body) they print the literal `undefined`; used standalone they silently leave the field empty. The same workflow works when run from the Test panel.

## Root cause

`WorkflowTriggerController.runWorkflowByPostRequest` passed `request.body` straight through as the trigger payload, i.e. whatever Express's body parser produced. `main.ts` registers `json`, `urlencoded` and `text` parsers, and a sender that POSTs a JSON document under the wrong content type gets it mangled:

| Content-Type | `request.body` |
| --- | --- |
| `application/json` | `{ need: …, companyName: …, requirements: … }` |
| `application/x-www-form-urlencoded` | `{ '{"need":…,"companyName":…}': '' }` — one key, the whole document |
| `text/plain` | `'{"need":…,"companyName":…}'` — a raw string |

The trigger's step result then has no `companyName` key, so `evalFromContext` returns `undefined` for every reference. This matches the reported run, whose trigger output shows `result {1}` with the entire JSON document sitting in the key position.

Test runs are unaffected because they go through the `runWorkflowVersion` GraphQL mutation, which receives an already-parsed JSON object.

## Changes

- `parse-webhook-trigger-payload.util.ts`: parse `request.rawBody` as JSON whenever it is JSON, whatever the content type. A genuinely form-encoded body is percent-encoded, so it can never parse back as JSON and keeps going through the regular body parser. `rawBody` is already populated for all three parsers via `rawBody: true` in `NestFactory.create`.
- `variable-resolver.ts`: an unresolved variable embedded in text now resolves to nothing instead of the string `undefined`, matching `resolveRichTextVariables` and `resolveWorkflowEmailTemplateString`. `null` is kept as-is so a variable used as a JSON value still produces valid JSON.

## Tests

- `parse-webhook-trigger-payload.util.spec.ts` covers JSON, form-encoded JSON, text JSON, a genuine form body, a JSON array, a scalar raw body and an absent body.
- Two cases added to `variable-resolver.test.ts` for the embedded-`undefined` and embedded-`null` behaviour.

`npx jest` passes for both suites; `packages/twenty-shared` runs 1384 tests green. oxlint, oxfmt and `tsgo --noEmit` are clean on the changed files. The 5 workflow suites and 13 typecheck errors that fail in this environment are pre-existing missing-module failures for unbuilt `twenty-emails` / `twenty-client-sdk` packages, verified identical with the changes stashed.

## Not covered

A body sent with a content type no parser handles (or with no `Content-Type` at all) still arrives empty, since neither `body` nor `rawBody` is populated in that case. Widening the parsers is a bootstrap-level change affecting the other public `/webhooks` endpoints, so it is left out here.