### PR TITLE
fix(twenty-server): resolve standard objects for app-defined indexes

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -113,6 +113,7 @@ export class ApplicationManifestMigrationService {
         manifest: preInstallOnlyManifest,
         ownerFlatApplication,
         fromAllFlatEntityMaps,
+        existingAllFlatEntityMaps,
         isLogicFunctionPrebuiltModeEnabled:
           featureFlagsMap[
             FeatureFlagKey.IS_LOGIC_FUNCTION_PREBUILT_MODE_ENABLED
@@ -210,6 +211,7 @@ export class ApplicationManifestMigrationService {
         manifest,
         ownerFlatApplication,
         fromAllFlatEntityMaps,
+        existingAllFlatEntityMaps,
         isLogicFunctionPrebuiltModeEnabled:
           featureFlagsMap[
             FeatureFlagKey.IS_LOGIC_FUNCTION_PREBUILT_MODE_ENABLED

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/__tests__/compute-application-manifest-all-universal-flat-entity-maps.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/__tests__/compute-application-manifest-all-universal-flat-entity-maps.service.spec.ts
@@ -1,0 +1,276 @@
+import { type Manifest } from 'twenty-shared/application';
+import { FieldMetadataType, IndexType } from 'twenty-shared/types';
+
+import { ComputeApplicationManifestAllUniversalFlatEntityMapsService } from 'src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service';
+import { type FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
+import { type SecretEncryptionService } from 'src/engine/core-modules/secret-encryption/secret-encryption.service';
+import { createEmptyAllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-all-flat-entity-maps.constant';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
+
+describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
+  const secretEncryptionService = {
+    encryptVersioned: jest.fn().mockReturnValue('encrypted'),
+  } as unknown as SecretEncryptionService;
+
+  const service =
+    new ComputeApplicationManifestAllUniversalFlatEntityMapsService(
+      secretEncryptionService,
+    );
+
+  const ownerFlatApplication = {
+    id: 'app-id-1',
+    universalIdentifier: 'app-universal-id-1',
+    sourceType: 'CUSTOM',
+  } as FlatApplication;
+
+  const now = '2026-01-01T00:00:00.000Z';
+  const workspaceId = 'ws-id-1';
+
+  const baseEmptyManifest: Manifest = {
+    application: {
+      universalIdentifier: ownerFlatApplication.universalIdentifier,
+    },
+    objects: [],
+    fields: [],
+    logicFunctions: [],
+    frontComponents: [],
+    permissionFlags: [],
+    roles: [],
+    skills: [],
+    agents: [],
+    publicAssets: [],
+    views: [],
+    viewFields: [],
+    navigationMenuItems: [],
+    pageLayouts: [],
+    pageLayoutTabs: [],
+    commandMenuItems: [],
+    timelineActivityTypes: [],
+  };
+
+  it('computes index defined on an app-defined custom object', () => {
+    const objectUniversalIdentifier = 'custom-obj-uuid';
+    const fieldUniversalIdentifier = 'custom-field-uuid';
+    const indexUniversalIdentifier = 'custom-index-uuid';
+
+    const manifest: Manifest = {
+      ...baseEmptyManifest,
+      objects: [
+        {
+          universalIdentifier: objectUniversalIdentifier,
+          nameSingular: 'customTicket',
+          namePlural: 'customTickets',
+          labelSingular: 'Custom Ticket',
+          labelPlural: 'Custom Tickets',
+          fields: [
+            {
+              universalIdentifier: fieldUniversalIdentifier,
+              name: 'ticketCode',
+              label: 'Ticket Code',
+              type: FieldMetadataType.TEXT,
+            },
+          ],
+        },
+      ],
+      indexes: [
+        {
+          universalIdentifier: indexUniversalIdentifier,
+          objectUniversalIdentifier,
+          indexType: IndexType.BTREE,
+          isUnique: true,
+          fields: [
+            {
+              universalIdentifier: 'index-field-entry-1',
+              fieldUniversalIdentifier,
+            },
+          ],
+        },
+      ],
+    };
+
+    const fromAllFlatEntityMaps = createEmptyAllFlatEntityMaps();
+    const result = service.compute({
+      manifest,
+      ownerFlatApplication,
+      fromAllFlatEntityMaps,
+      isLogicFunctionPrebuiltModeEnabled: false,
+      now,
+      workspaceId,
+    });
+
+    const index =
+      result.flatIndexMaps.byUniversalIdentifier[indexUniversalIdentifier];
+
+    expect(index).toBeDefined();
+    expect(index?.universalIdentifier).toBe(indexUniversalIdentifier);
+    expect(index?.objectMetadataUniversalIdentifier).toBe(
+      objectUniversalIdentifier,
+    );
+    expect(index?.isUnique).toBe(true);
+    expect(index?.universalFlatIndexFieldMetadatas).toHaveLength(1);
+    expect(
+      index?.universalFlatIndexFieldMetadatas[0]
+        .fieldMetadataUniversalIdentifier,
+    ).toBe(fieldUniversalIdentifier);
+  });
+
+  it('computes index defined on a standard object field added by the app', () => {
+    const standardCompanyUniversalIdentifier =
+      '20202020-b374-4779-a561-80086cb2e17f';
+    const appFieldUniversalIdentifier = 'app-field-uuid-company';
+    const appIndexUniversalIdentifier = 'app-index-uuid-company';
+
+    const existingStandardCompanyObject = {
+      id: 'company-id',
+      universalIdentifier: standardCompanyUniversalIdentifier,
+      nameSingular: 'company',
+      namePlural: 'companies',
+      labelSingular: 'Company',
+      labelPlural: 'Companies',
+      applicationUniversalIdentifier:
+        TWENTY_STANDARD_APPLICATION.universalIdentifier,
+    } as FlatObjectMetadata;
+
+    const existingAllFlatEntityMaps = createEmptyAllFlatEntityMaps();
+
+    existingAllFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
+      standardCompanyUniversalIdentifier
+    ] = existingStandardCompanyObject;
+
+    const manifest: Manifest = {
+      ...baseEmptyManifest,
+      fields: [
+        {
+          universalIdentifier: appFieldUniversalIdentifier,
+          objectUniversalIdentifier: standardCompanyUniversalIdentifier,
+          name: 'erpId',
+          label: 'ERP ID',
+          type: FieldMetadataType.TEXT,
+        },
+      ],
+      indexes: [
+        {
+          universalIdentifier: appIndexUniversalIdentifier,
+          objectUniversalIdentifier: standardCompanyUniversalIdentifier,
+          indexType: IndexType.BTREE,
+          isUnique: true,
+          fields: [
+            {
+              universalIdentifier: 'index-field-entry-company-1',
+              fieldUniversalIdentifier: appFieldUniversalIdentifier,
+            },
+          ],
+        },
+      ],
+    };
+
+    const fromAllFlatEntityMaps = createEmptyAllFlatEntityMaps();
+
+    const result = service.compute({
+      manifest,
+      ownerFlatApplication,
+      fromAllFlatEntityMaps,
+      existingAllFlatEntityMaps,
+      isLogicFunctionPrebuiltModeEnabled: false,
+      now,
+      workspaceId,
+    });
+
+    const index =
+      result.flatIndexMaps.byUniversalIdentifier[appIndexUniversalIdentifier];
+
+    expect(index).toBeDefined();
+    expect(index?.universalIdentifier).toBe(appIndexUniversalIdentifier);
+    expect(index?.objectMetadataUniversalIdentifier).toBe(
+      standardCompanyUniversalIdentifier,
+    );
+    expect(index?.isUnique).toBe(true);
+    expect(index?.name).toMatch(/^IDX_UNIQUE_/);
+    expect(index?.universalFlatIndexFieldMetadatas[0]).toMatchObject({
+      order: 0,
+      fieldMetadataUniversalIdentifier: appFieldUniversalIdentifier,
+      indexMetadataUniversalIdentifier: appIndexUniversalIdentifier,
+    });
+  });
+
+  it('throws when index references a field not defined in the application manifest', () => {
+    const standardCompanyUniversalIdentifier =
+      '20202020-b374-4779-a561-80086cb2e17f';
+    const standardFieldUniversalIdentifier =
+      '20202020-0000-0000-0000-000000000001';
+
+    const existingStandardCompanyObject = {
+      id: 'company-id',
+      universalIdentifier: standardCompanyUniversalIdentifier,
+      nameSingular: 'company',
+      applicationUniversalIdentifier:
+        TWENTY_STANDARD_APPLICATION.universalIdentifier,
+    } as FlatObjectMetadata;
+
+    const existingAllFlatEntityMaps = createEmptyAllFlatEntityMaps();
+
+    existingAllFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
+      standardCompanyUniversalIdentifier
+    ] = existingStandardCompanyObject;
+
+    const manifest: Manifest = {
+      ...baseEmptyManifest,
+      indexes: [
+        {
+          universalIdentifier: 'invalid-index-uuid',
+          objectUniversalIdentifier: standardCompanyUniversalIdentifier,
+          fields: [
+            {
+              universalIdentifier: 'field-entry-1',
+              fieldUniversalIdentifier: standardFieldUniversalIdentifier,
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(() =>
+      service.compute({
+        manifest,
+        ownerFlatApplication,
+        fromAllFlatEntityMaps: createEmptyAllFlatEntityMaps(),
+        existingAllFlatEntityMaps,
+        isLogicFunctionPrebuiltModeEnabled: false,
+        now,
+        workspaceId,
+      }),
+    ).toThrow(/references unknown field/);
+  });
+
+  it('throws when index references an unknown object', () => {
+    const manifest: Manifest = {
+      ...baseEmptyManifest,
+      indexes: [
+        {
+          universalIdentifier: 'index-unknown-obj',
+          objectUniversalIdentifier: 'unknown-obj-uuid',
+          fields: [
+            {
+              universalIdentifier: 'entry-1',
+              fieldUniversalIdentifier: 'field-1',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(() =>
+      service.compute({
+        manifest,
+        ownerFlatApplication,
+        fromAllFlatEntityMaps: createEmptyAllFlatEntityMaps(),
+        isLogicFunctionPrebuiltModeEnabled: false,
+        now,
+        workspaceId,
+      }),
+    ).toThrow(
+      'Index "index-unknown-obj" references unknown object unknown-obj-uuid',
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/__tests__/compute-application-manifest-all-universal-flat-entity-maps.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/__tests__/compute-application-manifest-all-universal-flat-entity-maps.service.spec.ts
@@ -22,7 +22,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
     id: 'app-id-1',
     universalIdentifier: 'app-universal-id-1',
     sourceType: 'CUSTOM',
-  } as FlatApplication;
+  } as unknown as FlatApplication;
 
   const now = '2026-01-01T00:00:00.000Z';
   const workspaceId = 'ws-id-1';
@@ -47,14 +47,14 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
     pageLayoutTabs: [],
     commandMenuItems: [],
     timelineActivityTypes: [],
-  };
+  } as unknown as Manifest;
 
   it('computes index defined on an app-defined custom object', () => {
     const objectUniversalIdentifier = 'custom-obj-uuid';
     const fieldUniversalIdentifier = 'custom-field-uuid';
     const indexUniversalIdentifier = 'custom-index-uuid';
 
-    const manifest: Manifest = {
+    const manifest = {
       ...baseEmptyManifest,
       objects: [
         {
@@ -87,7 +87,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
           ],
         },
       ],
-    };
+    } as unknown as Manifest;
 
     const fromAllFlatEntityMaps = createEmptyAllFlatEntityMaps();
     const result = service.compute({
@@ -130,7 +130,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
       labelPlural: 'Companies',
       applicationUniversalIdentifier:
         TWENTY_STANDARD_APPLICATION.universalIdentifier,
-    } as FlatObjectMetadata;
+    } as unknown as FlatObjectMetadata;
 
     const existingAllFlatEntityMaps = createEmptyAllFlatEntityMaps();
 
@@ -138,7 +138,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
       standardCompanyUniversalIdentifier
     ] = existingStandardCompanyObject;
 
-    const manifest: Manifest = {
+    const manifest = {
       ...baseEmptyManifest,
       fields: [
         {
@@ -163,7 +163,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
           ],
         },
       ],
-    };
+    } as unknown as Manifest;
 
     const fromAllFlatEntityMaps = createEmptyAllFlatEntityMaps();
 
@@ -206,7 +206,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
       nameSingular: 'company',
       applicationUniversalIdentifier:
         TWENTY_STANDARD_APPLICATION.universalIdentifier,
-    } as FlatObjectMetadata;
+    } as unknown as FlatObjectMetadata;
 
     const existingAllFlatEntityMaps = createEmptyAllFlatEntityMaps();
 
@@ -214,7 +214,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
       standardCompanyUniversalIdentifier
     ] = existingStandardCompanyObject;
 
-    const manifest: Manifest = {
+    const manifest = {
       ...baseEmptyManifest,
       indexes: [
         {
@@ -228,7 +228,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
           ],
         },
       ],
-    };
+    } as unknown as Manifest;
 
     expect(() =>
       service.compute({
@@ -244,7 +244,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
   });
 
   it('throws when index references an unknown object', () => {
-    const manifest: Manifest = {
+    const manifest = {
       ...baseEmptyManifest,
       indexes: [
         {
@@ -258,7 +258,7 @@ describe('ComputeApplicationManifestAllUniversalFlatEntityMapsService', () => {
           ],
         },
       ],
-    };
+    } as unknown as Manifest;
 
     expect(() =>
       service.compute({

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
@@ -56,6 +56,7 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
     manifest,
     ownerFlatApplication,
     fromAllFlatEntityMaps,
+    existingAllFlatEntityMaps,
     isLogicFunctionPrebuiltModeEnabled,
     now,
     workspaceId,
@@ -63,6 +64,7 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
     manifest: Manifest;
     ownerFlatApplication: FlatApplication;
     fromAllFlatEntityMaps: AllFlatEntityMaps;
+    existingAllFlatEntityMaps?: AllFlatEntityMaps;
     isLogicFunctionPrebuiltModeEnabled: boolean;
     now: string;
     workspaceId: string;
@@ -153,6 +155,11 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
     for (const indexManifest of manifest.indexes ?? []) {
       const flatObjectMetadata =
         allUniversalFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
+          indexManifest.objectUniversalIdentifier
+        ] ??
+        existingAllFlatEntityMaps?.flatObjectMetadataMaps
+          ?.byUniversalIdentifier[indexManifest.objectUniversalIdentifier] ??
+        fromAllFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
           indexManifest.objectUniversalIdentifier
         ];
 


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- START_SECTION:twenty-pr-header -->
<!-- END_SECTION:twenty-pr-header -->
<!-- prettier-ignore-end -->

### Summary

Resolves #23391.

When an application manifest defines an index on an app-defined field of an existing object (such as a standard object like `Company` or `Person`), `ComputeApplicationManifestAllUniversalFlatEntityMapsService.compute` failed with:
```
Index "..." references unknown object <standard_object_uuid>
```
This was because `flatObjectMetadata` was resolved solely against `allUniversalFlatEntityMaps.flatObjectMetadataMaps`, which only contains objects defined directly within the application's `manifest.objects`.

### Changes

1. **Object Fallback Resolution**: In `ComputeApplicationManifestAllUniversalFlatEntityMapsService`, when looking up the target object for an index declaration in `manifest.indexes`, fall back to `existingAllFlatEntityMaps` and `fromAllFlatEntityMaps` if the object is not defined in the manifest.
2. **Preserve Field Ownership Boundaries**: As established by @Weiko and @thomtrp, index field resolution continues to be strictly scoped to fields defined in the application manifest (`fieldsByObjectUniversalIdentifier`). An application can only index fields it defines, preventing physical index collisions across apps and ensuring clean error handling if a field is removed.
3. **Pass `existingAllFlatEntityMaps`**: Updated `ApplicationManifestMigrationService` to pass the already retrieved `existingAllFlatEntityMaps` into `computeManifestFlatEntityMapsService.compute`.
4. **Unit Tests**: Added comprehensive test coverage in `compute-application-manifest-all-universal-flat-entity-maps.service.spec.ts` validating:
   - App-defined index on app-defined custom object.
   - App-defined index on a standard object field added by the app.
   - Attempting to index an unowned / unknown field on a standard object cleanly throws.
   - Attempting to index an unknown object cleanly throws.

Closes #23391

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

