### PR TITLE
fix(twenty-server): separate app-dev file upload throttle budget

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-development/__tests__/application-development.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/__tests__/application-development.service.spec.ts
@@ -1,0 +1,116 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { FileFolder } from 'twenty-shared/types';
+
+import { ApplicationDevelopmentService } from 'src/engine/core-modules/application/application-development/application-development.service';
+import {
+  APP_DEV_FILE_UPLOAD_RATE_LIMIT_MAX,
+  APP_DEV_FILE_UPLOAD_RATE_LIMIT_WINDOW_MS,
+  APP_DEV_RATE_LIMIT_MAX,
+  APP_DEV_RATE_LIMIT_WINDOW_MS,
+} from 'src/engine/core-modules/application/application-development/constants/application-development.constants';
+import { ApplicationManifestApplyService } from 'src/engine/core-modules/application/application-manifest/application-manifest-apply.service';
+import { ApplicationSyncService } from 'src/engine/core-modules/application/application-manifest/application-sync.service';
+import { ApplicationManifestExportService } from 'src/engine/core-modules/application/application-manifest/services/application-manifest-export.service';
+import { ApplicationVersionValidationService } from 'src/engine/core-modules/application/application-package/application-version-validation.service';
+import { ApplicationRegistrationAssetService } from 'src/engine/core-modules/application/application-registration/application-registration-asset.service';
+import { ApplicationRegistrationService } from 'src/engine/core-modules/application/application-registration/application-registration.service';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
+import { FileStorageService } from 'src/engine/core-modules/file-storage/services/file-storage.service';
+import { ThrottlerService } from 'src/engine/core-modules/throttler/throttler.service';
+
+const WORKSPACE_ID = 'test-workspace-id';
+const APPLICATION_UNIVERSAL_IDENTIFIER = 'test-app-uid';
+
+describe('ApplicationDevelopmentService', () => {
+  let service: ApplicationDevelopmentService;
+
+  const throttlerService = {
+    tokenBucketThrottleOrThrow: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const applicationService = {
+    findByUniversalIdentifier: jest.fn().mockResolvedValue({
+      id: 'app-id',
+      universalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+    }),
+  };
+
+  const applicationRegistrationService = {
+    findOneByUniversalIdentifierGlobal: jest.fn().mockResolvedValue({
+      id: 'app-reg-id',
+      ownerWorkspaceId: WORKSPACE_ID,
+    }),
+  };
+
+  const fileStorageService = {
+    writeFile: jest.fn().mockResolvedValue({
+      id: 'file-id',
+      resourcePath: 'index.ts',
+    }),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationDevelopmentService,
+        { provide: ApplicationService, useValue: applicationService },
+        { provide: ApplicationSyncService, useValue: {} },
+        { provide: ApplicationManifestApplyService, useValue: {} },
+        { provide: ApplicationManifestExportService, useValue: {} },
+        {
+          provide: ApplicationRegistrationService,
+          useValue: applicationRegistrationService,
+        },
+        { provide: ApplicationRegistrationAssetService, useValue: {} },
+        { provide: ApplicationVersionValidationService, useValue: {} },
+        { provide: FileStorageService, useValue: fileStorageService },
+        { provide: ThrottlerService, useValue: throttlerService },
+        { provide: CacheLockService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<ApplicationDevelopmentService>(
+      ApplicationDevelopmentService,
+    );
+  });
+
+  describe('uploadApplicationFile', () => {
+    it('should throttle file uploads using dedicated bucket with higher rate limit', async () => {
+      await service.uploadApplicationFile({
+        workspaceId: WORKSPACE_ID,
+        applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+        fileFolder: FileFolder.Source,
+        filePath: 'index.ts',
+        getFileBuffer: async () => Buffer.from('console.log("hello")'),
+      });
+
+      expect(throttlerService.tokenBucketThrottleOrThrow).toHaveBeenCalledWith(
+        `app-dev-file-upload:${WORKSPACE_ID}:${APPLICATION_UNIVERSAL_IDENTIFIER}`,
+        1,
+        APP_DEV_FILE_UPLOAD_RATE_LIMIT_MAX,
+        APP_DEV_FILE_UPLOAD_RATE_LIMIT_WINDOW_MS,
+      );
+    });
+  });
+
+  describe('createDevelopmentApplication', () => {
+    it('should throttle createDevelopmentApplication using general app-dev bucket', async () => {
+      await service.createDevelopmentApplication({
+        universalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+        name: 'Test App',
+        workspaceId: WORKSPACE_ID,
+      });
+
+      expect(throttlerService.tokenBucketThrottleOrThrow).toHaveBeenCalledWith(
+        `app-dev:${WORKSPACE_ID}:${APPLICATION_UNIVERSAL_IDENTIFIER}`,
+        1,
+        APP_DEV_RATE_LIMIT_MAX,
+        APP_DEV_RATE_LIMIT_WINDOW_MS,
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.service.ts
@@ -5,6 +5,8 @@ import { isDefined } from 'twenty-shared/utils';
 
 import {
   ALLOWED_APPLICATION_FILE_FOLDERS,
+  APP_DEV_FILE_UPLOAD_RATE_LIMIT_MAX,
+  APP_DEV_FILE_UPLOAD_RATE_LIMIT_WINDOW_MS,
   APP_DEV_RATE_LIMIT_MAX,
   APP_DEV_RATE_LIMIT_WINDOW_MS,
 } from 'src/engine/core-modules/application/application-development/constants/application-development.constants';
@@ -192,7 +194,7 @@ export class ApplicationDevelopmentService {
     // Lazy so rejected or rate-limited uploads are not buffered into memory.
     getFileBuffer: () => Promise<Buffer>;
   }): Promise<FileDTO> {
-    await this.throttlePerApplication(
+    await this.throttleFileUploadPerApplication(
       applicationUniversalIdentifier,
       workspaceId,
     );
@@ -296,6 +298,18 @@ export class ApplicationDevelopmentService {
       1,
       APP_DEV_RATE_LIMIT_MAX,
       APP_DEV_RATE_LIMIT_WINDOW_MS,
+    );
+  }
+
+  private async throttleFileUploadPerApplication(
+    applicationIdentifier: string,
+    workspaceId: string,
+  ): Promise<void> {
+    await this.throttlerService.tokenBucketThrottleOrThrow(
+      `app-dev-file-upload:${workspaceId}:${applicationIdentifier}`,
+      1,
+      APP_DEV_FILE_UPLOAD_RATE_LIMIT_MAX,
+      APP_DEV_FILE_UPLOAD_RATE_LIMIT_WINDOW_MS,
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/constants/application-development.constants.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/constants/application-development.constants.ts
@@ -3,6 +3,9 @@ import { FileFolder } from 'twenty-shared/types';
 export const APP_DEV_RATE_LIMIT_MAX = 30;
 export const APP_DEV_RATE_LIMIT_WINDOW_MS = 30_000;
 
+export const APP_DEV_FILE_UPLOAD_RATE_LIMIT_MAX = 300;
+export const APP_DEV_FILE_UPLOAD_RATE_LIMIT_WINDOW_MS = 30_000;
+
 export const MAX_APPLICATION_FILE_UPLOAD_BATCH_SIZE = 100;
 
 export const ALLOWED_APPLICATION_FILE_FOLDERS: FileFolder[] = [


### PR DESCRIPTION
<!-- Describe the changes being made in this PR -->
### What this PR does

When running `twenty apply` on an application that contains multiple files, `uploadApplicationFile` consumed tokens from the shared `app-dev:${workspaceId}:${applicationIdentifier}` rate-limit bucket (limit 30 per 30 seconds). As a result, projects with 29+ files quickly hit the token limit before `syncApplication` could complete.

This PR introduces a dedicated token-bucket limiter for `uploadApplicationFile` (`app-dev-file-upload:${workspaceId}:${applicationIdentifier}`) with a limit of 300 requests per 30 seconds, while preserving the stricter 30 requests per 30 seconds limit for `createDevelopmentApplication` and `syncApplication`.

<!-- Link the issue being closed, e.g. Closes #1234 -->
Closes #23056

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

