### PR TITLE
fix(workflow): stop mirroring soft-deleted workflows into core

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-core-sync.service.ts
@@ -33,7 +33,11 @@ export class WorkflowCoreSyncService {
     workspaceId: string,
     workflows: WorkflowWorkspaceEntity[],
   ): Promise<void> {
-    if (workflows.length === 0) {
+    const liveWorkflows = workflows.filter(
+      (workflow) => !isDefined(workflow.deletedAt),
+    );
+
+    if (liveWorkflows.length === 0) {
       return;
     }
 
@@ -41,12 +45,12 @@ export class WorkflowCoreSyncService {
 
     const linkedCoreWorkflowIds = await this.resolveOwnedCoreWorkflowIds(
       workspaceId,
-      workflows,
+      liveWorkflows,
     );
 
     const coreWorkflowIdByWorkspaceRecordId = new Map<string, string>();
 
-    const coreRows = workflows.map((workflow) => {
+    const coreRows = liveWorkflows.map((workflow) => {
       const candidateCoreWorkflowId = workflow.coreWorkflowId;
 
       const linkedCoreWorkflowId =

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/core-workflows.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/core-workflows.integration-spec.ts
@@ -655,6 +655,14 @@ describe('coreWorkflows (e2e)', () => {
     expect(deletedWorkflowStatuses).toEqual(['DEACTIVATED']);
 
     for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+      if (!isDefined(await findCoreWorkflowByName(softDeletedName))) {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+
+    for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
       expect(await findCoreWorkflowByName(softDeletedName)).toBeUndefined();
 
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/core-workflows.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/core-workflows.integration-spec.ts
@@ -92,6 +92,18 @@ describe('coreWorkflows (e2e)', () => {
       .find((workflow) => workflow.workspaceWorkflowId === workflowId);
   };
 
+  const findCoreWorkflowByName = async (
+    name: string,
+  ): Promise<CoreWorkflow | undefined> => {
+    const response = await graphql(CORE_WORKFLOWS_QUERY);
+
+    expect(response.body.errors).toBeUndefined();
+
+    return (response.body.data.coreWorkflows.edges as { node: CoreWorkflow }[])
+      .map((edge) => edge.node)
+      .find((workflow) => workflow.name === name);
+  };
+
   const waitForCoreWorkflow = async (
     predicate: (workflow: CoreWorkflow | undefined) => boolean,
   ): Promise<CoreWorkflow | undefined> => {
@@ -492,6 +504,131 @@ describe('coreWorkflows (e2e)', () => {
     const secondPage = secondPageResponse.body.data.coreWorkflows;
 
     expect(secondPage.edges[0].node.id).not.toBe(firstPage.edges[0].node.id);
+  });
+
+  it('should not list a workflow once it is soft-deleted', async () => {
+    const softDeletedName = 'Core Workflows Soft Deleted';
+
+    const createResponse = await graphql(
+      `
+        mutation CreateWorkflow($name: String!) {
+          createWorkflow(data: { name: $name }) {
+            id
+          }
+        }
+      `,
+      { name: softDeletedName },
+    );
+
+    expect(createResponse.body.errors).toBeUndefined();
+
+    const softDeletedWorkflowId = createResponse.body.data.createWorkflow.id;
+
+    const versionResponse = await graphql(
+      `
+        query GetWorkflow($id: UUID!) {
+          workflow(filter: { id: { eq: $id } }) {
+            versions {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `,
+      { id: softDeletedWorkflowId },
+    );
+
+    const softDeletedVersionId =
+      versionResponse.body.data.workflow.versions.edges[0].node.id;
+
+    await updateWorkflowVersionTrigger({
+      workflowVersionId: softDeletedVersionId,
+      trigger: {
+        name: 'Manual Trigger',
+        type: 'MANUAL',
+        settings: { outputSchema: {} },
+        nextStepIds: [],
+        position: { x: 0, y: 0 },
+      },
+    });
+
+    await graphql(
+      `
+        mutation CreateWorkflowVersionStep(
+          $input: CreateWorkflowVersionStepInput!
+        ) {
+          createWorkflowVersionStep(input: $input) {
+            stepsDiff
+          }
+        }
+      `,
+      {
+        input: {
+          workflowVersionId: softDeletedVersionId,
+          stepType: 'FIND_RECORDS',
+          parentStepId: 'trigger',
+          position: { x: 200, y: 0 },
+        },
+      },
+    );
+
+    const activateResponse = await graphql(
+      `
+        mutation ActivateWorkflowVersion($workflowVersionId: UUID!) {
+          activateWorkflowVersion(workflowVersionId: $workflowVersionId)
+        }
+      `,
+      { workflowVersionId: softDeletedVersionId },
+    );
+
+    expect(activateResponse.body.errors).toBeUndefined();
+
+    for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+      const listed = await findCoreWorkflowByName(softDeletedName);
+
+      if (listed?.statuses.includes('ACTIVE') === true) {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+
+    const deleteResponse = await graphql(
+      `
+        mutation DeleteWorkflow($id: UUID!) {
+          deleteWorkflow(id: $id) {
+            id
+          }
+        }
+      `,
+      { id: softDeletedWorkflowId },
+    );
+
+    expect(deleteResponse.body.errors).toBeUndefined();
+
+    for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+      if (!isDefined(await findCoreWorkflowByName(softDeletedName))) {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+
+    expect(await findCoreWorkflowByName(softDeletedName)).toBeUndefined();
+
+    await graphql(
+      `
+        mutation DestroyWorkflow($id: UUID!) {
+          destroyWorkflow(id: $id) {
+            id
+          }
+        }
+      `,
+      { id: softDeletedWorkflowId },
+    );
   });
 
   it('should not list the workflow once it is destroyed', async () => {

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/core-workflows.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/core-workflows.integration-spec.ts
@@ -68,10 +68,11 @@ describe('coreWorkflows (e2e)', () => {
   let workflowId: string;
   let firstVersionId: string;
   let alreadyDestroyed = false;
+  let softDeletedWorkflowId: string | undefined;
 
-  const findCoreWorkflow = async (
+  const listCoreWorkflows = async (
     filter?: CoreWorkflowFilter,
-  ): Promise<CoreWorkflow | undefined> => {
+  ): Promise<CoreWorkflow[]> => {
     const response = await graphql(CORE_WORKFLOWS_QUERY, { filter });
 
     expect(response.body.errors).toBeUndefined();
@@ -87,22 +88,20 @@ describe('coreWorkflows (e2e)', () => {
       expect(totalCount).toBe(edges.length);
     }
 
-    return edges
-      .map((edge) => edge.node)
-      .find((workflow) => workflow.workspaceWorkflowId === workflowId);
+    return edges.map((edge) => edge.node);
   };
+
+  const findCoreWorkflow = async (
+    filter?: CoreWorkflowFilter,
+  ): Promise<CoreWorkflow | undefined> =>
+    (await listCoreWorkflows(filter)).find(
+      (workflow) => workflow.workspaceWorkflowId === workflowId,
+    );
 
   const findCoreWorkflowByName = async (
     name: string,
-  ): Promise<CoreWorkflow | undefined> => {
-    const response = await graphql(CORE_WORKFLOWS_QUERY);
-
-    expect(response.body.errors).toBeUndefined();
-
-    return (response.body.data.coreWorkflows.edges as { node: CoreWorkflow }[])
-      .map((edge) => edge.node)
-      .find((workflow) => workflow.name === name);
-  };
+  ): Promise<CoreWorkflow | undefined> =>
+    (await listCoreWorkflows()).find((workflow) => workflow.name === name);
 
   const waitForCoreWorkflow = async (
     predicate: (workflow: CoreWorkflow | undefined) => boolean,
@@ -153,6 +152,19 @@ describe('coreWorkflows (e2e)', () => {
   });
 
   afterAll(async () => {
+    if (isDefined(softDeletedWorkflowId)) {
+      await graphql(
+        `
+          mutation DestroyWorkflow($id: UUID!) {
+            destroyWorkflow(id: $id) {
+              id
+            }
+          }
+        `,
+        { id: softDeletedWorkflowId },
+      );
+    }
+
     if (alreadyDestroyed) {
       return;
     }
@@ -522,7 +534,7 @@ describe('coreWorkflows (e2e)', () => {
 
     expect(createResponse.body.errors).toBeUndefined();
 
-    const softDeletedWorkflowId = createResponse.body.data.createWorkflow.id;
+    softDeletedWorkflowId = createResponse.body.data.createWorkflow.id;
 
     const versionResponse = await graphql(
       `
@@ -586,15 +598,19 @@ describe('coreWorkflows (e2e)', () => {
 
     expect(activateResponse.body.errors).toBeUndefined();
 
-    for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
-      const listed = await findCoreWorkflowByName(softDeletedName);
+    let activated: CoreWorkflow | undefined;
 
-      if (listed?.statuses.includes('ACTIVE') === true) {
+    for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+      activated = await findCoreWorkflowByName(softDeletedName);
+
+      if (activated?.statuses.includes('ACTIVE') === true) {
         break;
       }
 
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
+
+    expect(activated?.statuses).toEqual(['ACTIVE']);
 
     const deleteResponse = await graphql(
       `
@@ -609,26 +625,40 @@ describe('coreWorkflows (e2e)', () => {
 
     expect(deleteResponse.body.errors).toBeUndefined();
 
+    let deletedWorkflowStatuses: string[] | undefined;
+
     for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
-      if (!isDefined(await findCoreWorkflowByName(softDeletedName))) {
+      const deletedWorkflowResponse = await graphql(
+        `
+          query DeletedWorkflow($id: UUID!) {
+            workflow(
+              filter: { id: { eq: $id }, not: { deletedAt: { is: "NULL" } } }
+            ) {
+              id
+              statuses
+            }
+          }
+        `,
+        { id: softDeletedWorkflowId },
+      );
+
+      deletedWorkflowStatuses =
+        deletedWorkflowResponse.body.data?.workflow?.statuses;
+
+      if (deletedWorkflowStatuses?.includes('DEACTIVATED') === true) {
         break;
       }
 
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
 
-    expect(await findCoreWorkflowByName(softDeletedName)).toBeUndefined();
+    expect(deletedWorkflowStatuses).toEqual(['DEACTIVATED']);
 
-    await graphql(
-      `
-        mutation DestroyWorkflow($id: UUID!) {
-          destroyWorkflow(id: $id) {
-            id
-          }
-        }
-      `,
-      { id: softDeletedWorkflowId },
-    );
+    for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+      expect(await findCoreWorkflowByName(softDeletedName)).toBeUndefined();
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
   });
 
   it('should not list the workflow once it is destroyed', async () => {

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/core-workflows.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/core-workflows.integration-spec.ts
@@ -603,7 +603,7 @@ describe('coreWorkflows (e2e)', () => {
     for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
       activated = await findCoreWorkflowByName(softDeletedName);
 
-      if (activated?.statuses.includes('ACTIVE') === true) {
+      if (activated?.statuses.includes('ACTIVE')) {
         break;
       }
 
@@ -645,7 +645,7 @@ describe('coreWorkflows (e2e)', () => {
       deletedWorkflowStatuses =
         deletedWorkflowResponse.body.data?.workflow?.statuses;
 
-      if (deletedWorkflowStatuses?.includes('DEACTIVATED') === true) {
+      if (deletedWorkflowStatuses?.includes('DEACTIVATED')) {
         break;
       }
 


### PR DESCRIPTION
Deleting a workflow leaves a row on the core workflows index that cannot be selected, opened or deleted again. It comes back seconds after the delete, with no checkbox and no link.

## What happens

The dual-write listener does the right thing on `workflow.deleted`: it hard-deletes the mirrored `core."workflow"` row. Then something updates the workflow again and puts the row back.

The update is real. Deleting a workflow deactivates its active version, which enqueues `WorkflowStatusesUpdateJob`, which writes the new `statuses` onto the workflow. The event snapshot is built with `withDeleted()`, so an update on a soft-deleted record still emits `workflow.updated`, and `handleUpdated` mirrors whatever it is given. `upsertToCore` never looked at `deletedAt`: it could not find the core row the delete handler had just removed, so it minted a new id, inserted a fresh row, and wrote that id back onto the deleted workspace record.

The list query is not at fault. It joins the workspace workflow on `deletedAt IS NULL`, which is why the resurrected row renders with `workspaceWorkflowId: null` — no link, no checkbox, no status.

Verified on a dev instance: for every soft-deleted workflow, `core."workflow"."createdAt"` equals the workspace record's `deletedAt` to the second, and the worker log shows `WorkflowStatusesUpdateJob` running at that same second.

## Change

`upsertToCore` skips workflows carrying a `deletedAt`. One guard covers the three handlers that call it (`created`, `updated`, `restored`), since none of them should mirror a record that is deleted at the moment the event is handled. Restore is unaffected: a restored record has no `deletedAt`, so it mirrors as before.

## Verified on a dev instance

Before: deleting an active workflow left `core."workflow"` holding a row whose `createdAt` equalled the workspace record's `deletedAt` to the second.

After: deleting an active workflow leaves `statuses` rewritten to `{DEACTIVATED}` with `updatedAt = deletedAt` — so the update that used to resurrect the row did fire — and the core row stays deleted. The count of core rows dropped by exactly one and did not come back over the following 30 seconds.

## Tests

`core-workflows.integration-spec.ts` had no soft-delete case at all. The new one activates a workflow before deleting it, because version deactivation is what triggers the status write, and that write is the resurrection.

Three details are load-bearing:

- It looks the workflow up **by name**. The existing helper matches on `workspaceWorkflowId`, which is null for exactly the rows this bug produces, so it would report the phantom as absent and pass on `main`.
- It waits until the deleted workflow reports `DEACTIVATED` before asserting anything. Without that wait the assertion runs inside the window between the delete handler removing the row and the status write putting it back, which is green on `main` too.
- It then asserts absence on every poll rather than breaking on the first one, so a row that comes back late still fails the test.

The suite's dedicated workflow is destroyed in `afterAll`, since a failing run would otherwise leave a record whose name the new lookup matches and poison every later run.

## Not in this PR

**A narrow create-then-delete race remains.** The guard reads the event snapshot, not live state. If a workflow is deleted while the CREATED handler is still mirroring it, the create snapshot has no `deletedAt` and the delete handler reads a `coreWorkflowId` that has not been written back yet, so the same phantom row can appear. Closing that means having the delete handler re-read the workspace record instead of trusting `before`, which is a change to the delete path rather than to this guard.

**Rows already orphaned this way stay until something removes them.** They are also invisible to the drift monitor: `orphanCore` only counts core rows with no workspace referrer at all, and a phantom still has one, its soft-deleted record. There is a precedent for the cleanup (`2-28-repair-orphan-core-workflow-versions`), but the policy differs: for versions a soft-deleted workspace version deliberately protects its core row, while for workflows the delete handler removes it. The repair therefore needs its own decision on the migration side, and it is data cleanup rather than the defect.
