### PR TITLE
Migrate existing Canvas tabs to vertical lists

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list.ts
@@ -1,0 +1,236 @@
+import { Logger } from '@nestjs/common';
+
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
+
+type AmbiguousCanvasTabCount = {
+  ambiguousTabCount: string;
+};
+
+const CREATE_MIGRATION_BACKUP_TABLE_QUERY = `
+  CREATE TABLE IF NOT EXISTS "core"."canvasTabToVerticalListMigrationBackup" (
+    "pageLayoutTabId" uuid PRIMARY KEY,
+    "pageLayoutWidgetId" uuid NOT NULL UNIQUE,
+    "pageLayoutWidgetPosition" jsonb,
+    "pageLayoutWidgetPositionOverride" jsonb,
+    "pageLayoutWidgetPositionOverrideWasMigrated" boolean NOT NULL
+  );
+
+  ALTER TABLE "core"."canvasTabToVerticalListMigrationBackup"
+    ADD COLUMN IF NOT EXISTS "pageLayoutWidgetPositionOverride" jsonb;
+
+  ALTER TABLE "core"."canvasTabToVerticalListMigrationBackup"
+    ADD COLUMN IF NOT EXISTS "pageLayoutWidgetPositionOverrideWasMigrated" boolean;
+
+  ALTER TABLE "core"."canvasTabToVerticalListMigrationBackup"
+    ALTER COLUMN "pageLayoutWidgetPositionOverrideWasMigrated" SET DEFAULT false;
+
+  UPDATE "core"."canvasTabToVerticalListMigrationBackup"
+  SET "pageLayoutWidgetPositionOverrideWasMigrated" = false
+  WHERE "pageLayoutWidgetPositionOverrideWasMigrated" IS NULL;
+
+  ALTER TABLE "core"."canvasTabToVerticalListMigrationBackup"
+    ALTER COLUMN "pageLayoutWidgetPositionOverrideWasMigrated" SET NOT NULL;
+`;
+
+@RegisteredInstanceCommand('2.39.0', 1788603039076, { type: 'slow' })
+export class MigrateCanvasTabsToVerticalListSlowInstanceCommand implements SlowInstanceCommand {
+  private readonly logger = new Logger(
+    MigrateCanvasTabsToVerticalListSlowInstanceCommand.name,
+  );
+
+  public async runDataMigration(dataSource: DataSource): Promise<void> {
+    await dataSource.query(CREATE_MIGRATION_BACKUP_TABLE_QUERY);
+
+    const [ambiguousCanvasTabCount] = (await dataSource.query(`
+      SELECT COUNT(*)::text AS "ambiguousTabCount"
+      FROM (
+        SELECT tab."id"
+        FROM "core"."pageLayoutTab" tab
+        LEFT JOIN "core"."pageLayoutWidget" widget
+          ON widget."pageLayoutTabId" = tab."id"
+        WHERE tab."layoutMode" = 'CANVAS'
+          AND tab."deletedAt" IS NULL
+        GROUP BY tab."id"
+        HAVING COUNT(widget."id") FILTER (
+          WHERE widget."deletedAt" IS NULL
+        ) <> 1
+          OR COUNT(widget."id") FILTER (
+            WHERE widget."deletedAt" IS NULL
+              AND widget."isActive" = true
+          ) <> 1
+      ) ambiguous_tabs
+    `)) as AmbiguousCanvasTabCount[];
+
+    if (Number(ambiguousCanvasTabCount?.ambiguousTabCount ?? 0) > 0) {
+      this.logger.warn(
+        `Leaving ${ambiguousCanvasTabCount.ambiguousTabCount} empty, inactive, or multi-widget Canvas tab(s) unchanged`,
+      );
+    }
+
+    await dataSource.query(`
+      WITH eligible_tabs AS MATERIALIZED (
+        SELECT tab."id"
+        FROM "core"."pageLayoutTab" tab
+        JOIN "core"."pageLayoutWidget" widget
+          ON widget."pageLayoutTabId" = tab."id"
+        WHERE tab."layoutMode" = 'CANVAS'
+          AND tab."deletedAt" IS NULL
+        GROUP BY tab."id"
+        HAVING COUNT(widget."id") FILTER (
+          WHERE widget."deletedAt" IS NULL
+        ) = 1
+          AND COUNT(widget."id") FILTER (
+            WHERE widget."deletedAt" IS NULL
+              AND widget."isActive" = true
+          ) = 1
+      ), eligible_widgets AS (
+        SELECT
+          eligible_tabs."id" AS "pageLayoutTabId",
+          widget."id" AS "pageLayoutWidgetId",
+          widget."position" AS "pageLayoutWidgetPosition",
+          widget."overrides"->'position' AS "pageLayoutWidgetPositionOverride",
+          COALESCE(
+            COALESCE(widget."overrides" ? 'position', false)
+              AND (
+                NOT COALESCE(widget."overrides" ? 'pageLayoutTabId', false)
+                OR widget."overrides"->>'pageLayoutTabId' = widget."pageLayoutTabId"::text
+              ),
+            false
+          ) AS "pageLayoutWidgetPositionOverrideWasMigrated"
+        FROM eligible_tabs
+        JOIN "core"."pageLayoutWidget" widget
+          ON widget."pageLayoutTabId" = eligible_tabs."id"
+          AND widget."deletedAt" IS NULL
+      ), backed_up_widgets AS (
+        INSERT INTO "core"."canvasTabToVerticalListMigrationBackup" (
+          "pageLayoutTabId",
+          "pageLayoutWidgetId",
+          "pageLayoutWidgetPosition",
+          "pageLayoutWidgetPositionOverride",
+          "pageLayoutWidgetPositionOverrideWasMigrated"
+        )
+        SELECT
+          "pageLayoutTabId",
+          "pageLayoutWidgetId",
+          "pageLayoutWidgetPosition",
+          "pageLayoutWidgetPositionOverride",
+          "pageLayoutWidgetPositionOverrideWasMigrated"
+        FROM eligible_widgets
+        ON CONFLICT ("pageLayoutTabId") DO NOTHING
+        RETURNING "pageLayoutTabId", "pageLayoutWidgetId"
+      ), widgets_to_migrate AS (
+        SELECT
+          eligible_widgets."pageLayoutTabId",
+          eligible_widgets."pageLayoutWidgetId",
+          eligible_widgets."pageLayoutWidgetPositionOverrideWasMigrated"
+        FROM eligible_widgets
+        WHERE eligible_widgets."pageLayoutTabId" IN (
+          SELECT "pageLayoutTabId" FROM backed_up_widgets
+        ) OR EXISTS (
+          SELECT 1
+          FROM "core"."canvasTabToVerticalListMigrationBackup" backup
+          WHERE backup."pageLayoutTabId" = eligible_widgets."pageLayoutTabId"
+            AND backup."pageLayoutWidgetId" = eligible_widgets."pageLayoutWidgetId"
+        )
+      ), migrated_widgets AS (
+        UPDATE "core"."pageLayoutWidget" widget
+        SET "position" = jsonb_build_object(
+          'layoutMode', 'VERTICAL_LIST',
+          'index', 0,
+          'heightBehavior', 'TAB_VIEWPORT'
+        ),
+        "overrides" = CASE
+          WHEN widgets_to_migrate."pageLayoutWidgetPositionOverrideWasMigrated" THEN jsonb_set(
+            widget."overrides",
+            '{position}',
+            jsonb_build_object(
+              'layoutMode', 'VERTICAL_LIST',
+              'index', 0,
+              'heightBehavior', 'TAB_VIEWPORT'
+            )
+          )
+          ELSE widget."overrides"
+        END
+        FROM widgets_to_migrate
+        WHERE widget."id" = widgets_to_migrate."pageLayoutWidgetId"
+        RETURNING widget."pageLayoutTabId"
+      )
+      UPDATE "core"."pageLayoutTab" tab
+      SET "layoutMode" = 'VERTICAL_LIST'
+      FROM migrated_widgets
+      WHERE tab."id" = migrated_widgets."pageLayoutTabId"
+    `);
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(CREATE_MIGRATION_BACKUP_TABLE_QUERY);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      WITH widgets_to_restore AS MATERIALIZED (
+        SELECT
+          backup."pageLayoutTabId",
+          backup."pageLayoutWidgetId",
+          backup."pageLayoutWidgetPosition",
+          backup."pageLayoutWidgetPositionOverride",
+          backup."pageLayoutWidgetPositionOverrideWasMigrated"
+        FROM "core"."canvasTabToVerticalListMigrationBackup" backup
+        JOIN "core"."pageLayoutTab" tab
+          ON tab."id" = backup."pageLayoutTabId"
+        JOIN "core"."pageLayoutWidget" widget
+          ON widget."id" = backup."pageLayoutWidgetId"
+        WHERE tab."layoutMode" = 'VERTICAL_LIST'
+          AND tab."deletedAt" IS NULL
+          AND widget."deletedAt" IS NULL
+          AND widget."isActive" = true
+          AND widget."position" = jsonb_build_object(
+            'layoutMode', 'VERTICAL_LIST',
+            'index', 0,
+            'heightBehavior', 'TAB_VIEWPORT'
+          )
+          AND CASE
+            WHEN backup."pageLayoutWidgetPositionOverrideWasMigrated" THEN
+              widget."overrides"->'position' = jsonb_build_object(
+                'layoutMode', 'VERTICAL_LIST',
+                'index', 0,
+                'heightBehavior', 'TAB_VIEWPORT'
+              )
+            ELSE true
+          END
+          AND (
+            SELECT COUNT(*)
+            FROM "core"."pageLayoutWidget" sibling
+            WHERE sibling."pageLayoutTabId" = tab."id"
+              AND sibling."deletedAt" IS NULL
+          ) = 1
+      ), restored_widgets AS (
+        UPDATE "core"."pageLayoutWidget" widget
+        SET "position" = widgets_to_restore."pageLayoutWidgetPosition",
+        "overrides" = CASE
+          WHEN widgets_to_restore."pageLayoutWidgetPositionOverrideWasMigrated" THEN
+            jsonb_set(
+              widget."overrides",
+              '{position}',
+              widgets_to_restore."pageLayoutWidgetPositionOverride"
+            )
+          ELSE widget."overrides"
+        END
+        FROM widgets_to_restore
+        WHERE widget."id" = widgets_to_restore."pageLayoutWidgetId"
+        RETURNING widget."pageLayoutTabId"
+      )
+      UPDATE "core"."pageLayoutTab" tab
+      SET "layoutMode" = 'CANVAS'
+      FROM restored_widgets
+      WHERE tab."id" = restored_widgets."pageLayoutTabId"
+    `);
+
+    await queryRunner.query(
+      `DROP TABLE "core"."canvasTabToVerticalListMigrationBackup"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/__tests__/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/__tests__/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list.spec.ts
@@ -1,0 +1,76 @@
+import { type DataSource, type QueryRunner } from 'typeorm';
+
+import { MigrateCanvasTabsToVerticalListSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list';
+
+describe('MigrateCanvasTabsToVerticalListSlowInstanceCommand', () => {
+  const command = new MigrateCanvasTabsToVerticalListSlowInstanceCommand();
+
+  it('migrates only unambiguous single-widget Canvas tabs', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ ambiguousTabCount: '2' }])
+      .mockResolvedValueOnce([]);
+
+    await command.runDataMigration({ query } as unknown as DataSource);
+
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(query.mock.calls[0][0]).toContain(
+      `CREATE TABLE IF NOT EXISTS "core"."canvasTabToVerticalListMigrationBackup"`,
+    );
+    expect(query.mock.calls[0][0]).toContain(
+      `ADD COLUMN IF NOT EXISTS "pageLayoutWidgetPositionOverride" jsonb`,
+    );
+    expect(query.mock.calls[0][0]).toContain(
+      `ADD COLUMN IF NOT EXISTS "pageLayoutWidgetPositionOverrideWasMigrated" boolean`,
+    );
+    expect(query.mock.calls[0][0]).toContain(
+      `ALTER COLUMN "pageLayoutWidgetPositionOverrideWasMigrated" SET NOT NULL`,
+    );
+    expect(query.mock.calls[2][0]).toContain(
+      `COUNT(widget."id") FILTER (
+          WHERE widget."deletedAt" IS NULL
+        ) = 1`,
+    );
+    expect(query.mock.calls[2][0]).toContain(
+      `'heightBehavior', 'TAB_VIEWPORT'`,
+    );
+    expect(query.mock.calls[2][0]).toContain(
+      `widget."overrides"->'position' AS "pageLayoutWidgetPositionOverride"`,
+    );
+    expect(query.mock.calls[2][0]).toContain(
+      `WHEN widgets_to_migrate."pageLayoutWidgetPositionOverrideWasMigrated"`,
+    );
+    expect(query.mock.calls[2][0]).toContain(
+      `widget."overrides"->>'pageLayoutTabId' = widget."pageLayoutTabId"::text`,
+    );
+    expect(query.mock.calls[2][0]).toContain(
+      `false
+          ) AS "pageLayoutWidgetPositionOverrideWasMigrated"`,
+    );
+    expect(query.mock.calls[2][0]).toContain(
+      `SET "layoutMode" = 'VERTICAL_LIST'`,
+    );
+  });
+
+  it('restores only backed-up Canvas data on downgrade', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+
+    await command.down({ query } as unknown as QueryRunner);
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0][0]).toContain(
+      `FROM "core"."canvasTabToVerticalListMigrationBackup" backup`,
+    );
+    expect(query.mock.calls[0][0]).toContain(
+      `SET "position" = widgets_to_restore."pageLayoutWidgetPosition"`,
+    );
+    expect(query.mock.calls[0][0]).toContain(
+      `widgets_to_restore."pageLayoutWidgetPositionOverride"`,
+    );
+    expect(query.mock.calls[0][0]).toContain(`SET "layoutMode" = 'CANVAS'`);
+    expect(query.mock.calls[1][0]).toContain(
+      `DROP TABLE "core"."canvasTabToVerticalListMigrationBackup"`,
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -176,6 +176,7 @@ import { EraseObjectNavigationCommandMenuItemPayloadsSlowInstanceCommand } from 
 import { ReshapeUsageLimitPeriodFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-instance-command-fast-1788367160891-reshape-usage-limit-period';
 import { AddLogoToConnectionProviderFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-instance-command-fast-1788542613404-add-logo-to-connection-provider';
 import { AddReadabilityToObjectMetadataFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-instance-command-fast-1788548844925-add-readability-to-object-metadata';
+import { MigrateCanvasTabsToVerticalListSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -354,4 +355,5 @@ export const INSTANCE_COMMANDS = [
   ReshapeUsageLimitPeriodFastInstanceCommand,
   AddLogoToConnectionProviderFastInstanceCommand,
   AddReadabilityToObjectMetadataFastInstanceCommand,
+  MigrateCanvasTabsToVerticalListSlowInstanceCommand,
 ];

--- a/packages/twenty-server/test/integration/upgrade/suites/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list.integration-spec.ts
+++ b/packages/twenty-server/test/integration/upgrade/suites/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list.integration-spec.ts
@@ -1,0 +1,476 @@
+import { isDefined } from 'twenty-shared/utils';
+import { DataSource } from 'typeorm';
+import { v4 } from 'uuid';
+
+import { MigrateCanvasTabsToVerticalListSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-instance-command-slow-1788603039076-migrate-canvas-tabs-to-vertical-list';
+
+jest.useRealTimers();
+
+type SeededTab = {
+  tabId: string;
+  widgetIds: string[];
+};
+
+type TabAndWidgetState = {
+  layoutMode: string;
+  overrides: Record<string, unknown> | null;
+  position: Record<string, unknown> | null;
+};
+
+describe('MigrateCanvasTabsToVerticalListSlowInstanceCommand (integration)', () => {
+  let dataSource: DataSource;
+  let command: MigrateCanvasTabsToVerticalListSlowInstanceCommand;
+  let workspaceId: string;
+  let applicationId: string;
+  let pageLayoutId: string;
+
+  const seedTab = async ({
+    layoutMode,
+    widgetIsActiveValues,
+    widgetOverrides = null,
+    widgetPosition = { layoutMode },
+  }: {
+    layoutMode: 'CANVAS' | 'VERTICAL_LIST';
+    widgetIsActiveValues: boolean[];
+    widgetOverrides?: Record<string, unknown> | null;
+    widgetPosition?: Record<string, unknown>;
+  }): Promise<SeededTab> => {
+    const tabId = v4();
+
+    await dataSource.query(
+      `INSERT INTO "core"."pageLayoutTab" (
+        "id",
+        "workspaceId",
+        "applicationId",
+        "universalIdentifier",
+        "pageLayoutId",
+        "title",
+        "position",
+        "layoutMode",
+        "isActive"
+      ) VALUES ($1, $2, $3, $4, $5, 'Migration test tab', 0, $6, true)`,
+      [tabId, workspaceId, applicationId, v4(), pageLayoutId, layoutMode],
+    );
+
+    const widgetIds: string[] = [];
+
+    for (const [index, isActive] of widgetIsActiveValues.entries()) {
+      const widgetId = v4();
+
+      await dataSource.query(
+        `INSERT INTO "core"."pageLayoutWidget" (
+          "id",
+          "workspaceId",
+          "applicationId",
+          "universalIdentifier",
+          "pageLayoutTabId",
+          "title",
+          "type",
+          "gridPosition",
+          "position",
+          "overrides",
+          "configuration",
+          "isActive"
+        ) VALUES (
+          $1,
+          $2,
+          $3,
+          $4,
+          $5,
+          'Migration test widget',
+          'VIEW',
+          $6,
+          $7,
+          $8,
+          $9,
+          $10
+        )`,
+        [
+          widgetId,
+          workspaceId,
+          applicationId,
+          v4(),
+          tabId,
+          JSON.stringify({ row: index, column: 0, rowSpan: 1, columnSpan: 12 }),
+          JSON.stringify(widgetPosition),
+          JSON.stringify(widgetOverrides),
+          JSON.stringify({ configurationType: 'VIEW' }),
+          isActive,
+        ],
+      );
+
+      widgetIds.push(widgetId);
+    }
+
+    return { tabId, widgetIds };
+  };
+
+  const readTabAndWidgetState = async ({
+    tabId,
+    widgetId,
+  }: {
+    tabId: string;
+    widgetId: string;
+  }): Promise<TabAndWidgetState> => {
+    const [state] = (await dataSource.query(
+      `SELECT tab."layoutMode", widget."position", widget."overrides"
+       FROM "core"."pageLayoutTab" tab
+       JOIN "core"."pageLayoutWidget" widget
+         ON widget."pageLayoutTabId" = tab."id"
+       WHERE tab."id" = $1 AND widget."id" = $2`,
+      [tabId, widgetId],
+    )) as TabAndWidgetState[];
+
+    if (!isDefined(state)) {
+      throw new Error('Seeded page layout tab or widget was not found');
+    }
+
+    return state;
+  };
+
+  const readTabLayoutMode = async (tabId: string): Promise<string> => {
+    const [state] = (await dataSource.query(
+      `SELECT "layoutMode"
+       FROM "core"."pageLayoutTab"
+       WHERE "id" = $1`,
+      [tabId],
+    )) as { layoutMode: string }[];
+
+    if (!isDefined(state)) {
+      throw new Error('Seeded page layout tab was not found');
+    }
+
+    return state.layoutMode;
+  };
+
+  const runDown = async (): Promise<void> => {
+    const queryRunner = dataSource.createQueryRunner();
+
+    await queryRunner.connect();
+
+    try {
+      await command.down(queryRunner);
+    } finally {
+      await queryRunner.release();
+    }
+  };
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'postgres',
+      url: process.env.PG_DATABASE_URL,
+      schema: 'core',
+      entities: [],
+      synchronize: false,
+    });
+    await dataSource.initialize();
+
+    command = new MigrateCanvasTabsToVerticalListSlowInstanceCommand();
+
+    const [source] = (await dataSource.query(
+      `SELECT "workspaceId", "applicationId"
+       FROM "core"."pageLayout"
+       LIMIT 1`,
+    )) as { workspaceId: string; applicationId: string }[];
+
+    if (!isDefined(source)) {
+      throw new Error(
+        'No seeded page layout found; run database:reset before the integration suite.',
+      );
+    }
+
+    workspaceId = source.workspaceId;
+    applicationId = source.applicationId;
+  }, 30000);
+
+  beforeEach(async () => {
+    pageLayoutId = v4();
+
+    await dataSource.query(
+      `INSERT INTO "core"."pageLayout" (
+        "id",
+        "workspaceId",
+        "applicationId",
+        "universalIdentifier",
+        "name",
+        "type"
+      ) VALUES ($1, $2, $3, $4, 'Canvas migration integration test', 'RECORD_PAGE')`,
+      [pageLayoutId, workspaceId, applicationId, v4()],
+    );
+  });
+
+  afterEach(async () => {
+    const [{ backupTable }] = (await dataSource.query(
+      `SELECT to_regclass('core."canvasTabToVerticalListMigrationBackup"') AS "backupTable"`,
+    )) as { backupTable: string | null }[];
+
+    if (isDefined(backupTable)) {
+      await runDown();
+    }
+
+    await dataSource.query(`DELETE FROM "core"."pageLayout" WHERE "id" = $1`, [
+      pageLayoutId,
+    ]);
+  });
+
+  afterAll(async () => {
+    await dataSource?.destroy();
+  });
+
+  it('migrates only eligible Canvas tabs and rolls back only the rows it changed', async () => {
+    const originalCanvasPosition = {
+      layoutMode: 'CANVAS',
+      preservedValue: 'original',
+    };
+    const originalCanvasOverrides = {
+      title: 'Preserved override title',
+      position: {
+        layoutMode: 'CANVAS',
+        preservedValue: 'original override',
+      },
+    };
+    const eligibleCanvasTab = await seedTab({
+      layoutMode: 'CANVAS',
+      widgetIsActiveValues: [true],
+      widgetOverrides: originalCanvasOverrides,
+      widgetPosition: originalCanvasPosition,
+    });
+    const eligibleCanvasTabWithoutOverride = await seedTab({
+      layoutMode: 'CANVAS',
+      widgetIsActiveValues: [true],
+      widgetPosition: {
+        layoutMode: 'CANVAS',
+        preservedValue: 'without override',
+      },
+    });
+    const multiWidgetCanvasTab = await seedTab({
+      layoutMode: 'CANVAS',
+      widgetIsActiveValues: [true, true],
+    });
+    const emptyCanvasTab = await seedTab({
+      layoutMode: 'CANVAS',
+      widgetIsActiveValues: [],
+    });
+    const inactiveWidgetCanvasTab = await seedTab({
+      layoutMode: 'CANVAS',
+      widgetIsActiveValues: [false],
+    });
+    const nativeViewportTab = await seedTab({
+      layoutMode: 'VERTICAL_LIST',
+      widgetIsActiveValues: [true],
+      widgetPosition: {
+        layoutMode: 'VERTICAL_LIST',
+        index: 0,
+        heightBehavior: 'TAB_VIEWPORT',
+      },
+    });
+    const movedCanvasWidgetPosition = {
+      layoutMode: 'CANVAS',
+      preservedValue: 'moved widget base position',
+    };
+    const movedCanvasWidgetOverrides = {
+      pageLayoutTabId: nativeViewportTab.tabId,
+      position: {
+        layoutMode: 'VERTICAL_LIST',
+        index: 1,
+        heightBehavior: 'FIT_CONTENT',
+      },
+    };
+    const movedCanvasWidgetTab = await seedTab({
+      layoutMode: 'CANVAS',
+      widgetIsActiveValues: [true],
+      widgetOverrides: movedCanvasWidgetOverrides,
+      widgetPosition: movedCanvasWidgetPosition,
+    });
+    const detachedCanvasWidgetPosition = {
+      layoutMode: 'CANVAS',
+      preservedValue: 'detached widget base position',
+    };
+    const detachedCanvasWidgetOverrides = {
+      pageLayoutTabId: null,
+      position: {
+        layoutMode: 'CANVAS',
+        preservedValue: 'detached widget override position',
+      },
+    };
+    const detachedCanvasWidgetTab = await seedTab({
+      layoutMode: 'CANVAS',
+      widgetIsActiveValues: [true],
+      widgetOverrides: detachedCanvasWidgetOverrides,
+      widgetPosition: detachedCanvasWidgetPosition,
+    });
+
+    await dataSource.query(`
+      CREATE TABLE "core"."canvasTabToVerticalListMigrationBackup" (
+        "pageLayoutTabId" uuid PRIMARY KEY,
+        "pageLayoutWidgetId" uuid NOT NULL UNIQUE,
+        "pageLayoutWidgetPosition" jsonb
+      )
+    `);
+
+    await command.runDataMigration(dataSource);
+
+    await expect(
+      readTabAndWidgetState({
+        tabId: eligibleCanvasTab.tabId,
+        widgetId: eligibleCanvasTab.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'VERTICAL_LIST',
+      overrides: {
+        title: 'Preserved override title',
+        position: {
+          layoutMode: 'VERTICAL_LIST',
+          index: 0,
+          heightBehavior: 'TAB_VIEWPORT',
+        },
+      },
+      position: {
+        layoutMode: 'VERTICAL_LIST',
+        index: 0,
+        heightBehavior: 'TAB_VIEWPORT',
+      },
+    });
+    await expect(
+      readTabAndWidgetState({
+        tabId: eligibleCanvasTabWithoutOverride.tabId,
+        widgetId: eligibleCanvasTabWithoutOverride.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'VERTICAL_LIST',
+      overrides: null,
+      position: {
+        layoutMode: 'VERTICAL_LIST',
+        index: 0,
+        heightBehavior: 'TAB_VIEWPORT',
+      },
+    });
+    await expect(
+      readTabAndWidgetState({
+        tabId: multiWidgetCanvasTab.tabId,
+        widgetId: multiWidgetCanvasTab.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'CANVAS',
+      overrides: null,
+      position: { layoutMode: 'CANVAS' },
+    });
+    await expect(
+      readTabAndWidgetState({
+        tabId: movedCanvasWidgetTab.tabId,
+        widgetId: movedCanvasWidgetTab.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'VERTICAL_LIST',
+      overrides: movedCanvasWidgetOverrides,
+      position: {
+        layoutMode: 'VERTICAL_LIST',
+        index: 0,
+        heightBehavior: 'TAB_VIEWPORT',
+      },
+    });
+    await expect(
+      readTabAndWidgetState({
+        tabId: detachedCanvasWidgetTab.tabId,
+        widgetId: detachedCanvasWidgetTab.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'VERTICAL_LIST',
+      overrides: detachedCanvasWidgetOverrides,
+      position: {
+        layoutMode: 'VERTICAL_LIST',
+        index: 0,
+        heightBehavior: 'TAB_VIEWPORT',
+      },
+    });
+    await expect(readTabLayoutMode(emptyCanvasTab.tabId)).resolves.toBe(
+      'CANVAS',
+    );
+    await expect(
+      readTabAndWidgetState({
+        tabId: inactiveWidgetCanvasTab.tabId,
+        widgetId: inactiveWidgetCanvasTab.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'CANVAS',
+      overrides: null,
+      position: { layoutMode: 'CANVAS' },
+    });
+
+    const postMigrationNativeViewportTab = await seedTab({
+      layoutMode: 'VERTICAL_LIST',
+      widgetIsActiveValues: [true],
+      widgetPosition: {
+        layoutMode: 'VERTICAL_LIST',
+        index: 0,
+        heightBehavior: 'TAB_VIEWPORT',
+      },
+    });
+
+    await runDown();
+
+    await expect(
+      readTabAndWidgetState({
+        tabId: eligibleCanvasTab.tabId,
+        widgetId: eligibleCanvasTab.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'CANVAS',
+      overrides: originalCanvasOverrides,
+      position: originalCanvasPosition,
+    });
+    await expect(
+      readTabAndWidgetState({
+        tabId: eligibleCanvasTabWithoutOverride.tabId,
+        widgetId: eligibleCanvasTabWithoutOverride.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'CANVAS',
+      overrides: null,
+      position: {
+        layoutMode: 'CANVAS',
+        preservedValue: 'without override',
+      },
+    });
+    await expect(
+      readTabAndWidgetState({
+        tabId: movedCanvasWidgetTab.tabId,
+        widgetId: movedCanvasWidgetTab.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'CANVAS',
+      overrides: movedCanvasWidgetOverrides,
+      position: movedCanvasWidgetPosition,
+    });
+    await expect(
+      readTabAndWidgetState({
+        tabId: detachedCanvasWidgetTab.tabId,
+        widgetId: detachedCanvasWidgetTab.widgetIds[0],
+      }),
+    ).resolves.toEqual({
+      layoutMode: 'CANVAS',
+      overrides: detachedCanvasWidgetOverrides,
+      position: detachedCanvasWidgetPosition,
+    });
+
+    for (const nativeTab of [
+      nativeViewportTab,
+      postMigrationNativeViewportTab,
+    ]) {
+      await expect(
+        readTabAndWidgetState({
+          tabId: nativeTab.tabId,
+          widgetId: nativeTab.widgetIds[0],
+        }),
+      ).resolves.toEqual({
+        layoutMode: 'VERTICAL_LIST',
+        overrides: null,
+        position: {
+          layoutMode: 'VERTICAL_LIST',
+          index: 0,
+          heightBehavior: 'TAB_VIEWPORT',
+        },
+      });
+    }
+  }, 60000);
+});


### PR DESCRIPTION
## Summary

Convert existing Canvas tabs with exactly one undeleted, active widget into vertical lists with an explicit `TAB_VIEWPORT` height. Empty, inactive, and multi-widget tabs remain unchanged.

Back up the original widget position and eligible overrides. Retries preserve the backup, and rollback restores only migration-owned state that has not subsequently changed. Keep the migration unit and PostgreSQL integration tests in this PR. The migration is registered after the newer 2.39 commands on main; its SQL is unchanged by the stack split.

Stack 3/3: runtime height support → manifest authoring → existing-data migration. Merge the two prerequisites first. The earlier implementation and review fixes from this PR are preserved across those layers.

Closes twentyhq/core-team-issues#2877.

Review and merge order:

1. [Widget height behavior](https://github.com/twentyhq/twenty/pull/25460)
2. [Manifest authoring](https://github.com/twentyhq/twenty/pull/25461)
3. [Existing Canvas data migration](https://github.com/twentyhq/twenty/pull/25349)
