### PR TITLE
fix(twenty-front): pair parent record with its metadata in relation section dropdown

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown.tsx
@@ -19,37 +19,24 @@ export const RecordDetailRelationSectionDropdown = ({
 }: RecordDetailRelationSectionDropdownProps) => {
   const { fieldDefinition, isRecordFieldReadOnly, recordId } =
     useContext(FieldContext);
-  const {
-    relationType,
-    objectMetadataNameSingular,
-    relationObjectMetadataNameSingular,
-  } = fieldDefinition.metadata as FieldRelationMetadata;
+  const { relationType, objectMetadataNameSingular } =
+    fieldDefinition.metadata as FieldRelationMetadata;
 
   const { objectMetadataItem: recordObjectMetadataItem } =
     useObjectMetadataItem({
       objectNameSingular: objectMetadataNameSingular ?? '',
     });
 
-  const { objectMetadataItem: relationObjectMetadataItem } =
-    useObjectMetadataItem({
-      objectNameSingular: relationObjectMetadataNameSingular,
-    });
   // TODO: use new relation type
   const isToOneObject = relationType === RelationType.MANY_TO_ONE;
   const isToManyObjects = relationType === RelationType.ONE_TO_MANY;
 
-  const isRecordReadOnlyFromRelatedRecordPerspective = useIsRecordReadOnly({
+  const isParentRecordReadOnly = useIsRecordReadOnly({
     recordId,
-    objectMetadataId: isToOneObject
-      ? recordObjectMetadataItem.id
-      : relationObjectMetadataItem.id,
+    objectMetadataId: recordObjectMetadataItem.id,
   });
 
-  if (
-    loading ||
-    isRecordFieldReadOnly ||
-    isRecordReadOnlyFromRelatedRecordPerspective
-  ) {
+  if (loading || isRecordFieldReadOnly || isParentRecordReadOnly) {
     return null;
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/__tests__/RecordDetailRelationSectionDropdown.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/__tests__/RecordDetailRelationSectionDropdown.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react';
+
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useIsRecordReadOnly } from '@/object-record/read-only/hooks/useIsRecordReadOnly';
+import { RecordDetailRelationSectionDropdown } from '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown';
+import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
+import { RelationType } from '~/generated-metadata/graphql';
+
+jest.mock('@/object-metadata/hooks/useObjectMetadataItem', () => ({
+  useObjectMetadataItem: jest.fn(),
+}));
+
+jest.mock('@/object-record/read-only/hooks/useIsRecordReadOnly', () => ({
+  useIsRecordReadOnly: jest.fn(),
+}));
+
+jest.mock(
+  '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToOne',
+  () => ({
+    RecordDetailRelationSectionDropdownToOne: () => (
+      <div data-testid="dropdown-to-one" />
+    ),
+  }),
+);
+
+jest.mock(
+  '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany',
+  () => ({
+    RecordDetailRelationSectionDropdownToMany: () => (
+      <div data-testid="dropdown-to-many" />
+    ),
+  }),
+);
+
+describe('RecordDetailRelationSectionDropdown', () => {
+  const mockUseObjectMetadataItem = useObjectMetadataItem as jest.Mock;
+  const mockUseIsRecordReadOnly = useIsRecordReadOnly as jest.Mock;
+
+  const companyRecordId = 'company-123';
+  const companyObjectMetadataId = 'meta-company-123';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseObjectMetadataItem.mockReturnValue({
+      objectMetadataItem: {
+        id: companyObjectMetadataId,
+        nameSingular: 'company',
+      },
+    });
+    mockUseIsRecordReadOnly.mockReturnValue(false);
+  });
+
+  const renderComponent = ({
+    loading = false,
+    isRecordFieldReadOnly = false,
+    relationType = RelationType.ONE_TO_MANY,
+  }: {
+    loading?: boolean;
+    isRecordFieldReadOnly?: boolean;
+    relationType?: RelationType;
+  } = {}) => {
+    return render(
+      <FieldContext.Provider
+        value={
+          {
+            recordId: companyRecordId,
+            isRecordFieldReadOnly,
+            fieldDefinition: {
+              metadata: {
+                relationType,
+                objectMetadataNameSingular: 'company',
+                relationObjectMetadataNameSingular: 'product',
+              },
+            },
+          } as any
+        }
+      >
+        <RecordDetailRelationSectionDropdown loading={loading} />
+      </FieldContext.Provider>,
+    );
+  };
+
+  it('checks read-only state using parent recordId and parent objectMetadataId', () => {
+    renderComponent({ relationType: RelationType.ONE_TO_MANY });
+
+    expect(mockUseIsRecordReadOnly).toHaveBeenCalledWith({
+      recordId: companyRecordId,
+      objectMetadataId: companyObjectMetadataId,
+    });
+    expect(screen.getByTestId('dropdown-to-many')).toBeInTheDocument();
+  });
+
+  it('renders dropdown-to-one when relation is MANY_TO_ONE', () => {
+    renderComponent({ relationType: RelationType.MANY_TO_ONE });
+
+    expect(mockUseIsRecordReadOnly).toHaveBeenCalledWith({
+      recordId: companyRecordId,
+      objectMetadataId: companyObjectMetadataId,
+    });
+    expect(screen.getByTestId('dropdown-to-one')).toBeInTheDocument();
+  });
+
+  it('renders null when parent record is read-only', () => {
+    mockUseIsRecordReadOnly.mockReturnValue(true);
+
+    const { container } = renderComponent();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders null when relation field is read-only', () => {
+    const { container } = renderComponent({ isRecordFieldReadOnly: true });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders null when loading is true', () => {
+    const { container } = renderComponent({ loading: true });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
<!-- Auto-closing linked issue -->
Closes #24351

## Problem

In record detail views (such as a Company record), relation sections for custom objects (e.g. Products) failed to render the action dropdown menu and the '+' item creation button on hover.

In `RecordDetailRelationSectionDropdown.tsx`, for ONE_TO_MANY relations (`isToOneObject === false`), `useIsRecordReadOnly` was called with the parent record ID (`recordId`) and the relation object's metadata ID (`relationObjectMetadataItem.id`). This mismatched pairing passed the parent's record ID to `useIsRecordDeleted({ recordId })` while evaluating read-only state against the related object's metadata, improperly hiding the section action dropdown.

## Solution

- Correct `useIsRecordReadOnly` in `RecordDetailRelationSectionDropdown.tsx` to always pass `recordObjectMetadataItem.id` alongside `recordId` so the parent record's read-only state is accurately determined.
- Remove the unused `relationObjectMetadataNameSingular` and `relationObjectMetadataItem` lookups.
- Add unit test suite for `RecordDetailRelationSectionDropdown` verifying read-only evaluation and conditional dropdown rendering.

## Verification

- `npx jest packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/__tests__/RecordDetailRelationSectionDropdown.test.tsx --config=packages/twenty-front/jest.config.mjs --runInBand` passed (5/5 tests).
- `npx nx lint:diff-with-main twenty-front --skip-nx-cache` passed with 0 errors and 0 warnings.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

