### PR TITLE
fix(twenty-front): parse escaped value when persisting percentage number field

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/NumberFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/NumberFieldInput.tsx
@@ -4,12 +4,8 @@ import { FieldInputEventContext } from '@/object-record/record-field/ui/contexts
 import { RecordFieldComponentInstanceContext } from '@/object-record/record-field/ui/states/contexts/RecordFieldComponentInstanceContext';
 import { FieldInputContainer } from '@/ui/field/input/components/FieldInputContainer';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
-import { isNull } from '@sniptt/guards';
 import { useContext } from 'react';
-import {
-  canBeCastAsNumberOrNull,
-  castAsNumberOrNull,
-} from '~/utils/cast-as-number-or-null';
+import { getNumberValueToPersist } from '@/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist';
 import { useNumberField } from '@/object-record/record-field/ui/meta-types/hooks/useNumberField';
 
 export const NumberFieldInput = () => {
@@ -23,36 +19,14 @@ export const NumberFieldInput = () => {
     RecordFieldComponentInstanceContext,
   );
 
-  const getNumberValueToPersist = (
-    newValue: string,
-  ): { success: boolean; value?: any } => {
-    if (fieldDefinition?.metadata?.settings?.type === 'percentage') {
-      const newValueEscaped = newValue.replaceAll('%', '');
-
-      if (!canBeCastAsNumberOrNull(newValueEscaped)) {
-        return { success: false };
-      }
-
-      const castedValue = castAsNumberOrNull(newValue);
-
-      if (!isNull(castedValue)) {
-        return { success: true, value: castedValue / 100 };
-      }
-
-      return { success: true, value: null };
-    }
-
-    if (!canBeCastAsNumberOrNull(newValue)) {
-      return { success: false };
-    }
-
-    const castedValue = castAsNumberOrNull(newValue);
-
-    return { success: true, value: castedValue };
-  };
+  const getNumberValue = (newValue: string) =>
+    getNumberValueToPersist({
+      newValue,
+      numberType: fieldDefinition?.metadata?.settings?.type,
+    });
 
   const handleEnter = (newText: string) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = getNumberValue(newText);
 
     const shouldNotPersist = !success;
 
@@ -60,7 +34,7 @@ export const NumberFieldInput = () => {
   };
 
   const handleEscape = (newText: string) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = getNumberValue(newText);
 
     const shouldNotPersist = !success;
 
@@ -71,7 +45,7 @@ export const NumberFieldInput = () => {
     event: MouseEvent | TouchEvent,
     newText: string,
   ) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = getNumberValue(newText);
 
     const shouldNotPersist = !success;
 
@@ -79,7 +53,7 @@ export const NumberFieldInput = () => {
   };
 
   const handleTab = (newText: string) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = getNumberValue(newText);
 
     const shouldNotPersist = !success;
 
@@ -87,7 +61,7 @@ export const NumberFieldInput = () => {
   };
 
   const handleShiftTab = (newText: string) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = getNumberValue(newText);
 
     const shouldNotPersist = !success;
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts
@@ -1,0 +1,84 @@
+import { getNumberValueToPersist } from '@/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist';
+
+describe('getNumberValueToPersist', () => {
+  describe('standard number', () => {
+    it('should persist a valid integer string', () => {
+      const result = getNumberValueToPersist({
+        newValue: '42',
+      });
+
+      expect(result).toEqual({ success: true, value: 42 });
+    });
+
+    it('should persist a valid float string', () => {
+      const result = getNumberValueToPersist({
+        newValue: '42.5',
+      });
+
+      expect(result).toEqual({ success: true, value: 42.5 });
+    });
+
+    it('should return null when empty string', () => {
+      const result = getNumberValueToPersist({
+        newValue: '',
+      });
+
+      expect(result).toEqual({ success: true, value: null });
+    });
+
+    it('should return success false when non-numeric string', () => {
+      const result = getNumberValueToPersist({
+        newValue: 'abc',
+      });
+
+      expect(result).toEqual({ success: false });
+    });
+  });
+
+  describe('percentage', () => {
+    it('should persist a percentage string with a % symbol without throwing', () => {
+      const result = getNumberValueToPersist({
+        newValue: '50%',
+        numberType: 'percentage',
+      });
+
+      expect(result).toEqual({ success: true, value: 0.5 });
+    });
+
+    it('should persist a decimal percentage string with a % symbol', () => {
+      const result = getNumberValueToPersist({
+        newValue: '12.5%',
+        numberType: 'percentage',
+      });
+
+      expect(result).toEqual({ success: true, value: 0.125 });
+    });
+
+    it('should persist a percentage string without a % symbol', () => {
+      const result = getNumberValueToPersist({
+        newValue: '25',
+        numberType: 'percentage',
+      });
+
+      expect(result).toEqual({ success: true, value: 0.25 });
+    });
+
+    it('should return null for empty percentage input', () => {
+      const result = getNumberValueToPersist({
+        newValue: '',
+        numberType: 'percentage',
+      });
+
+      expect(result).toEqual({ success: true, value: null });
+    });
+
+    it('should return success false for invalid percentage input', () => {
+      const result = getNumberValueToPersist({
+        newValue: 'foo%',
+        numberType: 'percentage',
+      });
+
+      expect(result).toEqual({ success: false });
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts
@@ -80,5 +80,48 @@ describe('getNumberValueToPersist', () => {
 
       expect(result).toEqual({ success: false });
     });
+
+    it('should return success false when input is only a % symbol', () => {
+      const result = getNumberValueToPersist({
+        newValue: '%',
+        numberType: 'percentage',
+      });
+
+      expect(result).toEqual({ success: false });
+    });
+
+    it('should return success false when % is in the middle', () => {
+      const result = getNumberValueToPersist({
+        newValue: '1%2',
+        numberType: 'percentage',
+      });
+
+      expect(result).toEqual({ success: false });
+    });
+
+    it('should return success false when multiple % symbols are present', () => {
+      expect(
+        getNumberValueToPersist({
+          newValue: '%%50',
+          numberType: 'percentage',
+        }),
+      ).toEqual({ success: false });
+
+      expect(
+        getNumberValueToPersist({
+          newValue: '50%%',
+          numberType: 'percentage',
+        }),
+      ).toEqual({ success: false });
+    });
+
+    it('should handle percentage with surrounding whitespace', () => {
+      const result = getNumberValueToPersist({
+        newValue: '  50 %  ',
+        numberType: 'percentage',
+      });
+
+      expect(result).toEqual({ success: true, value: 0.5 });
+    });
   });
 });

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
@@ -1,4 +1,5 @@
 import { isNull } from '@sniptt/guards';
+import { type FieldNumberVariant } from 'twenty-shared/types';
 
 import {
   canBeCastAsNumberOrNull,
@@ -7,7 +8,7 @@ import {
 
 type GetNumberValueToPersistArgs = {
   newValue: string;
-  numberType?: string;
+  numberType?: FieldNumberVariant;
 };
 
 type GetNumberValueToPersistResult = {
@@ -20,13 +21,24 @@ export const getNumberValueToPersist = ({
   numberType,
 }: GetNumberValueToPersistArgs): GetNumberValueToPersistResult => {
   if (numberType === 'percentage') {
-    const newValueEscaped = newValue.replaceAll('%', '');
+    const trimmedValue = newValue.trim();
 
-    if (!canBeCastAsNumberOrNull(newValueEscaped)) {
+    if (trimmedValue === '%') {
       return { success: false };
     }
 
-    const castedValue = castAsNumberOrNull(newValueEscaped);
+    const valueWithoutPercent = trimmedValue.endsWith('%')
+      ? trimmedValue.slice(0, -1).trim()
+      : trimmedValue;
+
+    if (
+      valueWithoutPercent.includes('%') ||
+      !canBeCastAsNumberOrNull(valueWithoutPercent)
+    ) {
+      return { success: false };
+    }
+
+    const castedValue = castAsNumberOrNull(valueWithoutPercent);
 
     if (!isNull(castedValue)) {
       return { success: true, value: castedValue / 100 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
@@ -1,0 +1,45 @@
+import { isNull } from '@sniptt/guards';
+
+import {
+  canBeCastAsNumberOrNull,
+  castAsNumberOrNull,
+} from '~/utils/cast-as-number-or-null';
+
+type GetNumberValueToPersistArgs = {
+  newValue: string;
+  numberType?: string;
+};
+
+type GetNumberValueToPersistResult = {
+  success: boolean;
+  value?: number | null;
+};
+
+export const getNumberValueToPersist = ({
+  newValue,
+  numberType,
+}: GetNumberValueToPersistArgs): GetNumberValueToPersistResult => {
+  if (numberType === 'percentage') {
+    const newValueEscaped = newValue.replaceAll('%', '');
+
+    if (!canBeCastAsNumberOrNull(newValueEscaped)) {
+      return { success: false };
+    }
+
+    const castedValue = castAsNumberOrNull(newValueEscaped);
+
+    if (!isNull(castedValue)) {
+      return { success: true, value: castedValue / 100 };
+    }
+
+    return { success: true, value: null };
+  }
+
+  if (!canBeCastAsNumberOrNull(newValue)) {
+    return { success: false };
+  }
+
+  const castedValue = castAsNumberOrNull(newValue);
+
+  return { success: true, value: castedValue };
+};

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
@@ -1,5 +1,6 @@
 import { isNull } from '@sniptt/guards';
-import { type FieldNumberVariant } from 'twenty-shared/types';
+
+import { type FieldNumberVariant } from '@/object-record/record-field/ui/types/FieldMetadata';
 
 import {
   canBeCastAsNumberOrNull,


### PR DESCRIPTION
## Description

When editing a percentage-type number field in `NumberFieldInput`, the input value may contain a `%` character. The code previously created `newValueEscaped` by removing `%` and validated it with `canBeCastAsNumberOrNull(newValueEscaped)`, but then incorrectly called `castAsNumberOrNull(newValue)` with the raw, unescaped string. Because `castAsNumberOrNull` expects a plain numeric string, passing an input with `%` threw an unhandled error (`Error: Cannot cast to number or null`), crashing on outside click, enter, or tab.

## Changes
- Extracted `getNumberValueToPersist` helper into a dedicated, unit-tested module (`packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts`).
- Passed `newValueEscaped` instead of `newValue` to `castAsNumberOrNull` when `numberType === 'percentage'`.
- Added unit tests covering standard numbers and percentage inputs with and without the `%` symbol.

Closes #17677

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

