### PR TITLE
Delete Fathom webhooks on disconnect

### DIFF
--- a/packages/twenty-apps/public/fathom/package.json
+++ b/packages/twenty-apps/public/fathom/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",
+    "twenty": ">=2.38.0",
     "yarn": ">=4.0.2"
   },
   "keywords": [],
@@ -26,8 +27,8 @@
     "@types/node": "^24.7.2",
     "@typescript/native-preview": "^7.0.0-dev.20260116.1",
     "oxlint": "^0.16.0",
-    "twenty-client-sdk": "2.35.0",
-    "twenty-sdk": "2.35.0",
+    "twenty-client-sdk": "2.38.0",
+    "twenty-sdk": "2.38.0",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.0.0"

--- a/packages/twenty-apps/public/fathom/src/logic-functions/__tests__/fathom-disconnect.test.ts
+++ b/packages/twenty-apps/public/fathom/src/logic-functions/__tests__/fathom-disconnect.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildFathomNotFoundError } from 'src/__tests__/utils/build-fathom-not-found-error.util';
+
+const sdkMocks = vi.hoisted(() => ({
+  deleteWebhook: vi.fn(),
+  getConnection: vi.fn(),
+  kvDelete: vi.fn(),
+  kvGet: vi.fn(),
+  kvSet: vi.fn(),
+}));
+
+vi.mock('twenty-sdk/define', () => ({
+  defineLogicFunction: (config: unknown) => config,
+}));
+
+vi.mock('twenty-sdk/logic-function', () => ({
+  kv: { get: sdkMocks.kvGet, set: sdkMocks.kvSet, delete: sdkMocks.kvDelete },
+  getConnection: sdkMocks.getConnection,
+}));
+
+vi.mock('fathom-typescript', () => ({
+  Fathom: class Fathom {
+    deleteWebhook = sdkMocks.deleteWebhook;
+  },
+}));
+
+const { fathomDisconnectHandler } = await import(
+  'src/logic-functions/fathom-disconnect'
+);
+
+const payload = {
+  connectionProviderId: 'provider-1',
+  connectionProviderName: 'fathom',
+  connectedAccountId: 'connection-1',
+};
+
+const registration = {
+  webhookId: 'webhook-1',
+  secret: 'secret',
+  isActive: true,
+  isInitialBackfillEnqueued: true,
+};
+
+describe('fathomDisconnectHandler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    sdkMocks.kvGet.mockResolvedValue(registration);
+    sdkMocks.getConnection.mockResolvedValue({
+      id: 'connection-1',
+      accessToken: 'token-1',
+    });
+  });
+
+  it('deletes the Fathom webhook, the registration and the server claim', async () => {
+    expect(await fathomDisconnectHandler(payload)).toEqual({ success: true });
+    expect(sdkMocks.deleteWebhook).toHaveBeenCalledWith({ id: 'webhook-1' });
+    expect(sdkMocks.kvDelete.mock.calls).toEqual([
+      ['fathom-webhook:connection-1'],
+      ['fathom-connection:connection-1', { scope: 'SERVER' }],
+    ]);
+  });
+
+  it('releases the server claim when no webhook was ever registered', async () => {
+    sdkMocks.kvGet.mockResolvedValue(null);
+
+    expect(await fathomDisconnectHandler(payload)).toEqual({ success: true });
+    expect(sdkMocks.getConnection).not.toHaveBeenCalled();
+    expect(sdkMocks.deleteWebhook).not.toHaveBeenCalled();
+    expect(sdkMocks.kvDelete.mock.calls).toEqual([
+      ['fathom-connection:connection-1', { scope: 'SERVER' }],
+    ]);
+  });
+
+  it('completes the cleanup when Fathom already dropped the webhook', async () => {
+    sdkMocks.deleteWebhook.mockRejectedValue(buildFathomNotFoundError());
+
+    expect(await fathomDisconnectHandler(payload)).toEqual({ success: true });
+    expect(sdkMocks.kvDelete).toHaveBeenCalledTimes(2);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps the inactive registration and logs the leaked webhook when Fathom fails', async () => {
+    sdkMocks.deleteWebhook.mockRejectedValue(new Error('Fathom unavailable'));
+
+    await expect(fathomDisconnectHandler(payload)).rejects.toThrow(
+      'Fathom unavailable',
+    );
+    expect(sdkMocks.kvSet).toHaveBeenCalledWith('fathom-webhook:connection-1', {
+      ...registration,
+      isActive: false,
+    });
+    expect(sdkMocks.kvDelete).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('leaked webhook webhook-1'),
+    );
+  });
+});

--- a/packages/twenty-apps/public/fathom/src/logic-functions/fathom-disconnect.ts
+++ b/packages/twenty-apps/public/fathom/src/logic-functions/fathom-disconnect.ts
@@ -9,6 +9,7 @@ import { createFathomClient } from 'src/logic-functions/utils/create-fathom-clie
 import { deleteStaleFathomWebhook } from 'src/logic-functions/utils/delete-stale-fathom-webhook.util';
 import { getFathomConnectionClaimKey } from 'src/logic-functions/utils/get-fathom-connection-claim-key.util';
 import { getFathomWebhookRegistrationKey } from 'src/logic-functions/utils/get-fathom-webhook-registration-key.util';
+import { toErrorMessage } from 'src/logic-functions/utils/to-error-message.util';
 
 export const fathomDisconnectHandler = async (
   payload: FathomConnectionHookPayload,
@@ -30,10 +31,22 @@ export const fathomDisconnectHandler = async (
 
   const connection = await getConnection(payload.connectedAccountId);
 
-  await deleteStaleFathomWebhook({
-    fathomClient: createFathomClient(connection.accessToken),
-    webhookId: registration.webhookId,
-  });
+  try {
+    await deleteStaleFathomWebhook({
+      fathomClient: createFathomClient(connection.accessToken),
+      webhookId: registration.webhookId,
+    });
+  } catch (error) {
+    // Twenty deletes the connected account right after this hook, so the
+    // registration left behind is keyed on an id that never comes back and this
+    // log line is the only record of the webhook still live in Fathom.
+    console.error(
+      `[fathom] leaked webhook ${registration.webhookId} for connected account ${payload.connectedAccountId}: ${toErrorMessage(error)}`,
+    );
+
+    throw error;
+  }
+
   await kv.delete(registrationKey);
   await kv.delete(getFathomConnectionClaimKey(payload.connectedAccountId), {
     scope: 'SERVER',

--- a/packages/twenty-apps/public/fathom/src/logic-functions/fathom-disconnect.ts
+++ b/packages/twenty-apps/public/fathom/src/logic-functions/fathom-disconnect.ts
@@ -1,10 +1,13 @@
 import { defineLogicFunction } from 'twenty-sdk/define';
-import { kv } from 'twenty-sdk/logic-function';
+import { getConnection, kv } from 'twenty-sdk/logic-function';
 import { isDefined } from 'src/utils/is-defined';
 
 import { FATHOM_DISCONNECT_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
 import { type FathomConnectionHookPayload } from 'src/logic-functions/types/fathom-connection-hook-payload.type';
 import { type FathomWebhookRegistration } from 'src/logic-functions/types/fathom-webhook-registration.type';
+import { createFathomClient } from 'src/logic-functions/utils/create-fathom-client.util';
+import { deleteStaleFathomWebhook } from 'src/logic-functions/utils/delete-stale-fathom-webhook.util';
+import { getFathomConnectionClaimKey } from 'src/logic-functions/utils/get-fathom-connection-claim-key.util';
 import { getFathomWebhookRegistrationKey } from 'src/logic-functions/utils/get-fathom-webhook-registration-key.util';
 
 export const fathomDisconnectHandler = async (
@@ -15,13 +18,26 @@ export const fathomDisconnectHandler = async (
   );
   const registration = await kv.get<FathomWebhookRegistration>(registrationKey);
 
-  if (isDefined(registration)) {
-    // Twenty runs onDisconnect after deleting the token, so the secret is kept only
-    // to acknowledge Fathom deliveries still in flight.
-    // TODO: delete the webhook, this registration and the server-scoped connection
-    // claim here, and drop isActive, once the engine carries #25215.
-    await kv.set(registrationKey, { ...registration, isActive: false });
+  if (!isDefined(registration)) {
+    await kv.delete(getFathomConnectionClaimKey(payload.connectedAccountId), {
+      scope: 'SERVER',
+    });
+
+    return { success: true };
   }
+
+  await kv.set(registrationKey, { ...registration, isActive: false });
+
+  const connection = await getConnection(payload.connectedAccountId);
+
+  await deleteStaleFathomWebhook({
+    fathomClient: createFathomClient(connection.accessToken),
+    webhookId: registration.webhookId,
+  });
+  await kv.delete(registrationKey);
+  await kv.delete(getFathomConnectionClaimKey(payload.connectedAccountId), {
+    scope: 'SERVER',
+  });
 
   return { success: true };
 };
@@ -30,7 +46,7 @@ export default defineLogicFunction({
   universalIdentifier: FATHOM_DISCONNECT_UNIVERSAL_IDENTIFIER,
   name: 'fathom-disconnect',
   description:
-    'Disables webhook ingestion after a user removes their Fathom connection.',
-  timeoutSeconds: 10,
+    'Deletes the registered Fathom webhook after a user removes their connection.',
+  timeoutSeconds: 30,
   handler: fathomDisconnectHandler,
 });

--- a/packages/twenty-apps/public/fathom/yarn.lock
+++ b/packages/twenty-apps/public/fathom/yarn.lock
@@ -933,8 +933,8 @@ __metadata:
     "@typescript/native-preview": "npm:^7.0.0-dev.20260116.1"
     fathom-typescript: "npm:0.0.43"
     oxlint: "npm:^0.16.0"
-    twenty-client-sdk: "npm:2.35.0"
-    twenty-sdk: "npm:2.35.0"
+    twenty-client-sdk: "npm:2.38.0"
+    twenty-sdk: "npm:2.38.0"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^4.0.0"
@@ -2808,22 +2808,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.35.0":
-  version: 2.35.0
-  resolution: "twenty-client-sdk@npm:2.35.0"
+"twenty-client-sdk@npm:2.38.0":
+  version: 2.38.0
+  resolution: "twenty-client-sdk@npm:2.38.0"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/2ce66e4647c6c6f4b4897896858f8abab3dd8aa6112b8c5c6387082ce484b6a2fb9b90060526601b13329c207ae530d25a6ba80197868a8653156505e0736f5d
+  checksum: 10c0/2ab1c0371a5b48187211477740d833c8454e624d45b4ea1b964864077745d85e6921f5e8452eacb1eceab44e698507a4854686e225e467dd4f5fc481553b047b
   languageName: node
   linkType: hard
 
-"twenty-sdk@npm:2.35.0":
-  version: 2.35.0
-  resolution: "twenty-sdk@npm:2.35.0"
+"twenty-sdk@npm:2.38.0":
+  version: 2.38.0
+  resolution: "twenty-sdk@npm:2.38.0"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -2842,12 +2842,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.35.3"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.35.0"
+    twenty-client-sdk: "npm:2.38.0"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/4cb27d3b449b2fbe692516cc29b2689232e4f40de1181132ea3d9743a1fc1c9284204ddf50632fc737d06748ff9c6903630124c02382b4f61eec120beaa9f9d5
+  checksum: 10c0/9946e0018f6233bbd8bd3ab0ca9dcc96276b25126b9c14328b90b15b8f2948d550ebb9395354ec87066bd8ab74372d242d94c4e5629b4cd16421bf21beb8a62e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- require Twenty 2.38.0 and update the app SDK dependencies to 2.38.0
- delete the registered Fathom webhook while the disconnect hook can still access the OAuth token
- remove the workspace registration and server routing claim after successful deletion, including when Fathom reports the webhook is already gone
- log the webhook id when Fathom deletion fails, since Twenty deletes the connected account right after the hook and nothing can reach that webhook again

## Context

Twenty 2.38.0 includes #25215, which runs connection-provider disconnect hooks before deleting their tokens. The Fathom app previously could only mark registrations inactive, leaving remote webhooks behind. Reconnecting accumulated duplicate callback deliveries to stale and orphaned connection URLs.

Deferred: a reconnect that reuses the connected account while this hook is awaiting Fathom still loses its registration. Closing that needs core to serialize the delete against the reconnect, so it is out of scope here.

## Validation

- yarn typecheck
- yarn lint
- yarn test:unit (42 tests)
- yarn twenty dev:typecheck
- yarn twenty dev:build

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
