### PR TITLE
fix(twenty-shared): support SQL wildcards in array containsIlike filter

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/is-record-matching-rls-row-level-permission-predicate.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/is-record-matching-rls-row-level-permission-predicate.util.spec.ts
@@ -134,6 +134,7 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
         joinColumnName: 'companyId',
       },
     ),
+    createMockFlatFieldMetadata('users-id', 'users', FieldMetadataType.ARRAY),
   ];
 
   const flatObjectMetadata = createMockFlatObjectMetadata(
@@ -152,6 +153,7 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
       addressCity: 'Paris',
     },
     companyId: 'company-1',
+    users: ['user-1', 'user-2'],
     deletedAt: null,
     id: 'record-1',
     createdAt: new Date().toISOString(),
@@ -337,6 +339,26 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
       isRecordMatchingRLSRowLevelPermissionPredicate({
         record: { ...baseRecord, company: { id: 'company-1' } } as ObjectRecord,
         filter: { company: { is: 'NULL' } },
+        flatObjectMetadata,
+        flatFieldMetadataMaps,
+      }),
+    ).toBe(false);
+  });
+
+  it('matches an array field with wildcard containsIlike from RLS rules', () => {
+    expect(
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: baseRecord,
+        filter: { users: { containsIlike: '%user-1%' } },
+        flatObjectMetadata,
+        flatFieldMetadataMaps,
+      }),
+    ).toBe(true);
+
+    expect(
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: baseRecord,
+        filter: { users: { containsIlike: '%user-999%' } },
         flatObjectMetadata,
         flatFieldMetadataMaps,
       }),

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingArrayFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingArrayFilter.test.ts
@@ -104,6 +104,59 @@ describe('isMatchingArrayFilter', () => {
         }),
       ).toBe(true);
     });
+
+    it('should match SQL wildcard patterns with percent signs', () => {
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: '%user-123%' },
+          value: ['user-123'],
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: '%user%' },
+          value: ['prefix-user-suffix', 'other'],
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: '%user' },
+          value: ['prefix-user'],
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: '%user' },
+          value: ['prefix-user-suffix'],
+        }),
+      ).toBe(false);
+
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: '%user-456%' },
+          value: ['user-123'],
+        }),
+      ).toBe(false);
+    });
+
+    it('should match SQL wildcard patterns with underscores', () => {
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: 'user_123' },
+          value: ['user-123'],
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: 'user_123' },
+          value: ['user--123'],
+        }),
+      ).toBe(false);
+    });
   });
 
   describe('error handling', () => {

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingArrayFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingArrayFilter.ts
@@ -1,3 +1,5 @@
+import escapeRegExp from 'lodash.escaperegexp';
+
 import { type ArrayFilter } from '@/types';
 
 export const isMatchingArrayFilter = ({
@@ -19,10 +21,33 @@ export const isMatchingArrayFilter = ({
       return Array.isArray(value) && value.length === 0;
     }
     case arrayFilter.containsIlike !== undefined: {
+      const hasWildcards =
+        arrayFilter.containsIlike.includes('%') ||
+        arrayFilter.containsIlike.includes('_');
+
+      if (hasWildcards) {
+        const escapedPattern = escapeRegExp(arrayFilter.containsIlike)
+          .replace(/%/g, '.*')
+          .replace(/_/g, '.');
+        const regexCaseInsensitive = new RegExp(`^${escapedPattern}$`, 'i');
+
+        return (
+          Array.isArray(value) &&
+          value.some(
+            (item) =>
+              typeof item === 'string' && regexCaseInsensitive.test(item),
+          )
+        );
+      }
+
       const searchTerm = arrayFilter.containsIlike.toLowerCase();
+
       return (
         Array.isArray(value) &&
-        value.some((item) => item.toLowerCase().includes(searchTerm))
+        value.some(
+          (item) =>
+            typeof item === 'string' && item.toLowerCase().includes(searchTerm),
+        )
       );
     }
     default: {


### PR DESCRIPTION
## Summary
- Supports SQL wildcards (`%` and `_`) in `isMatchingArrayFilter` for `containsIlike` operations
- Fixes in-memory RLS validation during record updates when an RLS rule uses `Array field CONTAINS current user`
- Retains backward compatibility for substring matching when no wildcards are present
- Adds unit tests in `isMatchingArrayFilter.test.ts` for wildcard patterns
- Adds test case in `is-record-matching-rls-row-level-permission-predicate.util.spec.ts`

## Testing
- `npx jest packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingArrayFilter.test.ts` (15/15 passed)
- `npx jest packages/twenty-server/src/engine/twenty-orm/utils/__tests__/is-record-matching-rls-row-level-permission-predicate.util.spec.ts` (10/10 passed)
- `git diff --check` passed

Closes #25247

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

