### PR TITLE
ci(docker): cover install.sh and 1-click.sh in the CI Docker workflow

### DIFF
--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -167,8 +167,6 @@ jobs:
         env:
           LC_ALL: C.UTF-8
         run: shellcheck --shell=bash --severity=error packages/twenty-docker/scripts/*.sh
-      # The scripts download docker-compose.yml, .env.example and install.sh from GitHub,
-      # so they are pointed at this pull request's head to exercise its own files.
       - name: Run install scripts against the pull request head
         run: bash packages/twenty-docker/scripts/install.test.sh "${{ github.event.pull_request.head.sha }}"
   ci-test-docker-status-check:

--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -19,6 +19,7 @@ jobs:
       files: |
         packages/twenty-docker/**
         docker-compose.yml
+        .github/workflows/ci-test-docker-compose.yaml
   test-compose:
     needs: changed-files-check
     if: needs.changed-files-check.outputs.any_changed == 'true'
@@ -154,11 +155,27 @@ jobs:
             echo "Still waiting... (${count}/300s) [HTTP ${status}]"
             sleep 1
           done
+  test-install-scripts:
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Lint scripts
+        env:
+          LC_ALL: C.UTF-8
+        run: shellcheck --shell=bash --severity=error packages/twenty-docker/scripts/*.sh
+      # The scripts download docker-compose.yml, .env.example and install.sh from GitHub,
+      # so they are pointed at this pull request's head to exercise its own files.
+      - name: Run install scripts against the pull request head
+        run: bash packages/twenty-docker/scripts/install.test.sh "${{ github.event.pull_request.head.sha }}"
   ci-test-docker-status-check:
     if: always() && !cancelled()
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: [changed-files-check, test-compose, test-app-dev]
+    needs: [changed-files-check, test-compose, test-app-dev, test-install-scripts]
     steps:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -12,13 +12,14 @@ pull_branch=${BRANCH:-twenty/$pull_version}
 
 install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
 
-if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh "$install_url"; then
-  rm -f twenty_install.sh
+if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh.tmp "$install_url"; then
+  rm -f twenty_install.sh.tmp
   echo "Error: Failed to download the install script from $install_url"
   echo "If this is a 404, the release may be incomplete; anything else is usually GitHub"
   echo "rate limiting your network, in which case retrying in a minute will work."
   exit 1
 fi
+mv twenty_install.sh.tmp twenty_install.sh
 
 chmod +x twenty_install.sh
 # Pass the resolved values down so the tagged install.sh does not resolve them again

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,19 +1,27 @@
-pull_version=${VERSION:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
+pull_version=${VERSION:-$(curl -fsS "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 
 if [[ -z "$pull_version" ]]; then
-  echo "Error: Unable to fetch the latest version tag. Please check your network connection or the GitHub API response."
+  echo "Error: Unable to fetch the latest version tag. Please check your network connection or the Docker Hub API response."
   exit 1
 fi
-pull_branch=${BRANCH:-$pull_version}
+# Release tags are namespaced since twenty/v2.9.1
+pull_branch=${BRANCH:-twenty/$pull_version}
 
 version_num=${pull_version#v}
 target_version="0.32.4"
 
 # We moved the install script to a different location in v0.32.4
 if [[ -n "$BRANCH" ]] || [[ "$(printf '%s\n' "$target_version" "$version_num" | sort -V | head -n1)" != "$version_num" ]]; then
-  curl -sL "https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh" -o twenty_install.sh
+  install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
 else
-  curl -sL "https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/install.sh" -o twenty_install.sh
+  install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/install.sh"
+fi
+
+if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh "$install_url"; then
+  echo "Error: Failed to download the install script from $install_url"
+  echo "If this is a 404, the release may be incomplete; anything else is usually GitHub"
+  echo "rate limiting your network, in which case retrying in a minute will work."
+  exit 1
 fi
 
 chmod +x twenty_install.sh

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,13 +1,16 @@
-# "latest" is only an alias of the newest release, resolve it to the real tag
-[[ "$VERSION" == "latest" ]] && unset VERSION
+release_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+$'
+if [[ -n "$VERSION" && ! "$VERSION" =~ $release_tag_pattern ]]; then
+  echo "Error: VERSION must be a full release tag such as v2.38.1, omit it to install the latest release."
+  exit 1
+fi
 
-pull_version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+pull_version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | cut -d'"' -f4 | grep -E "$release_tag_pattern" | sort -V | tail -n1)}
 
 if [[ -z "$pull_version" ]]; then
   echo "Error: Unable to fetch the latest version tag. Please check your network connection or the Docker Hub API response."
   exit 1
 fi
-# Release tags are namespaced since twenty/v2.9.1, older releases are not supported
+# Releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported
 pull_branch=${BRANCH:-twenty/$pull_version}
 
 install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
@@ -15,8 +18,8 @@ install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/pack
 if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh.tmp "$install_url"; then
   rm -f twenty_install.sh.tmp
   echo "Error: Failed to download the install script from $install_url"
-  echo "If this is a 404, the release may be incomplete; anything else is usually GitHub"
-  echo "rate limiting your network, in which case retrying in a minute will work."
+  echo "If this is a 404, the twenty/<version> ref does not exist: releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported."
+  echo "Anything else is usually GitHub rate limiting your network, in which case retrying in a minute will work."
   exit 1
 fi
 mv twenty_install.sh.tmp twenty_install.sh
@@ -24,5 +27,7 @@ mv twenty_install.sh.tmp twenty_install.sh
 chmod +x twenty_install.sh
 # Pass the resolved values down so the tagged install.sh does not resolve them again
 VERSION="$pull_version" BRANCH="$pull_branch" ./twenty_install.sh
+install_status=$?
 
 rm twenty_install.sh
+exit $install_status

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,23 +1,16 @@
-pull_version=${VERSION:-$(curl -fsS "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+pull_version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 
 if [[ -z "$pull_version" ]]; then
   echo "Error: Unable to fetch the latest version tag. Please check your network connection or the Docker Hub API response."
   exit 1
 fi
-# Release tags are namespaced since twenty/v2.9.1
+# Release tags are namespaced since twenty/v2.9.1, older releases are not supported
 pull_branch=${BRANCH:-twenty/$pull_version}
 
-version_num=${pull_version#v}
-target_version="0.32.4"
-
-# We moved the install script to a different location in v0.32.4
-if [[ -n "$BRANCH" ]] || [[ "$(printf '%s\n' "$target_version" "$version_num" | sort -V | head -n1)" != "$version_num" ]]; then
-  install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
-else
-  install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/install.sh"
-fi
+install_url="https://raw.githubusercontent.com/twentyhq/twenty/$pull_branch/packages/twenty-docker/scripts/install.sh"
 
 if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh "$install_url"; then
+  rm -f twenty_install.sh
   echo "Error: Failed to download the install script from $install_url"
   echo "If this is a 404, the release may be incomplete; anything else is usually GitHub"
   echo "rate limiting your network, in which case retrying in a minute will work."
@@ -25,6 +18,7 @@ if ! curl -fsSL --retry 3 --retry-delay 2 -o twenty_install.sh "$install_url"; t
 fi
 
 chmod +x twenty_install.sh
-VERSION="$VERSION" BRANCH="$BRANCH" ./twenty_install.sh
+# Pass the resolved values down so the tagged install.sh does not resolve them again
+VERSION="$pull_version" BRANCH="$pull_branch" ./twenty_install.sh
 
 rm twenty_install.sh

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,3 +1,6 @@
+# "latest" is only an alias of the newest release, resolve it to the real tag
+[[ "$VERSION" == "latest" ]] && unset VERSION
+
 pull_version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 
 if [[ -z "$pull_version" ]]; then

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -43,9 +43,28 @@ function on_exit {
 }
 trap on_exit EXIT
 
+# Download a file, failing loudly instead of writing an HTTP error page to disk.
+# curl retries 429/5xx on its own; raw.githubusercontent.com throttles by IP.
+function download {
+  local url=$1
+  local dest=$2
+  if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest" "$url"; then
+    echo -e "\t❌ Failed to download $url"
+    echo -e "\t\tIf this is a 404, the release may be incomplete; anything else is usually GitHub"
+    echo -e "\t\trate limiting your network, in which case retrying in a minute will work."
+    exit 1
+  fi
+}
+
 # Use environment variables VERSION and BRANCH, with defaults if not set
-version=${VERSION:-$(curl -s "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
-branch=${BRANCH:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
+version=${VERSION:-$(curl -fsS "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+if [ -z "$version" ]; then
+  echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."
+  exit 1
+fi
+# Release tags are namespaced since twenty/v2.9.1; deriving the branch from the
+# image tag also keeps docker-compose.yml and the image in lockstep.
+branch=${BRANCH:-twenty/$version}
 
 echo "🚀 Using docker version $version and Github branch $branch"
 
@@ -74,11 +93,11 @@ mkdir -p "$dir_name" && cd "$dir_name" || { echo "❌ Failed to create/access di
 
 # Copy twenty/packages/twenty-docker/docker-compose.yml in it
 echo -e "\t• Copying docker-compose.yml"
-curl -sLo docker-compose.yml https://raw.githubusercontent.com/twentyhq/twenty/$branch/packages/twenty-docker/docker-compose.yml
+download "https://raw.githubusercontent.com/twentyhq/twenty/$branch/packages/twenty-docker/docker-compose.yml" docker-compose.yml
 
 # Copy twenty/packages/twenty-docker/.env.example to .env
 echo -e "\t• Setting up .env file"
-curl -sLo .env https://raw.githubusercontent.com/twentyhq/twenty/$branch/packages/twenty-docker/.env.example
+download "https://raw.githubusercontent.com/twentyhq/twenty/$branch/packages/twenty-docker/.env.example" .env
 
 # Replace TAG=latest by TAG=<latest_release or version input>
 if [[ $(uname) == "Darwin" ]]; then

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -49,6 +49,7 @@ function download {
   local url=$1
   local dest=$2
   if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest" "$url"; then
+    rm -f "$dest"
     echo -e "\t❌ Failed to download $url"
     echo -e "\t\tIf this is a 404, the release may be incomplete; anything else is usually GitHub"
     echo -e "\t\trate limiting your network, in which case retrying in a minute will work."
@@ -57,13 +58,13 @@ function download {
 }
 
 # Use environment variables VERSION and BRANCH, with defaults if not set
-version=${VERSION:-$(curl -fsS "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 if [ -z "$version" ]; then
   echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."
   exit 1
 fi
-# Release tags are namespaced since twenty/v2.9.1; deriving the branch from the
-# image tag also keeps docker-compose.yml and the image in lockstep.
+# Release tags are namespaced since twenty/v2.9.1, older releases are not supported.
+# Deriving the branch from the image tag also keeps docker-compose.yml and the image in lockstep.
 branch=${BRANCH:-twenty/$version}
 
 echo "🚀 Using docker version $version and Github branch $branch"

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -58,6 +58,8 @@ function download {
 }
 
 # Use environment variables VERSION and BRANCH, with defaults if not set
+# "latest" is only an alias of the newest release, resolve it to the real tag
+[[ "$VERSION" == "latest" ]] && unset VERSION
 version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
 if [ -z "$version" ]; then
   echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -51,23 +51,26 @@ function download {
   if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest.tmp" "$url"; then
     rm -f "$dest.tmp"
     echo -e "\t❌ Failed to download $url"
-    echo -e "\t\tIf this is a 404, the release may be incomplete; anything else is usually GitHub"
-    echo -e "\t\trate limiting your network, in which case retrying in a minute will work."
+    echo -e "\t\tIf this is a 404, the twenty/<version> ref does not exist: releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported."
+    echo -e "\t\tAnything else is usually GitHub rate limiting your network, in which case retrying in a minute will work."
     exit 1
   fi
   mv "$dest.tmp" "$dest"
 }
 
 # Use environment variables VERSION and BRANCH, with defaults if not set
-# "latest" is only an alias of the newest release, resolve it to the real tag
-[[ "$VERSION" == "latest" ]] && unset VERSION
-version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+release_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+$'
+if [[ -n "$VERSION" && ! "$VERSION" =~ $release_tag_pattern ]]; then
+  echo -e "\t❌ VERSION must be a full release tag such as v2.38.1, omit it to install the latest release."
+  exit 1
+fi
+version=${VERSION:-$(curl -fsS --retry 3 --retry-delay 2 "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags?page_size=100" | grep -o '"name":"[^"]*"' | cut -d'"' -f4 | grep -E "$release_tag_pattern" | sort -V | tail -n1)}
 if [ -z "$version" ]; then
   echo -e "\t❌ Unable to resolve the latest release from Docker Hub. Check your network, or set VERSION explicitly."
   exit 1
 fi
-# Release tags are namespaced since twenty/v2.9.1, older releases are not supported.
-# Deriving the branch from the image tag also keeps docker-compose.yml and the image in lockstep.
+# Releases that predate the twenty/ tag namespace (v2.9.0 and older) are not supported.
+# Deriving the branch from the image tag keeps docker-compose.yml and the image in lockstep.
 branch=${BRANCH:-twenty/$version}
 
 echo "🚀 Using docker version $version and Github branch $branch"

--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -48,13 +48,14 @@ trap on_exit EXIT
 function download {
   local url=$1
   local dest=$2
-  if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest" "$url"; then
-    rm -f "$dest"
+  if ! curl -fsSL --retry 3 --retry-delay 2 -o "$dest.tmp" "$url"; then
+    rm -f "$dest.tmp"
     echo -e "\t❌ Failed to download $url"
     echo -e "\t\tIf this is a 404, the release may be incomplete; anything else is usually GitHub"
     echo -e "\t\trate limiting your network, in which case retrying in a minute will work."
     exit 1
   fi
+  mv "$dest.tmp" "$dest"
 }
 
 # Use environment variables VERSION and BRANCH, with defaults if not set

--- a/packages/twenty-docker/scripts/install.test.sh
+++ b/packages/twenty-docker/scripts/install.test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Exercises install.sh and 1-click.sh against the real Docker Hub and GitHub.
+# Usage: install.test.sh <git ref>
+# <git ref> is where the scripts under test fetch docker-compose.yml, .env.example and
+# install.sh from: the pull request head sha in CI, any pushed branch or sha locally.
+set -euo pipefail
+
+scripts_dir=$(cd "$(dirname "$0")" && pwd)
+ref=${1:?usage: $0 <git ref>}
+release_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+cd "$work_dir"
+
+function pass {
+  echo "✅ $1"
+}
+
+function fail {
+  echo "❌ $1"
+  exit 1
+}
+
+# Answers the directory prompt, declines to start the containers, and captures output and exit status
+function run_install {
+  local directory=$1
+  shift
+  install_output=$(printf '%s\nn\n' "$directory" | env "$@" "$scripts_dir/install.sh" 2>&1) && install_status=0 || install_status=$?
+}
+
+function run_one_click {
+  local directory=$1
+  shift
+  install_output=$(printf '%s\nn\n' "$directory" | env "$@" bash "$scripts_dir/1-click.sh" 2>&1) && install_status=0 || install_status=$?
+}
+
+function assert_install_directory {
+  local directory=$1
+  local expected_tag=$2
+  [ -f "$directory/docker-compose.yml" ] || fail "$directory/docker-compose.yml is missing"
+  [ -f "$directory/.env" ] || fail "$directory/.env is missing"
+  ! ls "$directory"/*.tmp >/dev/null 2>&1 || fail "$directory still contains a .tmp download"
+  grep -q "^TAG=$expected_tag$" "$directory/.env" || fail "$directory/.env does not pin TAG=$expected_tag"
+  grep -q "^ENCRYPTION_KEY=." "$directory/.env" || fail "$directory/.env has no generated ENCRYPTION_KEY"
+  grep -q "^PG_DATABASE_PASSWORD=." "$directory/.env" || fail "$directory/.env has no generated PG_DATABASE_PASSWORD"
+  (cd "$directory" && docker compose config --quiet 2>/dev/null) || fail "docker compose config rejects $directory"
+}
+
+echo "▶ default resolution pairs the newest Docker Hub release with its twenty/<version> git tag"
+run_install default
+[ "$install_status" -eq 0 ] || fail "install.sh failed without arguments: $install_output"
+resolved_version=$(echo "$install_output" | sed -n 's/.*Using docker version \([^ ]*\) and Github branch \([^ ]*\).*/\1/p')
+resolved_branch=$(echo "$install_output" | sed -n 's/.*Using docker version \([^ ]*\) and Github branch \([^ ]*\).*/\2/p')
+[[ "$resolved_version" =~ $release_tag_pattern ]] || fail "resolved version '$resolved_version' is not a release tag"
+[ "$resolved_branch" = "twenty/$resolved_version" ] || fail "resolved branch '$resolved_branch' does not match twenty/$resolved_version"
+assert_install_directory default "$resolved_version"
+pass "resolved $resolved_version from $resolved_branch"
+
+echo "▶ files fetched from $ref produce a valid setup"
+run_install from-ref BRANCH="$ref"
+[ "$install_status" -eq 0 ] || fail "install.sh failed with BRANCH=$ref: $install_output"
+assert_install_directory from-ref "$resolved_version"
+pass "BRANCH=$ref"
+
+echo "▶ a pinned version resolves its own twenty/<version> tag"
+run_install pinned VERSION="$resolved_version"
+[ "$install_status" -eq 0 ] || fail "install.sh failed with VERSION=$resolved_version: $install_output"
+echo "$install_output" | grep -q "Github branch twenty/$resolved_version" || fail "VERSION=$resolved_version did not resolve twenty/$resolved_version"
+assert_install_directory pinned "$resolved_version"
+pass "VERSION=$resolved_version"
+
+echo "▶ VERSION only accepts a full release tag"
+for rejected_version in latest v2 v2.38 v2.40.0-rc.1; do
+  run_install rejected VERSION="$rejected_version"
+  [ "$install_status" -ne 0 ] || fail "VERSION=$rejected_version was accepted"
+  echo "$install_output" | grep -q "full release tag" || fail "VERSION=$rejected_version did not explain the expected format: $install_output"
+  [ ! -d rejected ] || fail "VERSION=$rejected_version created a directory before failing"
+done
+pass "latest, floating and pre-release tags are rejected before any download"
+
+echo "▶ a release without a twenty/<version> tag aborts cleanly and keeps an existing config"
+mkdir keep
+echo "existing compose" > keep/docker-compose.yml
+echo "EXISTING_ENV=1" > keep/.env
+install_output=$(printf 'keep\ny\n' | VERSION=v2.9.0 "$scripts_dir/install.sh" 2>&1) && install_status=0 || install_status=$?
+[ "$install_status" -ne 0 ] || fail "VERSION=v2.9.0 succeeded although twenty/v2.9.0 does not exist"
+echo "$install_output" | grep -q "twenty/v2.9.0" || fail "the error does not name the missing ref: $install_output"
+[ "$(cat keep/docker-compose.yml)" = "existing compose" ] || fail "existing docker-compose.yml was modified"
+[ "$(cat keep/.env)" = "EXISTING_ENV=1" ] || fail "existing .env was modified"
+! ls keep/*.tmp >/dev/null 2>&1 || fail "a .tmp download was left behind"
+pass "VERSION=v2.9.0 fails without touching keep/"
+
+echo "▶ 1-click.sh bootstraps install.sh from $ref and forwards the resolved version and branch"
+run_one_click one-click BRANCH="$ref"
+[ "$install_status" -eq 0 ] || fail "1-click.sh failed with BRANCH=$ref: $install_output"
+echo "$install_output" | grep -q "Using docker version $resolved_version and Github branch $ref" || fail "1-click.sh did not forward VERSION and BRANCH: $install_output"
+assert_install_directory one-click "$resolved_version"
+[ ! -e twenty_install.sh ] || fail "1-click.sh left twenty_install.sh behind"
+pass "1-click.sh BRANCH=$ref"
+
+echo "▶ 1-click.sh rejects a non-release VERSION and propagates install failures"
+run_one_click one-click-rejected VERSION=v2
+[ "$install_status" -ne 0 ] || fail "1-click.sh accepted VERSION=v2"
+echo "$install_output" | grep -q "full release tag" || fail "1-click.sh did not explain the expected format: $install_output"
+run_one_click one-click-old VERSION=v2.9.0
+[ "$install_status" -ne 0 ] || fail "1-click.sh exited 0 although the install failed"
+[ ! -e twenty_install.sh ] || fail "1-click.sh left twenty_install.sh behind after failing"
+[ ! -e twenty_install.sh.tmp ] || fail "1-click.sh left twenty_install.sh.tmp behind after failing"
+pass "1-click.sh exit status and cleanup"
+
+echo "All install script checks passed"

--- a/packages/twenty-docker/scripts/install.test.sh
+++ b/packages/twenty-docker/scripts/install.test.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-# Exercises install.sh and 1-click.sh against the real Docker Hub and GitHub.
-# Usage: install.test.sh <git ref>
-# <git ref> is where the scripts under test fetch docker-compose.yml, .env.example and
-# install.sh from: the pull request head sha in CI, any pushed branch or sha locally.
 set -euo pipefail
 
 scripts_dir=$(cd "$(dirname "$0")" && pwd)
@@ -22,7 +18,6 @@ function fail {
   exit 1
 }
 
-# Answers the directory prompt, declines to start the containers, and captures output and exit status
 function run_install {
   local directory=$1
   shift

--- a/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
@@ -28,12 +28,18 @@ Install the latest stable version of Twenty with a single command:
 bash <(curl -sL https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/scripts/install.sh)
 ```
 
-To install a specific version or branch:
+To install a specific version:
 ```bash
-VERSION=vx.y.z BRANCH=branch-name bash <(curl -sL https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/scripts/install.sh)
+VERSION=v2.38.1 bash <(curl -sL https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/scripts/install.sh)
 ```
-- Replace x.y.z with the desired version number.
-- Replace branch-name with the name of the branch you want to install.
+- `VERSION` must be a full release tag published on [Docker Hub](https://hub.docker.com/r/twentycrm/twenty/tags), such as `v2.38.1`. Aliases such as `v2` or `latest` are not accepted.
+- The matching `docker-compose.yml` is fetched from the `twenty/<version>` git tag, so releases that predate these tags (v2.9.0 and older) can't be installed with the script.
+
+To fetch the configuration files from a branch instead, for example to test unreleased changes:
+```bash
+BRANCH=branch-name bash <(curl -sL https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/scripts/install.sh)
+```
+- Replace branch-name with the branch to fetch `docker-compose.yml` and `.env.example` from. The image still defaults to the latest release unless `VERSION` is also set.
 
 ## Option 2: Manual steps
 Follow these steps for a manual setup.


### PR DESCRIPTION
Follow-up to #25524. Stacked on `fix/install-script-tag-resolution`, to be retargeted to `main` once that merges.

## Why

Neither `install.sh` nor `1-click.sh` is exercised by CI. The CI Docker workflow tests `docker-compose.yml` with a locally built image and a hand-copied `.env`, but never runs the scripts users actually invoke. That is how the branch resolution stayed pinned to `v2.9.0` for three months.

## What

`packages/twenty-docker/scripts/install.test.sh` runs both scripts non-interactively against the real Docker Hub and GitHub, and asserts:

- default resolution yields a `vX.Y.Z` release whose `twenty/<version>` git tag exists, and the result passes `docker compose config`
- files fetched from the pull request head (`BRANCH=<sha>`) produce a valid setup, with `TAG` pinned and secrets generated
- a pinned `VERSION` resolves its own `twenty/<version>` tag
- `latest`, `v2`, `v2.38` and `v2.40.0-rc.1` are rejected before any download, with no directory created
- a release without a namespaced tag (`v2.9.0`) aborts naming the missing ref, leaves no `.tmp` file, and does not touch an existing `docker-compose.yml` or `.env`
- `1-click.sh` bootstraps `install.sh` from the pull request head, forwards the resolved `VERSION` and `BRANCH`, exits with the install status, and leaves nothing behind

A `test-install-scripts` job in `ci-test-docker-compose.yaml` lints the scripts with shellcheck at error severity and runs the harness against `github.event.pull_request.head.sha`. It is gated on the same changed-files check as the compose jobs and feeds the existing status-check job. The workflow file itself is added to the changed-files list.

The harness runs in about five seconds locally and can be run by hand against any pushed ref:

```bash
bash packages/twenty-docker/scripts/install.test.sh <branch or sha>
```

## Checked

- Harness passes against the `fix/install-script-tag-resolution` head
- Harness fails on the first assertion when run against `main`'s scripts, so it detects the bug the parent PR fixes
- `shellcheck --severity=error` is clean on all three scripts. One pre-existing warning (SC2046 in the health-wait loop of `install.sh`) is left alone, which is why the job lints at error severity

## Not covered

- A full `docker compose up` with the released image. The existing `test-compose` job already boots the stack; a scheduled drift check between Docker Hub tags and git tags could be added separately
- macOS, since GitHub macOS runners have no Docker daemon and the scripts abort on the dependency check


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgxmXBxLh1Ngm3L6mKJh8A)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

