### PR TITLE
Export an application's published translations in the manifest

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
+++ b/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
@@ -98,7 +98,7 @@ A plan only previews **metadata** changes. It also works for an app that was nev
 ## Pulling an installed app back to source
 
 <Warning>
-`yarn twenty pull` is **experimental**. It covers only part of an application today, its output shape may change between releases, and it overwrites the files that define the entities it pulls. It does not restore translations yet, so pushing a pulled tree replaces the app's published translations with whatever your `locales/` folder holds. Commit your work before running it, and review the diff.
+`yarn twenty pull` is **experimental**. It covers only part of an application today, its output shape may change between releases, and it overwrites the files that define the entities it pulls. It does not restore translations yet: the report names the locales the app has published, and pushing a pulled tree replaces them with whatever your `locales/` folder holds. Commit your work before running it, and review the diff.
 </Warning>
 
 `yarn twenty pull` is the inverse of `apply`: it reads an application out of the workspace and writes it back as define files.

--- a/packages/twenty-sdk/src/cli/commands/dev/pull.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/pull.ts
@@ -49,6 +49,7 @@ export class AppPullCommand {
       coverage: result.data.coverage,
       localOnlyRelativePaths: result.data.localOnlyRelativePaths,
       unreadableRelativePaths: result.data.unreadableRelativePaths,
+      translations: result.data.translations,
       verbose: options.verbose,
     });
 

--- a/packages/twenty-sdk/src/cli/operations/pull.ts
+++ b/packages/twenty-sdk/src/cli/operations/pull.ts
@@ -23,6 +23,7 @@ import {
 import { scanProjectDefineFiles } from '@/cli/utilities/pull/scan-project-define-files';
 import { runSafe } from '@/cli/utilities/run-safe';
 import { join } from 'node:path';
+import { type TranslationsManifest } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
 
 export type AppPullOptions = {
@@ -41,6 +42,7 @@ export type AppPullResult = {
   skipped: SkippedPullEntity[];
   coverage: ApplicationExportCoverageEntry[];
   unreadableRelativePaths: string[];
+  translations: TranslationsManifest | undefined;
   hadBase: boolean;
 };
 
@@ -186,6 +188,7 @@ const innerAppPull = async (
       unreadableRelativePaths: scannedFiles
         .filter((scannedFile) => !scannedFile.isReadable)
         .map((scannedFile) => scannedFile.relativePath),
+      translations: manifest.translations,
       hadBase: isDefined(baseManifest),
     },
   };

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/format-pull-report.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/format-pull-report.spec.ts
@@ -143,4 +143,22 @@ describe('formatPullReport', () => {
     );
     expect(report).toContain('src/objects/unpushed.object.ts');
   });
+
+  it('should warn that published translations were not written and point at the locales folder', () => {
+    const report = buildReport({
+      translations: {
+        'fr-FR': { greeting: 'Bonjour' },
+        en: { greeting: 'Hello' },
+      },
+    });
+
+    expect(report).toMatch(/^Published translations \(en, fr-FR\).*locales\//m);
+  });
+
+  it('should stay silent about translations when the workspace has none', () => {
+    expect(buildReport()).not.toContain('Published translations');
+    expect(buildReport({ translations: { en: {} } })).not.toContain(
+      'Published translations',
+    );
+  });
 });

--- a/packages/twenty-sdk/src/cli/utilities/pull/format-pull-report.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/format-pull-report.ts
@@ -4,6 +4,8 @@ import {
   type PullDeletion,
   type PullWrite,
 } from '@/cli/utilities/pull/plan-pull-writes';
+import { type TranslationsManifest } from 'twenty-shared/application';
+import { isDefined } from 'twenty-shared/utils';
 
 const MAX_LISTED_IDENTIFIERS = 20;
 
@@ -65,6 +67,7 @@ export const formatPullReport = ({
   coverage,
   localOnlyRelativePaths,
   unreadableRelativePaths = [],
+  translations = {},
   verbose = false,
 }: {
   writes: PullWrite[];
@@ -74,6 +77,7 @@ export const formatPullReport = ({
   coverage: ApplicationExportCoverageEntry[];
   localOnlyRelativePaths: string[];
   unreadableRelativePaths?: string[];
+  translations?: TranslationsManifest;
   verbose?: boolean;
 }): string => {
   const lines: string[] = [
@@ -160,6 +164,20 @@ export const formatPullReport = ({
         }
       }
     }
+  }
+
+  const publishedTranslationLocales = Object.entries(translations)
+    .filter(
+      ([, messages]) => isDefined(messages) && Object.keys(messages).length > 0,
+    )
+    .map(([locale]) => locale)
+    .sort();
+
+  if (publishedTranslationLocales.length > 0) {
+    lines.push(
+      '',
+      `Published translations (${publishedTranslationLocales.join(', ')}) not written: pull cannot restore them yet, and pushing this tree replaces them with the contents of locales/.`,
+    );
   }
 
   return lines.join('\n');

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/application-manifest-export.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/application-manifest-export.service.ts
@@ -10,6 +10,7 @@ import { assertFlatApplicationIsExportable } from 'src/engine/core-modules/appli
 import { classifyApplicationFlatEntities } from 'src/engine/core-modules/application/application-manifest/utils/classify-application-flat-entities.util';
 import { getApplicationSubAllFlatEntityMaps } from 'src/engine/core-modules/application/application-manifest/utils/get-application-sub-all-flat-entity-maps.util';
 import { reconstructDataModelManifest } from 'src/engine/core-modules/application/application-manifest/utils/reconstruct-data-model-manifest.util';
+import { ApplicationTranslationCacheService } from 'src/engine/core-modules/application/application-translation/application-translation-cache.service';
 import {
   ApplicationException,
   ApplicationExceptionCode,
@@ -33,7 +34,10 @@ const findUniversalIdentifierById = ({
 
 @Injectable()
 export class ApplicationManifestExportService {
-  constructor(private readonly workspaceCacheService: WorkspaceCacheService) {}
+  constructor(
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly applicationTranslationCacheService: ApplicationTranslationCacheService,
+  ) {}
 
   async exportApplication({
     workspaceId,
@@ -70,6 +74,11 @@ export class ApplicationManifestExportService {
     const { objects, fields, indexes, coverage } = reconstructDataModelManifest(
       { applicationAllFlatEntityMaps },
     );
+    const translations = isDefined(flatApplication.applicationRegistrationId)
+      ? await this.applicationTranslationCacheService.getCatalogsByLocale(
+          flatApplication.applicationRegistrationId,
+        )
+      : undefined;
 
     const manifest: Manifest = {
       application: fromFlatApplicationToApplicationManifest({
@@ -97,6 +106,7 @@ export class ApplicationManifestExportService {
       pageLayoutTabs: [],
       commandMenuItems: [],
       timelineActivityTypes: [],
+      ...(isDefined(translations) ? { translations } : {}),
     };
 
     return {

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-cache.service.ts
@@ -44,6 +44,18 @@ export class ApplicationTranslationCacheService {
     return catalogsByLocale?.[locale] ?? EMPTY_CATALOG;
   }
 
+  async getCatalogsByLocale(
+    applicationRegistrationId: string,
+  ): Promise<ApplicationCatalogsByLocale> {
+    const catalogsByLocale =
+      await this.catalogsMemoizer.memoizePromiseAndExecute(
+        this.getCacheKey(applicationRegistrationId),
+        () => this.loadCatalogsByLocale(applicationRegistrationId),
+      );
+
+    return catalogsByLocale ?? {};
+  }
+
   async invalidate(applicationRegistrationId: string): Promise<void> {
     await this.catalogsMemoizer.clearKeys(
       this.getCacheKey(applicationRegistrationId),

--- a/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-translation/application-translation-cache.service.ts
@@ -35,13 +35,11 @@ export class ApplicationTranslationCacheService {
     applicationRegistrationId: string;
     locale: keyof typeof APP_LOCALES;
   }): Promise<Record<string, string>> {
-    const catalogsByLocale =
-      await this.catalogsMemoizer.memoizePromiseAndExecute(
-        this.getCacheKey(applicationRegistrationId),
-        () => this.loadCatalogsByLocale(applicationRegistrationId),
-      );
+    const catalogsByLocale = await this.getCatalogsByLocale(
+      applicationRegistrationId,
+    );
 
-    return catalogsByLocale?.[locale] ?? EMPTY_CATALOG;
+    return catalogsByLocale[locale] ?? EMPTY_CATALOG;
   }
 
   async getCatalogsByLocale(

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-export-application-data-model.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-export-application-data-model.integration-spec.ts
@@ -8,6 +8,7 @@ import { syncApplication } from 'test/integration/metadata/suites/application/ut
 import {
   type FieldManifest,
   type ObjectManifest,
+  type TranslationsManifest,
   TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
 } from 'twenty-shared/application';
 import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
@@ -99,10 +100,18 @@ const companyTaglineField: FieldManifest = {
   objectUniversalIdentifier: STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.company,
 };
 
+const FIXTURE_TRANSLATIONS: TranslationsManifest = {
+  'fr-FR': {
+    'export.ticket.title': 'Titre du ticket',
+    'export.ticket.project': 'Projet',
+  },
+};
+
 const manifest = buildBaseManifest({
   appId: TEST_APP_ID,
   roleId: TEST_ROLE_ID,
   overrides: {
+    translations: FIXTURE_TRANSLATIONS,
     objects: [ticketObject, projectObject],
     fields: [companyTaglineField],
     indexes: [
@@ -153,6 +162,7 @@ describe('Application export - data model', () => {
       displayName: 'Test Application',
       sourceType: 'LOCAL',
     });
+    expect(exported.manifest.translations).toEqual(FIXTURE_TRANSLATIONS);
     expect(exported.manifest.application.defaultRoleUniversalIdentifier).toBe(
       TEST_ROLE_ID,
     );


### PR DESCRIPTION
## Context
The exportApplication query now fills manifest.translations with the compiled catalogs the application has published, read through the translation cache service, so a raw export carries them and yarn twenty pull can see them. Pull still cannot turn a compiled catalog back into a locales file, so its report names the locales whose translations were not written.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

