### PR TITLE
Keep text styles visible in closed rich text cells

### DIFF
--- a/packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/getFirstNonEmptyLineOfRichTextSegments.test.ts
+++ b/packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/getFirstNonEmptyLineOfRichTextSegments.test.ts
@@ -1,0 +1,68 @@
+import type { PartialBlock } from '@blocknote/core';
+
+import {
+  getFirstNonEmptyLineOfRichTextSegments,
+  getRichTextPreviewSegmentStyle,
+} from '@/blocknote-editor/utils/getFirstNonEmptyLineOfRichTextSegments';
+
+describe('getFirstNonEmptyLineOfRichTextSegments', () => {
+  it('returns an empty array if the input is null', () => {
+    expect(getFirstNonEmptyLineOfRichTextSegments(null)).toEqual([]);
+  });
+
+  it('keeps strike on the first non-empty line', () => {
+    const input: PartialBlock[] = [
+      { content: [{ text: '', type: 'text', styles: {} }] },
+      {
+        content: [
+          {
+            text: 'cancelled meeting',
+            type: 'text',
+            styles: { strike: true },
+          },
+        ],
+      },
+    ];
+
+    expect(getFirstNonEmptyLineOfRichTextSegments(input)).toEqual([
+      { text: 'cancelled meeting', styles: { strike: true } },
+    ]);
+  });
+
+  it('keeps mixed styles across inlines on the first line', () => {
+    const input: PartialBlock[] = [
+      {
+        content: [
+          { text: 'Keep ', type: 'text', styles: {} },
+          { text: 'this', type: 'text', styles: { strike: true } },
+          { text: 'that', type: 'text', styles: { underline: true } },
+        ],
+      },
+    ];
+
+    expect(getFirstNonEmptyLineOfRichTextSegments(input)).toEqual([
+      { text: 'Keep ', styles: {} },
+      { text: 'this', styles: { strike: true } },
+      { text: 'that', styles: { underline: true } },
+    ]);
+  });
+});
+
+describe('getRichTextPreviewSegmentStyle', () => {
+  it('maps strike to line-through', () => {
+    expect(getRichTextPreviewSegmentStyle({ strike: true })).toEqual({
+      textDecorationLine: 'line-through',
+    });
+  });
+
+  it('maps underline and strike onto one text-decoration-line', () => {
+    expect(
+      getRichTextPreviewSegmentStyle({
+        underline: true,
+        strike: true,
+      }),
+    ).toEqual({
+      textDecorationLine: 'underline line-through',
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/getFirstNonEmptyLineOfRichTextSegments.test.ts
+++ b/packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/getFirstNonEmptyLineOfRichTextSegments.test.ts
@@ -46,6 +46,24 @@ describe('getFirstNonEmptyLineOfRichTextSegments', () => {
       { text: 'that', styles: { underline: true } },
     ]);
   });
+
+  it('keeps a space between two styled words', () => {
+    const input: PartialBlock[] = [
+      {
+        content: [
+          { text: 'Hello', type: 'text', styles: { bold: true } },
+          { text: ' ', type: 'text', styles: {} },
+          { text: 'World', type: 'text', styles: { bold: true } },
+        ],
+      },
+    ];
+
+    expect(
+      getFirstNonEmptyLineOfRichTextSegments(input)
+        .map((segment) => segment.text)
+        .join(''),
+    ).toBe('Hello World');
+  });
 });
 
 describe('getRichTextPreviewSegmentStyle', () => {
@@ -53,16 +71,8 @@ describe('getRichTextPreviewSegmentStyle', () => {
     expect(getRichTextPreviewSegmentStyle({ strike: true })).toEqual({
       textDecorationLine: 'line-through',
     });
-  });
-
-  it('maps underline and strike onto one text-decoration-line', () => {
     expect(
-      getRichTextPreviewSegmentStyle({
-        underline: true,
-        strike: true,
-      }),
-    ).toEqual({
-      textDecorationLine: 'underline line-through',
-    });
+      getRichTextPreviewSegmentStyle({ underline: true, strike: true }),
+    ).toEqual({ textDecorationLine: 'underline line-through' });
   });
 });

--- a/packages/twenty-front/src/modules/blocknote-editor/utils/getFirstNonEmptyLineOfRichTextSegments.ts
+++ b/packages/twenty-front/src/modules/blocknote-editor/utils/getFirstNonEmptyLineOfRichTextSegments.ts
@@ -78,7 +78,7 @@ const getSegmentsFromInline = (
     return inline.content.flatMap(getSegmentsFromInline);
   }
 
-  if (!isDefined(inline.text) || inline.text.trim() === '') {
+  if (!isDefined(inline.text) || inline.text === '') {
     return [];
   }
 
@@ -117,8 +117,9 @@ export const getFirstNonEmptyLineOfRichTextSegments = (
 
   for (const block of blocks) {
     const segments = getSegmentsFromContent(block.content);
+    const lineText = segments.map((segment) => segment.text).join('');
 
-    if (segments.length > 0) {
+    if (lineText.trim() !== '') {
       return segments;
     }
   }

--- a/packages/twenty-front/src/modules/blocknote-editor/utils/getFirstNonEmptyLineOfRichTextSegments.ts
+++ b/packages/twenty-front/src/modules/blocknote-editor/utils/getFirstNonEmptyLineOfRichTextSegments.ts
@@ -1,0 +1,127 @@
+import type { PartialBlock } from '@blocknote/core';
+import { isDefined } from 'twenty-shared/utils';
+
+const PREVIEW_STYLE_KEYS = [
+  'bold',
+  'italic',
+  'underline',
+  'strike',
+  'code',
+] as const;
+
+type RichTextPreviewStyleKey = (typeof PREVIEW_STYLE_KEYS)[number];
+
+export type RichTextPreviewStyles = {
+  [styleKey in RichTextPreviewStyleKey]?: boolean;
+};
+
+export type RichTextPreviewSegment = {
+  text: string;
+  styles: RichTextPreviewStyles;
+};
+
+type BlockNoteInline = {
+  type?: string;
+  text?: string;
+  styles?: Record<string, unknown>;
+  content?: BlockNoteInline[];
+};
+
+export type RichTextPreviewSegmentStyle = {
+  fontWeight?: 'bold';
+  fontStyle?: 'italic';
+  textDecorationLine?: string;
+  fontFamily?: 'monospace';
+};
+
+export const getRichTextPreviewSegmentStyle = (
+  styles: RichTextPreviewStyles,
+): RichTextPreviewSegmentStyle => {
+  const textDecorationLine = [
+    styles.underline === true ? 'underline' : undefined,
+    styles.strike === true ? 'line-through' : undefined,
+  ]
+    .filter(isDefined)
+    .join(' ');
+
+  return {
+    ...(styles.bold === true ? { fontWeight: 'bold' } : {}),
+    ...(styles.italic === true ? { fontStyle: 'italic' } : {}),
+    ...(textDecorationLine.length > 0 ? { textDecorationLine } : {}),
+    ...(styles.code === true ? { fontFamily: 'monospace' } : {}),
+  };
+};
+
+const getPreviewStyles = (
+  styles: Record<string, unknown> | undefined,
+): RichTextPreviewStyles => {
+  if (!isDefined(styles)) {
+    return {};
+  }
+
+  return PREVIEW_STYLE_KEYS.reduce<RichTextPreviewStyles>(
+    (previewStyles, styleKey) => {
+      if (styles[styleKey] === true) {
+        return { ...previewStyles, [styleKey]: true };
+      }
+
+      return previewStyles;
+    },
+    {},
+  );
+};
+
+const getSegmentsFromInline = (
+  inline: BlockNoteInline,
+): RichTextPreviewSegment[] => {
+  if (inline.type === 'link' && Array.isArray(inline.content)) {
+    return inline.content.flatMap(getSegmentsFromInline);
+  }
+
+  if (!isDefined(inline.text) || inline.text.trim() === '') {
+    return [];
+  }
+
+  return [
+    {
+      text: inline.text,
+      styles: getPreviewStyles(inline.styles),
+    },
+  ];
+};
+
+const getSegmentsFromContent = (
+  content: PartialBlock['content'],
+): RichTextPreviewSegment[] => {
+  if (typeof content === 'string') {
+    return content.trim() === '' ? [] : [{ text: content, styles: {} }];
+  }
+
+  if (!isDefined(content)) {
+    return [];
+  }
+
+  const contentItems = Array.isArray(content) ? content : [content];
+
+  return contentItems.flatMap((contentItem) =>
+    getSegmentsFromInline(contentItem as BlockNoteInline),
+  );
+};
+
+export const getFirstNonEmptyLineOfRichTextSegments = (
+  blocks: PartialBlock[] | null,
+): RichTextPreviewSegment[] => {
+  if (!isDefined(blocks)) {
+    return [];
+  }
+
+  for (const block of blocks) {
+    const segments = getSegmentsFromContent(block.content);
+
+    if (segments.length > 0) {
+      return segments;
+    }
+  }
+
+  return [];
+};

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RichTextFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RichTextFieldDisplay.tsx
@@ -1,15 +1,26 @@
-import { useRichTextFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRichTextFieldDisplay';
-import { getFirstNonEmptyLineOfRichText } from '@/blocknote-editor/utils/getFirstNonEmptyLineOfRichText';
+import {
+  getFirstNonEmptyLineOfRichTextSegments,
+  getRichTextPreviewSegmentStyle,
+} from '@/blocknote-editor/utils/getFirstNonEmptyLineOfRichTextSegments';
 import { parseInitialBlocknote } from '@/blocknote-editor/utils/parseInitialBlocknote';
+import { useRichTextFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRichTextFieldDisplay';
 
 export const RichTextFieldDisplay = () => {
   const { fieldValue } = useRichTextFieldDisplay();
 
   const blocks = parseInitialBlocknote(fieldValue?.blocknote) ?? null;
+  const segments = getFirstNonEmptyLineOfRichTextSegments(blocks);
 
   return (
     <div>
-      <span>{getFirstNonEmptyLineOfRichText(blocks)}</span>
+      {segments.map((segment, index) => (
+        <span
+          key={index}
+          style={getRichTextPreviewSegmentStyle(segment.styles)}
+        >
+          {segment.text}
+        </span>
+      ))}
     </div>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/__tests__/RichTextFieldDisplay.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/__tests__/RichTextFieldDisplay.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
+import { RichTextFieldDisplay } from '@/object-record/record-field/ui/meta-types/display/components/RichTextFieldDisplay';
+import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
+import { type FieldRichTextMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
+import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import {
+  jotaiStore,
+  resetJotaiStore,
+} from '@/ui/utilities/state/jotai/jotaiStore';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
+
+const RECORD_ID = 'recordId';
+
+const richTextFieldDefinition: FieldDefinition<FieldRichTextMetadata> = {
+  fieldMetadataId: 'fieldMetadataId',
+  label: 'Body',
+  iconName: 'IconAlignLeft',
+  type: FieldMetadataType.RICH_TEXT,
+  defaultValue: { blocknote: null, markdown: null },
+  metadata: {
+    fieldName: 'bodyV2',
+  },
+};
+
+describe('RichTextFieldDisplay', () => {
+  it('renders strikethrough on closed-cell preview text', () => {
+    resetJotaiStore();
+    jotaiStore.set(recordStoreFamilyState.atomFamily(RECORD_ID), {
+      __typename: 'Note',
+      id: RECORD_ID,
+      bodyV2: {
+        blocknote: JSON.stringify([
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'cancelled meeting',
+                styles: { strike: true },
+              },
+            ],
+          },
+        ]),
+        markdown: null,
+      },
+    });
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={jotaiStore}>
+        <FieldContext.Provider
+          value={{
+            fieldDefinition: richTextFieldDefinition,
+            recordId: RECORD_ID,
+            isLabelIdentifier: false,
+            isRecordFieldReadOnly: false,
+          }}
+        >
+          {children}
+        </FieldContext.Provider>
+      </JotaiProvider>
+    );
+
+    render(<RichTextFieldDisplay />, { wrapper: Wrapper });
+
+    expect(screen.getByText('cancelled meeting')).toHaveStyle({
+      textDecorationLine: 'line-through',
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/25479

Closed Notes cells render `getFirstNonEmptyLineOfRichText`, which returns only `inline.text`. The fixture `{ text: 'cancelled meeting', styles: { strike: true } }` comes back as the plain string, so strike shows in the open BlockNote editor but not in the closed cell. A mixed line like "Keep ~~this~~" showed only "Keep".

This adds `getFirstNonEmptyLineOfRichTextSegments`, which walks the first non-empty line and keeps bold, italic, underline, strike, and code. `RichTextFieldDisplay` renders each segment as a span with `font-weight`, `font-style`, and `text-decoration-line`. Whitespace-only inlines are kept so `**Hello** **World**` stays `Hello World`. The string helper is unchanged for TaskRow summaries. NoteTile cards and BlockNote color styles are not touched.

```
npx jest packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/getFirstNonEmptyLineOfRichTextSegments.test.ts packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/__tests__/RichTextFieldDisplay.test.tsx packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/getFirstNonEmptyLineOfRichText.test.ts --config=packages/twenty-front/jest.config.mjs --no-coverage
```

15 passed. With the production files reverted, the display test fails (no `line-through`) and the mixed-style line shows only "Keep".


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

