### PR TITLE
Fix Danish email reply quotation stripping

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-text-without-reply-quotations.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-text-without-reply-quotations.util.spec.ts
@@ -21,12 +21,39 @@ describe('extractTextWithoutReplyQuotations', () => {
 
   it('should drop quoted history with Danish reply headers', () => {
     const result = extractTextWithoutReplyQuotations(
-      'Nyt svar her.\n\nFra: sender@example.com\nSendt: 3. september 2026 10:00\nTil: recipient@example.com\nEmne: Test\nTidligere besked',
+      'Nyt svar her.\n\n________________________________\nFra: sender@example.com\nSendt: 3. september 2026 10:00\nTil: recipient@example.com\nEmne: Test\nTidligere besked',
     );
 
     expect(result).toContain('Nyt svar her.');
     expect(result).not.toContain('Fra:');
     expect(result).not.toContain('Tidligere besked');
+  });
+
+  it('should drop Danish quoted history with copied recipients', () => {
+    const result = extractTextWithoutReplyQuotations(
+      'Nyt svar her.\n\n________________________________\nFra: sender@example.com\nSendt: 3. september 2026 10:00\nTil: recipient@example.com\nCc: copied@example.com\nBcc: hidden@example.com\nEmne: Test\nTidligere besked',
+    );
+
+    expect(result).toContain('Nyt svar her.');
+    expect(result).not.toContain('Tidligere besked');
+  });
+
+  it('should drop Danish quoted history with multiline recipients', () => {
+    const result = extractTextWithoutReplyQuotations(
+      'Nyt svar her.\n\n________________________________\nFra: sender@example.com\nSendt: 3. september 2026 10:00\nTil: recipient@example.com;\n  second@example.com\nEmne: Test\nTidligere besked',
+    );
+
+    expect(result).toContain('Nyt svar her.');
+    expect(result).not.toContain('Tidligere besked');
+  });
+
+  it('should keep authored content containing Danish header-like text', () => {
+    const body =
+      'Notes:\n\nFra: sender@example.com\nSendt: 3. september 2026 10:00\nTil: recipient@example.com\nEmne: Test\nKeep these notes.';
+
+    expect(extractTextWithoutReplyQuotations(body)).toContain(
+      'Keep these notes.',
+    );
   });
 
   it('should keep the full body when the message is entirely quoted (forward) and would otherwise be emptied', () => {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-text-without-reply-quotations.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-text-without-reply-quotations.util.spec.ts
@@ -19,6 +19,16 @@ describe('extractTextWithoutReplyQuotations', () => {
     expect(result).not.toContain('previous question');
   });
 
+  it('should drop quoted history with Danish reply headers', () => {
+    const result = extractTextWithoutReplyQuotations(
+      'Nyt svar her.\n\nFra: sender@example.com\nSendt: 3. september 2026 10:00\nTil: recipient@example.com\nEmne: Test\nTidligere besked',
+    );
+
+    expect(result).toContain('Nyt svar her.');
+    expect(result).not.toContain('Fra:');
+    expect(result).not.toContain('Tidligere besked');
+  });
+
   it('should keep the full body when the message is entirely quoted (forward) and would otherwise be emptied', () => {
     // Regression: forwarded emails are entirely quotation-like, so the parser
     // returned empty and the message body was lost.

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-text-without-reply-quotations.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-text-without-reply-quotations.util.ts
@@ -1,9 +1,19 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import EmailReplyParser from 'email-reply-parser';
 
+const danishReplyHeaderRegex =
+  /(?:^|\r?\n)Fra:.*\r?\nSendt:.*\r?\nTil:.*\r?\nEmne:.*/i;
+
 export const extractTextWithoutReplyQuotations = (text: string): string => {
+  const danishReplyHeaderMatch = text.match(danishReplyHeaderRegex);
+
+  const textWithoutDanishReplyQuotation =
+    danishReplyHeaderMatch?.index !== undefined
+      ? text.slice(0, danishReplyHeaderMatch.index)
+      : text;
+
   const textWithoutQuotations = new EmailReplyParser()
-    .read(text)
+    .read(textWithoutDanishReplyQuotation)
     .getFragments()
     .filter((fragment) => !fragment.isQuoted())
     .map((fragment) => fragment.getContent())

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-text-without-reply-quotations.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-text-without-reply-quotations.util.ts
@@ -2,7 +2,7 @@ import { isNonEmptyString } from '@sniptt/guards';
 import EmailReplyParser from 'email-reply-parser';
 
 const danishReplyHeaderRegex =
-  /(?:^|\r?\n)Fra:.*\r?\nSendt:.*\r?\nTil:.*\r?\nEmne:.*/i;
+  /(?:^|\r?\n)(?:_{5,}|-{5,})\r?\nFra:.*\r?\nSendt:.*\r?\nTil:.*(?:\r?\n[ \t]+.*)*(?:\r?\n(?:Cc|Bcc):.*(?:\r?\n[ \t]+.*)*)*\r?\nEmne:.*/i;
 
 export const extractTextWithoutReplyQuotations = (text: string): string => {
   const danishReplyHeaderMatch = text.match(danishReplyHeaderRegex);


### PR DESCRIPTION
## Summary

- Detect Danish reply headers (`Fra:`, `Sendt:`, `Til:`, `Emne:`)
- Strip Danish quoted reply history before passing the content to email-reply-parser
- Add a regression test for Danish reply headers

Fixes #25315

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

