### PR TITLE
fix(twenty-shared): honor SQL percent wildcards in array containsIlike (#25247)

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/is-record-matching-rls-row-level-permission-predicate.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/is-record-matching-rls-row-level-permission-predicate.util.spec.ts
@@ -134,6 +134,7 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
         joinColumnName: 'companyId',
       },
     ),
+    createMockFlatFieldMetadata('users-id', 'users', FieldMetadataType.ARRAY),
   ];
 
   const flatObjectMetadata = createMockFlatObjectMetadata(
@@ -152,6 +153,7 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
       addressCity: 'Paris',
     },
     companyId: 'company-1',
+    users: ['user-1', 'user-2'],
     deletedAt: null,
     id: 'record-1',
     createdAt: new Date().toISOString(),
@@ -337,6 +339,26 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
       isRecordMatchingRLSRowLevelPermissionPredicate({
         record: { ...baseRecord, company: { id: 'company-1' } } as ObjectRecord,
         filter: { company: { is: 'NULL' } },
+        flatObjectMetadata,
+        flatFieldMetadataMaps,
+      }),
+    ).toBe(false);
+  });
+
+  it('matches an array CONTAINS current-user filter that wraps the id in SQL wildcards', () => {
+    expect(
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: baseRecord,
+        filter: { users: { containsIlike: '%user-1%' } },
+        flatObjectMetadata,
+        flatFieldMetadataMaps,
+      }),
+    ).toBe(true);
+
+    expect(
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: baseRecord,
+        filter: { users: { containsIlike: '%user-999%' } },
         flatObjectMetadata,
         flatFieldMetadataMaps,
       }),

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingArrayFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingArrayFilter.test.ts
@@ -120,6 +120,22 @@ describe('isMatchingArrayFilter', () => {
         }),
       ).toBe(false);
     });
+
+    it('should treat a pattern without percent signs as a whole-string ILIKE match', () => {
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: 'test' },
+          value: ['TEST'],
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: 'test' },
+          value: ['test item'],
+        }),
+      ).toBe(false);
+    });
   });
 
   describe('error handling', () => {

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingArrayFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingArrayFilter.test.ts
@@ -72,7 +72,7 @@ describe('isMatchingArrayFilter', () => {
     it('should return true when array contains item matching case-insensitive search', () => {
       expect(
         isMatchingArrayFilter({
-          arrayFilter: { containsIlike: 'TEST' },
+          arrayFilter: { containsIlike: '%TEST%' },
           value: ['test item'],
         }),
       ).toBe(true);
@@ -81,7 +81,7 @@ describe('isMatchingArrayFilter', () => {
     it('should return false when array does not contain item matching search', () => {
       expect(
         isMatchingArrayFilter({
-          arrayFilter: { containsIlike: 'missing' },
+          arrayFilter: { containsIlike: '%missing%' },
           value: ['test item'],
         }),
       ).toBe(false);
@@ -90,7 +90,7 @@ describe('isMatchingArrayFilter', () => {
     it('should return false when value is null and using containsIlike', () => {
       expect(
         isMatchingArrayFilter({
-          arrayFilter: { containsIlike: 'test' },
+          arrayFilter: { containsIlike: '%test%' },
           value: null,
         }),
       ).toBe(false);
@@ -99,10 +99,26 @@ describe('isMatchingArrayFilter', () => {
     it('should match partial strings case-insensitively', () => {
       expect(
         isMatchingArrayFilter({
-          arrayFilter: { containsIlike: 'TE' },
+          arrayFilter: { containsIlike: '%TE%' },
           value: ['Test Item', 'Another Item'],
         }),
       ).toBe(true);
+    });
+
+    it('should treat percent signs as SQL ILIKE wildcards', () => {
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: '%user-1%' },
+          value: ['user-1'],
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingArrayFilter({
+          arrayFilter: { containsIlike: '%user-1%' },
+          value: ['user-2'],
+        }),
+      ).toBe(false);
     });
   });
 

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingArrayFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingArrayFilter.ts
@@ -1,5 +1,7 @@
 import { type ArrayFilter } from '@/types';
 
+import { isMatchingStringFilter } from './isMatchingStringFilter';
+
 export const isMatchingArrayFilter = ({
   arrayFilter,
   value,
@@ -19,10 +21,17 @@ export const isMatchingArrayFilter = ({
       return Array.isArray(value) && value.length === 0;
     }
     case arrayFilter.containsIlike !== undefined: {
-      const searchTerm = arrayFilter.containsIlike.toLowerCase();
+      const ilikePattern = arrayFilter.containsIlike;
+
+      // Postgres unnest(array) ILIKE :pattern treats % as a wildcard
       return (
         Array.isArray(value) &&
-        value.some((item) => item.toLowerCase().includes(searchTerm))
+        value.some((item) =>
+          isMatchingStringFilter({
+            stringFilter: { ilike: ilikePattern },
+            value: item,
+          }),
+        )
       );
     }
     default: {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/25247

An RLS rule `array field CONTAINS current user` compiles to `{ containsIlike: '%<id>%' }`. Postgres `unnest(array) ILIKE '%id%'` matches. The in-memory helper used `String.includes`, so `'user-1'.includes('%user-1%')` was false and updates threw `Updated record does not satisfy row-level security constraints of your current role` even when the row still satisfied the rule.

`containsIlike` now goes through `isMatchingStringFilter` `{ ilike }`, the same `%` to `.*` translation TEXT already uses. Existing substring cases in the unit file now use `%...%`, which is what `turnRecordFilterIntoGqlOperationFilter` emits. Underscore wildcard parity stays with #25489. Multi-line array items with `%` patterns share the TEXT helper's newline gap tracked in #25499.

A pattern with no `%` is whole-string case-insensitive equality (Postgres `ILIKE 'foo'`), not a substring. The unit file locks that.

```
npx jest packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingArrayFilter.test.ts --config=packages/twenty-shared/jest.config.mjs --no-coverage
```

15 passed. With the helper reverted, `containsIlike: '%user-1%'` against `['user-1']` is false. The RLS predicate spec is in the diff as a consumer-level lock. Server jest loads `twenty-shared` from dist, so that file is not cited as a revert check.
