### PR TITLE
Capture the provider response when an account is revoked

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception.ts
@@ -1,6 +1,6 @@
 import { type MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
-import { assertUnreachable } from 'twenty-shared/utils';
+import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 
 import { CustomException } from 'src/utils/custom-exception';
 
@@ -32,15 +32,24 @@ const getConnectedAccountRefreshAccessTokenExceptionUserFriendlyMessage = (
 };
 
 export class ConnectedAccountRefreshAccessTokenException extends CustomException<ConnectedAccountRefreshAccessTokenExceptionCode> {
+  cause?: unknown;
+
   constructor(
     message: string,
     code: ConnectedAccountRefreshAccessTokenExceptionCode,
-    { userFriendlyMessage }: { userFriendlyMessage?: MessageDescriptor } = {},
+    {
+      userFriendlyMessage,
+      cause,
+    }: { userFriendlyMessage?: MessageDescriptor; cause?: unknown } = {},
   ) {
     super(message, code, {
       userFriendlyMessage:
         userFriendlyMessage ??
         getConnectedAccountRefreshAccessTokenExceptionUserFriendlyMessage(code),
     });
+
+    if (isDefined(cause)) {
+      this.cause = cause;
+    }
   }
 }

--- a/packages/twenty-server/src/instrument.ts
+++ b/packages/twenty-server/src/instrument.ts
@@ -59,6 +59,7 @@ if (process.env.EXCEPTION_HANDLER_DRIVER === ExceptionHandlerDriver.SENTRY) {
       tracesSampleRate,
     }).filter((integration) => integration.name !== 'Modules'),
     integrations: [
+      Sentry.extraErrorDataIntegration(),
       Sentry.redisIntegration(),
       Sentry.httpIntegration(),
       Sentry.expressIntegration(),

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception.ts
@@ -1,6 +1,6 @@
 import { type MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
-import { assertUnreachable } from 'twenty-shared/utils';
+import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 
 import { CustomException } from 'src/utils/custom-exception';
 
@@ -41,15 +41,24 @@ const getCalendarEventImportDriverExceptionUserFriendlyMessage = (
 };
 
 export class CalendarEventImportDriverException extends CustomException<CalendarEventImportDriverExceptionCode> {
+  cause?: unknown;
+
   constructor(
     message: string,
     code: CalendarEventImportDriverExceptionCode,
-    { userFriendlyMessage }: { userFriendlyMessage?: MessageDescriptor } = {},
+    {
+      userFriendlyMessage,
+      cause,
+    }: { userFriendlyMessage?: MessageDescriptor; cause?: unknown } = {},
   ) {
     super(message, code, {
       userFriendlyMessage:
         userFriendlyMessage ??
         getCalendarEventImportDriverExceptionUserFriendlyMessage(code),
     });
+
+    if (isDefined(cause)) {
+      this.cause = cause;
+    }
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/google-calendar/services/google-calendar-get-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/google-calendar/services/google-calendar-get-events.service.ts
@@ -128,7 +128,7 @@ export class GoogleCalendarGetEventsService {
           '',
       };
 
-      throw parseGoogleCalendarError(googleCalendarError);
+      throw parseGoogleCalendarError(googleCalendarError, { cause: error });
     }
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/google-calendar/services/google-calendar-import-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/google-calendar/services/google-calendar-import-events.service.ts
@@ -46,11 +46,14 @@ export class GoogleCalendarImportEventsService {
               throw parseGaxiosError(error);
             }
 
-            throw parseGoogleCalendarError({
-              code: status,
-              reason: error.response?.data?.error?.errors?.[0].reason || '',
-              message: error.response?.data?.error?.errors?.[0].message || '',
-            });
+            throw parseGoogleCalendarError(
+              {
+                code: status,
+                reason: error.response?.data?.error?.errors?.[0].reason || '',
+                message: error.response?.data?.error?.errors?.[0].message || '',
+              },
+              { cause: error },
+            );
           }),
       ),
     );

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/google-calendar/utils/parse-google-calendar-error.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/google-calendar/utils/parse-google-calendar-error.util.ts
@@ -3,11 +3,14 @@ import {
   CalendarEventImportDriverExceptionCode,
 } from 'src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception';
 
-export const parseGoogleCalendarError = (error: {
-  code?: number;
-  reason: string;
-  message: string;
-}): CalendarEventImportDriverException => {
+export const parseGoogleCalendarError = (
+  error: {
+    code?: number;
+    reason: string;
+    message: string;
+  },
+  options?: { cause?: unknown },
+): CalendarEventImportDriverException => {
   const { code, reason, message } = error;
 
   if (code === 400) {
@@ -15,6 +18,7 @@ export const parseGoogleCalendarError = (error: {
       return new CalendarEventImportDriverException(
         message,
         CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+        options,
       );
     }
 
@@ -22,6 +26,7 @@ export const parseGoogleCalendarError = (error: {
       return new CalendarEventImportDriverException(
         message,
         CalendarEventImportDriverExceptionCode.UNKNOWN,
+        options,
       );
     }
   }
@@ -34,6 +39,7 @@ export const parseGoogleCalendarError = (error: {
     return new CalendarEventImportDriverException(
       message,
       CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+      options,
     );
   }
 
@@ -41,11 +47,13 @@ export const parseGoogleCalendarError = (error: {
     return new CalendarEventImportDriverException(
       message,
       CalendarEventImportDriverExceptionCode.NOT_FOUND,
+      options,
     );
   }
 
   return new CalendarEventImportDriverException(
     message,
     CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR,
+    options,
   );
 };

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/microsoft-calendar/utils/parse-microsoft-calendar-error.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/microsoft-calendar/utils/parse-microsoft-calendar-error.util.ts
@@ -19,6 +19,7 @@ export const parseMicrosoftCalendarError = (
     return new CalendarEventImportDriverException(
       `Disabled, deleted, unlicensed or inaccessible Microsoft account - code:${code}`,
       CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+      { cause: error },
     );
   }
 
@@ -26,6 +27,7 @@ export const parseMicrosoftCalendarError = (
     return new CalendarEventImportDriverException(
       message,
       CalendarEventImportDriverExceptionCode.UNKNOWN,
+      { cause: error },
     );
   }
 
@@ -33,6 +35,7 @@ export const parseMicrosoftCalendarError = (
     return new CalendarEventImportDriverException(
       message,
       CalendarEventImportDriverExceptionCode.NOT_FOUND,
+      { cause: error },
     );
   }
 
@@ -40,11 +43,13 @@ export const parseMicrosoftCalendarError = (
     return new CalendarEventImportDriverException(
       message,
       CalendarEventImportDriverExceptionCode.SYNC_CURSOR_ERROR,
+      { cause: error },
     );
   }
 
   return new CalendarEventImportDriverException(
     `Microsoft Graph API ${code} ${statusCode} error: ${message}`,
     CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR,
+    { cause: error },
   );
 };

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
@@ -45,7 +45,10 @@ export class CalendarEventImportErrorHandlerService {
       | TwentyOrmException
       | ConnectedAccountRefreshAccessTokenException,
     syncStep: CalendarEventImportSyncStep,
-    calendarChannel: Pick<CalendarChannelEntity, 'id' | 'throttleFailureCount'>,
+    calendarChannel: Pick<
+      CalendarChannelEntity,
+      'id' | 'throttleFailureCount' | 'connectedAccountId'
+    >,
     workspaceId: string,
   ): Promise<void> {
     switch (exception.code) {
@@ -70,6 +73,8 @@ export class CalendarEventImportErrorHandlerService {
       case ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND:
       case ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN:
         await this.handleInsufficientPermissionsException(
+          exception,
+          syncStep,
           calendarChannel,
           workspaceId,
         );
@@ -171,9 +176,20 @@ export class CalendarEventImportErrorHandlerService {
   }
 
   private async handleInsufficientPermissionsException(
-    calendarChannel: Pick<CalendarChannelEntity, 'id'>,
+    exception: Error,
+    syncStep: CalendarEventImportSyncStep,
+    calendarChannel: Pick<CalendarChannelEntity, 'id' | 'connectedAccountId'>,
     workspaceId: string,
   ): Promise<void> {
+    this.exceptionHandlerService.captureExceptions([exception], {
+      additionalData: {
+        calendarChannelId: calendarChannel.id,
+        connectedAccountId: calendarChannel.connectedAccountId,
+        syncStep,
+      },
+      workspace: { id: workspaceId },
+    });
+
     await this.calendarChannelSyncStatusService.markAsFailedInsufficientPermissionsAndFlushCalendarEventsToImport(
       [calendarChannel.id],
       workspaceId,

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/google/utils/parse-google-oauth-error.util.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/google/utils/parse-google-oauth-error.util.ts
@@ -14,6 +14,7 @@ export const parseGoogleOAuthError = (
     return new ConnectedAccountRefreshAccessTokenException(
       `Google refresh token network error: ${error.code} - ${error.message}`,
       ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR,
+      { cause: error },
     );
   }
 
@@ -32,11 +33,13 @@ export const parseGoogleOAuthError = (
     return new ConnectedAccountRefreshAccessTokenException(
       `Google auth error: ${googleOAuthError.reason} - ${googleOAuthError.message}`,
       ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+      { cause: error },
     );
   }
 
   return new ConnectedAccountRefreshAccessTokenException(
     `Google refresh token failed (${googleOAuthError.code ?? 'no status'}): ${googleOAuthError.reason} - ${googleOAuthError.message}`,
     ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR,
+    { cause: error },
   );
 };

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/microsoft/utils/parse-msal-error.util.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/microsoft/utils/parse-msal-error.util.ts
@@ -13,6 +13,7 @@ export const parseMsalError = (
     return new ConnectedAccountRefreshAccessTokenException(
       `Microsoft token refresh requires re-authentication: ${error.errorCode}`,
       ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+      { cause: error },
     );
   }
 
@@ -23,6 +24,7 @@ export const parseMsalError = (
     return new ConnectedAccountRefreshAccessTokenException(
       `Microsoft auth error: ${error.errorCode} - ${error.errorMessage}`,
       ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+      { cause: error },
     );
   }
 
@@ -31,5 +33,6 @@ export const parseMsalError = (
   return new ConnectedAccountRefreshAccessTokenException(
     `Microsoft token refresh failed: ${message}`,
     ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR,
+    { cause: error },
   );
 };

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-exception-handler.service.ts
@@ -20,7 +20,7 @@ import {
 
 type WebhookSubscribableChannelReference = Pick<
   WebhookSubscribableChannel,
-  'id' | 'webhookSubscriptionExternalId'
+  'id' | 'webhookSubscriptionExternalId' | 'connectedAccountId'
 >;
 
 @Injectable()
@@ -41,6 +41,7 @@ export class WebhookSubscriptionExceptionHandlerService {
       switch (exception.code) {
         case WebhookSubscriptionDriverExceptionCode.NOT_FOUND:
           return await this.handleNotFoundException(
+            exception,
             operation,
             channelType,
             channel,
@@ -48,8 +49,11 @@ export class WebhookSubscriptionExceptionHandlerService {
           );
         case WebhookSubscriptionDriverExceptionCode.INSUFFICIENT_PERMISSIONS:
           return await this.handleInsufficientPermissionsException(
+            exception,
+            operation,
             channelType,
             channel,
+            workspaceId,
           );
         case WebhookSubscriptionDriverExceptionCode.TEMPORARY_ERROR:
           return await this.handleTemporaryException(
@@ -76,8 +80,11 @@ export class WebhookSubscriptionExceptionHandlerService {
         case ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND:
         case ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN:
           return await this.handleInsufficientPermissionsException(
+            exception,
+            operation,
             channelType,
             channel,
+            workspaceId,
           );
         case ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR:
           return await this.handleTemporaryException(
@@ -106,6 +113,7 @@ export class WebhookSubscriptionExceptionHandlerService {
   }
 
   private async handleNotFoundException(
+    exception: unknown,
     operation: WebhookSubscriptionOperation,
     channelType: WebhookSubscriptionChannelType,
     channel: WebhookSubscribableChannelReference,
@@ -113,8 +121,11 @@ export class WebhookSubscriptionExceptionHandlerService {
   ): Promise<WebhookSubscriptionRecoveryAction> {
     if (operation === 'CREATE') {
       return await this.handleInsufficientPermissionsException(
+        exception,
+        operation,
         channelType,
         channel,
+        workspaceId,
       );
     }
 
@@ -130,9 +141,22 @@ export class WebhookSubscriptionExceptionHandlerService {
   }
 
   private async handleInsufficientPermissionsException(
+    exception: unknown,
+    operation: WebhookSubscriptionOperation,
     channelType: WebhookSubscriptionChannelType,
     channel: WebhookSubscribableChannelReference,
+    workspaceId: string,
   ): Promise<WebhookSubscriptionRecoveryAction> {
+    this.exceptionHandlerService.captureExceptions([exception], {
+      additionalData: {
+        channelId: channel.id,
+        channelType,
+        connectedAccountId: channel.connectedAccountId,
+        operation,
+      },
+      workspace: { id: workspaceId },
+    });
+
     await this.webhookSubscriptionStatusService.markAsExpired(
       channelType,
       channel.id,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-api-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-api-error.util.ts
@@ -26,6 +26,7 @@ export const parseGmailApiError = (
       return new MessageImportDriverException(
         gmailApiError.message,
         MessageImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+        { cause: error },
       );
     }
 
@@ -36,6 +37,7 @@ export const parseGmailApiError = (
       return new MessageImportDriverException(
         gmailApiError.message,
         MessageImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+        { cause: error },
       );
     }
 
@@ -43,6 +45,7 @@ export const parseGmailApiError = (
       return new MessageImportDriverException(
         gmailApiError.message,
         MessageImportDriverExceptionCode.UNKNOWN,
+        { cause: error },
       );
     }
   }
@@ -51,6 +54,7 @@ export const parseGmailApiError = (
     return new MessageImportDriverException(
       gmailApiError.message,
       MessageImportDriverExceptionCode.SYNC_CURSOR_ERROR,
+      { cause: error },
     );
   }
 
@@ -59,6 +63,7 @@ export const parseGmailApiError = (
       gmailApiError.message,
       MessageImportDriverExceptionCode.TEMPORARY_ERROR,
       {
+        cause: error,
         throttleRetryAfter: parseGmailErrorRetryAfter(gmailApiError.message),
       },
     );
@@ -67,5 +72,6 @@ export const parseGmailApiError = (
   return new MessageImportDriverException(
     gmailApiError.message,
     MessageImportDriverExceptionCode.TEMPORARY_ERROR,
+    { cause: error },
   );
 };

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
@@ -97,12 +97,16 @@ export class MessageImportExceptionHandlerService {
             message: `${exception.code}: ${exception.message ?? ''}`,
           });
           await this.handleInsufficientPermissionsException(
+            exception,
+            syncStep,
             messageChannel,
             workspaceId,
           );
           break;
         case MessageImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS:
           await this.handleInsufficientPermissionsException(
+            exception,
+            syncStep,
             messageChannel,
             workspaceId,
           );
@@ -229,9 +233,20 @@ export class MessageImportExceptionHandlerService {
   }
 
   private async handleInsufficientPermissionsException(
-    messageChannel: Pick<MessageChannelEntity, 'id'>,
+    exception: Error,
+    syncStep: MessageImportSyncStep,
+    messageChannel: Pick<MessageChannelEntity, 'id' | 'connectedAccountId'>,
     workspaceId: string,
   ): Promise<void> {
+    this.exceptionHandlerService.captureExceptions([exception], {
+      additionalData: {
+        messageChannelId: messageChannel.id,
+        connectedAccountId: messageChannel.connectedAccountId,
+        syncStep,
+      },
+      workspace: { id: workspaceId },
+    });
+
     await this.messageChannelSyncStatusService.markAsFailed(
       [messageChannel.id],
       workspaceId,


### PR DESCRIPTION
Every parser rebuilt a typed exception and dropped the raw provider error, so a channel flipping to FAILED_INSUFFICIENT_PERMISSIONS reached Sentry with nothing but a formatted message.

Attach the raw error as `cause` in the Gmail, Google Calendar, Google OAuth, Microsoft Graph and MSAL parsers, enable Sentry's extraErrorDataIntegration so the cause's own fields are reported, and capture the exception at the three revoke sinks with the channel, connected account and sync step.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

