### PR TITLE
Fix sidebar Link items in folders redirecting to a doubled URL

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/common/hooks/useNavigateToNavigationMenuItemLink.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/hooks/useNavigateToNavigationMenuItemLink.ts
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+import { isAbsoluteUrl } from 'twenty-shared/utils';
+
+export const useNavigateToNavigationMenuItemLink = () => {
+  const navigate = useNavigate();
+
+  const navigateToNavigationMenuItemLink = (link: string) => {
+    if (isAbsoluteUrl(link)) {
+      window.open(link, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
+    navigate(link);
+  };
+
+  return { navigateToNavigationMenuItemLink };
+};

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/NavigationMenuItemFolderSubItem.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/NavigationMenuItemFolderSubItem.tsx
@@ -1,11 +1,11 @@
 import { useLingui } from '@lingui/react/macro';
 import { type ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { FeatureFlagKey, NavigationMenuItemType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { type NavigationMenuItem } from '~/generated-metadata/graphql';
 
 import { lastClickedNavigationMenuItemIdState } from '@/navigation-menu-item/common/states/lastClickedNavigationMenuItemIdState';
+import { useNavigateToNavigationMenuItemLink } from '@/navigation-menu-item/common/hooks/useNavigateToNavigationMenuItemLink';
 import { getNavigationMenuItemColor } from '@/navigation-menu-item/common/utils/getNavigationMenuItemColor';
 import { NavigationMenuItemIcon } from '@/navigation-menu-item/display/components/NavigationMenuItemIcon';
 import { useIdentifyActiveNavigationMenuItems } from '@/navigation-menu-item/display/hooks/useIdentifyActiveNavigationMenuItems';
@@ -61,7 +61,8 @@ export const NavigationMenuItemFolderSubItem = ({
   const lastVisitedViewPerObjectMetadataItem = useAtomStateValue(
     lastVisitedViewPerObjectMetadataItemState,
   );
-  const navigate = useNavigate();
+  const { navigateToNavigationMenuItemLink } =
+    useNavigateToNavigationMenuItemLink();
   const setLastClickedNavigationMenuItemId = useSetAtomState(
     lastClickedNavigationMenuItemIdState,
   );
@@ -114,7 +115,7 @@ export const NavigationMenuItemFolderSubItem = ({
           })
       : () => {
           setLastClickedNavigationMenuItemId(navigationMenuItem.id);
-          navigate(computedLink);
+          navigateToNavigationMenuItemLink(computedLink);
         });
 
   const isCoreWorkflowsIndexItem = isCoreWorkflowsObjectNavigationMenuItem({

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/__tests__/NavigationMenuItemFolderSubItem.test.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/__tests__/NavigationMenuItemFolderSubItem.test.tsx
@@ -48,6 +48,7 @@ describe('NavigationMenuItemFolderSubItem', () => {
 
     await userEvent.click(screen.getByText('Q3 deck'));
 
+    expect(windowOpen).toHaveBeenCalledTimes(1);
     expect(windowOpen).toHaveBeenCalledWith(
       'https://google.com/search',
       '_blank',

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/__tests__/NavigationMenuItemFolderSubItem.test.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/__tests__/NavigationMenuItemFolderSubItem.test.tsx
@@ -1,0 +1,60 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { NavigationMenuItemType } from 'twenty-shared/types';
+import { type NavigationMenuItem } from '~/generated-metadata/graphql';
+
+import { NavigationMenuItemFolderSubItem } from '@/navigation-menu-item/display/folder/components/NavigationMenuItemFolderSubItem';
+
+const LocationProbe = () => {
+  const location = useLocation();
+
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
+const linkNavigationMenuItem = {
+  id: 'link-item-id',
+  type: NavigationMenuItemType.LINK,
+  name: 'Q3 deck',
+  link: 'https://google.com/search',
+  folderId: 'folder-id',
+  position: 0,
+} as NavigationMenuItem;
+
+describe('NavigationMenuItemFolderSubItem', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('opens a link item in a new tab instead of routing to its absolute URL', async () => {
+    const windowOpen = jest.spyOn(window, 'open').mockImplementation();
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter initialEntries={['/objects/companies']}>
+          <NavigationMenuItemFolderSubItem
+            navigationMenuItem={linkNavigationMenuItem}
+            index={0}
+            arrayLength={1}
+            selectedIndex={-1}
+            isDragging={false}
+          />
+          <LocationProbe />
+        </MemoryRouter>
+      </I18nProvider>,
+    );
+
+    await userEvent.click(screen.getByText('Q3 deck'));
+
+    expect(windowOpen).toHaveBeenCalledWith(
+      'https://google.com/search',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/objects/companies',
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/hooks/useNavigationMenuItemEditOrganizeActions.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/hooks/useNavigationMenuItemEditOrganizeActions.ts
@@ -1,6 +1,5 @@
 import { useLingui } from '@lingui/react/macro';
 import { isNonEmptyString } from '@sniptt/guards';
-import { useNavigate } from 'react-router-dom';
 import { SidePanelPages } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { IconDotsVertical } from 'twenty-ui/icon';
@@ -8,6 +7,7 @@ import { IconDotsVertical } from 'twenty-ui/icon';
 import { pendingInsertionNavigationMenuItemState } from '@/navigation-menu-item/common/states/pendingInsertionNavigationMenuItemState';
 import { selectedNavigationMenuItemIdInEditModeState } from '@/navigation-menu-item/common/states/selectedNavigationMenuItemIdInEditModeState';
 import { type PendingInsertionNavigationMenuItem } from '@/navigation-menu-item/common/types/PendingInsertionNavigationMenuItem';
+import { useNavigateToNavigationMenuItemLink } from '@/navigation-menu-item/common/hooks/useNavigateToNavigationMenuItemLink';
 import { getNavigationMenuItemComputedLink } from '@/navigation-menu-item/display/utils/getNavigationMenuItemComputedLink';
 import { useNavigationMenuItemEditSectionItems } from '@/navigation-menu-item/edit/hooks/useNavigationMenuItemEditSectionItems';
 import { useNavigationMenuItemMoveRemove } from '@/navigation-menu-item/edit/hooks/useNavigationMenuItemMoveRemove';
@@ -49,7 +49,8 @@ const computeInsertionPosition = (
 export const useNavigationMenuItemEditOrganizeActions =
   (): OrganizeActionsProps => {
     const { t } = useLingui();
-    const navigate = useNavigate();
+    const { navigateToNavigationMenuItemLink } =
+      useNavigateToNavigationMenuItemLink();
     const { closeSidePanelMenu } = useSidePanelMenu();
     const { navigateSidePanel } = useNavigateSidePanel();
     const { navigateToSidePanelSubPage } = useSidePanelSubPageHistory();
@@ -127,7 +128,7 @@ export const useNavigationMenuItemEditOrganizeActions =
           lastVisitedViewPerObjectMetadataItem,
         });
         if (isNonEmptyString(link)) {
-          navigate(link);
+          navigateToNavigationMenuItemLink(link);
         }
         navigateSidePanel({
           page: SidePanelPages.NavigationMenuItemEdit,


### PR DESCRIPTION
Clicking a Link item inside a sidebar folder navigated to the current origin with the link's full URL appended (`https://host/https:/host/object/dashboard/<id>`): the item handed the absolute URL to react-router's `navigate()`, which has no absolute-URL guard and resolves any string as a relative path.

Adds `useNavigateToNavigationMenuItemLink`, which sends a full URL to `window.open` (new tab, like top-level Link items) and everything else to `navigate()`, and uses it at the two nav-menu sites that can receive a Link item's URL: the folder sub-item click and the navigate-to-next-sibling after removing an item. A regression test pins the folder case.