### PR TITLE
Deliver SSE events once instead of twice

### DIFF
--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts
@@ -127,100 +127,33 @@ export const useTriggerEventStreamCreation = () => {
             return;
           }
 
-          handleFirstEventReceived();
-
-          const eventSubscription = value?.data?.onEventSubscription;
-
-          const objectRecordEventsWithQueryIds =
-            eventSubscription?.objectRecordEventsWithQueryIds ?? [];
-
-          const metadataEvents = eventSubscription?.metadataEvents ?? [];
-
-          const queueJobEvents = eventSubscription?.queueJobEvents ?? [];
-
-          const objectRecordEvents = objectRecordEventsWithQueryIds.map(
-            (item) => item.objectRecordEvent,
-          );
-
-          dispatchMetadataEventsFromSseToBrowserEvents(metadataEvents);
-
-          dispatchQueueJobEventsFromSseToBrowserEvents(queueJobEvents);
-
-          triggerOptimisticEffectFromSseEvents({
-            objectRecordEvents,
-          });
-
-          dispatchObjectRecordEventsFromSseToBrowserEvents(
-            objectRecordEventsWithQueryIds,
-          );
-        },
-        error: (error) => {
-          captureException(error);
-          store.set(shouldDestroyEventStreamState.atom, true);
-        },
-        complete: () => {
-          store.set(shouldDestroyEventStreamState.atom, true);
-        },
-      },
-      {
-        message: ({ data, event }) => {
-          const result = data as ExecutionResult<{
-            onEventSubscription: EventSubscription;
-          }>;
-
           try {
-            if (event === 'next') {
-              store.set(lastSseEventReceivedTimestampState.atom, Date.now());
+            handleFirstEventReceived();
 
-              if (isDefined(result?.errors)) {
-                const extensions = getGraphqlErrorExtensionsFromError(
-                  result.errors[0],
-                );
+            const eventSubscription = value?.data?.onEventSubscription;
 
-                if (
-                  !isGracefullyHandledEventStreamError({
-                    subCode: extensions?.subCode,
-                    code: extensions?.code,
-                  })
-                ) {
-                  for (const error of result.errors) {
-                    captureException(error);
-                  }
-                }
+            const objectRecordEventsWithQueryIds =
+              eventSubscription?.objectRecordEventsWithQueryIds ?? [];
 
-                store.set(shouldDestroyEventStreamState.atom, true);
-              } else {
-                handleFirstEventReceived();
+            const metadataEvents = eventSubscription?.metadataEvents ?? [];
 
-                const objectRecordEventsWithQueryIds =
-                  result?.data?.onEventSubscription
-                    ?.objectRecordEventsWithQueryIds ?? [];
+            const queueJobEvents = eventSubscription?.queueJobEvents ?? [];
 
-                const objectRecordEvents = objectRecordEventsWithQueryIds.map(
-                  (objectRecordEventWithQueryIds) => {
-                    return objectRecordEventWithQueryIds.objectRecordEvent;
-                  },
-                );
+            const objectRecordEvents = objectRecordEventsWithQueryIds.map(
+              (item) => item.objectRecordEvent,
+            );
 
-                const metadataEvents =
-                  result?.data?.onEventSubscription?.metadataEvents ?? [];
+            dispatchMetadataEventsFromSseToBrowserEvents(metadataEvents);
 
-                const queueJobEvents =
-                  result?.data?.onEventSubscription?.queueJobEvents ?? [];
+            dispatchQueueJobEventsFromSseToBrowserEvents(queueJobEvents);
 
-                dispatchMetadataEventsFromSseToBrowserEvents(metadataEvents);
+            triggerOptimisticEffectFromSseEvents({
+              objectRecordEvents,
+            });
 
-                dispatchQueueJobEventsFromSseToBrowserEvents(queueJobEvents);
-
-                triggerOptimisticEffectFromSseEvents({
-                  objectRecordEvents,
-                });
-
-                dispatchObjectRecordEventsFromSseToBrowserEvents(
-                  objectRecordEventsWithQueryIds,
-                );
-              }
-            }
+            dispatchObjectRecordEventsFromSseToBrowserEvents(
+              objectRecordEventsWithQueryIds,
+            );
           } catch (error) {
             const errorProcessingSSEMessage = new Error(
               'Error while processing SSE message',
@@ -229,6 +162,13 @@ export const useTriggerEventStreamCreation = () => {
 
             captureException(errorProcessingSSEMessage);
           }
+        },
+        error: (error) => {
+          captureException(error);
+          store.set(shouldDestroyEventStreamState.atom, true);
+        },
+        complete: () => {
+          store.set(shouldDestroyEventStreamState.atom, true);
         },
       },
     );


### PR DESCRIPTION
The on.message listener is an observability hook in graphql-sse, but it was processing the payload alongside sink.next, so every SSE event was dispatched twice. Keep sink.next as the single delivery path and move its try/catch there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

