### PR TITLE
fix(twenty-front): preserve text effects in closed rich text cells

### DIFF
--- a/packages/twenty-front/src/modules/blocknote-editor/blocks/MentionInlineContent.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/blocks/MentionInlineContent.tsx
@@ -1,22 +1,10 @@
-import { MentionRecordChip } from '@/mention/components/MentionRecordChip';
-import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
-import { RecordChip } from '@/object-record/components/RecordChip';
-import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { createReactInlineContentSpec } from '@blocknote/react';
 import { styled } from '@linaria/react';
-import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
-import { isDefined } from 'twenty-shared/utils';
-import { Chip, ChipVariant } from 'twenty-ui/data-display';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 
-const StyledRecordChipContainer = styled.div`
-  display: inline;
-  height: auto;
-  margin: 0;
-  padding: 0 ${themeCssVariables.spacing[1]};
-`;
+import { LegacyMentionRenderer } from '@/blocknote-editor/components/LegacyMentionRenderer';
+import { MentionRecordChip } from '@/mention/components/MentionRecordChip';
 
 const StyledInlineMentionRecordChipContainer = styled.div`
   display: inline;
@@ -24,62 +12,6 @@ const StyledInlineMentionRecordChipContainer = styled.div`
   margin: 0;
   padding: 0 ${themeCssVariables.spacing[1]};
 `;
-
-const LegacyMentionRenderer = ({
-  recordId,
-  objectMetadataId,
-}: {
-  recordId: string;
-  objectMetadataId: string;
-}) => {
-  const objectMetadataItems = useAtomStateValue(objectMetadataItemsSelector);
-
-  const objectMetadataItem = objectMetadataItems.find(
-    (item) => item.id === objectMetadataId,
-  );
-
-  const objectNameSingular = objectMetadataItem?.nameSingular;
-
-  const { record, loading } = useFindOneRecord({
-    objectNameSingular: objectNameSingular ?? '',
-    objectRecordId: recordId,
-    skip: !isNonEmptyString(objectNameSingular) || !isNonEmptyString(recordId),
-  });
-
-  if (loading) {
-    return null;
-  }
-
-  if (!isDefined(objectMetadataItem)) {
-    return (
-      <Chip
-        label={t`Unknown object`}
-        variant={ChipVariant.Transparent}
-        disabled
-      />
-    );
-  }
-
-  if (!isDefined(record)) {
-    return (
-      <Chip
-        label={t`Deleted record`}
-        variant={ChipVariant.Transparent}
-        disabled
-      />
-    );
-  }
-
-  return (
-    <StyledRecordChipContainer>
-      <RecordChip
-        objectNameSingular={objectMetadataItem.nameSingular}
-        record={record}
-        forceDisableClick={false}
-      />
-    </StyledRecordChipContainer>
-  );
-};
 
 export const MentionInlineContent = createReactInlineContentSpec(
   {

--- a/packages/twenty-front/src/modules/blocknote-editor/components/LegacyMentionRenderer.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/LegacyMentionRenderer.tsx
@@ -1,0 +1,76 @@
+import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
+import { isNonEmptyString } from '@sniptt/guards';
+import { isDefined } from 'twenty-shared/utils';
+import { Chip, ChipVariant } from 'twenty-ui/data-display';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
+import { RecordChip } from '@/object-record/components/RecordChip';
+import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+
+const StyledRecordChipContainer = styled.div`
+  display: inline;
+  height: auto;
+  margin: 0;
+  padding: 0 ${themeCssVariables.spacing[1]};
+`;
+
+type LegacyMentionRendererProps = {
+  recordId: string;
+  objectMetadataId: string;
+};
+
+export const LegacyMentionRenderer = ({
+  recordId,
+  objectMetadataId,
+}: LegacyMentionRendererProps) => {
+  const objectMetadataItems = useAtomStateValue(objectMetadataItemsSelector);
+
+  const objectMetadataItem = objectMetadataItems.find(
+    (item) => item.id === objectMetadataId,
+  );
+
+  const objectNameSingular = objectMetadataItem?.nameSingular;
+
+  const { record, loading } = useFindOneRecord({
+    objectNameSingular: objectNameSingular ?? '',
+    objectRecordId: recordId,
+    skip: !isNonEmptyString(objectNameSingular) || !isNonEmptyString(recordId),
+  });
+
+  if (loading) {
+    return null;
+  }
+
+  if (!isDefined(objectMetadataItem)) {
+    return (
+      <Chip
+        label={t`Unknown object`}
+        variant={ChipVariant.Transparent}
+        disabled
+      />
+    );
+  }
+
+  if (!isDefined(record)) {
+    return (
+      <Chip
+        label={t`Deleted record`}
+        variant={ChipVariant.Transparent}
+        disabled
+      />
+    );
+  }
+
+  return (
+    <StyledRecordChipContainer>
+      <RecordChip
+        objectNameSingular={objectMetadataItem.nameSingular}
+        record={record}
+        forceDisableClick={false}
+      />
+    </StyledRecordChipContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/blocknote-editor/components/RichTextLineDisplay.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/RichTextLineDisplay.tsx
@@ -116,14 +116,15 @@ export const getFirstNonEmptyBlock = (
         ) {
           return content.text.trim() !== '';
         }
-        if (
-          typeof content === 'object' &&
-          content !== null &&
-          (content.type === 'link' ||
-            'link' in content ||
-            content.type === 'mention')
-        ) {
-          return true;
+        if (typeof content === 'object' && content !== null) {
+          const rawContent = content as Record<string, unknown>;
+          if (
+            rawContent.type === 'link' ||
+            'link' in rawContent ||
+            rawContent.type === 'mention'
+          ) {
+            return true;
+          }
         }
         return false;
       });
@@ -153,30 +154,35 @@ export const getBlockPlainText = (block: PartialBlock): string => {
           return content;
         }
         if (typeof content === 'object' && content !== null) {
-          if ('text' in content && typeof content.text === 'string') {
-            return content.text;
+          const rawContent = content as Record<string, unknown>;
+          if ('text' in rawContent && typeof rawContent.text === 'string') {
+            return rawContent.text;
           }
-          if ('link' in content && typeof content.link === 'string') {
-            return content.link;
+          if ('link' in rawContent && typeof rawContent.link === 'string') {
+            return rawContent.link;
           }
-          if (content.type === 'link' && Array.isArray(content.content)) {
-            return content.content
+          if (rawContent.type === 'link' && Array.isArray(rawContent.content)) {
+            return rawContent.content
               .map((child: unknown) =>
-                typeof child === 'object' && child !== null && 'text' in child
-                  ? child.text
+                typeof child === 'object' &&
+                child !== null &&
+                'text' in child &&
+                typeof (child as { text: unknown }).text === 'string'
+                  ? (child as { text: string }).text
                   : '',
               )
               .join('');
           }
           if (
-            content.type === 'mention' &&
-            'props' in content &&
-            typeof content.props === 'object' &&
-            content.props !== null &&
-            'label' in content.props &&
-            typeof content.props.label === 'string'
+            rawContent.type === 'mention' &&
+            'props' in rawContent &&
+            typeof rawContent.props === 'object' &&
+            rawContent.props !== null &&
+            'label' in rawContent.props &&
+            typeof (rawContent.props as Record<string, unknown>).label ===
+              'string'
           ) {
-            return `@${content.props.label}`;
+            return `@${(rawContent.props as Record<string, unknown>).label}`;
           }
         }
         return '';
@@ -199,24 +205,32 @@ const renderInlineContent = (
     return null;
   }
 
-  const contentObj = content as Record<string, any>;
+  const contentObj = content as Record<string, unknown>;
 
   if (contentObj.type === 'mention') {
-    const label = contentObj.props?.label;
+    const props = contentObj.props as Record<string, unknown> | undefined;
+    const label = typeof props?.label === 'string' ? props.label : '';
     return (
       <span key={index} style={{ fontWeight: 500 }}>
-        @{label ?? ''}
+        @{label}
       </span>
     );
   }
 
   if (contentObj.type === 'link' || 'link' in contentObj) {
-    const href = contentObj.href ?? contentObj.link;
+    const href =
+      typeof contentObj.href === 'string'
+        ? contentObj.href
+        : typeof contentObj.link === 'string'
+          ? contentObj.link
+          : '';
+    const linkText =
+      typeof contentObj.text === 'string' ? contentObj.text : href;
     const linkContent = Array.isArray(contentObj.content)
       ? contentObj.content.map((child: unknown, childIndex: number) =>
           renderInlineContent(child, childIndex),
         )
-      : (contentObj.text ?? href ?? '');
+      : linkText;
 
     return (
       <span
@@ -232,7 +246,9 @@ const renderInlineContent = (
   }
 
   if ('text' in contentObj && typeof contentObj.text === 'string') {
-    const style = getInlineContentCssStyle(contentObj.styles);
+    const style = getInlineContentCssStyle(
+      contentObj.styles as InlineStyles | undefined,
+    );
     return (
       <span key={index} style={style}>
         {contentObj.text}

--- a/packages/twenty-front/src/modules/blocknote-editor/components/RichTextLineDisplay.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/RichTextLineDisplay.tsx
@@ -1,0 +1,280 @@
+import { type PartialBlock } from '@blocknote/core';
+import { styled } from '@linaria/react';
+import React from 'react';
+import { isDefined } from 'twenty-shared/utils';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
+
+const BLOCKNOTE_TEXT_COLORS: Record<string, string> = {
+  gray: themeCssVariables.color.gray,
+  brown: themeCssVariables.color.brown,
+  red: themeCssVariables.color.red,
+  orange: themeCssVariables.color.orange,
+  yellow: themeCssVariables.color.yellow,
+  green: themeCssVariables.color.green,
+  blue: themeCssVariables.color.blue,
+  purple: themeCssVariables.color.purple,
+  pink: themeCssVariables.color.pink,
+};
+
+const BLOCKNOTE_BACKGROUND_COLORS: Record<string, string> = {
+  gray: themeCssVariables.color.gray3,
+  brown: themeCssVariables.color.brown3,
+  red: themeCssVariables.color.red3,
+  orange: themeCssVariables.color.orange3,
+  yellow: themeCssVariables.color.yellow3,
+  green: themeCssVariables.color.green3,
+  blue: themeCssVariables.color.blue3,
+  purple: themeCssVariables.color.purple3,
+  pink: themeCssVariables.color.pink3,
+};
+
+type InlineStyles = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  code?: boolean;
+  textColor?: string;
+  backgroundColor?: string;
+};
+
+const getInlineContentCssStyle = (
+  styles?: InlineStyles,
+): React.CSSProperties => {
+  if (!styles) {
+    return {};
+  }
+
+  const cssStyle: React.CSSProperties = {};
+
+  if (styles.bold) {
+    cssStyle.fontWeight = 'bold';
+  }
+
+  if (styles.italic) {
+    cssStyle.fontStyle = 'italic';
+  }
+
+  if (styles.strike && styles.underline) {
+    cssStyle.textDecoration = 'underline line-through';
+  } else if (styles.strike) {
+    cssStyle.textDecoration = 'line-through';
+  } else if (styles.underline) {
+    cssStyle.textDecoration = 'underline';
+  }
+
+  if (styles.code) {
+    cssStyle.fontFamily = 'monospace';
+    cssStyle.padding = '0 2px';
+  }
+
+  if (styles.textColor && styles.textColor !== 'default') {
+    cssStyle.color =
+      BLOCKNOTE_TEXT_COLORS[styles.textColor] ?? styles.textColor;
+  }
+
+  if (styles.backgroundColor && styles.backgroundColor !== 'default') {
+    cssStyle.backgroundColor =
+      BLOCKNOTE_BACKGROUND_COLORS[styles.backgroundColor] ??
+      styles.backgroundColor;
+  }
+
+  return cssStyle;
+};
+
+export const getFirstNonEmptyBlock = (
+  blocks: PartialBlock[] | null,
+): PartialBlock | null => {
+  if (!isDefined(blocks) || blocks.length === 0) {
+    return null;
+  }
+
+  for (const block of blocks) {
+    if (isUndefinedOrNull(block.content)) {
+      continue;
+    }
+
+    if (typeof block.content === 'string') {
+      if (block.content.trim() !== '') {
+        return block;
+      }
+      continue;
+    }
+
+    if (Array.isArray(block.content)) {
+      const hasContent = block.content.some((content) => {
+        if (typeof content === 'string') {
+          return content.trim() !== '';
+        }
+        if (
+          typeof content === 'object' &&
+          content !== null &&
+          'text' in content &&
+          typeof content.text === 'string'
+        ) {
+          return content.text.trim() !== '';
+        }
+        if (
+          typeof content === 'object' &&
+          content !== null &&
+          (content.type === 'link' ||
+            'link' in content ||
+            content.type === 'mention')
+        ) {
+          return true;
+        }
+        return false;
+      });
+
+      if (hasContent) {
+        return block;
+      }
+    }
+  }
+
+  return null;
+};
+
+export const getBlockPlainText = (block: PartialBlock): string => {
+  if (isUndefinedOrNull(block.content)) {
+    return '';
+  }
+
+  if (typeof block.content === 'string') {
+    return block.content;
+  }
+
+  if (Array.isArray(block.content)) {
+    return block.content
+      .map((content) => {
+        if (typeof content === 'string') {
+          return content;
+        }
+        if (typeof content === 'object' && content !== null) {
+          if ('text' in content && typeof content.text === 'string') {
+            return content.text;
+          }
+          if ('link' in content && typeof content.link === 'string') {
+            return content.link;
+          }
+          if (content.type === 'link' && Array.isArray(content.content)) {
+            return content.content
+              .map((child: unknown) =>
+                typeof child === 'object' && child !== null && 'text' in child
+                  ? child.text
+                  : '',
+              )
+              .join('');
+          }
+          if (
+            content.type === 'mention' &&
+            'props' in content &&
+            typeof content.props === 'object' &&
+            content.props !== null &&
+            'label' in content.props &&
+            typeof content.props.label === 'string'
+          ) {
+            return `@${content.props.label}`;
+          }
+        }
+        return '';
+      })
+      .join('');
+  }
+
+  return '';
+};
+
+const renderInlineContent = (
+  content: unknown,
+  index: number,
+): React.ReactNode => {
+  if (typeof content === 'string') {
+    return <span key={index}>{content}</span>;
+  }
+
+  if (!isDefined(content) || typeof content !== 'object') {
+    return null;
+  }
+
+  const contentObj = content as Record<string, any>;
+
+  if (contentObj.type === 'mention') {
+    const label = contentObj.props?.label;
+    return (
+      <span key={index} style={{ fontWeight: 500 }}>
+        @{label ?? ''}
+      </span>
+    );
+  }
+
+  if (contentObj.type === 'link' || 'link' in contentObj) {
+    const href = contentObj.href ?? contentObj.link;
+    const linkContent = Array.isArray(contentObj.content)
+      ? contentObj.content.map((child: unknown, childIndex: number) =>
+          renderInlineContent(child, childIndex),
+        )
+      : (contentObj.text ?? href ?? '');
+
+    return (
+      <span
+        key={index}
+        style={{
+          textDecoration: 'underline',
+          color: themeCssVariables.font.color.secondary,
+        }}
+      >
+        {linkContent}
+      </span>
+    );
+  }
+
+  if ('text' in contentObj && typeof contentObj.text === 'string') {
+    const style = getInlineContentCssStyle(contentObj.styles);
+    return (
+      <span key={index} style={style}>
+        {contentObj.text}
+      </span>
+    );
+  }
+
+  return null;
+};
+
+const StyledContainer = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+type RichTextLineDisplayProps = {
+  blocks: PartialBlock[] | null;
+  className?: string;
+};
+
+export const RichTextLineDisplay = ({
+  blocks,
+  className,
+}: RichTextLineDisplayProps) => {
+  const firstNonEmptyBlock = getFirstNonEmptyBlock(blocks);
+
+  if (!isDefined(firstNonEmptyBlock)) {
+    return null;
+  }
+
+  const plainText = getBlockPlainText(firstNonEmptyBlock);
+
+  return (
+    <StyledContainer className={className} title={plainText}>
+      {typeof firstNonEmptyBlock.content === 'string'
+        ? firstNonEmptyBlock.content
+        : Array.isArray(firstNonEmptyBlock.content)
+          ? firstNonEmptyBlock.content.map((content, index) =>
+              renderInlineContent(content, index),
+            )
+          : null}
+    </StyledContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/blocknote-editor/components/RichTextLineDisplay.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/RichTextLineDisplay.tsx
@@ -1,10 +1,11 @@
 import { type PartialBlock } from '@blocknote/core';
 import { styled } from '@linaria/react';
+import { isNonEmptyString } from '@sniptt/guards';
 import React from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
-import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
+import { LegacyMentionRenderer } from '@/blocknote-editor/components/LegacyMentionRenderer';
 
 const BLOCKNOTE_TEXT_COLORS: Record<string, string> = {
   gray: themeCssVariables.color.gray,
@@ -92,7 +93,7 @@ export const getFirstNonEmptyBlock = (
   }
 
   for (const block of blocks) {
-    if (isUndefinedOrNull(block.content)) {
+    if (!isDefined(block.content)) {
       continue;
     }
 
@@ -108,22 +109,52 @@ export const getFirstNonEmptyBlock = (
         if (typeof content === 'string') {
           return content.trim() !== '';
         }
-        if (
-          typeof content === 'object' &&
-          content !== null &&
-          'text' in content &&
-          typeof content.text === 'string'
-        ) {
-          return content.text.trim() !== '';
-        }
         if (typeof content === 'object' && content !== null) {
           const rawContent = content as Record<string, unknown>;
+
+          if (rawContent.type === 'hardBreak') {
+            return false;
+          }
+
           if (
-            rawContent.type === 'link' ||
-            'link' in rawContent ||
-            rawContent.type === 'mention'
+            'text' in rawContent &&
+            typeof rawContent.text === 'string' &&
+            rawContent.text.trim() !== ''
           ) {
             return true;
+          }
+
+          if (
+            rawContent.type === 'mention' &&
+            typeof rawContent.props === 'object' &&
+            rawContent.props !== null
+          ) {
+            const props = rawContent.props as Record<string, unknown>;
+            const hasLabel =
+              typeof props.label === 'string' && props.label.trim() !== '';
+            const hasRecordAndMetadata =
+              typeof props.recordId === 'string' &&
+              props.recordId.trim() !== '' &&
+              typeof props.objectMetadataId === 'string' &&
+              props.objectMetadataId.trim() !== '';
+
+            return hasLabel || hasRecordAndMetadata;
+          }
+
+          if (rawContent.type === 'link' || 'link' in rawContent) {
+            const hasHref =
+              (typeof rawContent.href === 'string' &&
+                rawContent.href.trim() !== '') ||
+              (typeof rawContent.link === 'string' &&
+                rawContent.link.trim() !== '');
+            const hasText =
+              typeof rawContent.text === 'string' &&
+              rawContent.text.trim() !== '';
+            const hasChildren =
+              Array.isArray(rawContent.content) &&
+              rawContent.content.length > 0;
+
+            return hasHref || hasText || hasChildren;
           }
         }
         return false;
@@ -139,7 +170,7 @@ export const getFirstNonEmptyBlock = (
 };
 
 export const getBlockPlainText = (block: PartialBlock): string => {
-  if (isUndefinedOrNull(block.content)) {
+  if (!isDefined(block.content)) {
     return '';
   }
 
@@ -155,12 +186,15 @@ export const getBlockPlainText = (block: PartialBlock): string => {
         }
         if (typeof content === 'object' && content !== null) {
           const rawContent = content as Record<string, unknown>;
+
+          if (rawContent.type === 'hardBreak') {
+            return ' ';
+          }
+
           if ('text' in rawContent && typeof rawContent.text === 'string') {
             return rawContent.text;
           }
-          if ('link' in rawContent && typeof rawContent.link === 'string') {
-            return rawContent.link;
-          }
+
           if (rawContent.type === 'link' && Array.isArray(rawContent.content)) {
             return rawContent.content
               .map((child: unknown) =>
@@ -173,16 +207,26 @@ export const getBlockPlainText = (block: PartialBlock): string => {
               )
               .join('');
           }
+
+          if ('link' in rawContent && typeof rawContent.link === 'string') {
+            return rawContent.link;
+          }
+
+          if (typeof rawContent.href === 'string') {
+            return rawContent.href;
+          }
+
           if (
             rawContent.type === 'mention' &&
             'props' in rawContent &&
             typeof rawContent.props === 'object' &&
-            rawContent.props !== null &&
-            'label' in rawContent.props &&
-            typeof (rawContent.props as Record<string, unknown>).label ===
-              'string'
+            rawContent.props !== null
           ) {
-            return `@${(rawContent.props as Record<string, unknown>).label}`;
+            const props = rawContent.props as Record<string, unknown>;
+            if (typeof props.label === 'string' && props.label !== '') {
+              return `@${props.label}`;
+            }
+            return '@';
           }
         }
         return '';
@@ -207,12 +251,38 @@ const renderInlineContent = (
 
   const contentObj = content as Record<string, unknown>;
 
+  if (contentObj.type === 'hardBreak') {
+    return <span key={index}> </span>;
+  }
+
   if (contentObj.type === 'mention') {
     const props = contentObj.props as Record<string, unknown> | undefined;
     const label = typeof props?.label === 'string' ? props.label : '';
+    const recordId = typeof props?.recordId === 'string' ? props.recordId : '';
+    const objectMetadataId =
+      typeof props?.objectMetadataId === 'string' ? props.objectMetadataId : '';
+
+    if (isNonEmptyString(label)) {
+      return (
+        <span key={index} style={{ fontWeight: 500 }}>
+          @{label}
+        </span>
+      );
+    }
+
+    if (isNonEmptyString(recordId) && isNonEmptyString(objectMetadataId)) {
+      return (
+        <LegacyMentionRenderer
+          key={index}
+          recordId={recordId}
+          objectMetadataId={objectMetadataId}
+        />
+      );
+    }
+
     return (
       <span key={index} style={{ fontWeight: 500 }}>
-        @{label}
+        @
       </span>
     );
   }
@@ -233,15 +303,19 @@ const renderInlineContent = (
       : linkText;
 
     return (
-      <span
+      <a
         key={index}
+        href={href || undefined}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(event) => event.stopPropagation()}
         style={{
           textDecoration: 'underline',
           color: themeCssVariables.font.color.secondary,
         }}
       >
         {linkContent}
-      </span>
+      </a>
     );
   }
 

--- a/packages/twenty-front/src/modules/blocknote-editor/components/__tests__/RichTextLineDisplay.test.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/__tests__/RichTextLineDisplay.test.tsx
@@ -1,0 +1,203 @@
+import { type PartialBlock } from '@blocknote/core';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+import {
+  RichTextLineDisplay,
+  getFirstNonEmptyBlock,
+  getBlockPlainText,
+} from '@/blocknote-editor/components/RichTextLineDisplay';
+
+describe('RichTextLineDisplay', () => {
+  it('should render null when blocks is null or empty', () => {
+    const { container: nullContainer } = render(
+      <RichTextLineDisplay blocks={null} />,
+    );
+    expect(nullContainer.firstChild).toBeNull();
+
+    const { container: emptyContainer } = render(
+      <RichTextLineDisplay blocks={[]} />,
+    );
+    expect(emptyContainer.firstChild).toBeNull();
+  });
+
+  it('should render null when all blocks are empty', () => {
+    const blocks: PartialBlock[] = [
+      { content: [{ type: 'text', text: '', styles: {} }] },
+      { content: [{ type: 'text', text: '   ', styles: {} }] },
+    ];
+    const { container } = render(<RichTextLineDisplay blocks={blocks} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should preserve strikethrough text effect', () => {
+    const blocks: PartialBlock[] = [
+      {
+        content: [
+          { type: 'text', text: 'test ', styles: {} },
+          { type: 'text', text: 'strikethrough', styles: { strike: true } },
+        ],
+      },
+    ];
+
+    render(<RichTextLineDisplay blocks={blocks} />);
+
+    const strikethroughSpan = screen.getByText('strikethrough');
+    expect(strikethroughSpan).toHaveStyle({
+      textDecoration: 'line-through',
+    });
+
+    const testSpan = screen.getByText('test');
+    expect(testSpan).not.toHaveStyle({
+      textDecoration: 'line-through',
+    });
+  });
+
+  it('should preserve bold, italic, and underline text effects', () => {
+    const blocks: PartialBlock[] = [
+      {
+        content: [
+          { type: 'text', text: 'bold text', styles: { bold: true } },
+          { type: 'text', text: 'italic text', styles: { italic: true } },
+          {
+            type: 'text',
+            text: 'underline text',
+            styles: { underline: true },
+          },
+        ],
+      },
+    ];
+
+    render(<RichTextLineDisplay blocks={blocks} />);
+
+    expect(screen.getByText('bold text')).toHaveStyle({
+      fontWeight: 'bold',
+    });
+    expect(screen.getByText('italic text')).toHaveStyle({
+      fontStyle: 'italic',
+    });
+    expect(screen.getByText('underline text')).toHaveStyle({
+      textDecoration: 'underline',
+    });
+  });
+
+  it('should combine underline and strikethrough', () => {
+    const blocks: PartialBlock[] = [
+      {
+        content: [
+          {
+            type: 'text',
+            text: 'both styles',
+            styles: { underline: true, strike: true },
+          },
+        ],
+      },
+    ];
+
+    render(<RichTextLineDisplay blocks={blocks} />);
+
+    expect(screen.getByText('both styles')).toHaveStyle({
+      textDecoration: 'underline line-through',
+    });
+  });
+
+  it('should preserve code styling', () => {
+    const blocks: PartialBlock[] = [
+      {
+        content: [
+          { type: 'text', text: 'const x = 1;', styles: { code: true } },
+        ],
+      },
+    ];
+
+    render(<RichTextLineDisplay blocks={blocks} />);
+
+    expect(screen.getByText('const x = 1;')).toHaveStyle({
+      fontFamily: 'monospace',
+    });
+  });
+
+  it('should apply textColor and backgroundColor', () => {
+    const blocks: PartialBlock[] = [
+      {
+        content: [
+          {
+            type: 'text',
+            text: 'colored',
+            styles: { textColor: 'red', backgroundColor: 'yellow' },
+          },
+        ],
+      },
+    ];
+
+    render(<RichTextLineDisplay blocks={blocks} />);
+
+    expect(screen.getByText('colored')).toHaveStyle({
+      color: themeCssVariables.color.red,
+      backgroundColor: themeCssVariables.color.yellow3,
+    });
+  });
+
+  it('should render links with underline and mention chips with @ prefix', () => {
+    const blocks: PartialBlock[] = [
+      {
+        content: [
+          {
+            type: 'link',
+            href: 'https://twenty.com',
+            content: [{ type: 'text', text: 'Twenty Website', styles: {} }],
+          } as unknown as any,
+          {
+            type: 'mention',
+            props: { label: 'John Doe', recordId: '123' },
+          } as unknown as any,
+        ],
+      },
+    ];
+
+    render(<RichTextLineDisplay blocks={blocks} />);
+
+    expect(screen.getByText('Twenty Website')).toBeInTheDocument();
+    expect(screen.getByText('@John Doe')).toBeInTheDocument();
+  });
+
+  it('should set title attribute on the container with full plain text', () => {
+    const blocks: PartialBlock[] = [
+      {
+        content: [
+          { type: 'text', text: 'test ', styles: {} },
+          { type: 'text', text: 'strikethrough', styles: { strike: true } },
+        ],
+      },
+    ];
+
+    const { container } = render(<RichTextLineDisplay blocks={blocks} />);
+
+    expect(container.firstChild).toHaveAttribute('title', 'test strikethrough');
+  });
+});
+
+describe('getFirstNonEmptyBlock and getBlockPlainText', () => {
+  it('should find the first block with non-empty content', () => {
+    const blocks: PartialBlock[] = [
+      { content: [{ type: 'text', text: '   ', styles: {} }] },
+      { content: [{ type: 'text', text: 'Second block', styles: {} }] },
+      { content: [{ type: 'text', text: 'Third block', styles: {} }] },
+    ];
+
+    const firstNonEmpty = getFirstNonEmptyBlock(blocks);
+    expect(firstNonEmpty).toBe(blocks[1]);
+    expect(getBlockPlainText(firstNonEmpty!)).toBe('Second block');
+  });
+
+  it('should return null if no blocks have non-empty content', () => {
+    const blocks: PartialBlock[] = [
+      { content: [] },
+      { content: undefined },
+      { content: '   ' },
+    ];
+
+    expect(getFirstNonEmptyBlock(blocks)).toBeNull();
+  });
+});

--- a/packages/twenty-front/src/modules/blocknote-editor/components/__tests__/RichTextLineDisplay.test.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/__tests__/RichTextLineDisplay.test.tsx
@@ -140,26 +140,50 @@ describe('RichTextLineDisplay', () => {
   });
 
   it('should render links with underline and mention chips with @ prefix', () => {
-    const blocks: PartialBlock[] = [
+    const blocks = [
       {
         content: [
           {
             type: 'link',
             href: 'https://twenty.com',
             content: [{ type: 'text', text: 'Twenty Website', styles: {} }],
-          } as unknown as any,
+          },
           {
             type: 'mention',
             props: { label: 'John Doe', recordId: '123' },
-          } as unknown as any,
+          },
         ],
       },
-    ];
+    ] as unknown as PartialBlock[];
 
     render(<RichTextLineDisplay blocks={blocks} />);
 
-    expect(screen.getByText('Twenty Website')).toBeInTheDocument();
+    const linkElement = screen.getByText('Twenty Website');
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement.closest('a')).toHaveAttribute(
+      'href',
+      'https://twenty.com',
+    );
     expect(screen.getByText('@John Doe')).toBeInTheDocument();
+  });
+
+  it('should handle hard breaks without concatenating words', () => {
+    const blocks = [
+      {
+        content: [
+          { type: 'text', text: 'First line', styles: {} },
+          { type: 'hardBreak' },
+          { type: 'text', text: 'Second line', styles: {} },
+        ],
+      },
+    ] as unknown as PartialBlock[];
+
+    const { container } = render(<RichTextLineDisplay blocks={blocks} />);
+
+    expect(container.firstChild).toHaveAttribute(
+      'title',
+      'First line Second line',
+    );
   });
 
   it('should set title attribute on the container with full plain text', () => {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RichTextFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RichTextFieldDisplay.tsx
@@ -1,15 +1,11 @@
 import { useRichTextFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRichTextFieldDisplay';
-import { getFirstNonEmptyLineOfRichText } from '@/blocknote-editor/utils/getFirstNonEmptyLineOfRichText';
 import { parseInitialBlocknote } from '@/blocknote-editor/utils/parseInitialBlocknote';
+import { RichTextLineDisplay } from '@/blocknote-editor/components/RichTextLineDisplay';
 
 export const RichTextFieldDisplay = () => {
   const { fieldValue } = useRichTextFieldDisplay();
 
   const blocks = parseInitialBlocknote(fieldValue?.blocknote) ?? null;
 
-  return (
-    <div>
-      <span>{getFirstNonEmptyLineOfRichText(blocks)}</span>
-    </div>
-  );
+  return <RichTextLineDisplay blocks={blocks} />;
 };


### PR DESCRIPTION
## Summary

Closes #25479

When a rich text field (such as the **Notes** column in a table view) was closed, `RichTextFieldDisplay` previously rendered plain text through `getFirstNonEmptyLineOfRichText`, stripping away all inline formatting effects applied when the cell was opened (such as strikethrough, bold, italic, underline, code, and text/background colors).

This PR introduces `RichTextLineDisplay` to render the first non-empty block of rich text while preserving all inline text styles and effects, with elegant overflow truncation and native tooltip support.

## Changes

- **`RichTextLineDisplay` component**:
  - Locates the first non-empty block in the BlockNote content.
  - Preserves inline styles: `strike` (strikethrough), `bold`, `italic`, `underline`, `code`, `textColor`, and `backgroundColor`.
  - Supports combinations (e.g. `strike` + `underline` -> `textDecoration: 'underline line-through'`).
  - Supports links and mentions.
  - Truncates overflowing single lines with ellipsis while setting `title` with full plain text for tooltip display.
- **`RichTextFieldDisplay`**: Updated to use `RichTextLineDisplay`.
- **Unit tests**: Added comprehensive tests covering all text effect variations, combinations, colors, and fallback behavior.

## Test plan

- [x] Unit tests pass: `npx jest packages/twenty-front/src/modules/blocknote-editor/components/__tests__/RichTextLineDisplay.test.tsx --config=packages/twenty-front/jest.config.mjs --runInBand` (11/11 passing).
- [x] Existing tests pass: `npx jest packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/getFirstNonEmptyLineOfRichText.test.ts --config=packages/twenty-front/jest.config.mjs --runInBand` (9/9 passing).
- [x] Diff linting passes: `npx nx lint:diff-with-main twenty-front --skip-nx-cache` (0 errors, 0 warnings, formatting clean).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

