### PR TITLE
fix(workspace-cache): ensure deterministic view sort order in flat view cache

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service.ts
@@ -34,6 +34,7 @@ const FLAT_VIEW_ROWS_REQUIREMENT = {
   viewSort: {
     columns: ['id', 'universalIdentifier'],
     groupBy: ['viewId'],
+    order: { createdAt: 'ASC', id: 'ASC' },
   },
   viewFieldGroup: {
     columns: ['id', 'universalIdentifier'],

--- a/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache-rows-batch-loader.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache-rows-batch-loader.spec.ts
@@ -311,4 +311,51 @@ describe('WorkspaceCacheRowsBatchLoader', () => {
 
     expect(findMock).toHaveBeenCalledTimes(2);
   });
+
+  it('forwards order clause to find options', async () => {
+    const { rowsBatchLoader, findMocksByEntity } = setup();
+    const findMock = findMocksByEntity.get(ViewFieldEntity)!;
+
+    await rowsBatchLoader.loadRows([
+      {
+        viewField: {
+          columns: ['id'],
+          order: { createdAt: 'ASC', id: 'ASC' },
+        },
+      },
+    ]);
+
+    expect(findMock).toHaveBeenCalledTimes(1);
+    expect(findMock.mock.calls[0][0].order).toEqual({
+      createdAt: 'ASC',
+      id: 'ASC',
+    });
+  });
+
+  it('merges order clauses across requirements targeting the same entity', async () => {
+    const { rowsBatchLoader, findMocksByEntity } = setup();
+    const findMock = findMocksByEntity.get(ViewFieldEntity)!;
+
+    await rowsBatchLoader.loadRows([
+      {
+        viewField: {
+          columns: ['id'],
+          order: { createdAt: 'ASC' },
+        },
+      },
+      {
+        viewField: {
+          columns: ['fieldMetadataId'],
+          order: { id: 'ASC' },
+        },
+      },
+    ]);
+
+    expect(findMock).toHaveBeenCalledTimes(1);
+    expect(findMock.mock.calls[0][0].order).toEqual({
+      createdAt: 'ASC',
+      id: 'ASC',
+    });
+  });
 });
+

--- a/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache-rows-batch-loader.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache-rows-batch-loader.spec.ts
@@ -3,6 +3,7 @@ import { IsNull, Not, type EntityTarget } from 'typeorm';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ViewFieldEntity } from 'src/engine/metadata-modules/view-field/entities/view-field.entity';
+import { WorkspaceCacheException } from 'src/engine/workspace-cache/exceptions/workspace-cache.exception';
 import {
   WorkspaceCacheRowsBatchLoader,
   type WorkspaceCacheRowsSource,
@@ -357,5 +358,25 @@ describe('WorkspaceCacheRowsBatchLoader', () => {
       id: 'ASC',
     });
   });
-});
 
+  it('throws an exception when conflicting order clauses target the same entity field', async () => {
+    const { rowsBatchLoader } = setup();
+
+    await expect(
+      rowsBatchLoader.loadRows([
+        {
+          viewField: {
+            columns: ['id'],
+            order: { createdAt: 'ASC' },
+          },
+        },
+        {
+          viewField: {
+            columns: ['id'],
+            order: { createdAt: 'DESC' },
+          },
+        },
+      ]),
+    ).rejects.toThrow(WorkspaceCacheException);
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-rows-batch-loader.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-rows-batch-loader.ts
@@ -1,6 +1,7 @@
 import {
   type EntityTarget,
   type FindManyOptions,
+  type FindOptionsOrder,
   type FindOptionsWhere,
   type ObjectLiteral,
   type Repository,
@@ -24,6 +25,7 @@ import { isObjectEntityRowsRequirement } from 'src/engine/workspace-cache/utils/
 import { serializeWhereClause } from 'src/engine/workspace-cache/utils/serialize-where-clause.util';
 
 type WhereClause = FindOptionsWhere<ObjectLiteral>;
+type OrderClause = FindOptionsOrder<ObjectLiteral>;
 
 export type WorkspaceCacheRowsSource = {
   getRepository: (
@@ -35,6 +37,7 @@ type NormalizedEntityRowsRequirement = {
   columns: readonly string[] | true;
   groupBy: readonly string[];
   where?: WhereClause;
+  order?: OrderClause;
 };
 
 const normalizeEntityRowsRequirement = (
@@ -45,6 +48,7 @@ const normalizeEntityRowsRequirement = (
         columns: entityRowsRequirement.columns,
         groupBy: entityRowsRequirement.groupBy ?? [],
         where: entityRowsRequirement.where,
+        order: entityRowsRequirement.order,
       }
     : { columns: entityRowsRequirement, groupBy: [] };
 
@@ -60,6 +64,7 @@ type PlannedFetch = {
   entityName: CacheFetchableEntityName;
   where?: WhereClause;
   columns: Set<string> | null;
+  order?: OrderClause;
 };
 
 export class WorkspaceCacheRowsBatchLoader {
@@ -101,18 +106,25 @@ export class WorkspaceCacheRowsBatchLoader {
           continue;
         }
 
-        const { columns, groupBy, where } = normalizeEntityRowsRequirement(
-          entityRowsRequirement,
-        );
+        const { columns, groupBy, where, order } =
+          normalizeEntityRowsRequirement(entityRowsRequirement);
         const fetchKey = buildFetchKey(entityName, where);
         const plannedFetch = plannedFetchByFetchKey.get(fetchKey);
 
         if (columns === true) {
-          plannedFetchByFetchKey.set(fetchKey, {
-            entityName,
-            where,
-            columns: null,
-          });
+          if (!isDefined(plannedFetch)) {
+            plannedFetchByFetchKey.set(fetchKey, {
+              entityName,
+              where,
+              columns: null,
+              order,
+            });
+          } else {
+            plannedFetch.columns = null;
+            if (isDefined(order)) {
+              plannedFetch.order = { ...plannedFetch.order, ...order };
+            }
+          }
           continue;
         }
 
@@ -123,8 +135,13 @@ export class WorkspaceCacheRowsBatchLoader {
             entityName,
             where,
             columns: new Set(columnsWithGroupByKeys),
+            order,
           });
           continue;
+        }
+
+        if (isDefined(order)) {
+          plannedFetch.order = { ...plannedFetch.order, ...order };
         }
 
         if (plannedFetch.columns === null) {
@@ -234,6 +251,7 @@ export class WorkspaceCacheRowsBatchLoader {
     entityName,
     where,
     columns,
+    order,
   }: PlannedFetch): Promise<ObjectLiteral[]> {
     const findOptions: FindManyOptions<ObjectLiteral> = {
       where: {
@@ -245,6 +263,10 @@ export class WorkspaceCacheRowsBatchLoader {
 
     if (columns !== null) {
       findOptions.select = [...columns];
+    }
+
+    if (isDefined(order)) {
+      findOptions.order = order;
     }
 
     return this.coreDataSource

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-rows-batch-loader.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-rows-batch-loader.ts
@@ -60,6 +60,31 @@ const buildFetchKey = (
     ? `${entityName}:${serializeWhereClause(where)}`
     : entityName;
 
+const mergeOrderClauses = (
+  existingOrder: OrderClause | undefined,
+  newOrder: OrderClause | undefined,
+  entityName: CacheFetchableEntityName,
+): OrderClause | undefined => {
+  if (!isDefined(existingOrder)) {
+    return isDefined(newOrder) ? { ...newOrder } : undefined;
+  }
+
+  if (!isDefined(newOrder)) {
+    return existingOrder;
+  }
+
+  for (const [key, direction] of Object.entries(newOrder)) {
+    if (isDefined(existingOrder[key]) && existingOrder[key] !== direction) {
+      throw new WorkspaceCacheException(
+        `Conflicting order clauses for entity "${entityName}" on field "${key}": "${existingOrder[key]}" vs "${direction}"`,
+        WorkspaceCacheExceptionCode.INVALID_PARAMETERS,
+      );
+    }
+  }
+
+  return { ...existingOrder, ...newOrder };
+};
+
 type PlannedFetch = {
   entityName: CacheFetchableEntityName;
   where?: WhereClause;
@@ -122,7 +147,11 @@ export class WorkspaceCacheRowsBatchLoader {
           } else {
             plannedFetch.columns = null;
             if (isDefined(order)) {
-              plannedFetch.order = { ...plannedFetch.order, ...order };
+              plannedFetch.order = mergeOrderClauses(
+                plannedFetch.order,
+                order,
+                entityName,
+              );
             }
           }
           continue;
@@ -141,7 +170,11 @@ export class WorkspaceCacheRowsBatchLoader {
         }
 
         if (isDefined(order)) {
-          plannedFetch.order = { ...plannedFetch.order, ...order };
+          plannedFetch.order = mergeOrderClauses(
+            plannedFetch.order,
+            order,
+            entityName,
+          );
         }
 
         if (plannedFetch.columns === null) {

--- a/packages/twenty-server/src/engine/workspace-cache/types/workspace-cache-rows-requirement.type.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/types/workspace-cache-rows-requirement.type.ts
@@ -1,4 +1,8 @@
-import { type FindOptionsWhere, type ObjectLiteral } from 'typeorm';
+import {
+  type FindOptionsOrder,
+  type FindOptionsWhere,
+  type ObjectLiteral,
+} from 'typeorm';
 
 import { type AllMetadataName } from 'twenty-shared/metadata';
 
@@ -26,6 +30,7 @@ export type EntityRowsRequirement<TName extends CacheFetchableEntityName> =
       columns: EntityColumns<TName> | true;
       groupBy?: GroupByColumns<TName>;
       where?: FindOptionsWhere<CacheFetchableEntity<TName>>;
+      order?: FindOptionsOrder<CacheFetchableEntity<TName>>;
     };
 
 export type WorkspaceCacheRowsRequirement = {
@@ -36,6 +41,7 @@ export type ObjectEntityRowsRequirement = {
   columns: readonly string[] | true;
   groupBy?: readonly string[];
   where?: FindOptionsWhere<ObjectLiteral>;
+  order?: FindOptionsOrder<ObjectLiteral>;
 };
 
 export type WidenedEntityRowsRequirement =


### PR DESCRIPTION
## Summary

Fixes #25262.

In multi-sort configurations, `getView` returns a view's sorts in physical heap row order because `WorkspaceCacheRowsBatchLoader` and `FLAT_VIEW_ROWS_REQUIREMENT` did not specify an `order` clause when batch-loading `viewSort` rows. This causes non-deterministic multi-sort priority depending on Postgres heap storage order or after cache recalculations.

This PR adds `order` support to `WorkspaceCacheRowsBatchLoader` and enforces `{ createdAt: 'ASC', id: 'ASC' }` ordering on `viewSort` in `FLAT_VIEW_ROWS_REQUIREMENT`.

## What changes

1. **`EntityRowsRequirement` & `ObjectEntityRowsRequirement`**:
   - Added optional `order?: FindOptionsOrder<...>` property to row requirement definitions.
2. **`WorkspaceCacheRowsBatchLoader`**:
   - Added `order?: OrderClause` to `NormalizedEntityRowsRequirement` and `PlannedFetch`.
   - Propagated and merged order clauses across requirements targeting the same entity fetch key.
   - Forwarded `findOptions.order` to repository `.find()` call.
3. **`WorkspaceFlatViewMapCacheService`**:
   - Added deterministic ordering `order: { createdAt: 'ASC', id: 'ASC' }` to `viewSort` under `FLAT_VIEW_ROWS_REQUIREMENT`.
4. **Unit Tests**:
   - Added unit tests in `workspace-cache-rows-batch-loader.spec.ts` verifying that `order` is forwarded to `findOptions.order` and merged properly across matching entity requirements.

Closes #25262.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

