### PR TITLE
chore(billing): centralize dollars to micro-credits conversion

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -54,7 +54,7 @@ import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entiti
 import { repairToolCall } from 'src/engine/metadata-modules/ai/ai-agent/utils/repair-tool-call.util';
 import { NATIVE_WEB_SEARCH_COST_PER_CALL_DOLLARS } from 'src/engine/metadata-modules/ai/ai-billing/constants/native-web-search-cost-per-call-dollars';
 import { AiBillingService } from 'src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service';
-import { convertDollarsToBillingCredits } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-billing-credits.util';
+import { convertDollarsToCreditsMicro } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-credits-micro.util';
 import { countNativeWebSearchCallsFromSteps } from 'src/engine/metadata-modules/ai/ai-billing/utils/count-native-web-search-calls-from-steps.util';
 import {
   extractCacheCreationTokens,
@@ -552,9 +552,7 @@ export class AgentAsyncExecutorService {
       const totalCostInDollars =
         tokenCostInDollars +
         nativeWebSearchCallCount * NATIVE_WEB_SEARCH_COST_PER_CALL_DOLLARS;
-      const creditsUsedMicro = Math.round(
-        convertDollarsToBillingCredits(totalCostInDollars),
-      );
+      const creditsUsedMicro = convertDollarsToCreditsMicro(totalCostInDollars);
 
       return {
         result,
@@ -581,9 +579,7 @@ export class AgentAsyncExecutorService {
         usage: accumulatedUsage,
         cacheCreationTokens,
       });
-      const creditsUsedMicro = Math.round(
-        convertDollarsToBillingCredits(costInDollars),
-      );
+      const creditsUsedMicro = convertDollarsToCreditsMicro(costInDollars);
       const totalTokens =
         (accumulatedUsage.inputTokens ?? 0) +
         (accumulatedUsage.outputTokens ?? 0);

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service.ts
@@ -11,7 +11,7 @@ import { UsageUnit } from 'src/engine/core-modules/usage/enums/usage-unit.enum';
 import { UsageRecorderService } from 'src/engine/core-modules/usage/services/usage-recorder.service';
 import { NATIVE_WEB_SEARCH_COST_PER_CALL_DOLLARS } from 'src/engine/metadata-modules/ai/ai-billing/constants/native-web-search-cost-per-call-dollars';
 import { computeCostBreakdown } from 'src/engine/metadata-modules/ai/ai-billing/utils/compute-cost-breakdown.util';
-import { convertDollarsToBillingCredits } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-billing-credits.util';
+import { convertDollarsToCreditsMicro } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-credits-micro.util';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
 import { type ModelId } from 'src/engine/metadata-modules/ai/ai-models/types/model-id.type';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
@@ -66,9 +66,7 @@ export class AiBillingService {
     userWorkspaceId?: string | null,
   ): Promise<void> {
     const costInDollars = this.calculateCost(modelId, billingInput);
-    const creditsUsedMicro = Math.round(
-      convertDollarsToBillingCredits(costInDollars),
-    );
+    const creditsUsedMicro = convertDollarsToCreditsMicro(costInDollars);
 
     const totalTokens =
       (billingInput.usage.inputTokens ?? 0) +
@@ -102,9 +100,7 @@ export class AiBillingService {
     }
 
     const costInDollars = this.calculateCost(modelId, billingInput);
-    const creditsUsedMicro = Math.round(
-      convertDollarsToBillingCredits(costInDollars),
-    );
+    const creditsUsedMicro = convertDollarsToCreditsMicro(costInDollars);
 
     const remainingCredits =
       await this.billingUsageService.decrementAvailableCreditsInCache({
@@ -126,9 +122,7 @@ export class AiBillingService {
 
     const costInDollars =
       nativeWebSearchCallCount * NATIVE_WEB_SEARCH_COST_PER_CALL_DOLLARS;
-    const creditsUsedMicro = Math.round(
-      convertDollarsToBillingCredits(costInDollars),
-    );
+    const creditsUsedMicro = convertDollarsToCreditsMicro(costInDollars);
 
     this.logger.log(
       `Native web search billing: ${nativeWebSearchCallCount} calls, $${costInDollars.toFixed(4)}`,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-credits-micro.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-credits-micro.util.ts
@@ -1,4 +1,4 @@
 import { DOLLAR_TO_CREDIT_MULTIPLIER } from 'src/engine/metadata-modules/ai/ai-billing/constants/dollar-to-credit-multiplier';
 
-export const convertDollarsToBillingCredits = (dollars: number): number =>
-  dollars * DOLLAR_TO_CREDIT_MULTIPLIER;
+export const convertDollarsToCreditsMicro = (dollars: number): number =>
+  Math.round(dollars * DOLLAR_TO_CREDIT_MULTIPLIER);

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat.job.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat.job.ts
@@ -23,7 +23,7 @@ import { toDisplayCredits } from 'src/engine/core-modules/usage/utils/to-display
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AgentMessageRole } from 'src/engine/metadata-modules/ai/ai-agent-execution/entities/agent-message.entity';
 import { computeCostBreakdown } from 'src/engine/metadata-modules/ai/ai-billing/utils/compute-cost-breakdown.util';
-import { convertDollarsToBillingCredits } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-billing-credits.util';
+import { convertDollarsToCreditsMicro } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-credits-micro.util';
 import { extractCacheCreationTokens } from 'src/engine/metadata-modules/ai/ai-billing/utils/extract-cache-creation-tokens.util';
 import {
   AiException,
@@ -695,11 +695,11 @@ export class StreamAgentChatJob {
         cacheCreationTokens: totalCacheCreationTokens,
       });
 
-      const inputCredits = Math.round(
-        convertDollarsToBillingCredits(breakdown.inputCostInDollars),
+      const inputCredits = convertDollarsToCreditsMicro(
+        breakdown.inputCostInDollars,
       );
-      const outputCredits = Math.round(
-        convertDollarsToBillingCredits(breakdown.outputCostInDollars),
+      const outputCredits = convertDollarsToCreditsMicro(
+        breakdown.outputCostInDollars,
       );
 
       onUpdateUsage({

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -49,7 +49,7 @@ import { AGENT_CONFIG } from 'src/engine/metadata-modules/ai/ai-agent/constants/
 import { BrowsingContextType } from 'src/engine/metadata-modules/ai/ai-agent/types/browsingContext.type';
 import { repairToolCall } from 'src/engine/metadata-modules/ai/ai-agent/utils/repair-tool-call.util';
 import { AiBillingService } from 'src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service';
-import { convertDollarsToBillingCredits } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-billing-credits.util';
+import { convertDollarsToCreditsMicro } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-credits-micro.util';
 import { countNativeWebSearchCallsFromSteps } from 'src/engine/metadata-modules/ai/ai-billing/utils/count-native-web-search-calls-from-steps.util';
 import {
   extractCacheCreationTokens,
@@ -424,9 +424,7 @@ export class ChatExecutionService {
         registeredModel.modelId,
         { usage, cacheCreationTokens },
       );
-      const creditsUsedMicro = Math.round(
-        convertDollarsToBillingCredits(costInDollars),
-      );
+      const creditsUsedMicro = convertDollarsToCreditsMicro(costInDollars);
 
       await this.aiBillingService.emitAiTokenUsageEvent(
         workspace.id,

--- a/packages/twenty-server/src/modules/emailing/services/email-billing.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/email-billing.service.ts
@@ -9,7 +9,7 @@ import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-op
 import { UsageResourceType } from 'src/engine/core-modules/usage/enums/usage-resource-type.enum';
 import { UsageUnit } from 'src/engine/core-modules/usage/enums/usage-unit.enum';
 import { UsageRecorderService } from 'src/engine/core-modules/usage/services/usage-recorder.service';
-import { convertDollarsToBillingCredits } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-billing-credits.util';
+import { convertDollarsToCreditsMicro } from 'src/engine/metadata-modules/ai/ai-billing/utils/convert-dollars-to-credits-micro.util';
 import { type EmailCreditContext } from 'src/modules/emailing/types/email-credit-context.type';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { EMAIL_MARGIN_MULTIPLIER } from 'src/modules/emailing/constants/email-margin-multiplier';
@@ -70,9 +70,7 @@ export class EmailBillingService {
     const providerCostInDollars =
       (sentEmailCount / 1000) * SES_EMAIL_COST_PER_THOUSAND_DOLLARS;
     const chargedInDollars = providerCostInDollars * EMAIL_MARGIN_MULTIPLIER;
-    const creditsUsedMicro = Math.round(
-      convertDollarsToBillingCredits(chargedInDollars),
-    );
+    const creditsUsedMicro = convertDollarsToCreditsMicro(chargedInDollars);
 
     if (this.billingService.isBillingEnabled()) {
       const currentBillingSubscription =


### PR DESCRIPTION
Follow-up to a review comment by martmull on https://github.com/twentyhq/twenty/pull/25279: the dollars to micro-credits rounding was duplicated at every call site.

- Rename `convertDollarsToBillingCredits` to `convertDollarsToCreditsMicro` and make it return a rounded integer.
- Replace the 9 `Math.round(convertDollarsToBillingCredits(...))` call sites across ai-billing, agent-async-executor, stream-agent-chat, chat-execution and email-billing.

No behavior change: every caller already rounded to nearest.