### PR TITLE
fix(twenty-front): skip aggregate refetch on no-op SSE update echoes

### DIFF
--- a/packages/twenty-front/src/modules/sse-db-event/hooks/__tests__/useTriggerOptimisticEffectFromSseUpdateEvents.test.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/__tests__/useTriggerOptimisticEffectFromSseUpdateEvents.test.ts
@@ -1,0 +1,193 @@
+import { renderHook } from '@testing-library/react';
+import { useStore } from 'jotai';
+
+import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { getRecordFromCache } from '@/object-record/cache/utils/getRecordFromCache';
+import { getRecordNodeFromRecord } from '@/object-record/cache/utils/getRecordNodeFromRecord';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { useRefetchAggregateQueriesForObjectMetadataItem } from '@/object-record/hooks/useRefetchAggregateQueriesForObjectMetadataItem';
+import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
+import { useTriggerOptimisticEffectFromSseUpdateEvents } from '@/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents';
+import {
+  DatabaseEventAction,
+  type ObjectRecordEvent,
+} from '~/generated-metadata/graphql';
+
+jest.mock('jotai', () => ({
+  ...jest.requireActual('jotai'),
+  useStore: jest.fn(),
+}));
+
+jest.mock('@/object-metadata/hooks/useApolloCoreClient');
+jest.mock('@/object-record/hooks/useObjectPermissions');
+jest.mock(
+  '@/object-record/hooks/useRefetchAggregateQueriesForObjectMetadataItem',
+);
+jest.mock('@/object-record/record-store/hooks/useUpsertRecordsInStore');
+jest.mock('@/object-record/cache/utils/getRecordFromCache');
+jest.mock('@/object-record/cache/utils/getRecordNodeFromRecord');
+jest.mock('@/object-record/cache/utils/updateRecordFromCache');
+jest.mock(
+  '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect',
+);
+jest.mock('@/object-record/utils/computeOptimisticRecordFromInput', () => ({
+  computeOptimisticRecordFromInput: jest.fn(({ recordInput }) => ({
+    ...recordInput,
+  })),
+}));
+jest.mock(
+  '@/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromRecord',
+  () => ({
+    generateDepthRecordGqlFieldsFromRecord: jest.fn(() => ({})),
+  }),
+);
+
+describe('useTriggerOptimisticEffectFromSseUpdateEvents', () => {
+  const mockRefetchAggregateQueries = jest.fn();
+  const mockUpsertRecordsInStore = jest.fn();
+
+  const mockObjectMetadataItem = {
+    id: 'person-metadata-id',
+    nameSingular: 'person',
+    namePlural: 'people',
+    fields: [
+      { id: 'f1', name: 'firstName' },
+      { id: 'f2', name: 'lastName' },
+      { id: 'f3', name: 'updatedAt' },
+    ],
+  } as unknown as EnrichedObjectMetadataItem;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useStore as jest.Mock).mockReturnValue({
+      get: jest.fn().mockReturnValue([mockObjectMetadataItem]),
+    });
+
+    (useApolloCoreClient as jest.Mock).mockReturnValue({
+      cache: {},
+    });
+
+    (useObjectPermissions as jest.Mock).mockReturnValue({
+      objectPermissionsByObjectMetadataId: {},
+    });
+
+    (
+      useRefetchAggregateQueriesForObjectMetadataItem as jest.Mock
+    ).mockReturnValue({
+      refetchAggregateQueriesForObjectMetadataItem: mockRefetchAggregateQueries,
+    });
+
+    (useUpsertRecordsInStore as jest.Mock).mockReturnValue({
+      upsertRecordsInStore: mockUpsertRecordsInStore,
+    });
+  });
+
+  it('skips aggregate refetch when updated record values match cached values (no-op / self-echo)', () => {
+    const cachedRecord = {
+      id: 'rec-1',
+      firstName: 'John',
+      lastName: 'Doe',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    (getRecordFromCache as jest.Mock).mockReturnValue(cachedRecord);
+    (getRecordNodeFromRecord as jest.Mock).mockReturnValue(cachedRecord);
+
+    const sseEvent: ObjectRecordEvent = {
+      action: DatabaseEventAction.UPDATED,
+      objectNameSingular: 'person',
+      recordId: 'rec-1',
+      properties: {
+        after: {
+          id: 'rec-1',
+          firstName: 'John',
+          lastName: 'Doe',
+          updatedAt: '2026-01-01T00:01:00.000Z',
+        },
+        updatedFields: ['firstName', 'updatedAt'],
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useTriggerOptimisticEffectFromSseUpdateEvents(),
+    );
+
+    result.current.triggerOptimisticEffectFromSseUpdateEvents({
+      objectRecordEvents: [sseEvent],
+      objectMetadataItem: mockObjectMetadataItem,
+    });
+
+    expect(mockRefetchAggregateQueries).not.toHaveBeenCalled();
+  });
+
+  it('triggers aggregate refetch when at least one field value differs from cache', () => {
+    const cachedRecord = {
+      id: 'rec-1',
+      firstName: 'John',
+      lastName: 'Doe',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    (getRecordFromCache as jest.Mock).mockReturnValue(cachedRecord);
+    (getRecordNodeFromRecord as jest.Mock).mockReturnValue(cachedRecord);
+
+    const sseEvent: ObjectRecordEvent = {
+      action: DatabaseEventAction.UPDATED,
+      objectNameSingular: 'person',
+      recordId: 'rec-1',
+      properties: {
+        after: {
+          id: 'rec-1',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          updatedAt: '2026-01-01T00:01:00.000Z',
+        },
+        updatedFields: ['firstName', 'updatedAt'],
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useTriggerOptimisticEffectFromSseUpdateEvents(),
+    );
+
+    result.current.triggerOptimisticEffectFromSseUpdateEvents({
+      objectRecordEvents: [sseEvent],
+      objectMetadataItem: mockObjectMetadataItem,
+    });
+
+    expect(mockRefetchAggregateQueries).toHaveBeenCalledTimes(1);
+    expect(mockRefetchAggregateQueries).toHaveBeenCalledWith({
+      objectMetadataItem: mockObjectMetadataItem,
+    });
+  });
+
+  it('triggers aggregate refetch when record is not found in cache (conservative fallback)', () => {
+    (getRecordFromCache as jest.Mock).mockReturnValue(null);
+    (getRecordNodeFromRecord as jest.Mock).mockReturnValue(null);
+
+    const sseEvent: ObjectRecordEvent = {
+      action: DatabaseEventAction.UPDATED,
+      objectNameSingular: 'person',
+      recordId: 'rec-2',
+      properties: {
+        after: {
+          id: 'rec-2',
+          firstName: 'Alice',
+        },
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useTriggerOptimisticEffectFromSseUpdateEvents(),
+    );
+
+    result.current.triggerOptimisticEffectFromSseUpdateEvents({
+      objectRecordEvents: [sseEvent],
+      objectMetadataItem: mockObjectMetadataItem,
+    });
+
+    expect(mockRefetchAggregateQueries).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents.ts
@@ -20,6 +20,7 @@ import {
   DatabaseEventAction,
   type ObjectRecordEvent,
 } from '~/generated-metadata/graphql';
+import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
   const store = useStore();
@@ -49,6 +50,8 @@ export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
       const updateEvents = objectRecordEvents.filter((objectRecordEvent) => {
         return objectRecordEvent.action === DatabaseEventAction.UPDATED;
       });
+
+      let hasAnyRecordActuallyChanged = false;
 
       for (const updateEvent of updateEvents) {
         const recordFromEvent = updateEvent.properties.after;
@@ -129,7 +132,22 @@ export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
           !isDefined(cachedRecord) ||
           !isDefined(cachedRecordWithConnection)
         ) {
+          hasAnyRecordActuallyChanged = true;
           continue;
+        }
+
+        const updatedFieldNames = (
+          updateEvent.properties.updatedFields ?? Object.keys(updatedRecord)
+        ).filter((fieldName) => fieldName in updatedRecord);
+
+        const hasThisEventChangedAnyFieldValue = updatedFieldNames.some(
+          (fieldName) =>
+            fieldName !== 'updatedAt' &&
+            !isDeeplyEqual(cachedRecord[fieldName], updatedRecord[fieldName]),
+        );
+
+        if (hasThisEventChangedAnyFieldValue) {
+          hasAnyRecordActuallyChanged = true;
         }
 
         upsertRecordsInStore({ partialRecords: [updatedRecord] });
@@ -165,7 +183,7 @@ export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
         });
       }
 
-      if (isNonEmptyArray(updateEvents)) {
+      if (hasAnyRecordActuallyChanged) {
         refetchAggregateQueriesForObjectMetadataItem({
           objectMetadataItem,
         });


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- START_SECTION:twenty-pr-header -->
<!-- END_SECTION:twenty-pr-header -->
<!-- prettier-ignore-end -->

### Summary

Resolves #22460.

When an inline edit occurs on a record, `useUpdateOneRecord` immediately updates the local Apollo cache and store and calls `refetchAggregateQueries` once the mutation completes. Shortly after, the server publishes an SSE `UPDATED` event for the same mutation back to the client. `useTriggerOptimisticEffectFromSseUpdateEvents` previously executed `refetchAggregateQueriesForObjectMetadataItem` unconditionally whenever `updateEvents` was non-empty, causing duplicate aggregate GraphQL requests (e.g. `AggregatePeople`) to be dispatched back-to-back for a single edit.

### Changes

1. **Change-Detection Guard**: In `useTriggerOptimisticEffectFromSseUpdateEvents`, inspect the updated fields from each incoming SSE event (using `updateEvent.properties.updatedFields` when available, falling back to `updatedRecord` keys) and compare against `cachedRecord` using `isDeeplyEqual` (ignoring timestamp-only updates like `updatedAt`).
2. **Conservative Fallback**: If a record is not found in cache (e.g. pagination or filtered view), assume a change may have occurred and preserve aggregate refetch.
3. **Unit Tests**: Added focused unit tests in `useTriggerOptimisticEffectFromSseUpdateEvents.test.ts` verifying:
   - No-op / self-echo SSE update events skip redundant aggregate refetches.
   - Genuine field changes from other tabs/users trigger aggregate refetches.
   - Missing cache entries conservatively trigger aggregate refetches.

Closes #22460

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

