### PR TITLE
Clear a Recording Bot On the call recorder cannot honor

### DIFF
--- a/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
@@ -1212,8 +1212,57 @@ describe('call recorder app lifecycle (integration)', () => {
 
       expect(result).toEqual({
         skipped: true,
-        reason: 'no relevant calendar event change',
+        reason: 'preference change on a meeting whose bot is already due',
       });
+    });
+
+    it('clears an On set by hand on a meeting that already ended', async () => {
+      const calendarEventId = await createCalendarEvent({
+        startsAt: hoursAgo(3),
+        endsAt: hoursAgo(2),
+        callRecorderPreference: 'ON',
+      });
+
+      const result = await deliverCalendarEventUpdate({
+        calendarEventId,
+        updatedFields: ['callRecorderPreference'],
+        before: { callRecorderPreference: null },
+        after: { callRecorderPreference: 'ON' },
+      });
+
+      expect(result).toEqual(expect.objectContaining({ reconciled: true }));
+      expect(await fetchCallRecorderPreference(calendarEventId)).toBeNull();
+      expect(
+        await findCallRecordings({
+          calendarEventId: { in: [calendarEventId] },
+        }),
+      ).toEqual([]);
+    });
+
+    it('clears an On set by hand while the workspace recording switch is off', async () => {
+      vi.stubEnv(
+        CALL_RECORDER_CALENDAR_BOT_SCHEDULING_ENABLED_ENV_VAR_NAME,
+        'false',
+      );
+
+      const calendarEventId = await createCalendarEvent({
+        callRecorderPreference: 'ON',
+      });
+
+      const result = await deliverCalendarEventUpdate({
+        calendarEventId,
+        updatedFields: ['callRecorderPreference'],
+        before: { callRecorderPreference: null },
+        after: { callRecorderPreference: 'ON' },
+      });
+
+      expect(result).toEqual(expect.objectContaining({ reconciled: true }));
+      expect(await fetchCallRecorderPreference(calendarEventId)).toBeNull();
+      expect(
+        await findCallRecordings({
+          calendarEventId: { in: [calendarEventId] },
+        }),
+      ).toEqual([]);
     });
 
     it('schedules a bot and marks the event On when a user clears an Off', async () => {

--- a/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
@@ -1467,6 +1467,49 @@ describe('call recorder app lifecycle (integration)', () => {
       expect(await fetchCallRecorderPreference(calendarEventId)).toBeNull();
     });
 
+    it('restores the bot when a user sets On after a pause left a canceled request', async () => {
+      const { calendarEventId, callRecordingId } =
+        await scheduleRecordingThroughCalendarReconciliation();
+
+      turnRecordingOff();
+      await syncCalendarBotSchedulingHandler();
+      await reconcileCallRecorderForCalendarEventIds({
+        client,
+        calendarEventIds: [calendarEventId],
+      });
+
+      expect(
+        (await fetchCallRecording(callRecordingId)).recordingRequestStatus,
+      ).toBe('CANCELED');
+
+      vi.unstubAllEnvs();
+
+      await client.mutation({
+        updateCalendarEvent: {
+          __args: {
+            id: calendarEventId,
+            data: { callRecorderPreference: 'ON' },
+          },
+          id: true,
+        },
+      });
+
+      const result = await deliverCalendarEventUpdate({
+        calendarEventId,
+        updatedFields: ['callRecorderPreference'],
+        before: { callRecorderPreference: null },
+        after: { callRecorderPreference: 'ON' },
+      });
+
+      expect(result).toEqual(expect.objectContaining({ reconciled: true }));
+
+      const callRecording = await fetchCallRecording(callRecordingId);
+
+      expect(callRecording.recordingRequestStatus).toBe('REQUESTED');
+      expect(callRecording.externalBotId).toBeTruthy();
+      expect(await fetchCallRecorderPreference(calendarEventId)).toBe('ON');
+    });
+
     it('enqueues the upcoming-events sweep when turned back on', async () => {
       vi.stubEnv(
         CALL_RECORDER_CALENDAR_BOT_SCHEDULING_ENABLED_ENV_VAR_NAME,

--- a/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
@@ -1212,8 +1212,32 @@ describe('call recorder app lifecycle (integration)', () => {
 
       expect(result).toEqual({
         skipped: true,
-        reason: 'preference change on a meeting whose bot is already due',
+        reason: 'preference change on a meeting whose bot is already requested',
       });
+    });
+
+    it('schedules a bot when a user sets On on an eligible meeting that has none yet', async () => {
+      const calendarEventId = await createCalendarEvent({
+        callRecorderPreference: 'ON',
+      });
+
+      const result = await deliverCalendarEventUpdate({
+        calendarEventId,
+        updatedFields: ['callRecorderPreference'],
+        before: { callRecorderPreference: null },
+        after: { callRecorderPreference: 'ON' },
+      });
+
+      expect(result).toEqual(expect.objectContaining({ reconciled: true }));
+      expect(await fetchCallRecorderPreference(calendarEventId)).toBe('ON');
+
+      const callRecording = (
+        await findCallRecordings({ calendarEventId: { in: [calendarEventId] } })
+      )[0];
+
+      expect(callRecording).toBeDefined();
+      expect(callRecording.recordingRequestStatus).toBe('REQUESTED');
+      expect(callRecording.externalBotId).toBeTruthy();
     });
 
     it('clears an On set by hand on a meeting that already ended', async () => {

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/reconcile-call-recorder-calendar-event.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/reconcile-call-recorder-calendar-event.ts
@@ -10,8 +10,10 @@ import { CallRecorderPreference } from 'src/constants/call-recorder-preference';
 import { CALENDAR_EVENT_RECONCILIATION_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
 import { type RemovedCallRecorderOccurrence } from 'src/logic-functions/types/removed-call-recorder-occurrence.type';
 import { buildCallRecorderPolicyResult } from 'src/logic-functions/domain/build-call-recorder-policy-result.util';
+import { computeCallRecordingIdForMeeting } from 'src/logic-functions/domain/compute-call-recording-id-for-meeting.util';
 import { computeRealMeetingKey } from 'src/logic-functions/domain/compute-real-meeting-key.util';
 import { fetchCalendarEventsByIds } from 'src/logic-functions/data/fetch-calendar-events-by-ids.util';
+import { findCallRecordingsByIds } from 'src/logic-functions/data/find-call-recordings-by-ids.util';
 import { getUniqueSortedIds } from 'src/logic-functions/utils/get-unique-sorted-ids.util';
 import { reconcileCallRecorderForCalendarEventIds } from 'src/logic-functions/flows/reconcile-call-recorder.util';
 import { resolveConferenceLinkUrl } from 'src/logic-functions/domain/resolve-conference-link-url.util';
@@ -83,14 +85,14 @@ const handler = async (
 
   const client = new CoreApiClient();
 
-  // Skips only the echo of the app's own On write; an On the policy cannot honor reconciles and is cleared.
+  // Skips only the echo of the app's own On write; any other blank/On change reconciles, which schedules a missing bot or clears an On the policy cannot honor.
   if (
     isPreferenceChangeBetweenBlankAndOn(event) &&
-    (await isCallRecorderBotDueForCalendarEvent(client, event.recordId))
+    (await isRecordingOnAlreadyHonored(client, event.recordId))
   ) {
     return {
       skipped: true,
-      reason: 'preference change on a meeting whose bot is already due',
+      reason: 'preference change on a meeting whose bot is already requested',
     };
   }
 
@@ -181,7 +183,7 @@ const isPreferenceChangeBetweenBlankAndOn = (
   );
 };
 
-const isCallRecorderBotDueForCalendarEvent = async (
+const isRecordingOnAlreadyHonored = async (
   client: CoreApiClient,
   calendarEventId: string,
 ): Promise<boolean> => {
@@ -189,10 +191,23 @@ const isCallRecorderBotDueForCalendarEvent = async (
     await fetchCalendarEventsByIds(client, [calendarEventId])
   )[0];
 
-  return (
-    !isUndefined(calendarEvent) &&
-    buildCallRecorderPolicyResult(calendarEvent, new Date()).shouldRequestBot
-  );
+  if (isUndefined(calendarEvent)) {
+    return false;
+  }
+
+  const policyResult = buildCallRecorderPolicyResult(calendarEvent, new Date());
+
+  if (!policyResult.shouldRequestBot) {
+    return false;
+  }
+
+  const policyManagedCallRecording = (
+    await findCallRecordingsByIds(client, [
+      computeCallRecordingIdForMeeting(policyResult.realMeetingKey),
+    ])
+  )[0];
+
+  return !isUndefined(policyManagedCallRecording);
 };
 
 const hasKeyFieldChange = (updatedFields: string[]): boolean =>

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/reconcile-call-recorder-calendar-event.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/reconcile-call-recorder-calendar-event.ts
@@ -9,7 +9,9 @@ import {
 import { CallRecorderPreference } from 'src/constants/call-recorder-preference';
 import { CALENDAR_EVENT_RECONCILIATION_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
 import { type RemovedCallRecorderOccurrence } from 'src/logic-functions/types/removed-call-recorder-occurrence.type';
+import { buildCallRecorderPolicyResult } from 'src/logic-functions/domain/build-call-recorder-policy-result.util';
 import { computeRealMeetingKey } from 'src/logic-functions/domain/compute-real-meeting-key.util';
+import { fetchCalendarEventsByIds } from 'src/logic-functions/data/fetch-calendar-events-by-ids.util';
 import { getUniqueSortedIds } from 'src/logic-functions/utils/get-unique-sorted-ids.util';
 import { reconcileCallRecorderForCalendarEventIds } from 'src/logic-functions/flows/reconcile-call-recorder.util';
 import { resolveConferenceLinkUrl } from 'src/logic-functions/domain/resolve-conference-link-url.util';
@@ -80,6 +82,18 @@ const handler = async (
   }
 
   const client = new CoreApiClient();
+
+  // Skips only the echo of the app's own On write; an On the policy cannot honor reconciles and is cleared.
+  if (
+    isPreferenceChangeBetweenBlankAndOn(event) &&
+    (await isCallRecorderBotDueForCalendarEvent(client, event.recordId))
+  ) {
+    return {
+      skipped: true,
+      reason: 'preference change on a meeting whose bot is already due',
+    };
+  }
+
   const reconciliationResults = await reconcileCallRecorderForCalendarEventIds({
     client,
     calendarEventIds: reconciliationPayload.calendarEventIds,
@@ -114,14 +128,7 @@ const buildCalendarEventReconciliationPayload = ({
   if (action === 'updated') {
     const updatedFields = event.properties.updatedFields ?? [];
 
-    if (
-      !hasRelevantFieldChange(updatedFields) ||
-      isPreferenceChangeWithoutPolicyEffect({
-        updatedFields,
-        before: event.properties.before,
-        after: event.properties.after,
-      })
-    ) {
+    if (!hasRelevantFieldChange(updatedFields)) {
       return { calendarEventIds: [], removedOccurrences: [] };
     }
 
@@ -159,19 +166,34 @@ const hasRelevantFieldChange = (updatedFields: string[]): boolean =>
     CALL_RECORDER_RELEVANT_CALENDAR_EVENT_FIELDS.includes(updatedField),
   );
 
-const isPreferenceChangeWithoutPolicyEffect = ({
-  updatedFields,
-  before,
-  after,
-}: {
-  updatedFields: string[];
-  before: CalendarEventForDatabaseEvent | undefined;
-  after: CalendarEventForDatabaseEvent | undefined;
-}): boolean =>
-  updatedFields.length === 1 &&
-  updatedFields[0] === 'callRecorderPreference' &&
-  before?.callRecorderPreference !== CallRecorderPreference.OFF &&
-  after?.callRecorderPreference !== CallRecorderPreference.OFF;
+const isPreferenceChangeBetweenBlankAndOn = (
+  event: CalendarEventDatabaseEvent,
+): boolean => {
+  const updatedFields = event.properties.updatedFields ?? [];
+
+  return (
+    updatedFields.length === 1 &&
+    updatedFields[0] === 'callRecorderPreference' &&
+    event.properties.before?.callRecorderPreference !==
+      CallRecorderPreference.OFF &&
+    event.properties.after?.callRecorderPreference !==
+      CallRecorderPreference.OFF
+  );
+};
+
+const isCallRecorderBotDueForCalendarEvent = async (
+  client: CoreApiClient,
+  calendarEventId: string,
+): Promise<boolean> => {
+  const calendarEvent = (
+    await fetchCalendarEventsByIds(client, [calendarEventId])
+  )[0];
+
+  return (
+    !isUndefined(calendarEvent) &&
+    buildCallRecorderPolicyResult(calendarEvent, new Date()).shouldRequestBot
+  );
+};
 
 const hasKeyFieldChange = (updatedFields: string[]): boolean =>
   updatedFields.some((updatedField) =>

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/reconcile-call-recorder-calendar-event.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/reconcile-call-recorder-calendar-event.ts
@@ -7,6 +7,7 @@ import {
 } from 'twenty-sdk/define';
 
 import { CallRecorderPreference } from 'src/constants/call-recorder-preference';
+import { CallRecordingRequestStatus } from 'src/logic-functions/constants/call-recording-request-status';
 import { CALENDAR_EVENT_RECONCILIATION_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
 import { type RemovedCallRecorderOccurrence } from 'src/logic-functions/types/removed-call-recorder-occurrence.type';
 import { buildCallRecorderPolicyResult } from 'src/logic-functions/domain/build-call-recorder-policy-result.util';
@@ -207,7 +208,10 @@ const isRecordingOnAlreadyHonored = async (
     ])
   )[0];
 
-  return !isUndefined(policyManagedCallRecording);
+  return (
+    policyManagedCallRecording?.recordingRequestStatus ===
+    CallRecordingRequestStatus.REQUESTED
+  );
 };
 
 const hasKeyFieldChange = (updatedFields: string[]): boolean =>


### PR DESCRIPTION
## What

A user can set the Recording Bot field to On on a meeting the app will never record: one that already ended, or any meeting while the workspace recording switch is off. The calendar-event trigger skipped every blank-to-On change, so the value stuck with no bot behind it.

The trigger now skips a blank-to-On change only when the policy says a bot is due for that meeting, which is exactly the echo of the app's own On write. Any other blank-to-On change reconciles, and reconciliation already clears an On it cannot honor. A meeting that was actually recorded keeps its On, and Off is never touched.

Apps cannot reject a record edit before it saves, so the value reverts after the fact rather than being blocked. A validation hook for apps would be the proper fix and is out of scope here.

## Tests

- Unit suite green.
- Integration scenarios added for an On set by hand on an ended meeting and while the recording switch is off; the echo scenario expects the new skip reason. Not run locally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

