### PR TITLE
Read created fields back from the migration, not the workspace cache

### DIFF
--- a/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
@@ -51,6 +51,10 @@ export class DataSeedWorkspaceCommand extends CommandRunner {
     } catch (error) {
       this.logger.error(error);
       this.logger.error(error.stack);
+
+      // Without this the command exits 0 on a half-seeded workspace, and every
+      // later suite fails on missing roles and auth context instead of here.
+      throw error;
     }
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service.ts
@@ -348,17 +348,11 @@ export class FieldMetadataService {
       );
     }
 
-    const { flatFieldMetadataMaps: recomputedFlatFieldMetadataMaps } =
-      await this.flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
-        {
-          workspaceId,
-          flatMapsKeys: ['flatFieldMetadataMaps'],
-        },
-      );
-
     return findFlatEntityByUniversalIdentifierOrThrow({
       universalIdentifier: flatFieldMetadatasToUpdate[0].universalIdentifier,
-      flatEntityMaps: recomputedFlatFieldMetadataMaps,
+      flatEntityMaps:
+        validateAndBuildResult.appliedAllFlatEntityMaps
+          ?.flatFieldMetadataMaps ?? existingFlatFieldMetadataMaps,
     });
   }
 
@@ -456,21 +450,15 @@ export class FieldMetadataService {
       );
     }
 
-    const { flatFieldMetadataMaps: recomputedFlatFieldMetadataMaps } =
-      await this.flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
-        {
-          workspaceId,
-          flatMapsKeys: ['flatFieldMetadataMaps'],
-        },
-      );
-
     return findManyFlatEntityByUniversalIdentifierInUniversalFlatEntityMapsOrThrow(
       {
         universalIdentifiers: allTranspiledTranspilationInputs.map(
           ({ result: { flatFieldMetadatas } }) =>
             flatFieldMetadatas[0].universalIdentifier,
         ),
-        flatEntityMaps: recomputedFlatFieldMetadataMaps,
+        flatEntityMaps:
+          validateAndBuildResult.appliedAllFlatEntityMaps
+            ?.flatFieldMetadataMaps ?? existingFlatFieldMetadataMaps,
       },
     );
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
@@ -11,6 +11,7 @@ import { WORKSPACE_MIGRATION_DURATION_MS_BUCKET_BOUNDARIES } from 'src/engine/co
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
 import { AllFlatEntityOperationRecordByMetadataName } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-operation-record-by-metadata-name.type';
 import { AllFlatEntityOperationByMetadataName } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-to-create-delete-update.type';
 import { getFlatEntityMapsExceptionContext } from 'src/engine/metadata-modules/flat-entity/utils/get-flat-entity-maps-exception-context.util';
@@ -33,6 +34,15 @@ import {
   WorkspaceMigrationOrchestratorSuccessfulResult,
 } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-orchestrator.type';
 import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+// appliedAllFlatEntityMaps is the state the runner ended on, so a caller can read back
+// the entities it just committed instead of going through the eventually consistent
+// workspace cache. Undefined when nothing ran: a dry run, or zero resolved actions.
+type ValidateBuildAndRunSuccessfulResult =
+  WorkspaceMigrationOrchestratorSuccessfulResult & {
+    hasSchemaMetadataChanged: boolean;
+    appliedAllFlatEntityMaps: AllFlatEntityMaps | undefined;
+  };
 
 type ValidateBuildAndRunWorkspaceMigrationFromMatriceArgs = {
   workspaceId: string;
@@ -91,9 +101,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     },
   ): Promise<
     | WorkspaceMigrationOrchestratorFailedResult
-    | (WorkspaceMigrationOrchestratorSuccessfulResult & {
-        hasSchemaMetadataChanged: boolean;
-      })
+    | ValidateBuildAndRunSuccessfulResult
   > {
     const { idByUniversalIdentifierByMetadataName, dryRun, ...buildArgs } =
       args;
@@ -158,6 +166,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
         status: 'success',
         workspaceMigration,
         hasSchemaMetadataChanged: false,
+        appliedAllFlatEntityMaps: undefined,
       };
     }
 
@@ -182,7 +191,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     });
 
     const runStart = performance.now();
-    const { hasSchemaMetadataChanged, metadataEvents } =
+    const { hasSchemaMetadataChanged, metadataEvents, allFlatEntityMaps } =
       await this.workspaceMigrationRunnerService.run({
         workspaceId: args.workspaceId,
         workspaceMigration,
@@ -203,6 +212,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
       status: 'success',
       workspaceMigration,
       hasSchemaMetadataChanged,
+      appliedAllFlatEntityMaps: allFlatEntityMaps,
     };
   }
 
@@ -214,9 +224,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     dryRun,
   }: ValidateBuildAndRunWorkspaceMigrationFromMatriceArgs): Promise<
     | WorkspaceMigrationOrchestratorFailedResult
-    | (WorkspaceMigrationOrchestratorSuccessfulResult & {
-        hasSchemaMetadataChanged: boolean;
-      })
+    | ValidateBuildAndRunSuccessfulResult
   > {
     return await this.validateBuildAndRunWorkspaceMigrationFromRecord({
       allFlatEntityOperationRecordByMetadataName:
@@ -234,9 +242,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     args: ValidateBuildAndRunWorkspaceMigrationFromRecordArgs,
   ): Promise<
     | WorkspaceMigrationOrchestratorFailedResult
-    | (WorkspaceMigrationOrchestratorSuccessfulResult & {
-        hasSchemaMetadataChanged: boolean;
-      })
+    | ValidateBuildAndRunSuccessfulResult
   > {
     return await this.validateBuildAndRunWorkspaceMigrationFromRecordInternal({
       ...args,
@@ -259,9 +265,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     dryRun,
   }: ValidateBuildAndRunWorkspaceMigrationFromMatriceArgs): Promise<
     | WorkspaceMigrationOrchestratorFailedResult
-    | (WorkspaceMigrationOrchestratorSuccessfulResult & {
-        hasSchemaMetadataChanged: boolean;
-      })
+    | ValidateBuildAndRunSuccessfulResult
   > {
     return await this.validateBuildAndRunWorkspaceMigrationFromRecordInternal({
       allFlatEntityOperationRecordByMetadataName:
@@ -285,9 +289,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     skipSideEffectExpandEngine,
   }: ValidateBuildAndRunWorkspaceMigrationFromRecordInternalArgs): Promise<
     | WorkspaceMigrationOrchestratorFailedResult
-    | (WorkspaceMigrationOrchestratorSuccessfulResult & {
-        hasSchemaMetadataChanged: boolean;
-      })
+    | ValidateBuildAndRunSuccessfulResult
   > {
     const callerMetadataNames = Object.keys(
       allFlatEntityOperationRecordByMetadataName,
@@ -350,9 +352,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     allMetadataNameCacheToCompute,
   }: ComputeAndRunWorkspaceMigrationFromResolvedOperationsArgs): Promise<
     | WorkspaceMigrationOrchestratorFailedResult
-    | (WorkspaceMigrationOrchestratorSuccessfulResult & {
-        hasSchemaMetadataChanged: boolean;
-      })
+    | ValidateBuildAndRunSuccessfulResult
   > {
     const {
       fromToAllFlatEntityMaps,


### PR DESCRIPTION
Fixes the integration shard failures where a shard dies with `Could not find flat entity with universal identifier` in the dev seeder, then every later suite fails on `UNAUTHENTICATED / INVALID_AUTH_CONTEXT`.

`createManyFields` wrote its fields and then re-read them through the eventually consistent workspace cache, so a read resolving after the invalidation could install an older snapshot missing the field just written. The migration runner already returns the maps it ended on — surface them as `appliedAllFlatEntityMaps` and read back from those.

Also stops the dev seeder swallowing the failure: it logged and exited 0, so `database:reset` reported success against a half-seeded workspace and the real error surfaced 30 suites later as auth failures.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

