### PR TITLE
feat(workflow): idempotency hint under the retry setting

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/step/settings/components/SidePanelWorkflowStepSettingsContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/step/settings/components/SidePanelWorkflowStepSettingsContent.tsx
@@ -81,6 +81,7 @@ const SidePanelWorkflowStepSettingsForm = ({
             })),
           ]}
           value={Number(errorHandlingOptions.retryOnFailure.value) || 0}
+          description={t`Only enable for steps that are safe to run twice: a failed attempt may already have written data or sent messages.`}
           onChange={(value) =>
             updateErrorHandlingOptions({ retryOnFailure: { value } })
           }


### PR DESCRIPTION
## What it does

Adds a description under the Retry on failure select in the Node settings page (#25314):

> Only enable for steps that are safe to run twice: a failed attempt may already have written data or sent messages.

Retrying re-executes the step, so a step that failed after its side effect landed (a created record, a sent email, an HTTP POST) duplicates it. The executor cannot tell "failed before the write" from "failed after", so the safety call belongs to the person enabling the setting — this puts that in front of them, the way Retool's retry block hints at idempotency.

Uses the `description` prop the `Select` component already has; one line plus its translation.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

