### PR TITLE
Stop pruning published translations when a project has no locales folder

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/translations/overview.mdx
+++ b/packages/twenty-docs/developers/extend/apps/translations/overview.mdx
@@ -132,6 +132,12 @@ syncing is enough to see the new text. Front component catalogs are baked into
 each component bundle at build time, so changing one of those still means
 re-running `twenty dev:build` (and redeploying).
 
+A project without a `locales/` folder says nothing about translations, so a
+sync from it leaves whatever the app already published untouched. To remove
+published translations on purpose, keep the folder and delete the locale files
+inside it: a `locales/` folder that compiles to no locale is an explicit
+declaration, and the sync prunes accordingly.
+
 `Trans` text children may span multiple lines — whitespace is collapsed the
 same way JSX collapses it, so both of these extract to the key `Welcome back`:
 

--- a/packages/twenty-sdk/src/cli/__tests__/apps/minimal-app/__integration__/app-dev/expected-manifest.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/minimal-app/__integration__/app-dev/expected-manifest.ts
@@ -17,7 +17,6 @@ export const EXPECTED_MANIFEST: Manifest = {
   },
   permissionFlags: [],
   skills: [],
-  translations: {},
   agents: [],
   publicAssets: [],
   indexes: [],

--- a/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/expected-manifest.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/expected-manifest.ts
@@ -83,7 +83,6 @@ export const EXPECTED_MANIFEST: Manifest = {
     },
   ],
   skills: [],
-  translations: {},
   agents: [],
   application: {
     applicationVariables: {

--- a/packages/twenty-sdk/src/cli/utilities/translations/__tests__/application-translations.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/translations/__tests__/application-translations.spec.ts
@@ -159,8 +159,33 @@ describe('compileApplicationTranslations', () => {
     });
   });
 
-  it('returns no locales when there is no locales directory', async () => {
+  it('declares nothing when there is no locales directory, so the sync leaves stored translations alone', async () => {
     const appPath = await mkdtemp(join(tmpdir(), 'twenty-translations-empty-'));
+
+    expect(await compileApplicationTranslations(appPath)).toBeUndefined();
+  });
+
+  it('declares zero locales when the locales directory exists but holds none', async () => {
+    const appPath = await mkdtemp(
+      join(tmpdir(), 'twenty-translations-no-locale-'),
+    );
+
+    await mkdir(join(appPath, 'locales'), { recursive: true });
+
+    expect(await compileApplicationTranslations(appPath)).toEqual({});
+  });
+
+  it('declares zero locales when only the source locale is present', async () => {
+    const appPath = await mkdtemp(
+      join(tmpdir(), 'twenty-translations-source-only-'),
+    );
+    const localesDir = join(appPath, 'locales');
+
+    await mkdir(localesDir, { recursive: true });
+    await writeFile(
+      join(localesDir, 'en.json'),
+      JSON.stringify({ Company: 'Company' }),
+    );
 
     expect(await compileApplicationTranslations(appPath)).toEqual({});
   });

--- a/packages/twenty-sdk/src/cli/utilities/translations/compile-application-translations.ts
+++ b/packages/twenty-sdk/src/cli/utilities/translations/compile-application-translations.ts
@@ -16,11 +16,11 @@ const isSupportedLocale = (locale: string): locale is AppLocale =>
 
 export const compileApplicationTranslations = async (
   appPath: string,
-): Promise<TranslationsManifest> => {
+): Promise<TranslationsManifest | undefined> => {
   const localesDir = path.join(appPath, LOCALES_DIR);
 
   if (!(await pathExists(localesDir))) {
-    return {};
+    return undefined;
   }
 
   const localeFiles = (await readdir(localesDir)).filter((entry) =>


### PR DESCRIPTION
## What

Applying from a project that has no `locales/` folder soft-deleted every published translation of the application, across every workspace on the instance. This makes the CLI stop declaring an empty catalog when it has no catalog at all.

## The bug

Translations travel inside the manifest and are applied by a separate step after the workspace migration. The server contract for that step is deliberate and pinned by its own specs:

- `translations` absent: no information, leave the stored rows alone.
- `translations: {}`: zero locales declared, prune everything not listed.

The CLI broke that contract on its side. `compileApplicationTranslations` returned `{}` when the `locales/` folder did not exist, and every caller (`apply`, `dev`, `dev:build`) sets the key unconditionally, so a project with no folder told the server "I declare zero locales". The rows are keyed by the application registration rather than the workspace, so the deletion reached every workspace where the app is installed.

The server comment on that step describes exactly this scenario as the one that must not happen. The fix aligns the CLI with it.

## The change

`compileApplicationTranslations` now returns `undefined` when the folder is absent, so the key drops out of the payload and the server leaves published translations untouched. It still returns `{}` when the folder exists but compiles to no locale.

Behaviour by case, with only the first one changing:

| `locales/` | Sent | Server does |
| --- | --- | --- |
| Missing | key absent | leaves published translations alone (was: erased them all) |
| Present, populated | the catalog | replaces the set: upserts listed locales, soft-deletes the rest, as before |
| Present, empty or source locale only | `{}` | erases all, as before |

Two things worth knowing that this PR does not change:

- With the folder present, the sync replaces the whole set of locales rather than merging. A folder holding only `fr-FR.json` removes a previously published `de-DE`.
- The compiler skips the source locale, so a folder holding only `locales/en.json`, which is what `dev:translations-extract` produces on a fresh project, counts as empty and prunes. That is the documented way to remove translations on purpose.

Why the missing-folder case is not tied to `--no-delete`: every other deletion a pruning apply performs is scoped to the workspace being synced, and every one of them appears in `plan`. This one is instance-global, and the translation step runs behind `if (!dryRun)`, so `plan` can never show it. Letting a pruning apply reach across workspaces silently on absence alone is a bigger contract change than the flag was designed for. Threading the flag into the translation step so that `--no-delete` also skips the prune in the explicit empty-folder case is a reasonable follow-up, discussed and deliberately left out of this change.

## Not fixable from the CLI

Packages built by older SDK versions carry `translations: {}` in their bundled manifest and will keep pruning on `app:install` until they are republished. A server-side guard would cover them, but it would make removing all translations by emptying the folder impossible, so it is left as a product decision.

## Tests and docs

- The compiler spec pins all three cases: no folder, empty folder, source locale only.
- The minimal-app and rich-app expected manifests, which pinned `translations: {}` for fixtures that have no `locales/` folder, no longer carry the key.
- The translations docs state the rule: a missing folder says nothing, an empty folder declares zero.
