### PR TITLE
Make Slack app logic function executions free and simplify its README

### DIFF
--- a/packages/twenty-apps/public/slack/README.md
+++ b/packages/twenty-apps/public/slack/README.md
@@ -4,20 +4,13 @@
 
 ## ✨ What you get
 
-- **A CRM assistant in Slack**: `@twenty how many open opportunities do we have?` It answers in the thread and can read, create, update and soft-delete records
-- **It acts as whoever tagged it**: Slack accounts are matched to workspace members, so nobody gets more access through Slack than they already have in Twenty
-- **Follow-ups without re-mentioning**: once it has replied, keep talking in the thread for 24 hours in a channel, indefinitely in a DM
-- **Record link previews**: paste a link to a person, company, opportunity, note or task and Slack shows a card with the record's key fields
+- **A CRM assistant in Slack**: `@twenty how many open opportunities do we have?` It answers as whoever tagged it
 - **Slack steps for your workflows**: post, update or delete messages, send ephemerals, add reactions, list channels
 
 ## 💳 Billing
 
-No per-seat or per-message charge. The app's runs are metered like any other app's, at **$0.0001 per logic function invocation** plus runtime, and answers use AI credits on the model's token usage.
+The app's logic function executions are free: no per-seat, per-message or per-event charge. Assistant answers use AI credits on the model's token usage.
 
-Every Slack event the bot subscribes to costs an invocation, including messages it never answers. Drop the `message.channels` and `message.groups` subscriptions to limit it to explicit mentions and DMs.
+## 📌 Getting started
 
-## 📌 Heads up
-
-- **You create the Slack app**: Twenty connects to a Slack app you own, so an admin has to create it and set its credentials before anyone can connect. See [SETUP.md](https://github.com/twentyhq/twenty/blob/main/packages/twenty-apps/public/slack/SETUP.md).
-- **One Slack workspace per Twenty workspace**: connecting claims that Slack team until the last connection using it is removed.
-- **Private channels need an invite**: public channels are covered automatically.
+Open the Slack app in Twenty, click **Add connection**, and complete the Slack sign-in. You're all set.

--- a/packages/twenty-apps/public/slack/README.md
+++ b/packages/twenty-apps/public/slack/README.md
@@ -9,7 +9,7 @@
 
 ## 💳 Billing
 
-The app's logic function executions are free: no per-seat, per-message or per-event charge. Assistant answers use AI credits on the model's token usage.
+**Free to run**: no per-seat, per-message or per-event charge. Assistant answers use AI credits on the model's token usage.
 
 ## 📌 Getting started
 

--- a/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
+++ b/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
@@ -27,7 +27,7 @@ For most teams, standard automations are effectively free — you'll only make a
 </Note>
 
 <Note>
-Not every app charges for its runs. Call Recorder and Last Contact react to every email and calendar event imported into your workspace, so their logic function runs are free. You are still charged for the metered work they do, such as recorded call minutes.
+Not every app charges for its runs. Call Recorder and Last Contact react to every email and calendar event imported into your workspace, and Slack runs on every Slack event its bot subscribes to, so their logic function runs are free. You are still charged for the metered work they do, such as recorded call minutes or the AI credits behind Slack assistant answers.
 </Note>
 
 ## How logic function runs are metered

--- a/packages/twenty-server/src/engine/core-modules/application/application-marketplace/constants/marketplace-billing-exempt-applications.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-marketplace/constants/marketplace-billing-exempt-applications.constant.ts
@@ -1,10 +1,11 @@
 // First-party apps whose logic-function executions do not consume the
-// workspace's credits by default. These apps react to per-record events during
-// mailbox/calendar import (Call Recorder, Last contact), which would otherwise
-// drain the free-tier allowance. Operators can override this per app from the
-// Admin Panel; the default is only applied when the registration is first
-// created from the catalog.
+// workspace's credits. Call Recorder and Last contact react to per-record
+// events during mailbox/calendar import, and Slack runs on every subscribed
+// Slack event including messages it never answers; either would otherwise
+// drain the free-tier allowance. Explicit chargeCredits calls and AI token
+// usage from within a function are billed separately.
 export const MARKETPLACE_BILLING_EXEMPT_UNIVERSAL_IDENTIFIERS: string[] = [
   '8da4b8b5-5edf-4880-b51f-ab6e679ec617',
   '66a504cc-0a75-410e-a43f-cdeae1db1522',
+  'a8c47f21-3b9e-4d2a-8f61-9c0e7d4a2b51',
 ];

--- a/packages/twenty-server/src/engine/core-modules/application/application-marketplace/utils/__tests__/is-billing-exempt-application.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-marketplace/utils/__tests__/is-billing-exempt-application.util.spec.ts
@@ -4,6 +4,7 @@ describe('isBillingExemptApplication', () => {
   it.each([
     '8da4b8b5-5edf-4880-b51f-ab6e679ec617',
     '66a504cc-0a75-410e-a43f-cdeae1db1522',
+    'a8c47f21-3b9e-4d2a-8f61-9c0e7d4a2b51',
   ])('should return true for billing-exempt app %s', (universalIdentifier) => {
     expect(isBillingExemptApplication(universalIdentifier)).toBe(true);
   });

--- a/packages/twenty-server/src/engine/core-modules/application/application-marketplace/utils/is-billing-exempt-application.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-marketplace/utils/is-billing-exempt-application.util.ts
@@ -1,8 +1,9 @@
 import { MARKETPLACE_BILLING_EXEMPT_UNIVERSAL_IDENTIFIERS } from 'src/engine/core-modules/application/application-marketplace/constants/marketplace-billing-exempt-applications.constant';
 
 // Logic-function executions for these first-party apps (Call Recorder,
-// Last contact) do not consume the workspace's credits. Explicit chargeCredits
-// calls and AI token usage from within the function are billed separately.
+// Last contact, Slack) do not consume the workspace's credits. Explicit
+// chargeCredits calls and AI token usage from within the function are billed
+// separately.
 export const isBillingExemptApplication = (
   universalIdentifier: string,
 ): boolean =>


### PR DESCRIPTION
Follows a discussion with @martmull: the Slack app should not consume workspace credits for its logic function executions, and its README should focus on the user installing the app.

## Billing exemption

- Adds the Slack app (`a8c47f21-3b9e-4d2a-8f61-9c0e7d4a2b51`) to `MARKETPLACE_BILLING_EXEMPT_UNIVERSAL_IDENTIFIERS`, alongside Call Recorder and Last contact, with the util spec covering it. The app runs on every subscribed Slack event, including messages it never answers (`message.channels` / `message.groups` fire for every message in channels the bot sits in), so per-invocation metering would drain the free-tier allowance the same way per-record import triggers would. Explicit `chargeCredits` calls and AI token usage from within functions stay billed.
- Drops a stale sentence from the constant's comment claiming operators can override the exemption per app from the Admin Panel and that the default only applies at registration creation: no such override exists anywhere in the codebase, and the executor reads the constant at execution time.

## README

Trimmed to what a user installing the app needs:

- The assistant bullet now reads "It answers as whoever tagged it"; the separate access-matching bullet, the follow-ups bullet, and the record-link-previews bullet are removed.
- Billing states executions are free (no per-seat, per-message or per-event charge); assistant answers still use AI credits on token usage. The now-obsolete advice to drop event subscriptions to save credits is gone.
- "Heads up" replaced by a "Getting started" line: open the Slack app in Twenty, Add connection, complete the Slack sign-in.
- The admin content (creating the Slack app, SETUP link, team claim, private-channel membership) is out of the README; each of those facts is already documented in SETUP.md, which is the admin-facing doc.

## Validation

- `is-billing-exempt-application.util.spec.ts` passes (4 tests)
- `npx nx lint:diff-with-main twenty-server` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYyiPFprpyCDwhb1J3mCkU)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

