### PR TITLE
Improve failed payment recovery flow (in-product payment update)

### DIFF
--- a/packages/twenty-front/src/modules/information-banner/components/billing/InformationBannerFailPaymentInfo.tsx
+++ b/packages/twenty-front/src/modules/information-banner/components/billing/InformationBannerFailPaymentInfo.tsx
@@ -1,49 +1,42 @@
-import { useRedirect } from '@/domain-manager/hooks/useRedirect';
 import { InformationBanner } from '@/information-banner/components/InformationBanner';
+import { UpdatePaymentMethodModal } from '@/settings/billing/components/UpdatePaymentMethodModal';
 import { usePermissionFlagMap } from '@/settings/roles/hooks/usePermissionFlagMap';
+import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { t } from '@lingui/core/macro';
-import { SettingsPath } from 'twenty-shared/types';
-import { getSettingsPath, isDefined } from 'twenty-shared/utils';
-import { useQuery } from '@apollo/client/react';
-import {
-  PermissionFlagType,
-  BillingPortalSessionDocument,
-} from '~/generated-metadata/graphql';
+import { PermissionFlagType } from '~/generated-metadata/graphql';
+
+const FAILED_PAYMENT_UPDATE_PAYMENT_MODAL_ID =
+  'failed-payment-update-payment-modal';
 
 export const InformationBannerFailPaymentInfo = () => {
-  const { redirect } = useRedirect();
+  const { openModal } = useModal();
 
-  const { data, loading } = useQuery(BillingPortalSessionDocument, {
-    variables: {
-      returnUrlPath: getSettingsPath(SettingsPath.Billing),
-    },
-  });
-
-  const {
-    [PermissionFlagType.WORKSPACE]: hasPermissionToUpdateBillingDetails,
-  } = usePermissionFlagMap();
-
-  const openBillingPortal = () => {
-    if (isDefined(data) && isDefined(data.billingPortalSession.url)) {
-      redirect(data.billingPortalSession.url);
-    }
-  };
+  const { [PermissionFlagType.BILLING]: hasPermissionToUpdateBillingDetails } =
+    usePermissionFlagMap();
 
   return (
-    <InformationBanner
-      componentInstanceId="information-banner-fail-payment-info"
-      color="danger"
-      variant="secondary"
-      message={
-        hasPermissionToUpdateBillingDetails
-          ? t`Last payment failed. Please update your billing details.`
-          : t`Last payment failed. Please contact your admin.`
-      }
-      buttonTitle={
-        hasPermissionToUpdateBillingDetails ? t`Update payment` : undefined
-      }
-      buttonOnClick={() => openBillingPortal()}
-      isButtonDisabled={loading || !isDefined(data)}
-    />
+    <>
+      <InformationBanner
+        componentInstanceId="information-banner-fail-payment-info"
+        color="danger"
+        variant="secondary"
+        message={
+          hasPermissionToUpdateBillingDetails
+            ? t`A payment method is needed to keep your workspace active.`
+            : t`A payment method is needed. Please contact your admin.`
+        }
+        buttonTitle={
+          hasPermissionToUpdateBillingDetails
+            ? t`Add payment method`
+            : undefined
+        }
+        buttonOnClick={() => openModal(FAILED_PAYMENT_UPDATE_PAYMENT_MODAL_ID)}
+      />
+      {hasPermissionToUpdateBillingDetails && (
+        <UpdatePaymentMethodModal
+          modalInstanceId={FAILED_PAYMENT_UPDATE_PAYMENT_MODAL_ID}
+        />
+      )}
+    </>
   );
 };

--- a/packages/twenty-front/src/modules/settings/billing/components/AddPaymentMethodForm.tsx
+++ b/packages/twenty-front/src/modules/settings/billing/components/AddPaymentMethodForm.tsx
@@ -25,6 +25,7 @@ import { CreateBillingPaymentMethodSetupIntentDocument } from '~/generated-metad
 type AddPaymentMethodFormContentProps = {
   finalRedirectPath?: string;
   onPaymentMethodAdded: () => Promise<void>;
+  shouldStartSubscriptionAfterPaymentMethod?: boolean;
 };
 
 type AddPaymentMethodFormProps = AddPaymentMethodFormContentProps;
@@ -39,6 +40,7 @@ const StyledFormContainer = styled.div`
 const AddPaymentMethodFormContent = ({
   finalRedirectPath,
   onPaymentMethodAdded,
+  shouldStartSubscriptionAfterPaymentMethod = true,
 }: AddPaymentMethodFormContentProps) => {
   const stripe = useStripe();
   const elements = useElements();
@@ -59,10 +61,12 @@ const AddPaymentMethodFormContent = ({
       finalRedirectPath ?? `${location.pathname}${location.search}`;
     const returnUrl = new URL(basePath, window.location.origin);
 
-    returnUrl.searchParams.set(
-      START_SUBSCRIPTION_AFTER_PAYMENT_METHOD_QUERY_PARAM,
-      'true',
-    );
+    if (shouldStartSubscriptionAfterPaymentMethod) {
+      returnUrl.searchParams.set(
+        START_SUBSCRIPTION_AFTER_PAYMENT_METHOD_QUERY_PARAM,
+        'true',
+      );
+    }
 
     return returnUrl.toString();
   };
@@ -156,6 +160,7 @@ const AddPaymentMethodFormContent = ({
 export const AddPaymentMethodForm = ({
   finalRedirectPath,
   onPaymentMethodAdded,
+  shouldStartSubscriptionAfterPaymentMethod,
 }: AddPaymentMethodFormProps) => {
   const stripePromise = useStripePromise();
   const appearance = useStripeAppearance();
@@ -179,6 +184,9 @@ export const AddPaymentMethodForm = ({
       <AddPaymentMethodFormContent
         finalRedirectPath={finalRedirectPath}
         onPaymentMethodAdded={onPaymentMethodAdded}
+        shouldStartSubscriptionAfterPaymentMethod={
+          shouldStartSubscriptionAfterPaymentMethod
+        }
       />
     </Elements>
   );

--- a/packages/twenty-front/src/modules/settings/billing/components/SettingsBillingContent.tsx
+++ b/packages/twenty-front/src/modules/settings/billing/components/SettingsBillingContent.tsx
@@ -4,11 +4,13 @@ import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { SettingsBillingCreditsSection } from '@/settings/billing/components/SettingsBillingCreditsSection';
 import { SettingsBillingSubscriptionInfo } from '@/settings/billing/components/SettingsBillingSubscriptionInfo';
 import { SettingsBillingTrialNoPaymentMethodBanner } from '@/settings/billing/components/SettingsBillingTrialNoPaymentMethodBanner';
+import { UpdatePaymentMethodModal } from '@/settings/billing/components/UpdatePaymentMethodModal';
 import { useBillingPortalSession } from '@/settings/billing/hooks/useBillingPortalSession';
 import { useGetResourceCreditUsage } from '@/settings/billing/hooks/useGetResourceCreditUsage';
 import { billingHasPaymentMethodSelector } from '@/settings/billing/states/billingHasPaymentMethodSelector';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { useSubscriptionStatus } from '@/workspace/hooks/useSubscriptionStatus';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
@@ -17,8 +19,13 @@ import { H2Title } from 'twenty-ui/typography';
 import { Button } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
 import { SubscriptionStatus } from '~/generated-metadata/graphql';
+
+const SETTINGS_BILLING_UPDATE_PAYMENT_MODAL_ID =
+  'settings-billing-update-payment-modal';
+
 export const SettingsBillingContent = () => {
   const { t } = useLingui();
+  const { openModal } = useModal();
 
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
 
@@ -62,8 +69,11 @@ export const SettingsBillingContent = () => {
           <SettingsBillingSubscriptionInfo
             currentWorkspace={currentWorkspace}
             currentBillingSubscription={currentBillingSubscription}
-            onUpdatePayment={openBillingPortal}
-            isUpdatePaymentDisabled={isBillingPortalSessionDisabled}
+            onManageBilling={openBillingPortal}
+            onUpdatePayment={() =>
+              openModal(SETTINGS_BILLING_UPDATE_PAYMENT_MODAL_ID)
+            }
+            isUpdatePaymentDisabled={false}
           />
         )}
       {hasNotCanceledCurrentSubscription &&
@@ -72,8 +82,11 @@ export const SettingsBillingContent = () => {
         isUsageQueryLoaded && (
           <SettingsBillingCreditsSection
             currentBillingSubscription={currentBillingSubscription}
-            onUpdatePayment={openBillingPortal}
-            isUpdatePaymentDisabled={isBillingPortalSessionDisabled}
+            onManageBilling={openBillingPortal}
+            onUpdatePayment={() =>
+              openModal(SETTINGS_BILLING_UPDATE_PAYMENT_MODAL_ID)
+            }
+            isUpdatePaymentDisabled={false}
           />
         )}
       <Section>
@@ -105,6 +118,9 @@ export const SettingsBillingContent = () => {
           />
         </Section>
       )}
+      <UpdatePaymentMethodModal
+        modalInstanceId={SETTINGS_BILLING_UPDATE_PAYMENT_MODAL_ID}
+      />
     </SettingsPageContainer>
   );
 };

--- a/packages/twenty-front/src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
+++ b/packages/twenty-front/src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
@@ -118,12 +118,14 @@ const StyledCreditUsageFooterActions = styled.div`
 
 export const SettingsBillingCreditsSection = ({
   currentBillingSubscription,
+  onManageBilling,
   onUpdatePayment,
   isUpdatePaymentDisabled,
 }: {
   currentBillingSubscription: NonNullable<
     CurrentWorkspace['currentBillingSubscription']
   >;
+  onManageBilling: () => void;
   onUpdatePayment: () => void;
   isUpdatePaymentDisabled: boolean;
 }) => {
@@ -242,7 +244,7 @@ export const SettingsBillingCreditsSection = ({
             shouldRedirectToManageBilling={isCancellationScheduled}
             shouldRedirectToUpdatePayment={shouldUpdatePayment}
             canEndTrialPeriod={hasPermissionToEndTrialPeriod}
-            onManageBilling={onUpdatePayment}
+            onManageBilling={onManageBilling}
             isManageBillingDisabled={isUpdatePaymentDisabled}
             onUpdatePayment={onUpdatePayment}
             isUpdatePaymentDisabled={isUpdatePaymentDisabled}

--- a/packages/twenty-front/src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
+++ b/packages/twenty-front/src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
@@ -46,6 +46,7 @@ import { beautifyExactDate } from '~/utils/date-utils';
 export const SettingsBillingSubscriptionInfo = ({
   currentWorkspace,
   currentBillingSubscription,
+  onManageBilling,
   onUpdatePayment,
   isUpdatePaymentDisabled,
 }: {
@@ -53,6 +54,7 @@ export const SettingsBillingSubscriptionInfo = ({
   currentBillingSubscription: NonNullable<
     CurrentWorkspace['currentBillingSubscription']
   >;
+  onManageBilling: () => void;
   onUpdatePayment: () => void;
   isUpdatePaymentDisabled: boolean;
 }) => {
@@ -501,6 +503,7 @@ export const SettingsBillingSubscriptionInfo = ({
               openModal(BILLING_MODAL_IDS.cancelSwitchBillingPlan)
             }
             onEndTrialPeriod={() => openModal(BILLING_MODAL_IDS.endTrialPeriod)}
+            onManageBilling={onManageBilling}
             onUpdatePayment={onUpdatePayment}
             shouldUpdatePayment={shouldUpdatePayment}
           />

--- a/packages/twenty-front/src/modules/settings/billing/components/UpdatePaymentMethodModal.tsx
+++ b/packages/twenty-front/src/modules/settings/billing/components/UpdatePaymentMethodModal.tsx
@@ -1,0 +1,74 @@
+import { AddPaymentMethodForm } from '@/settings/billing/components/AddPaymentMethodForm';
+import { ModalStatefulWrapper } from '@/ui/layout/modal/components/ModalStatefulWrapper';
+import { useModal } from '@/ui/layout/modal/hooks/useModal';
+import { styled } from '@linaria/react';
+import { useLingui } from '@lingui/react/macro';
+import { Button } from 'twenty-ui/input';
+import { Section, SectionAlignment, SectionFontColor } from 'twenty-ui/layout';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { H1Title, H1TitleFontColor } from 'twenty-ui/typography';
+
+type UpdatePaymentMethodModalProps = {
+  modalInstanceId: string;
+};
+
+const StyledCenteredTitle = styled.div`
+  text-align: center;
+`;
+
+const StyledSectionContainer = styled.div`
+  margin-bottom: ${themeCssVariables.spacing[6]};
+`;
+
+const StyledCancelButtonContainer = styled.div`
+  margin-top: ${themeCssVariables.spacing[4]};
+`;
+
+export const UpdatePaymentMethodModal = ({
+  modalInstanceId,
+}: UpdatePaymentMethodModalProps) => {
+  const { t } = useLingui();
+  const { closeModal } = useModal();
+
+  return (
+    <ModalStatefulWrapper
+      modalInstanceId={modalInstanceId}
+      isClosable
+      size="medium"
+      padding="large"
+      overlay="dark"
+      dataGloballyPreventClickOutside
+      renderInDocumentBody
+      smallBorderRadius
+      autoHeight
+    >
+      <StyledCenteredTitle>
+        <H1Title
+          title={t`Update your payment method`}
+          fontColor={H1TitleFontColor.Primary}
+        />
+      </StyledCenteredTitle>
+      <StyledSectionContainer>
+        <Section
+          alignment={SectionAlignment.Center}
+          fontColor={SectionFontColor.Primary}
+        >
+          {t`Add a card below to update your billing details and retry your payment.`}
+        </Section>
+      </StyledSectionContainer>
+      <AddPaymentMethodForm
+        onPaymentMethodAdded={async () => closeModal(modalInstanceId)}
+        shouldStartSubscriptionAfterPaymentMethod={false}
+      />
+      <StyledCancelButtonContainer>
+        <Button
+          onClick={() => closeModal(modalInstanceId)}
+          variant="secondary"
+          title={t`Cancel`}
+          fullWidth
+          justify="center"
+        />
+      </StyledCancelButtonContainer>
+    </ModalStatefulWrapper>
+  );
+};

--- a/packages/twenty-front/src/modules/settings/billing/components/internal/SettingsBillingSubscriptionInfoCardHeaderActions.tsx
+++ b/packages/twenty-front/src/modules/settings/billing/components/internal/SettingsBillingSubscriptionInfoCardHeaderActions.tsx
@@ -22,6 +22,7 @@ export type SettingsBillingSubscriptionInfoCardHeaderActionsProps = {
   onCancelIntervalSwitch: () => void;
   onCancelPlanSwitch: () => void;
   onEndTrialPeriod: () => void;
+  onManageBilling: () => void;
   onUpdatePayment: () => void;
   shouldUpdatePayment: boolean;
 };
@@ -39,6 +40,7 @@ export const SettingsBillingSubscriptionInfoCardHeaderActions = ({
   onCancelIntervalSwitch,
   onCancelPlanSwitch,
   onEndTrialPeriod,
+  onManageBilling,
   onUpdatePayment,
   shouldUpdatePayment,
 }: SettingsBillingSubscriptionInfoCardHeaderActionsProps) => {
@@ -52,7 +54,7 @@ export const SettingsBillingSubscriptionInfoCardHeaderActions = ({
         variant="primary"
         accent="blue"
         size="small"
-        onClick={onUpdatePayment}
+        onClick={onManageBilling}
         disabled={isUpdatePaymentDisabled}
       />
     );

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
@@ -201,7 +201,11 @@ export class BillingSubscriptionService {
       { stripeCustomerId: data.object.customer as string },
     );
 
-    if (billingSubscription.status === SubscriptionStatus.Unpaid) {
+    if (
+      [SubscriptionStatus.PastDue, SubscriptionStatus.Unpaid].includes(
+        billingSubscription.status,
+      )
+    ) {
       await this.stripeSubscriptionService.collectLastInvoice(
         billingSubscription.stripeSubscriptionId,
       );


### PR DESCRIPTION
### Motivation
- Clicking billing actions sent users to the Stripe billing portal which surfaced an alarming “outstanding invoice” UI and prevented a simple in-product card update flow for trial / failed-payment recovery. 
- Provide a smoother, permission-gated in-product path to add or update a card and retry payment without forcing users into the Stripe portal for every payment fix. 
- Ensure server-side recovery re-attempts cover both `past_due` and `unpaid` subscription states after a successful payment method setup.

### Description
- Add an `UpdatePaymentMethodModal` component and open it from failed-payment banners and billing-page update actions so users can add a card in-product using Stripe’s `PaymentElement` instead of immediately redirecting to the billing portal. (`packages/twenty-front/src/modules/settings/billing/components/UpdatePaymentMethodModal.tsx`, `.../InformationBannerFailPaymentInfo.tsx`, `.../SettingsBillingContent.tsx`)
- Add `shouldStartSubscriptionAfterPaymentMethod` flag to `AddPaymentMethodForm` and wire it so an update flow does not accidentally trigger the “start subscription after payment method” redirect path. (`packages/twenty-front/src/modules/settings/billing/components/AddPaymentMethodForm.tsx`)
- Preserve the billing portal for invoice viewing / subscription management while using the new modal for card updates by splitting “manage billing” vs “update payment” handlers and adding an `onManageBilling` callback across billing components. (updated `SettingsBillingContent`, `SettingsBillingSubscriptionInfo`, `SettingsBillingCreditsSection`, and `SettingsBillingSubscriptionInfoCardHeaderActions`)
- Improve information-banner copy and permission usage to be more neutral and action-oriented, and gate the in-product add-card action on the billing permission. (`InformationBannerFailPaymentInfo.tsx`)
- Server-side: extend `handleUnpaidInvoices` to retry collection for both `SubscriptionStatus.PastDue` and `SubscriptionStatus.Unpaid` after a successful setup intent. (`packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts`)

### Testing
- Ran typecheck for packages with `npx tsgo -p tsconfig.json --noEmit` inside `packages/twenty-front` and `packages/twenty-server`, which completed without blocking errors. 
- Ran lint/format and checks including `npx nx lint:diff-with-main twenty-front`, `npx nx format:write --files=...` and `git diff --check`, all of which completed with no blocking failures reported. 
- End-to-end visual verification could not be performed here because the Stripe flows require a running workspace and configured Stripe keys; the code changes are localized and rely on existing Stripe setup hooks/components used elsewhere.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a8fb9719c832faffaff9cd0f2b86c)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

