### PR TITLE
fix(server): ship ClickHouse migrations in the server build

### DIFF
--- a/packages/twenty-server/nest-cli.json
+++ b/packages/twenty-server/nest-cli.json
@@ -49,7 +49,7 @@
         "outDir": "dist/assets"
       },
       {
-        "include": "database/clickHouse/migrations/*.sql",
+        "include": "database/clickhouse/migrations/*.sql",
         "outDir": "dist"
       },
       {

--- a/packages/twenty-server/src/database/clickhouse/migrations/run-migrations.ts
+++ b/packages/twenty-server/src/database/clickhouse/migrations/run-migrations.ts
@@ -80,6 +80,12 @@ async function runMigrations() {
   const dir = path.join(__dirname);
   const files = fs.readdirSync(dir).filter((f) => f.endsWith('.sql'));
 
+  if (files.length === 0) {
+    throw new Error(
+      `No .sql migration file in ${dir}: the build did not copy the ClickHouse migrations`,
+    );
+  }
+
   await ensureDatabaseExists();
 
   const client = createClient({


### PR DESCRIPTION
## Problem

Since #24760 no ClickHouse migration runs in any deployed environment. That PR renamed `src/database/clickHouse` to `src/database/clickhouse` and updated the project.json commands, but the `nest-cli.json` asset rule kept `database/clickHouse/migrations/*.sql`. On the Linux image build the glob matches nothing (macOS is case-insensitive, so `nest build` still copies the files locally), `dist/database/clickhouse/migrations` ships without `.sql` files, and the ArgoCD PostSync job `yarn clickhouse:migrate:prod` prints `All migrations applied` for an empty directory and exits 0.

Evidence:
- prod-eu migration job logs: the 2026-08-25 15:30 UTC run lists 001 to 006 as already applied, every run from 2026-08-26 11:15 UTC on prints only `All migrations applied`.
- dev pod: `dist/database/clickhouse/migrations` contains only `run-migrations.js`, and the `_migration` table stops at 006.
- Consequence today: 007 (spender columns) and 008 (consumption projection) are missing in dev and prod, so the quota engine's warm query fails with `Unknown expression identifier apiKeyId` and admits on failure (#25278, #25279 are inert), and usage events lose their spender attribution (#24960).

## Fix

- `nest-cli.json`: asset glob lowercased to match the directory.
- `run-migrations.ts`: throw when the directory holds no `.sql` file. The repo always ships at least one, so an empty directory only means the build dropped them; the job now fails instead of reporting success.

## Verification

Ran nest's asset glob (`glob` 11.1.0, `dot: true`) on a case-sensitive Linux filesystem against the source tree: the old pattern matches 0 files, the new one matches 001 to 008. Both migrations are idempotent (`ADD COLUMN IF NOT EXISTS`, `DROP PROJECTION IF EXISTS` then `ADD PROJECTION IF NOT EXISTS`), so the next PostSync run applies them without manual steps.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

