### PR TITLE
fix(messaging): strip Danish Outlook Fra: quote headers

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-text-without-reply-quotations.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-text-without-reply-quotations.util.spec.ts
@@ -29,4 +29,44 @@ describe('extractTextWithoutReplyQuotations', () => {
       forwardedBody,
     );
   });
+
+  it('should drop a Danish Outlook Fra:/Sendt:/Til:/Emne: quoted thread', () => {
+    const result = extractTextWithoutReplyQuotations(
+      'Hej Jane\n\nKan vi mødes i morgen?\n\nFra: John Doe <john@example.com>\nSendt: 1. september 2026 10:00\nTil: Jane Doe <jane@example.com>\nEmne: Re: Møde\n\nGammel besked her',
+    );
+
+    expect(result).toContain('Kan vi mødes i morgen?');
+    expect(result).not.toContain('Gammel besked her');
+    expect(result).not.toContain('john@example.com');
+  });
+
+  it('should keep a Danish forward that starts with Fra:', () => {
+    const forwardedBody =
+      'Fra: John Doe <john@example.com>\nSendt: 1. september 2026\n\nGammel besked her';
+
+    expect(extractTextWithoutReplyQuotations(forwardedBody)).toBe(
+      forwardedBody,
+    );
+  });
+
+  it('should leave Fra: intact when the Outlook separator sits above the header', () => {
+    const bodyWithSeparator =
+      'Svar her\n\n________________________________\nFra: John Doe <john@example.com>\nSendt: i dag\n\nGammel besked her';
+
+    expect(extractTextWithoutReplyQuotations(bodyWithSeparator)).toBe(
+      bodyWithSeparator,
+    );
+    expect(extractTextWithoutReplyQuotations(bodyWithSeparator)).not.toContain(
+      'From:',
+    );
+  });
+
+  it('should leave unmatched mid-message Fra: without an email address intact', () => {
+    const bodyWithoutBrackets =
+      'Hej\n\nFra: John Doe\nSendt: i dag\n\nGammel besked her';
+
+    expect(extractTextWithoutReplyQuotations(bodyWithoutBrackets)).toBe(
+      bodyWithoutBrackets,
+    );
+  });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-text-without-reply-quotations.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-text-without-reply-quotations.util.ts
@@ -1,10 +1,28 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import EmailReplyParser from 'email-reply-parser';
 
+// email-reply-parser matches From:/Von:/De:/Van:/Da: but not Danish/Norwegian Fra:.
+// Require a same-line <email>. Case-sensitive, so "fra: kl 10" is left alone.
+const LOCALIZED_OUTLOOK_FROM_HEADER =
+  /^[ \t]*Fra([ \t]*:.+(?:\[|<).+(?:\]|>))/gm;
+
 export const extractTextWithoutReplyQuotations = (text: string): string => {
-  const textWithoutQuotations = new EmailReplyParser()
-    .read(text)
-    .getFragments()
+  const textWithEnglishOutlookFromHeader = text.replace(
+    LOCALIZED_OUTLOOK_FROM_HEADER,
+    'From$1',
+  );
+
+  const fragments = new EmailReplyParser()
+    .read(textWithEnglishOutlookFromHeader)
+    .getFragments();
+
+  const hasQuotedFragment = fragments.some((fragment) => fragment.isQuoted());
+
+  if (!hasQuotedFragment) {
+    return text;
+  }
+
+  const textWithoutQuotations = fragments
     .filter((fragment) => !fragment.isQuoted())
     .map((fragment) => fragment.getContent())
     .join('\n');


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/25315

`extractTextWithoutReplyQuotations` uses `email-reply-parser`. A Danish Outlook reply with a `Fra:` header comes back as one unquoted fragment, so the reply chain stays in the synced body. The same body with `From:` splits and quotes the history (node dump against email-reply-parser 2.3.5).

The util now rewrites a line-start `Fra:` that has a same-line email to `From:` before parsing. If the parser quotes nothing, the original text is returned so `From:` is not persisted into `messageText`.

```
npx jest packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-text-without-reply-quotations.util.spec.ts --config=packages/twenty-server/jest.config.mjs --no-coverage
```

7 passed. With the util swapped back to the version on 40eba2d the Danish thread test fails and `Gammel besked her` stays in the result.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

