### PR TITLE
fix(front): accept null Actor context.provider (#25532)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
@@ -316,7 +316,8 @@ export const FieldActorValueSchema = z.object({
   name: z.string(),
   context: z
     .object({
-      provider: z.enum(ConnectedAccountProvider).optional(),
+      // GraphQL ActorContext returns provider: null for MANUAL/SYSTEM/… actors
+      provider: z.enum(ConnectedAccountProvider).nullish(),
     })
     .nullable(),
 });

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/types/guards/__tests__/isFieldActorValue.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/types/guards/__tests__/isFieldActorValue.test.ts
@@ -1,0 +1,42 @@
+import { isFieldActorValue } from '@/object-record/record-field/ui/types/guards/isFieldActorValue';
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+describe('isFieldActorValue', () => {
+  it('accepts MANUAL actors whose context.provider is null (GraphQL ActorContext shape)', () => {
+    expect(
+      isFieldActorValue({
+        source: 'MANUAL',
+        workspaceMemberId: 'member-id',
+        name: 'Dani S',
+        context: { provider: null },
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts actors with a connected-account provider', () => {
+    expect(
+      isFieldActorValue({
+        source: 'CALENDAR',
+        workspaceMemberId: 'member-id',
+        name: 'Dani S',
+        context: { provider: ConnectedAccountProvider.MICROSOFT },
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts actors with context.provider omitted', () => {
+    expect(
+      isFieldActorValue({
+        source: 'SYSTEM',
+        workspaceMemberId: null,
+        name: 'System',
+        context: {},
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects non-actor values', () => {
+    expect(isFieldActorValue(null)).toBe(false);
+    expect(isFieldActorValue({ name: 'Dani S' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Treat GraphQL `ActorContext.provider: null` as valid in `FieldActorValueSchema` (`.nullish()` instead of `.optional()`)
- Add regression coverage in `isFieldActorValue` for MANUAL actors with `provider: null`

Fixes #25532

## Test plan
- [ ] Create a company manually → Companies list “Created by” shows the author (not blank)
- [ ] Calendar/email-sourced actors still render with provider
- [ ] CI: `isFieldActorValue` unit tests pass