### PR TITLE
feat(slack): branch the assistant failure reply on the failure kind

### DIFF
--- a/packages/twenty-apps/public/slack/src/__tests__/slack-assistant-worker.integration-test.ts
+++ b/packages/twenty-apps/public/slack/src/__tests__/slack-assistant-worker.integration-test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createSlackMessageTimestampSequence } from 'src/__tests__/utils/create-slack-message-timestamp-sequence.util';
 import { requireDefinedOrThrow } from 'src/__tests__/utils/require-defined-or-throw.util';
 import { setupSlackIntegrationTest } from 'src/__tests__/utils/setup-slack-integration-test.util';
+import { SLACK_ASSISTANT_DEADLINE_ERROR } from 'src/logic-functions/constants/slack-assistant-deadline-error';
+import { SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-deadline-failure-text';
 import { SLACK_ASSISTANT_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-failure-text';
 import { SLACK_ASSISTANT_FEEDBACK_ACTION_ID } from 'src/logic-functions/constants/slack-assistant-feedback-action-id';
 import { SLACK_ASSISTANT_REQUEST_STATUS } from 'src/logic-functions/constants/slack-assistant-request-status';
@@ -332,6 +334,45 @@ describe('Slack assistant worker', () => {
       expect.objectContaining({
         status: SLACK_ASSISTANT_REQUEST_STATUS.FAILED,
         errorMessage: 'Agent is not available',
+      }),
+    );
+  });
+
+  it('should tell the member to narrow the request when the answer deadline passes', async () => {
+    slack.addChannel({ id: CHANNEL_ID, name: 'sales' });
+    const slackMessageTimestamp = nextMessageTimestamp();
+
+    appRuntime.setAgentResult({
+      success: false,
+      result: null,
+      error: SLACK_ASSISTANT_DEADLINE_ERROR,
+    });
+
+    const request = await createRequestRecord({
+      slackChannelId: CHANNEL_ID,
+      slackMessageTimestamp,
+      requestText: 'summarize every opportunity we opened this year',
+    });
+
+    await slackAssistantWorkerHandler(
+      buildRequestCreatedEvent({
+        ...request,
+        slackChannelId: CHANNEL_ID,
+        slackMessageTimestamp,
+        requestText: 'summarize every opportunity we opened this year',
+      }),
+    );
+
+    expect(slack.messagesIn(CHANNEL_ID)).toEqual([
+      expect.objectContaining({
+        text: SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT,
+        threadTimestamp: slackMessageTimestamp,
+      }),
+    ]);
+    await expect(readRequest(request.id)).resolves.toEqual(
+      expect.objectContaining({
+        status: SLACK_ASSISTANT_REQUEST_STATUS.FAILED,
+        errorMessage: SLACK_ASSISTANT_DEADLINE_ERROR,
       }),
     );
   });

--- a/packages/twenty-apps/public/slack/src/__tests__/slack-assistant-worker.integration-test.ts
+++ b/packages/twenty-apps/public/slack/src/__tests__/slack-assistant-worker.integration-test.ts
@@ -354,7 +354,7 @@ describe('Slack assistant worker', () => {
       requestText: 'summarize every opportunity we opened this year',
     });
 
-    await slackAssistantWorkerHandler(
+    const result = await slackAssistantWorkerHandler(
       buildRequestCreatedEvent({
         ...request,
         slackChannelId: CHANNEL_ID,
@@ -363,6 +363,10 @@ describe('Slack assistant worker', () => {
       }),
     );
 
+    expect(result).toEqual({
+      failed: true,
+      reason: SLACK_ASSISTANT_DEADLINE_ERROR,
+    });
     expect(slack.messagesIn(CHANNEL_ID)).toEqual([
       expect.objectContaining({
         text: SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT,

--- a/packages/twenty-apps/public/slack/src/__tests__/slack-assistant-worker.integration-test.ts
+++ b/packages/twenty-apps/public/slack/src/__tests__/slack-assistant-worker.integration-test.ts
@@ -5,6 +5,8 @@ import { requireDefinedOrThrow } from 'src/__tests__/utils/require-defined-or-th
 import { setupSlackIntegrationTest } from 'src/__tests__/utils/setup-slack-integration-test.util';
 import { SLACK_ASSISTANT_DEADLINE_ERROR } from 'src/logic-functions/constants/slack-assistant-deadline-error';
 import { SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-deadline-failure-text';
+import { SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR } from 'src/logic-functions/constants/slack-assistant-empty-response-error';
+import { SLACK_ASSISTANT_EMPTY_RESPONSE_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-empty-response-failure-text';
 import { SLACK_ASSISTANT_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-failure-text';
 import { SLACK_ASSISTANT_FEEDBACK_ACTION_ID } from 'src/logic-functions/constants/slack-assistant-feedback-action-id';
 import { SLACK_ASSISTANT_REQUEST_STATUS } from 'src/logic-functions/constants/slack-assistant-request-status';
@@ -377,6 +379,49 @@ describe('Slack assistant worker', () => {
       expect.objectContaining({
         status: SLACK_ASSISTANT_REQUEST_STATUS.FAILED,
         errorMessage: SLACK_ASSISTANT_DEADLINE_ERROR,
+      }),
+    );
+  });
+
+  it('should invite the member to ask again when the agent answers with nothing', async () => {
+    slack.addChannel({ id: CHANNEL_ID, name: 'sales' });
+    const slackMessageTimestamp = nextMessageTimestamp();
+
+    appRuntime.setAgentResult({
+      success: true,
+      result: null,
+      error: null,
+    });
+
+    const request = await createRequestRecord({
+      slackChannelId: CHANNEL_ID,
+      slackMessageTimestamp,
+      requestText: 'what changed on Acme this week?',
+    });
+
+    const result = await slackAssistantWorkerHandler(
+      buildRequestCreatedEvent({
+        ...request,
+        slackChannelId: CHANNEL_ID,
+        slackMessageTimestamp,
+        requestText: 'what changed on Acme this week?',
+      }),
+    );
+
+    expect(result).toEqual({
+      failed: true,
+      reason: SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR,
+    });
+    expect(slack.messagesIn(CHANNEL_ID)).toEqual([
+      expect.objectContaining({
+        text: SLACK_ASSISTANT_EMPTY_RESPONSE_FAILURE_TEXT,
+        threadTimestamp: slackMessageTimestamp,
+      }),
+    ]);
+    await expect(readRequest(request.id)).resolves.toEqual(
+      expect.objectContaining({
+        status: SLACK_ASSISTANT_REQUEST_STATUS.FAILED,
+        errorMessage: SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR,
       }),
     );
   });

--- a/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-assistant-deadline-failure-text.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-assistant-deadline-failure-text.ts
@@ -1,0 +1,2 @@
+export const SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT =
+  'That request took longer than I have to answer it. Narrowing it usually works: fewer records, or one question at a time.';

--- a/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-assistant-empty-response-error.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-assistant-empty-response-error.ts
@@ -1,0 +1,2 @@
+export const SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR =
+  'Agent returned an empty response';

--- a/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-assistant-empty-response-failure-text.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-assistant-empty-response-failure-text.ts
@@ -1,0 +1,2 @@
+export const SLACK_ASSISTANT_EMPTY_RESPONSE_FAILURE_TEXT =
+  "I finished without an answer to that one. Ask me again, or rephrase it and I'll have another go.";

--- a/packages/twenty-apps/public/slack/src/logic-functions/slack-assistant-worker.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/slack-assistant-worker.ts
@@ -11,6 +11,7 @@ import {
   SLACK_ASSISTANT_WORKER_UNIVERSAL_IDENTIFIER,
 } from 'src/constants/universal-identifiers';
 import { SLACK_ASSISTANT_AGENT_BUDGET_SECONDS } from 'src/logic-functions/constants/slack-assistant-agent-budget-seconds';
+import { SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR } from 'src/logic-functions/constants/slack-assistant-empty-response-error';
 import { SLACK_ASSISTANT_REQUEST_STATUS } from 'src/logic-functions/constants/slack-assistant-request-status';
 import { SLACK_ASSISTANT_WORKER_TIMEOUT_SECONDS } from 'src/logic-functions/constants/slack-assistant-worker-timeout-seconds';
 import { SLACK_MARKDOWN_BLOCK_MAX_LENGTH } from 'src/logic-functions/constants/slack-markdown-block-max-length';
@@ -156,7 +157,7 @@ export const slackAssistantWorkerHandler = async (
     if (responseText === undefined) {
       return await finishSlackAssistantRequestWithFailure({
         ...failureContext,
-        errorMessage: 'Agent returned an empty response',
+        errorMessage: SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR,
       });
     }
 

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/get-slack-assistant-failure-text.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/get-slack-assistant-failure-text.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { SLACK_ASSISTANT_DEADLINE_ERROR } from 'src/logic-functions/constants/slack-assistant-deadline-error';
+import { SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-deadline-failure-text';
+import { SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR } from 'src/logic-functions/constants/slack-assistant-empty-response-error';
+import { SLACK_ASSISTANT_EMPTY_RESPONSE_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-empty-response-failure-text';
+import { SLACK_ASSISTANT_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-failure-text';
+import { getSlackAssistantFailureText } from 'src/logic-functions/utils/get-slack-assistant-failure-text';
+
+describe('getSlackAssistantFailureText', () => {
+  it('should tell the member to narrow the request when the answer deadline passed', () => {
+    expect(getSlackAssistantFailureText(SLACK_ASSISTANT_DEADLINE_ERROR)).toBe(
+      SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT,
+    );
+  });
+
+  it('should invite the member to ask again when the agent answered with nothing', () => {
+    expect(
+      getSlackAssistantFailureText(SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR),
+    ).toBe(SLACK_ASSISTANT_EMPTY_RESPONSE_FAILURE_TEXT);
+  });
+
+  it('should point at an admin for a failure the member cannot act on', () => {
+    expect(getSlackAssistantFailureText('Agent is not available')).toBe(
+      SLACK_ASSISTANT_FAILURE_TEXT,
+    );
+  });
+
+  it('should never surface the underlying error to the member', () => {
+    const errorMessage =
+      'Could not deliver Slack answer: channel_not_found at postMessage()';
+
+    expect(getSlackAssistantFailureText(errorMessage)).toBe(
+      SLACK_ASSISTANT_FAILURE_TEXT,
+    );
+  });
+});

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/finish-slack-assistant-request-with-failure.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/finish-slack-assistant-request-with-failure.ts
@@ -1,9 +1,9 @@
 import { type CoreApiClient } from 'twenty-client-sdk/core';
 
-import { SLACK_ASSISTANT_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-failure-text';
 import { SLACK_ASSISTANT_REQUEST_STATUS } from 'src/logic-functions/constants/slack-assistant-request-status';
 import { updateSlackAssistantRequest } from 'src/logic-functions/data/update-slack-assistant-request';
 import { slackPostMessageHandler } from 'src/logic-functions/handlers/slack-post-message-handler';
+import { getSlackAssistantFailureText } from 'src/logic-functions/utils/get-slack-assistant-failure-text';
 
 type SlackAssistantRequestFailureResult = {
   failed: true;
@@ -25,7 +25,7 @@ export const finishSlackAssistantRequestWithFailure = async ({
 }): Promise<SlackAssistantRequestFailureResult> => {
   await slackPostMessageHandler({
     slackChannelId,
-    messageText: SLACK_ASSISTANT_FAILURE_TEXT,
+    messageText: getSlackAssistantFailureText(errorMessage),
     parentMessageTimestamp,
   });
 

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-assistant-failure-text.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-assistant-failure-text.ts
@@ -4,8 +4,7 @@ import { SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR } from 'src/logic-functions/consta
 import { SLACK_ASSISTANT_EMPTY_RESPONSE_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-empty-response-failure-text';
 import { SLACK_ASSISTANT_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-failure-text';
 
-// Only failures the member can act on get their own reply; everything else
-// stays generic so no internal error text reaches Slack.
+// Unmapped failures stay generic so no internal error text reaches Slack.
 export const getSlackAssistantFailureText = (errorMessage: string): string => {
   if (errorMessage === SLACK_ASSISTANT_DEADLINE_ERROR) {
     return SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT;

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-assistant-failure-text.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-assistant-failure-text.ts
@@ -1,0 +1,19 @@
+import { SLACK_ASSISTANT_DEADLINE_ERROR } from 'src/logic-functions/constants/slack-assistant-deadline-error';
+import { SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-deadline-failure-text';
+import { SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR } from 'src/logic-functions/constants/slack-assistant-empty-response-error';
+import { SLACK_ASSISTANT_EMPTY_RESPONSE_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-empty-response-failure-text';
+import { SLACK_ASSISTANT_FAILURE_TEXT } from 'src/logic-functions/constants/slack-assistant-failure-text';
+
+// Only failures the member can act on get their own reply; everything else
+// stays generic so no internal error text reaches Slack.
+export const getSlackAssistantFailureText = (errorMessage: string): string => {
+  if (errorMessage === SLACK_ASSISTANT_DEADLINE_ERROR) {
+    return SLACK_ASSISTANT_DEADLINE_FAILURE_TEXT;
+  }
+
+  if (errorMessage === SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR) {
+    return SLACK_ASSISTANT_EMPTY_RESPONSE_FAILURE_TEXT;
+  }
+
+  return SLACK_ASSISTANT_FAILURE_TEXT;
+};


### PR DESCRIPTION
## Problem

A member whose request outran the agent budget got the same reply as a crash.

`raceSlackAssistantAgentDeadline` resolves `{ success: false, error: SLACK_ASSISTANT_DEADLINE_ERROR }`, the worker treats that like any other `!agentResult.success`, and `finishSlackAssistantRequestWithFailure` posted `SLACK_ASSISTANT_FAILURE_TEXT` unconditionally. So after ~4 minutes and three escalating status updates (30s / 90s / 180s), the member was told to go find an admin, with no hint that the request was simply too big and that narrowing it would work.

The budget split exists specifically for this case: 240s worker timeout minus a 30s reserve leaves 210s of agent time, the status ladder runs to 180s of that, and `buildSlackAssistantMessages` already injects "This run is killed after N seconds and the member gets an error instead of an answer" into every prompt. The timeout is a designed-for failure mode, but the reply didn't reflect it.

## Change

`getSlackAssistantFailureText` maps a failure to its member-facing text, defaulting to the existing generic string so an unrecognised error can never leak into Slack. Two failures get their own reply:

- **Deadline**: "That request took longer than I have to answer it. Narrowing it usually works: fewer records, or one question at a time."
- **Empty response**: "I finished without an answer to that one. Ask me again, or rephrase it and I'll have another go."

Everything else stays generic. The `errorMessage` stored on the Slack Assistant Request record is unchanged, so admins keep the detailed reason.

The worker's inline `'Agent returned an empty response'` literal is promoted to `SLACK_ASSISTANT_EMPTY_RESPONSE_ERROR` so the mapping keys off a constant rather than a string literal.

### Failures deliberately left generic

- **No Slack connection** — `fetchSlackAssistantContext` degrades to an unreachable context, and the failure notice itself goes out through `slackPostMessageHandler`. With no connection, nothing reaches the member at all.
- **Delivery failure** — the same channel is broken; the member can't act on it.
- **Permission denied** — never reaches this path. `buildPermissionSection` instructs the agent to explain the limit and name who to ask, so it arrives as a normal successful answer.

## Tests

- Unit test on the mapping, including that a `Could not deliver Slack answer: channel_not_found` message falls through to the generic text.
- Integration test asserting the deadline path posts the deadline-specific text while the record keeps the internal error; the existing generic-failure test covers the other half.

`yarn lint`, `yarn typecheck` and `yarn test:unit` (620 passed) are clean. `yarn test` was run against a locally built and running twenty-server: 57 integration tests passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LuSfiiMqwPkC6BYPjNXwHz)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

