### PR TITLE
Record sharing 9/14: sync writes mailbox and calendar share rows

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/2-39-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/2-39-upgrade-version-command.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { ConvertLogicFunctionsToPrebuiltCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-workspace-command-1788338950836-convert-logic-functions-to-prebuilt.command';
@@ -6,21 +7,29 @@ import { BackfillRecordFormCommand } from 'src/database/commands/upgrade-version
 import { SyncRecordShareObjectCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-workspace-command-1788553681056-sync-record-share-object.command';
 import { MakeCallRecordingPrivateCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-workspace-command-1788555747635-make-call-recording-private.command';
 import { BackfillCallRecordingSharesCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-workspace-command-1788555749940-backfill-call-recording-shares.command';
+import { BackfillChannelRecordSharesCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-workspace-command-1788561701130-backfill-channel-record-shares.command';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { RecordShareModule } from 'src/engine/record-share/record-share.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
 import { WorkspaceSchemaMigrationRunnerActionHandlersModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/workspace-schema-migration-runner-action-handlers.module';
+import { CalendarCommonModule } from 'src/modules/calendar/common/calendar-common.module';
+import { MessagingCommonModule } from 'src/modules/messaging/common/messaging-common.module';
 
 @Module({
   imports: [
     ApplicationModule,
+    CalendarCommonModule,
     FeatureFlagModule,
+    MessagingCommonModule,
     RecordShareModule,
     TypeORMModule,
+    TypeOrmModule.forFeature([MessageChannelEntity, CalendarChannelEntity]),
     WorkspaceCacheModule,
     WorkspaceIteratorModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
@@ -33,6 +42,7 @@ import { WorkspaceSchemaMigrationRunnerActionHandlersModule } from 'src/engine/w
     SyncRecordShareObjectCommand,
     MakeCallRecordingPrivateCommand,
     BackfillCallRecordingSharesCommand,
+    BackfillChannelRecordSharesCommand,
   ],
 })
 export class V2_39_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/2-39-workspace-command-1788561701130-backfill-channel-record-shares.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-39/2-39-workspace-command-1788561701130-backfill-channel-record-shares.command.ts
@@ -1,0 +1,117 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { CalendarChannelRecordShareService } from 'src/modules/calendar/common/services/calendar-channel-record-share.service';
+import { MessageChannelRecordShareService } from 'src/modules/messaging/common/services/message-channel-record-share.service';
+
+@RegisteredWorkspaceCommand('2.39.0', 1788561701130)
+@Command({
+  name: 'upgrade:2-39:backfill-channel-record-shares',
+  description:
+    'Rebuild the owner FULL and everyone READ recordShare rows of every message channel and calendar channel from their association tables, so messages, threads and calendar events keep their readers once those objects become PRIVATE',
+})
+export class BackfillChannelRecordSharesCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    @InjectRepository(MessageChannelEntity)
+    private readonly messageChannelRepository: Repository<MessageChannelEntity>,
+    @InjectRepository(CalendarChannelEntity)
+    private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
+    private readonly messageChannelRecordShareService: MessageChannelRecordShareService,
+    private readonly calendarChannelRecordShareService: CalendarChannelRecordShareService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const { flatObjectMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+      ]);
+
+    const recordShareFlatObjectMetadata =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier: STANDARD_OBJECTS.recordShare.universalIdentifier,
+      });
+
+    if (!isDefined(recordShareFlatObjectMetadata)) {
+      this.logger.warn(
+        `recordShare object not found for workspace ${workspaceId}, skipping channel record share backfill`,
+      );
+
+      return;
+    }
+
+    if (
+      !isDefined(
+        flatObjectMetadataMaps.byUniversalIdentifier[
+          STANDARD_OBJECTS.message.universalIdentifier
+        ],
+      ) ||
+      !isDefined(
+        flatObjectMetadataMaps.byUniversalIdentifier[
+          STANDARD_OBJECTS.calendarEvent.universalIdentifier
+        ],
+      )
+    ) {
+      this.logger.warn(
+        `message or calendarEvent object not found for workspace ${workspaceId}, skipping channel record share backfill`,
+      );
+
+      return;
+    }
+
+    const messageChannels = await this.messageChannelRepository.find({
+      where: { workspaceId },
+      select: { id: true },
+    });
+    const calendarChannels = await this.calendarChannelRepository.find({
+      where: { workspaceId },
+      select: { id: true },
+    });
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Backfilling record shares for ${messageChannels.length} message channel(s) and ${calendarChannels.length} calendar channel(s) in workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    for (const messageChannel of messageChannels) {
+      await this.messageChannelRecordShareService.rebuildRecordSharesForMessageChannel(
+        { workspaceId, messageChannelId: messageChannel.id },
+      );
+    }
+
+    for (const calendarChannel of calendarChannels) {
+      await this.calendarChannelRecordShareService.rebuildRecordSharesForCalendarChannel(
+        { workspaceId, calendarChannelId: calendarChannel.id },
+      );
+    }
+
+    this.logger.log(
+      `Backfilled record shares for ${messageChannels.length} message channel(s) and ${calendarChannels.length} calendar channel(s) in workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/calendar-channel/calendar-channel-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/calendar-channel/calendar-channel-metadata.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { isDefined } from 'twenty-shared/utils';
 import { In, Repository } from 'typeorm';
 
 import {
@@ -8,6 +9,9 @@ import {
   CalendarChannelVisibility,
 } from 'twenty-shared/types';
 
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import {
   CalendarChannelException,
   CalendarChannelExceptionCode,
@@ -18,6 +22,10 @@ import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-chan
 import { type CalendarChannelDeletedEvent } from 'src/engine/metadata-modules/calendar-channel/types/calendar-channel-deleted.type';
 import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
+import {
+  RefreshCalendarChannelRecordSharesJob,
+  type RefreshCalendarChannelRecordSharesJobData,
+} from 'src/modules/calendar/common/jobs/refresh-calendar-channel-record-shares.job';
 
 @Injectable()
 export class CalendarChannelMetadataService {
@@ -26,6 +34,8 @@ export class CalendarChannelMetadataService {
     private readonly repository: Repository<CalendarChannelEntity>,
     private readonly connectedAccountMetadataService: ConnectedAccountMetadataService,
     private readonly workspaceEventEmitter: WorkspaceEventEmitter,
+    @InjectMessageQueue(MessageQueue.calendarQueue)
+    private readonly messageQueueService: MessageQueueService,
   ) {}
 
   async findAll(workspaceId: string): Promise<CalendarChannelDTO[]> {
@@ -166,10 +176,29 @@ export class CalendarChannelMetadataService {
     workspaceId: string;
     data: Partial<CalendarChannelEntity>;
   }): Promise<CalendarChannelDTO> {
+    const previousVisibility = isDefined(data.visibility)
+      ? (
+          await this.repository.findOneOrFail({
+            where: { id, workspaceId },
+            select: { visibility: true },
+          })
+        ).visibility
+      : undefined;
+
     await this.repository.update(
       { id, workspaceId },
       data as Record<string, unknown>,
     );
+
+    if (
+      isDefined(previousVisibility) &&
+      data.visibility !== previousVisibility
+    ) {
+      await this.messageQueueService.add<RefreshCalendarChannelRecordSharesJobData>(
+        RefreshCalendarChannelRecordSharesJob.name,
+        { workspaceId, calendarChannelId: id },
+      );
+    }
 
     return this.repository.findOneOrFail({ where: { id, workspaceId } });
   }

--- a/packages/twenty-server/src/engine/metadata-modules/message-channel/message-channel-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/message-channel/message-channel-metadata.service.ts
@@ -20,6 +20,9 @@ import {
 import { EmailingDomainDriver } from 'src/engine/core-modules/emailing-domain/drivers/types/emailing-domain-driver.type';
 import { EmailingDomainService } from 'src/engine/core-modules/emailing-domain/services/emailing-domain.service';
 import { StorageDriverType } from 'src/engine/core-modules/file-storage/interfaces/file-storage.interface';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
 import { MESSAGE_CHANNEL_DELETED_EVENT } from 'src/engine/metadata-modules/message-channel/constants/message-channel-deleted.constant';
@@ -32,6 +35,10 @@ import {
 } from 'src/engine/metadata-modules/message-channel/message-channel.exception';
 import { type MessageChannelDeletedEvent } from 'src/engine/metadata-modules/message-channel/types/message-channel-deleted.type';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
+import {
+  RefreshMessageChannelRecordSharesJob,
+  type RefreshMessageChannelRecordSharesJobData,
+} from 'src/modules/messaging/common/jobs/refresh-message-channel-record-shares.job';
 import { INBOUND_EMAIL_LOCAL_PART_PREFIX } from 'src/modules/messaging/message-import-manager/drivers/inbound-email/constants/inbound-email-local-part-prefix.constant';
 import { INBOUND_EMAIL_LOCAL_PART_RANDOM_BYTES } from 'src/modules/messaging/message-import-manager/drivers/inbound-email/constants/inbound-email-local-part-random-bytes.constant';
 import { getDomainFromEmail } from 'src/utils/get-domain-from-email';
@@ -45,6 +52,8 @@ export class MessageChannelMetadataService {
     private readonly twentyConfigService: TwentyConfigService,
     private readonly emailingDomainService: EmailingDomainService,
     private readonly workspaceEventEmitter: WorkspaceEventEmitter,
+    @InjectMessageQueue(MessageQueue.messagingQueue)
+    private readonly messageQueueService: MessageQueueService,
   ) {}
 
   async findAll(workspaceId: string): Promise<MessageChannelDTO[]> {
@@ -203,10 +212,29 @@ export class MessageChannelMetadataService {
     workspaceId: string;
     data: Partial<MessageChannelEntity>;
   }): Promise<MessageChannelDTO> {
+    const previousVisibility = isDefined(data.visibility)
+      ? (
+          await this.repository.findOneOrFail({
+            where: { id, workspaceId },
+            select: { visibility: true },
+          })
+        ).visibility
+      : undefined;
+
     await this.repository.update(
       { id, workspaceId },
       data as Record<string, unknown>,
     );
+
+    if (
+      isDefined(previousVisibility) &&
+      data.visibility !== previousVisibility
+    ) {
+      await this.messageQueueService.add<RefreshMessageChannelRecordSharesJobData>(
+        RefreshMessageChannelRecordSharesJob.name,
+        { workspaceId, messageChannelId: id },
+      );
+    }
 
     return this.repository.findOneOrFail({ where: { id, workspaceId } });
   }

--- a/packages/twenty-server/src/engine/record-share/utils/build-channel-record-shares.util.ts
+++ b/packages/twenty-server/src/engine/record-share/utils/build-channel-record-shares.util.ts
@@ -1,0 +1,49 @@
+import { EVERYONE_PRINCIPAL_ID } from 'twenty-shared/constants';
+import {
+  RecordShareAccessLevel,
+  RecordSharePrincipalType,
+  RecordShareRowCause,
+} from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type RecordShareInput } from 'src/engine/record-share/types/record-share-input.type';
+
+export const buildChannelRecordShares = ({
+  sourceId,
+  ownerWorkspaceMemberId,
+  isSharedWithEveryone,
+  records,
+}: {
+  sourceId: string;
+  ownerWorkspaceMemberId: string | null;
+  isSharedWithEveryone: boolean;
+  records: { recordId: string; objectMetadataId: string }[];
+}): RecordShareInput[] =>
+  records.flatMap(({ recordId, objectMetadataId }) => [
+    ...(isDefined(ownerWorkspaceMemberId)
+      ? [
+          {
+            recordId,
+            objectMetadataId,
+            principalId: ownerWorkspaceMemberId,
+            principalType: RecordSharePrincipalType.WORKSPACE_MEMBER,
+            accessLevel: RecordShareAccessLevel.FULL,
+            rowCause: RecordShareRowCause.APPLICATION,
+            sourceId,
+          },
+        ]
+      : []),
+    ...(isSharedWithEveryone
+      ? [
+          {
+            recordId,
+            objectMetadataId,
+            principalId: EVERYONE_PRINCIPAL_ID,
+            principalType: RecordSharePrincipalType.EVERYONE,
+            accessLevel: RecordShareAccessLevel.READ,
+            rowCause: RecordShareRowCause.APPLICATION,
+            sourceId,
+          },
+        ]
+      : []),
+  ]);

--- a/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/calendar-event-cleaner.module.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/calendar-event-cleaner.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
+import { RecordShareModule } from 'src/engine/record-share/record-share.module';
 import { CalendarChannelDeletionCleanupJob } from 'src/modules/calendar/calendar-event-cleaner/jobs/calendar-channel-deletion-cleanup.job';
 import { DeleteConnectedAccountAssociatedCalendarDataJob } from 'src/modules/calendar/calendar-event-cleaner/jobs/delete-connected-account-associated-calendar-data.job';
 
@@ -9,7 +10,7 @@ import { CalendarEventCleanerConnectedAccountListener } from 'src/modules/calend
 import { CalendarEventCleanerService } from 'src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service';
 
 @Module({
-  imports: [FeatureFlagModule],
+  imports: [FeatureFlagModule, RecordShareModule],
   providers: [
     CalendarEventCleanerService,
     CalendarChannelDeletionCleanupJob,

--- a/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/jobs/calendar-channel-deletion-cleanup.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/jobs/calendar-channel-deletion-cleanup.job.ts
@@ -3,6 +3,7 @@ import { Logger, Scope } from '@nestjs/common';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { RecordShareService } from 'src/engine/record-share/services/record-share.service';
 import { CalendarEventCleanerService } from 'src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service';
 
 export type CalendarChannelDeletionCleanupJobData = {
@@ -19,6 +20,7 @@ export class CalendarChannelDeletionCleanupJob {
 
   constructor(
     private readonly calendarEventCleanerService: CalendarEventCleanerService,
+    private readonly recordShareService: RecordShareService,
   ) {}
 
   @Process(CalendarChannelDeletionCleanupJob.name)
@@ -37,5 +39,10 @@ export class CalendarChannelDeletionCleanupJob {
     await this.calendarEventCleanerService.cleanWorkspaceCalendarEvents(
       data.workspaceId,
     );
+
+    await this.recordShareService.deleteBySourceId({
+      workspaceId: data.workspaceId,
+      sourceId: data.calendarChannelId,
+    });
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/calendar-event-import-manager.module.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/calendar-event-import-manager.module.ts
@@ -9,6 +9,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { RecordShareModule } from 'src/engine/record-share/record-share.module';
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { CalendarEventCleanerModule } from 'src/modules/calendar/calendar-event-cleaner/calendar-event-cleaner.module';
@@ -64,6 +65,7 @@ import { BlocklistRepository } from 'src/modules/blocklist/repositories/blocklis
     CalendarCommonModule,
     MetricsModule,
     FeatureFlagModule,
+    RecordShareModule,
   ],
   providers: [
     BlocklistRepository,

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
@@ -10,10 +10,17 @@ import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/typ
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { type CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { BlocklistRepository } from 'src/modules/blocklist/repositories/blocklist.repository';
 import { CalendarEventCleanerService } from 'src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service';
+import {
+  RefreshCalendarChannelRecordSharesJob,
+  type RefreshCalendarChannelRecordSharesJobData,
+} from 'src/modules/calendar/common/jobs/refresh-calendar-channel-record-shares.job';
 import { CALENDAR_EVENT_IMPORT_BATCH_SIZE } from 'src/modules/calendar/calendar-event-import-manager/constants/calendar-event-import-batch-size';
 import {
   CalendarEventImportDriverException,
@@ -46,6 +53,8 @@ export class CalendarEventsImportService {
     private readonly emailAliasManagerService: EmailAliasManagerService,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
+    @InjectMessageQueue(MessageQueue.calendarQueue)
+    private readonly messageQueueService: MessageQueueService,
   ) {}
 
   public async processCalendarEventsImport(
@@ -177,6 +186,11 @@ export class CalendarEventsImportService {
                 ),
                 workspaceId,
               },
+            );
+
+            await this.messageQueueService.add<RefreshCalendarChannelRecordSharesJobData>(
+              RefreshCalendarChannelRecordSharesJob.name,
+              { workspaceId, calendarChannelId: calendarChannel.id },
             );
           }
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -6,9 +6,16 @@ import { Any, Repository } from 'typeorm';
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { CalendarEventCleanerService } from 'src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service';
+import {
+  RefreshCalendarChannelRecordSharesJob,
+  type RefreshCalendarChannelRecordSharesJobData,
+} from 'src/modules/calendar/common/jobs/refresh-calendar-channel-record-shares.job';
 import {
   CalendarEventImportErrorHandlerService,
   CalendarEventImportSyncStep,
@@ -32,6 +39,8 @@ export class CalendarFetchEventsService {
     private readonly getCalendarEventsService: CalendarGetCalendarEventsService,
     private readonly calendarEventImportErrorHandlerService: CalendarEventImportErrorHandlerService,
     private readonly calendarEventCleanerService: CalendarEventCleanerService,
+    @InjectMessageQueue(MessageQueue.calendarQueue)
+    private readonly messageQueueService: MessageQueueService,
   ) {}
 
   public async fetchCalendarEvents(
@@ -86,6 +95,11 @@ export class CalendarFetchEventsService {
                 ),
                 workspaceId,
               },
+            );
+
+            await this.messageQueueService.add<RefreshCalendarChannelRecordSharesJobData>(
+              RefreshCalendarChannelRecordSharesJob.name,
+              { workspaceId, calendarChannelId: calendarChannel.id },
             );
           }
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
@@ -4,20 +4,25 @@ import { Any } from 'typeorm';
 
 import { type CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { RecordShareService } from 'src/engine/record-share/services/record-share.service';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { buildCalendarEventSaveOperations } from 'src/modules/calendar/calendar-event-import-manager/utils/build-calendar-event-save-operations.util';
 import { CalendarEventParticipantService } from 'src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service';
 import { buildCalendarEventParticipantSaveOperations } from 'src/modules/calendar/calendar-event-participant-manager/utils/build-calendar-event-participant-save-operations.util';
+import { CalendarChannelRecordShareService } from 'src/modules/calendar/common/services/calendar-channel-record-share.service';
 import { type CalendarChannelEventAssociationWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel-event-association.workspace-entity';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 import { type FetchedCalendarEvent } from 'src/modules/calendar/common/types/fetched-calendar-event';
+import { buildCalendarEventRecordSharesToInsert } from 'src/modules/calendar/common/utils/build-calendar-event-record-shares-to-insert.util';
 
 @Injectable()
 export class CalendarSaveEventsService {
   constructor(
     private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly calendarEventParticipantService: CalendarEventParticipantService,
+    private readonly calendarChannelRecordShareService: CalendarChannelRecordShareService,
+    private readonly recordShareService: RecordShareService,
   ) {}
 
   public async saveCalendarEventsAndEnqueueContactCreationJob(
@@ -27,6 +32,12 @@ export class CalendarSaveEventsService {
     workspaceId: string,
   ): Promise<{ calendarEventIds: string[] }> {
     const authContext = buildSystemAuthContext(workspaceId);
+    const calendarChannelRecordShareSource =
+      await this.calendarChannelRecordShareService.buildSource({
+        calendarChannel,
+        connectedAccount,
+        workspaceId,
+      });
 
     const { savedParticipantIds, calendarEventIds } =
       await this.workspaceOrmManager.executeInWorkspaceContext(
@@ -102,6 +113,20 @@ export class CalendarSaveEventsService {
                 await associationRepository.insert(
                   saveOperations.associationsToInsert,
                 );
+
+                await this.recordShareService.insertMany({
+                  workspaceId,
+                  recordShares: buildCalendarEventRecordSharesToInsert({
+                    calendarChannel: calendarChannelRecordShareSource,
+                    calendarEventIds: saveOperations.associationsToInsert.map(
+                      ({ calendarEventId }) => calendarEventId,
+                    ),
+                    calendarEventObjectMetadataId:
+                      calendarEventRepository.internalContext
+                        .objectIdByNameSingular.calendarEvent,
+                  }),
+                  transactionScope,
+                });
               }
 
               if (saveOperations.associationsToUpdate.length > 0) {

--- a/packages/twenty-server/src/modules/calendar/common/calendar-common.module.ts
+++ b/packages/twenty-server/src/modules/calendar/common/calendar-common.module.ts
@@ -5,7 +5,10 @@ import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { RecordShareModule } from 'src/engine/record-share/record-share.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
+import { RefreshCalendarChannelRecordSharesJob } from 'src/modules/calendar/common/jobs/refresh-calendar-channel-record-shares.job';
+import { CalendarChannelRecordShareService } from 'src/modules/calendar/common/services/calendar-channel-record-share.service';
 import { CalendarChannelSyncStatusService } from 'src/modules/calendar/common/services/calendar-channel-sync-status.service';
 import { ConnectedAccountModule } from 'src/modules/connected-account/connected-account.module';
 
@@ -19,8 +22,16 @@ import { ConnectedAccountModule } from 'src/modules/connected-account/connected-
     ]),
     ConnectedAccountModule,
     MetricsModule,
+    RecordShareModule,
   ],
-  providers: [CalendarChannelSyncStatusService],
-  exports: [CalendarChannelSyncStatusService],
+  providers: [
+    CalendarChannelSyncStatusService,
+    CalendarChannelRecordShareService,
+    RefreshCalendarChannelRecordSharesJob,
+  ],
+  exports: [
+    CalendarChannelSyncStatusService,
+    CalendarChannelRecordShareService,
+  ],
 })
 export class CalendarCommonModule {}

--- a/packages/twenty-server/src/modules/calendar/common/jobs/refresh-calendar-channel-record-shares.job.ts
+++ b/packages/twenty-server/src/modules/calendar/common/jobs/refresh-calendar-channel-record-shares.job.ts
@@ -1,0 +1,28 @@
+import { Scope } from '@nestjs/common';
+
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { CalendarChannelRecordShareService } from 'src/modules/calendar/common/services/calendar-channel-record-share.service';
+
+export type RefreshCalendarChannelRecordSharesJobData = {
+  workspaceId: string;
+  calendarChannelId: string;
+};
+
+@Processor({
+  queueName: MessageQueue.calendarQueue,
+  scope: Scope.REQUEST,
+})
+export class RefreshCalendarChannelRecordSharesJob {
+  constructor(
+    private readonly calendarChannelRecordShareService: CalendarChannelRecordShareService,
+  ) {}
+
+  @Process(RefreshCalendarChannelRecordSharesJob.name)
+  async handle(data: RefreshCalendarChannelRecordSharesJobData): Promise<void> {
+    await this.calendarChannelRecordShareService.rebuildRecordSharesForCalendarChannel(
+      data,
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/calendar/common/services/calendar-channel-record-share.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/services/calendar-channel-record-share.service.ts
@@ -1,0 +1,132 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { isDefined } from 'twenty-shared/utils';
+import { MoreThan, Repository } from 'typeorm';
+
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { RecordShareService } from 'src/engine/record-share/services/record-share.service';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
+import { type CalendarChannelEventAssociationWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel-event-association.workspace-entity';
+import { type CalendarChannelRecordShareSource } from 'src/modules/calendar/common/types/calendar-channel-record-share-source.type';
+import { buildCalendarEventRecordSharesToInsert } from 'src/modules/calendar/common/utils/build-calendar-event-record-shares-to-insert.util';
+import { ConnectedAccountOwnerService } from 'src/modules/connected-account/services/connected-account-owner.service';
+
+const CALENDAR_CHANNEL_RECORD_SHARE_BATCH_SIZE = 500;
+
+@Injectable()
+export class CalendarChannelRecordShareService {
+  constructor(
+    @InjectRepository(CalendarChannelEntity)
+    private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
+    private readonly connectedAccountOwnerService: ConnectedAccountOwnerService,
+    private readonly recordShareService: RecordShareService,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
+  ) {}
+
+  async buildSource({
+    calendarChannel,
+    connectedAccount,
+    workspaceId,
+  }: {
+    calendarChannel: Pick<CalendarChannelEntity, 'id' | 'visibility'>;
+    connectedAccount: Pick<ConnectedAccountEntity, 'userWorkspaceId'>;
+    workspaceId: string;
+  }): Promise<CalendarChannelRecordShareSource> {
+    return {
+      calendarChannelId: calendarChannel.id,
+      visibility: calendarChannel.visibility,
+      ownerWorkspaceMemberId:
+        await this.connectedAccountOwnerService.findOwnerWorkspaceMemberId({
+          userWorkspaceId: connectedAccount.userWorkspaceId,
+          workspaceId,
+        }),
+    };
+  }
+
+  async rebuildRecordSharesForCalendarChannel({
+    workspaceId,
+    calendarChannelId,
+  }: {
+    workspaceId: string;
+    calendarChannelId: string;
+  }): Promise<void> {
+    const calendarChannel = await this.calendarChannelRepository.findOne({
+      where: { id: calendarChannelId, workspaceId },
+      relations: { connectedAccount: true },
+    });
+
+    if (!isDefined(calendarChannel)) {
+      await this.recordShareService.deleteBySourceId({
+        workspaceId,
+        sourceId: calendarChannelId,
+      });
+
+      return;
+    }
+
+    const source = await this.buildSource({
+      calendarChannel,
+      connectedAccount: calendarChannel.connectedAccount,
+      workspaceId,
+    });
+
+    await this.workspaceOrmManager.executeInWorkspaceContext(
+      () =>
+        this.workspaceOrmManager.runInWorkspaceTransaction(
+          async (transactionScope) => {
+            const calendarChannelEventAssociationRepository =
+              transactionScope.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+                'calendarChannelEventAssociation',
+                { shouldBypassPermissionChecks: true },
+              );
+            const { objectIdByNameSingular } =
+              calendarChannelEventAssociationRepository.internalContext;
+
+            await this.recordShareService.deleteBySourceId({
+              workspaceId,
+              sourceId: calendarChannelId,
+              transactionScope,
+            });
+
+            let cursor: string | undefined;
+
+            for (;;) {
+              const associations =
+                await calendarChannelEventAssociationRepository.find({
+                  where: isDefined(cursor)
+                    ? { calendarChannelId, id: MoreThan(cursor) }
+                    : { calendarChannelId },
+                  select: { id: true, calendarEventId: true },
+                  order: { id: 'ASC' },
+                  take: CALENDAR_CHANNEL_RECORD_SHARE_BATCH_SIZE,
+                });
+
+              if (associations.length === 0) {
+                break;
+              }
+
+              cursor = associations[associations.length - 1].id;
+
+              await this.recordShareService.insertMany({
+                workspaceId,
+                recordShares: buildCalendarEventRecordSharesToInsert({
+                  calendarChannel: source,
+                  calendarEventIds: associations.map(
+                    (association) => association.calendarEventId,
+                  ),
+                  calendarEventObjectMetadataId:
+                    objectIdByNameSingular.calendarEvent,
+                }),
+                transactionScope,
+              });
+            }
+          },
+        ),
+      buildSystemAuthContext(workspaceId),
+      { lite: true },
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/calendar/common/types/calendar-channel-record-share-source.type.ts
+++ b/packages/twenty-server/src/modules/calendar/common/types/calendar-channel-record-share-source.type.ts
@@ -1,0 +1,7 @@
+import { type CalendarChannelVisibility } from 'twenty-shared/types';
+
+export type CalendarChannelRecordShareSource = {
+  calendarChannelId: string;
+  visibility: CalendarChannelVisibility;
+  ownerWorkspaceMemberId: string | null;
+};

--- a/packages/twenty-server/src/modules/calendar/common/utils/__tests__/build-calendar-event-record-shares-to-insert.util.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/common/utils/__tests__/build-calendar-event-record-shares-to-insert.util.spec.ts
@@ -1,0 +1,88 @@
+import { EVERYONE_PRINCIPAL_ID } from 'twenty-shared/constants';
+import {
+  CalendarChannelVisibility,
+  RecordShareAccessLevel,
+  RecordSharePrincipalType,
+  RecordShareRowCause,
+} from 'twenty-shared/types';
+
+import { buildCalendarEventRecordSharesToInsert } from 'src/modules/calendar/common/utils/build-calendar-event-record-shares-to-insert.util';
+
+const CALENDAR_CHANNEL_ID = 'calendar-channel-1';
+const OWNER_WORKSPACE_MEMBER_ID = 'workspace-member-1';
+const CALENDAR_EVENT_OBJECT_METADATA_ID = 'calendar-event-object';
+
+const ownerRow = (recordId: string) => ({
+  recordId,
+  objectMetadataId: CALENDAR_EVENT_OBJECT_METADATA_ID,
+  principalId: OWNER_WORKSPACE_MEMBER_ID,
+  principalType: RecordSharePrincipalType.WORKSPACE_MEMBER,
+  accessLevel: RecordShareAccessLevel.FULL,
+  rowCause: RecordShareRowCause.APPLICATION,
+  sourceId: CALENDAR_CHANNEL_ID,
+});
+
+const everyoneRow = (recordId: string) => ({
+  recordId,
+  objectMetadataId: CALENDAR_EVENT_OBJECT_METADATA_ID,
+  principalId: EVERYONE_PRINCIPAL_ID,
+  principalType: RecordSharePrincipalType.EVERYONE,
+  accessLevel: RecordShareAccessLevel.READ,
+  rowCause: RecordShareRowCause.APPLICATION,
+  sourceId: CALENDAR_CHANNEL_ID,
+});
+
+describe('buildCalendarEventRecordSharesToInsert', () => {
+  it.each([
+    CalendarChannelVisibility.METADATA,
+    CalendarChannelVisibility.SHARE_EVERYTHING,
+  ])(
+    'should give the owner FULL and everyone READ on each event once under %s visibility',
+    (visibility) => {
+      expect(
+        buildCalendarEventRecordSharesToInsert({
+          calendarChannel: {
+            calendarChannelId: CALENDAR_CHANNEL_ID,
+            visibility,
+            ownerWorkspaceMemberId: OWNER_WORKSPACE_MEMBER_ID,
+          },
+          calendarEventIds: ['event-1', 'event-2', 'event-1'],
+          calendarEventObjectMetadataId: CALENDAR_EVENT_OBJECT_METADATA_ID,
+        }),
+      ).toEqual([
+        ownerRow('event-1'),
+        everyoneRow('event-1'),
+        ownerRow('event-2'),
+        everyoneRow('event-2'),
+      ]);
+    },
+  );
+
+  it('should write no owner row when the owner has no workspace member', () => {
+    expect(
+      buildCalendarEventRecordSharesToInsert({
+        calendarChannel: {
+          calendarChannelId: CALENDAR_CHANNEL_ID,
+          visibility: CalendarChannelVisibility.SHARE_EVERYTHING,
+          ownerWorkspaceMemberId: null,
+        },
+        calendarEventIds: ['event-1'],
+        calendarEventObjectMetadataId: CALENDAR_EVENT_OBJECT_METADATA_ID,
+      }),
+    ).toEqual([everyoneRow('event-1')]);
+  });
+
+  it('should return an empty array without events', () => {
+    expect(
+      buildCalendarEventRecordSharesToInsert({
+        calendarChannel: {
+          calendarChannelId: CALENDAR_CHANNEL_ID,
+          visibility: CalendarChannelVisibility.SHARE_EVERYTHING,
+          ownerWorkspaceMemberId: OWNER_WORKSPACE_MEMBER_ID,
+        },
+        calendarEventIds: [],
+        calendarEventObjectMetadataId: CALENDAR_EVENT_OBJECT_METADATA_ID,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/modules/calendar/common/utils/build-calendar-event-record-shares-to-insert.util.ts
+++ b/packages/twenty-server/src/modules/calendar/common/utils/build-calendar-event-record-shares-to-insert.util.ts
@@ -1,0 +1,33 @@
+import { CalendarChannelVisibility } from 'twenty-shared/types';
+
+import { type RecordShareInput } from 'src/engine/record-share/types/record-share-input.type';
+import { buildChannelRecordShares } from 'src/engine/record-share/utils/build-channel-record-shares.util';
+import { type CalendarChannelRecordShareSource } from 'src/modules/calendar/common/types/calendar-channel-record-share-source.type';
+
+const CALENDAR_CHANNEL_VISIBILITIES_SHARED_WITH_EVERYONE: CalendarChannelVisibility[] =
+  [
+    CalendarChannelVisibility.METADATA,
+    CalendarChannelVisibility.SHARE_EVERYTHING,
+  ];
+
+export const buildCalendarEventRecordSharesToInsert = ({
+  calendarChannel,
+  calendarEventIds,
+  calendarEventObjectMetadataId,
+}: {
+  calendarChannel: CalendarChannelRecordShareSource;
+  calendarEventIds: string[];
+  calendarEventObjectMetadataId: string;
+}): RecordShareInput[] =>
+  buildChannelRecordShares({
+    sourceId: calendarChannel.calendarChannelId,
+    ownerWorkspaceMemberId: calendarChannel.ownerWorkspaceMemberId,
+    isSharedWithEveryone:
+      CALENDAR_CHANNEL_VISIBILITIES_SHARED_WITH_EVERYONE.includes(
+        calendarChannel.visibility,
+      ),
+    records: Array.from(new Set(calendarEventIds), (recordId) => ({
+      recordId,
+      objectMetadataId: calendarEventObjectMetadataId,
+    })),
+  });

--- a/packages/twenty-server/src/modules/connected-account/connected-account.module.ts
+++ b/packages/twenty-server/src/modules/connected-account/connected-account.module.ts
@@ -6,13 +6,18 @@ import { UserVarsModule } from 'src/engine/core-modules/user/user-vars/user-vars
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountListener } from 'src/modules/connected-account/listeners/connected-account.listener';
 import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
+import { ConnectedAccountOwnerService } from 'src/modules/connected-account/services/connected-account-owner.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ConnectedAccountEntity, UserWorkspaceEntity]),
     UserVarsModule,
   ],
-  providers: [AccountsToReconnectService, ConnectedAccountListener],
-  exports: [AccountsToReconnectService],
+  providers: [
+    AccountsToReconnectService,
+    ConnectedAccountOwnerService,
+    ConnectedAccountListener,
+  ],
+  exports: [AccountsToReconnectService, ConnectedAccountOwnerService],
 })
 export class ConnectedAccountModule {}

--- a/packages/twenty-server/src/modules/connected-account/services/connected-account-owner.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/services/connected-account-owner.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
+
+import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
+import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+@Injectable()
+export class ConnectedAccountOwnerService {
+  constructor(
+    @InjectRepository(UserWorkspaceEntity)
+    private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
+  ) {}
+
+  async findOwnerWorkspaceMemberId({
+    userWorkspaceId,
+    workspaceId,
+  }: {
+    userWorkspaceId: string;
+    workspaceId: string;
+  }): Promise<string | null> {
+    const userWorkspace = await this.userWorkspaceRepository.findOne({
+      where: { id: userWorkspaceId, workspaceId },
+    });
+
+    if (!isDefined(userWorkspace)) {
+      return null;
+    }
+
+    return this.workspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const workspaceMember = await this.workspaceOrmManager
+          .getRepository<WorkspaceMemberWorkspaceEntity>('workspaceMember', {
+            shouldBypassPermissionChecks: true,
+          })
+          .findOne({
+            where: { userId: userWorkspace.userId },
+            select: { id: true },
+          });
+
+        return workspaceMember?.id ?? null;
+      },
+      buildSystemAuthContext(workspaceId),
+      { lite: true },
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/emailing/emailing.module.ts
+++ b/packages/twenty-server/src/modules/emailing/emailing.module.ts
@@ -12,6 +12,7 @@ import { UsageModule } from 'src/engine/core-modules/usage/usage.module';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { MessageChannelMetadataModule } from 'src/engine/metadata-modules/message-channel/message-channel-metadata.module';
+import { RecordShareModule } from 'src/engine/record-share/record-share.module';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
@@ -43,12 +44,15 @@ import { MessageCampaignService } from 'src/modules/emailing/services/message-ca
 import { MessageSuppressionService } from 'src/modules/emailing/services/message-suppression.service';
 import { UnsubscribeTopicService } from 'src/modules/emailing/services/unsubscribe-topic.service';
 import { SaveCampaignTool } from 'src/modules/emailing/tools/save-campaign-tool';
+import { MessagingCommonModule } from 'src/modules/messaging/common/messaging-common.module';
 
 @Module({
   imports: [
     EmailingDomainModule,
     ThrottlerModule,
     MessageChannelMetadataModule,
+    MessagingCommonModule,
+    RecordShareModule,
     FeatureFlagModule,
     PermissionsModule,
     UserRoleModule,

--- a/packages/twenty-server/src/modules/emailing/services/message-campaign-materialization.service.ts
+++ b/packages/twenty-server/src/modules/emailing/services/message-campaign-materialization.service.ts
@@ -1,6 +1,7 @@
 import { CAMPAIGN_SEND_RETRY_LIMIT } from 'src/engine/core-modules/emailing-domain/constants/campaign-send-retry-limit.constant';
 import { CAMPAIGN_SEND_RETRY_BACKOFF } from 'src/engine/core-modules/emailing-domain/constants/campaign-send-retry-backoff.constant';
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 
 import { CampaignDeliveryEntity } from 'src/engine/core-modules/emailing-domain/campaign-delivery.entity';
 import { CAMPAIGN_DELIVERY_STATE } from 'src/engine/core-modules/emailing-domain/constants/campaign-delivery-state.constant';
@@ -8,7 +9,7 @@ import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 
 import chunk from 'lodash.chunk';
-import { In, type ObjectLiteral } from 'typeorm';
+import { In, type ObjectLiteral, Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
 import {
@@ -21,6 +22,8 @@ import { type SendCampaignEmailJobData } from 'src/engine/core-modules/emailing-
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { RecordShareService } from 'src/engine/record-share/services/record-share.service';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { MessageCampaignLifecycleService } from 'src/modules/emailing/services/message-campaign-lifecycle.service';
@@ -30,10 +33,13 @@ import { type CampaignMessageRecipient } from 'src/modules/emailing/types/campai
 import { buildCampaignMessageId } from 'src/modules/emailing/utils/build-campaign-message-id.util';
 import { compileCampaignEmailContent } from 'src/modules/emailing/utils/compile-campaign-email-content.util';
 import { MessageDirection } from 'src/modules/messaging/common/enums/message-direction.enum';
+import { MessageChannelRecordShareService } from 'src/modules/messaging/common/services/message-channel-record-share.service';
 import { MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { MessageParticipantWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-participant.workspace-entity';
 import { MessageThreadWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-thread.workspace-entity';
 import { MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
+import { type MessageChannelRecordShareSource } from 'src/modules/messaging/common/types/message-channel-record-share-source.type';
+import { buildMessageRecordSharesToInsert } from 'src/modules/messaging/common/utils/build-message-record-shares-to-insert.util';
 import {
   MessageCampaignStatus,
   MessageParticipantRole,
@@ -63,6 +69,10 @@ export class MessageCampaignMaterializationService {
     private readonly messageCampaignLifecycleService: MessageCampaignLifecycleService,
     @InjectMessageQueue(MessageQueue.campaignQueue)
     private readonly messageQueueService: MessageQueueService,
+    @InjectRepository(MessageChannelEntity)
+    private readonly messageChannelRepository: Repository<MessageChannelEntity>,
+    private readonly messageChannelRecordShareService: MessageChannelRecordShareService,
+    private readonly recordShareService: RecordShareService,
   ) {}
 
   async processMaterializeJob({
@@ -374,9 +384,19 @@ export class MessageCampaignMaterializationService {
     now: Date;
     recipients: CampaignMessageRecipient[];
   }): Promise<void> {
+    const messageChannel = await this.messageChannelRepository.findOneOrFail({
+      where: { id: messageChannelId, workspaceId },
+      relations: { connectedAccount: true },
+    });
+
     await this.insertChunk({
+      workspaceId,
       campaignId,
-      messageChannelId,
+      messageChannel: await this.messageChannelRecordShareService.buildSource({
+        messageChannel,
+        connectedAccount: messageChannel.connectedAccount,
+        workspaceId,
+      }),
       fromAddress,
       subjectTemplate,
       text,
@@ -403,16 +423,18 @@ export class MessageCampaignMaterializationService {
   }
 
   private async insertChunk({
+    workspaceId,
     campaignId,
-    messageChannelId,
+    messageChannel,
     fromAddress,
     subjectTemplate,
     text,
     now,
     rows,
   }: {
+    workspaceId: string;
     campaignId: string;
-    messageChannelId: string;
+    messageChannel: MessageChannelRecordShareSource;
     fromAddress: string;
     subjectTemplate: string;
     text: string;
@@ -450,12 +472,29 @@ export class MessageCampaignMaterializationService {
           rows.map((row) => ({
             id: v4(),
             messageId: row.messageId,
-            messageChannelId,
+            messageChannelId: messageChannel.messageChannelId,
             messageExternalId: row.temporaryExternalId,
             messageThreadExternalId: row.temporaryExternalId,
             direction: MessageDirection.OUTGOING,
           })),
         );
+
+        const { objectIdByNameSingular } =
+          repositoryFor<MessageWorkspaceEntity>('message').internalContext;
+
+        await this.recordShareService.insertMany({
+          workspaceId,
+          recordShares: buildMessageRecordSharesToInsert({
+            messageChannel,
+            messages: rows.map((row) => ({
+              id: row.messageId,
+              messageThreadId: row.threadId,
+            })),
+            messageObjectMetadataId: objectIdByNameSingular.message,
+            messageThreadObjectMetadataId: objectIdByNameSingular.messageThread,
+          }),
+          transactionScope,
+        });
 
         await repositoryFor<MessageParticipantWorkspaceEntity>(
           'messageParticipant',

--- a/packages/twenty-server/src/modules/messaging/common/jobs/refresh-message-channel-record-shares.job.ts
+++ b/packages/twenty-server/src/modules/messaging/common/jobs/refresh-message-channel-record-shares.job.ts
@@ -1,0 +1,28 @@
+import { Scope } from '@nestjs/common';
+
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageChannelRecordShareService } from 'src/modules/messaging/common/services/message-channel-record-share.service';
+
+export type RefreshMessageChannelRecordSharesJobData = {
+  workspaceId: string;
+  messageChannelId: string;
+};
+
+@Processor({
+  queueName: MessageQueue.messagingQueue,
+  scope: Scope.REQUEST,
+})
+export class RefreshMessageChannelRecordSharesJob {
+  constructor(
+    private readonly messageChannelRecordShareService: MessageChannelRecordShareService,
+  ) {}
+
+  @Process(RefreshMessageChannelRecordSharesJob.name)
+  async handle(data: RefreshMessageChannelRecordSharesJobData): Promise<void> {
+    await this.messageChannelRecordShareService.rebuildRecordSharesForMessageChannel(
+      data,
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/messaging/common/messaging-common.module.ts
+++ b/packages/twenty-server/src/modules/messaging/common/messaging-common.module.ts
@@ -6,8 +6,11 @@ import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
+import { RecordShareModule } from 'src/engine/record-share/record-share.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { ConnectedAccountModule } from 'src/modules/connected-account/connected-account.module';
+import { RefreshMessageChannelRecordSharesJob } from 'src/modules/messaging/common/jobs/refresh-message-channel-record-shares.job';
+import { MessageChannelRecordShareService } from 'src/modules/messaging/common/services/message-channel-record-share.service';
 import { MessageChannelSyncStatusService } from 'src/modules/messaging/common/services/message-channel-sync-status.service';
 
 @Module({
@@ -21,8 +24,13 @@ import { MessageChannelSyncStatusService } from 'src/modules/messaging/common/se
     ]),
     ConnectedAccountModule,
     MetricsModule,
+    RecordShareModule,
   ],
-  providers: [MessageChannelSyncStatusService],
-  exports: [MessageChannelSyncStatusService],
+  providers: [
+    MessageChannelSyncStatusService,
+    MessageChannelRecordShareService,
+    RefreshMessageChannelRecordSharesJob,
+  ],
+  exports: [MessageChannelSyncStatusService, MessageChannelRecordShareService],
 })
 export class MessagingCommonModule {}

--- a/packages/twenty-server/src/modules/messaging/common/services/message-channel-record-share.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/services/message-channel-record-share.service.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { isDefined } from 'twenty-shared/utils';
+import { In, MoreThan, Repository } from 'typeorm';
+
+import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { RecordShareService } from 'src/engine/record-share/services/record-share.service';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
+import { ConnectedAccountOwnerService } from 'src/modules/connected-account/services/connected-account-owner.service';
+import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
+import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
+import { type MessageChannelRecordShareSource } from 'src/modules/messaging/common/types/message-channel-record-share-source.type';
+import { buildMessageRecordSharesToInsert } from 'src/modules/messaging/common/utils/build-message-record-shares-to-insert.util';
+
+const MESSAGE_CHANNEL_RECORD_SHARE_BATCH_SIZE = 500;
+
+@Injectable()
+export class MessageChannelRecordShareService {
+  constructor(
+    @InjectRepository(MessageChannelEntity)
+    private readonly messageChannelRepository: Repository<MessageChannelEntity>,
+    private readonly connectedAccountOwnerService: ConnectedAccountOwnerService,
+    private readonly recordShareService: RecordShareService,
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
+  ) {}
+
+  async buildSource({
+    messageChannel,
+    connectedAccount,
+    workspaceId,
+  }: {
+    messageChannel: Pick<MessageChannelEntity, 'id' | 'visibility'>;
+    connectedAccount: Pick<ConnectedAccountEntity, 'userWorkspaceId'>;
+    workspaceId: string;
+  }): Promise<MessageChannelRecordShareSource> {
+    return {
+      messageChannelId: messageChannel.id,
+      visibility: messageChannel.visibility,
+      ownerWorkspaceMemberId:
+        await this.connectedAccountOwnerService.findOwnerWorkspaceMemberId({
+          userWorkspaceId: connectedAccount.userWorkspaceId,
+          workspaceId,
+        }),
+    };
+  }
+
+  async rebuildRecordSharesForMessageChannel({
+    workspaceId,
+    messageChannelId,
+  }: {
+    workspaceId: string;
+    messageChannelId: string;
+  }): Promise<void> {
+    const messageChannel = await this.messageChannelRepository.findOne({
+      where: { id: messageChannelId, workspaceId },
+      relations: { connectedAccount: true },
+    });
+
+    if (!isDefined(messageChannel)) {
+      await this.recordShareService.deleteBySourceId({
+        workspaceId,
+        sourceId: messageChannelId,
+      });
+
+      return;
+    }
+
+    const source = await this.buildSource({
+      messageChannel,
+      connectedAccount: messageChannel.connectedAccount,
+      workspaceId,
+    });
+
+    await this.workspaceOrmManager.executeInWorkspaceContext(
+      () =>
+        this.workspaceOrmManager.runInWorkspaceTransaction(
+          async (transactionScope) => {
+            const messageChannelMessageAssociationRepository =
+              transactionScope.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+                'messageChannelMessageAssociation',
+                { shouldBypassPermissionChecks: true },
+              );
+            const messageRepository =
+              transactionScope.getRepository<MessageWorkspaceEntity>(
+                'message',
+                { shouldBypassPermissionChecks: true },
+              );
+            const { objectIdByNameSingular } =
+              messageRepository.internalContext;
+
+            await this.recordShareService.deleteBySourceId({
+              workspaceId,
+              sourceId: messageChannelId,
+              transactionScope,
+            });
+
+            let cursor: string | undefined;
+
+            for (;;) {
+              const associations =
+                await messageChannelMessageAssociationRepository.find({
+                  where: isDefined(cursor)
+                    ? { messageChannelId, id: MoreThan(cursor) }
+                    : { messageChannelId },
+                  select: { id: true, messageId: true },
+                  order: { id: 'ASC' },
+                  take: MESSAGE_CHANNEL_RECORD_SHARE_BATCH_SIZE,
+                });
+
+              if (associations.length === 0) {
+                break;
+              }
+
+              cursor = associations[associations.length - 1].id;
+
+              const messages = await messageRepository.find({
+                where: {
+                  id: In(
+                    associations.map((association) => association.messageId),
+                  ),
+                },
+                select: { id: true, messageThreadId: true },
+              });
+
+              await this.recordShareService.insertMany({
+                workspaceId,
+                recordShares: buildMessageRecordSharesToInsert({
+                  messageChannel: source,
+                  messages,
+                  messageObjectMetadataId: objectIdByNameSingular.message,
+                  messageThreadObjectMetadataId:
+                    objectIdByNameSingular.messageThread,
+                }),
+                transactionScope,
+              });
+            }
+          },
+        ),
+      buildSystemAuthContext(workspaceId),
+      { lite: true },
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/messaging/common/types/message-channel-record-share-source.type.ts
+++ b/packages/twenty-server/src/modules/messaging/common/types/message-channel-record-share-source.type.ts
@@ -1,0 +1,7 @@
+import { type MessageChannelVisibility } from 'twenty-shared/types';
+
+export type MessageChannelRecordShareSource = {
+  messageChannelId: string;
+  visibility: MessageChannelVisibility;
+  ownerWorkspaceMemberId: string | null;
+};

--- a/packages/twenty-server/src/modules/messaging/common/utils/__tests__/build-message-record-shares-to-insert.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/common/utils/__tests__/build-message-record-shares-to-insert.util.spec.ts
@@ -1,0 +1,138 @@
+import { EVERYONE_PRINCIPAL_ID } from 'twenty-shared/constants';
+import {
+  MessageChannelVisibility,
+  RecordShareAccessLevel,
+  RecordSharePrincipalType,
+  RecordShareRowCause,
+} from 'twenty-shared/types';
+
+import { buildMessageRecordSharesToInsert } from 'src/modules/messaging/common/utils/build-message-record-shares-to-insert.util';
+
+const MESSAGE_CHANNEL_ID = 'message-channel-1';
+const OWNER_WORKSPACE_MEMBER_ID = 'workspace-member-1';
+const MESSAGE_OBJECT_METADATA_ID = 'message-object';
+const MESSAGE_THREAD_OBJECT_METADATA_ID = 'message-thread-object';
+
+const ownerRow = (recordId: string, objectMetadataId: string) => ({
+  recordId,
+  objectMetadataId,
+  principalId: OWNER_WORKSPACE_MEMBER_ID,
+  principalType: RecordSharePrincipalType.WORKSPACE_MEMBER,
+  accessLevel: RecordShareAccessLevel.FULL,
+  rowCause: RecordShareRowCause.APPLICATION,
+  sourceId: MESSAGE_CHANNEL_ID,
+});
+
+const everyoneRow = (recordId: string, objectMetadataId: string) => ({
+  recordId,
+  objectMetadataId,
+  principalId: EVERYONE_PRINCIPAL_ID,
+  principalType: RecordSharePrincipalType.EVERYONE,
+  accessLevel: RecordShareAccessLevel.READ,
+  rowCause: RecordShareRowCause.APPLICATION,
+  sourceId: MESSAGE_CHANNEL_ID,
+});
+
+describe('buildMessageRecordSharesToInsert', () => {
+  it('should give the owner FULL and everyone READ on each message and on their thread once', () => {
+    expect(
+      buildMessageRecordSharesToInsert({
+        messageChannel: {
+          messageChannelId: MESSAGE_CHANNEL_ID,
+          visibility: MessageChannelVisibility.SHARE_EVERYTHING,
+          ownerWorkspaceMemberId: OWNER_WORKSPACE_MEMBER_ID,
+        },
+        messages: [
+          { id: 'message-1', messageThreadId: 'thread-1' },
+          { id: 'message-2', messageThreadId: 'thread-1' },
+        ],
+        messageObjectMetadataId: MESSAGE_OBJECT_METADATA_ID,
+        messageThreadObjectMetadataId: MESSAGE_THREAD_OBJECT_METADATA_ID,
+      }),
+    ).toEqual([
+      ownerRow('message-1', MESSAGE_OBJECT_METADATA_ID),
+      everyoneRow('message-1', MESSAGE_OBJECT_METADATA_ID),
+      ownerRow('message-2', MESSAGE_OBJECT_METADATA_ID),
+      everyoneRow('message-2', MESSAGE_OBJECT_METADATA_ID),
+      ownerRow('thread-1', MESSAGE_THREAD_OBJECT_METADATA_ID),
+      everyoneRow('thread-1', MESSAGE_THREAD_OBJECT_METADATA_ID),
+    ]);
+  });
+
+  it.each([
+    MessageChannelVisibility.METADATA,
+    MessageChannelVisibility.SUBJECT,
+  ])('should keep the everyone row under %s visibility', (visibility) => {
+    expect(
+      buildMessageRecordSharesToInsert({
+        messageChannel: {
+          messageChannelId: MESSAGE_CHANNEL_ID,
+          visibility,
+          ownerWorkspaceMemberId: OWNER_WORKSPACE_MEMBER_ID,
+        },
+        messages: [{ id: 'message-1', messageThreadId: 'thread-1' }],
+        messageObjectMetadataId: MESSAGE_OBJECT_METADATA_ID,
+        messageThreadObjectMetadataId: MESSAGE_THREAD_OBJECT_METADATA_ID,
+      }),
+    ).toEqual([
+      ownerRow('message-1', MESSAGE_OBJECT_METADATA_ID),
+      everyoneRow('message-1', MESSAGE_OBJECT_METADATA_ID),
+      ownerRow('thread-1', MESSAGE_THREAD_OBJECT_METADATA_ID),
+      everyoneRow('thread-1', MESSAGE_THREAD_OBJECT_METADATA_ID),
+    ]);
+  });
+
+  it('should write no owner row when the owner has no workspace member', () => {
+    expect(
+      buildMessageRecordSharesToInsert({
+        messageChannel: {
+          messageChannelId: MESSAGE_CHANNEL_ID,
+          visibility: MessageChannelVisibility.SHARE_EVERYTHING,
+          ownerWorkspaceMemberId: null,
+        },
+        messages: [{ id: 'message-1', messageThreadId: 'thread-1' }],
+        messageObjectMetadataId: MESSAGE_OBJECT_METADATA_ID,
+        messageThreadObjectMetadataId: MESSAGE_THREAD_OBJECT_METADATA_ID,
+      }),
+    ).toEqual([
+      everyoneRow('message-1', MESSAGE_OBJECT_METADATA_ID),
+      everyoneRow('thread-1', MESSAGE_THREAD_OBJECT_METADATA_ID),
+    ]);
+  });
+
+  it('should skip the thread rows of a message without thread and deduplicate messages', () => {
+    expect(
+      buildMessageRecordSharesToInsert({
+        messageChannel: {
+          messageChannelId: MESSAGE_CHANNEL_ID,
+          visibility: MessageChannelVisibility.SHARE_EVERYTHING,
+          ownerWorkspaceMemberId: OWNER_WORKSPACE_MEMBER_ID,
+        },
+        messages: [
+          { id: 'message-1', messageThreadId: null },
+          { id: 'message-1', messageThreadId: null },
+        ],
+        messageObjectMetadataId: MESSAGE_OBJECT_METADATA_ID,
+        messageThreadObjectMetadataId: MESSAGE_THREAD_OBJECT_METADATA_ID,
+      }),
+    ).toEqual([
+      ownerRow('message-1', MESSAGE_OBJECT_METADATA_ID),
+      everyoneRow('message-1', MESSAGE_OBJECT_METADATA_ID),
+    ]);
+  });
+
+  it('should return an empty array without messages', () => {
+    expect(
+      buildMessageRecordSharesToInsert({
+        messageChannel: {
+          messageChannelId: MESSAGE_CHANNEL_ID,
+          visibility: MessageChannelVisibility.SHARE_EVERYTHING,
+          ownerWorkspaceMemberId: OWNER_WORKSPACE_MEMBER_ID,
+        },
+        messages: [],
+        messageObjectMetadataId: MESSAGE_OBJECT_METADATA_ID,
+        messageThreadObjectMetadataId: MESSAGE_THREAD_OBJECT_METADATA_ID,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/common/utils/build-message-record-shares-to-insert.util.ts
+++ b/packages/twenty-server/src/modules/messaging/common/utils/build-message-record-shares-to-insert.util.ts
@@ -1,0 +1,49 @@
+import { MessageChannelVisibility } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type RecordShareInput } from 'src/engine/record-share/types/record-share-input.type';
+import { buildChannelRecordShares } from 'src/engine/record-share/utils/build-channel-record-shares.util';
+import { type MessageChannelRecordShareSource } from 'src/modules/messaging/common/types/message-channel-record-share-source.type';
+
+const MESSAGE_CHANNEL_VISIBILITIES_SHARED_WITH_EVERYONE: MessageChannelVisibility[] =
+  [
+    MessageChannelVisibility.METADATA,
+    MessageChannelVisibility.SUBJECT,
+    MessageChannelVisibility.SHARE_EVERYTHING,
+  ];
+
+export const buildMessageRecordSharesToInsert = ({
+  messageChannel,
+  messages,
+  messageObjectMetadataId,
+  messageThreadObjectMetadataId,
+}: {
+  messageChannel: MessageChannelRecordShareSource;
+  messages: { id: string; messageThreadId: string | null }[];
+  messageObjectMetadataId: string;
+  messageThreadObjectMetadataId: string;
+}): RecordShareInput[] => {
+  const messageIds = new Set(messages.map((message) => message.id));
+  const messageThreadIds = new Set(
+    messages.map((message) => message.messageThreadId).filter(isDefined),
+  );
+
+  return buildChannelRecordShares({
+    sourceId: messageChannel.messageChannelId,
+    ownerWorkspaceMemberId: messageChannel.ownerWorkspaceMemberId,
+    isSharedWithEveryone:
+      MESSAGE_CHANNEL_VISIBILITIES_SHARED_WITH_EVERYONE.includes(
+        messageChannel.visibility,
+      ),
+    records: [
+      ...Array.from(messageIds, (recordId) => ({
+        recordId,
+        objectMetadataId: messageObjectMetadataId,
+      })),
+      ...Array.from(messageThreadIds, (recordId) => ({
+        recordId,
+        objectMetadataId: messageThreadObjectMetadataId,
+      })),
+    ],
+  });
+};

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/jobs/messaging-message-channel-deletion-cleanup.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/jobs/messaging-message-channel-deletion-cleanup.job.ts
@@ -3,6 +3,7 @@ import { Logger, Scope } from '@nestjs/common';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { RecordShareService } from 'src/engine/record-share/services/record-share.service';
 import { MessagingMessageCleanerService } from 'src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service';
 
 export type MessagingMessageChannelDeletionCleanupJobData = {
@@ -21,6 +22,7 @@ export class MessagingMessageChannelDeletionCleanupJob {
 
   constructor(
     private readonly messageCleanerService: MessagingMessageCleanerService,
+    private readonly recordShareService: RecordShareService,
   ) {}
 
   @Process(MessagingMessageChannelDeletionCleanupJob.name)
@@ -41,5 +43,10 @@ export class MessagingMessageChannelDeletionCleanupJob {
     await this.messageCleanerService.cleanOrphanMessagesAndThreads(
       data.workspaceId,
     );
+
+    await this.recordShareService.deleteBySourceId({
+      workspaceId: data.workspaceId,
+      sourceId: data.messageChannelId,
+    });
   }
 }

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/messaging-message-cleaner.module.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/messaging-message-cleaner.module.ts
@@ -5,6 +5,7 @@ import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/w
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { RecordShareModule } from 'src/engine/record-share/record-share.module';
 import { MessagingCommonModule } from 'src/modules/messaging/common/messaging-common.module';
 import { MatchParticipantModule } from 'src/modules/match-participant/match-participant.module';
 import { MessagingMessageCleanerRemoveOrphansCommand } from 'src/modules/messaging/message-cleaner/commands/messaging-message-clearner-remove-orphans.command';
@@ -22,6 +23,7 @@ import { MessagingMessageCleanerService } from 'src/modules/messaging/message-cl
     FeatureFlagModule,
     MessagingCommonModule,
     MatchParticipantModule,
+    RecordShareModule,
     WorkspaceIteratorModule,
   ],
   providers: [

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -4,10 +4,17 @@ import chunk from 'lodash.chunk';
 import { isDefined } from 'twenty-shared/utils';
 import { In, MoreThan } from 'typeorm';
 
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace-repository';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { ParticipantTargetReconciliationService } from 'src/modules/match-participant/participant-target-reconciliation.service';
+import {
+  RefreshMessageChannelRecordSharesJob,
+  type RefreshMessageChannelRecordSharesJobData,
+} from 'src/modules/messaging/common/jobs/refresh-message-channel-record-shares.job';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { type MessageThreadWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-thread.workspace-entity';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
@@ -20,6 +27,8 @@ export class MessagingMessageCleanerService {
   constructor(
     private readonly workspaceOrmManager: WorkspaceOrmManager,
     private readonly participantTargetReconciliationService: ParticipantTargetReconciliationService,
+    @InjectMessageQueue(MessageQueue.messagingQueue)
+    private readonly messageQueueService: MessageQueueService,
   ) {}
 
   async deleteMessagesChannelMessageAssociationsAndRelatedOrphans({
@@ -48,6 +57,8 @@ export class MessagingMessageCleanerService {
                 'messageThread',
               );
 
+            let hasDeletedAssociations = false;
+
             for (const messageExternalIdsChunk of chunk(
               messageExternalIds,
               500,
@@ -67,6 +78,8 @@ export class MessagingMessageCleanerService {
               await messageChannelMessageAssociationRepository.delete(
                 associationsToDelete.map(({ id }) => id),
               );
+
+              hasDeletedAssociations = true;
 
               this.logger.log(
                 `WorkspaceId: ${workspaceId} Deleting ${associationsToDelete.length} message channel message associations`,
@@ -123,6 +136,15 @@ export class MessagingMessageCleanerService {
                   transactionScope,
                 },
               );
+            }
+
+            if (hasDeletedAssociations) {
+              transactionScope.afterCommit(async () => {
+                await this.messageQueueService.add<RefreshMessageChannelRecordSharesJobData>(
+                  RefreshMessageChannelRecordSharesJob.name,
+                  { workspaceId, messageChannelId },
+                );
+              });
             }
           },
         );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/messaging-import-manager.module.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/messaging-import-manager.module.ts
@@ -9,6 +9,7 @@ import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-ac
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { RecordShareModule } from 'src/engine/record-share/record-share.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/workspace-event-emitter.module';
 import { ConnectedAccountModule } from 'src/modules/connected-account/connected-account.module';
@@ -85,6 +86,7 @@ import { BlocklistRepository } from 'src/modules/blocklist/repositories/blocklis
     MessagingMessageCleanerModule,
     WorkspaceEventEmitterModule,
     ConnectedAccountModule,
+    RecordShareModule,
   ],
   providers: [
     BlocklistRepository,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
@@ -4,12 +4,15 @@ import { isDefined } from 'twenty-shared/utils';
 import { In } from 'typeorm';
 import { v4 } from 'uuid';
 
+import { RecordShareService } from 'src/engine/record-share/services/record-share.service';
 import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
 import { type WorkspaceTransactionScope } from 'src/engine/twenty-orm/types/workspace-transaction-scope.type';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { type MessageThreadWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-thread.workspace-entity';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
+import { type MessageChannelRecordShareSource } from 'src/modules/messaging/common/types/message-channel-record-share-source.type';
+import { buildMessageRecordSharesToInsert } from 'src/modules/messaging/common/utils/build-message-record-shares-to-insert.util';
 import { type MessageWithParticipants } from 'src/modules/messaging/message-import-manager/types/message';
 
 type MessageAccumulator = {
@@ -41,11 +44,14 @@ type MessageAccumulator = {
 export class MessagingMessageService {
   private readonly logger = new Logger(MessagingMessageService.name);
 
-  constructor(private readonly workspaceOrmManager: WorkspaceOrmManager) {}
+  constructor(
+    private readonly workspaceOrmManager: WorkspaceOrmManager,
+    private readonly recordShareService: RecordShareService,
+  ) {}
 
   public async saveMessagesWithinTransaction(
     messages: MessageWithParticipants[],
-    messageChannelId: string,
+    messageChannel: MessageChannelRecordShareSource,
     transactionScope: WorkspaceTransactionScope,
     workspaceId: string,
   ): Promise<{
@@ -58,6 +64,7 @@ export class MessagingMessageService {
     messageExternalIdToMessageThreadIdMap: Map<string, string>;
   }> {
     const authContext = buildSystemAuthContext(workspaceId);
+    const { messageChannelId } = messageChannel;
 
     return this.workspaceOrmManager.executeInWorkspaceContext(
       async () => {
@@ -315,6 +322,34 @@ export class MessagingMessageService {
             );
           }
         }
+
+        await this.recordShareService.insertMany({
+          workspaceId,
+          recordShares: buildMessageRecordSharesToInsert({
+            messageChannel,
+            messages: Array.from(messageAccumulatorMap.values()).flatMap(
+              (accumulator) =>
+                isDefined(accumulator.messageChannelMessageAssociationToCreate)
+                  ? [
+                      {
+                        id: accumulator.messageChannelMessageAssociationToCreate
+                          .messageId,
+                        messageThreadId:
+                          accumulator.messageToCreate?.messageThreadId ??
+                          accumulator.existingMessageInDB?.messageThreadId ??
+                          null,
+                      },
+                    ]
+                  : [],
+            ),
+            messageObjectMetadataId:
+              messageRepository.internalContext.objectIdByNameSingular.message,
+            messageThreadObjectMetadataId:
+              messageRepository.internalContext.objectIdByNameSingular
+                .messageThread,
+          }),
+          transactionScope,
+        });
 
         return {
           createdMessages: messagesToCreate,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
@@ -18,6 +18,7 @@ import {
   CreateCompanyAndContactJob,
   type CreateCompanyAndContactJobData,
 } from 'src/modules/contact-creation-manager/jobs/create-company-and-contact.job';
+import { MessageChannelRecordShareService } from 'src/modules/messaging/common/services/message-channel-record-share.service';
 import {
   type Participant,
   type ParticipantWithMessageId,
@@ -38,6 +39,7 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
     private readonly messageService: MessagingMessageService,
     private readonly messageParticipantService: MessagingMessageParticipantService,
     private readonly messageFolderAssociationService: MessagingMessageFolderAssociationService,
+    private readonly messageChannelRecordShareService: MessageChannelRecordShareService,
     private readonly workspaceOrmManager: WorkspaceOrmManager,
   ) {}
 
@@ -55,6 +57,12 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
   > {
     const handleAliases = connectedAccount.handleAliases || [];
     const authContext = buildSystemAuthContext(workspaceId);
+    const messageChannelRecordShareSource =
+      await this.messageChannelRecordShareService.buildSource({
+        messageChannel,
+        connectedAccount,
+        workspaceId,
+      });
 
     const savedMessagesResult =
       await this.workspaceOrmManager.executeInWorkspaceContext(
@@ -67,7 +75,7 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
                 messageExternalIdToMessageThreadIdMap,
               } = await this.messageService.saveMessagesWithinTransaction(
                 messagesToSave,
-                messageChannel.id,
+                messageChannelRecordShareSource,
                 transactionScope,
                 workspaceId,
               );

--- a/packages/twenty-server/test/integration/google/messaging/channel-record-shares.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/channel-record-shares.integration-spec.ts
@@ -1,0 +1,430 @@
+import { randomUUID } from 'node:crypto';
+
+import { EVERYONE_PRINCIPAL_ID } from 'twenty-shared/constants';
+import {
+  CalendarChannelVisibility,
+  ConnectedAccountProvider,
+  MessageChannelVisibility,
+  RecordShareAccessLevel,
+  RecordSharePrincipalType,
+  RecordShareRowCause,
+} from 'twenty-shared/types';
+import { In } from 'typeorm';
+
+import { BackfillChannelRecordSharesCommand } from 'src/database/commands/upgrade-version-command/2-39/2-39-workspace-command-1788561701130-backfill-channel-record-shares.command';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { RecordShareService } from 'src/engine/record-share/services/record-share.service';
+import { type RecordShareInput } from 'src/engine/record-share/types/record-share-input.type';
+import { type RecordShare } from 'src/engine/record-share/types/record-share.type';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkspaceOrmManager } from 'src/engine/twenty-orm/workspace-orm.manager';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+import { gmailMessage } from 'test/integration/google/mocks/gmail-message.util';
+import { googleCalendarEvent } from 'test/integration/google/mocks/google-calendar-event.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { findRecordNodesByFilter } from 'test/integration/utils/find-records-by-filter.util';
+import { getAppProviderByClassName } from 'test/integration/utils/get-app-provider-by-class-name.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import {
+  updateCalendarChannel,
+  updateMessageChannel,
+} from 'test/integration/utils/query-messaging.util';
+import { runCalendarChannelEventsImport } from 'test/integration/utils/run-calendar-channel-events-import.util';
+import { runCalendarChannelListFetch } from 'test/integration/utils/run-calendar-channel-list-fetch.util';
+import { runMessageChannelSync } from 'test/integration/utils/run-message-channel-sync.util';
+import { waitForAllJobsToFinish } from 'test/integration/utils/wait-for-all-jobs-to-finish.util';
+
+const HANDLE = 'gmail-channel-record-shares@apple.dev';
+const SECOND_HANDLE = 'gmail-channel-record-shares-second@apple.dev';
+
+const authContext = buildSystemAuthContext(SEED_APPLE_WORKSPACE_ID);
+
+type ShareableRecord = { recordId: string; objectMetadataId: string };
+
+const sortRecordShares = <TRow extends object>(rows: TRow[]): TRow[] =>
+  [...rows].sort((left, right) =>
+    JSON.stringify(left).localeCompare(JSON.stringify(right)),
+  );
+
+const toComparable = (recordShares: RecordShare[]): RecordShareInput[] =>
+  sortRecordShares(
+    recordShares.map(
+      ({
+        recordId,
+        objectMetadataId,
+        principalId,
+        principalType,
+        accessLevel,
+        rowCause,
+        sourceId,
+      }) => ({
+        recordId,
+        objectMetadataId,
+        principalId,
+        principalType,
+        accessLevel,
+        rowCause,
+        sourceId,
+      }),
+    ),
+  );
+
+const expectedRowsFor = ({
+  sourceId,
+  records,
+}: {
+  sourceId: string;
+  records: ShareableRecord[];
+}): RecordShareInput[] =>
+  sortRecordShares(
+    records.flatMap(({ recordId, objectMetadataId }) => [
+      {
+        recordId,
+        objectMetadataId,
+        principalId: WORKSPACE_MEMBER_DATA_SEED_IDS.JANE,
+        principalType: RecordSharePrincipalType.WORKSPACE_MEMBER,
+        accessLevel: RecordShareAccessLevel.FULL,
+        rowCause: RecordShareRowCause.APPLICATION,
+        sourceId,
+      },
+      {
+        recordId,
+        objectMetadataId,
+        principalId: EVERYONE_PRINCIPAL_ID,
+        principalType: RecordSharePrincipalType.EVERYONE,
+        accessLevel: RecordShareAccessLevel.READ,
+        rowCause: RecordShareRowCause.APPLICATION,
+        sourceId,
+      },
+    ]),
+  );
+
+describe('Message channel record shares (integration)', () => {
+  const inbox = [gmailMessage()];
+  const gmail = setupGoogleMock({ handle: HANDLE, inbox });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let secondChannel:
+    | Awaited<ReturnType<typeof connectMessagingAccount>>
+    | undefined;
+  let workspaceOrmManager: WorkspaceOrmManager;
+  let recordShareService: RecordShareService;
+  let backfillCommand: BackfillChannelRecordSharesCommand;
+  let objectMetadataIdByNameSingular: Record<string, string>;
+
+  const findRecordSharesOfRecords = async (
+    records: ShareableRecord[],
+    sourceIds: string[],
+  ): Promise<RecordShare[]> => {
+    const recordIdsByObjectMetadataId = new Map<string, string[]>();
+
+    for (const { recordId, objectMetadataId } of records) {
+      recordIdsByObjectMetadataId.set(objectMetadataId, [
+        ...(recordIdsByObjectMetadataId.get(objectMetadataId) ?? []),
+        recordId,
+      ]);
+    }
+
+    const recordShares = await Promise.all(
+      Array.from(recordIdsByObjectMetadataId.entries(), (entry) =>
+        recordShareService.findByRecordIds({
+          workspaceId: SEED_APPLE_WORKSPACE_ID,
+          objectMetadataId: entry[0],
+          recordIds: entry[1],
+        }),
+      ),
+    );
+
+    return recordShares
+      .flat()
+      .filter((recordShare) => sourceIds.includes(recordShare.sourceId));
+  };
+
+  const insertStrayRecordShare = async (sourceId: string) => {
+    const strayRecord = {
+      recordId: randomUUID(),
+      objectMetadataId: objectMetadataIdByNameSingular.message,
+    };
+
+    await recordShareService.insertMany({
+      workspaceId: SEED_APPLE_WORKSPACE_ID,
+      recordShares: [
+        {
+          ...strayRecord,
+          principalId: EVERYONE_PRINCIPAL_ID,
+          principalType: RecordSharePrincipalType.EVERYONE,
+          accessLevel: RecordShareAccessLevel.READ,
+          rowCause: RecordShareRowCause.APPLICATION,
+          sourceId,
+        },
+      ],
+    });
+
+    return strayRecord;
+  };
+
+  const deleteRecordSharesBySourceIds = async (sourceIds: string[]) => {
+    for (const sourceId of sourceIds) {
+      await recordShareService.deleteBySourceId({
+        workspaceId: SEED_APPLE_WORKSPACE_ID,
+        sourceId,
+      });
+    }
+  };
+
+  const findMessageRecordsOfChannel = async (
+    messageChannelId: string,
+  ): Promise<ShareableRecord[]> => {
+    const associations = await findRecordNodesByFilter<{
+      messageId: string;
+      message: { messageThreadId: string };
+    }>(
+      'messageChannelMessageAssociation',
+      'messageChannelMessageAssociations',
+      'messageId message { messageThreadId }',
+      { messageChannelId: { eq: messageChannelId } },
+    );
+
+    return [
+      ...associations.map(({ messageId }) => ({
+        recordId: messageId,
+        objectMetadataId: objectMetadataIdByNameSingular.message,
+      })),
+      ...[
+        ...new Set(associations.map(({ message }) => message.messageThreadId)),
+      ].map((messageThreadId) => ({
+        recordId: messageThreadId,
+        objectMetadataId: objectMetadataIdByNameSingular.messageThread,
+      })),
+    ];
+  };
+
+  const findCalendarEventRecordsOfChannel = async (
+    calendarChannelId: string,
+  ): Promise<ShareableRecord[]> => {
+    const associations = await findRecordNodesByFilter<{
+      calendarEventId: string;
+    }>(
+      'calendarChannelEventAssociation',
+      'calendarChannelEventAssociations',
+      'calendarEventId',
+      { calendarChannelId: { eq: calendarChannelId } },
+    );
+
+    return associations.map(({ calendarEventId }) => ({
+      recordId: calendarEventId,
+      objectMetadataId: objectMetadataIdByNameSingular.calendarEvent,
+    }));
+  };
+
+  const runBackfill = (options: { dryRun?: boolean } = {}) =>
+    workspaceOrmManager.executeInWorkspaceContext(
+      () =>
+        backfillCommand.runOnWorkspace({
+          workspaceId: SEED_APPLE_WORKSPACE_ID,
+          options,
+          index: 0,
+          total: 1,
+        }),
+      authContext,
+    );
+
+  const sourceIds = () =>
+    [
+      channel.channelId,
+      channel.calendarChannelId,
+      secondChannel?.channelId,
+    ].filter((sourceId): sourceId is string => sourceId !== undefined);
+
+  beforeAll(async () => {
+    workspaceOrmManager = getAppProviderByClassName<WorkspaceOrmManager>(
+      'WorkspaceOrmManager',
+    );
+    recordShareService =
+      getAppProviderByClassName<RecordShareService>('RecordShareService');
+    backfillCommand =
+      getAppProviderByClassName<BackfillChannelRecordSharesCommand>(
+        'BackfillChannelRecordSharesCommand',
+      );
+
+    const objectMetadataItems = await getCoreRepository<ObjectMetadataEntity>(
+      ObjectMetadataEntity,
+    ).find({
+      where: {
+        workspaceId: SEED_APPLE_WORKSPACE_ID,
+        nameSingular: In(['message', 'messageThread', 'calendarEvent']),
+      },
+    });
+
+    objectMetadataIdByNameSingular = Object.fromEntries(
+      objectMetadataItems.map((objectMetadata) => [
+        objectMetadata.nameSingular,
+        objectMetadata.id,
+      ]),
+    );
+
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    await runMessageChannelSync(channel.channelId);
+  }, 120000);
+
+  afterAll(async () => {
+    await deleteRecordSharesBySourceIds(sourceIds()).catch(() => undefined);
+    await channel?.cleanup().catch(() => undefined);
+    await secondChannel?.cleanup().catch(() => undefined);
+  });
+
+  it('gives the owner FULL and everyone READ on the imported message and its thread', async () => {
+    const records = await findMessageRecordsOfChannel(channel.channelId);
+
+    expect(records).toHaveLength(2);
+
+    expect(
+      toComparable(
+        await findRecordSharesOfRecords(records, [channel.channelId]),
+      ),
+    ).toEqual(expectedRowsFor({ sourceId: channel.channelId, records }));
+  }, 60000);
+
+  it('adds its own rows when a second mailbox imports the same thread', async () => {
+    gmail.actAsAccount(SECOND_HANDLE);
+
+    secondChannel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: SECOND_HANDLE,
+    });
+
+    await runMessageChannelSync(secondChannel.channelId);
+
+    const records = await findMessageRecordsOfChannel(secondChannel.channelId);
+
+    expect(sortRecordShares(records)).toEqual(
+      sortRecordShares(await findMessageRecordsOfChannel(channel.channelId)),
+    );
+
+    expect(
+      toComparable(
+        await findRecordSharesOfRecords(records, [secondChannel.channelId]),
+      ),
+    ).toEqual(expectedRowsFor({ sourceId: secondChannel.channelId, records }));
+    expect(
+      toComparable(
+        await findRecordSharesOfRecords(records, [channel.channelId]),
+      ),
+    ).toEqual(expectedRowsFor({ sourceId: channel.channelId, records }));
+  }, 120000);
+
+  it('rebuilds exactly the same rows after a visibility change', async () => {
+    const records = await findMessageRecordsOfChannel(channel.channelId);
+    const rowsBefore = toComparable(
+      await findRecordSharesOfRecords(records, [channel.channelId]),
+    );
+
+    expect(rowsBefore).toHaveLength(4);
+
+    const strayRecord = await insertStrayRecordShare(channel.channelId);
+    const recordsWithStray = [...records, strayRecord];
+
+    expect(
+      await findRecordSharesOfRecords(recordsWithStray, [channel.channelId]),
+    ).toHaveLength(5);
+
+    await updateMessageChannel(channel.channelId, {
+      visibility: MessageChannelVisibility.METADATA,
+    });
+    await waitForAllJobsToFinish();
+
+    expect(
+      toComparable(
+        await findRecordSharesOfRecords(recordsWithStray, [channel.channelId]),
+      ),
+    ).toEqual(rowsBefore);
+  }, 60000);
+
+  it('gives the owner FULL and everyone READ on the imported calendar event', async () => {
+    gmail.actAsAccount(HANDLE);
+    gmail.serveCalendarEvents([googleCalendarEvent()]);
+
+    await runCalendarChannelListFetch(channel.calendarChannelId);
+    await runCalendarChannelEventsImport(channel.calendarChannelId);
+
+    const records = await findCalendarEventRecordsOfChannel(
+      channel.calendarChannelId,
+    );
+
+    expect(records).toHaveLength(1);
+
+    expect(
+      toComparable(
+        await findRecordSharesOfRecords(records, [channel.calendarChannelId]),
+      ),
+    ).toEqual(
+      expectedRowsFor({ sourceId: channel.calendarChannelId, records }),
+    );
+  }, 120000);
+
+  it('rebuilds exactly the same calendar event rows after a calendar visibility change', async () => {
+    const records = await findCalendarEventRecordsOfChannel(
+      channel.calendarChannelId,
+    );
+    const rowsBefore = toComparable(
+      await findRecordSharesOfRecords(records, [channel.calendarChannelId]),
+    );
+
+    expect(rowsBefore).toHaveLength(2);
+
+    const strayRecord = await insertStrayRecordShare(channel.calendarChannelId);
+    const recordsWithStray = [...records, strayRecord];
+
+    expect(
+      await findRecordSharesOfRecords(recordsWithStray, [
+        channel.calendarChannelId,
+      ]),
+    ).toHaveLength(3);
+
+    await updateCalendarChannel(channel.calendarChannelId, {
+      visibility: CalendarChannelVisibility.METADATA,
+    });
+    await waitForAllJobsToFinish();
+
+    expect(
+      toComparable(
+        await findRecordSharesOfRecords(recordsWithStray, [
+          channel.calendarChannelId,
+        ]),
+      ),
+    ).toEqual(rowsBefore);
+  }, 60000);
+
+  it('backfills the same rows as the live writer, skipping writes on a dry run', async () => {
+    const records = [
+      ...(await findMessageRecordsOfChannel(channel.channelId)),
+      ...(await findCalendarEventRecordsOfChannel(channel.calendarChannelId)),
+    ];
+    const rowsBefore = toComparable(
+      await findRecordSharesOfRecords(records, sourceIds()),
+    );
+
+    expect(rowsBefore).toHaveLength(10);
+
+    await deleteRecordSharesBySourceIds(sourceIds());
+    await runBackfill({ dryRun: true });
+
+    expect(await findRecordSharesOfRecords(records, sourceIds())).toHaveLength(
+      0,
+    );
+
+    await runBackfill();
+    await runBackfill();
+
+    expect(
+      toComparable(await findRecordSharesOfRecords(records, sourceIds())),
+    ).toEqual(rowsBefore);
+  }, 120000);
+});

--- a/packages/twenty-server/test/integration/utils/query-messaging.util.ts
+++ b/packages/twenty-server/test/integration/utils/query-messaging.util.ts
@@ -2,6 +2,8 @@ import gql from 'graphql-tag';
 
 import {
   type CalendarChannelContactAutoCreationPolicy,
+  type CalendarChannelVisibility,
+  type MessageChannelVisibility,
   type MessageFolderImportPolicy,
 } from 'twenty-shared/types';
 
@@ -70,12 +72,14 @@ type MessageChannelUpdate = {
   messageFolderImportPolicy?: MessageFolderImportPolicy;
   isSyncEnabled?: boolean;
   isContactAutoCreationEnabled?: boolean;
+  visibility?: MessageChannelVisibility;
 };
 
 type CalendarChannelUpdate = {
   isSyncEnabled?: boolean;
   isContactAutoCreationEnabled?: boolean;
   contactAutoCreationPolicy?: CalendarChannelContactAutoCreationPolicy;
+  visibility?: CalendarChannelVisibility;
 };
 
 const MESSAGE_CHANNEL_FIELDS = gql`


### PR DESCRIPTION
Eighth PR of the record-sharing stack in merge order (plan number 9), stacked on #25439 (inherited objects). Inert: message, messageThread and calendarEvent stay OPEN until the next PR flips them, so the rows written here are not consulted yet.

## What changes

- Next to every channel association the sync writes share rows for the message, its thread and the calendar event: one `FULL` row for the channel's connected account owner (the workspace member behind `connectedAccount.userWorkspaceId`, skipped when that member left) and one `EVERYONE` `READ` row, both `rowCause` `APPLICATION` with `sourceId` = the channel id. A thread or message imported by two mailboxes carries both channels' rows (the unique index keys on `sourceId`).
- Rows are written in the same transaction as the association insert, in `saveMessagesWithinTransaction`, in `calendar-save-events.service.ts`, and in campaign materialization, which inserts messages and associations directly.
- A channel visibility change enqueues `RefreshMessageChannelRecordSharesJob` / `RefreshCalendarChannelRecordSharesJob`: one transaction that deletes the channel's rows and rebuilds them from the association table, keyset-paged by 500. An association removal (mailbox cleanup, folder exclusion, blocklist, cancelled or deleted events) enqueues the same rebuild; a channel deletion removes its rows.
- `upgrade:2-39:backfill-channel-record-shares` runs the rebuild for every message and calendar channel of every workspace, skipping workspaces without the recordShare, message or calendarEvent objects, with `--dry-run`.
- `ConnectedAccountOwnerService` resolves a connected account's owner to a workspace member (nothing did that in one place before).

## Ambiguity to decide before PR 10

The plan says "the channel owner for a personal channel, EVERYONE for a share-everything one". Today no channel visibility hides messages from other members at the row level: `METADATA` and `SUBJECT` only blank fields. To keep today's behaviour, this PR writes the `EVERYONE` `READ` row for every visibility and the owner row on top; the field-level tiers stay in the read hooks. If the intent is that `METADATA` and `SUBJECT` mailboxes become owner-only once email is `PRIVATE`, only the visibility rule in the two row builders changes.

## Things to know

- A rebuild holds the channel's recordShare row locks for its whole transaction, so a sync of that channel that inserts rows at the same time waits for it.
- The dev seeder writes associations without rows; seeded workspaces need the backfill before the flag is turned on (the next PR handles it).
- Rows of hard-deleted messages, threads and events are left in place (uuids are never reused); a channel deletion removes its rows in bulk.

## Tests

- Unit: the two row builders (owner and everyone per record, one thread row per batch, owner missing, every visibility value).
- Integration `test/integration/google/messaging/channel-record-shares.integration-spec.ts` (6 cases, Google mocks): imported thread and messages carry the owner FULL and EVERYONE READ rows sourced from the channel; a second mailbox importing the same thread adds its own rows; a visibility change rebuilds the rows and removes a stray row; the calendar twin; the backfill dry run writes nothing and two real runs reproduce the live writer's rows exactly. The existing messaging and calendar channel-visibility and channel-deletion-cleanup suites still pass.

## Stack

1. #25421 readability level
2. #25425 recordShare object and service
3. #25426 read and write gate
4. #25428 shareWith on create
5. #25429 in-memory twin for events
6. #25438 call recording goes PRIVATE
7. #25439 INHERITED objects follow their parent
8. **This PR**: sync writes mailbox and calendar share rows
9. email and calendar go PRIVATE (next)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHyBCoxHaBFnPeHVnpTC3h)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

