### PR TITLE
Stream nx task output so a killed task still prints its stack

### DIFF
--- a/.github/actions/nx-affected/action.yaml
+++ b/.github/actions/nx-affected/action.yaml
@@ -33,4 +33,7 @@ runs:
         NX_PARALLEL: ${{ inputs.parallel }}
         NX_TAG: ${{ inputs.tag }}
         NX_ARGS: ${{ inputs.args }}
-      run: npx nx affected --nxBail --configuration="$NX_CONFIGURATION" -t="$NX_TASKS" --parallel="$NX_PARALLEL" --exclude="*,!tag:$NX_TAG" $NX_ARGS
+      # Nx buffers task output into an internal stream by default, so a task
+      # that gets killed takes its buffer with it: the log ends on whatever last
+      # happened to flush and the stack trace is never printed.
+      run: npx nx affected --nxBail --outputStyle=stream --configuration="$NX_CONFIGURATION" -t="$NX_TASKS" --parallel="$NX_PARALLEL" --exclude="*,!tag:$NX_TAG" $NX_ARGS


### PR DESCRIPTION
Nx buffers task output into an internal stream by default, so a task that gets killed takes its buffer with it. The job log ends on whatever last happened to flush and the crash is never printed — an integration shard currently exits 1 after 18 passing suites with no summary, no failing test and no stack trace.

`--outputStyle=stream` is nx's own flag for this: "nx by default logs output to an internal output stream, enable this option to stream logs to stdout / stderr".