### PR TITLE
bump call recorder app version to 1.13.0

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/call-recorder",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",


### PR DESCRIPTION
Bumps the call-recorder app to 1.13.0 to release the changes merged since 1.12.0:

- send-to-all-calendar-meetings toggle (#25431)
- Recording Bot preference reads On only when a bot is scheduled (#25412)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

