### PR TITLE
Keep undeclared application references on additive apply

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
+++ b/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
@@ -54,7 +54,7 @@ This is your first diagnostic: it tells you exactly which objects, fields, and l
 
 Destructive changes (`to destroy`) are listed with what they drop (e.g. `objectMetadata "auditNote" — drops the table and all its rows`) and require interactive confirmation, or `--force` in scripts.
 
-A sync deletes every entity your app owns that your source no longer declares. When a plan contains destroys it says so and points at `--no-delete`, which makes the sync additive: creates and updates are applied, nothing missing from your source is deleted. Use it when your source is intentionally partial, for example while adopting an app that was built in the UI.
+A sync deletes every entity your app owns that your source no longer declares. When a plan contains destroys it says so and points at `--no-delete`, which makes the sync additive: creates and updates are applied, nothing missing from your source is deleted, and the settings component and uninstall hook bindings of the app stay as they are when your source does not declare them. Use it when your source is intentionally partial, for example while adopting an app that was built in the UI.
 
 When a sync fails on a single entity, the error names the offending entity and its `universalIdentifier`, for example:
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -268,6 +268,7 @@ export class ApplicationManifestMigrationService {
         manifest,
         workspaceId,
         ownerFlatApplication,
+        inferDeletionFromMissingEntities,
       });
     }
 
@@ -281,10 +282,12 @@ export class ApplicationManifestMigrationService {
     manifest,
     workspaceId,
     ownerFlatApplication,
+    inferDeletionFromMissingEntities,
   }: {
     manifest: Manifest;
     workspaceId: string;
     ownerFlatApplication: FlatApplication;
+    inferDeletionFromMissingEntities: boolean;
   }) {
     const {
       flatRoleMaps: refreshedFlatRoleMaps,
@@ -345,8 +348,14 @@ export class ApplicationManifestMigrationService {
 
     await this.applicationService.update(ownerFlatApplication.id, {
       workspaceId,
-      settingsCustomTabFrontComponentId,
-      uninstallLogicFunctionId,
+      ...(isDefined(settingsCustomTabFrontComponentId) ||
+      inferDeletionFromMissingEntities
+        ? { settingsCustomTabFrontComponentId }
+        : {}),
+      ...(isDefined(uninstallLogicFunctionId) ||
+      inferDeletionFromMissingEntities
+        ? { uninstallLogicFunctionId }
+        : {}),
       ...(isDefined(defaultRoleId) ? { defaultRoleId } : {}),
     });
   }

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-additive-mode.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-additive-mode.integration-spec.ts
@@ -3,6 +3,7 @@ import { buildDefaultObjectManifest } from 'test/integration/metadata/suites/app
 import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
 import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
 import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { uploadApplicationFile } from 'test/integration/metadata/suites/application/utils/upload-application-file.util';
 import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
 import { deactivateSkill } from 'test/integration/metadata/suites/skill/utils/deactivate-skill.util';
 import { findSkills } from 'test/integration/metadata/suites/skill/utils/find-skills.util';
@@ -13,6 +14,9 @@ import { v4 as uuidv4 } from 'uuid';
 const TEST_APP_ID = uuidv4();
 const TEST_ROLE_ID = uuidv4();
 const SKILL_NAME = 'additiveModeSkill';
+const CLEANUP_LOGIC_FUNCTION_ID = uuidv4();
+const SETTINGS_FRONT_COMPONENT_ID = uuidv4();
+const BUILT_SETTINGS_COMPONENT_PATH = 'src/front-components/settings.mjs';
 
 const skill: SkillManifest = {
   universalIdentifier: uuidv4(),
@@ -47,6 +51,67 @@ const buildManifest = (
     roleId: TEST_ROLE_ID,
     overrides: { skills: [skill], ...overrides },
   });
+
+const buildManifestWithApplicationReferences = (): Manifest => {
+  const baseManifest = buildManifest({
+    objects: [ticketObject, invoiceObject],
+  });
+
+  return {
+    ...baseManifest,
+    application: {
+      ...baseManifest.application,
+      settingsFrontComponent: {
+        universalIdentifier: SETTINGS_FRONT_COMPONENT_ID,
+      },
+      uninstallLogicFunction: {
+        universalIdentifier: CLEANUP_LOGIC_FUNCTION_ID,
+      },
+    },
+    logicFunctions: [
+      {
+        universalIdentifier: CLEANUP_LOGIC_FUNCTION_ID,
+        name: 'Cleanup',
+        description: 'Uninstall cleanup logic function',
+        handlerName: 'handler',
+        sourceHandlerPath: 'src/cleanup.ts',
+        builtHandlerPath: 'dist/cleanup.mjs',
+        builtHandlerChecksum: 'checksum-cleanup',
+        httpRouteTriggerSettings: {
+          path: '/cleanup',
+          httpMethod: 'POST',
+          isAuthRequired: true,
+        },
+      },
+    ],
+    frontComponents: [
+      {
+        universalIdentifier: SETTINGS_FRONT_COMPONENT_ID,
+        name: 'SettingsComponent',
+        description: 'The settings tab of the application',
+        sourceComponentPath: 'src/front-components/settings.tsx',
+        builtComponentPath: BUILT_SETTINGS_COMPONENT_PATH,
+        builtComponentChecksum: 'settings-checksum',
+        componentName: 'SettingsComponent',
+        isHeadless: false,
+      },
+    ],
+  };
+};
+
+const findApplicationReferences = async (): Promise<{
+  settingsCustomTabFrontComponentId: string | null;
+  uninstallLogicFunctionId: string | null;
+}> => {
+  const [application] = await globalThis.testDataSource.query(
+    `SELECT "settingsCustomTabFrontComponentId", "uninstallLogicFunctionId"
+     FROM core."application"
+     WHERE "universalIdentifier" = $1 AND "deletedAt" IS NULL`,
+    [TEST_APP_ID],
+  );
+
+  return application;
+};
 
 const findObjectNames = async (): Promise<string[]> => {
   const { objects } = await findManyObjectMetadata({
@@ -136,6 +201,55 @@ describe('Manifest sync - additive mode', () => {
 
     expect(objectNames).toContain('additiveTicket');
     expect(objectNames).toContain('additiveInvoice');
+  }, 60000);
+
+  it('keeps the settings component and uninstall hook bindings when the source stops declaring them and deletions are turned off', async () => {
+    jest.useRealTimers();
+
+    await uploadApplicationFile({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      fileFolder: 'BuiltFrontComponent',
+      filePath: BUILT_SETTINGS_COMPONENT_PATH,
+      fileBuffer: Buffer.from('dummy built component content'),
+      filename: 'settings.mjs',
+      contentType: 'application/javascript',
+      expectToFail: false,
+    });
+
+    jest.useFakeTimers();
+
+    await syncApplication({
+      manifest: buildManifestWithApplicationReferences(),
+      expectToFail: false,
+    });
+
+    const declaredReferences = await findApplicationReferences();
+
+    expect(declaredReferences.settingsCustomTabFrontComponentId).not.toBeNull();
+    expect(declaredReferences.uninstallLogicFunctionId).not.toBeNull();
+
+    const manifestWithoutReferences = buildManifest({
+      objects: [ticketObject, invoiceObject],
+    });
+
+    const additiveSync = await syncApplication({
+      manifest: manifestWithoutReferences,
+      inferDeletionFromMissingEntities: false,
+      expectToFail: false,
+    });
+
+    expect(additiveSync.errors).toBeUndefined();
+    expect(await findApplicationReferences()).toEqual(declaredReferences);
+
+    await syncApplication({
+      manifest: manifestWithoutReferences,
+      expectToFail: false,
+    });
+
+    expect(await findApplicationReferences()).toEqual({
+      settingsCustomTabFrontComponentId: null,
+      uninstallLogicFunctionId: null,
+    });
   }, 60000);
 
   it('keeps a skill deactivated by the workspace across a sync', async () => {


### PR DESCRIPTION
## Context
--no-delete keeps entities the source no longer declares, but the application's own references (settings front component, uninstall logic function) were still reset to null on every apply. This makes the reference sync follow the same rule: in additive mode an undeclared reference keeps its current value, in pruning mode it is cleared as before. Needed by the pull flow, where a data-model-only source is applied additively onto an app that already has its code installed. Integration case on the additive-mode suite, docs sentence updated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

