### PR TITLE
fix: cap the SVG size that file upload completion will sanitize

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.resolver.ts
@@ -53,10 +53,8 @@ import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import {
-  StreamSizeExceededError,
-  streamToBuffer,
-} from 'src/utils/stream-to-buffer';
+import { StreamSizeExceededError } from 'src/utils/stream-size-exceeded-error';
+import { streamToBuffer } from 'src/utils/stream-to-buffer';
 import { ApplicationRegistrationVariableDTO } from 'src/engine/core-modules/application/application-registration-variable/dtos/application-registration-variable.dto';
 import {
   ApplicationRegistrationException,

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.resolver.ts
@@ -53,7 +53,10 @@ import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import { streamToBuffer } from 'src/utils/stream-to-buffer';
+import {
+  StreamSizeExceededError,
+  streamToBuffer,
+} from 'src/utils/stream-to-buffer';
 import { ApplicationRegistrationVariableDTO } from 'src/engine/core-modules/application/application-registration-variable/dtos/application-registration-variable.dto';
 import {
   ApplicationRegistrationException,
@@ -277,10 +280,7 @@ export class ApplicationRegistrationResolver {
         ownerWorkspaceId: workspaceId,
       });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes('maximum allowed size')
-      ) {
+      if (error instanceof StreamSizeExceededError) {
         throw new ApplicationRegistrationException(
           `Tarball exceeds maximum size of ${maxSize} bytes`,
           ApplicationRegistrationExceptionCode.INVALID_INPUT,

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant.ts
@@ -1,0 +1,5 @@
+// DOMPurify needs the whole SVG as a string plus a JSDOM tree, so the peak
+// heap is a large multiple of the file. Anything bigger is refused rather
+// than sanitized: node's max string length would throw well below the
+// direct upload cap anyway.
+export const MAX_SANITIZABLE_SVG_BYTES = 2 * 1024 * 1024;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant.ts
@@ -2,4 +2,4 @@
 // heap is a large multiple of the file. Anything bigger is refused rather
 // than sanitized: node's max string length would throw well below the
 // direct upload cap anyway.
-export const MAX_SANITIZABLE_SVG_BYTES = 2 * 1024 * 1024;
+export const MAX_SANITIZABLE_SVG_BYTES = 3 * 1024 * 1024;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload-completion.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload-completion.service.spec.ts
@@ -1,0 +1,127 @@
+import { Readable } from 'stream';
+
+import { FileFolder } from 'twenty-shared/types';
+
+import { type FileStorageService } from 'src/engine/core-modules/file-storage/services/file-storage.service';
+import { type FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
+import { MAX_SANITIZABLE_SVG_BYTES } from 'src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant';
+import { FileUploadExceptionCode } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
+import { FileUploadCompletionService } from 'src/engine/core-modules/file/file-upload/services/file-upload-completion.service';
+import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
+import { type WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
+
+describe('FileUploadCompletionService.completeUploadedFile', () => {
+  const workspaceId = '20202020-0000-4000-8000-000000000001';
+  const fileId = '20202020-0000-4000-8000-000000000002';
+
+  const svgContent =
+    '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>';
+  const pngContent = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    0x49, 0x48, 0x44, 0x52,
+  ]);
+
+  let fileStorageService: jest.Mocked<FileStorageService>;
+  let fileRepository: jest.Mocked<WorkspaceScopedRepository<FileEntity>>;
+
+  const buildStorageLocation = (ext: string) => ({
+    fileFolder: FileFolder.FilesField,
+    applicationUniversalIdentifier: 'application-universal-identifier',
+    workspaceId,
+    resourcePath: `${fileId}.${ext}`,
+  });
+
+  const buildFile = (ext: string, size: number) =>
+    ({
+      id: fileId,
+      path: `${FileFolder.FilesField}/${fileId}.${ext}`,
+      size,
+      status: FILE_STATUS.PENDING,
+      mimeType: 'application/octet-stream',
+      createdAt: new Date(),
+    }) as FileEntity;
+
+  const buildService = () =>
+    new FileUploadCompletionService(fileStorageService, fileRepository);
+
+  beforeEach(() => {
+    fileStorageService = {
+      getFileMetadata: jest.fn(),
+      readFilePrefix: jest.fn().mockResolvedValue(Buffer.from(svgContent)),
+      readFile: jest
+        .fn()
+        .mockImplementation(async () => Readable.from(Buffer.from(svgContent))),
+      writeFileStream: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<FileStorageService>;
+
+    fileRepository = {
+      update: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<WorkspaceScopedRepository<FileEntity>>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should refuse an SVG larger than the sanitizable limit without reading it', async () => {
+    const size = MAX_SANITIZABLE_SVG_BYTES + 1;
+
+    fileStorageService.getFileMetadata.mockResolvedValue({ size });
+
+    await expect(
+      buildService().completeUploadedFile({
+        workspaceId,
+        file: buildFile('svg', size),
+        storageLocation: buildStorageLocation('svg'),
+      }),
+    ).rejects.toMatchObject({
+      code: FileUploadExceptionCode.FILE_TOO_LARGE,
+    });
+
+    expect(fileStorageService.readFile).not.toHaveBeenCalled();
+    expect(fileRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should sanitize an SVG within the limit and store its new size', async () => {
+    const size = Buffer.byteLength(svgContent);
+
+    fileStorageService.getFileMetadata.mockResolvedValue({ size });
+
+    const completedFile = await buildService().completeUploadedFile({
+      workspaceId,
+      file: buildFile('svg', size),
+      storageLocation: buildStorageLocation('svg'),
+    });
+
+    expect(completedFile.mimeType).toBe('image/svg+xml');
+    expect(completedFile.size).toBeLessThan(size);
+    expect(fileStorageService.writeFileStream).toHaveBeenCalledTimes(1);
+    expect(fileRepository.update).toHaveBeenCalledWith(
+      workspaceId,
+      { id: fileId },
+      expect.objectContaining({
+        status: FILE_STATUS.UPLOADED,
+        mimeType: 'image/svg+xml',
+        size: completedFile.size,
+      }),
+    );
+  });
+
+  it('should not read a file that does not need sanitizing', async () => {
+    const size = pngContent.length;
+
+    fileStorageService.getFileMetadata.mockResolvedValue({ size });
+    fileStorageService.readFilePrefix.mockResolvedValue(pngContent);
+
+    const completedFile = await buildService().completeUploadedFile({
+      workspaceId,
+      file: buildFile('png', size),
+      storageLocation: buildStorageLocation('png'),
+    });
+
+    expect(completedFile.mimeType).toBe('image/png');
+    expect(completedFile.size).toBe(size);
+    expect(fileStorageService.readFile).not.toHaveBeenCalled();
+    expect(fileStorageService.writeFileStream).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload-completion.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload-completion.service.spec.ts
@@ -82,6 +82,29 @@ describe('FileUploadCompletionService.completeUploadedFile', () => {
     expect(fileRepository.update).not.toHaveBeenCalled();
   });
 
+  it('should report an oversized read as FILE_TOO_LARGE when storage understated the size', async () => {
+    const declaredSize = 1024;
+
+    fileStorageService.getFileMetadata.mockResolvedValue({
+      size: declaredSize,
+    });
+    fileStorageService.readFile.mockResolvedValue(
+      Readable.from(Buffer.alloc(MAX_SANITIZABLE_SVG_BYTES + 1)),
+    );
+
+    await expect(
+      buildService().completeUploadedFile({
+        workspaceId,
+        file: buildFile('svg', declaredSize),
+        storageLocation: buildStorageLocation('svg'),
+      }),
+    ).rejects.toMatchObject({
+      code: FileUploadExceptionCode.FILE_TOO_LARGE,
+    });
+
+    expect(fileRepository.update).not.toHaveBeenCalled();
+  });
+
   it('should sanitize an SVG within the limit and store its new size', async () => {
     const size = Buffer.byteLength(svgContent);
 

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload.service.create-file-upload.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload.service.create-file-upload.spec.ts
@@ -1,0 +1,52 @@
+import { FileFolder } from 'twenty-shared/types';
+
+import { MAX_SANITIZABLE_SVG_BYTES } from 'src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant';
+import { FileUploadExceptionCode } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
+import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
+
+describe('FileUploadService.createFileUpload', () => {
+  const workspaceId = '20202020-0000-4000-8000-000000000001';
+
+  // The oversized SVG guard rejects before reaching any collaborator.
+  const buildService = () =>
+    new FileUploadService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+  const createUpload = (filename: string, size: number) =>
+    buildService().createFileUpload({
+      workspaceId,
+      filename,
+      size,
+      fileFolder: FileFolder.FilesField,
+      fieldMetadataId: '20202020-0000-4000-8000-000000000002',
+    });
+
+  it.each(['logo.svg', 'logo.SVG', 'logo.Svg'])(
+    'should refuse an oversized %s before handing out an upload target',
+    async (filename) => {
+      await expect(
+        createUpload(filename, MAX_SANITIZABLE_SVG_BYTES + 1),
+      ).rejects.toMatchObject({
+        code: FileUploadExceptionCode.FILE_TOO_LARGE,
+      });
+    },
+  );
+
+  it('should not refuse an SVG within the limit', async () => {
+    // Reaching a collaborator means the guard let it through, which is what
+    // this asserts: the empty mocks make that surface as a TypeError.
+    await expect(
+      createUpload('logo.svg', MAX_SANITIZABLE_SVG_BYTES),
+    ).rejects.not.toMatchObject({
+      code: FileUploadExceptionCode.FILE_TOO_LARGE,
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -9,6 +9,7 @@ import { FileStorageService } from 'src/engine/core-modules/file-storage/service
 import { FileDTO } from 'src/engine/core-modules/file/dtos/file.dto';
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { FILE_CONTENT_SNIFF_BYTE_COUNT } from 'src/engine/core-modules/file/file-upload/constants/file-content-sniff.constant';
+import { MAX_SANITIZABLE_SVG_BYTES } from 'src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant';
 import {
   FileUploadException,
   FileUploadExceptionCode,
@@ -199,9 +200,19 @@ export class FileUploadCompletionService {
       return size;
     }
 
+    if (size > MAX_SANITIZABLE_SVG_BYTES) {
+      throw new FileUploadException(
+        `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
+        FileUploadExceptionCode.FILE_TOO_LARGE,
+        {
+          userFriendlyMessage: msg`This SVG is too large to be processed.`,
+        },
+      );
+    }
+
     const stream = await this.fileStorageService.readFile(storageLocation);
     const sanitizedFile = sanitizeFile({
-      file: await streamToBuffer(stream),
+      file: await streamToBuffer(stream, MAX_SANITIZABLE_SVG_BYTES),
       ext: 'svg',
       mimeType,
     });

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -24,10 +24,8 @@ import { removeFileFolderFromFileEntityPath } from 'src/engine/core-modules/file
 import { sanitizeFile } from 'src/engine/core-modules/file/utils/sanitize-file.utils';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
-import {
-  StreamSizeExceededError,
-  streamToBuffer,
-} from 'src/utils/stream-to-buffer';
+import { StreamSizeExceededError } from 'src/utils/stream-size-exceeded-error';
+import { streamToBuffer } from 'src/utils/stream-to-buffer';
 
 export type BatchCompleteUploadRequest = {
   workspaceId: string;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -23,7 +23,10 @@ import { removeFileFolderFromFileEntityPath } from 'src/engine/core-modules/file
 import { sanitizeFile } from 'src/engine/core-modules/file/utils/sanitize-file.utils';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
-import { streamToBuffer } from 'src/utils/stream-to-buffer';
+import {
+  StreamSizeExceededError,
+  streamToBuffer,
+} from 'src/utils/stream-to-buffer';
 
 export type BatchCompleteUploadRequest = {
   workspaceId: string;
@@ -187,6 +190,16 @@ export class FileUploadCompletionService {
     );
   }
 
+  private buildSvgTooLargeException(size: number): FileUploadException {
+    return new FileUploadException(
+      `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
+      FileUploadExceptionCode.FILE_TOO_LARGE,
+      {
+        userFriendlyMessage: msg`This SVG is too large to be processed.`,
+      },
+    );
+  }
+
   private async sanitizeUploadedFileIfNeeded({
     storageLocation,
     mimeType,
@@ -201,18 +214,25 @@ export class FileUploadCompletionService {
     }
 
     if (size > MAX_SANITIZABLE_SVG_BYTES) {
-      throw new FileUploadException(
-        `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
-        FileUploadExceptionCode.FILE_TOO_LARGE,
-        {
-          userFriendlyMessage: msg`This SVG is too large to be processed.`,
-        },
-      );
+      throw this.buildSvgTooLargeException(size);
     }
 
     const stream = await this.fileStorageService.readFile(storageLocation);
+
+    let file: Buffer;
+
+    try {
+      file = await streamToBuffer(stream, MAX_SANITIZABLE_SVG_BYTES);
+    } catch (error) {
+      if (error instanceof StreamSizeExceededError) {
+        throw this.buildSvgTooLargeException(size);
+      }
+
+      throw error;
+    }
+
     const sanitizedFile = sanitizeFile({
-      file: await streamToBuffer(stream, MAX_SANITIZABLE_SVG_BYTES),
+      file,
       ext: 'svg',
       mimeType,
     });

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -15,6 +15,7 @@ import {
   FileUploadExceptionCode,
 } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
 import { type BatchFileResult } from 'src/engine/core-modules/file/file-upload/types/batch-file-result.type';
+import { buildSvgTooLargeException } from 'src/engine/core-modules/file/file-upload/utils/build-svg-too-large-exception.util';
 import { toBatchErrorMessage } from 'src/engine/core-modules/file/file-upload/utils/to-batch-error-message.util';
 import { fileFolderConfigs } from 'src/engine/core-modules/file/interfaces/file-folder.interface';
 import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
@@ -190,16 +191,6 @@ export class FileUploadCompletionService {
     );
   }
 
-  private buildSvgTooLargeException(size: number): FileUploadException {
-    return new FileUploadException(
-      `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
-      FileUploadExceptionCode.FILE_TOO_LARGE,
-      {
-        userFriendlyMessage: msg`This SVG is too large to be processed.`,
-      },
-    );
-  }
-
   private async sanitizeUploadedFileIfNeeded({
     storageLocation,
     mimeType,
@@ -214,7 +205,9 @@ export class FileUploadCompletionService {
     }
 
     if (size > MAX_SANITIZABLE_SVG_BYTES) {
-      throw this.buildSvgTooLargeException(size);
+      throw buildSvgTooLargeException(
+        `storage reports ${size} bytes, above the ${MAX_SANITIZABLE_SVG_BYTES} byte limit`,
+      );
     }
 
     const stream = await this.fileStorageService.readFile(storageLocation);
@@ -225,7 +218,11 @@ export class FileUploadCompletionService {
       file = await streamToBuffer(stream, MAX_SANITIZABLE_SVG_BYTES);
     } catch (error) {
       if (error instanceof StreamSizeExceededError) {
-        throw this.buildSvgTooLargeException(size);
+        // Deliberately does not quote `size`: storage understated it, so
+        // repeating it here would contradict the failure being reported.
+        throw buildSvgTooLargeException(
+          `content exceeds the ${MAX_SANITIZABLE_SVG_BYTES} byte limit`,
+        );
       }
 
       throw error;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
@@ -27,6 +27,7 @@ import {
 } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
 import { FileUploadCompletionService } from 'src/engine/core-modules/file/file-upload/services/file-upload-completion.service';
 import { FileUploadTargetService } from 'src/engine/core-modules/file/file-upload/services/file-upload-target.service';
+import { buildSvgTooLargeException } from 'src/engine/core-modules/file/file-upload/utils/build-svg-too-large-exception.util';
 import { FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
 import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
 import { buildFileInfo } from 'src/engine/core-modules/file/utils/build-file-info.utils';
@@ -108,13 +109,9 @@ export class FileUploadService {
     // Completion refuses to sanitize an SVG this big, so reject before the
     // client transfers it. The declared extension is a client claim, which
     // only makes this a shortcut: the sniffed check at completion decides.
-    if (ext === 'svg' && size > MAX_SANITIZABLE_SVG_BYTES) {
-      throw new FileUploadException(
-        `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
-        FileUploadExceptionCode.FILE_TOO_LARGE,
-        {
-          userFriendlyMessage: msg`This SVG is too large to be processed.`,
-        },
+    if (ext.toLowerCase() === 'svg' && size > MAX_SANITIZABLE_SVG_BYTES) {
+      throw buildSvgTooLargeException(
+        `declared size ${size} exceeds the ${MAX_SANITIZABLE_SVG_BYTES} byte limit`,
       );
     }
 

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
@@ -19,6 +19,7 @@ import { FileStorageService } from 'src/engine/core-modules/file-storage/service
 import { FileWithSignedUrlDTO } from 'src/engine/core-modules/file/dtos/file-with-sign-url.dto';
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { COMPLETE_FILE_UPLOAD_DEADLINE_MS } from 'src/engine/core-modules/file/file-upload/constants/complete-file-upload-deadline.constant';
+import { MAX_SANITIZABLE_SVG_BYTES } from 'src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant';
 import { FileUploadTargetDTO } from 'src/engine/core-modules/file/file-upload/dtos/file-upload-target.dto';
 import {
   FileUploadException,
@@ -103,6 +104,20 @@ export class FileUploadService {
     }
 
     const { ext } = buildFileInfo(filename);
+
+    // Completion refuses to sanitize an SVG this big, so reject before the
+    // client transfers it. The declared extension is a client claim, which
+    // only makes this a shortcut: the sniffed check at completion decides.
+    if (ext === 'svg' && size > MAX_SANITIZABLE_SVG_BYTES) {
+      throw new FileUploadException(
+        `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
+        FileUploadExceptionCode.FILE_TOO_LARGE,
+        {
+          userFriendlyMessage: msg`This SVG is too large to be processed.`,
+        },
+      );
+    }
+
     const mimeType = 'application/octet-stream';
 
     const fileId = v4();

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/utils/build-svg-too-large-exception.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/utils/build-svg-too-large-exception.util.ts
@@ -1,0 +1,17 @@
+import { msg } from '@lingui/core/macro';
+
+import {
+  FileUploadException,
+  FileUploadExceptionCode,
+} from 'src/engine/core-modules/file/file-upload/file-upload.exception';
+
+export const buildSvgTooLargeException = (
+  detail: string,
+): FileUploadException =>
+  new FileUploadException(
+    `SVG cannot be sanitized: ${detail}`,
+    FileUploadExceptionCode.FILE_TOO_LARGE,
+    {
+      userFriendlyMessage: msg`This SVG is too large to be processed.`,
+    },
+  );

--- a/packages/twenty-server/src/utils/stream-size-exceeded-error.ts
+++ b/packages/twenty-server/src/utils/stream-size-exceeded-error.ts
@@ -1,0 +1,8 @@
+// Callers that cap a read need to tell "too big" apart from a storage failure
+// without matching on a message, so they can map it to their own domain error.
+export class StreamSizeExceededError extends Error {
+  constructor(maxSizeBytes: number) {
+    super(`Stream exceeds maximum allowed size of ${maxSizeBytes} bytes`);
+    this.name = 'StreamSizeExceededError';
+  }
+}

--- a/packages/twenty-server/src/utils/stream-to-buffer.ts
+++ b/packages/twenty-server/src/utils/stream-to-buffer.ts
@@ -1,13 +1,6 @@
 import { type Readable } from 'stream';
 
-// Callers that cap a read need to tell "too big" apart from a storage failure
-// without matching on a message, so they can map it to their own domain error.
-export class StreamSizeExceededError extends Error {
-  constructor(maxSizeBytes: number) {
-    super(`Stream exceeds maximum allowed size of ${maxSizeBytes} bytes`);
-    this.name = 'StreamSizeExceededError';
-  }
-}
+import { StreamSizeExceededError } from 'src/utils/stream-size-exceeded-error';
 
 export const streamToBuffer = async (
   stream: Readable,

--- a/packages/twenty-server/src/utils/stream-to-buffer.ts
+++ b/packages/twenty-server/src/utils/stream-to-buffer.ts
@@ -1,5 +1,14 @@
 import { type Readable } from 'stream';
 
+// Callers that cap a read need to tell "too big" apart from a storage failure
+// without matching on a message, so they can map it to their own domain error.
+export class StreamSizeExceededError extends Error {
+  constructor(maxSizeBytes: number) {
+    super(`Stream exceeds maximum allowed size of ${maxSizeBytes} bytes`);
+    this.name = 'StreamSizeExceededError';
+  }
+}
+
 export const streamToBuffer = async (
   stream: Readable,
   maxSizeBytes?: number,
@@ -37,11 +46,7 @@ export const streamToBuffer = async (
           isResolved = true;
           cleanup();
           stream.destroy();
-          reject(
-            new Error(
-              `Stream exceeds maximum allowed size of ${maxSizeBytes} bytes`,
-            ),
-          );
+          reject(new StreamSizeExceededError(maxSizeBytes));
 
           return;
         }


### PR DESCRIPTION
First of three stacked PRs on the direct upload path. This one stands alone.

## Context

`completeFileUpload` sanitizes SVGs by reading the whole object into a buffer, converting it to a UTF-8 string and building a JSDOM tree for DOMPurify. `sanitizeUploadedFileIfNeeded` called `streamToBuffer` without passing the `maxSizeBytes` that helper already accepts, so the read was unbounded against the 1GB `maxDirectUploadFileSize` cap.

SVG is reachable in the four direct upload folders that declare no MIME allowlist (FilesField, Workflow, EmailAttachment, AgentChat), so a large one puts a multiple of its size on the heap: the buffer, the string, and the DOM. Node's max string length throws well below 1GB, and the sizes in between are enough to take the process out.

The 60s completion deadline does not contain this. `withDeadline` races the promise without cancelling it, so the buffering continues after the client has been answered.

This is live on the current default configuration: the completion path runs whether the bytes arrived through a presigned PUT or through the server's streaming endpoint.

## Changes

**Cap the sanitize read.** An SVG above `MAX_SANITIZABLE_SVG_BYTES` (3MB) is refused with a `FILE_TOO_LARGE` `FileUploadException`. The check uses `metadata.size`, which has already been verified against storage, so an oversized SVG is rejected without reading anything. The same cap is passed to `streamToBuffer` for the reads that do happen.

Rejecting is deliberate rather than storing it unsanitized: an SVG past a few MB is not a plausible icon or avatar, and "too large to be checked" is the honest answer.

**Reject at creation too.** `createFileUpload` refuses an oversized SVG on the declared extension before handing out an upload target, so the client does not transfer a file completion is guaranteed to reject and leave a PENDING row behind. That extension is a client claim, which makes this only a shortcut: the sniffed check at completion stays authoritative. Matched case-insensitively, since `buildFileInfo` returns the extension as written.

**Type the stream cap.** `streamToBuffer`'s backup cap rejected with a generic `Error`, so the sanitize path would have surfaced an unhandled internal error instead of the `FILE_TOO_LARGE` it means. It now rejects with a `StreamSizeExceededError` that the one call site with a domain error converts, leaving genuine stream failures to propagate as themselves. The application tarball upload discriminated on the message text for the same reason and now matches on the type.

## Tests

- `file-upload-completion.service.spec.ts`: an SVG over the limit is refused with nothing read or written; an oversized read is reported as `FILE_TOO_LARGE` when storage understated the size; an SVG under the limit is sanitized and its post-sanitization size stored; a file needing no sanitizing is never read in full
- `file-upload.service.create-file-upload.spec.ts`: `.svg`, `.SVG` and `.Svg` are all refused at creation when oversized, and one within the limit is not

## Verification

- 450 tests pass across `core-modules/file`, `core-modules/file-storage` and `src/utils`
- `tsgo -p tsconfig.json --noEmit` on twenty-server: only the pre-existing errors from unbuilt sibling packages (`twenty-emails`, `twenty-sdk`, `twenty-client-sdk`)
- `nx lint:diff-with-main twenty-server` clean