### PR TITLE
Fix phone input editor sizing

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -73,8 +73,8 @@ const StyledCustomPhoneInputWrapper = styled.div`
     }
 
     &:focus {
-      outline: 2px solid ${themeCssVariables.color.blue};
-      outline-offset: 0;
+      box-shadow: 0 0 0 2px ${themeCssVariables.color.blue};
+      outline: none;
     }
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -75,6 +75,10 @@ const StyledCustomPhoneInputWrapper = styled.div`
     &:focus {
       box-shadow: 0 0 0 2px ${themeCssVariables.color.blue};
       outline: none;
+
+      @media (forced-colors: active) {
+        outline: 2px solid transparent;
+      }
     }
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -72,7 +72,7 @@ const StyledCustomPhoneInputWrapper = styled.div`
       font-weight: ${themeCssVariables.font.weight.medium};
     }
 
-    :focus {
+    &:focus {
       outline: none;
     }
   }

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -63,6 +63,7 @@ const StyledCustomPhoneInputWrapper = styled.div`
     box-sizing: border-box;
     color: ${themeCssVariables.font.color.primary};
     height: 100%;
+    outline: none;
     padding-left: ${themeCssVariables.spacing[2]};
 
     &::placeholder,
@@ -70,11 +71,6 @@ const StyledCustomPhoneInputWrapper = styled.div`
       color: ${themeCssVariables.font.color.light};
       font-family: ${themeCssVariables.font.family};
       font-weight: ${themeCssVariables.font.weight.medium};
-    }
-
-    &:focus {
-      outline: 2px solid ${themeCssVariables.color.blue};
-      outline-offset: -2px;
     }
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -73,12 +73,8 @@ const StyledCustomPhoneInputWrapper = styled.div`
     }
 
     &:focus {
-      box-shadow: 0 0 0 2px ${themeCssVariables.color.blue};
-      outline: none;
-
-      @media (forced-colors: active) {
-        outline: 2px solid transparent;
-      }
+      outline: 2px solid ${themeCssVariables.color.blue};
+      outline-offset: -2px;
     }
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -53,11 +53,17 @@ const StyledCustomPhoneInputWrapper = styled.div`
   height: 100%;
   width: calc(100% - ${themeCssVariables.spacing[8]});
 
+  .PhoneInput {
+    height: 100%;
+  }
+
   .PhoneInputInput {
     background: none;
     border: none;
+    box-sizing: border-box;
     color: ${themeCssVariables.font.color.primary};
-    margin-left: ${themeCssVariables.spacing[2]};
+    height: 100%;
+    padding-left: ${themeCssVariables.spacing[2]};
 
     &::placeholder,
     &::-webkit-input-placeholder {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -63,7 +63,6 @@ const StyledCustomPhoneInputWrapper = styled.div`
     box-sizing: border-box;
     color: ${themeCssVariables.font.color.primary};
     height: 100%;
-    outline: none;
     padding-left: ${themeCssVariables.spacing[2]};
 
     &::placeholder,
@@ -71,6 +70,10 @@ const StyledCustomPhoneInputWrapper = styled.div`
       color: ${themeCssVariables.font.color.light};
       font-family: ${themeCssVariables.font.family};
       font-weight: ${themeCssVariables.font.weight.medium};
+    }
+
+    :focus {
+      outline: none;
     }
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -72,8 +72,9 @@ const StyledCustomPhoneInputWrapper = styled.div`
       font-weight: ${themeCssVariables.font.weight.medium};
     }
 
-    :focus {
-      outline: none;
+    &:focus {
+      outline: 2px solid ${themeCssVariables.color.blue};
+      outline-offset: 0;
     }
   }
 


### PR DESCRIPTION
## Summary

- Make the phone number input fill the full height of its edit row.
- Keep the number inset using internal padding instead of an external margin.
- Remove the blue focus outline from the phone number input.

## Before/After

**Before**

<img width="692" height="206" alt="Phone input before fix" src="https://github.com/user-attachments/assets/11b0a76a-486b-4d1c-be67-d49f73a6135c" />

**After**

<img width="350" height="170" alt="Phone input after fix without blue outline" src="https://github.com/user-attachments/assets/399f3bb6-197e-4395-a5c3-73d7f5557c36" />
