### PR TITLE
fix(twenty-front): match floating inline cell editor width to reference anchor

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
@@ -13,6 +13,7 @@ import {
   flip,
   offset,
   shift,
+  size,
   useFloating,
   type MiddlewareState,
 } from '@floating-ui/react';
@@ -25,7 +26,9 @@ const StyledInlineCellEditModeContainer = styled.div`
   background: transparent;
   display: flex;
   height: 24px;
+  left: 0;
   position: absolute;
+  top: 0;
 
   width: 100%;
 `;
@@ -83,6 +86,14 @@ export const RecordInlineCellEditMode = ({
               crossAxis: -5,
             },
       ),
+      size({
+        apply({ rects, elements, availableWidth }) {
+          if (!isCentered && rects.reference.width > 0) {
+            elements.floating.style.minWidth = `${rects.reference.width}px`;
+          }
+          elements.floating.style.maxWidth = `${availableWidth}px`;
+        },
+      }),
       shift({ padding: 8 }),
       setFieldInputLayoutDirectionMiddleware,
     ],

--- a/packages/twenty-front/src/modules/ui/field/input/components/TextAreaInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/TextAreaInput.tsx
@@ -25,7 +25,10 @@ export type TextAreaInputProps = {
   copyButton?: boolean;
 };
 
-const StyledTextAreaContainer = styled.div`
+const StyledTextAreaContainer = styled.div<{ hasCopyButton?: boolean }>`
+  flex: 1;
+  width: 100%;
+
   > textarea {
     align-items: center;
     background-color: transparent;
@@ -50,7 +53,8 @@ const StyledTextAreaContainer = styled.div`
     padding: ${themeCssVariables.spacing[0]} ${themeCssVariables.spacing[2]};
     resize: none;
 
-    width: calc(100% - ${themeCssVariables.spacing[7]});
+    width: ${({ hasCopyButton }) =>
+      hasCopyButton ? `calc(100% - ${themeCssVariables.spacing[7]})` : '100%'};
   }
 `;
 
@@ -113,7 +117,7 @@ export const TextAreaInput = ({
 
   return (
     <>
-      <StyledTextAreaContainer>
+      <StyledTextAreaContainer hasCopyButton={copyButton}>
         <TextareaAutosize
           placeholder={placeholder}
           disabled={disabled}


### PR DESCRIPTION
Closes #22841

## Context

When clicking on a text field in a widened side panel or show page, the floating inline editor rendered with a default collapsed width (~200px) instead of matching the field anchor width. This caused longer single-line text values to wrap prematurely into multiple lines in the textarea, leaving the unhidden display text underneath partially exposed to the right.

## Root Cause

1. `RecordInlineCellEditMode` positions the floating `OverlayContainer` using Floating UI without the `size` middleware. As a result, the portaled floating container relied on intrinsic content width and collapsed to `FieldInputContainer`'s `min-width: 200px`.
2. `StyledInlineCellEditModeContainer` lacked explicit `top: 0; left: 0;`, relying on static positioning inside `StyledValueContainer`.
3. In `TextAreaInput`, `StyledTextAreaContainer` lacked `flex: 1` and `width: 100%`, preventing the textarea container from filling available horizontal space inside the input container.

## Changes

1. In `RecordInlineCellEditMode.tsx`:
   - Anchored `StyledInlineCellEditModeContainer` explicitly with `top: 0; left: 0;`.
   - Added Floating UI's `size()` middleware setting `minWidth` to `rects.reference.width` (for non-centered layouts) and `maxWidth` to `availableWidth`. Using `minWidth` ensures wide panels expand to match the cell anchor while multi-field or naturally wider components (e.g. address, rich text) are never clipped when placed in narrow columns.
2. In `TextAreaInput.tsx`:
   - Added `flex: 1; width: 100%;` to `StyledTextAreaContainer`.
   - Dynamically calculated textarea width (`calc(100% - spacing[7])` when the copy button is present, `100%` when omitted).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

