### PR TITLE
Remove an unused import from defineObject

### DIFF
--- a/packages/twenty-sdk/src/sdk/define/objects/define-object.ts
+++ b/packages/twenty-sdk/src/sdk/define/objects/define-object.ts
@@ -4,7 +4,6 @@ import { getFieldDefaultValueWarnings } from '@/sdk/define/fields/get-field-defa
 import { validateFields } from '@/sdk/define/fields/validate-fields';
 import { isEngineDerivedLabelIdentifier } from '@/sdk/define/objects/is-engine-derived-label-identifier';
 import { type ObjectConfig } from '@/sdk/define/objects/object-config';
-import { isDefined } from 'twenty-shared/utils';
 
 export const defineObject: DefineEntity<ObjectConfig> = (config) => {
   const errors = [];


### PR DESCRIPTION
## What

Removes the `isDefined` import that `src/sdk/define/objects/define-object.ts` no longer uses. It was the one warning every `nx lint twenty-sdk` run reported; the package now lints clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

