### PR TITLE
fix(twenty-shared): honor wildcard parity in rich text ilike filter

### DIFF
--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts
@@ -28,6 +28,118 @@ describe('isMatchingRichTextFilter', () => {
         }),
       ).toBe(true);
     });
+
+    it('should treat underscore as a single character wildcard like SQL ILIKE', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'a_c' } },
+          value: 'abc',
+        }),
+      ).toBe(true);
+    });
+
+    it('should not match several characters for underscore', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'a_c' } },
+          value: 'abxc',
+        }),
+      ).toBe(false);
+    });
+
+    it('should match a newline with underscore like SQL ILIKE', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'a_c' } },
+          value: 'a\nc',
+        }),
+      ).toBe(true);
+    });
+
+    it('should match a newline with percent like SQL ILIKE', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'a%c' } },
+          value: 'a\nc',
+        }),
+      ).toBe(true);
+    });
+
+    it('should match an astral character with underscore like SQL ILIKE', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'a_c' } },
+          value: 'a\u{1F600}c',
+        }),
+      ).toBe(true);
+    });
+
+    it('should keep an escaped percent literal like SQL ILIKE', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '100\\%' } },
+          value: '100%',
+        }),
+      ).toBe(true);
+    });
+
+    it('should not let an escaped percent act as a wildcard', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '100\\%' } },
+          value: '100a',
+        }),
+      ).toBe(false);
+    });
+
+    it('should keep an escaped underscore literal like SQL ILIKE', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'a\\_c' } },
+          value: 'a_c',
+        }),
+      ).toBe(true);
+    });
+
+    it('should not let an escaped underscore act as a wildcard', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'a\\_c' } },
+          value: 'abc',
+        }),
+      ).toBe(false);
+    });
+
+    it('should keep an escaped backslash literal like SQL ILIKE', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'a\\\\c' } },
+          value: 'a\\c',
+        }),
+      ).toBe(true);
+    });
+
+    it('should keep a trailing escape char literal', () => {
+      // postgres rejects a pattern ending with a lone escape char, the mirror
+      // stays lenient and treats it as a literal backslash
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'abc\\' } },
+          value: 'abc\\',
+        }),
+      ).toBe(true);
+    });
+
+    it('should not match when the markdown filter has no ilike', () => {
+      // ILIKE NULL is never true in postgres, the old code matched the literal
+      // word undefined bcs escapeRegExp coerced its argument
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: {} },
+          value: 'undefined',
+        }),
+      ).toBe(false);
+    });
   });
 
   describe('default', () => {

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingRichTextFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingRichTextFilter.ts
@@ -1,5 +1,37 @@
 import { type RichTextFilter } from '@/types';
+import { isDefined } from '@/utils/validation/isDefined';
 import escapeRegExp from 'lodash.escaperegexp';
+
+// postgres ILIKE treats a backslash as an escape for the next char (default
+// escape char), so an escaped % or _ is a literal and must not become a
+// wildcard, the walk parses escape sequences before the wildcard translation
+const translateIlikeWildcards = (pattern: string): string => {
+  let translated = '';
+  let isEscaped = false;
+
+  for (const char of pattern) {
+    if (isEscaped) {
+      translated += escapeRegExp(char);
+      isEscaped = false;
+    } else if (char === '\\') {
+      isEscaped = true;
+    } else if (char === '%') {
+      translated += '[\\s\\S]*';
+    } else if (char === '_') {
+      translated += '[\\s\\S]';
+    } else {
+      translated += escapeRegExp(char);
+    }
+  }
+
+  // postgres rejects an ILIKE pattern ending with a lone escape char, the
+  // mirror stays lenient and keeps it as a literal backslash
+  if (isEscaped) {
+    translated += escapeRegExp('\\');
+  }
+
+  return translated;
+};
 
 export const isMatchingRichTextFilter = ({
   richTextFilter,
@@ -10,9 +42,18 @@ export const isMatchingRichTextFilter = ({
 }) => {
   switch (true) {
     case richTextFilter.markdown !== undefined: {
-      const escapedPattern = escapeRegExp(richTextFilter.markdown.ilike);
-      const regexPattern = escapedPattern.replace(/%/g, '.*');
-      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'i');
+      // a markdown leaf without ilike matches nothing in postgres (ILIKE NULL
+      // is never true), the mirror returns false instead of coercing a string
+      if (!isDefined(richTextFilter.markdown.ilike)) {
+        return false;
+      }
+
+      // the u flag keeps both wildcards code-point based so postgres parity
+      // holds for newline and astral values (% and _ match a\nc / a\ud83d\ude00c in postgres)
+      const regexPattern = translateIlikeWildcards(
+        richTextFilter.markdown.ilike,
+      );
+      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'iu');
 
       return regexCaseInsensitive.test(value);
     }


### PR DESCRIPTION
> **Context:** sibling of #25489 (string like/ilike) and #25485 (array containsIlike). Same parity break, rich text side: isMatchingRichTextFilter (packages/twenty-shared/src/utils/filter/utils/isMatchingRichTextFilter.ts) translates % in the markdown ilike case but leaves _ as a literal underscore
>
> **Fixes #25652** — this PR also closes the rich text side (`_` matches one char incl newline, `%` matches any sequence incl newlines, escaped chars stay literal)

## Summary

- sql ILIKE treats _ as a single character wildcard and % matches any sequence including newlines, the in-memory mirror only translated % to .* without dotall, so a markdown filter could grant a row in postgres and deny it in memory
- this shows up on the update path: the enterprise rls predicate (is-record-matching-rls-row-level-permission-predicate.util.ts) routes RICH_TEXT fields through isMatchingRichTextFilter, so a rule with _ or a multiline % pattern denies updates the database would grant
- the fix parses backslash escapes before the wildcard translation (postgres default escape char), matches both wildcards code-point aware with the u flag, and a markdown leaf without ilike returns false like ILIKE NULL does in postgres

### Steps to reproduce

1. npx jest packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts --config=packages/twenty-shared/jest.config.mjs
2. Expected: the wildcard parity cases pass, SQL parity means ILIKE 'a_c' matches 'abc' and 'a\nc' in postgres
3. Actual (raw output on untouched main 46965e1f):

```
FAIL twenty-shared packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts
  ● isMatchingRichTextFilter › markdown ilike › should treat underscore as a single character wildcard like SQL ILIKE

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      36 |           value: 'abc',
      37 |         }),
    > 38 |       ).toBe(true);
         |         ^
      at Object.toBe (src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts:38:9)

  ● isMatchingRichTextFilter › markdown ilike › should match a newline with underscore like SQL ILIKE

    Expected: true
    Received: false

      54 |           value: 'a\nc',
    > 56 |       ).toBe(true);
      at Object.toBe (src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts:56:9)

  ● isMatchingRichTextFilter › markdown ilike › should match a newline with percent like SQL ILIKE

    Expected: true
    Received: false

      63 |           value: 'a\nc',
    > 65 |       ).toBe(true);
      at Object.toBe (src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts:65:9)

  ● isMatchingRichTextFilter › markdown ilike › should match an astral character with underscore like SQL ILIKE

    Expected: true
    Received: false

      72 |           value: 'a\u{1F600}c',
    > 74 |       ).toBe(true);
      at Object.toBe (src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts:74:9)

  ● isMatchingRichTextFilter › markdown ilike › should keep an escaped percent literal like SQL ILIKE

    Expected: true
    Received: false

      81 |           value: '100%',
    > 83 |       ).toBe(true);
      at Object.toBe (src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts:83:9)

Tests:       7 failed, 9 passed, 16 total
```

(the five shown are the wildcard parity cores, the other two red are the escaped-backslash and no-ilike cases, stack traces trimmed to the assertion cores)

## Testing

- the spec is 16/16 green with the fix and 7 red without it (checked out main's isMatchingRichTextFilter.ts over the fix and re-ran, the five wildcard cores above plus the escaped-backslash and no-ilike cases fail)
- whole filter suite 43 suites / 560 tests green, tsgo typecheck clean, nx lint twenty-shared clean