### PR TITLE
fix(twenty-server): scope post-commit cache invalidation to mutated metadata

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -31,6 +31,7 @@ import { WorkspaceMigrationRunnerActionHandlerRegistryService } from 'src/engine
 import { type AfterCommitSideEffect } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/after-commit-side-effect.type';
 import { type MetadataEvent } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event';
 import { buildPreallocatedIdByUniversalIdentifierFromActions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/build-preallocated-id-by-universal-identifier-from-actions.util';
+import { getInvalidatedMetadataNamesFromActions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util';
 
 @Injectable()
 export class WorkspaceMigrationRunnerService {
@@ -272,6 +273,16 @@ export class WorkspaceMigrationRunnerService {
       getMetadataFlatEntityMapsKey,
     );
 
+    // Invalidate only the maps each action can actually change. Recomputing
+    // validation-only maps (e.g. object/field metadata for a viewField position
+    // update) is the dominant cost on metadata-heavy workspaces.
+    const invalidatedFlatEntityMapsKeys = [
+      ...new Set([
+        ...getInvalidatedMetadataNamesFromActions(actions),
+        ...searchVectorRebuildMetadataNames,
+      ]),
+    ].map(getMetadataFlatEntityMapsKey);
+
     let allFlatEntityMaps =
       await this.flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps<
         typeof allFlatEntityMapsKeys
@@ -493,7 +504,7 @@ export class WorkspaceMigrationRunnerService {
 
     try {
       await this.invalidateCache({
-        allFlatEntityMapsKeys,
+        allFlatEntityMapsKeys: invalidatedFlatEntityMapsKeys,
         workspaceId,
       });
 
@@ -519,7 +530,7 @@ export class WorkspaceMigrationRunnerService {
       performance.now() - postCommitInvalidateStart;
 
     this.logger.perf(
-      `[install-perf] Runner post-commit invalidateCache took ${postCommitInvalidateMs.toFixed(1)}ms for ${allFlatEntityMapsKeys.length} flat-maps keys`,
+      `[install-perf] Runner post-commit invalidateCache took ${postCommitInvalidateMs.toFixed(1)}ms for ${invalidatedFlatEntityMapsKeys.length} flat-maps keys`,
       'Runner',
     );
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/get-invalidated-metadata-names-from-actions.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/get-invalidated-metadata-names-from-actions.util.spec.ts
@@ -1,0 +1,123 @@
+import { type AllUniversalWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-action-common';
+import { getInvalidatedMetadataNamesFromActions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util';
+
+describe('getInvalidatedMetadataNamesFromActions', () => {
+  it('invalidates only the mutated map for an attribute-only update', () => {
+    const actions = [
+      {
+        type: 'update' as const,
+        metadataName: 'viewField' as const,
+        universalIdentifier: 'view-field-1',
+        update: { position: 3 },
+      },
+    ] as AllUniversalWorkspaceMigrationAction[];
+
+    const result = getInvalidatedMetadataNamesFromActions(actions);
+
+    expect(result).toEqual(['viewField']);
+  });
+
+  it('invalidates related maps when an update moves a relation foreign key', () => {
+    const actions = [
+      {
+        type: 'update' as const,
+        metadataName: 'viewField' as const,
+        universalIdentifier: 'view-field-1',
+        update: { viewFieldGroupId: 'group-2' },
+      },
+    ] as AllUniversalWorkspaceMigrationAction[];
+
+    const result = getInvalidatedMetadataNamesFromActions(actions);
+
+    expect(result.sort()).toEqual(
+      ['fieldMetadata', 'view', 'viewField', 'viewFieldGroup'].sort(),
+    );
+    expect(result).not.toContain('objectMetadata');
+  });
+
+  it('detects relation changes expressed with a universal foreign key', () => {
+    const actions = [
+      {
+        type: 'update' as const,
+        metadataName: 'viewField' as const,
+        universalIdentifier: 'view-field-1',
+        update: { viewFieldGroupUniversalIdentifier: 'group-2' },
+      },
+    ] as AllUniversalWorkspaceMigrationAction[];
+
+    const result = getInvalidatedMetadataNamesFromActions(actions);
+
+    expect(result).toContain('viewFieldGroup');
+  });
+
+  it('invalidates serialized relation maps when an update modifies serialized relations', () => {
+    const actions = [
+      {
+        type: 'update' as const,
+        metadataName: 'pageLayoutWidget' as const,
+        universalIdentifier: 'widget-1',
+        update: { configuration: {} },
+      },
+    ] as AllUniversalWorkspaceMigrationAction[];
+
+    const result = getInvalidatedMetadataNamesFromActions(actions);
+
+    expect(result).toContain('pageLayoutWidget');
+    expect(result).toContain('fieldMetadata');
+    expect(result).toContain('view');
+    expect(result).toContain('viewFieldGroup');
+    expect(result).toContain('frontComponent');
+  });
+
+  it('invalidates related maps on create', () => {
+    const actions = [
+      {
+        type: 'create' as const,
+        metadataName: 'viewField' as const,
+        flatEntity: {},
+      },
+    ] as AllUniversalWorkspaceMigrationAction[];
+
+    const result = getInvalidatedMetadataNamesFromActions(actions);
+
+    expect(result.sort()).toEqual(
+      ['fieldMetadata', 'view', 'viewField', 'viewFieldGroup'].sort(),
+    );
+  });
+
+  it('invalidates related maps on delete', () => {
+    const actions = [
+      {
+        type: 'delete' as const,
+        metadataName: 'viewField' as const,
+        universalIdentifier: 'view-field-1',
+      },
+    ] as AllUniversalWorkspaceMigrationAction[];
+
+    const result = getInvalidatedMetadataNamesFromActions(actions);
+
+    expect(result).toContain('view');
+    expect(result).toContain('viewField');
+  });
+
+  it('deduplicates across multiple actions', () => {
+    const actions = [
+      {
+        type: 'update' as const,
+        metadataName: 'viewField' as const,
+        universalIdentifier: 'view-field-1',
+        update: { position: 1 },
+      },
+      {
+        type: 'update' as const,
+        metadataName: 'viewField' as const,
+        universalIdentifier: 'view-field-2',
+        update: { position: 2 },
+      },
+    ] as AllUniversalWorkspaceMigrationAction[];
+
+    const result = getInvalidatedMetadataNamesFromActions(actions);
+
+    expect(result).toEqual(['viewField']);
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/get-invalidated-metadata-names-from-actions.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/get-invalidated-metadata-names-from-actions.util.spec.ts
@@ -23,7 +23,7 @@ describe('getInvalidatedMetadataNamesFromActions', () => {
         type: 'update' as const,
         metadataName: 'viewField' as const,
         universalIdentifier: 'view-field-1',
-        update: { viewFieldGroupId: 'group-2' },
+        update: { viewUniversalIdentifier: 'view-2' },
       },
     ] as AllUniversalWorkspaceMigrationAction[];
 
@@ -56,7 +56,7 @@ describe('getInvalidatedMetadataNamesFromActions', () => {
         type: 'update' as const,
         metadataName: 'pageLayoutWidget' as const,
         universalIdentifier: 'widget-1',
-        update: { configuration: {} },
+        update: { universalConfiguration: {} as any },
       },
     ] as AllUniversalWorkspaceMigrationAction[];
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util.ts
@@ -1,0 +1,69 @@
+import { type AllMetadataName } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ALL_MANY_TO_ONE_METADATA_RELATIONS } from 'src/engine/metadata-modules/flat-entity/constant/all-many-to-one-metadata-relations.constant';
+import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-related-metadata-names.util';
+import { getMetadataSerializedRelationNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-serialized-relation-names.util';
+import { ALL_JSONB_PROPERTIES_WITH_SERIALIZED_RELATION_BY_METADATA_NAME } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/constants/all-jsonb-properties-with-serialized-relation-by-metadata-name.constant';
+import { type AllUniversalWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-action-common';
+
+const getMetadataManyToOneForeignKeys = (
+  metadataName: AllMetadataName,
+): string[] =>
+  Object.values(ALL_MANY_TO_ONE_METADATA_RELATIONS[metadataName])
+    .filter(isDefined)
+    .flatMap((relation) => [relation.foreignKey, relation.universalForeignKey]);
+
+const getMetadataSerializedProperties = (
+  metadataName: AllMetadataName,
+): string[] =>
+  Object.keys(
+    ALL_JSONB_PROPERTIES_WITH_SERIALIZED_RELATION_BY_METADATA_NAME[
+      metadataName
+    ] ?? {},
+  );
+
+// A mutation only affects a related entity's cached flat map when it changes
+// which entities reference each other: create, delete, or an update that moves
+// a relation foreign key or modifies serialized relations. A plain attribute
+// update (e.g. a viewField position change) leaves every related map untouched,
+// so only the mutated entity's own map needs invalidation.
+const actionChangesRelationMembership = (
+  action: AllUniversalWorkspaceMigrationAction,
+): boolean => {
+  if (action.type !== 'update') {
+    return true;
+  }
+
+  const foreignKeys = getMetadataManyToOneForeignKeys(action.metadataName);
+  const serializedProperties = getMetadataSerializedProperties(
+    action.metadataName,
+  );
+
+  return Object.keys(action.update).some(
+    (updatedKey) =>
+      foreignKeys.includes(updatedKey) ||
+      serializedProperties.includes(updatedKey),
+  );
+};
+
+export const getInvalidatedMetadataNamesFromActions = (
+  actions: AllUniversalWorkspaceMigrationAction[],
+): AllMetadataName[] => {
+  const metadataNames = new Set<AllMetadataName>();
+
+  for (const action of actions) {
+    metadataNames.add(action.metadataName);
+
+    if (actionChangesRelationMembership(action)) {
+      getMetadataRelatedMetadataNames(action.metadataName).forEach(
+        (metadataName) => metadataNames.add(metadataName),
+      );
+      getMetadataSerializedRelationNames(action.metadataName).forEach(
+        (metadataName) => metadataNames.add(metadataName),
+      );
+    }
+  }
+
+  return [...metadataNames];
+};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util.ts
@@ -16,12 +16,20 @@ const getMetadataManyToOneForeignKeys = (
 
 const getMetadataSerializedProperties = (
   metadataName: AllMetadataName,
-): string[] =>
-  Object.keys(
+): string[] => {
+  const propertyNames = Object.keys(
     ALL_JSONB_PROPERTIES_WITH_SERIALIZED_RELATION_BY_METADATA_NAME[
       metadataName
     ] ?? {},
   );
+
+  return [
+    ...propertyNames,
+    ...propertyNames.map(
+      (name) => `universal${name.charAt(0).toUpperCase()}${name.slice(1)}`,
+    ),
+  ];
+};
 
 // A mutation only affects a related entity's cached flat map when it changes
 // which entities reference each other: create, delete, or an update that moves


### PR DESCRIPTION
## Problem

Closes #23918.

Reordering a single column in a record-table view executes a fast single-row `UPDATE` on `core."viewField"`, but then spends 230–450 ms in post-commit cache invalidation, recomputing five flat entity maps including the two largest (`flatObjectMetadataMaps`, `flatFieldMetadataMaps`). A view-field position update cannot alter object or field metadata, meaning that work is redundant and scales with workspace metadata size.

## Root cause

`WorkspaceMigrationRunnerService` constructs a wide metadata key set (`allFlatEntityMapsKeys`) combining actions, related metadata, and validation requirements. While this set is necessary for initial cache retrieval to validate incoming actions, reusing it for post-commit cache invalidation causes unnecessary recomputations. For a `viewField` update, the validation set includes `flatFieldMetadataMaps` and `flatObjectMetadataMaps`, which in turn triggers `shouldIncrementMetadataGraphqlSchemaVersion` and the legacy ORM/roles cache invalidation cascade.

## Fix

Derive the post-commit cache invalidation set directly from the entities mutated by each migration action:
- **create / delete**: Invalidate the mutated entity map along with related entity maps (both many-to-one and one-to-many) and serialized relation maps.
- **update**: Invalidate only the mutated entity map by default. When an update modifies many-to-one foreign keys (reparenting) or JSONB properties containing serialized relations, include related and serialized relation maps as well.
- Validation-only dependencies are excluded from post-commit invalidation.
- The search-vector rebuild path preserves invalidation of `flatIndexMaps`.
- Rollback invalidation retains the complete initial key set.

## Tests

Added unit tests in `packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/get-invalidated-metadata-names-from-actions.util.spec.ts` covering:
- Attribute-only updates (narrowed to mutated map only)
- Foreign key reparenting (standard and universal keys)
- Serialized relation property updates
- Entity creation and deletion
- Deduplication across actions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

