### PR TITLE
fix(front): report the records an interrupted incremental delete already removed

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useIncrementalDeleteManyRecords.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useIncrementalDeleteManyRecords.test.tsx
@@ -4,11 +4,14 @@ import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useIncrementalDeleteManyRecords } from '@/object-record/hooks/useIncrementalDeleteManyRecords';
 import { useIncrementalFetchAndMutateRecords } from '@/object-record/hooks/useIncrementalFetchAndMutateRecords';
+import { useRefetchAggregateQueries } from '@/object-record/hooks/useRefetchAggregateQueries';
 import { renderHook } from '@testing-library/react';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
 
 jest.mock('@/object-metadata/hooks/useObjectMetadataItem');
 jest.mock('@/object-metadata/hooks/useApolloCoreClient');
 jest.mock('@/object-record/hooks/useIncrementalFetchAndMutateRecords');
+jest.mock('@/object-record/hooks/useRefetchAggregateQueries');
 jest.mock('@/browser-event/utils/dispatchObjectRecordOperationBrowserEvent');
 jest.mock(
   '@/navigation-menu-item/common/hooks/useRemoveNavigationMenuItemByTargetRecordId',
@@ -25,11 +28,6 @@ jest.mock('@/object-record/cache/hooks/useGetRecordFromCache', () => ({
 jest.mock('@/object-record/hooks/useObjectPermissions', () => ({
   useObjectPermissions: () => ({ objectPermissionsByObjectMetadataId: {} }),
 }));
-jest.mock('@/object-record/hooks/useRefetchAggregateQueries', () => ({
-  useRefetchAggregateQueries: () => ({
-    refetchAggregateQueries: jest.fn(),
-  }),
-}));
 jest.mock('@/object-record/record-store/hooks/useUpsertRecordsInStore', () => ({
   useUpsertRecordsInStore: () => ({ upsertRecordsInStore: jest.fn() }),
 }));
@@ -45,6 +43,7 @@ const mockUseApolloCoreClient = jest.mocked(useApolloCoreClient);
 const mockUseIncrementalFetchAndMutateRecords = jest.mocked(
   useIncrementalFetchAndMutateRecords,
 );
+const mockUseRefetchAggregateQueries = jest.mocked(useRefetchAggregateQueries);
 const mockDispatchObjectRecordOperationBrowserEvent = jest.mocked(
   dispatchObjectRecordOperationBrowserEvent,
 );
@@ -52,9 +51,12 @@ const mockUseRemoveNavigationMenuItemByTargetRecordId = jest.mocked(
   useRemoveNavigationMenuItemByTargetRecordId,
 );
 
+const objectMetadataItem = getMockObjectMetadataItemOrThrow('company');
+
 describe('useIncrementalDeleteManyRecords', () => {
   const mockIncrementalFetchAndMutate = jest.fn();
   const mockRemoveNavigationMenuItemsByTargetRecordIds = jest.fn();
+  const mockRefetchAggregateQueries = jest.fn();
   const mockMutate = jest.fn();
 
   const renderDeleteHook = () =>
@@ -65,23 +67,23 @@ describe('useIncrementalDeleteManyRecords', () => {
       }),
     );
 
+  const deleteBatchOf = (recordIds: string[]) => ({
+    recordIds,
+    totalFetchedCount: recordIds.length,
+    totalCount: recordIds.length,
+    abortSignal: new AbortController().signal,
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseObjectMetadataItem.mockReturnValue({
-      objectMetadataItem: {
-        id: 'object-metadata-id',
-        nameSingular: 'company',
-        namePlural: 'companies',
-        fields: [],
-      } as any,
-    });
+    mockUseObjectMetadataItem.mockReturnValue({ objectMetadataItem });
 
     mockMutate.mockResolvedValue({});
     mockUseApolloCoreClient.mockReturnValue({
       mutate: mockMutate,
       cache: {},
-    } as any);
+    } as unknown as ReturnType<typeof useApolloCoreClient>);
 
     mockUseIncrementalFetchAndMutateRecords.mockReturnValue({
       incrementalFetchAndMutate: mockIncrementalFetchAndMutate,
@@ -89,19 +91,17 @@ describe('useIncrementalDeleteManyRecords', () => {
       isProcessing: false,
       updateProgress: jest.fn(),
       cancel: jest.fn(),
-    } as any);
+    });
+
+    mockRefetchAggregateQueries.mockResolvedValue(undefined);
+    mockUseRefetchAggregateQueries.mockReturnValue({
+      refetchAggregateQueries: mockRefetchAggregateQueries,
+    });
 
     mockUseRemoveNavigationMenuItemByTargetRecordId.mockReturnValue({
       removeNavigationMenuItemsByTargetRecordIds:
         mockRemoveNavigationMenuItemsByTargetRecordIds,
-    } as any);
-  });
-
-  const deleteBatchOf = (recordIds: string[]) => ({
-    recordIds,
-    totalFetchedCount: recordIds.length,
-    totalCount: recordIds.length,
-    abortSignal: new AbortController().signal,
+    });
   });
 
   it('should report every deleted record when all batches succeed', async () => {
@@ -116,14 +116,26 @@ describe('useIncrementalDeleteManyRecords', () => {
       3,
     );
 
-    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        operation: {
-          type: 'delete-many',
-          deletedRecordIds: ['record-1', 'record-2', 'record-3'],
-        },
-      }),
+    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledTimes(
+      1,
     );
+    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledWith({
+      objectMetadataItem,
+      operation: {
+        type: 'delete-many',
+        deletedRecordIds: ['record-1', 'record-2', 'record-3'],
+      },
+    });
+    expect(
+      mockRemoveNavigationMenuItemsByTargetRecordIds,
+    ).toHaveBeenCalledTimes(1);
+    expect(mockRemoveNavigationMenuItemsByTargetRecordIds).toHaveBeenCalledWith(
+      ['record-1', 'record-2', 'record-3'],
+    );
+    expect(mockRefetchAggregateQueries).toHaveBeenCalledTimes(1);
+    expect(mockRefetchAggregateQueries).toHaveBeenCalledWith({
+      objectMetadataNamePlural: objectMetadataItem.namePlural,
+    });
   });
 
   it('should report the records a failing run already deleted', async () => {
@@ -139,16 +151,71 @@ describe('useIncrementalDeleteManyRecords', () => {
       'Deletion failed',
     );
 
-    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        operation: {
-          type: 'delete-many',
-          deletedRecordIds: ['record-1', 'record-2'],
-        },
-      }),
+    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledTimes(
+      1,
     );
+    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledWith({
+      objectMetadataItem,
+      operation: {
+        type: 'delete-many',
+        deletedRecordIds: ['record-1', 'record-2'],
+      },
+    });
+    expect(
+      mockRemoveNavigationMenuItemsByTargetRecordIds,
+    ).toHaveBeenCalledTimes(1);
     expect(mockRemoveNavigationMenuItemsByTargetRecordIds).toHaveBeenCalledWith(
       ['record-1', 'record-2'],
+    );
+    expect(mockRefetchAggregateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not report a deletion when no record was deleted', async () => {
+    mockIncrementalFetchAndMutate.mockRejectedValue(new Error('Fetch failed'));
+
+    const { result } = renderDeleteHook();
+
+    await expect(result.current.incrementalDeleteManyRecords()).rejects.toThrow(
+      'Fetch failed',
+    );
+
+    expect(
+      mockDispatchObjectRecordOperationBrowserEvent,
+    ).not.toHaveBeenCalled();
+    expect(
+      mockRemoveNavigationMenuItemsByTargetRecordIds,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should keep the deletion error when the aggregate refetch also fails', async () => {
+    mockIncrementalFetchAndMutate.mockImplementation(async (mutateBatch) => {
+      await mutateBatch(deleteBatchOf(['record-1']));
+
+      throw new Error('Deletion failed');
+    });
+    mockRefetchAggregateQueries.mockRejectedValue(new Error('Refetch failed'));
+
+    const { result } = renderDeleteHook();
+
+    await expect(result.current.incrementalDeleteManyRecords()).rejects.toThrow(
+      'Deletion failed',
+    );
+
+    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('should surface a failing aggregate refetch when the deletion succeeded', async () => {
+    mockIncrementalFetchAndMutate.mockImplementation(async (mutateBatch) => {
+      await mutateBatch(deleteBatchOf(['record-1']));
+    });
+    mockRefetchAggregateQueries.mockRejectedValue(new Error('Refetch failed'));
+
+    const { result } = renderDeleteHook();
+
+    await expect(result.current.incrementalDeleteManyRecords()).rejects.toThrow(
+      'Refetch failed',
     );
   });
 });

--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useIncrementalDeleteManyRecords.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useIncrementalDeleteManyRecords.test.tsx
@@ -1,0 +1,154 @@
+import { dispatchObjectRecordOperationBrowserEvent } from '@/browser-event/utils/dispatchObjectRecordOperationBrowserEvent';
+import { useRemoveNavigationMenuItemByTargetRecordId } from '@/navigation-menu-item/common/hooks/useRemoveNavigationMenuItemByTargetRecordId';
+import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useIncrementalDeleteManyRecords } from '@/object-record/hooks/useIncrementalDeleteManyRecords';
+import { useIncrementalFetchAndMutateRecords } from '@/object-record/hooks/useIncrementalFetchAndMutateRecords';
+import { renderHook } from '@testing-library/react';
+
+jest.mock('@/object-metadata/hooks/useObjectMetadataItem');
+jest.mock('@/object-metadata/hooks/useApolloCoreClient');
+jest.mock('@/object-record/hooks/useIncrementalFetchAndMutateRecords');
+jest.mock('@/browser-event/utils/dispatchObjectRecordOperationBrowserEvent');
+jest.mock(
+  '@/navigation-menu-item/common/hooks/useRemoveNavigationMenuItemByTargetRecordId',
+);
+jest.mock('@/object-metadata/hooks/useObjectMetadataItems', () => ({
+  useObjectMetadataItems: () => ({ objectMetadataItems: [] }),
+}));
+jest.mock('@/object-record/hooks/useDeleteManyRecordsMutation', () => ({
+  useDeleteManyRecordsMutation: () => ({ deleteManyRecordsMutation: {} }),
+}));
+jest.mock('@/object-record/cache/hooks/useGetRecordFromCache', () => ({
+  useGetRecordFromCache: () => () => undefined,
+}));
+jest.mock('@/object-record/hooks/useObjectPermissions', () => ({
+  useObjectPermissions: () => ({ objectPermissionsByObjectMetadataId: {} }),
+}));
+jest.mock('@/object-record/hooks/useRefetchAggregateQueries', () => ({
+  useRefetchAggregateQueries: () => ({
+    refetchAggregateQueries: jest.fn(),
+  }),
+}));
+jest.mock('@/object-record/record-store/hooks/useUpsertRecordsInStore', () => ({
+  useUpsertRecordsInStore: () => ({ upsertRecordsInStore: jest.fn() }),
+}));
+jest.mock(
+  '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffectByBatch',
+  () => ({
+    triggerUpdateRecordOptimisticEffectByBatch: jest.fn(),
+  }),
+);
+
+const mockUseObjectMetadataItem = jest.mocked(useObjectMetadataItem);
+const mockUseApolloCoreClient = jest.mocked(useApolloCoreClient);
+const mockUseIncrementalFetchAndMutateRecords = jest.mocked(
+  useIncrementalFetchAndMutateRecords,
+);
+const mockDispatchObjectRecordOperationBrowserEvent = jest.mocked(
+  dispatchObjectRecordOperationBrowserEvent,
+);
+const mockUseRemoveNavigationMenuItemByTargetRecordId = jest.mocked(
+  useRemoveNavigationMenuItemByTargetRecordId,
+);
+
+describe('useIncrementalDeleteManyRecords', () => {
+  const mockIncrementalFetchAndMutate = jest.fn();
+  const mockRemoveNavigationMenuItemsByTargetRecordIds = jest.fn();
+  const mockMutate = jest.fn();
+
+  const renderDeleteHook = () =>
+    renderHook(() =>
+      useIncrementalDeleteManyRecords({
+        objectNameSingular: 'company',
+        delayInMsBetweenMutations: 0,
+      }),
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseObjectMetadataItem.mockReturnValue({
+      objectMetadataItem: {
+        id: 'object-metadata-id',
+        nameSingular: 'company',
+        namePlural: 'companies',
+        fields: [],
+      } as any,
+    });
+
+    mockMutate.mockResolvedValue({});
+    mockUseApolloCoreClient.mockReturnValue({
+      mutate: mockMutate,
+      cache: {},
+    } as any);
+
+    mockUseIncrementalFetchAndMutateRecords.mockReturnValue({
+      incrementalFetchAndMutate: mockIncrementalFetchAndMutate,
+      progress: { displayType: 'number' },
+      isProcessing: false,
+      updateProgress: jest.fn(),
+      cancel: jest.fn(),
+    } as any);
+
+    mockUseRemoveNavigationMenuItemByTargetRecordId.mockReturnValue({
+      removeNavigationMenuItemsByTargetRecordIds:
+        mockRemoveNavigationMenuItemsByTargetRecordIds,
+    } as any);
+  });
+
+  const deleteBatchOf = (recordIds: string[]) => ({
+    recordIds,
+    totalFetchedCount: recordIds.length,
+    totalCount: recordIds.length,
+    abortSignal: new AbortController().signal,
+  });
+
+  it('should report every deleted record when all batches succeed', async () => {
+    mockIncrementalFetchAndMutate.mockImplementation(async (mutateBatch) => {
+      await mutateBatch(deleteBatchOf(['record-1', 'record-2']));
+      await mutateBatch(deleteBatchOf(['record-3']));
+    });
+
+    const { result } = renderDeleteHook();
+
+    await expect(result.current.incrementalDeleteManyRecords()).resolves.toBe(
+      3,
+    );
+
+    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: {
+          type: 'delete-many',
+          deletedRecordIds: ['record-1', 'record-2', 'record-3'],
+        },
+      }),
+    );
+  });
+
+  it('should report the records a failing run already deleted', async () => {
+    mockIncrementalFetchAndMutate.mockImplementation(async (mutateBatch) => {
+      await mutateBatch(deleteBatchOf(['record-1', 'record-2']));
+
+      throw new Error('Deletion failed');
+    });
+
+    const { result } = renderDeleteHook();
+
+    await expect(result.current.incrementalDeleteManyRecords()).rejects.toThrow(
+      'Deletion failed',
+    );
+
+    expect(mockDispatchObjectRecordOperationBrowserEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: {
+          type: 'delete-many',
+          deletedRecordIds: ['record-1', 'record-2'],
+        },
+      }),
+    );
+    expect(mockRemoveNavigationMenuItemsByTargetRecordIds).toHaveBeenCalledWith(
+      ['record-1', 'record-2'],
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/hooks/useIncrementalDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useIncrementalDeleteManyRecords.ts
@@ -18,7 +18,7 @@ import { useRefetchAggregateQueries } from '@/object-record/hooks/useRefetchAggr
 import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { useCallback } from 'react';
-import { isDefined } from 'twenty-shared/utils';
+import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 import { sleep } from '~/utils/sleep';
 
 const DEFAULT_DELAY_BETWEEN_MUTATIONS_MS = 50;
@@ -224,6 +224,8 @@ export const useIncrementalDeleteManyRecords = <T>({
     let totalDeletedCount = 0;
     const allDeletedRecordIds: string[] = [];
 
+    let deletionError: unknown;
+
     try {
       await incrementalFetchAndMutate(
         async ({ recordIds, totalCount, abortSignal }) => {
@@ -235,13 +237,11 @@ export const useIncrementalDeleteManyRecords = <T>({
           updateProgress(totalDeletedCount, totalCount);
         },
       );
-    } finally {
-      // A failing batch leaves the earlier ones deleted, so what did go through
-      // is reported before the error propagates.
-      await refetchAggregateQueries({
-        objectMetadataNamePlural: objectMetadataItem.namePlural,
-      });
+    } catch (error) {
+      deletionError = error;
+    }
 
+    if (isNonEmptyArray(allDeletedRecordIds)) {
       removeNavigationMenuItemsByTargetRecordIds(allDeletedRecordIds);
 
       dispatchObjectRecordOperationBrowserEvent({
@@ -251,6 +251,18 @@ export const useIncrementalDeleteManyRecords = <T>({
           deletedRecordIds: allDeletedRecordIds,
         },
       });
+    }
+
+    await refetchAggregateQueries({
+      objectMetadataNamePlural: objectMetadataItem.namePlural,
+    }).catch((refetchError: unknown) => {
+      if (!isDefined(deletionError)) {
+        throw refetchError;
+      }
+    });
+
+    if (isDefined(deletionError)) {
+      throw deletionError;
     }
 
     return totalDeletedCount;

--- a/packages/twenty-front/src/modules/object-record/hooks/useIncrementalDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useIncrementalDeleteManyRecords.ts
@@ -224,30 +224,34 @@ export const useIncrementalDeleteManyRecords = <T>({
     let totalDeletedCount = 0;
     const allDeletedRecordIds: string[] = [];
 
-    await incrementalFetchAndMutate(
-      async ({ recordIds, totalCount, abortSignal }) => {
-        await deleteManyRecordsBatch(recordIds, abortSignal);
+    try {
+      await incrementalFetchAndMutate(
+        async ({ recordIds, totalCount, abortSignal }) => {
+          await deleteManyRecordsBatch(recordIds, abortSignal);
 
-        allDeletedRecordIds.push(...recordIds);
-        totalDeletedCount += recordIds.length;
+          allDeletedRecordIds.push(...recordIds);
+          totalDeletedCount += recordIds.length;
 
-        updateProgress(totalDeletedCount, totalCount);
-      },
-    );
+          updateProgress(totalDeletedCount, totalCount);
+        },
+      );
+    } finally {
+      // A failing batch leaves the earlier ones deleted, so what did go through
+      // is reported before the error propagates.
+      await refetchAggregateQueries({
+        objectMetadataNamePlural: objectMetadataItem.namePlural,
+      });
 
-    await refetchAggregateQueries({
-      objectMetadataNamePlural: objectMetadataItem.namePlural,
-    });
+      removeNavigationMenuItemsByTargetRecordIds(allDeletedRecordIds);
 
-    removeNavigationMenuItemsByTargetRecordIds(allDeletedRecordIds);
-
-    dispatchObjectRecordOperationBrowserEvent({
-      objectMetadataItem,
-      operation: {
-        type: 'delete-many',
-        deletedRecordIds: allDeletedRecordIds,
-      },
-    });
+      dispatchObjectRecordOperationBrowserEvent({
+        objectMetadataItem,
+        operation: {
+          type: 'delete-many',
+          deletedRecordIds: allDeletedRecordIds,
+        },
+      });
+    }
 
     return totalDeletedCount;
   };


### PR DESCRIPTION
Follow-up to the review comment on #25415: deleting 31 records deletes the first 30, then a failing second batch leaves all 31 on screen.

## What happens today

`incrementalDeleteManyRecords` loops over batches and does its post-work after the loop. A batch that fails rolls back its own optimistic update and rethrows, which propagates out of `incrementalFetchAndMutate` and skips all three post-steps for the batches that already succeeded:

- `refetchAggregateQueries`, so every count still includes deleted records.
- `removeNavigationMenuItemsByTargetRecordIds`, so favourites and menu entries survive their record.
- `dispatchObjectRecordOperationBrowserEvent`, so anything listening for `delete-many` never hears about the deletion.

Record indexes half-recover on their own, because their rows come from the Apollo cache and only the failing batch's optimistic update is reverted. Surfaces that are not cache-backed do not: the core workflows index learns about deletions only from the event, so it keeps all 31 rows and the selection, with just an error snackbar to go on.

## Change

The batch loop's error is captured rather than thrown immediately, the post-steps run over the ids that actually got deleted, and the error is rethrown afterwards. On the success path the same three calls run with the same arguments as before.

Order matters and is deliberate. The navigation cleanup and the `delete-many` event are synchronous and go first, so a failing aggregate refetch cannot suppress them. The refetch runs last, and its rejection is only rethrown when the deletion itself succeeded: when both fail, the caller gets the deletion error, which is the one worth showing.

Both are guarded by `isNonEmptyArray(allDeletedRecordIds)`, so a run that deletes nothing dispatches no event and resets no listening table.

## Tests

`useIncrementalDeleteManyRecords` had no spec. Five cases: every batch succeeding reports all the ids through all three post-steps; a run that deletes one batch and then fails reports that batch's ids and still rejects; a run that deletes nothing reports nothing; a deletion failure followed by a refetch failure surfaces the deletion error; and a refetch failure on a successful deletion still surfaces. The second fails on `main`.
