### PR TITLE
fix(front): reset confirmation modal input when reopened

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -100,7 +100,15 @@ export const ConfirmationModal = ({
     useState<string>('');
   const [isValidValue, setIsValidValue] = useState(!confirmationValue);
 
+  const isValueMatchingInput = useDebouncedCallback(
+    (value?: string, inputValue?: string) => {
+      setIsValidValue(Boolean(value && inputValue && value === inputValue));
+    },
+    250,
+  );
+
   const resetConfirmationState = () => {
+    isValueMatchingInput.cancel();
     setInputConfirmationValue('');
     setIsValidValue(!confirmationValue);
   };
@@ -109,13 +117,6 @@ export const ConfirmationModal = ({
     setInputConfirmationValue(value);
     isValueMatchingInput(confirmationValue, value);
   };
-
-  const isValueMatchingInput = useDebouncedCallback(
-    (value?: string, inputValue?: string) => {
-      setIsValidValue(Boolean(value && inputValue && value === inputValue));
-    },
-    250,
-  );
 
   const { closeModal } = useModal();
 

--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -100,6 +100,11 @@ export const ConfirmationModal = ({
     useState<string>('');
   const [isValidValue, setIsValidValue] = useState(!confirmationValue);
 
+  const resetConfirmationState = () => {
+    setInputConfirmationValue('');
+    setIsValidValue(!confirmationValue);
+  };
+
   const handleInputConfimrationValueChange = (value: string) => {
     setInputConfirmationValue(value);
     isValueMatchingInput(confirmationValue, value);
@@ -115,11 +120,13 @@ export const ConfirmationModal = ({
   const { closeModal } = useModal();
 
   const handleConfirmClick = () => {
+    resetConfirmationState();
     closeModal(modalInstanceId);
     onConfirmClick();
   };
 
   const handleCancelClick = () => {
+    resetConfirmationState();
     closeModal(modalInstanceId);
     onClose?.();
   };
@@ -134,6 +141,7 @@ export const ConfirmationModal = ({
     <ModalStatefulWrapper
       modalInstanceId={modalInstanceId}
       onClose={() => {
+        resetConfirmationState();
         onClose?.();
       }}
       onEnter={handleEnter}


### PR DESCRIPTION
Closes #25628

### Type of change

- [x] Bug fix

### What does this PR do?

ConfirmationModal stays mounted. Type the confirm string, Cancel, open it again: input is empty but Delete is still enabled.

Reset the input + validity on close, and cancel the 250ms debounce so it can't flip the button back on.

### How did you verify your code works?

Story `ResetsInputWhenReopened`. Repro: Settings → API key → Delete → type yes → Cancel → Delete again.

### Screenshots

**Before (reopen):** empty input, Delete enabled

![before](https://raw.githubusercontent.com/mydd7/twenty/screens-25564/before.png)

**After (reopen):** empty input, Delete disabled

![after](https://raw.githubusercontent.com/mydd7/twenty/screens-25564/after.png)
