### PR TITLE
Chunk calendar participant updates back under the 200 row limit

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
@@ -63,10 +63,11 @@ export class CalendarEventParticipantService {
       });
     }
 
-    if (operations.participantsToUpdate.length > 0) {
-      await calendarEventParticipantRepository.updateMany(
-        operations.participantsToUpdate,
-      );
+    for (const participantsChunk of chunk(
+      operations.participantsToUpdate,
+      CALENDAR_EVENT_PARTICIPANT_CHUNK_SIZE,
+    )) {
+      await calendarEventParticipantRepository.updateMany(participantsChunk);
     }
 
     for (const participantsChunk of chunk(

--- a/packages/twenty-server/test/integration/google/calendar/event-save-operations.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/calendar/event-save-operations.integration-spec.ts
@@ -110,6 +110,23 @@ describe('Calendar event save operations (integration)', () => {
     return Number(rows[0].count);
   };
 
+  const countParticipantsByHandleSuffixAndDisplayName = async (
+    handleSuffix: string,
+    displayName: string,
+  ): Promise<number> => {
+    const rows: { count: string }[] =
+      await getCoreRepository<CalendarChannelEntity>(
+        CalendarChannelEntity,
+      ).manager.query(
+        `SELECT count(*) AS count FROM "${getWorkspaceSchemaName(
+          SEED_APPLE_WORKSPACE_ID,
+        )}"."calendarEventParticipant" WHERE handle LIKE $1 AND "displayName" = $2`,
+        [`%${handleSuffix}`, displayName],
+      );
+
+    return Number(rows[0].count);
+  };
+
   beforeAll(async () => {
     channel = await connectMessagingAccount({
       provider: ConnectedAccountProvider.GOOGLE,
@@ -326,6 +343,44 @@ describe('Calendar event save operations (integration)', () => {
     await importEvents(events);
 
     expect(await countParticipantsByHandleSuffix(attendeeSuffix)).toBe(300);
+  }, 300000);
+
+  it('should update every participant when a re-import spans more than one update chunk', async () => {
+    const titlePrefix = `Calendar event ${randomUUID()}`;
+    const eventIdSuffix = randomUUID();
+    const attendeeSuffix = `rechunked-${randomUUID()}@acme.com`;
+
+    const buildEvents = (displayName: string): calendar_v3.Schema$Event[] =>
+      Array.from({ length: 100 }, (_unused, eventIndex) =>
+        googleCalendarEvent({
+          id: `google-calendar-event-${eventIndex}-${eventIdSuffix}`,
+          summary: `${titlePrefix} ${eventIndex}`,
+          attendees: [
+            { email: `a-${eventIndex}-${attendeeSuffix}`, displayName },
+            { email: `b-${eventIndex}-${attendeeSuffix}`, displayName },
+            { email: `c-${eventIndex}-${attendeeSuffix}`, displayName },
+          ],
+        }),
+      );
+
+    await importEvents(buildEvents('Before'));
+
+    expect(
+      await countParticipantsByHandleSuffixAndDisplayName(
+        attendeeSuffix,
+        'Before',
+      ),
+    ).toBe(300);
+
+    await importEvents(buildEvents('After'));
+
+    expect(await countParticipantsByHandleSuffix(attendeeSuffix)).toBe(300);
+    expect(
+      await countParticipantsByHandleSuffixAndDisplayName(
+        attendeeSuffix,
+        'After',
+      ),
+    ).toBe(300);
   }, 300000);
 
   it('should update exactly one row and leave the other untouched when two participants share a handle on the same event', async () => {


### PR DESCRIPTION
#24681 replaced the chunked participant update loop with a single `updateMany` over the whole batch. An import batch is 100 events, so re-importing events with more than two attendees each exceeds the 200 row `updateMany` cap and the batch dies with `Cannot update more than 200 records at once`. The event ids were already popped off Redis, so those events are never retried.

Restores chunking by `CALENDAR_EVENT_PARTICIPANT_CHUNK_SIZE`, matching the inserts right below it.

The existing chunk boundary test imports once, so all 300 participants are inserts and the update path is never exercised at size. Added a re-import case that crosses the boundary as updates.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

