### PR TITLE
Fix Slack app doc inaccuracies found in review

### DIFF
--- a/packages/twenty-apps/public/slack/SETUP.md
+++ b/packages/twenty-apps/public/slack/SETUP.md
@@ -353,7 +353,7 @@ configured.
 - **Answer feedback.** Short answers end with Slack's native thumbs up / thumbs
   down buttons. A click stores a Positive or Negative rating on the matching
   Slack Assistant Request record (last click wins). Very long answers fall back
-  to a plain markdown message without buttons.
+  to a plain text message without buttons.
 - **Thread memory.** After a successful reply the bot stays active in that
   thread, so follow-ups need no mention. Channel threads stay active for 24
   hours after the last reply (each reply renews it); DM threads never expire.

--- a/packages/twenty-apps/public/slack/SETUP.md
+++ b/packages/twenty-apps/public/slack/SETUP.md
@@ -353,7 +353,7 @@ configured.
 - **Answer feedback.** Short answers end with Slack's native thumbs up / thumbs
   down buttons. A click stores a Positive or Negative rating on the matching
   Slack Assistant Request record (last click wins). Very long answers fall back
-  to a plain text message without buttons.
+  to a plain message without buttons.
 - **Thread memory.** After a successful reply the bot stays active in that
   thread, so follow-ups need no mention. Channel threads stay active for 24
   hours after the last reply (each reply renews it); DM threads never expire.

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-webhook-secret.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-webhook-secret.ts
@@ -11,7 +11,7 @@ export const getSlackWebhookSecret = ():
     return {
       success: false,
       error:
-        'SLACK_WEBHOOK_SECRET application variable is not set. Set it in Twenty under Settings > Applications > Slack > Application registration, using the signing secret from your Slack app (Basic Information > App Credentials).',
+        'SLACK_WEBHOOK_SECRET application variable is not set. Set it on the Slack application registration in Twenty (Settings > Applications, admin only), using the signing secret from your Slack app (Basic Information > App Credentials).',
     };
   }
 

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-webhook-secret.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-webhook-secret.ts
@@ -11,7 +11,7 @@ export const getSlackWebhookSecret = ():
     return {
       success: false,
       error:
-        'SLACK_WEBHOOK_SECRET application variable is not set. Set it in the Twenty Slack app settings, using the signing secret from your Slack app (Basic Information > App Credentials).',
+        'SLACK_WEBHOOK_SECRET application variable is not set. Set it in Twenty under Settings > Applications > Slack > Application registration, using the signing secret from your Slack app (Basic Information > App Credentials).',
     };
   }
 


### PR DESCRIPTION
Two small accuracy fixes from a full review of the Slack app's README, SETUP, and app manifest against the code and Slack's docs.

## What changed

- **SETUP.md behaviour notes**: very long assistant answers were described as falling back to "a plain markdown message". Answers over 12,000 chars skip the markdown block, and the `markdown_text` retry hits the same 12,000-char Slack limit, so the fallback chain lands on plain `text`. Now says "plain text message".
- **`get-slack-webhook-secret.ts`**: the missing-variable error pointed at "the Twenty Slack app settings", but the app's display name is "Slack". It now spells out the real path (Settings > Applications > Slack > Application registration), matching SETUP.md.

## Also verified, no changes needed

- README billing section, scope table, PKCE notes, event list, webhook URLs, and behaviour notes all match the code and Slack's documentation.
- `slack-app-manifest.json` checked field by field: all 16 bot scopes exactly match the connection provider's requested scopes; every subscribed event has a route in `slack-events-resolver`; both webhook UUIDs match the resolver identifiers; `features.rich_previews { is_active, entity_types }` and `agent_view.agent_description` verified against Slack's official manifest schema and CLI source; `slack#/entities/item` / `slack#/entities/task` match the code's entity constants; `display_information` lengths are within Slack's limits (long_description 191/175 min).

## Validation

- `yarn lint` 0 warnings / 0 errors
- `yarn test:unit` 616 tests pass
- `yarn typecheck` reports 9 pre-existing errors on `main` in files this PR does not touch (twenty-sdk type drift: `AppConnection.workspaceMemberId`, `MetadataWritability`); none are introduced or affected by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYyiPFprpyCDwhb1J3mCkU)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

