### PR TITLE
feat(usage-limit): count quota admits on failure and the credits they let through

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
@@ -60,6 +60,8 @@ export enum MetricsKeys {
   CommonApiQueryRateLimited = 'common-api-query/rate-limited',
   CommonApiApplicationQueryRateLimited = 'common-api-query/application-rate-limited',
   JobEnqueueApplicationRateLimited = 'job/enqueue-application-rate-limited',
+  UsageLimitQuotaAdmittedOnFailure = 'usage-limit-quota/admitted-on-failure',
+  UsageLimitQuotaAdmittedOnFailureCreditsMicro = 'usage-limit-quota/admitted-on-failure-credits-micro',
   JobCompleted = 'job/completed',
   JobFailed = 'job/failed',
   JobStalled = 'job/stalled',

--- a/packages/twenty-server/src/engine/core-modules/usage-limit/services/__tests__/usage-limit-quota.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/usage-limit/services/__tests__/usage-limit-quota.service.spec.ts
@@ -8,6 +8,8 @@ import {
   CacheLockExceptionCode,
 } from 'src/engine/core-modules/cache-lock/exceptions/cache-lock.exception';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import {
   UsageLimitException,
   UsageLimitExceptionCode,
@@ -113,6 +115,10 @@ describe('UsageLimitQuotaService', () => {
     findCurrentPeriodsByUnit: jest.fn(),
   };
 
+  const metricsService = {
+    incrementCounterBy: jest.fn(),
+  };
+
   let periodByUnit: Partial<Record<PeriodUnit, UsagePeriod>>;
 
   const setLimits = (limits: FlatUsageLimit[]) => {
@@ -184,6 +190,7 @@ describe('UsageLimitQuotaService', () => {
         { provide: CacheLockService, useValue: cacheLockService },
         { provide: ClickHouseService, useValue: clickHouseService },
         { provide: UsagePeriodService, useValue: usagePeriodService },
+        { provide: MetricsService, useValue: metricsService },
         {
           provide: DiscoveryService,
           useValue: {
@@ -370,6 +377,37 @@ describe('UsageLimitQuotaService', () => {
     cacheStorage.mget.mockRejectedValue(new Error('Socket closed'));
 
     await expect(assertQuotaNotExhausted()).resolves.toBeUndefined();
+    expect(metricsService.incrementCounterBy).toHaveBeenCalledTimes(1);
+    expect(metricsService.incrementCounterBy).toHaveBeenCalledWith({
+      key: MetricsKeys.UsageLimitQuotaAdmittedOnFailure,
+      amount: 1,
+      attributes: { operation: 'assert', resourceType: UsageResourceType.AI },
+    });
+  });
+
+  it('counts the credits admitted when a consume fails', async () => {
+    setLimits([buildLimit({})]);
+    cacheStorage.mget.mockRejectedValue(new Error('Socket closed'));
+
+    await expect(consumeQuota(50, 7)).resolves.toEqual({ exhausted: [] });
+    expect(metricsService.incrementCounterBy).toHaveBeenCalledWith({
+      key: MetricsKeys.UsageLimitQuotaAdmittedOnFailure,
+      amount: 1,
+      attributes: { operation: 'consume', resourceType: UsageResourceType.AI },
+    });
+    expect(metricsService.incrementCounterBy).toHaveBeenCalledWith({
+      key: MetricsKeys.UsageLimitQuotaAdmittedOnFailureCreditsMicro,
+      amount: 50,
+      attributes: { operation: 'consume', resourceType: UsageResourceType.AI },
+    });
+  });
+
+  it('does not count an admit on a successful consume', async () => {
+    setLimits([buildLimit({})]);
+    cacheStorage.runScript.mockResolvedValue([1, 500]);
+
+    await expect(consumeQuota(50)).resolves.toEqual({ exhausted: [] });
+    expect(metricsService.incrementCounterBy).not.toHaveBeenCalled();
   });
 
   it('admits when the warm query fails instead of granting a fresh budget', async () => {
@@ -643,6 +681,16 @@ describe('UsageLimitQuotaService', () => {
         service.getAllowanceRemainingMicro('workspace-1'),
       ).resolves.toBeNull();
       expect(cacheStorage.mget).not.toHaveBeenCalled();
+    });
+
+    it('does not count a failed read as an admit', async () => {
+      setAllowance(2_000_000);
+      cacheStorage.mget.mockRejectedValue(new Error('Socket closed'));
+
+      await expect(
+        service.getAllowanceRemainingMicro('workspace-1'),
+      ).resolves.toBeNull();
+      expect(metricsService.incrementCounterBy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/usage-limit/services/usage-limit-quota.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/usage-limit/services/usage-limit-quota.service.ts
@@ -14,6 +14,8 @@ import {
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import { CONSUME_QUOTA_COUNTERS_SCRIPT } from 'src/engine/core-modules/usage-limit/constants/consume-quota-counters-script.constant';
 import {
   UsageLimitException,
@@ -56,6 +58,12 @@ type AllowanceSumRow = {
   total: string | number | null;
 };
 
+type QuotaEnforcement = {
+  operation: 'assert' | 'consume';
+  resourceType: UsageResourceType;
+  cost?: QuotaCost;
+};
+
 type QuotaConsumeArgs = {
   workspaceId: string;
   resourceType: UsageResourceType;
@@ -78,6 +86,7 @@ export class UsageLimitQuotaService implements OnModuleInit {
     private readonly usagePeriodService: UsagePeriodService,
     private readonly discoveryService: DiscoveryService,
     private readonly usageLimitEntitlementService: UsageLimitEntitlementService,
+    private readonly metricsService: MetricsService,
   ) {}
 
   onModuleInit() {
@@ -283,6 +292,7 @@ export class UsageLimitQuotaService implements OnModuleInit {
       return this.admitOnFailure({
         error,
         workspaceId: args.workspaceId,
+        enforcement: { operation: 'assert', resourceType: args.resourceType },
         admitted: [],
       });
     }
@@ -321,6 +331,11 @@ export class UsageLimitQuotaService implements OnModuleInit {
       return this.admitOnFailure({
         error,
         workspaceId: args.workspaceId,
+        enforcement: {
+          operation: 'consume',
+          resourceType: args.resourceType,
+          cost,
+        },
         admitted: [],
       });
     }
@@ -378,10 +393,12 @@ export class UsageLimitQuotaService implements OnModuleInit {
   private admitOnFailure<TAdmitted>({
     error,
     workspaceId,
+    enforcement,
     admitted,
   }: {
     error: unknown;
     workspaceId: string;
+    enforcement?: QuotaEnforcement;
     admitted: TAdmitted;
   }): TAdmitted {
     if (
@@ -395,7 +412,33 @@ export class UsageLimitQuotaService implements OnModuleInit {
       `Usage quota enforcement degraded for workspace ${workspaceId}: ${error instanceof Error ? error.message : 'unknown error'}`,
     );
 
+    if (isDefined(enforcement)) {
+      this.countAdmitOnFailure(enforcement);
+    }
+
     return admitted;
+  }
+
+  private countAdmitOnFailure({
+    operation,
+    resourceType,
+    cost,
+  }: QuotaEnforcement): void {
+    const attributes = { operation, resourceType };
+
+    this.metricsService.incrementCounterBy({
+      key: MetricsKeys.UsageLimitQuotaAdmittedOnFailure,
+      amount: 1,
+      attributes,
+    });
+
+    if (isDefined(cost) && cost.creditsUsedMicro > 0) {
+      this.metricsService.incrementCounterBy({
+        key: MetricsKeys.UsageLimitQuotaAdmittedOnFailureCreditsMicro,
+        amount: cost.creditsUsedMicro,
+        attributes,
+      });
+    }
   }
 
   private async buildCounters(args: QuotaConsumeArgs): Promise<QuotaCounter[]> {

--- a/packages/twenty-server/src/engine/core-modules/usage-limit/usage-limit.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/usage-limit/usage-limit.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ClickHouseModule } from 'src/database/clickhouse/clickhouse.module';
 import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { CacheLockModule } from 'src/engine/core-modules/cache-lock/cache-lock.module';
+import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { UsageLimitQuotaService } from 'src/engine/core-modules/usage-limit/services/usage-limit-quota.service';
 import { UsagePeriodService } from 'src/engine/core-modules/usage-limit/services/usage-period.service';
 import { UsageModule } from 'src/engine/core-modules/usage/usage.module';
@@ -37,6 +38,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     DiscoveryModule,
     CacheLockModule,
     ClickHouseModule,
+    MetricsModule,
     UsageModule,
   ],
   providers: [


### PR DESCRIPTION
## What

Adds two counters so we can follow how often quota enforcement degrades open, and how many credits that lets through.

- `usage-limit-quota/admitted-on-failure`: +1 each time `UsageLimitQuotaService` admits a request because Redis, ClickHouse or the allowance provider failed.
- `usage-limit-quota/admitted-on-failure-credits-micro`: the `creditsUsedMicro` of the cost that was admitted without being debited.
- Both carry `operation` (`assert` | `consume`) and `resourceType` attributes.
- Only the enforcement paths count. The allowance balance read used by the billing credit gate still degrades open and logs, but is not a quota admit and records nothing.
- The credits counter is only fed by `consume`, the one path that knows the cost. An `assert` admit is counted but carries no credits.

Behaviour is unchanged: the same errors are still rethrown (`WorkspaceCacheException`, `UsageLimitException`) and everything else still admits.

## Why

Quota enforcement fails open by design. Today the only trace is a server log line, so we cannot see whether degradation is rare noise or a steady leak, nor what it costs. Occurrences give the rate, the credit counter gives the size of what slipped past the allowance.

## Test

- Unit specs on `UsageLimitQuotaService`:
  - an assert that cannot read its counters admits and records one occurrence tagged `assert`
  - a consume that cannot read its counters admits, records one occurrence tagged `consume` and the credits of the cost
  - a successful consume records nothing
  - a failed allowance balance read admits and records nothing
- `oxlint` and `tsgo --noEmit` clean on `twenty-server`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

