### PR TITLE
fix(front): persist percentage values that still include a percent sign (#17677)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/NumberFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/NumberFieldInput.tsx
@@ -19,25 +19,23 @@ export const NumberFieldInput = () => {
     RecordFieldComponentInstanceContext,
   );
 
-  const persistNumberValue = (newValue: string) =>
-    getNumberValueToPersist({
+  const getFieldInputEventArgs = (newValue: string) => {
+    const persistResult = getNumberValueToPersist({
       newValue,
       numberType: fieldDefinition.metadata.settings?.type,
     });
 
-  const getFieldInputEventArgs = (
-    persistResult: ReturnType<typeof persistNumberValue>,
-  ) =>
-    persistResult.success
+    return persistResult.success
       ? { newValue: persistResult.value, skipPersist: false }
       : { skipPersist: true };
+  };
 
   const handleEnter = (newText: string) => {
-    onEnter?.(getFieldInputEventArgs(persistNumberValue(newText)));
+    onEnter?.(getFieldInputEventArgs(newText));
   };
 
   const handleEscape = (newText: string) => {
-    onEscape?.(getFieldInputEventArgs(persistNumberValue(newText)));
+    onEscape?.(getFieldInputEventArgs(newText));
   };
 
   const handleClickOutside = (
@@ -45,17 +43,17 @@ export const NumberFieldInput = () => {
     newText: string,
   ) => {
     onClickOutside?.({
-      ...getFieldInputEventArgs(persistNumberValue(newText)),
+      ...getFieldInputEventArgs(newText),
       event,
     });
   };
 
   const handleTab = (newText: string) => {
-    onTab?.(getFieldInputEventArgs(persistNumberValue(newText)));
+    onTab?.(getFieldInputEventArgs(newText));
   };
 
   const handleShiftTab = (newText: string) => {
-    onShiftTab?.(getFieldInputEventArgs(persistNumberValue(newText)));
+    onShiftTab?.(getFieldInputEventArgs(newText));
   };
 
   const handleChange = (newText: string) => {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/NumberFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/NumberFieldInput.tsx
@@ -1,16 +1,12 @@
-import { TextInput } from '@/ui/field/input/components/TextInput';
+import { useContext } from 'react';
 
 import { FieldInputEventContext } from '@/object-record/record-field/ui/contexts/FieldInputEventContext';
+import { useNumberField } from '@/object-record/record-field/ui/meta-types/hooks/useNumberField';
+import { getNumberValueToPersist } from '@/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist';
 import { RecordFieldComponentInstanceContext } from '@/object-record/record-field/ui/states/contexts/RecordFieldComponentInstanceContext';
 import { FieldInputContainer } from '@/ui/field/input/components/FieldInputContainer';
+import { TextInput } from '@/ui/field/input/components/TextInput';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
-import { isNull } from '@sniptt/guards';
-import { useContext } from 'react';
-import {
-  canBeCastAsNumberOrNull,
-  castAsNumberOrNull,
-} from '~/utils/cast-as-number-or-null';
-import { useNumberField } from '@/object-record/record-field/ui/meta-types/hooks/useNumberField';
 
 export const NumberFieldInput = () => {
   const { fieldDefinition, draftValue, setDraftValue } = useNumberField();
@@ -23,36 +19,14 @@ export const NumberFieldInput = () => {
     RecordFieldComponentInstanceContext,
   );
 
-  const getNumberValueToPersist = (
-    newValue: string,
-  ): { success: boolean; value?: any } => {
-    if (fieldDefinition?.metadata?.settings?.type === 'percentage') {
-      const newValueEscaped = newValue.replaceAll('%', '');
-
-      if (!canBeCastAsNumberOrNull(newValueEscaped)) {
-        return { success: false };
-      }
-
-      const castedValue = castAsNumberOrNull(newValue);
-
-      if (!isNull(castedValue)) {
-        return { success: true, value: castedValue / 100 };
-      }
-
-      return { success: true, value: null };
-    }
-
-    if (!canBeCastAsNumberOrNull(newValue)) {
-      return { success: false };
-    }
-
-    const castedValue = castAsNumberOrNull(newValue);
-
-    return { success: true, value: castedValue };
-  };
+  const persistNumberValue = (newValue: string) =>
+    getNumberValueToPersist({
+      newValue,
+      numberType: fieldDefinition.metadata.settings?.type,
+    });
 
   const handleEnter = (newText: string) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = persistNumberValue(newText);
 
     const shouldNotPersist = !success;
 
@@ -60,7 +34,7 @@ export const NumberFieldInput = () => {
   };
 
   const handleEscape = (newText: string) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = persistNumberValue(newText);
 
     const shouldNotPersist = !success;
 
@@ -71,7 +45,7 @@ export const NumberFieldInput = () => {
     event: MouseEvent | TouchEvent,
     newText: string,
   ) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = persistNumberValue(newText);
 
     const shouldNotPersist = !success;
 
@@ -79,7 +53,7 @@ export const NumberFieldInput = () => {
   };
 
   const handleTab = (newText: string) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = persistNumberValue(newText);
 
     const shouldNotPersist = !success;
 
@@ -87,7 +61,7 @@ export const NumberFieldInput = () => {
   };
 
   const handleShiftTab = (newText: string) => {
-    const { success, value } = getNumberValueToPersist(newText);
+    const { success, value } = persistNumberValue(newText);
 
     const shouldNotPersist = !success;
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/NumberFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/NumberFieldInput.tsx
@@ -25,47 +25,37 @@ export const NumberFieldInput = () => {
       numberType: fieldDefinition.metadata.settings?.type,
     });
 
+  const getFieldInputEventArgs = (
+    persistResult: ReturnType<typeof persistNumberValue>,
+  ) =>
+    persistResult.success
+      ? { newValue: persistResult.value, skipPersist: false }
+      : { skipPersist: true };
+
   const handleEnter = (newText: string) => {
-    const { success, value } = persistNumberValue(newText);
-
-    const shouldNotPersist = !success;
-
-    onEnter?.({ newValue: value, skipPersist: shouldNotPersist });
+    onEnter?.(getFieldInputEventArgs(persistNumberValue(newText)));
   };
 
   const handleEscape = (newText: string) => {
-    const { success, value } = persistNumberValue(newText);
-
-    const shouldNotPersist = !success;
-
-    onEscape?.({ newValue: value, skipPersist: shouldNotPersist });
+    onEscape?.(getFieldInputEventArgs(persistNumberValue(newText)));
   };
 
   const handleClickOutside = (
     event: MouseEvent | TouchEvent,
     newText: string,
   ) => {
-    const { success, value } = persistNumberValue(newText);
-
-    const shouldNotPersist = !success;
-
-    onClickOutside?.({ newValue: value, skipPersist: shouldNotPersist, event });
+    onClickOutside?.({
+      ...getFieldInputEventArgs(persistNumberValue(newText)),
+      event,
+    });
   };
 
   const handleTab = (newText: string) => {
-    const { success, value } = persistNumberValue(newText);
-
-    const shouldNotPersist = !success;
-
-    onTab?.({ newValue: value, skipPersist: shouldNotPersist });
+    onTab?.(getFieldInputEventArgs(persistNumberValue(newText)));
   };
 
   const handleShiftTab = (newText: string) => {
-    const { success, value } = persistNumberValue(newText);
-
-    const shouldNotPersist = !success;
-
-    onShiftTab?.({ newValue: value, skipPersist: shouldNotPersist });
+    onShiftTab?.(getFieldInputEventArgs(persistNumberValue(newText)));
   };
 
   const handleChange = (newText: string) => {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts
@@ -1,0 +1,57 @@
+import { getNumberValueToPersist } from '@/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist';
+
+describe('getNumberValueToPersist', () => {
+  it('should persist a percentage that still has the percent sign', () => {
+    expect(
+      getNumberValueToPersist({
+        newValue: '50%',
+        numberType: 'percentage',
+      }),
+    ).toEqual({ success: true, value: 0.5 });
+  });
+
+  it('should persist a percentage typed without the percent sign', () => {
+    expect(
+      getNumberValueToPersist({
+        newValue: '50',
+        numberType: 'percentage',
+      }),
+    ).toEqual({ success: true, value: 0.5 });
+  });
+
+  it('should persist an empty percentage as null', () => {
+    expect(
+      getNumberValueToPersist({
+        newValue: '',
+        numberType: 'percentage',
+      }),
+    ).toEqual({ success: true, value: null });
+  });
+
+  it('should not persist a percentage that is not numeric', () => {
+    expect(
+      getNumberValueToPersist({
+        newValue: 'abc%',
+        numberType: 'percentage',
+      }),
+    ).toEqual({ success: false });
+  });
+
+  it('should persist a plain number', () => {
+    expect(
+      getNumberValueToPersist({
+        newValue: '50',
+        numberType: 'number',
+      }),
+    ).toEqual({ success: true, value: 50 });
+  });
+
+  it('should not persist a percent sign on a plain number field', () => {
+    expect(
+      getNumberValueToPersist({
+        newValue: '50%',
+        numberType: 'number',
+      }),
+    ).toEqual({ success: false });
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts
@@ -37,6 +37,24 @@ describe('getNumberValueToPersist', () => {
     ).toEqual({ success: false });
   });
 
+  it('should not persist a percentage with a percent sign that is not a trailing suffix', () => {
+    expect(
+      getNumberValueToPersist({
+        newValue: '5%0',
+        numberType: 'percentage',
+      }),
+    ).toEqual({ success: false });
+  });
+
+  it('should not persist a percentage with more than one trailing percent sign', () => {
+    expect(
+      getNumberValueToPersist({
+        newValue: '50%%',
+        numberType: 'percentage',
+      }),
+    ).toEqual({ success: false });
+  });
+
   it('should persist a plain number', () => {
     expect(
       getNumberValueToPersist({

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
@@ -6,7 +6,7 @@ import {
   castAsNumberOrNull,
 } from '~/utils/cast-as-number-or-null';
 
-export type NumberValueToPersistResult =
+type NumberValueToPersistResult =
   | { success: false }
   | { success: true; value: number | null };
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
@@ -20,7 +20,7 @@ export const getNumberValueToPersist = ({
   numberType,
 }: GetNumberValueToPersistParams): NumberValueToPersistResult => {
   const valueToCast =
-    numberType === 'percentage' ? newValue.replaceAll('%', '') : newValue;
+    numberType === 'percentage' ? newValue.replace(/%$/, '') : newValue;
 
   if (!canBeCastAsNumberOrNull(valueToCast)) {
     return { success: false };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/getNumberValueToPersist.ts
@@ -1,0 +1,36 @@
+import { isNull } from '@sniptt/guards';
+
+import { type FieldNumberVariant } from '@/object-record/record-field/ui/types/FieldMetadata';
+import {
+  canBeCastAsNumberOrNull,
+  castAsNumberOrNull,
+} from '~/utils/cast-as-number-or-null';
+
+export type NumberValueToPersistResult =
+  | { success: false }
+  | { success: true; value: number | null };
+
+type GetNumberValueToPersistParams = {
+  newValue: string;
+  numberType?: FieldNumberVariant;
+};
+
+export const getNumberValueToPersist = ({
+  newValue,
+  numberType,
+}: GetNumberValueToPersistParams): NumberValueToPersistResult => {
+  const valueToCast =
+    numberType === 'percentage' ? newValue.replaceAll('%', '') : newValue;
+
+  if (!canBeCastAsNumberOrNull(valueToCast)) {
+    return { success: false };
+  }
+
+  const castedValue = castAsNumberOrNull(valueToCast);
+
+  if (numberType === 'percentage' && !isNull(castedValue)) {
+    return { success: true, value: castedValue / 100 };
+  }
+
+  return { success: true, value: castedValue };
+};


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/17677

`NumberFieldInput` strips `%` only for the `canBeCastAsNumberOrNull` guard, then passes the raw `50%` to `castAsNumberOrNull`. `+'50%'` is NaN, so it throws `Cannot cast to number or null`.

The persist helper now casts the stripped string, then divides by 100. Only a single trailing `%` is removed, so `5%0` and `50%%` are rejected instead of being saved as `0.5`.

```
npx jest packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/utils/__tests__/getNumberValueToPersist.test.ts --config=packages/twenty-front/jest.config.mjs --no-coverage
```

8 passed.
