### PR TITLE
Add a color scheme toolbar to twenty-ui Storybook with dark catalog stories for Field and Text

### DIFF
--- a/packages/twenty-ui/.storybook/preview-head.html
+++ b/packages/twenty-ui/.storybook/preview-head.html
@@ -8,6 +8,10 @@
   html {
     font-size: 13px;
   }
+  html.dark {
+    background: var(--t-background-primary);
+    color: var(--t-font-color-primary);
+  }
   .sbdocs-wrapper {
     padding: 0 !important;
   }

--- a/packages/twenty-ui/.storybook/preview.tsx
+++ b/packages/twenty-ui/.storybook/preview.tsx
@@ -14,10 +14,30 @@ const preview: Preview = {
       test: 'error',
     },
   },
+  globalTypes: {
+    colorScheme: {
+      description: 'Color scheme applied by ThemeProvider',
+      toolbar: {
+        title: 'Color scheme',
+        icon: 'circlehollow',
+        items: [
+          { value: 'light', title: 'Light', icon: 'sun' },
+          { value: 'dark', title: 'Dark', icon: 'moon' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    colorScheme: 'light',
+  },
   decorators: [
-    (Story) => {
+    (Story, context) => {
+      const colorScheme =
+        context.globals.colorScheme === 'dark' ? 'dark' : 'light';
+
       return (
-        <ThemeProvider colorScheme="light">
+        <ThemeProvider colorScheme={colorScheme}>
           <Story />
         </ThemeProvider>
       );

--- a/packages/twenty-ui/src/input/Field/__stories__/Field.stories.tsx
+++ b/packages/twenty-ui/src/input/Field/__stories__/Field.stories.tsx
@@ -1,13 +1,17 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { A11Y_DEFER_COLOR_CONTRAST, ComponentDecorator } from '@ui/testing';
+import {
+  A11Y_DEFER_COLOR_CONTRAST,
+  CatalogDecorator,
+  type CatalogStory,
+  ComponentDecorator,
+} from '@ui/testing';
 
 import { Field } from '@ui/input/Field/Field';
 
 const meta: Meta<typeof Field.Root> = {
   title: 'UI/Input/Field',
   component: Field.Root,
-  decorators: [ComponentDecorator],
 };
 
 export default meta;
@@ -15,6 +19,7 @@ export default meta;
 type Story = StoryObj<typeof Field.Root>;
 
 export const Default: Story = {
+  decorators: [ComponentDecorator],
   parameters: { a11y: A11Y_DEFER_COLOR_CONTRAST },
   render: () => (
     <Field.Root>
@@ -25,6 +30,7 @@ export const Default: Story = {
 };
 
 export const WithError: Story = {
+  decorators: [ComponentDecorator],
   parameters: { a11y: A11Y_DEFER_COLOR_CONTRAST },
   render: () => (
     <Field.Root>
@@ -32,4 +38,52 @@ export const WithError: Story = {
       <Field.Error match>This field is required</Field.Error>
     </Field.Root>
   ),
+};
+
+type FieldCatalogState = 'default' | 'invalid' | 'disabled';
+type FieldCatalogHelper = 'description' | 'error';
+
+export const Catalog: CatalogStory<Story, typeof Field.Root> = {
+  parameters: {
+    a11y: A11Y_DEFER_COLOR_CONTRAST,
+    catalog: {
+      dimensions: [
+        {
+          name: 'state',
+          values: [
+            'default',
+            'invalid',
+            'disabled',
+          ] satisfies FieldCatalogState[],
+          props: (state: FieldCatalogState) => ({
+            disabled: state === 'disabled',
+            invalid: state === 'invalid',
+          }),
+        },
+        {
+          name: 'helper',
+          values: ['description', 'error'] satisfies FieldCatalogHelper[],
+          props: (helper: FieldCatalogHelper) => ({
+            children: (
+              <>
+                <Field.Label>Label</Field.Label>
+                {helper === 'error' ? (
+                  <Field.Error match>This field is required</Field.Error>
+                ) : (
+                  <Field.Description>This is a hint</Field.Description>
+                )}
+              </>
+            ),
+          }),
+        },
+      ],
+    },
+  },
+  decorators: [CatalogDecorator],
+};
+
+export const CatalogDark: CatalogStory<Story, typeof Field.Root> = {
+  ...Catalog,
+  tags: ['!autodocs'],
+  globals: { colorScheme: 'dark' },
 };

--- a/packages/twenty-ui/src/testing/types/CatalogStory.ts
+++ b/packages/twenty-ui/src/testing/types/CatalogStory.ts
@@ -12,8 +12,10 @@ export type CatalogStory<
 > = {
   args?: StoryType['args'];
   argTypes?: StoryType['argTypes'];
+  globals?: StoryType['globals'];
   play?: StoryType['play'];
   render?: StoryType['render'];
+  tags?: StoryType['tags'];
   parameters: StoryType['parameters'] & {
     catalog: {
       dimensions: CatalogDimension<ComponentType>[];

--- a/packages/twenty-ui/src/typography/Text/__stories__/Text.stories.tsx
+++ b/packages/twenty-ui/src/typography/Text/__stories__/Text.stories.tsx
@@ -1,14 +1,18 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
 
-import { ComponentDecorator } from '@ui/testing';
+import {
+  A11Y_DEFER_COLOR_CONTRAST,
+  CatalogDecorator,
+  type CatalogStory,
+  ComponentDecorator,
+} from '@ui/testing';
 
 import { Text } from '@ui/typography/Text/Text';
 
 const meta: Meta<typeof Text> = {
   title: 'UI/Typography/Text',
   component: Text,
-  decorators: [ComponentDecorator],
 };
 
 export default meta;
@@ -19,6 +23,7 @@ const LONG_TEXT =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore';
 
 export const Truncate: Story = {
+  decorators: [ComponentDecorator],
   args: {
     truncate: true,
     children: LONG_TEXT,
@@ -39,6 +44,7 @@ export const Truncate: Story = {
 };
 
 export const LineClamp: Story = {
+  decorators: [ComponentDecorator],
   args: {
     lineClamp: 2,
     children: LONG_TEXT,
@@ -56,4 +62,48 @@ export const LineClamp: Story = {
     await expect(overflow).toBe('hidden');
     await expect(text.scrollHeight).toBeGreaterThan(text.clientHeight);
   },
+};
+
+type TextCatalogOverflow = 'wrap' | 'truncate' | 'lineClamp';
+
+const getTextCatalogOverflowProps = (overflow: TextCatalogOverflow) => {
+  if (overflow === 'truncate') {
+    return { truncate: true };
+  }
+
+  if (overflow === 'lineClamp') {
+    return { lineClamp: 2 };
+  }
+
+  return {};
+};
+
+export const Catalog: CatalogStory<Story, typeof Text> = {
+  args: { children: LONG_TEXT },
+  parameters: {
+    a11y: A11Y_DEFER_COLOR_CONTRAST,
+    catalog: {
+      dimensions: [
+        {
+          name: 'overflow',
+          values: [
+            'wrap',
+            'truncate',
+            'lineClamp',
+          ] satisfies TextCatalogOverflow[],
+          props: getTextCatalogOverflowProps,
+        },
+      ],
+      options: {
+        elementContainer: { style: { width: 120 } },
+      },
+    },
+  },
+  decorators: [CatalogDecorator],
+};
+
+export const CatalogDark: CatalogStory<Story, typeof Text> = {
+  ...Catalog,
+  tags: ['!autodocs'],
+  globals: { colorScheme: 'dark' },
 };


### PR DESCRIPTION
twenty-ui's Storybook hardcoded `<ThemeProvider colorScheme="light">`, so neither the axe gate nor the Argos screenshots ever saw the dark palette. This adds a color scheme toolbar (`globalTypes.colorScheme`, light by default so every existing story renders as before) and paints the dark canvas from `preview-head.html` once the `dark` class is on `<html>`.

Each component family gets one opt-in dark story: `CatalogDark` spreads the family's `Catalog` and pins `globals: { colorScheme: 'dark' }`, so axe and Argos cover the dark palette on exactly one story per family instead of doubling every snapshot. `CatalogStory` gains the optional `globals` and `tags` keys for it. Field and Text, the two families already on main, get a `Catalog` and a `CatalogDark` here. Their existing stories are untouched; their `ComponentDecorator` moves from meta to story level to match the other catalog files, with identical output.

The toolbar shows the locked value on `CatalogDark` stories. The Field part stylesheets have no invalid or disabled styling yet, so those catalog rows are currently identical; the axis is there for when they get styled.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

