### PR TITLE
fix(auth): mark OAuth callback URLs as env-only and resolve dynamically

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/__tests__/google-auth-strategy.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/__tests__/google-auth-strategy.spec.ts
@@ -1,0 +1,99 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { type Request } from 'express';
+
+import { GoogleStrategy } from 'src/engine/core-modules/auth/strategies/google.auth.strategy';
+import { MicrosoftStrategy } from 'src/engine/core-modules/auth/strategies/microsoft.auth.strategy';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { isEnvOnlyConfigVar } from 'src/engine/core-modules/twenty-config/utils/is-env-only-config-var.util';
+
+describe('OAuth Strategies', () => {
+  let googleStrategy: GoogleStrategy;
+  let microsoftStrategy: MicrosoftStrategy;
+  let twentyConfigService: TwentyConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GoogleStrategy,
+        MicrosoftStrategy,
+        {
+          provide: TwentyConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'AUTH_GOOGLE_CLIENT_ID') return 'google-client-id';
+              if (key === 'AUTH_GOOGLE_CLIENT_SECRET')
+                return 'google-client-secret';
+              if (key === 'AUTH_GOOGLE_CALLBACK_URL')
+                return 'http://localhost:3000/auth/google/redirect';
+              if (key === 'AUTH_MICROSOFT_CLIENT_ID') return 'ms-client-id';
+              if (key === 'AUTH_MICROSOFT_CLIENT_SECRET')
+                return 'ms-client-secret';
+              if (key === 'AUTH_MICROSOFT_CALLBACK_URL')
+                return 'http://localhost:3000/auth/microsoft/redirect';
+              return null;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    googleStrategy = module.get<GoogleStrategy>(GoogleStrategy);
+    microsoftStrategy = module.get<MicrosoftStrategy>(MicrosoftStrategy);
+    twentyConfigService = module.get<TwentyConfigService>(TwentyConfigService);
+  });
+
+  it('marks OAuth callback URLs as isEnvOnly', () => {
+    expect(isEnvOnlyConfigVar('AUTH_GOOGLE_CALLBACK_URL')).toBe(true);
+    expect(isEnvOnlyConfigVar('AUTH_GOOGLE_APIS_CALLBACK_URL')).toBe(true);
+    expect(isEnvOnlyConfigVar('AUTH_MICROSOFT_CALLBACK_URL')).toBe(true);
+    expect(isEnvOnlyConfigVar('AUTH_MICROSOFT_APIS_CALLBACK_URL')).toBe(true);
+  });
+
+  it('dynamically injects current AUTH_GOOGLE_CALLBACK_URL when GoogleStrategy.authenticate is called', () => {
+    const mockReq = {
+      query: {},
+      params: {},
+    } as unknown as Request;
+
+    const superAuthenticateSpy = jest
+      .spyOn(Object.getPrototypeOf(GoogleStrategy.prototype), 'authenticate')
+      .mockImplementation(() => {});
+
+    jest
+      .spyOn(twentyConfigService, 'get')
+      .mockReturnValue('https://custom-domain.com/auth/google/redirect');
+
+    googleStrategy.authenticate(mockReq, {});
+
+    expect(superAuthenticateSpy).toHaveBeenCalledWith(
+      mockReq,
+      expect.objectContaining({
+        callbackURL: 'https://custom-domain.com/auth/google/redirect',
+      }),
+    );
+  });
+
+  it('dynamically injects current AUTH_MICROSOFT_CALLBACK_URL when MicrosoftStrategy.authenticate is called', () => {
+    const mockReq = {
+      query: {},
+      params: {},
+    } as unknown as Request;
+
+    const superAuthenticateSpy = jest
+      .spyOn(Object.getPrototypeOf(MicrosoftStrategy.prototype), 'authenticate')
+      .mockImplementation(() => {});
+
+    jest
+      .spyOn(twentyConfigService, 'get')
+      .mockReturnValue('https://custom-domain.com/auth/microsoft/redirect');
+
+    microsoftStrategy.authenticate(mockReq, {});
+
+    expect(superAuthenticateSpy).toHaveBeenCalledWith(
+      mockReq,
+      expect.objectContaining({
+        callbackURL: 'https://custom-domain.com/auth/microsoft/redirect',
+      }),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google.auth.strategy.ts
@@ -38,7 +38,7 @@ export type GoogleRequest = Omit<
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
-  constructor(twentyConfigService: TwentyConfigService) {
+  constructor(private readonly twentyConfigService: TwentyConfigService) {
     super({
       clientID: twentyConfigService.get('AUTH_GOOGLE_CLIENT_ID'),
       clientSecret: twentyConfigService.get('AUTH_GOOGLE_CLIENT_SECRET'),
@@ -52,6 +52,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   authenticate(req: Request, options: any) {
     options = {
       ...options,
+      callbackURL: this.twentyConfigService.get('AUTH_GOOGLE_CALLBACK_URL'),
       state: JSON.stringify({
         workspaceInviteHash: req.query.workspaceInviteHash,
         workspaceId: req.params.workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
@@ -14,7 +14,7 @@ import {
 import { type MicrosoftPassportProfile } from 'src/engine/core-modules/auth/types/microsoft-passport-profile.type';
 import { type SocialSsoSignInUpActionType } from 'src/engine/core-modules/auth/types/signInUp.type';
 import { type SocialSsoState } from 'src/engine/core-modules/auth/types/social-sso-state.type';
-import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
 export type MicrosoftRequest = Omit<
   Request,
@@ -36,7 +36,7 @@ export type MicrosoftRequest = Omit<
 
 @Injectable()
 export class MicrosoftStrategy extends PassportStrategy(Strategy, 'microsoft') {
-  constructor(twentyConfigService: TwentyConfigService) {
+  constructor(private readonly twentyConfigService: TwentyConfigService) {
     super({
       clientID: twentyConfigService.get('AUTH_MICROSOFT_CLIENT_ID'),
       clientSecret: twentyConfigService.get('AUTH_MICROSOFT_CLIENT_SECRET'),
@@ -51,6 +51,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy, 'microsoft') {
   authenticate(req: Request, options: any) {
     options = {
       ...options,
+      callbackURL: this.twentyConfigService.get('AUTH_MICROSOFT_CALLBACK_URL'),
       state: JSON.stringify({
         workspaceInviteHash: req.query.workspaceInviteHash,
         workspaceId: req.params.workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -144,6 +144,7 @@ export class ConfigVariables {
     description: 'Callback URL for Google Auth APIs',
     type: ConfigVariableType.STRING,
     isSensitive: false,
+    isEnvOnly: true,
   })
   AUTH_GOOGLE_APIS_CALLBACK_URL: string;
 
@@ -178,6 +179,7 @@ export class ConfigVariables {
     isSensitive: false,
     description: 'Callback URL for Google authentication',
     type: ConfigVariableType.STRING,
+    isEnvOnly: true,
   })
   @IsUrl({ require_tld: false, require_protocol: true })
   @ValidateIf((env) => env.AUTH_GOOGLE_ENABLED)
@@ -278,6 +280,7 @@ export class ConfigVariables {
     isSensitive: false,
     description: 'Callback URL for Microsoft authentication',
     type: ConfigVariableType.STRING,
+    isEnvOnly: true,
   })
   @IsUrl({ require_tld: false, require_protocol: true })
   @ValidateIf((env) => env.AUTH_MICROSOFT_ENABLED)
@@ -288,6 +291,7 @@ export class ConfigVariables {
     isSensitive: false,
     description: 'Callback URL for Microsoft APIs',
     type: ConfigVariableType.STRING,
+    isEnvOnly: true,
   })
   @IsUrl({ require_tld: false, require_protocol: true })
   @ValidateIf((env) => env.AUTH_MICROSOFT_ENABLED)


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- START_SECTION:twenty-pr-header -->
<!-- END_SECTION:twenty-pr-header -->
<!-- prettier-ignore-end -->

### Summary

Resolves #22606.

When running in self-hosted Docker environments or multi-environment deployments, updating OAuth callback URLs (`AUTH_GOOGLE_CALLBACK_URL`, `AUTH_GOOGLE_APIS_CALLBACK_URL`, `AUTH_MICROSOFT_CALLBACK_URL`, `AUTH_MICROSOFT_APIS_CALLBACK_URL`) in environment variables did not take effect because database-backed configurations in `core.keyValuePair` took precedence over runtime environment variables when `IS_CONFIG_VARIABLES_IN_DB_ENABLED=true`. Furthermore, Passport strategies stored the callback URL at constructor time.

### Changes

1. **Config Variables**: Marked `AUTH_GOOGLE_CALLBACK_URL`, `AUTH_GOOGLE_APIS_CALLBACK_URL`, `AUTH_MICROSOFT_CALLBACK_URL`, and `AUTH_MICROSOFT_APIS_CALLBACK_URL` with `isEnvOnly: true` in `config-variables.ts`. Like `SERVER_URL`, these deployment-specific infrastructure URLs should always be driven by container environment variables rather than stale DB rows.
2. **Dynamic Strategy Callbacks**: Updated `GoogleStrategy` and `MicrosoftStrategy` to inject `callbackURL: this.twentyConfigService.get(...)` in their `authenticate()` method so each authentication flow resolves the latest configured callback URL.
3. **Unit Tests**: Added regression tests in `google-auth-strategy.spec.ts` validating:
   - All four OAuth callback variables are configured as `isEnvOnly`.
   - `GoogleStrategy.authenticate` dynamically supplies the current callback URL.
   - `MicrosoftStrategy.authenticate` dynamically supplies the current callback URL.

Closes #22606

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

