### PR TITLE
test(engine): add index definitions comparator edge validation suite

### DIFF
--- a/packages/twenty-server/src/engine/utils/__tests__/wave-index-comparator-validation.spec.ts
+++ b/packages/twenty-server/src/engine/utils/__tests__/wave-index-comparator-validation.spec.ts
@@ -1,0 +1,21 @@
+import { areIndexDefinitionsEquivalent } from '../are-index-definitions-equivalent';
+
+describe('Wave 1: Index Definitions Comparator Edge Validation', () => {
+  it('should treat identical single-column index definitions with matching orders as equivalent', () => {
+    const idxA = { columns: [{ name: 'createdAt', order: 'DESC' }] };
+    const idxB = { columns: [{ name: 'createdAt', order: 'DESC' }] };
+    expect(areIndexDefinitionsEquivalent(idxA as any, idxB as any)).toBe(true);
+  });
+
+  it('should detect differences in composite index ordering correctly', () => {
+    const idxA = { columns: [{ name: 'workspaceId', order: 'ASC' }, { name: 'position', order: 'DESC' }] };
+    const idxB = { columns: [{ name: 'workspaceId', order: 'ASC' }, { name: 'position', order: 'ASC' }] };
+    expect(areIndexDefinitionsEquivalent(idxA as any, idxB as any)).toBe(false);
+  });
+
+  it('should return true for empty column configurations when both are blank', () => {
+    const idxA = { columns: [] };
+    const idxB = { columns: [] };
+    expect(areIndexDefinitionsEquivalent(idxA as any, idxB as any)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Wave 1 Contribution: Twenty CRM

- Adds comprehensive unit test specs for index definition comparator.
- Validates single-column and composite index order equivalences under strict schemas.
- All tests pass with zero side effects.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

