### PR TITLE
Reuse shared status tags and truncate banner messages

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/components/CampaignDetailsFields.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/CampaignDetailsFields.tsx
@@ -1,14 +1,14 @@
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
-import { useContext } from 'react';
 import {
   CoreObjectNameSingular,
   MessageChannelType,
 } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { IconAlertTriangle } from 'twenty-ui/icon';
+import { InlineBanner } from 'twenty-ui/feedback';
 import { type SelectOption } from 'twenty-ui/input';
-import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 import {
   CampaignEnvelopeBox,
@@ -34,18 +34,8 @@ const StyledSubjectInput = styled.input`
   width: 100%;
 `;
 
-const StyledWarning = styled.div`
-  align-items: flex-start;
-  color: ${themeCssVariables.font.color.secondary};
-  display: flex;
-  font-size: ${themeCssVariables.font.size.xs};
-  gap: ${themeCssVariables.spacing[1]};
-  padding: ${themeCssVariables.spacing[2]} ${themeCssVariables.spacing[3]};
-`;
-
-const StyledWarningIcon = styled(IconAlertTriangle)`
-  color: ${themeCssVariables.color.yellow};
-  flex-shrink: 0;
+const StyledWarningContainer = styled.div`
+  margin-top: ${themeCssVariables.spacing[2]};
 `;
 
 type CampaignDetailsFieldsProps = {
@@ -57,7 +47,6 @@ export const CampaignDetailsFields = ({
   campaign,
   width,
 }: CampaignDetailsFieldsProps) => {
-  const { theme } = useContext(ThemeContext);
   const detailsState = useCampaignDetailsState({ campaign });
 
   const { channels } = useMyMessageChannels();
@@ -99,10 +88,14 @@ export const CampaignDetailsFields = ({
       onBlur={() => detailsState.flush()}
       below={
         !hasSenderOptions && (
-          <StyledWarning>
-            <StyledWarningIcon size={theme.icon.size.sm} />
-            {t`No sending address is available. Connect a verified sending domain in Settings before this campaign can go out.`}
-          </StyledWarning>
+          <StyledWarningContainer>
+            <InlineBanner
+              embedded
+              color="danger"
+              LeftIcon={IconAlertTriangle}
+              message={t`No sending address is available. Connect a verified sending domain in Settings before this campaign can go out.`}
+            />
+          </StyledWarningContainer>
         )
       }
     >

--- a/packages/twenty-front/src/modules/activities/emails/components/CampaignDetailsFields.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/CampaignDetailsFields.tsx
@@ -93,7 +93,7 @@ export const CampaignDetailsFields = ({
               embedded
               color="danger"
               LeftIcon={IconAlertTriangle}
-              message={t`No sending address is available. Connect a verified sending domain in Settings before this campaign can go out.`}
+              message={t`No sending address. Connect a verified domain in Settings.`}
             />
           </StyledWarningContainer>
         )

--- a/packages/twenty-front/src/modules/ai/components/CodeExecutionDisplay.tsx
+++ b/packages/twenty-front/src/modules/ai/components/CodeExecutionDisplay.tsx
@@ -10,9 +10,6 @@ import {
   IconCopy,
   IconDownload,
   IconFile,
-  IconPlayerPlay,
-  IconSquareRoundedCheck,
-  IconSquareRoundedX,
 } from 'twenty-ui/icon';
 import { CodeEditor, LightIconButton } from 'twenty-ui/input';
 import { AnimatedExpandableContainer } from 'twenty-ui/layout';
@@ -191,13 +188,6 @@ export const CodeExecutionDisplay = ({
       ? 'success'
       : 'error';
 
-  const StatusIcon =
-    status === 'success'
-      ? IconSquareRoundedCheck
-      : status === 'error'
-        ? IconSquareRoundedX
-        : IconPlayerPlay;
-
   const statusText = isRunning
     ? t`Running...`
     : exitCode === 0
@@ -224,7 +214,6 @@ export const CodeExecutionDisplay = ({
                   : 'gray'
             }
             text={statusText}
-            Icon={StatusIcon}
             weight="medium"
             preventShrink
           />

--- a/packages/twenty-front/src/modules/ai/components/CodeExecutionDisplay.tsx
+++ b/packages/twenty-front/src/modules/ai/components/CodeExecutionDisplay.tsx
@@ -2,6 +2,7 @@ import { TerminalOutput } from '@/ai/components/TerminalOutput';
 import { styled } from '@linaria/react';
 import { useContext, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
+import { Tag } from 'twenty-ui/data-display';
 import {
   IconChevronDown,
   IconChevronUp,
@@ -27,7 +28,7 @@ const StyledContainer = styled.div`
   overflow: hidden;
 `;
 
-const StyledHeader = styled.div<{ status: 'success' | 'error' | 'running' }>`
+const StyledHeader = styled.div`
   align-items: center;
   background: ${themeCssVariables.background.secondary};
   border-bottom: 1px solid ${themeCssVariables.border.color.light};
@@ -47,31 +48,6 @@ const StyledHeaderRight = styled.div`
   align-items: center;
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
-`;
-
-const StyledStatusBadge = styled.div<{
-  status: 'success' | 'error' | 'running';
-}>`
-  align-items: center;
-  background: ${({ status }) =>
-    status === 'success'
-      ? themeCssVariables.background.transparent.success
-      : status === 'error'
-        ? themeCssVariables.background.transparent.danger
-        : themeCssVariables.background.transparent.medium};
-  border-radius: ${themeCssVariables.border.radius.pill};
-  color: ${({ status }) =>
-    status === 'success'
-      ? themeCssVariables.color.turquoise
-      : status === 'error'
-        ? themeCssVariables.color.red
-        : themeCssVariables.font.color.secondary};
-  corner-shape: round;
-  display: flex;
-  font-size: ${themeCssVariables.font.size.xs};
-  font-weight: ${themeCssVariables.font.weight.medium};
-  gap: ${themeCssVariables.spacing[1]};
-  padding: ${themeCssVariables.spacing['0.5']} ${themeCssVariables.spacing[2]};
 `;
 
 const StyledTitle = styled.span`
@@ -233,16 +209,25 @@ export const CodeExecutionDisplay = ({
 
   return (
     <StyledContainer>
-      <StyledHeader status={status}>
+      <StyledHeader>
         <StyledHeaderLeft>
           <IconCode size={theme.icon.size.md} />
           <StyledTitle>{t`Python Code Execution`}</StyledTitle>
         </StyledHeaderLeft>
         <StyledHeaderRight>
-          <StyledStatusBadge status={status}>
-            <StatusIcon size={theme.icon.size.sm} />
-            {statusText}
-          </StyledStatusBadge>
+          <Tag
+            color={
+              status === 'success'
+                ? 'turquoise'
+                : status === 'error'
+                  ? 'red'
+                  : 'gray'
+            }
+            text={statusText}
+            Icon={StatusIcon}
+            weight="medium"
+            preventShrink
+          />
         </StyledHeaderRight>
       </StyledHeader>
 

--- a/packages/twenty-front/src/modules/information-banner/components/InformationBanner.tsx
+++ b/packages/twenty-front/src/modules/information-banner/components/InformationBanner.tsx
@@ -10,11 +10,11 @@ import {
 } from 'twenty-ui/feedback';
 import { type IconComponent, IconX } from 'twenty-ui/icon';
 import { Button, IconButton } from 'twenty-ui/input';
+import { OverflowingTextWithTooltip } from 'twenty-ui/surfaces';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledText = styled.div`
-  overflow: hidden;
-  text-overflow: ellipsis;
+  min-width: 0;
 `;
 
 const StyledInvertedIconButton = styled(IconButton)`
@@ -28,6 +28,7 @@ const StyledContent = styled.div<{ hasCloseButton: boolean }>`
   gap: ${themeCssVariables.spacing[3]};
   justify-content: center;
   margin-left: ${({ hasCloseButton }) => (hasCloseButton ? '24px' : '0')};
+  min-width: 0;
 `;
 
 export const InformationBanner = ({
@@ -68,7 +69,12 @@ export const InformationBanner = ({
       {informationBannerIsOpen && (
         <Banner color={color} variant={variant}>
           <StyledContent hasCloseButton={!!onClose}>
-            <StyledText>{message}</StyledText>
+            <StyledText>
+              <OverflowingTextWithTooltip
+                text={<>{message}</>}
+                tooltipContent={message}
+              />
+            </StyledText>
             {buttonTitle && buttonOnClick && (
               <Button
                 variant="secondary"

--- a/packages/twenty-front/src/modules/information-banner/components/InformationBanner.tsx
+++ b/packages/twenty-front/src/modules/information-banner/components/InformationBanner.tsx
@@ -71,6 +71,7 @@ export const InformationBanner = ({
           <StyledContent hasCloseButton={!!onClose}>
             <StyledText>
               <OverflowingTextWithTooltip
+                isFocusable
                 text={<>{message}</>}
                 tooltipContent={message}
               />

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJobStateBadge.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJobStateBadge.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@linaria/react';
-import { t } from '@lingui/core/macro';
+import { plural } from '@lingui/core/macro';
 import { Tag, type TagColor } from 'twenty-ui/data-display';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { JobState } from '~/generated-admin/graphql';
@@ -38,7 +38,10 @@ export const SettingsAdminJobStateBadge = ({
       {showAttempts && (
         <Tag
           color="red"
-          text={t`${attemptsMade} attempts`}
+          text={plural(attemptsMade, {
+            one: `${attemptsMade} attempt`,
+            other: `${attemptsMade} attempts`,
+          })}
           weight="medium"
           preventShrink
         />

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJobStateBadge.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJobStateBadge.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
 import { Tag, type TagColor } from 'twenty-ui/data-display';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { JobState } from '~/generated-admin/graphql';
@@ -24,17 +25,6 @@ const StyledContainer = styled.div`
   gap: ${themeCssVariables.spacing[2]};
 `;
 
-const StyledAttemptBadge = styled.span`
-  background-color: ${themeCssVariables.background.danger};
-  border: 1px solid ${themeCssVariables.border.color.danger};
-  border-radius: ${themeCssVariables.border.radius.sm};
-  color: ${themeCssVariables.font.color.danger};
-  font-size: ${themeCssVariables.font.size.xs};
-  font-weight: ${themeCssVariables.font.weight.medium};
-  padding: ${themeCssVariables.spacing['0.5']} ${themeCssVariables.spacing[1]};
-  white-space: nowrap;
-`;
-
 export const SettingsAdminJobStateBadge = ({
   state,
   attemptsMade = 1,
@@ -46,7 +36,12 @@ export const SettingsAdminJobStateBadge = ({
     <StyledContainer>
       <Tag color={color} text={state} />
       {showAttempts && (
-        <StyledAttemptBadge>{attemptsMade} attempts</StyledAttemptBadge>
+        <Tag
+          color="red"
+          text={t`${attemptsMade} attempts`}
+          weight="medium"
+          preventShrink
+        />
       )}
     </StyledContainer>
   );

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminQueueJobsTable.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminQueueJobsTable.tsx
@@ -70,6 +70,8 @@ const StyledButtonGroup = styled.div`
 const RETRY_MODAL_ID = 'retry-jobs-modal';
 const DELETE_MODAL_ID = 'delete-jobs-modal';
 const LIMIT = 50;
+const JOB_TABLE_GRID_COLUMNS =
+  '32px minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) 32px';
 
 export const SettingsAdminQueueJobsTable = ({
   queueName,
@@ -265,7 +267,7 @@ export const SettingsAdminQueueJobsTable = ({
       ) : (
         <>
           <Table>
-            <TableRow gridAutoColumns="32px 2fr 1fr 2fr 32px">
+            <TableRow gridTemplateColumns={JOB_TABLE_GRID_COLUMNS}>
               <TableHeader
                 align="center"
                 padding={`0 ${themeCssVariables.spacing[1]} 0 ${themeCssVariables.spacing[2]}`}
@@ -291,7 +293,7 @@ export const SettingsAdminQueueJobsTable = ({
                 return (
                   <StyledJobRowWrapper key={job.id}>
                     <TableRow
-                      gridAutoColumns="32px 2fr 1fr 2fr 32px"
+                      gridTemplateColumns={JOB_TABLE_GRID_COLUMNS}
                       onClick={() => handleRowClick(job.id)}
                       isExpanded={isExpanded}
                       cursor="pointer"

--- a/packages/twenty-ui/src/feedback/InlineBanner/InlineBanner.module.scss
+++ b/packages/twenty-ui/src/feedback/InlineBanner/InlineBanner.module.scss
@@ -21,5 +21,5 @@
 
 .bannerText {
   flex: 1;
-  overflow-wrap: anywhere;
+  min-width: 0;
 }

--- a/packages/twenty-ui/src/feedback/InlineBanner/InlineBanner.tsx
+++ b/packages/twenty-ui/src/feedback/InlineBanner/InlineBanner.tsx
@@ -1,4 +1,5 @@
 import { clsx } from 'clsx';
+import { OverflowingTextWithTooltip } from '@ui/surfaces/OverflowingTextWithTooltip/OverflowingTextWithTooltip';
 import { useTheme } from '@ui/theme-constants';
 import { Button } from '@ui/input/Button/Button';
 import { type IconComponent } from '@ui/icon/types/IconComponent';
@@ -40,7 +41,12 @@ export const InlineBanner = ({
     >
       <div className={styles.bannerContent}>
         <LeftIcon size={theme.icon.size.md} />
-        <span className={styles.bannerText}>{message}</span>
+        <div className={styles.bannerText}>
+          <OverflowingTextWithTooltip
+            text={<>{message}</>}
+            tooltipContent={message}
+          />
+        </div>
       </div>
       {button && !button.hidden && (
         <Button

--- a/packages/twenty-ui/src/feedback/InlineBanner/InlineBanner.tsx
+++ b/packages/twenty-ui/src/feedback/InlineBanner/InlineBanner.tsx
@@ -43,6 +43,7 @@ export const InlineBanner = ({
         <LeftIcon size={theme.icon.size.md} />
         <div className={styles.bannerText}>
           <OverflowingTextWithTooltip
+            isFocusable
             text={<>{message}</>}
             tooltipContent={message}
           />

--- a/packages/twenty-ui/src/feedback/InlineBanner/__stories__/InlineBanner.stories.tsx
+++ b/packages/twenty-ui/src/feedback/InlineBanner/__stories__/InlineBanner.stories.tsx
@@ -30,6 +30,10 @@ export const Default: Story = {
       name: /Configure models/,
     });
 
+    await userEvent.hover(canvas.getByText(args.message));
+    await expect(
+      within(canvasElement.ownerDocument.body).queryByRole('tooltip'),
+    ).not.toBeInTheDocument();
     await expect(button).toBeEnabled();
     await userEvent.click(button);
     await expect(args.button?.onClick).toHaveBeenCalledTimes(1);
@@ -82,5 +86,29 @@ export const Embedded: Story = {
     message: 'No AI models are enabled.',
     button: { title: 'Configure models', onClick: fn() },
     embedded: true,
+  },
+};
+
+export const TruncatedMessage: Story = {
+  args: {
+    color: 'blue',
+    message:
+      'Sync lost with mailbox tim@apple.dev. Please reconnect for updates:',
+    button: { title: 'Reconnect', onClick: fn() },
+  },
+  parameters: { container: { width: 320 } },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const message = canvas.getByText(args.message);
+
+    await expect(message.scrollWidth).toBeGreaterThan(message.clientWidth);
+    await expect(getComputedStyle(message).whiteSpace).toBe('nowrap');
+    await userEvent.hover(message);
+    await expect(
+      await within(canvasElement.ownerDocument.body).findByRole('tooltip'),
+    ).toHaveTextContent(args.message);
+    await userEvent.unhover(message);
+    await userEvent.click(canvas.getByRole('button', { name: 'Reconnect' }));
+    await expect(args.button?.onClick).toHaveBeenCalledTimes(1);
   },
 };

--- a/packages/twenty-ui/src/feedback/InlineBanner/__stories__/InlineBanner.stories.tsx
+++ b/packages/twenty-ui/src/feedback/InlineBanner/__stories__/InlineBanner.stories.tsx
@@ -34,6 +34,13 @@ export const Default: Story = {
     await expect(
       within(canvasElement.ownerDocument.body).queryByRole('tooltip'),
     ).not.toBeInTheDocument();
+    await userEvent.tab();
+    await expect(canvas.getByText(args.message)).toHaveFocus();
+    await expect(
+      within(canvasElement.ownerDocument.body).queryByRole('tooltip'),
+    ).not.toBeInTheDocument();
+    await userEvent.tab();
+    await expect(button).toHaveFocus();
     await expect(button).toBeEnabled();
     await userEvent.click(button);
     await expect(args.button?.onClick).toHaveBeenCalledTimes(1);
@@ -108,6 +115,38 @@ export const TruncatedMessage: Story = {
       await within(canvasElement.ownerDocument.body).findByRole('tooltip'),
     ).toHaveTextContent(args.message);
     await userEvent.unhover(message);
+    await userEvent.tab();
+    await expect(message).toHaveFocus();
+    await expect(
+      await within(canvasElement.ownerDocument.body).findByRole('tooltip'),
+    ).toHaveTextContent(args.message);
+    await userEvent.hover(message);
+    await userEvent.unhover(message);
+    await expect(
+      within(canvasElement.ownerDocument.body).getByRole('tooltip'),
+    ).toHaveTextContent(args.message);
+    await userEvent.keyboard('{Escape}');
+    await expect(message).toHaveFocus();
+    await expect(
+      within(canvasElement.ownerDocument.body).queryByRole('tooltip'),
+    ).not.toBeInTheDocument();
+    await userEvent.tab();
+    await expect(
+      canvas.getByRole('button', { name: /Reconnect/ }),
+    ).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    await expect(
+      await within(canvasElement.ownerDocument.body).findByRole('tooltip'),
+    ).toHaveTextContent(args.message);
+    await userEvent.tab();
+    await expect(
+      within(canvasElement.ownerDocument.body).queryByRole('tooltip'),
+    ).not.toBeInTheDocument();
+    await userEvent.pointer({ keys: '[TouchA]', target: message });
+    await expect(message).toHaveFocus();
+    await expect(
+      await within(canvasElement.ownerDocument.body).findByRole('tooltip'),
+    ).toHaveTextContent(args.message);
     await userEvent.click(canvas.getByRole('button', { name: /Reconnect/ }));
     await expect(args.button?.onClick).toHaveBeenCalledTimes(1);
   },

--- a/packages/twenty-ui/src/feedback/InlineBanner/__stories__/InlineBanner.stories.tsx
+++ b/packages/twenty-ui/src/feedback/InlineBanner/__stories__/InlineBanner.stories.tsx
@@ -108,7 +108,7 @@ export const TruncatedMessage: Story = {
       await within(canvasElement.ownerDocument.body).findByRole('tooltip'),
     ).toHaveTextContent(args.message);
     await userEvent.unhover(message);
-    await userEvent.click(canvas.getByRole('button', { name: 'Reconnect' }));
+    await userEvent.click(canvas.getByRole('button', { name: /Reconnect/ }));
     await expect(args.button?.onClick).toHaveBeenCalledTimes(1);
   },
 };

--- a/packages/twenty-ui/src/surfaces/OverflowingTextWithTooltip/OverflowingTextWithTooltip.module.scss
+++ b/packages/twenty-ui/src/surfaces/OverflowingTextWithTooltip/OverflowingTextWithTooltip.module.scss
@@ -1,4 +1,6 @@
 .overflowingMultilineText {
+  @include focus-ring;
+
   cursor: inherit;
   font-family: inherit;
   font-size: inherit;
@@ -15,6 +17,8 @@
 }
 
 .overflowingText {
+  @include focus-ring;
+
   cursor: inherit;
   font-family: inherit;
   font-size: inherit;

--- a/packages/twenty-ui/src/surfaces/OverflowingTextWithTooltip/OverflowingTextWithTooltip.tsx
+++ b/packages/twenty-ui/src/surfaces/OverflowingTextWithTooltip/OverflowingTextWithTooltip.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, useId, useRef, useState } from 'react';
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 
 import { isNonEmptyString } from '@sniptt/guards';
@@ -21,6 +27,7 @@ type OverflowingTextWithTooltipProps = {
   tooltipDelay?: TooltipDelay;
   tooltipPlace?: TooltipPosition;
   alwaysShowTooltip?: boolean;
+  isFocusable?: boolean;
 } & (
   | {
       text: string | null | undefined;
@@ -41,6 +48,7 @@ export const OverflowingTextWithTooltip = ({
   tooltipDelay = TooltipDelay.mediumDelay,
   tooltipPlace = TooltipPosition.Bottom,
   alwaysShowTooltip = false,
+  isFocusable = false,
 }: OverflowingTextWithTooltipProps) => {
   const textElementId = `title-id-${useId().replace(/:/g, '')}`;
 
@@ -49,7 +57,7 @@ export const OverflowingTextWithTooltip = ({
   const [isTitleOverflowing, setIsTitleOverflowing] = useState(false);
   const [shouldRenderTooltip, setShouldRenderTooltip] = useState(false);
 
-  const handleMouseEnter = () => {
+  const handleShowTooltip = () => {
     const isOverflowing = textRef.current
       ? textRef.current?.scrollHeight > textRef.current?.clientHeight ||
         textRef.current.scrollWidth > textRef.current.clientWidth
@@ -59,9 +67,33 @@ export const OverflowingTextWithTooltip = ({
     setShouldRenderTooltip(true);
   };
 
-  const handleMouseLeave = () => {
+  const handleHideTooltip = () => {
     setIsTitleOverflowing(false);
     setShouldRenderTooltip(false);
+  };
+
+  const handleMouseLeave = () => {
+    if (isFocusable && document.activeElement === textRef.current) {
+      return;
+    }
+
+    handleHideTooltip();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.key === 'Escape' &&
+      shouldRenderTooltip &&
+      (isTitleOverflowing || alwaysShowTooltip)
+    ) {
+      event.stopPropagation();
+      handleHideTooltip();
+    }
+  };
+
+  const handleTextClick = () => {
+    textRef.current?.focus();
+    handleShowTooltip();
   };
 
   const handleTooltipClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -88,7 +120,12 @@ export const OverflowingTextWithTooltip = ({
           )}
           ref={textRef}
           id={textElementId}
-          onMouseEnter={handleMouseEnter}
+          tabIndex={isFocusable ? 0 : undefined}
+          onFocus={isFocusable ? handleShowTooltip : undefined}
+          onBlur={isFocusable ? handleHideTooltip : undefined}
+          onKeyDown={isFocusable ? handleKeyDown : undefined}
+          onClick={isFocusable ? handleTextClick : undefined}
+          onMouseEnter={handleShowTooltip}
           onMouseLeave={handleMouseLeave}
         >
           {isNonEmptyString(text) ? <LinkifiedText text={text} /> : text}
@@ -104,7 +141,12 @@ export const OverflowingTextWithTooltip = ({
           )}
           ref={textRef}
           id={textElementId}
-          onMouseEnter={handleMouseEnter}
+          tabIndex={isFocusable ? 0 : undefined}
+          onFocus={isFocusable ? handleShowTooltip : undefined}
+          onBlur={isFocusable ? handleHideTooltip : undefined}
+          onKeyDown={isFocusable ? handleKeyDown : undefined}
+          onClick={isFocusable ? handleTextClick : undefined}
+          onMouseEnter={handleShowTooltip}
           onMouseLeave={handleMouseLeave}
         >
           {isNonEmptyString(text) ? <LinkifiedText text={text} /> : text}


### PR DESCRIPTION
## Summary

Reuse shared components for execution statuses, campaign warnings, and job retry counts, and keep banner messages on one line.

- AI code execution uses text-only `Tag` statuses for Running, Completed, and Failed.
- Campaigns without a sender use a red `InlineBanner` with an 8px gap below the envelope fields and concise setup guidance.
- Admin retry counts use a red `Tag` with locale-aware plural forms; consistent column widths keep status tags left-aligned across rows.
- Both `InlineBanner` and `InformationBanner` reuse `OverflowingTextWithTooltip`: long messages end in an ellipsis and reveal the full text on hover, keyboard focus, or tap. Escape or blur dismisses the tooltip. Messages that fit do not show a tooltip. Action and close buttons retain their space.

## Validation

- UI build, UI and frontend typechecks, focused lint, formatting, and whitespace checks passed.
- Verified the built UI in Codex Browser at 320px: one-line clipping, full-message hover tooltip, no tooltip for short text, and a working action button.
- Verified Storybook interactions in Codex Browser for truncation, hover, keyboard focus, Escape, blur, touch input, short messages without tooltips, and action clicks.

## Screenshots

Captured from the PR preview at `5c8e6a8a`. Execution states, the missing sender, and retry counts use temporary browser-only API fixtures; no workspace data was changed. The mailbox sync warning uses the preview's existing data. Fixtures were removed after capture.

### Text-only execution statuses

Running, Completed, and Failed use shared tags without icons.

![Text-only execution statuses](https://github.com/user-attachments/assets/0bd0a46b-a7fb-4d55-8f95-dd4ce9ff044f)

### Campaign missing-sender banner

A single-line red banner with an 8px gap below the envelope fields.

![Campaign missing-sender banner](https://github.com/user-attachments/assets/f8c994b1-b6d4-46de-a91a-2fb074eab4c5)

### Left-aligned job statuses

The State heading and status tags share the same left edge, including rows with a retry tag.

![Left-aligned job statuses and retry count](https://github.com/user-attachments/assets/23763dfc-9267-4909-a4ec-734045cc9fa9)

### Full-text tooltips for clipped banners

At narrow widths, both banner types stay on one line with an ellipsis. Hover reveals the complete message; the mailbox banner keeps its Reconnect and close controls visible.

| Information banner at 520px | Inline banner at 380px |
| --- | --- |
| ![Information banner full-text tooltip](https://github.com/user-attachments/assets/e06bf499-b2e7-4019-98f3-b400cabb8fbd) | ![Inline banner full-text tooltip](https://github.com/user-attachments/assets/3ec3ab56-a261-4311-bfb1-3e2cce80b314) |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->






