### PR TITLE
fix(server): verify mail server TLS certificates by default

### DIFF
--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -76,6 +76,7 @@ FRONTEND_URL=http://localhost:3001
 # API_RATE_LIMITING_LIMIT=
 # MUTATION_MAXIMUM_AFFECTED_RECORDS=100
 # PG_SSL_ALLOW_SELF_SIGNED=true
+# MAIL_TLS_ALLOW_SELF_SIGNED=true
 # ENTERPRISE_KEY=replace_me_with_a_valid_enterprise_key
 # SERVER_ID=
 # SSL_KEY_PATH="./certs/your-cert.key"

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -17,6 +17,7 @@ import {
 } from 'src/engine/core-modules/imap-smtp-caldav-connection/types/imap-smtp-caldav-connection.type';
 import { buildImapTlsOptions } from 'src/engine/core-modules/imap-smtp-caldav-connection/utils/build-imap-tls-options.util';
 import { buildSmtpTlsOptions } from 'src/engine/core-modules/imap-smtp-caldav-connection/utils/build-smtp-tls-options.util';
+import { isTlsCertificateError } from 'src/engine/core-modules/imap-smtp-caldav-connection/utils/is-tls-certificate-error.util';
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { CalDavClientService } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-client.service';
@@ -99,6 +100,15 @@ export class ImapSmtpCaldavService {
         );
       }
 
+      if (isTlsCertificateError(error)) {
+        throw new UserInputError(
+          `IMAP connection failed: TLS certificate verification error (${error.code}).`,
+          {
+            userFriendlyMessage: msg`We couldn't verify your email server's TLS certificate. If it uses a self-signed or private certificate, ask your administrator to trust the certificate authority (NODE_EXTRA_CA_CERTS) or enable MAIL_TLS_ALLOW_SELF_SIGNED.`,
+          },
+        );
+      }
+
       throw new UserInputError(`IMAP connection failed: ${error.message}`, {
         userFriendlyMessage: msg`We encountered an issue connecting to your email account. Please check your settings and try again.`,
       });
@@ -138,6 +148,16 @@ export class ImapSmtpCaldavService {
         `SMTP connection failed: ${error.message}`,
         error.stack,
       );
+
+      if (isTlsCertificateError(error)) {
+        throw new UserInputError(
+          `SMTP connection failed: TLS certificate verification error (${error.code}).`,
+          {
+            userFriendlyMessage: msg`We couldn't verify your outgoing email server's TLS certificate. If it uses a self-signed or private certificate, ask your administrator to trust the certificate authority (NODE_EXTRA_CA_CERTS) or enable MAIL_TLS_ALLOW_SELF_SIGNED.`,
+          },
+        );
+      }
+
       throw new UserInputError(`SMTP connection failed: ${error.message}`, {
         userFriendlyMessage: msg`We couldn't connect to your outgoing email server. Please check your SMTP settings and try again.`,
       });

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -51,7 +51,9 @@ export class ImapSmtpCaldavService {
       },
       logger: false,
       tls: {
-        rejectUnauthorized: false,
+        rejectUnauthorized: !this.twentyConfigService.get(
+          'MAIL_TLS_ALLOW_SELF_SIGNED',
+        ),
       },
     });
 
@@ -123,7 +125,9 @@ export class ImapSmtpCaldavService {
         pass: params.password,
       },
       tls: {
-        rejectUnauthorized: false,
+        rejectUnauthorized: !this.twentyConfigService.get(
+          'MAIL_TLS_ALLOW_SELF_SIGNED',
+        ),
       },
     });
 

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import { isIP } from 'node:net';
+
 import { msg } from '@lingui/core/macro';
 import { ImapFlow } from 'imapflow';
 import { createTransport } from 'nodemailer';
@@ -55,6 +57,10 @@ export class ImapSmtpCaldavService {
         rejectUnauthorized: !this.twentyConfigService.get(
           'MAIL_TLS_ALLOW_SELF_SIGNED',
         ),
+        // getValidatedHost returns the resolved IP when outbound HTTP safe mode
+        // is enabled: connect to the pinned IP, but validate the certificate
+        // against the configured hostname. IP literals keep validating the IP.
+        ...(isIP(params.host) === 0 && { servername: params.host }),
       },
     });
 
@@ -138,6 +144,10 @@ export class ImapSmtpCaldavService {
         rejectUnauthorized: !this.twentyConfigService.get(
           'MAIL_TLS_ALLOW_SELF_SIGNED',
         ),
+        // getValidatedHost returns the resolved IP when outbound HTTP safe mode
+        // is enabled: connect to the pinned IP, but validate the certificate
+        // against the configured hostname. IP literals keep validating the IP.
+        ...(isIP(params.host) === 0 && { servername: params.host }),
       },
     });
 

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/__tests__/is-tls-certificate-error.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/__tests__/is-tls-certificate-error.util.spec.ts
@@ -1,0 +1,40 @@
+import { isTlsCertificateError } from 'src/engine/core-modules/imap-smtp-caldav-connection/utils/is-tls-certificate-error.util';
+
+describe('isTlsCertificateError', () => {
+  it('returns true for Node TLS certificate error codes', () => {
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('self signed certificate'), {
+          code: 'SELF_SIGNED_CERT_IN_CHAIN',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError({ code: 'DEPTH_ZERO_SELF_SIGNED_CERT' }),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError({ code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' }),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError({ code: 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY' }),
+    ).toBe(true);
+    expect(isTlsCertificateError({ code: 'CERT_HAS_EXPIRED' })).toBe(true);
+    expect(isTlsCertificateError({ code: 'ERR_TLS_CERT_ALTNAME_INVALID' })).toBe(
+      true,
+    );
+  });
+
+  it('returns false for non-certificate errors', () => {
+    expect(isTlsCertificateError({ code: 'ECONNREFUSED' })).toBe(false);
+    expect(isTlsCertificateError(new Error('plain error'))).toBe(false);
+    expect(isTlsCertificateError('string error')).toBe(false);
+    expect(isTlsCertificateError(null)).toBe(false);
+    expect(isTlsCertificateError(undefined)).toBe(false);
+    expect(isTlsCertificateError(42)).toBe(false);
+  });
+
+  it('returns false when code is not a string', () => {
+    expect(isTlsCertificateError({ code: 500 })).toBe(false);
+    expect(isTlsCertificateError({})).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/__tests__/is-tls-certificate-error.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/__tests__/is-tls-certificate-error.util.spec.ts
@@ -24,6 +24,94 @@ describe('isTlsCertificateError', () => {
     );
   });
 
+  it('returns true for nodemailer ESOCKET errors wrapping TLS certificate failures', () => {
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('self signed certificate'), {
+          code: 'ESOCKET',
+          command: 'CONN',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError({
+        code: 'ESOCKET',
+        command: 'CONN',
+        message: 'self-signed certificate in certificate chain',
+      }),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('unable to verify the first certificate'), {
+          code: 'ESOCKET',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('unable to get local issuer certificate'), {
+          code: 'ESOCKET',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('unable to get issuer certificate'), {
+          code: 'ESOCKET',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('certificate has expired'), {
+          code: 'ESOCKET',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('certificate is not yet valid'), {
+          code: 'ESOCKET',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTlsCertificateError(
+        Object.assign(
+          new Error("Hostname/IP does not match certificate's altnames"),
+          { code: 'ESOCKET' },
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for ESOCKET errors unrelated to certificates', () => {
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:587'), {
+          code: 'ESOCKET',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('connection timeout'), { code: 'ESOCKET' }),
+      ),
+    ).toBe(false);
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('getaddrinfo ENOTFOUND smtp.example.com'), {
+          code: 'ESOCKET',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTlsCertificateError(
+        Object.assign(new Error('wrong password'), { code: 'ESOCKET' }),
+      ),
+    ).toBe(false);
+  });
+
   it('returns false for non-certificate errors', () => {
     expect(isTlsCertificateError({ code: 'ECONNREFUSED' })).toBe(false);
     expect(isTlsCertificateError(new Error('plain error'))).toBe(false);

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/is-tls-certificate-error.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/is-tls-certificate-error.util.ts
@@ -1,0 +1,18 @@
+import { isDefined } from 'twenty-shared/utils';
+
+const TLS_CERTIFICATE_ERROR_CODES: Record<string, true> = {
+  SELF_SIGNED_CERT_IN_CHAIN: true,
+  DEPTH_ZERO_SELF_SIGNED_CERT: true,
+  UNABLE_TO_VERIFY_LEAF_SIGNATURE: true,
+  UNABLE_TO_GET_ISSUER_CERT_LOCALLY: true,
+  CERT_HAS_EXPIRED: true,
+  CERT_NOT_YET_VALID: true,
+  ERR_TLS_CERT_ALTNAME_INVALID: true,
+};
+
+export const isTlsCertificateError = (error: unknown): boolean =>
+  isDefined(error) &&
+  typeof error === 'object' &&
+  'code' in error &&
+  typeof error.code === 'string' &&
+  TLS_CERTIFICATE_ERROR_CODES[error.code] === true;

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/is-tls-certificate-error.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/is-tls-certificate-error.util.ts
@@ -10,9 +10,41 @@ const TLS_CERTIFICATE_ERROR_CODES: Record<string, true> = {
   ERR_TLS_CERT_ALTNAME_INVALID: true,
 };
 
-export const isTlsCertificateError = (error: unknown): boolean =>
-  isDefined(error) &&
-  typeof error === 'object' &&
-  'code' in error &&
-  typeof error.code === 'string' &&
-  TLS_CERTIFICATE_ERROR_CODES[error.code] === true;
+/**
+ * Nodemailer's verify() wraps TLS handshake failures into errors whose only
+ * distinctive top-level property is code: 'ESOCKET' (no reason, no original
+ * TLS error code). The underlying OpenSSL failure only survives in the
+ * message, so certificate failures are also detected by message phrasing.
+ */
+const TLS_CERTIFICATE_ERROR_MESSAGE_PATTERNS: RegExp[] = [
+  /self[- ]signed certificate/i,
+  /unable to verify (?:the first certificate|the leaf certificate|leaf signature)/i,
+  /unable to get (?:local )?issuer certificate/i,
+  /certificate has expired/i,
+  /certificate is not yet valid/i,
+  /hostname\/ip does not match certificate's altnames/i,
+];
+
+export const isTlsCertificateError = (error: unknown): boolean => {
+  if (
+    !isDefined(error) ||
+    typeof error !== 'object' ||
+    !('code' in error) ||
+    typeof error.code !== 'string'
+  ) {
+    return false;
+  }
+
+  if (TLS_CERTIFICATE_ERROR_CODES[error.code] === true) {
+    return true;
+  }
+
+  return (
+    error.code === 'ESOCKET' &&
+    'message' in error &&
+    typeof error.message === 'string' &&
+    TLS_CERTIFICATE_ERROR_MESSAGE_PATTERNS.some((pattern) =>
+      pattern.test(error.message),
+    )
+  );
+};

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/is-tls-certificate-error.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/utils/is-tls-certificate-error.util.ts
@@ -39,12 +39,13 @@ export const isTlsCertificateError = (error: unknown): boolean => {
     return true;
   }
 
+  const message = 'message' in error ? error.message : undefined;
+
   return (
     error.code === 'ESOCKET' &&
-    'message' in error &&
-    typeof error.message === 'string' &&
+    typeof message === 'string' &&
     TLS_CERTIFICATE_ERROR_MESSAGE_PATTERNS.some((pattern) =>
-      pattern.test(error.message),
+      pattern.test(message),
     )
   );
 };

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1339,6 +1339,16 @@ export class ConfigVariables {
   PG_SSL_ALLOW_SELF_SIGNED = false;
 
   @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.SERVER_CONFIG,
+    description:
+      'Allow IMAP/SMTP connections to mail servers with self-signed certificates (disables TLS certificate verification for messaging)',
+    isEnvOnly: true,
+    type: ConfigVariableType.BOOLEAN,
+  })
+  @IsOptional()
+  MAIL_TLS_ALLOW_SELF_SIGNED = false;
+
+  @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,
     description: 'Maximum number of clients in pg connection pool',
     isEnvOnly: true,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1341,7 +1341,7 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description:
-      'Allow IMAP/SMTP connections to mail servers with self-signed certificates (disables TLS certificate verification for messaging)',
+      'Allow IMAP/SMTP connections to mail servers with self-signed certificates (disables TLS certificate verification for messaging). CalDAV servers are always verified; use NODE_EXTRA_CA_CERTS for them',
     isEnvOnly: true,
     type: ConfigVariableType.BOOLEAN,
   })

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.spec.ts
@@ -1,0 +1,115 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { ImapFlow } from 'imapflow';
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+import { Repository } from 'typeorm';
+
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
+import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+
+import { ImapClientProvider } from './imap-client.provider';
+
+jest.mock('imapflow', () => ({
+  ImapFlow: jest.fn().mockImplementation(() => ({
+    connect: jest.fn().mockResolvedValue(undefined),
+    logout: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn(),
+  })),
+}));
+
+const mockImapParams = {
+  host: 'imap.example.com',
+  port: 993,
+  username: 'user@example.com',
+  password: 'plaintext-password',
+};
+
+const mockConnectionParameters = {
+  IMAP: {
+    host: 'imap.example.com',
+    port: 993,
+    username: 'user@example.com',
+    password: 'encrypted-password',
+  },
+};
+
+const mockConnectedAccount = {
+  id: 'account-456',
+  workspaceId: 'workspace-123',
+  provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+  handle: 'user@example.com',
+  connectionParameters: mockConnectionParameters,
+} as unknown as ConnectedAccountEntity;
+
+describe('ImapClientProvider', () => {
+  let provider: ImapClientProvider;
+
+  const mockGetValidatedHost = jest
+    .fn()
+    .mockImplementation((host: string) => Promise.resolve(host));
+
+  const mockTwentyConfigGet = jest.fn().mockReturnValue(false);
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockTwentyConfigGet.mockReturnValue(false);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ImapClientProvider,
+        {
+          provide: SecureHttpClientService,
+          useValue: { getValidatedHost: mockGetValidatedHost },
+        },
+        {
+          provide: ConnectedAccountTokenEncryptionService,
+          useValue: {
+            decryptProtocolPassword: jest.fn().mockReturnValue(mockImapParams),
+          },
+        },
+        {
+          provide: TwentyConfigService,
+          useValue: { get: mockTwentyConfigGet },
+        },
+        {
+          provide: getRepositoryToken(ConnectedAccountEntity),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(mockConnectedAccount),
+          } as unknown as Repository<ConnectedAccountEntity>,
+        },
+      ],
+    }).compile();
+
+    provider = module.get<ImapClientProvider>(ImapClientProvider);
+  });
+
+  describe('getClient', () => {
+    it('verifies TLS certificates by default', async () => {
+      await provider.getClient('account-456');
+
+      expect(mockTwentyConfigGet).toHaveBeenCalledWith(
+        'MAIL_TLS_ALLOW_SELF_SIGNED',
+      );
+      expect(ImapFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tls: { rejectUnauthorized: true },
+        }),
+      );
+    });
+
+    it('skips TLS certificate verification when MAIL_TLS_ALLOW_SELF_SIGNED is enabled', async () => {
+      mockTwentyConfigGet.mockReturnValue(true);
+
+      await provider.getClient('account-456');
+
+      expect(ImapFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tls: { rejectUnauthorized: false },
+        }),
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.spec.ts
@@ -49,13 +49,16 @@ describe('ImapClientProvider', () => {
 
   const mockGetValidatedHost = jest
     .fn()
-    .mockImplementation((host: string) => Promise.resolve(host));
+    .mockImplementation(() => Promise.resolve('93.184.216.34'));
+
+  const mockDecryptProtocolPassword = jest.fn();
 
   const mockTwentyConfigGet = jest.fn().mockReturnValue(false);
 
   beforeEach(async () => {
     jest.clearAllMocks();
     mockTwentyConfigGet.mockReturnValue(false);
+    mockDecryptProtocolPassword.mockReturnValue(mockImapParams);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -67,7 +70,7 @@ describe('ImapClientProvider', () => {
         {
           provide: ConnectedAccountTokenEncryptionService,
           useValue: {
-            decryptProtocolPassword: jest.fn().mockReturnValue(mockImapParams),
+            decryptProtocolPassword: mockDecryptProtocolPassword,
           },
         },
         {
@@ -87,6 +90,34 @@ describe('ImapClientProvider', () => {
   });
 
   describe('getClient', () => {
+    it('connects to the validated IP while validating TLS against the configured host', async () => {
+      await provider.getClient('account-456');
+
+      expect(mockGetValidatedHost).toHaveBeenCalledWith('imap.example.com');
+      expect(ImapFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: '93.184.216.34',
+          tls: expect.objectContaining({ servername: 'imap.example.com' }),
+        }),
+      );
+    });
+
+    it('does not set a servername when the configured host is an IP literal', async () => {
+      mockDecryptProtocolPassword.mockReturnValue({
+        ...mockImapParams,
+        host: '93.184.216.34',
+      });
+
+      await provider.getClient('account-456');
+
+      expect(ImapFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: '93.184.216.34',
+          tls: { rejectUnauthorized: true },
+        }),
+      );
+    });
+
     it('verifies TLS certificates by default', async () => {
       await provider.getClient('account-456');
 
@@ -95,7 +126,7 @@ describe('ImapClientProvider', () => {
       );
       expect(ImapFlow).toHaveBeenCalledWith(
         expect.objectContaining({
-          tls: { rejectUnauthorized: true },
+          tls: { rejectUnauthorized: true, servername: 'imap.example.com' },
         }),
       );
     });
@@ -107,7 +138,7 @@ describe('ImapClientProvider', () => {
 
       expect(ImapFlow).toHaveBeenCalledWith(
         expect.objectContaining({
-          tls: { rejectUnauthorized: false },
+          tls: { rejectUnauthorized: false, servername: 'imap.example.com' },
         }),
       );
     });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -8,6 +8,7 @@ import { Repository } from 'typeorm';
 
 import { buildImapTlsOptions } from 'src/engine/core-modules/imap-smtp-caldav-connection/utils/build-imap-tls-options.util';
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
 import {
@@ -26,6 +27,7 @@ export class ImapClientProvider {
   constructor(
     private readonly secureHttpClientService: SecureHttpClientService,
     private readonly connectedAccountTokenEncryptionService: ConnectedAccountTokenEncryptionService,
+    private readonly twentyConfigService: TwentyConfigService,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
   ) {}
@@ -104,7 +106,9 @@ export class ImapClientProvider {
       },
       logger: false,
       tls: {
-        rejectUnauthorized: false,
+        rejectUnauthorized: !this.twentyConfigService.get(
+          'MAIL_TLS_ALLOW_SELF_SIGNED',
+        ),
       },
       connectionTimeout: ImapClientProvider.CONNECTION_TIMEOUT_MS,
       greetingTimeout: ImapClientProvider.GREETING_TIMEOUT_MS,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { isIP } from 'node:net';
+
 import { ImapFlow } from 'imapflow';
 import { ConnectedAccountProvider } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -109,6 +111,10 @@ export class ImapClientProvider {
         rejectUnauthorized: !this.twentyConfigService.get(
           'MAIL_TLS_ALLOW_SELF_SIGNED',
         ),
+        // getValidatedHost returns the resolved IP when outbound HTTP safe mode
+        // is enabled: connect to the pinned IP, but validate the certificate
+        // against the configured hostname. IP literals keep validating the IP.
+        ...(isIP(imapParams.host) === 0 && { servername: imapParams.host }),
       },
       connectionTimeout: ImapClientProvider.CONNECTION_TIMEOUT_MS,
       greetingTimeout: ImapClientProvider.GREETING_TIMEOUT_MS,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.spec.ts
@@ -1,0 +1,111 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { createTransport } from 'nodemailer';
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+import { Repository } from 'typeorm';
+
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
+import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+
+import { SmtpClientProvider } from './smtp-client.provider';
+
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(),
+}));
+
+const mockSmtpParams = {
+  host: 'smtp.example.com',
+  port: 587,
+  username: 'user@example.com',
+  password: 'plaintext-password',
+};
+
+const mockConnectionParameters = {
+  SMTP: {
+    host: 'smtp.example.com',
+    port: 587,
+    username: 'user@example.com',
+    password: 'encrypted-password',
+  },
+};
+
+const mockConnectedAccount = {
+  id: 'account-456',
+  workspaceId: 'workspace-123',
+  provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+  handle: 'user@example.com',
+  connectionParameters: mockConnectionParameters,
+} as unknown as ConnectedAccountEntity;
+
+describe('SmtpClientProvider', () => {
+  let provider: SmtpClientProvider;
+
+  const mockGetValidatedHost = jest
+    .fn()
+    .mockImplementation((host: string) => Promise.resolve(host));
+
+  const mockTwentyConfigGet = jest.fn().mockReturnValue(false);
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockTwentyConfigGet.mockReturnValue(false);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SmtpClientProvider,
+        {
+          provide: SecureHttpClientService,
+          useValue: { getValidatedHost: mockGetValidatedHost },
+        },
+        {
+          provide: ConnectedAccountTokenEncryptionService,
+          useValue: {
+            decryptProtocolPassword: jest.fn().mockReturnValue(mockSmtpParams),
+          },
+        },
+        {
+          provide: TwentyConfigService,
+          useValue: { get: mockTwentyConfigGet },
+        },
+        {
+          provide: getRepositoryToken(ConnectedAccountEntity),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(mockConnectedAccount),
+          } as unknown as Repository<ConnectedAccountEntity>,
+        },
+      ],
+    }).compile();
+
+    provider = module.get<SmtpClientProvider>(SmtpClientProvider);
+  });
+
+  describe('getClient', () => {
+    it('verifies TLS certificates by default', async () => {
+      await provider.getClient('account-456');
+
+      expect(mockTwentyConfigGet).toHaveBeenCalledWith(
+        'MAIL_TLS_ALLOW_SELF_SIGNED',
+      );
+      expect(createTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tls: { rejectUnauthorized: true },
+        }),
+      );
+    });
+
+    it('skips TLS certificate verification when MAIL_TLS_ALLOW_SELF_SIGNED is enabled', async () => {
+      mockTwentyConfigGet.mockReturnValue(true);
+
+      await provider.getClient('account-456');
+
+      expect(createTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tls: { rejectUnauthorized: false },
+        }),
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.spec.ts
@@ -45,13 +45,16 @@ describe('SmtpClientProvider', () => {
 
   const mockGetValidatedHost = jest
     .fn()
-    .mockImplementation((host: string) => Promise.resolve(host));
+    .mockImplementation(() => Promise.resolve('93.184.216.34'));
+
+  const mockDecryptProtocolPassword = jest.fn();
 
   const mockTwentyConfigGet = jest.fn().mockReturnValue(false);
 
   beforeEach(async () => {
     jest.clearAllMocks();
     mockTwentyConfigGet.mockReturnValue(false);
+    mockDecryptProtocolPassword.mockReturnValue(mockSmtpParams);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -63,7 +66,7 @@ describe('SmtpClientProvider', () => {
         {
           provide: ConnectedAccountTokenEncryptionService,
           useValue: {
-            decryptProtocolPassword: jest.fn().mockReturnValue(mockSmtpParams),
+            decryptProtocolPassword: mockDecryptProtocolPassword,
           },
         },
         {
@@ -83,6 +86,34 @@ describe('SmtpClientProvider', () => {
   });
 
   describe('getClient', () => {
+    it('connects to the validated IP while validating TLS against the configured host', async () => {
+      await provider.getClient('account-456');
+
+      expect(mockGetValidatedHost).toHaveBeenCalledWith('smtp.example.com');
+      expect(createTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: '93.184.216.34',
+          tls: expect.objectContaining({ servername: 'smtp.example.com' }),
+        }),
+      );
+    });
+
+    it('does not set a servername when the configured host is an IP literal', async () => {
+      mockDecryptProtocolPassword.mockReturnValue({
+        ...mockSmtpParams,
+        host: '93.184.216.34',
+      });
+
+      await provider.getClient('account-456');
+
+      expect(createTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: '93.184.216.34',
+          tls: { rejectUnauthorized: true },
+        }),
+      );
+    });
+
     it('verifies TLS certificates by default', async () => {
       await provider.getClient('account-456');
 
@@ -91,7 +122,7 @@ describe('SmtpClientProvider', () => {
       );
       expect(createTransport).toHaveBeenCalledWith(
         expect.objectContaining({
-          tls: { rejectUnauthorized: true },
+          tls: { rejectUnauthorized: true, servername: 'smtp.example.com' },
         }),
       );
     });
@@ -103,7 +134,7 @@ describe('SmtpClientProvider', () => {
 
       expect(createTransport).toHaveBeenCalledWith(
         expect.objectContaining({
-          tls: { rejectUnauthorized: false },
+          tls: { rejectUnauthorized: false, servername: 'smtp.example.com' },
         }),
       );
     });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.ts
@@ -11,6 +11,7 @@ import { Repository } from 'typeorm';
 
 import { buildSmtpTlsOptions } from 'src/engine/core-modules/imap-smtp-caldav-connection/utils/build-smtp-tls-options.util';
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
 
@@ -19,6 +20,7 @@ export class SmtpClientProvider {
   constructor(
     private readonly secureHttpClientService: SecureHttpClientService,
     private readonly connectedAccountTokenEncryptionService: ConnectedAccountTokenEncryptionService,
+    private readonly twentyConfigService: TwentyConfigService,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
   ) {}
@@ -59,7 +61,9 @@ export class SmtpClientProvider {
         pass: smtpParams.password,
       },
       tls: {
-        rejectUnauthorized: false,
+        rejectUnauthorized: !this.twentyConfigService.get(
+          'MAIL_TLS_ALLOW_SELF_SIGNED',
+        ),
       },
     };
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { isIP } from 'node:net';
+
 import { createTransport, type Transporter } from 'nodemailer';
 
 import type SMTPConnection from 'nodemailer/lib/smtp-connection';
@@ -64,6 +66,10 @@ export class SmtpClientProvider {
         rejectUnauthorized: !this.twentyConfigService.get(
           'MAIL_TLS_ALLOW_SELF_SIGNED',
         ),
+        // getValidatedHost returns the resolved IP when outbound HTTP safe mode
+        // is enabled: connect to the pinned IP, but validate the certificate
+        // against the configured hostname. IP literals keep validating the IP.
+        ...(isIP(smtpParams.host) === 0 && { servername: smtpParams.host }),
       },
     };
 


### PR DESCRIPTION
## Summary

All four IMAP/SMTP client construction sites (connection tester for both protocols, `ImapClientProvider`, `SmtpClientProvider`) hardcode `tls: { rejectUnauthorized: false }`, silently accepting any certificate — self-signed, expired, or issued for another host — and defeating the connection-security (`NONE`/`STARTTLS`/`SSL_TLS`) handling around it.

This PR drives `rejectUnauthorized` from a new env-only boolean `MAIL_TLS_ALLOW_SELF_SIGNED` (default `false`), mirroring the existing `PG_SSL_ALLOW_SELF_SIGNED` escape hatch:

- `packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts` (IMAP + SMTP connection test)
- `packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts` (message import driver)
- `packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.ts` (send driver)
- `packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts` + `.env.example` (flag)

The connection tester additionally surfaces TLS certificate failures (`DEPTH_ZERO_SELF_SIGNED_CERT`, `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`, `ERR_TLS_CERT_ALTNAME_INVALID`, …) as a dedicated `UserInputError` whose `userFriendlyMessage` names the two supported remedies, instead of a generic "check your settings" error. Unit tests cover both providers and the code map.

CalDAV is out of scope here: it already goes through the SSRF-safe HTTP client and is always verified; private-CA deployments should install their CA via `NODE_EXTRA_CA_CERTS`.

## Migration note

Behavior change: TLS certificate verification is now **on by default** for IMAP and SMTP. Deployments whose mail servers use self-signed or private-CA certificates must either:

- install the CA into the Node trust store (`NODE_EXTRA_CA_CERTS=/path/to/ca.crt`), or
- set `MAIL_TLS_ALLOW_SELF_SIGNED=true` to restore the previous behavior.

Public-CA (Let's Encrypt etc.) setups are unaffected.

## Verification

Verified end-to-end on a private-CA stack (self-hosted Stalwart, container-local CA):

- **Positive**: with the CA trusted via `NODE_EXTRA_CA_CERTS` and no flag set, IMAP connection + sync and SMTP send all succeed; mail import continues to work (4/4 strict-TLS mail checks pass).
- **Negative**: pointing `saveImapSmtpCaldavAccount` at a rogue self-signed server is rejected at the GraphQL boundary —
  - IMAP: `IMAP connection failed: TLS certificate verification error (DEPTH_ZERO_SELF_SIGNED_CERT)` with the actionable `userFriendlyMessage`.
  - SMTP: rejected with the underlying Node TLS error text.

Known cosmetic follow-up (not addressed here): `nodemailer`'s `verify()` wraps socket errors as `ESOCKET`, so on the SMTP path the TLS-specific message branch is generally not reached — the connection is still refused, but users see the raw Node message instead of the friendly one. Extending `isTlsCertificateError` (e.g. matching `error.code === 'ESOCKET'` with a TLS-flavored `error.message`, or inspecting the wrapped error) would close that gap.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

