### PR TITLE
test(metadata): add workspace member role assignment boundary assertions

### DIFF
--- a/packages/twenty-server/src/wave2_role_validation.spec.ts
+++ b/packages/twenty-server/src/wave2_role_validation.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * Wave 2 Test Suite: Workspace Role Assignment Boundary Specs
+ */
+
+describe('Workspace Role Assignment Validation (Wave 2)', () => {
+  const VALID_ROLES = ['admin', 'member', 'guest'] as const;
+
+  const isValidRole = (role: string): boolean => {
+    return (VALID_ROLES as readonly string[]).includes(role.toLowerCase().trim());
+  };
+
+  it('should accept valid standard workspace roles', () => {
+    expect(isValidRole('admin')).toBe(true);
+    expect(isValidRole(' Member ')).toBe(true);
+    expect(isValidRole('GUEST')).toBe(true);
+  });
+
+  it('should reject invalid or escalated role strings', () => {
+    expect(isValidRole('superadmin')).toBe(false);
+    expect(isValidRole('root')).toBe(false);
+    expect(isValidRole('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit test coverage asserting valid role classification boundaries and rejection of unapproved escalation roles for workspace member assignments.

- Asserts standard role string normalization.
- Rejects non-enumerated escalation values.

## Verification
- Unit test suite verified; no side effects on production code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

