### PR TITLE
Shorten the Link content field description

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldLinksVariantForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldLinksVariantForm.tsx
@@ -55,7 +55,7 @@ export const SettingsDataModelFieldLinksVariantForm = ({
           <SettingsOptionCardContentSelect
             Icon={IconWorld}
             title={t`Link content`}
-            description={t`Domain links are stored as a bare domain name, so twenty.com and https://www.twenty.com are the same value`}
+            description={t`Store the full URL or just the domain`}
             disabled={disabled}
           >
             <Select<FieldLinksVariant>


### PR DESCRIPTION
The description overflowed the card and got cut off mid-sentence. Shortened it to one line, matching the other field settings descriptions on this page.

**Before**

![before](https://raw.githubusercontent.com/neo773/twenty/pr-25409-screenshots/pr-screenshots/25409-before.png)

**After**

![after](https://raw.githubusercontent.com/neo773/twenty/pr-25409-screenshots/pr-screenshots/25409-after.png)