### PR TITLE
refactor: make each file folder state its MIME policy explicitly

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.resolver.ts
@@ -53,10 +53,8 @@ import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import {
-  StreamSizeExceededError,
-  streamToBuffer,
-} from 'src/utils/stream-to-buffer';
+import { StreamSizeExceededError } from 'src/utils/stream-size-exceeded-error';
+import { streamToBuffer } from 'src/utils/stream-to-buffer';
 import { ApplicationRegistrationVariableDTO } from 'src/engine/core-modules/application/application-registration-variable/dtos/application-registration-variable.dto';
 import {
   ApplicationRegistrationException,

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.resolver.ts
@@ -53,7 +53,10 @@ import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import { streamToBuffer } from 'src/utils/stream-to-buffer';
+import {
+  StreamSizeExceededError,
+  streamToBuffer,
+} from 'src/utils/stream-to-buffer';
 import { ApplicationRegistrationVariableDTO } from 'src/engine/core-modules/application/application-registration-variable/dtos/application-registration-variable.dto';
 import {
   ApplicationRegistrationException,
@@ -277,10 +280,7 @@ export class ApplicationRegistrationResolver {
         ownerWorkspaceId: workspaceId,
       });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes('maximum allowed size')
-      ) {
+      if (error instanceof StreamSizeExceededError) {
         throw new ApplicationRegistrationException(
           `Tarball exceeds maximum size of ${maxSize} bytes`,
           ApplicationRegistrationExceptionCode.INVALID_INPUT,

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant.ts
@@ -1,0 +1,5 @@
+// DOMPurify needs the whole SVG as a string plus a JSDOM tree, so the peak
+// heap is a large multiple of the file. Anything bigger is refused rather
+// than sanitized: node's max string length would throw well below the
+// direct upload cap anyway.
+export const MAX_SANITIZABLE_SVG_BYTES = 2 * 1024 * 1024;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant.ts
@@ -2,4 +2,4 @@
 // heap is a large multiple of the file. Anything bigger is refused rather
 // than sanitized: node's max string length would throw well below the
 // direct upload cap anyway.
-export const MAX_SANITIZABLE_SVG_BYTES = 2 * 1024 * 1024;
+export const MAX_SANITIZABLE_SVG_BYTES = 3 * 1024 * 1024;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload-completion.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload-completion.service.spec.ts
@@ -1,0 +1,127 @@
+import { Readable } from 'stream';
+
+import { FileFolder } from 'twenty-shared/types';
+
+import { type FileStorageService } from 'src/engine/core-modules/file-storage/services/file-storage.service';
+import { type FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
+import { MAX_SANITIZABLE_SVG_BYTES } from 'src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant';
+import { FileUploadExceptionCode } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
+import { FileUploadCompletionService } from 'src/engine/core-modules/file/file-upload/services/file-upload-completion.service';
+import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
+import { type WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
+
+describe('FileUploadCompletionService.completeUploadedFile', () => {
+  const workspaceId = '20202020-0000-4000-8000-000000000001';
+  const fileId = '20202020-0000-4000-8000-000000000002';
+
+  const svgContent =
+    '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>';
+  const pngContent = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    0x49, 0x48, 0x44, 0x52,
+  ]);
+
+  let fileStorageService: jest.Mocked<FileStorageService>;
+  let fileRepository: jest.Mocked<WorkspaceScopedRepository<FileEntity>>;
+
+  const buildStorageLocation = (ext: string) => ({
+    fileFolder: FileFolder.FilesField,
+    applicationUniversalIdentifier: 'application-universal-identifier',
+    workspaceId,
+    resourcePath: `${fileId}.${ext}`,
+  });
+
+  const buildFile = (ext: string, size: number) =>
+    ({
+      id: fileId,
+      path: `${FileFolder.FilesField}/${fileId}.${ext}`,
+      size,
+      status: FILE_STATUS.PENDING,
+      mimeType: 'application/octet-stream',
+      createdAt: new Date(),
+    }) as FileEntity;
+
+  const buildService = () =>
+    new FileUploadCompletionService(fileStorageService, fileRepository);
+
+  beforeEach(() => {
+    fileStorageService = {
+      getFileMetadata: jest.fn(),
+      readFilePrefix: jest.fn().mockResolvedValue(Buffer.from(svgContent)),
+      readFile: jest
+        .fn()
+        .mockImplementation(async () => Readable.from(Buffer.from(svgContent))),
+      writeFileStream: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<FileStorageService>;
+
+    fileRepository = {
+      update: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<WorkspaceScopedRepository<FileEntity>>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should refuse an SVG larger than the sanitizable limit without reading it', async () => {
+    const size = MAX_SANITIZABLE_SVG_BYTES + 1;
+
+    fileStorageService.getFileMetadata.mockResolvedValue({ size });
+
+    await expect(
+      buildService().completeUploadedFile({
+        workspaceId,
+        file: buildFile('svg', size),
+        storageLocation: buildStorageLocation('svg'),
+      }),
+    ).rejects.toMatchObject({
+      code: FileUploadExceptionCode.FILE_TOO_LARGE,
+    });
+
+    expect(fileStorageService.readFile).not.toHaveBeenCalled();
+    expect(fileRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should sanitize an SVG within the limit and store its new size', async () => {
+    const size = Buffer.byteLength(svgContent);
+
+    fileStorageService.getFileMetadata.mockResolvedValue({ size });
+
+    const completedFile = await buildService().completeUploadedFile({
+      workspaceId,
+      file: buildFile('svg', size),
+      storageLocation: buildStorageLocation('svg'),
+    });
+
+    expect(completedFile.mimeType).toBe('image/svg+xml');
+    expect(completedFile.size).toBeLessThan(size);
+    expect(fileStorageService.writeFileStream).toHaveBeenCalledTimes(1);
+    expect(fileRepository.update).toHaveBeenCalledWith(
+      workspaceId,
+      { id: fileId },
+      expect.objectContaining({
+        status: FILE_STATUS.UPLOADED,
+        mimeType: 'image/svg+xml',
+        size: completedFile.size,
+      }),
+    );
+  });
+
+  it('should not read a file that does not need sanitizing', async () => {
+    const size = pngContent.length;
+
+    fileStorageService.getFileMetadata.mockResolvedValue({ size });
+    fileStorageService.readFilePrefix.mockResolvedValue(pngContent);
+
+    const completedFile = await buildService().completeUploadedFile({
+      workspaceId,
+      file: buildFile('png', size),
+      storageLocation: buildStorageLocation('png'),
+    });
+
+    expect(completedFile.mimeType).toBe('image/png');
+    expect(completedFile.size).toBe(size);
+    expect(fileStorageService.readFile).not.toHaveBeenCalled();
+    expect(fileStorageService.writeFileStream).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload-completion.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload-completion.service.spec.ts
@@ -82,6 +82,29 @@ describe('FileUploadCompletionService.completeUploadedFile', () => {
     expect(fileRepository.update).not.toHaveBeenCalled();
   });
 
+  it('should report an oversized read as FILE_TOO_LARGE when storage understated the size', async () => {
+    const declaredSize = 1024;
+
+    fileStorageService.getFileMetadata.mockResolvedValue({
+      size: declaredSize,
+    });
+    fileStorageService.readFile.mockResolvedValue(
+      Readable.from(Buffer.alloc(MAX_SANITIZABLE_SVG_BYTES + 1)),
+    );
+
+    await expect(
+      buildService().completeUploadedFile({
+        workspaceId,
+        file: buildFile('svg', declaredSize),
+        storageLocation: buildStorageLocation('svg'),
+      }),
+    ).rejects.toMatchObject({
+      code: FileUploadExceptionCode.FILE_TOO_LARGE,
+    });
+
+    expect(fileRepository.update).not.toHaveBeenCalled();
+  });
+
   it('should sanitize an SVG within the limit and store its new size', async () => {
     const size = Buffer.byteLength(svgContent);
 

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload.service.create-file-upload.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/__tests__/file-upload.service.create-file-upload.spec.ts
@@ -1,0 +1,52 @@
+import { FileFolder } from 'twenty-shared/types';
+
+import { MAX_SANITIZABLE_SVG_BYTES } from 'src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant';
+import { FileUploadExceptionCode } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
+import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
+
+describe('FileUploadService.createFileUpload', () => {
+  const workspaceId = '20202020-0000-4000-8000-000000000001';
+
+  // The oversized SVG guard rejects before reaching any collaborator.
+  const buildService = () =>
+    new FileUploadService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+  const createUpload = (filename: string, size: number) =>
+    buildService().createFileUpload({
+      workspaceId,
+      filename,
+      size,
+      fileFolder: FileFolder.FilesField,
+      fieldMetadataId: '20202020-0000-4000-8000-000000000002',
+    });
+
+  it.each(['logo.svg', 'logo.SVG', 'logo.Svg'])(
+    'should refuse an oversized %s before handing out an upload target',
+    async (filename) => {
+      await expect(
+        createUpload(filename, MAX_SANITIZABLE_SVG_BYTES + 1),
+      ).rejects.toMatchObject({
+        code: FileUploadExceptionCode.FILE_TOO_LARGE,
+      });
+    },
+  );
+
+  it('should not refuse an SVG within the limit', async () => {
+    // Reaching a collaborator means the guard let it through, which is what
+    // this asserts: the empty mocks make that surface as a TypeError.
+    await expect(
+      createUpload('logo.svg', MAX_SANITIZABLE_SVG_BYTES),
+    ).rejects.not.toMatchObject({
+      code: FileUploadExceptionCode.FILE_TOO_LARGE,
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -9,6 +9,7 @@ import { FileStorageService } from 'src/engine/core-modules/file-storage/service
 import { FileDTO } from 'src/engine/core-modules/file/dtos/file.dto';
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { FILE_CONTENT_SNIFF_BYTE_COUNT } from 'src/engine/core-modules/file/file-upload/constants/file-content-sniff.constant';
+import { MAX_SANITIZABLE_SVG_BYTES } from 'src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant';
 import {
   FileUploadException,
   FileUploadExceptionCode,
@@ -199,9 +200,19 @@ export class FileUploadCompletionService {
       return size;
     }
 
+    if (size > MAX_SANITIZABLE_SVG_BYTES) {
+      throw new FileUploadException(
+        `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
+        FileUploadExceptionCode.FILE_TOO_LARGE,
+        {
+          userFriendlyMessage: msg`This SVG is too large to be processed.`,
+        },
+      );
+    }
+
     const stream = await this.fileStorageService.readFile(storageLocation);
     const sanitizedFile = sanitizeFile({
-      file: await streamToBuffer(stream),
+      file: await streamToBuffer(stream, MAX_SANITIZABLE_SVG_BYTES),
       ext: 'svg',
       mimeType,
     });

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -24,10 +24,8 @@ import { removeFileFolderFromFileEntityPath } from 'src/engine/core-modules/file
 import { sanitizeFile } from 'src/engine/core-modules/file/utils/sanitize-file.utils';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
-import {
-  StreamSizeExceededError,
-  streamToBuffer,
-} from 'src/utils/stream-to-buffer';
+import { StreamSizeExceededError } from 'src/utils/stream-size-exceeded-error';
+import { streamToBuffer } from 'src/utils/stream-to-buffer';
 
 export type BatchCompleteUploadRequest = {
   workspaceId: string;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -16,7 +16,10 @@ import {
 } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
 import { type BatchFileResult } from 'src/engine/core-modules/file/file-upload/types/batch-file-result.type';
 import { toBatchErrorMessage } from 'src/engine/core-modules/file/file-upload/utils/to-batch-error-message.util';
-import { fileFolderConfigs } from 'src/engine/core-modules/file/interfaces/file-folder.interface';
+import {
+  ANY_MIME_TYPE,
+  fileFolderConfigs,
+} from 'src/engine/core-modules/file/interfaces/file-folder.interface';
 import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
 import { extractFileInfoOrThrow } from 'src/engine/core-modules/file/utils/extract-file-info-or-throw.utils';
 import { removeFileFolderFromFileEntityPath } from 'src/engine/core-modules/file/utils/remove-file-folder-from-file-entity-path.utils';
@@ -174,7 +177,10 @@ export class FileUploadCompletionService {
   ): void {
     const { allowedMimeTypes } = fileFolderConfigs[fileFolder];
 
-    if (!allowedMimeTypes || allowedMimeTypes.includes(mimeType)) {
+    if (
+      allowedMimeTypes === ANY_MIME_TYPE ||
+      allowedMimeTypes.includes(mimeType)
+    ) {
       return;
     }
 

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -23,7 +23,10 @@ import { removeFileFolderFromFileEntityPath } from 'src/engine/core-modules/file
 import { sanitizeFile } from 'src/engine/core-modules/file/utils/sanitize-file.utils';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
-import { streamToBuffer } from 'src/utils/stream-to-buffer';
+import {
+  StreamSizeExceededError,
+  streamToBuffer,
+} from 'src/utils/stream-to-buffer';
 
 export type BatchCompleteUploadRequest = {
   workspaceId: string;
@@ -187,6 +190,16 @@ export class FileUploadCompletionService {
     );
   }
 
+  private buildSvgTooLargeException(size: number): FileUploadException {
+    return new FileUploadException(
+      `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
+      FileUploadExceptionCode.FILE_TOO_LARGE,
+      {
+        userFriendlyMessage: msg`This SVG is too large to be processed.`,
+      },
+    );
+  }
+
   private async sanitizeUploadedFileIfNeeded({
     storageLocation,
     mimeType,
@@ -201,18 +214,25 @@ export class FileUploadCompletionService {
     }
 
     if (size > MAX_SANITIZABLE_SVG_BYTES) {
-      throw new FileUploadException(
-        `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
-        FileUploadExceptionCode.FILE_TOO_LARGE,
-        {
-          userFriendlyMessage: msg`This SVG is too large to be processed.`,
-        },
-      );
+      throw this.buildSvgTooLargeException(size);
     }
 
     const stream = await this.fileStorageService.readFile(storageLocation);
+
+    let file: Buffer;
+
+    try {
+      file = await streamToBuffer(stream, MAX_SANITIZABLE_SVG_BYTES);
+    } catch (error) {
+      if (error instanceof StreamSizeExceededError) {
+        throw this.buildSvgTooLargeException(size);
+      }
+
+      throw error;
+    }
+
     const sanitizedFile = sanitizeFile({
-      file: await streamToBuffer(stream, MAX_SANITIZABLE_SVG_BYTES),
+      file,
       ext: 'svg',
       mimeType,
     });

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload-completion.service.ts
@@ -15,6 +15,7 @@ import {
   FileUploadExceptionCode,
 } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
 import { type BatchFileResult } from 'src/engine/core-modules/file/file-upload/types/batch-file-result.type';
+import { buildSvgTooLargeException } from 'src/engine/core-modules/file/file-upload/utils/build-svg-too-large-exception.util';
 import { toBatchErrorMessage } from 'src/engine/core-modules/file/file-upload/utils/to-batch-error-message.util';
 import { fileFolderConfigs } from 'src/engine/core-modules/file/interfaces/file-folder.interface';
 import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
@@ -190,16 +191,6 @@ export class FileUploadCompletionService {
     );
   }
 
-  private buildSvgTooLargeException(size: number): FileUploadException {
-    return new FileUploadException(
-      `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
-      FileUploadExceptionCode.FILE_TOO_LARGE,
-      {
-        userFriendlyMessage: msg`This SVG is too large to be processed.`,
-      },
-    );
-  }
-
   private async sanitizeUploadedFileIfNeeded({
     storageLocation,
     mimeType,
@@ -214,7 +205,9 @@ export class FileUploadCompletionService {
     }
 
     if (size > MAX_SANITIZABLE_SVG_BYTES) {
-      throw this.buildSvgTooLargeException(size);
+      throw buildSvgTooLargeException(
+        `storage reports ${size} bytes, above the ${MAX_SANITIZABLE_SVG_BYTES} byte limit`,
+      );
     }
 
     const stream = await this.fileStorageService.readFile(storageLocation);
@@ -225,7 +218,11 @@ export class FileUploadCompletionService {
       file = await streamToBuffer(stream, MAX_SANITIZABLE_SVG_BYTES);
     } catch (error) {
       if (error instanceof StreamSizeExceededError) {
-        throw this.buildSvgTooLargeException(size);
+        // Deliberately does not quote `size`: storage understated it, so
+        // repeating it here would contradict the failure being reported.
+        throw buildSvgTooLargeException(
+          `content exceeds the ${MAX_SANITIZABLE_SVG_BYTES} byte limit`,
+        );
       }
 
       throw error;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
@@ -27,6 +27,7 @@ import {
 } from 'src/engine/core-modules/file/file-upload/file-upload.exception';
 import { FileUploadCompletionService } from 'src/engine/core-modules/file/file-upload/services/file-upload-completion.service';
 import { FileUploadTargetService } from 'src/engine/core-modules/file/file-upload/services/file-upload-target.service';
+import { buildSvgTooLargeException } from 'src/engine/core-modules/file/file-upload/utils/build-svg-too-large-exception.util';
 import { FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
 import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
 import { buildFileInfo } from 'src/engine/core-modules/file/utils/build-file-info.utils';
@@ -108,13 +109,9 @@ export class FileUploadService {
     // Completion refuses to sanitize an SVG this big, so reject before the
     // client transfers it. The declared extension is a client claim, which
     // only makes this a shortcut: the sniffed check at completion decides.
-    if (ext === 'svg' && size > MAX_SANITIZABLE_SVG_BYTES) {
-      throw new FileUploadException(
-        `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
-        FileUploadExceptionCode.FILE_TOO_LARGE,
-        {
-          userFriendlyMessage: msg`This SVG is too large to be processed.`,
-        },
+    if (ext.toLowerCase() === 'svg' && size > MAX_SANITIZABLE_SVG_BYTES) {
+      throw buildSvgTooLargeException(
+        `declared size ${size} exceeds the ${MAX_SANITIZABLE_SVG_BYTES} byte limit`,
       );
     }
 

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
@@ -19,6 +19,7 @@ import { FileStorageService } from 'src/engine/core-modules/file-storage/service
 import { FileWithSignedUrlDTO } from 'src/engine/core-modules/file/dtos/file-with-sign-url.dto';
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { COMPLETE_FILE_UPLOAD_DEADLINE_MS } from 'src/engine/core-modules/file/file-upload/constants/complete-file-upload-deadline.constant';
+import { MAX_SANITIZABLE_SVG_BYTES } from 'src/engine/core-modules/file/file-upload/constants/max-sanitizable-svg-size.constant';
 import { FileUploadTargetDTO } from 'src/engine/core-modules/file/file-upload/dtos/file-upload-target.dto';
 import {
   FileUploadException,
@@ -103,6 +104,20 @@ export class FileUploadService {
     }
 
     const { ext } = buildFileInfo(filename);
+
+    // Completion refuses to sanitize an SVG this big, so reject before the
+    // client transfers it. The declared extension is a client claim, which
+    // only makes this a shortcut: the sniffed check at completion decides.
+    if (ext === 'svg' && size > MAX_SANITIZABLE_SVG_BYTES) {
+      throw new FileUploadException(
+        `SVG of ${size} bytes exceeds the ${MAX_SANITIZABLE_SVG_BYTES} bytes that can be sanitized`,
+        FileUploadExceptionCode.FILE_TOO_LARGE,
+        {
+          userFriendlyMessage: msg`This SVG is too large to be processed.`,
+        },
+      );
+    }
+
     const mimeType = 'application/octet-stream';
 
     const fileId = v4();

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/utils/build-svg-too-large-exception.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/utils/build-svg-too-large-exception.util.ts
@@ -1,0 +1,17 @@
+import { msg } from '@lingui/core/macro';
+
+import {
+  FileUploadException,
+  FileUploadExceptionCode,
+} from 'src/engine/core-modules/file/file-upload/file-upload.exception';
+
+export const buildSvgTooLargeException = (
+  detail: string,
+): FileUploadException =>
+  new FileUploadException(
+    `SVG cannot be sanitized: ${detail}`,
+    FileUploadExceptionCode.FILE_TOO_LARGE,
+    {
+      userFriendlyMessage: msg`This SVG is too large to be processed.`,
+    },
+  );

--- a/packages/twenty-server/src/engine/core-modules/file/interfaces/file-folder.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/interfaces/file-folder.interface.ts
@@ -7,9 +7,6 @@ registerEnumType(FileFolder, {
   name: 'FileFolder',
 });
 
-// Folders that accept arbitrary user content declare this instead of a list.
-// Spelling it out keeps a new folder from silently inheriting "accept
-// everything" by leaving the field off.
 export const ANY_MIME_TYPE = 'any' as const;
 
 export type FileFolderConfig = {

--- a/packages/twenty-server/src/engine/core-modules/file/interfaces/file-folder.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/interfaces/file-folder.interface.ts
@@ -7,10 +7,15 @@ registerEnumType(FileFolder, {
   name: 'FileFolder',
 });
 
+// Folders that accept arbitrary user content declare this instead of a list.
+// Spelling it out keeps a new folder from silently inheriting "accept
+// everything" by leaving the field off.
+export const ANY_MIME_TYPE = 'any' as const;
+
 export type FileFolderConfig = {
   ignoreExpirationToken: boolean;
   cacheControl: string | null;
-  allowedMimeTypes?: readonly string[];
+  allowedMimeTypes: readonly string[] | typeof ANY_MIME_TYPE;
 };
 
 export const IMMUTABLE_FILE_CACHE_CONTROL = 'private, max-age=86400, immutable';
@@ -26,42 +31,52 @@ export const fileFolderConfigs: Record<FileFolder, FileFolderConfig> = {
   [FileFolder.CorePicture]: {
     ignoreExpirationToken: true,
     cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.AgentChat]: {
     ignoreExpirationToken: false,
     cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.BuiltLogicFunction]: {
     ignoreExpirationToken: false,
     cacheControl: null,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.BuiltFrontComponent]: {
     ignoreExpirationToken: false,
     cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.PublicAsset]: {
     ignoreExpirationToken: true,
     cacheControl: PUBLIC_ASSET_CACHE_CONTROL,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.Source]: {
     ignoreExpirationToken: false,
     cacheControl: null,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.FilesField]: {
     ignoreExpirationToken: false,
     cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.Dependencies]: {
     ignoreExpirationToken: false,
     cacheControl: null,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.Workflow]: {
     ignoreExpirationToken: false,
     cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.EmailAttachment]: {
     ignoreExpirationToken: false,
     cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.EmailImage]: {
     ignoreExpirationToken: true,
@@ -71,13 +86,16 @@ export const fileFolderConfigs: Record<FileFolder, FileFolderConfig> = {
   [FileFolder.AppTarball]: {
     ignoreExpirationToken: false,
     cacheControl: null,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.GeneratedSdkClient]: {
     ignoreExpirationToken: false,
     cacheControl: null,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
   [FileFolder.Dpa]: {
     ignoreExpirationToken: false,
     cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
+    allowedMimeTypes: ANY_MIME_TYPE,
   },
 };

--- a/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
@@ -233,15 +233,10 @@ export class FileService {
 
     if (isDefined(presignedUrl)) {
       // The storage provider serves presigned downloads directly and handles
-      // Range requests without proxying the file through the server.
-      //
-      // S3 can only echo the response-* overrides set above, so this path
-      // cannot carry the X-Content-Type-Options: nosniff that the streamed
-      // path sets. Accepted rather than worked around: the response still
-      // pins Content-Type to the type sniffed at upload, and anything not in
-      // INLINE_SAFE_MIME_TYPES is served as an attachment. Restoring the
-      // header would take a CDN response-headers policy in front of the
-      // bucket, not a change here.
+      // Range requests without proxying the file through the server. It can
+      // only echo the response-* overrides set above, so this path carries no
+      // X-Content-Type-Options: nosniff; the headers it does carry pin the
+      // type sniffed at upload and attach anything not inline-safe.
       return { type: 'redirect', presignedUrl };
     }
 

--- a/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
@@ -234,6 +234,14 @@ export class FileService {
     if (isDefined(presignedUrl)) {
       // The storage provider serves presigned downloads directly and handles
       // Range requests without proxying the file through the server.
+      //
+      // S3 can only echo the response-* overrides set above, so this path
+      // cannot carry the X-Content-Type-Options: nosniff that the streamed
+      // path sets. Accepted rather than worked around: the response still
+      // pins Content-Type to the type sniffed at upload, and anything not in
+      // INLINE_SAFE_MIME_TYPES is served as an attachment. Restoring the
+      // header would take a CDN response-headers policy in front of the
+      // bucket, not a change here.
       return { type: 'redirect', presignedUrl };
     }
 

--- a/packages/twenty-server/src/utils/stream-size-exceeded-error.ts
+++ b/packages/twenty-server/src/utils/stream-size-exceeded-error.ts
@@ -1,0 +1,8 @@
+// Callers that cap a read need to tell "too big" apart from a storage failure
+// without matching on a message, so they can map it to their own domain error.
+export class StreamSizeExceededError extends Error {
+  constructor(maxSizeBytes: number) {
+    super(`Stream exceeds maximum allowed size of ${maxSizeBytes} bytes`);
+    this.name = 'StreamSizeExceededError';
+  }
+}

--- a/packages/twenty-server/src/utils/stream-to-buffer.ts
+++ b/packages/twenty-server/src/utils/stream-to-buffer.ts
@@ -1,13 +1,6 @@
 import { type Readable } from 'stream';
 
-// Callers that cap a read need to tell "too big" apart from a storage failure
-// without matching on a message, so they can map it to their own domain error.
-export class StreamSizeExceededError extends Error {
-  constructor(maxSizeBytes: number) {
-    super(`Stream exceeds maximum allowed size of ${maxSizeBytes} bytes`);
-    this.name = 'StreamSizeExceededError';
-  }
-}
+import { StreamSizeExceededError } from 'src/utils/stream-size-exceeded-error';
 
 export const streamToBuffer = async (
   stream: Readable,

--- a/packages/twenty-server/src/utils/stream-to-buffer.ts
+++ b/packages/twenty-server/src/utils/stream-to-buffer.ts
@@ -1,5 +1,14 @@
 import { type Readable } from 'stream';
 
+// Callers that cap a read need to tell "too big" apart from a storage failure
+// without matching on a message, so they can map it to their own domain error.
+export class StreamSizeExceededError extends Error {
+  constructor(maxSizeBytes: number) {
+    super(`Stream exceeds maximum allowed size of ${maxSizeBytes} bytes`);
+    this.name = 'StreamSizeExceededError';
+  }
+}
+
 export const streamToBuffer = async (
   stream: Readable,
   maxSizeBytes?: number,
@@ -37,11 +46,7 @@ export const streamToBuffer = async (
           isResolved = true;
           cleanup();
           stream.destroy();
-          reject(
-            new Error(
-              `Stream exceeds maximum allowed size of ${maxSizeBytes} bytes`,
-            ),
-          );
+          reject(new StreamSizeExceededError(maxSizeBytes));
 
           return;
         }


### PR DESCRIPTION
Second of three stacked PRs on the direct upload path. Based on twentyhq/twenty#25340, review that one first.

No behaviour change.

## Context

`FileFolderConfig.allowedMimeTypes` was optional, so eleven of the fourteen folders left it off. `assertMimeTypeAllowedForFolder` returns early on a missing list, which means it was a no-op for every direct upload folder except `EmailImage`.

For attachment folders that is the intended policy: FilesField, Workflow, EmailAttachment and AgentChat hold arbitrary user content and a list would be wrong. The problem is that the policy was expressed by omission, so the call site reads as a check with broad reach when it has almost none, and a new folder inherits "accept everything" by default rather than by decision.

## Changes

**Require the field.** `allowedMimeTypes` becomes `readonly string[] | typeof ANY_MIME_TYPE`, and folders that take arbitrary content say `ANY_MIME_TYPE`. Adding a folder is now a compile error until its policy is stated. `EmailImage` keeps `EMAIL_IMAGE_MIME_TYPES` as before, and the check itself is unchanged apart from reading the sentinel. The only server consumer of `allowedMimeTypes` is that one call site, so nothing else sees the sentinel.

**State the presigned download header constraint.** The streamed download path sets `X-Content-Type-Options: nosniff`; the presigned path 302s to S3, which can only echo the `response-*` overrides, so it carries no such header. The comment at that divergence now records the constraint and what the response does carry instead: `Content-Type` pinned to the type sniffed at upload, and an attachment disposition for anything not inline-safe.

## Verification

- 312 tests pass across `core-modules/file` and `core-modules/file-storage`
- `tsgo -p tsconfig.json --noEmit` on twenty-server: only the pre-existing errors from unbuilt sibling packages
- `nx lint:diff-with-main twenty-server` clean

The diff shown above may include twentyhq/twenty#25340's changes: that PR was squash-merged, which leaves this branch's merge base behind and makes the already-merged work reappear in the comparison. Only the three files below are this PR's: `file-folder.interface.ts`, `file-upload-completion.service.ts` and `file.service.ts`.