### PR TITLE
feat(apps): confirm before adding a second connection to an app

### DIFF
--- a/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
@@ -1,13 +1,18 @@
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { SettingsPath } from 'twenty-shared/types';
-import { getSettingsPath } from 'twenty-shared/utils';
+import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
+import {
+  ConfirmationModal,
+  StyledCenteredButton,
+} from '@/ui/layout/modal/components/ConfirmationModal';
+import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { Table } from '@/ui/layout/table/components/Table';
 import { TableCell } from '@/ui/layout/table/components/TableCell';
 import { TableHeader } from '@/ui/layout/table/components/TableHeader';
@@ -26,7 +31,10 @@ import { Section } from 'twenty-ui/layout';
 import { MenuItem } from 'twenty-ui/navigation';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 import { useFindApplicationConnectionProviders } from '~/pages/settings/applications/hooks/useFindApplicationConnectionProviders';
-import { useMyAppConnectedAccounts } from '~/pages/settings/applications/hooks/useMyAppConnectedAccounts';
+import {
+  type AppConnectedAccount,
+  useMyAppConnectedAccounts,
+} from '~/pages/settings/applications/hooks/useMyAppConnectedAccounts';
 import { useTriggerAppOAuth } from '~/pages/settings/applications/hooks/useTriggerAppOAuth';
 import { type FrontendApplicationConnectionProvider } from '~/pages/settings/applications/types/FrontendApplicationConnectionProvider';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
@@ -44,6 +52,14 @@ const StyledTableRowsContainer = styled.div`
   border-bottom: 1px solid ${themeCssVariables.border.color.light};
   padding: ${themeCssVariables.spacing[2]} 0;
 `;
+
+const getConnectionName = (connection: AppConnectedAccount) =>
+  connection.name ?? connection.handle;
+
+const getConnectionVisibility = (
+  connection: AppConnectedAccount,
+): 'user' | 'workspace' =>
+  connection.visibility === 'workspace' ? 'workspace' : 'user';
 
 const AddConnectionDropdown = ({
   provider,
@@ -94,6 +110,164 @@ const AddConnectionDropdown = ({
   );
 };
 
+type AddConnectionConfirmation = {
+  title: string;
+  subtitle: string;
+  confirmButtonText: string;
+  onConfirmClick: () => void;
+  onConnectAnotherAccount: (() => void) | null;
+};
+
+type AddConnectionActionProps = {
+  applicationId: string;
+  provider: FrontendApplicationConnectionProvider;
+  providerConnections: AppConnectedAccount[];
+};
+
+const AddConnectionAction = ({
+  applicationId,
+  provider,
+  providerConnections,
+}: AddConnectionActionProps) => {
+  const { t } = useLingui();
+  const { openModal, closeModal } = useModal();
+  const { triggerAppOAuth } = useTriggerAppOAuth();
+  const [confirmation, setConfirmation] =
+    useState<AddConnectionConfirmation | null>(null);
+
+  const modalId = `add-application-connection-modal-${provider.id}`;
+
+  const connectAnotherAccount = (visibility: 'user' | 'workspace') => {
+    triggerAppOAuth({
+      applicationId,
+      providerName: provider.name,
+      visibility,
+    });
+  };
+
+  const reconnectExistingConnection = ({
+    connection,
+    visibility,
+  }: {
+    connection: AppConnectedAccount;
+    visibility: 'user' | 'workspace';
+  }) => {
+    triggerAppOAuth({
+      applicationId,
+      providerName: provider.name,
+      visibility,
+      reconnectingConnectedAccountId: connection.id,
+    });
+  };
+
+  const getConfirmation = (
+    visibility: 'user' | 'workspace',
+  ): AddConnectionConfirmation => {
+    const existingConnection =
+      providerConnections.length === 1 ? providerConnections[0] : undefined;
+
+    if (!isDefined(existingConnection)) {
+      const connectionNames = providerConnections
+        .map((connection) => getConnectionName(connection))
+        .join(', ');
+
+      return {
+        title: t`You already have ${providerConnections.length} ${provider.displayName} connections`,
+        subtitle: t`Already connected: ${connectionNames}.`,
+        confirmButtonText: t`Connect a different account`,
+        onConfirmClick: () => connectAnotherAccount(visibility),
+        onConnectAnotherAccount: null,
+      };
+    }
+
+    const existingConnectionName = getConnectionName(existingConnection);
+    const existingConnectionVisibility =
+      getConnectionVisibility(existingConnection);
+
+    if (existingConnectionVisibility === visibility) {
+      return {
+        title:
+          visibility === 'workspace'
+            ? t`You already have a shared ${provider.displayName} connection`
+            : t`You already have a ${provider.displayName} connection`,
+        subtitle:
+          visibility === 'workspace'
+            ? t`${existingConnectionName} is shared with the workspace.`
+            : t`${existingConnectionName}, connected just for you.`,
+        confirmButtonText: t`Reconnect ${existingConnectionName}`,
+        onConfirmClick: () =>
+          reconnectExistingConnection({
+            connection: existingConnection,
+            visibility,
+          }),
+        onConnectAnotherAccount: () => connectAnotherAccount(visibility),
+      };
+    }
+
+    if (visibility === 'workspace') {
+      return {
+        title: t`Share your existing connection, or connect another account?`,
+        subtitle: t`${existingConnectionName} is connected just for you. Sharing it requires authorizing again, so make sure you are signed in to ${provider.displayName} as the same account.`,
+        confirmButtonText: t`Reconnect and share ${existingConnectionName}`,
+        onConfirmClick: () =>
+          reconnectExistingConnection({
+            connection: existingConnection,
+            visibility: 'workspace',
+          }),
+        onConnectAnotherAccount: () => connectAnotherAccount(visibility),
+      };
+    }
+
+    return {
+      title: t`You already have a shared ${provider.displayName} connection`,
+      subtitle: t`${existingConnectionName} is shared with the workspace. Connecting again adds a separate connection just for you.`,
+      confirmButtonText: t`Connect an account just for me`,
+      onConfirmClick: () => connectAnotherAccount(visibility),
+      onConnectAnotherAccount: null,
+    };
+  };
+
+  const handlePick = (visibility: 'user' | 'workspace') => {
+    if (providerConnections.length === 0) {
+      connectAnotherAccount(visibility);
+      return;
+    }
+
+    setConfirmation(getConfirmation(visibility));
+    openModal(modalId);
+  };
+
+  return (
+    <>
+      <AddConnectionDropdown provider={provider} onPick={handlePick} />
+      {isDefined(confirmation) && (
+        <ConfirmationModal
+          modalInstanceId={modalId}
+          title={confirmation.title}
+          subtitle={confirmation.subtitle}
+          onConfirmClick={confirmation.onConfirmClick}
+          confirmButtonText={confirmation.confirmButtonText}
+          confirmButtonAccent="blue"
+          AdditionalButtons={
+            isDefined(confirmation.onConnectAnotherAccount) ? (
+              <StyledCenteredButton
+                title={t`Connect a different account`}
+                variant="secondary"
+                fullWidth
+                justify="center"
+                onClick={() => {
+                  closeModal(modalId);
+                  confirmation.onConnectAnotherAccount?.();
+                }}
+              />
+            ) : undefined
+          }
+        />
+      )}
+    </>
+  );
+};
+
 export const SettingsApplicationConnectionsSection = ({
   applicationId,
 }: {
@@ -101,7 +275,6 @@ export const SettingsApplicationConnectionsSection = ({
 }) => {
   const { t } = useLingui();
   const { theme } = useContext(ThemeContext);
-  const { triggerAppOAuth } = useTriggerAppOAuth();
   const { connectionProviders, loading } =
     useFindApplicationConnectionProviders(applicationId);
   const { accounts: connectedAccounts } = useMyAppConnectedAccounts();
@@ -174,7 +347,7 @@ export const SettingsApplicationConnectionsSection = ({
                         textOverflow="ellipsis"
                         whiteSpace="nowrap"
                       >
-                        {connection.name ?? connection.handle}
+                        {getConnectionName(connection)}
                       </TableCell>
                       <TableCell clickable>
                         {connection.authFailedAt ? (
@@ -215,15 +388,10 @@ export const SettingsApplicationConnectionsSection = ({
             )}
             {isClientCredentialsConfigured && (
               <StyledFooter>
-                <AddConnectionDropdown
+                <AddConnectionAction
+                  applicationId={applicationId}
                   provider={provider}
-                  onPick={(visibility) =>
-                    triggerAppOAuth({
-                      applicationId,
-                      providerName: provider.name,
-                      visibility,
-                    })
-                  }
+                  providerConnections={providerConnections}
                 />
               </StyledFooter>
             )}

--- a/packages/twenty-front/src/pages/settings/applications/tabs/__tests__/SettingsApplicationConnectionsSection.test.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/__tests__/SettingsApplicationConnectionsSection.test.tsx
@@ -1,6 +1,8 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { SettingsApplicationConnectionsSection } from '~/pages/settings/applications/tabs/SettingsApplicationConnectionsSection';
@@ -29,6 +31,21 @@ jest.mock('~/pages/settings/applications/hooks/useTriggerAppOAuth', () => ({
   })),
 }));
 
+jest.mock('@/ui/layout/dropdown/components/Dropdown', () => ({
+  Dropdown: ({
+    clickableComponent,
+    dropdownComponents,
+  }: {
+    clickableComponent: ReactNode;
+    dropdownComponents: ReactNode;
+  }) => (
+    <div>
+      {clickableComponent}
+      <div role="menu">{dropdownComponents}</div>
+    </div>
+  ),
+}));
+
 const mockedUseFindApplicationConnectionProviders =
   useFindApplicationConnectionProviders as jest.MockedFunction<
     typeof useFindApplicationConnectionProviders
@@ -39,30 +56,78 @@ const mockedUseMyAppConnectedAccounts =
     typeof useMyAppConnectedAccounts
   >;
 
+const mockConnectionProviders = ({
+  isClientCredentialsConfigured,
+}: {
+  isClientCredentialsConfigured: boolean;
+}) => {
+  mockedUseFindApplicationConnectionProviders.mockReturnValue({
+    connectionProviders: [
+      {
+        id: 'provider-1',
+        applicationId: 'app-1',
+        type: 'oauth',
+        name: 'google-calendar',
+        displayName: 'Google Calendar',
+        logoUrl: null,
+        oauth: {
+          scopes: ['calendar.readonly'],
+          isClientCredentialsConfigured,
+        },
+      },
+    ],
+    loading: false,
+    refetch: jest.fn(),
+  });
+};
+
+const PERSONAL_CONNECTION = {
+  __typename: 'ConnectedAccountPublicDTO' as const,
+  id: 'account-1',
+  handle: 'me@example.com',
+  provider: 'app',
+  authFailedAt: null,
+  scopes: ['calendar.readonly'],
+  handleAliases: [],
+  lastSignedInAt: null,
+  userWorkspaceId: 'user-workspace-1',
+  connectionProviderId: 'provider-1',
+  name: 'Main connection',
+  visibility: 'user',
+  lastCredentialsRefreshedAt: null,
+  connectionParameters: null,
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+};
+
+const renderSection = () =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <MemoryRouter>
+        <SettingsApplicationConnectionsSection applicationId="app-1" />
+      </MemoryRouter>
+    </I18nProvider>,
+  );
+
+const pickJustForMe = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(within(screen.getByRole('menu')).getByText('Just for me'));
+};
+
+const pickWorkspaceShared = async (
+  user: ReturnType<typeof userEvent.setup>,
+) => {
+  await user.click(
+    within(screen.getByRole('menu')).getByText('Workspace shared'),
+  );
+};
+
 describe('SettingsApplicationConnectionsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders app connection rows as links to the connection detail page', () => {
-    mockedUseFindApplicationConnectionProviders.mockReturnValue({
-      connectionProviders: [
-        {
-          id: 'provider-1',
-          applicationId: 'app-1',
-          type: 'oauth',
-          name: 'google-calendar',
-          displayName: 'Google Calendar',
-          logoUrl: null,
-          oauth: {
-            scopes: ['calendar.readonly'],
-            isClientCredentialsConfigured: false,
-          },
-        },
-      ],
-      loading: false,
-      refetch: jest.fn(),
-    });
+    mockConnectionProviders({ isClientCredentialsConfigured: false });
 
     mockedUseMyAppConnectedAccounts.mockReturnValue({
       accounts: [
@@ -89,13 +154,7 @@ describe('SettingsApplicationConnectionsSection', () => {
       refetch: jest.fn(),
     });
 
-    render(
-      <I18nProvider i18n={i18n}>
-        <MemoryRouter>
-          <SettingsApplicationConnectionsSection applicationId="app-1" />
-        </MemoryRouter>
-      </I18nProvider>,
-    );
+    renderSection();
 
     expect(
       screen.getByRole('link', { name: /Main connection/i }),
@@ -106,10 +165,118 @@ describe('SettingsApplicationConnectionsSection', () => {
     expect(screen.getByText('Reconnect needed')).toBeVisible();
     expect(screen.getByText('Workspace shared')).toBeVisible();
     expect(
-      screen.queryByRole('button', { name: 'Reconnect' }),
+      screen.queryByRole('button', { name: /Reconnect/ }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Delete' }),
+      screen.queryByRole('button', { name: /Delete/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it('starts the OAuth redirect right away when there is no connection yet', async () => {
+    const user = userEvent.setup();
+
+    mockConnectionProviders({ isClientCredentialsConfigured: true });
+    mockedUseMyAppConnectedAccounts.mockReturnValue({
+      accounts: [],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    renderSection();
+
+    await pickJustForMe(user);
+
+    expect(mockTriggerAppOAuth).toHaveBeenCalledWith({
+      applicationId: 'app-1',
+      providerName: 'google-calendar',
+      visibility: 'user',
+    });
+    expect(
+      screen.queryByRole('button', { name: /Connect a different account/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('offers to reconnect the existing personal connection instead of adding a second one', async () => {
+    const user = userEvent.setup();
+
+    mockConnectionProviders({ isClientCredentialsConfigured: true });
+    mockedUseMyAppConnectedAccounts.mockReturnValue({
+      accounts: [PERSONAL_CONNECTION],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    renderSection();
+
+    await pickJustForMe(user);
+
+    expect(
+      screen.getByText('You already have a Google Calendar connection'),
+    ).toBeVisible();
+    expect(mockTriggerAppOAuth).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', { name: /Reconnect Main connection/ }),
+    );
+
+    expect(mockTriggerAppOAuth).toHaveBeenCalledWith({
+      applicationId: 'app-1',
+      providerName: 'google-calendar',
+      visibility: 'user',
+      reconnectingConnectedAccountId: 'account-1',
+    });
+  });
+
+  it('shares the existing personal connection when workspace visibility is picked', async () => {
+    const user = userEvent.setup();
+
+    mockConnectionProviders({ isClientCredentialsConfigured: true });
+    mockedUseMyAppConnectedAccounts.mockReturnValue({
+      accounts: [PERSONAL_CONNECTION],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    renderSection();
+
+    await pickWorkspaceShared(user);
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /Reconnect and share Main connection/,
+      }),
+    );
+
+    expect(mockTriggerAppOAuth).toHaveBeenCalledWith({
+      applicationId: 'app-1',
+      providerName: 'google-calendar',
+      visibility: 'workspace',
+      reconnectingConnectedAccountId: 'account-1',
+    });
+  });
+
+  it('still lets the user connect a different account from the modal', async () => {
+    const user = userEvent.setup();
+
+    mockConnectionProviders({ isClientCredentialsConfigured: true });
+    mockedUseMyAppConnectedAccounts.mockReturnValue({
+      accounts: [PERSONAL_CONNECTION],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    renderSection();
+
+    await pickJustForMe(user);
+
+    await user.click(
+      screen.getByRole('button', { name: /Connect a different account/ }),
+    );
+
+    expect(mockTriggerAppOAuth).toHaveBeenCalledWith({
+      applicationId: 'app-1',
+      providerName: 'google-calendar',
+      visibility: 'user',
+    });
   });
 });


### PR DESCRIPTION
## Problem

The same account can be connected to an app over and over. Picking a visibility from **Add connection** redirects straight to the provider, and the OAuth callback creates a new `connectedAccount` row unconditionally unless it was started as an explicit reconnect. Re-authorizing an account you already connected produces a second credential rather than refreshing the first, and you can do it as "Just for me" and again as "Workspace shared" indefinitely.

For an app like Fathom each connection registers its own webhook, so duplicates mean the same recording delivered twice down two ingestion paths, and disconnecting one leaves the other quietly ingesting.

## What this does

Makes the second connection a deliberate choice instead of the default. When a connection already exists for that provider, picking a visibility asks first:

| Situation | Primary action |
|---|---|
| One connection, same visibility as picked | Reconnect it |
| One personal connection, "Workspace shared" picked | Share it with the workspace |
| One shared connection, "Just for me" picked | Connect an account just for me |
| Several connections | Connect a different account |

In the first three cases the modal also offers **Connect a different account**, so someone with two Slack workspaces or a work and a personal Google account is never blocked. With several connections we can't know which one was meant, so no reconnect is offered and reconnecting a specific one stays on the connection detail page.

**The first connection is untouched** — no existing connections means no modal, straight to the provider as before.

A shared connection is never offered for reconnection when the user asked for a personal one. The only "reconnect" available there would un-share it, changing the credential everyone else in the workspace is using, which is not something a primary button should do.

## Scope

This is a UX guard, not an invariant. The authorize endpoint still accepts a bare create, and `myConnectedAccounts` only returns the caller's own rows, so this cannot see a workspace-shared connection created by someone else. A database-level constraint needs the server to know *which* remote account was authorized, which it currently never learns. That is the follow-up stack, starting with #25437.

Front-end only. No schema, no server change.

## Testing

`SettingsApplicationConnectionsSection.test.tsx` covers the three paths that matter: no modal on the first connection, reconnect passing the existing connection id, and "connect a different account" passing none. Full suite green, `lint:diff-with-main` clean, and no typecheck errors in `settings/applications`.
