### PR TITLE
fix(docker): resolve release tags from the twenty/v* namespace and fail on bad downloads

### DIFF
--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -10,7 +10,6 @@ if [[ -z "$pull_version" ]]; then
   echo "Error: Unable to fetch the latest version tag. Please check your network connection or the Docker Hub API response."
   exit 1
 fi
-# Releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported
 pull_branch=${BRANCH:-twenty/$pull_version}
 
 install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
@@ -25,7 +24,6 @@ fi
 mv twenty_install.sh.tmp twenty_install.sh
 
 chmod +x twenty_install.sh
-# Pass the resolved values down so the tagged install.sh does not resolve them again
 VERSION="$pull_version" BRANCH="$pull_branch" ./twenty_install.sh
 install_status=$?
 

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -12,13 +12,14 @@ pull_branch=${BRANCH:-twenty/$pull_version}
 
 install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
 
-if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh "$install_url"; then
-  rm -f twenty_install.sh
+if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh.tmp "$install_url"; then
+  rm -f twenty_install.sh.tmp
   echo "Error: Failed to download the install script from $install_url"
   echo "If this is a 404, the release may be incomplete; anything else is usually GitHub"
   echo "rate limiting your network, in which case retrying in a minute will work."
   exit 1
 fi
+mv twenty_install.sh.tmp twenty_install.sh
 
 chmod +x twenty_install.sh
 # Pass the resolved values down so the tagged install.sh does not resolve them again

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,19 +1,27 @@
-pull_version=${VERSION:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
+pull_version=${VERSION:-$(curl -fsS "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 
 if [[ -z "$pull_version" ]]; then
-  echo "Error: Unable to fetch the latest version tag. Please check your network connection or the GitHub API response."
+  echo "Error: Unable to fetch the latest version tag. Please check your network connection or the Docker Hub API response."
   exit 1
 fi
-pull_branch=${BRANCH:-$pull_version}
+# Release tags are namespaced since twenty/v2.9.1
+pull_branch=${BRANCH:-twenty/$pull_version}
 
 version_num=${pull_version#v}
 target_version="0.32.4"
 
 # We moved the install script to a different location in v0.32.4
 if [[ -n "$BRANCH" ]] || [[ "$(printf '%s\n' "$target_version" "$version_num" | sort -V | head -n1)" != "$version_num" ]]; then
-  curl -sL "https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh" -o twenty_install.sh
+  install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
 else
-  curl -sL "https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/install.sh" -o twenty_install.sh
+  install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/install.sh"
+fi
+
+if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh "$install_url"; then
+  echo "Error: Failed to download the install script from $install_url"
+  echo "If this is a 404, the release may be incomplete; anything else is usually GitHub"
+  echo "rate limiting your network, in which case retrying in a minute will work."
+  exit 1
 fi
 
 chmod +x twenty_install.sh

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,13 +1,16 @@
-# "latest" is only an alias of the newest release, resolve it to the real tag
-[[ "$VERSION" == "latest" ]] && unset VERSION
+release_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+$'
+if [[ -n "$VERSION" && ! "$VERSION" =~ $release_tag_pattern ]]; then
+  echo "Error: VERSION must be a full release tag such as v2.38.1, omit it to install the latest release."
+  exit 1
+fi
 
-pull_version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+pull_version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | cut -d'"' -f4 | grep -E "$release_tag_pattern" | sort -V | tail -n1)}
 
 if [[ -z "$pull_version" ]]; then
   echo "Error: Unable to fetch the latest version tag. Please check your network connection or the Docker Hub API response."
   exit 1
 fi
-# Release tags are namespaced since twenty/v2.9.1, older releases are not supported
+# Releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported
 pull_branch=${BRANCH:-twenty/$pull_version}
 
 install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
@@ -15,8 +18,8 @@ install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/pack
 if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh.tmp "$install_url"; then
   rm -f twenty_install.sh.tmp
   echo "Error: Failed to download the install script from $install_url"
-  echo "If this is a 404, the release may be incomplete; anything else is usually GitHub"
-  echo "rate limiting your network, in which case retrying in a minute will work."
+  echo "If this is a 404, the twenty/<version> ref does not exist: releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported."
+  echo "Anything else is usually GitHub rate limiting your network, in which case retrying in a minute will work."
   exit 1
 fi
 mv twenty_install.sh.tmp twenty_install.sh
@@ -24,5 +27,7 @@ mv twenty_install.sh.tmp twenty_install.sh
 chmod +x twenty_install.sh
 # Pass the resolved values down so the tagged install.sh does not resolve them again
 VERSION="$pull_version" BRANCH="$pull_branch" ./twenty_install.sh
+install_status=$?
 
 rm twenty_install.sh
+exit $install_status

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,23 +1,16 @@
-pull_version=${VERSION:-$(curl -fsS "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+pull_version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 
 if [[ -z "$pull_version" ]]; then
   echo "Error: Unable to fetch the latest version tag. Please check your network connection or the Docker Hub API response."
   exit 1
 fi
-# Release tags are namespaced since twenty/v2.9.1
+# Release tags are namespaced since twenty/v2.9.1, older releases are not supported
 pull_branch=${BRANCH:-twenty/$pull_version}
 
-version_num=${pull_version#v}
-target_version="0.32.4"
-
-# We moved the install script to a different location in v0.32.4
-if [[ -n "$BRANCH" ]] || [[ "$(printf '%s\n' "$target_version" "$version_num" | sort -V | head -n1)" != "$version_num" ]]; then
-  install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
-else
-  install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/install.sh"
-fi
+install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
 
 if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh "$install_url"; then
+  rm -f twenty_install.sh
   echo "Error: Failed to download the install script from $install_url"
   echo "If this is a 404, the release may be incomplete; anything else is usually GitHub"
   echo "rate limiting your network, in which case retrying in a minute will work."
@@ -25,6 +18,7 @@ if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh "$install_url"; t
 fi
 
 chmod +x twenty_install.sh
-VERSION="$VERSION" BRANCH="$BRANCH" ./twenty_install.sh
+# Pass the resolved values down so the tagged install.sh does not resolve them again
+VERSION="$pull_version" BRANCH="$pull_branch" ./twenty_install.sh
 
 rm twenty_install.sh

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,3 +1,6 @@
+# "latest" is only an alias of the newest release, resolve it to the real tag
+[[ "$VERSION" == "latest" ]] && unset VERSION
+
 pull_version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 
 if [[ -z "$pull_version" ]]; then

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -43,9 +43,28 @@ function on_exit {
 }
 trap on_exit EXIT
 
+# Download a file, failing loudly instead of writing an HTTP error page to disk.
+# curl retries 429/5xx on its own; raw.githubusercontent.com throttles by IP.
+function download {
+  local url=$1
+  local dest=$2
+  if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest" "$url"; then
+    echo -e "\t❌ Failed to download $url"
+    echo -e "\t\tIf this is a 404, the release may be incomplete; anything else is usually GitHub"
+    echo -e "\t\trate limiting your network, in which case retrying in a minute will work."
+    exit 1
+  fi
+}
+
 # Use environment variables VERSION and BRANCH, with defaults if not set
-version=${VERSION:-$(curl -s "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
-branch=${BRANCH:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
+version=${VERSION:-$(curl -fsS "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+if [ -z "$version" ]; then
+  echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."
+  exit 1
+fi
+# Release tags are namespaced since twenty/v2.9.1; deriving the branch from the
+# image tag also keeps docker-compose.yml and the image in lockstep.
+branch=${BRANCH:-twenty/$version}
 
 echo "🚀 Using docker version $version and Github branch $branch"
 
@@ -74,11 +93,11 @@ mkdir -p "$dir_name" && cd "$dir_name" || { echo "❌ Failed to create/access di
 
 # Copy twenty/packages/twenty-docker/docker-compose.yml in it
 echo -e "\t• Copying docker-compose.yml"
-curl -sLo docker-compose.yml https://raw.githubusercontent.com/twentyhq/twenty/$branch/packages/twenty-docker/docker-compose.yml
+download "https://raw.githubusercontent.com/twentyhq/twenty/$branch/packages/twenty-docker/docker-compose.yml" docker-compose.yml
 
 # Copy twenty/packages/twenty-docker/.env.example to .env
 echo -e "\t• Setting up .env file"
-curl -sLo .env https://raw.githubusercontent.com/twentyhq/twenty/$branch/packages/twenty-docker/.env.example
+download "https://raw.githubusercontent.com/twentyhq/twenty/$branch/packages/twenty-docker/.env.example" .env
 
 # Replace TAG=latest by TAG=<latest_release or version input>
 if [[ $(uname) == "Darwin" ]]; then

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -49,6 +49,7 @@ function download {
   local url=$1
   local dest=$2
   if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest" "$url"; then
+    rm -f "$dest"
     echo -e "\t❌ Failed to download $url"
     echo -e "\t\tIf this is a 404, the release may be incomplete; anything else is usually GitHub"
     echo -e "\t\trate limiting your network, in which case retrying in a minute will work."
@@ -57,13 +58,13 @@ function download {
 }
 
 # Use environment variables VERSION and BRANCH, with defaults if not set
-version=${VERSION:-$(curl -fsS "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 if [ -z "$version" ]; then
   echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."
   exit 1
 fi
-# Release tags are namespaced since twenty/v2.9.1; deriving the branch from the
-# image tag also keeps docker-compose.yml and the image in lockstep.
+# Release tags are namespaced since twenty/v2.9.1, older releases are not supported.
+# Deriving the branch from the image tag also keeps docker-compose.yml and the image in lockstep.
 branch=${BRANCH:-twenty/$version}
 
 echo "🚀 Using docker version $version and Github branch $branch"

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -58,6 +58,8 @@ function download {
 }
 
 # Use environment variables VERSION and BRANCH, with defaults if not set
+# "latest" is only an alias of the newest release, resolve it to the real tag
+[[ "$VERSION" == "latest" ]] && unset VERSION
 version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 if [ -z "$version" ]; then
   echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -51,23 +51,26 @@ function download {
   if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest.tmp" "$url"; then
     rm -f "$dest.tmp"
     echo -e "\t❌ Failed to download $url"
-    echo -e "\t\tIf this is a 404, the release may be incomplete; anything else is usually GitHub"
-    echo -e "\t\trate limiting your network, in which case retrying in a minute will work."
+    echo -e "\t\tIf this is a 404, the twenty/<version> ref does not exist: releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported."
+    echo -e "\t\tAnything else is usually GitHub rate limiting your network, in which case retrying in a minute will work."
     exit 1
   fi
   mv "$dest.tmp" "$dest"
 }
 
 # Use environment variables VERSION and BRANCH, with defaults if not set
-# "latest" is only an alias of the newest release, resolve it to the real tag
-[[ "$VERSION" == "latest" ]] && unset VERSION
-version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+release_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+$'
+if [[ -n "$VERSION" && ! "$VERSION" =~ $release_tag_pattern ]]; then
+  echo -e "\t❌ VERSION must be a full release tag such as v2.38.1, omit it to install the latest release."
+  exit 1
+fi
+version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | cut -d'"' -f4 | grep -E "$release_tag_pattern" | sort -V | tail -n1)}
 if [ -z "$version" ]; then
   echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."
   exit 1
 fi
-# Release tags are namespaced since twenty/v2.9.1, older releases are not supported.
-# Deriving the branch from the image tag also keeps docker-compose.yml and the image in lockstep.
+# Releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported.
+# Deriving the branch from the image tag keeps docker-compose.yml and the image in lockstep.
 branch=${BRANCH:-twenty/$version}
 
 echo "🚀 Using docker version $version and Github branch $branch"

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -48,13 +48,14 @@ trap on_exit EXIT
 function download {
   local url=$1
   local dest=$2
-  if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest" "$url"; then
-    rm -f "$dest"
+  if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest.tmp" "$url"; then
+    rm -f "$dest.tmp"
     echo -e "\t❌ Failed to download $url"
     echo -e "\t\tIf this is a 404, the release may be incomplete; anything else is usually GitHub"
     echo -e "\t\trate limiting your network, in which case retrying in a minute will work."
     exit 1
   fi
+  mv "$dest.tmp" "$dest"
 }
 
 # Use environment variables VERSION and BRANCH, with defaults if not set

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -69,7 +69,6 @@ if [ -z "$version" ]; then
   echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."
   exit 1
 fi
-# Releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported.
 # Deriving the branch from the image tag keeps docker-compose.yml and the image in lockstep.
 branch=${BRANCH:-twenty/$version}
 

--- a/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
@@ -28,12 +28,18 @@ Install the latest stable version of Twenty with a single command:
 bash <(curl -sL https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/scripts/install.sh)
 ```
 
-To install a specific version or branch:
+To install a specific version:
 ```bash
-VERSION=vx.y.z BRANCH=branch-name bash <(curl -sL https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/scripts/install.sh)
+VERSION=v2.38.1 bash <(curl -sL https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/scripts/install.sh)
 ```
-- Replace x.y.z with the desired version number.
-- Replace branch-name with the name of the branch you want to install.
+- `VERSION` must be a full release tag published on [Docker Hub](https://hub.docker.com/r/twentycrm/twenty/tags), such as `v2.38.1`. Aliases such as `v2` or `latest` are not accepted.
+- The matching `docker-compose.yml` is fetched from the `twenty/<version>` git tag, so releases that predate these tags (v2.9.0 and older) can't be installed with the script.
+
+To fetch the configuration files from a branch instead, for example to test unreleased changes:
+```bash
+BRANCH=branch-name bash <(curl -sL https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/scripts/install.sh)
+```
+- Replace branch-name with the branch to fetch `docker-compose.yml` and `.env.example` from. The image still defaults to the latest release unless `VERSION` is also set.
 
 ## Option 2: Manual steps
 Follow these steps for a manual setup.


### PR DESCRIPTION
## Introduction

The one-click install currently fails with a YAML parse error that has nothing to do with YAML:

```
🚀 Using docker version v2.38.1 and Github branch v2.9.0
	• Copying docker-compose.yml
🐳 Starting Docker containers...
yaml: line 2: could not find expected ':'
❌ Something went wrong, exiting: 15
```

Two independent bugs combine to produce it.

## Stale branch resolution

Both scripts resolved the branch from the GitHub tags API:

```bash
branch=${BRANCH:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
```

That endpoint sorts lexicographically, not by version, so `head -n 1` never meant "latest". Since #21247 moved releases to the `twenty/v*` and `sdk/v*` namespaces, the bare `v*` tags stop at v2.9.0, and `twenty/...` sorts after every remaining `v...` so it never appears on the first page:

```
2026-06-04  v2.9.0        <- last bare tag
2026-06-05  sdk/v2.9.1
2026-06-05  twenty/v2.9.1
```

So the branch has been pinned to v2.9.0 since June 5, while the image tag resolved correctly from Docker Hub to v2.38.1. Every install for the past three months has paired a v2.9.0 compose file with a v2.38.1 image. It went unnoticed because the two files barely drifted: the v2.9.0 compose hardcodes the database name where current makes it overridable via `PG_DATABASE_NAME`.

The branch is now derived from the resolved image tag:

```bash
branch=${BRANCH:-twenty/$version}
```

This makes the mismatch unrepresentable rather than merely fixed, and drops a network call. I checked every image tag currently on Docker Hub against the repo, and each one has a matching `twenty/vX.Y.Z` git tag.

## Downloads that succeed at failing

```bash
curl -sLo docker-compose.yml https://raw.githubusercontent.com/.../docker-compose.yml
```

Without `--fail`, curl writes the HTTP error body to the destination and exits 0. In the report above, raw.githubusercontent.com returned a 429 for one of three requests in the same run, and the resulting `docker-compose.yml` was:

```
429: Too Many Requests
For more on scraping GitHub and how it may affect your rights, please review our Terms of Service
```

That parses as YAML until line 2, which is why the failure surfaced 30 seconds later as a compose error rather than a download error. Downloads now go through a helper using `--fail` (abort with the real cause) and `--retry 3 --retry-delay 2`. curl counts 429 as a transient error, so the exact failure reported would now recover on its own.

Empty version resolution is also caught explicitly instead of producing a `twenty/` branch.

## Scope and follow-ups

- `VERSION` only accepts a full release tag (`vX.Y.Z`), which is what the docs already promised. Aliases such as `latest`, `v2` or `v2.38` and pre-release tags are rejected with a targeted message instead of failing on a missing git ref. Default resolution applies the same pattern, so an rc or alias tag on Docker Hub can never become the default install.
- Releases published before the `twenty/v*` namespace only carry a bare `vX.Y.Z` git tag (`v2.9.0`, `v2.8.3`, `v2.7.3`, ...) while their images are still on Docker Hub. Pinning one of them is no longer supported and aborts with a message naming the missing `twenty/<version>` ref. The namespace is not a clean version cutoff: hotfixes such as `twenty/v2.6.3` and `twenty/v2.8.4` were published after the move and do carry it, so the "each image tag has a matching `twenty/` git tag" statement above only holds for releases since then.
- The documented entry point is `install.sh` fetched from `main`, so the fix applies to every documented run as soon as this merges. `1-click.sh` forwards the resolved `VERSION` and `BRANCH` to the tagged `install.sh` and now exits with the install status, so the branch fix also applies there for existing releases.
- Downloads go to a temporary file and are moved into place on success, so a failed run never leaves a partial file or overwrites an existing config.
- The Docker Compose docs page now shows `VERSION` and `BRANCH` as separate examples and states the accepted format and the oldest supported release. Locale copies are pulled from Crowdin and left untouched.
- Neither script is exercised by CI today. A follow-up PR will add coverage: syntax and shellcheck, default resolution asserting the `twenty/<version>` ref exists, a non-interactive run of both scripts against the PR head validated with `docker compose config`, the failure paths, and a scheduled drift check between Docker Hub tags and git tags.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture>``&lt;source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;&lt;source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"&gt;&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</picture></a>
<!-- End of auto-generated description by cubic. -->
