### PR TITLE
Skip delayed workflow resume when the run no longer exists

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/delay/jobs/resume-delayed-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/delay/jobs/resume-delayed-workflow.job.ts
@@ -1,5 +1,6 @@
 import { Scope } from '@nestjs/common';
 
+import { isDefined } from 'twenty-shared/utils';
 import { StepStatus } from 'twenty-shared/workflow';
 
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
@@ -43,17 +44,22 @@ export class ResumeDelayedWorkflowJob {
     const authContext = buildSystemAuthContext(workspaceId);
 
     await this.workspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRun = await this.workflowRunWorkspaceService.getWorkflowRun(
+        {
+          workflowRunId,
+          workspaceId,
+        },
+      );
+
+      if (!isDefined(workflowRun)) {
+        return;
+      }
+
+      if (workflowRun.status !== WorkflowRunStatus.RUNNING) {
+        return;
+      }
+
       try {
-        const workflowRun =
-          await this.workflowRunWorkspaceService.getWorkflowRunOrFail({
-            workflowRunId,
-            workspaceId,
-          });
-
-        if (workflowRun.status !== WorkflowRunStatus.RUNNING) {
-          return;
-        }
-
         const step = workflowRun.state?.flow?.steps?.find(
           (step) => step.id === stepId,
         );


### PR DESCRIPTION
## Context

[TWENTY-SERVER-6HF](https://twenty-v7.sentry.io/issues/6696593779) (~385 events): `ResumeDelayedWorkflowJob` fires after the configured delay, which can be hours or days. If the workflow run was deleted in the meantime (manual deletion, workflow deletion, or the workflow run cleanup job), `getWorkflowRunOrFail` threw inside the try, and the catch then called `endWorkflowRun` on the same missing run, which threw the same NOT_FOUND again and escaped the job as a worker error.

## Fix

Fetch the run with the nullable `getWorkflowRun` before the try and return early when it is gone, same as the existing early return when the run is no longer RUNNING. The catch now only wraps work done on an existing run, so `endWorkflowRun` is only called on runs that can actually be ended.

Fixes TWENTY-SERVER-6HF

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

