### PR TITLE
feat(apps): declare remote account identity on connection providers

### DIFF
--- a/packages/twenty-sdk/src/sdk/define/common/utils/is-valid-https-url.ts
+++ b/packages/twenty-sdk/src/sdk/define/common/utils/is-valid-https-url.ts
@@ -1,0 +1,14 @@
+export const isValidHttpsUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+
+    return (
+      url.protocol === 'https:' &&
+      url.hostname !== '' &&
+      url.username === '' &&
+      url.password === ''
+    );
+  } catch {
+    return false;
+  }
+};

--- a/packages/twenty-sdk/src/sdk/define/connection-providers/__tests__/define-connection-provider.spec.ts
+++ b/packages/twenty-sdk/src/sdk/define/connection-providers/__tests__/define-connection-provider.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { defineConnectionProvider } from '@/sdk/define';
+import { type OAuthConnectionProviderIdentityConfig } from 'twenty-shared/application';
 
 const baseValidConfig = {
   universalIdentifier: '99fcd8e8-fbb1-4d2c-bc16-7c61ef3eaaaa',
@@ -114,4 +115,101 @@ describe('defineConnectionProvider', () => {
       ).toBe(true);
     },
   );
+
+  const validIdentity = {
+    endpoint: 'https://api.linear.app/graphql',
+    accountIdPath: 'data.viewer.id',
+  } satisfies OAuthConnectionProviderIdentityConfig;
+
+  const defineWithIdentity = (
+    identity: OAuthConnectionProviderIdentityConfig,
+  ) =>
+    defineConnectionProvider({
+      ...baseValidConfig,
+      oauth: { ...baseValidConfig.oauth, identity },
+    });
+
+  it('accepts a valid identity block', () => {
+    const result = defineWithIdentity({
+      ...validIdentity,
+      method: 'POST',
+      body: '{"query":"{ viewer { id name } }"}',
+      labelPath: 'data.viewer.name',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('rejects an identity endpoint that is empty or not an https URL', () => {
+    const missingEndpointResult = defineWithIdentity({
+      ...validIdentity,
+      endpoint: '',
+    });
+
+    expect(missingEndpointResult.success).toBe(false);
+    expect(
+      missingEndpointResult.errors.some((error) =>
+        error.includes('must have an endpoint'),
+      ),
+    ).toBe(true);
+
+    const insecureEndpointResult = defineWithIdentity({
+      ...validIdentity,
+      endpoint: 'http://api.linear.app/graphql',
+    });
+
+    expect(insecureEndpointResult.success).toBe(false);
+    expect(
+      insecureEndpointResult.errors.some((error) =>
+        error.includes('must be an absolute https URL'),
+      ),
+    ).toBe(true);
+
+    const credentialsEndpointResult = defineWithIdentity({
+      ...validIdentity,
+      endpoint: 'https://user:pass@api.linear.app/graphql',
+    });
+
+    expect(credentialsEndpointResult.success).toBe(false);
+  });
+
+  it('rejects an identity accountIdPath that is only whitespace', () => {
+    const result = defineWithIdentity({
+      ...validIdentity,
+      accountIdPath: '   ',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((error) => error.includes('accountIdPath'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects an unsupported identity method', () => {
+    const result = defineWithIdentity({
+      ...validIdentity,
+      // @ts-expect-error verifies runtime validation for JavaScript callers.
+      method: 'PUT',
+    });
+
+    expect(result.success).toBe(false);
+    expect(
+      result.errors.some((error) =>
+        error.includes('identity method "PUT" is not supported'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects an identity body when the method is GET', () => {
+    const result = defineWithIdentity({
+      ...validIdentity,
+      body: '{"query":"{ viewer { id } }"}',
+    });
+
+    expect(result.success).toBe(false);
+    expect(
+      result.errors.some((error) => error.includes("Set `method: 'POST'`")),
+    ).toBe(true);
+  });
 });

--- a/packages/twenty-sdk/src/sdk/define/connection-providers/define-connection-provider.ts
+++ b/packages/twenty-sdk/src/sdk/define/connection-providers/define-connection-provider.ts
@@ -1,11 +1,21 @@
+import { isNonEmptyString } from '@sniptt/guards';
 import { type DefineEntity } from '@/sdk/define/common/types/define-entity.type';
 import { createValidationResult } from '@/sdk/define/common/utils/create-validation-result';
+import { isValidHttpsUrl } from '@/sdk/define/common/utils/is-valid-https-url';
 import { isValidPostgresUuid } from '@/sdk/define/common/utils/is-valid-postgres-uuid';
-import { type ConnectionProviderManifest } from 'twenty-shared/application';
+import {
+  type ConnectionProviderManifest,
+  type OAuthConnectionProviderIdentityMethod,
+} from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
 
 const PROVIDER_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
 const SUPPORTED_TYPES = ['oauth'] as const;
+const DEFAULT_IDENTITY_METHOD = 'GET' as const;
+const SUPPORTED_IDENTITY_METHODS = [
+  'GET',
+  'POST',
+] as const satisfies readonly OAuthConnectionProviderIdentityMethod[];
 
 type ConnectionProviderLifecycleHookKey = Extract<
   keyof ConnectionProviderManifest,
@@ -88,6 +98,51 @@ export const defineConnectionProvider: DefineEntity<
       }
       if (!Array.isArray(oauth.scopes)) {
         errors.push('OAuth connection provider must declare a scopes array');
+      }
+
+      const identity = oauth.identity;
+
+      if (isDefined(identity)) {
+        if (
+          !isNonEmptyString(identity.endpoint) ||
+          identity.endpoint.trim() === ''
+        ) {
+          errors.push(
+            'OAuth connection provider identity must have an endpoint (the URL called with the access token to resolve the authorized account)',
+          );
+        } else if (!isValidHttpsUrl(identity.endpoint)) {
+          errors.push(
+            `OAuth connection provider identity endpoint "${identity.endpoint}" must be an absolute https URL with no embedded credentials (e.g. https://api.example.com/me)`,
+          );
+        }
+
+        if (
+          !isNonEmptyString(identity.accountIdPath) ||
+          identity.accountIdPath.trim() === ''
+        ) {
+          errors.push(
+            'OAuth connection provider identity must have an accountIdPath (dot-delimited path to the account id in the endpoint response, e.g. `user.id`)',
+          );
+        }
+
+        const method = identity.method ?? DEFAULT_IDENTITY_METHOD;
+
+        if (
+          isDefined(identity.method) &&
+          !(SUPPORTED_IDENTITY_METHODS as readonly string[]).includes(
+            identity.method,
+          )
+        ) {
+          errors.push(
+            `OAuth connection provider identity method "${identity.method}" is not supported. Supported methods: ${SUPPORTED_IDENTITY_METHODS.join(', ')}.`,
+          );
+        }
+
+        if (isNonEmptyString(identity.body) && method === 'GET') {
+          errors.push(
+            "OAuth connection provider identity `body` is only sent with method 'POST'. Set `method: 'POST'` or remove the body.",
+          );
+        }
       }
     }
   }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/2-39-instance-command-fast-1788557326426-add-external-account-id-to-connected-account.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/2-39-instance-command-fast-1788557326426-add-external-account-id-to-connected-account.ts
@@ -1,0 +1,19 @@
+import { QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+@RegisteredInstanceCommand('2.39.0', 1788557326426)
+export class AddExternalAccountIdToConnectedAccountFastInstanceCommand implements FastInstanceCommand {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "core"."connectedAccount" ADD "externalAccountId" character varying',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "core"."connectedAccount" DROP COLUMN "externalAccountId"',
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -175,6 +175,7 @@ import { RelaxNavigationPayloadCheckFastInstanceCommand } from 'src/database/com
 import { EraseObjectNavigationCommandMenuItemPayloadsSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-instance-command-slow-1788272351971-erase-object-navigation-command-menu-item-payloads';
 import { ReshapeUsageLimitPeriodFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-38/2-38-instance-command-fast-1788367160891-reshape-usage-limit-period';
 import { AddLogoToConnectionProviderFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-instance-command-fast-1788542613404-add-logo-to-connection-provider';
+import { AddExternalAccountIdToConnectedAccountFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-instance-command-fast-1788557326426-add-external-account-id-to-connected-account';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -352,4 +353,5 @@ export const INSTANCE_COMMANDS = [
   EraseObjectNavigationCommandMenuItemPayloadsSlowInstanceCommand,
   ReshapeUsageLimitPeriodFastInstanceCommand,
   AddLogoToConnectionProviderFastInstanceCommand,
+  AddExternalAccountIdToConnectedAccountFastInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-connection-provider-manifest-to-universal-flat-connection-provider.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-connection-provider-manifest-to-universal-flat-connection-provider.util.spec.ts
@@ -50,11 +50,41 @@ describe('fromConnectionProviderManifestToUniversalFlatConnectionProvider', () =
         authorizationParams: null,
         tokenRequestContentType: 'json',
         usePkce: true,
+        identity: null,
       },
       onConnectLogicFunctionUniversalIdentifier: null,
       onDisconnectLogicFunctionUniversalIdentifier: null,
       createdAt: NOW,
       updatedAt: NOW,
+    });
+  });
+
+  it('fills the identity defaults the manifest leaves out', () => {
+    const result =
+      fromConnectionProviderManifestToUniversalFlatConnectionProvider({
+        connectionProviderManifest: buildManifest({
+          oauth: {
+            authorizationEndpoint: 'https://linear.app/oauth/authorize',
+            tokenEndpoint: 'https://api.linear.app/oauth/token',
+            scopes: ['read', 'write'],
+            clientIdVariable: 'LINEAR_CLIENT_ID',
+            clientSecretVariable: 'LINEAR_CLIENT_SECRET',
+            identity: {
+              endpoint: 'https://api.linear.app/graphql',
+              accountIdPath: 'data.viewer.id',
+            },
+          },
+        }),
+        applicationUniversalIdentifier: APP_UID,
+        now: NOW,
+      });
+
+    expect(result.oauthConfig?.identity).toEqual({
+      endpoint: 'https://api.linear.app/graphql',
+      method: 'GET',
+      body: null,
+      accountIdPath: 'data.viewer.id',
+      labelPath: null,
     });
   });
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-connection-provider-manifest-to-universal-flat-connection-provider.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-connection-provider-manifest-to-universal-flat-connection-provider.util.ts
@@ -2,6 +2,7 @@ import {
   type ConnectionProviderManifest,
   type StoredOAuthConnectionProviderConfig,
 } from 'twenty-shared/application';
+import { isDefined } from 'twenty-shared/utils';
 
 import { type UniversalFlatConnectionProvider } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-connection-provider.type';
 
@@ -33,6 +34,18 @@ export const fromConnectionProviderManifestToUniversalFlatConnectionProvider =
               connectionProviderManifest.oauth.tokenRequestContentType ??
               'json',
             usePkce: connectionProviderManifest.oauth.usePkce ?? true,
+            identity: isDefined(connectionProviderManifest.oauth.identity)
+              ? {
+                  endpoint: connectionProviderManifest.oauth.identity.endpoint,
+                  method:
+                    connectionProviderManifest.oauth.identity.method ?? 'GET',
+                  body: connectionProviderManifest.oauth.identity.body ?? null,
+                  accountIdPath:
+                    connectionProviderManifest.oauth.identity.accountIdPath,
+                  labelPath:
+                    connectionProviderManifest.oauth.identity.labelPath ?? null,
+                }
+              : null,
           }
         : null;
 

--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/entities/connected-account.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/entities/connected-account.entity.ts
@@ -18,6 +18,7 @@ import { ApplicationEntity } from 'src/engine/core-modules/application/applicati
 import { ConnectionProviderEntity } from 'src/engine/core-modules/application/connection-provider/connection-provider.entity';
 import { type EncryptedImapSmtpCaldavParams } from 'src/engine/core-modules/imap-smtp-caldav-connection/types/imap-smtp-caldav-connection.type';
 import { type EncryptedString } from 'src/engine/core-modules/secret-encryption/branded-strings/encrypted-string.type';
+import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorators/was-introduced-in-upgrade.decorator';
 import { type CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { type MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { WorkspaceRelatedEntity } from 'src/engine/workspace-manager/types/workspace-related-entity';
@@ -83,6 +84,13 @@ export class ConnectedAccountEntity extends WorkspaceRelatedEntity {
 
   @Column({ type: 'jsonb', nullable: true })
   oidcTokenClaims: Record<string, unknown> | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.39.0_AddExternalAccountIdToConnectedAccountFastInstanceCommand_1788557326426',
+  })
+  externalAccountId: string | null;
 
   @Column({ type: 'uuid', nullable: false })
   userWorkspaceId: string;

--- a/packages/twenty-shared/src/application/index.ts
+++ b/packages/twenty-shared/src/application/index.ts
@@ -149,6 +149,10 @@ export type {
 export type { TranslationsManifest, Manifest } from './manifestType';
 export type { NavigationMenuItemManifest } from './navigationMenuItemManifestType';
 export type { OAuthConnectionProviderConfig } from './oauthConnectionProviderConfigType';
+export type {
+  OAuthConnectionProviderIdentityMethod,
+  OAuthConnectionProviderIdentityConfig,
+} from './oauthConnectionProviderIdentityConfigType';
 export type { OAuthProviderTokenRequestContentType } from './oauthProviderTokenRequestContentType.type';
 export type { ObjectFieldManifest } from './objectFieldManifest.type';
 export type { ObjectManifest } from './objectManifestType';
@@ -181,7 +185,10 @@ export type { ServerRouteDispatchResult } from './serverRouteDispatchResultType'
 export type { ServerRouteTriggerSettings } from './serverRouteTriggerSettingsType';
 export type { SettingsFrontComponentApplicationManifest } from './settingsFrontComponentApplicationType';
 export type { SkillManifest } from './skillManifestType';
-export type { StoredOAuthConnectionProviderConfig } from './storedOAuthConnectionProviderConfigType';
+export type {
+  StoredOAuthConnectionProviderIdentityConfig,
+  StoredOAuthConnectionProviderConfig,
+} from './storedOAuthConnectionProviderConfigType';
 export type { SyncableEntityOptions } from './syncableEntityOptionsType';
 export type {
   TimelineActivityTypeEmitThroughManifest,

--- a/packages/twenty-shared/src/application/oauthConnectionProviderConfigType.ts
+++ b/packages/twenty-shared/src/application/oauthConnectionProviderConfigType.ts
@@ -1,3 +1,4 @@
+import { type OAuthConnectionProviderIdentityConfig } from '@/application/oauthConnectionProviderIdentityConfigType';
 import { type OAuthProviderTokenRequestContentType } from '@/application/oauthProviderTokenRequestContentType.type';
 
 export type OAuthConnectionProviderConfig = {
@@ -10,4 +11,5 @@ export type OAuthConnectionProviderConfig = {
   authorizationParams?: Record<string, string>;
   tokenRequestContentType?: OAuthProviderTokenRequestContentType;
   usePkce?: boolean;
+  identity?: OAuthConnectionProviderIdentityConfig;
 };

--- a/packages/twenty-shared/src/application/oauthConnectionProviderIdentityConfigType.ts
+++ b/packages/twenty-shared/src/application/oauthConnectionProviderIdentityConfigType.ts
@@ -1,0 +1,9 @@
+export type OAuthConnectionProviderIdentityMethod = 'GET' | 'POST';
+
+export type OAuthConnectionProviderIdentityConfig = {
+  endpoint: string;
+  method?: OAuthConnectionProviderIdentityMethod;
+  body?: string;
+  accountIdPath: string;
+  labelPath?: string;
+};

--- a/packages/twenty-shared/src/application/storedOAuthConnectionProviderConfigType.ts
+++ b/packages/twenty-shared/src/application/storedOAuthConnectionProviderConfigType.ts
@@ -1,4 +1,13 @@
+import { type OAuthConnectionProviderIdentityMethod } from '@/application/oauthConnectionProviderIdentityConfigType';
 import { type OAuthProviderTokenRequestContentType } from '@/application/oauthProviderTokenRequestContentType.type';
+
+export type StoredOAuthConnectionProviderIdentityConfig = {
+  endpoint: string;
+  method: OAuthConnectionProviderIdentityMethod;
+  body: string | null;
+  accountIdPath: string;
+  labelPath: string | null;
+};
 
 // Resolved form of `OAuthConnectionProviderConfig` as stored in the
 // `connectionProvider.oauthConfig` JSONB column — manifest defaults are
@@ -13,4 +22,7 @@ export type StoredOAuthConnectionProviderConfig = {
   authorizationParams: Record<string, string> | null;
   tokenRequestContentType: OAuthProviderTokenRequestContentType;
   usePkce: boolean;
+  // Optional unlike its siblings: rows written before this field existed have
+  // no `identity` key at all, so reads must guard with isDefined, not `!== null`.
+  identity?: StoredOAuthConnectionProviderIdentityConfig | null;
 };


### PR DESCRIPTION
## Why

An app connection can be created twice for the same remote account, and the server has no way to notice. On the OAuth callback it reads an email from an `id_token` when the provider is OIDC, and otherwise falls back to the *Twenty user's own* email. Fathom asks for scope `public_api` with no `openid`, so every Fathom connection stores the same handle regardless of which Fathom account was actually authorized.

Core connected accounts don't have this problem: `google-apis.service.ts` finds by `(handle, userWorkspaceId, workspaceId, provider)` and upserts, where `handle` is the real authorized address off the Google profile. The app layer can't copy that until it can identify the remote account.

This PR is the plumbing for that. **It deliberately changes no behaviour** — nothing reads the new config or the new column yet.

## What's here

**An optional `identity` block on the OAuth provider manifest:**

```ts
identity?: {
  endpoint: string;
  method?: 'GET' | 'POST';
  body?: string;
  accountIdPath: string;
  labelPath?: string;
};
```

`endpoint` gets called with the freshly issued access token; the two paths are dot-delimited into the JSON response. `body` exists so a GraphQL provider can send a static query — Linear's `viewer` works without a bespoke code path — which is why it's only meaningful with `POST`.

**`defineConnectionProvider` validation**, only when the block is present: endpoint must be an absolute https URL with no embedded credentials, `accountIdPath` non-empty after trimming, `method` one of GET/POST, and a non-empty `body` rejected with GET pointing the developer at `method: 'POST'`.

**A nullable `externalAccountId` column** on `connectedAccount`, with the generated fast instance command. No index and no unique constraint — that's the last PR in the stack.

## Notes for review

- **`identity` is optional on the stored type, unlike every sibling field there.** That's deliberate and the one comment in this diff explains it: rows written before this field existed have no `identity` key, so at runtime the value is `undefined`, not `null`. Declaring it `| null` only would make `if (config.identity !== null)` typecheck and then throw. I first tried backfilling the JSONB instead, but the repo's `no-data-mutation-in-fast-instance-command` lint rule correctly rejects a bulk `UPDATE` sharing an `ACCESS EXCLUSIVE` lock with `ADD COLUMN`, and a slow command only runs under `--include-slow`, so a backfill wouldn't guarantee the invariant anyway.
- `@WasIntroducedInUpgrade` is required here, not decorative. `ConnectedAccountEntity` is reflected over by `UpgradeAwareEntityMetadataAdapter`, so without it a server on new code against a pre-upgrade database would `SELECT "externalAccountId"` from a table that lacks it. Verified: the migration run logs `hidden columns on ConnectedAccountEntity: externalAccountId` before the command applies.
- `isValidHttpsUrl` is new rather than reused. `isSafeUrl` allows http/mailto/tel/relative and `absoluteUrlSchema` *prepends* a protocol to bare domains, so neither expresses "must already be https".
- Identity config is validated in the SDK only. A manifest that never went through `defineConnectionProvider` could store any endpoint, so the PR that actually performs the fetch must re-validate server-side and route the call through `SecureHttpClientService`.

## Testing

Seven validation tests on `defineConnectionProvider` and one on the converter's defaulting. Migration applied against a real database and the column verified present. `twenty-server` and `twenty-sdk` typecheck clean, `lint:diff-with-main` clean.

## Stack

1. #25436 — ask before creating a second connection (independent, front-end only)
2. **This PR** — identity config and storage
3. Resolve identity at the OAuth callback (stacks on this)
4. Unique indexes and upsert on re-auth (stacks on 3)
