### PR TITLE
Granola 6/8: Expose Granola notes to workflows and AI

### DIFF
--- a/packages/twenty-apps/public/granola/src/__tests__/deployed-functions.integration-test.ts
+++ b/packages/twenty-apps/public/granola/src/__tests__/deployed-functions.integration-test.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { MetadataApiClient } from 'twenty-client-sdk/metadata';
+import { functionExecute } from 'twenty-sdk/cli';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { GRANOLA_BACKFILL_ROUTE_PATH } from 'src/constants/granola-backfill-route-path';
+
+const APP_PATH = process.cwd();
+const MANIFEST_SCHEMA = z.object({
+  logicFunctions: z.array(z.object({ name: z.string() })),
+});
+
+const executeDeployedFunction = async ({
+  functionName,
+  payload,
+}: {
+  functionName: string;
+  payload: Record<string, unknown>;
+}) => {
+  const result = await functionExecute({
+    appPath: APP_PATH,
+    functionName,
+    payload,
+  });
+  if (!result.success) {
+    throw new Error(
+      `Could not execute ${functionName}: ${result.error.message}`,
+    );
+  }
+  return result.data;
+};
+
+const buildBackfillRoutePayload = (body: Record<string, unknown>) => ({
+  headers: {},
+  queryStringParameters: {},
+  pathParameters: {},
+  body,
+  isBase64Encoded: false,
+  requestContext: {
+    http: { method: 'POST', path: GRANOLA_BACKFILL_ROUTE_PATH },
+  },
+});
+
+describe('Granola deployed functions', () => {
+  it('deploys every function declared by the built application', async () => {
+    const manifest = MANIFEST_SCHEMA.parse(
+      JSON.parse(
+        readFileSync(
+          join(APP_PATH, '.twenty', 'output', 'manifest.json'),
+          'utf8',
+        ),
+      ),
+    );
+    const result = await new MetadataApiClient().query({
+      findManyLogicFunctions: { name: true },
+    });
+    const deployedNames = result.findManyLogicFunctions.map(
+      (logicFunction) => logicFunction.name,
+    );
+    for (const { name } of manifest.logicFunctions) {
+      expect(deployedNames).toContain(name);
+    }
+  });
+
+  it('reports the missing API key from the deployed connection status route', async () => {
+    const execution = await executeDeployedFunction({
+      functionName: 'granola-connection-status',
+      payload: {},
+    });
+    expect(execution.status).toBe('SUCCESS');
+    expect(execution.data).toEqual({ isConnected: false, isApiKeySet: false });
+  });
+
+  it.each([0, -1, 3651, 1.5, '31'])(
+    'rejects the invalid backfill window %s before enqueueing',
+    async (days) => {
+      const execution = await executeDeployedFunction({
+        functionName: 'granola-backfill',
+        payload: buildBackfillRoutePayload({ days }),
+      });
+      expect(execution.status).toBe('SUCCESS');
+      expect(execution.data).toEqual({
+        success: false,
+        error: expect.stringContaining('between 1 and 3650'),
+      });
+    },
+  );
+
+  it.each([
+    {
+      functionName: 'granola-sync-note',
+      payload: { noteId: 'not_invalid' },
+      error: 'A valid Granola note ID is required.',
+    },
+    {
+      functionName: 'granola-list-notes',
+      payload: { limit: 31 },
+      error:
+        'Use valid date filters, a Granola folder ID, and a limit between 1 and 30.',
+    },
+    {
+      functionName: 'granola-list-notes',
+      payload: { createdAfter: 'not-a-date' },
+      error:
+        'Use valid date filters, a Granola folder ID, and a limit between 1 and 30.',
+    },
+    {
+      functionName: 'granola-list-folders',
+      payload: { limit: 0 },
+      error: 'Use a limit between 1 and 30 and a valid pagination cursor.',
+    },
+  ])(
+    'validates inputs in deployed $functionName',
+    async ({ functionName, payload, error }) => {
+      const execution = await executeDeployedFunction({
+        functionName,
+        payload,
+      });
+      expect(execution.status).toBe('SUCCESS');
+      expect(execution.data).toEqual({ success: false, error });
+    },
+  );
+
+  it.each([
+    {
+      functionName: 'granola-sync-note',
+      payload: { noteId: 'not_12345678901234' },
+    },
+    { functionName: 'granola-list-notes', payload: { limit: 1 } },
+    { functionName: 'granola-list-folders', payload: { limit: 1 } },
+  ])(
+    'reports the missing key from deployed $functionName',
+    async ({ functionName, payload }) => {
+      const execution = await executeDeployedFunction({
+        functionName,
+        payload,
+      });
+      expect(execution.status).toBe('SUCCESS');
+      expect(execution.data).toEqual({
+        success: false,
+        error: expect.stringContaining('Connect Granola'),
+      });
+    },
+  );
+});

--- a/packages/twenty-apps/public/granola/src/constants/granola-api.constant.ts
+++ b/packages/twenty-apps/public/granola/src/constants/granola-api.constant.ts
@@ -1,2 +1,3 @@
 export const GRANOLA_NOTE_ID_PATTERN = /^not_[a-zA-Z0-9]{14}$/;
+export const GRANOLA_FOLDER_ID_PATTERN = /^fol_[a-zA-Z0-9]{14}$/;
 export const GRANOLA_MAX_PAGE_SIZE = 30;

--- a/packages/twenty-apps/public/granola/src/constants/granola-page-parameters.constant.ts
+++ b/packages/twenty-apps/public/granola/src/constants/granola-page-parameters.constant.ts
@@ -1,0 +1,21 @@
+import { type InputJsonSchema } from 'twenty-sdk/logic-function';
+
+import { GRANOLA_MAX_PAGE_SIZE } from 'src/constants/granola-api.constant';
+
+export const GRANOLA_PAGE_PARAMETERS_INPUT_SCHEMA: Record<
+  'cursor' | 'limit',
+  InputJsonSchema
+> = {
+  cursor: {
+    type: 'string',
+    label: 'Cursor',
+    description: 'The next cursor returned by the previous page.',
+  },
+  limit: {
+    type: 'integer',
+    label: 'Limit',
+    description: `Maximum items in this page, between 1 and ${GRANOLA_MAX_PAGE_SIZE}. Defaults to ${GRANOLA_MAX_PAGE_SIZE}.`,
+    minimum: 1,
+    maximum: GRANOLA_MAX_PAGE_SIZE,
+  },
+};

--- a/packages/twenty-apps/public/granola/src/logic-functions/constants/granola-not-connected-error-message.constant.ts
+++ b/packages/twenty-apps/public/granola/src/logic-functions/constants/granola-not-connected-error-message.constant.ts
@@ -1,0 +1,2 @@
+export const GRANOLA_NOT_CONNECTED_ERROR_MESSAGE =
+  'Connect Granola in the application settings first.';

--- a/packages/twenty-apps/public/granola/src/logic-functions/granola-connection-status.ts
+++ b/packages/twenty-apps/public/granola/src/logic-functions/granola-connection-status.ts
@@ -1,18 +1,17 @@
-import { isNonEmptyString } from '@sniptt/guards';
 import { defineLogicFunction } from 'twenty-sdk/define';
 import { RetryableLogicFunctionError } from 'twenty-sdk/logic-function';
 import { isDefined } from 'twenty-sdk/utils';
 
 import { GRANOLA_CONNECTION_STATUS_ROUTE_PATH } from 'src/constants/granola-connection-status-route-path';
 import { GRANOLA_CONNECTION_STATUS_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
-import { GRANOLA_API_KEY_ENV_VAR_NAME } from 'src/logic-functions/constants/granola-api-key-env-var-name';
 import { GranolaApiError } from 'src/logic-functions/types/granola-api-error';
 import { createGranolaClientOrThrow } from 'src/logic-functions/utils/create-granola-client-or-throw.util';
 import { currentUserCanManageGranolaOrThrow } from 'src/logic-functions/utils/current-user-can-manage-granola-or-throw.util';
 import { findGranolaRegistrationForCurrentKey } from 'src/logic-functions/utils/find-granola-registration-for-current-key.util';
+import { isGranolaApiKeySet } from 'src/logic-functions/utils/is-granola-api-key-set.util';
 
 export const granolaConnectionStatusHandler = async () => {
-  if (!isNonEmptyString(process.env[GRANOLA_API_KEY_ENV_VAR_NAME]?.trim())) {
+  if (!isGranolaApiKeySet()) {
     return { isConnected: false, isApiKeySet: false };
   }
   const client = createGranolaClientOrThrow();

--- a/packages/twenty-apps/public/granola/src/logic-functions/granola-list-folders.ts
+++ b/packages/twenty-apps/public/granola/src/logic-functions/granola-list-folders.ts
@@ -1,0 +1,57 @@
+import { defineLogicFunction } from 'twenty-sdk/define';
+import { type InputJsonSchema } from 'twenty-sdk/logic-function';
+import { isDefined } from 'twenty-sdk/utils';
+
+import { GRANOLA_PAGE_PARAMETERS_INPUT_SCHEMA } from 'src/constants/granola-page-parameters.constant';
+import { GRANOLA_LIST_FOLDERS_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import { GRANOLA_NOT_CONNECTED_ERROR_MESSAGE } from 'src/logic-functions/constants/granola-not-connected-error-message.constant';
+import { GRANOLA_PAGE_PARAMETERS_SCHEMA } from 'src/logic-functions/schemas/granola-page-parameters.schema';
+import { createGranolaClientOrThrow } from 'src/logic-functions/utils/create-granola-client-or-throw.util';
+import { isGranolaApiKeySet } from 'src/logic-functions/utils/is-granola-api-key-set.util';
+
+const GRANOLA_LIST_FOLDERS_INPUT_SCHEMA: InputJsonSchema = {
+  type: 'object',
+  properties: GRANOLA_PAGE_PARAMETERS_INPUT_SCHEMA,
+  additionalProperties: false,
+};
+
+export const granolaListFoldersHandler = async (parameters: unknown) => {
+  const parsed = GRANOLA_PAGE_PARAMETERS_SCHEMA.safeParse(parameters);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: 'Use a limit between 1 and 30 and a valid pagination cursor.',
+    };
+  }
+
+  if (!isGranolaApiKeySet()) {
+    return { success: false, error: GRANOLA_NOT_CONNECTED_ERROR_MESSAGE };
+  }
+
+  const page = await createGranolaClientOrThrow().listFolders({
+    cursor: parsed.data.cursor,
+    page_size: parsed.data.limit,
+  });
+
+  return {
+    success: true,
+    folders: page.folders.map(({ id, name, parent_folder_id }) => ({
+      id,
+      name,
+      parentFolderId: parent_folder_id,
+    })),
+    hasMore: page.hasMore,
+    ...(isDefined(page.cursor) ? { cursor: page.cursor } : {}),
+  };
+};
+
+export default defineLogicFunction({
+  universalIdentifier: GRANOLA_LIST_FOLDERS_UNIVERSAL_IDENTIFIER,
+  name: 'granola-list-folders',
+  description:
+    'Lists a page of accessible Granola folders. Pass a folder ID to List Granola Notes; use the cursor to read more folders.',
+  timeoutSeconds: 30,
+  handler: granolaListFoldersHandler,
+  toolTriggerSettings: { inputSchema: GRANOLA_LIST_FOLDERS_INPUT_SCHEMA },
+});

--- a/packages/twenty-apps/public/granola/src/logic-functions/granola-list-notes.ts
+++ b/packages/twenty-apps/public/granola/src/logic-functions/granola-list-notes.ts
@@ -1,0 +1,134 @@
+import { defineLogicFunction } from 'twenty-sdk/define';
+import {
+  type InputJsonSchema,
+  jsonSchemaToInputSchema,
+} from 'twenty-sdk/logic-function';
+import { z } from 'zod';
+
+import { GRANOLA_LIST_NOTES_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import { GRANOLA_FOLDER_ID_PATTERN } from 'src/constants/granola-api.constant';
+import { GRANOLA_PAGE_PARAMETERS_INPUT_SCHEMA } from 'src/constants/granola-page-parameters.constant';
+import { GRANOLA_NOT_CONNECTED_ERROR_MESSAGE } from 'src/logic-functions/constants/granola-not-connected-error-message.constant';
+import { GRANOLA_PAGE_PARAMETERS_SCHEMA } from 'src/logic-functions/schemas/granola-page-parameters.schema';
+import { GRANOLA_DATE_TIME_SCHEMA } from 'src/logic-functions/types/granola-api.type';
+import { isGranolaApiKeySet } from 'src/logic-functions/utils/is-granola-api-key-set.util';
+import { createGranolaClientOrThrow } from 'src/logic-functions/utils/create-granola-client-or-throw.util';
+import { isDefined } from 'twenty-sdk/utils';
+
+const GRANOLA_LIST_NOTES_INPUT_SCHEMA: InputJsonSchema = {
+  type: 'object',
+  properties: {
+    folderId: {
+      type: 'string',
+      label: 'Folder ID',
+      description: 'An optional fol_ identifier; includes subfolders.',
+    },
+    createdAfter: {
+      type: 'string',
+      label: 'Created after',
+      description: 'An ISO date or date-time.',
+    },
+    createdBefore: {
+      type: 'string',
+      label: 'Created before',
+      description: 'An ISO date or date-time.',
+    },
+    ...GRANOLA_PAGE_PARAMETERS_INPUT_SCHEMA,
+  },
+  additionalProperties: false,
+};
+const GRANOLA_DATE_FILTER_SCHEMA = z.union([
+  z.iso.date(),
+  GRANOLA_DATE_TIME_SCHEMA,
+]);
+const GRANOLA_LIST_NOTES_PARAMETERS_SCHEMA =
+  GRANOLA_PAGE_PARAMETERS_SCHEMA.extend({
+    folderId: z.string().regex(GRANOLA_FOLDER_ID_PATTERN).optional(),
+    createdAfter: GRANOLA_DATE_FILTER_SCHEMA.optional(),
+    createdBefore: GRANOLA_DATE_FILTER_SCHEMA.optional(),
+  });
+
+export const granolaListNotesHandler = async (parameters: unknown) => {
+  const parsed = GRANOLA_LIST_NOTES_PARAMETERS_SCHEMA.safeParse(parameters);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error:
+        'Use valid date filters, a Granola folder ID, and a limit between 1 and 30.',
+    };
+  }
+
+  if (!isGranolaApiKeySet()) {
+    return { success: false, error: GRANOLA_NOT_CONNECTED_ERROR_MESSAGE };
+  }
+
+  const page = await createGranolaClientOrThrow().listNotes({
+    folder_id: parsed.data.folderId,
+    created_after: parsed.data.createdAfter,
+    created_before: parsed.data.createdBefore,
+    cursor: parsed.data.cursor,
+    page_size: parsed.data.limit,
+  });
+  const notes = page.notes.map((note) => ({
+    id: note.id,
+    ...(isDefined(note.title) ? { title: note.title } : {}),
+    owner: {
+      email: note.owner.email,
+      ...(isDefined(note.owner.name) ? { name: note.owner.name } : {}),
+    },
+    createdAt: note.created_at,
+    updatedAt: note.updated_at,
+  }));
+
+  return {
+    success: true,
+    notes,
+    hasMore: page.hasMore,
+    ...(isDefined(page.cursor) ? { cursor: page.cursor } : {}),
+  };
+};
+
+export default defineLogicFunction({
+  universalIdentifier: GRANOLA_LIST_NOTES_UNIVERSAL_IDENTIFIER,
+  name: 'granola-list-notes',
+  description:
+    'Lists a page of Granola note IDs, titles, owners and dates using the workspace key. Filter by folder or date; pass a returned ID to Sync Granola Note to import its transcript and summary.',
+  timeoutSeconds: 30,
+  handler: granolaListNotesHandler,
+  toolTriggerSettings: { inputSchema: GRANOLA_LIST_NOTES_INPUT_SCHEMA },
+  workflowActionTriggerSettings: {
+    label: 'List Granola Notes',
+    inputSchema: jsonSchemaToInputSchema(GRANOLA_LIST_NOTES_INPUT_SCHEMA),
+    outputSchema: [
+      {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean' },
+          error: { type: 'string' },
+          hasMore: { type: 'boolean' },
+          cursor: { type: 'string' },
+          notes: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                title: { type: 'string' },
+                owner: {
+                  type: 'object',
+                  properties: {
+                    email: { type: 'string' },
+                    name: { type: 'string' },
+                  },
+                },
+                createdAt: { type: 'string' },
+                updatedAt: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+});

--- a/packages/twenty-apps/public/granola/src/logic-functions/granola-sync-note.ts
+++ b/packages/twenty-apps/public/granola/src/logic-functions/granola-sync-note.ts
@@ -1,0 +1,78 @@
+import { CoreApiClient } from 'twenty-client-sdk/core';
+import { defineLogicFunction } from 'twenty-sdk/define';
+import {
+  type InputJsonSchema,
+  jsonSchemaToInputSchema,
+} from 'twenty-sdk/logic-function';
+import { z } from 'zod';
+
+import { GRANOLA_NOTE_ID_PATTERN } from 'src/constants/granola-api.constant';
+import { GRANOLA_SYNC_NOTE_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import { GRANOLA_NOT_CONNECTED_ERROR_MESSAGE } from 'src/logic-functions/constants/granola-not-connected-error-message.constant';
+import { createGranolaClientOrThrow } from 'src/logic-functions/utils/create-granola-client-or-throw.util';
+import { isGranolaApiKeySet } from 'src/logic-functions/utils/is-granola-api-key-set.util';
+import { syncGranolaNoteToCallRecordingOrThrow } from 'src/logic-functions/utils/sync-granola-note-to-call-recording-or-throw.util';
+
+const GRANOLA_SYNC_NOTE_INPUT_SCHEMA: InputJsonSchema = {
+  type: 'object',
+  properties: {
+    noteId: {
+      type: 'string',
+      label: 'Granola note ID',
+      description: 'The not_ identifier returned by List Granola Notes.',
+    },
+  },
+  required: ['noteId'],
+  additionalProperties: false,
+};
+const GRANOLA_SYNC_NOTE_PARAMETERS_SCHEMA = z.object({
+  noteId: z.string().regex(GRANOLA_NOTE_ID_PATTERN),
+});
+
+export const granolaSyncNoteHandler = async (parameters: unknown) => {
+  const parsed = GRANOLA_SYNC_NOTE_PARAMETERS_SCHEMA.safeParse(parameters);
+
+  if (!parsed.success) {
+    return { success: false, error: 'A valid Granola note ID is required.' };
+  }
+
+  if (!isGranolaApiKeySet()) {
+    return { success: false, error: GRANOLA_NOT_CONNECTED_ERROR_MESSAGE };
+  }
+
+  const result = await syncGranolaNoteToCallRecordingOrThrow({
+    coreApiClient: new CoreApiClient({ runAs: 'application' }),
+    client: createGranolaClientOrThrow(),
+    noteId: parsed.data.noteId,
+  });
+
+  return { success: true, noteId: parsed.data.noteId, ...result };
+};
+
+export default defineLogicFunction({
+  universalIdentifier: GRANOLA_SYNC_NOTE_UNIVERSAL_IDENTIFIER,
+  name: 'granola-sync-note',
+  description:
+    'Sync one accessible Granola note into a Call Recording with its transcript and summary. Uses the workspace API key and preserves recordings deleted in Twenty.',
+  timeoutSeconds: 900,
+  handler: granolaSyncNoteHandler,
+  toolTriggerSettings: { inputSchema: GRANOLA_SYNC_NOTE_INPUT_SCHEMA },
+  workflowActionTriggerSettings: {
+    label: 'Sync Granola Note',
+    inputSchema: jsonSchemaToInputSchema(GRANOLA_SYNC_NOTE_INPUT_SCHEMA),
+    outputSchema: [
+      {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean' },
+          error: { type: 'string' },
+          noteId: { type: 'string' },
+          callRecordingId: { type: 'string' },
+          calendarEventId: { type: 'string' },
+          created: { type: 'boolean' },
+          skipped: { type: 'boolean' },
+        },
+      },
+    ],
+  },
+});

--- a/packages/twenty-apps/public/granola/src/logic-functions/schemas/granola-page-parameters.schema.ts
+++ b/packages/twenty-apps/public/granola/src/logic-functions/schemas/granola-page-parameters.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+import { GRANOLA_MAX_PAGE_SIZE } from 'src/constants/granola-api.constant';
+
+export const GRANOLA_PAGE_PARAMETERS_SCHEMA = z.object({
+  cursor: z.string().min(1).optional(),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(GRANOLA_MAX_PAGE_SIZE)
+    .default(GRANOLA_MAX_PAGE_SIZE),
+});

--- a/packages/twenty-apps/public/granola/src/logic-functions/types/granola-api.type.ts
+++ b/packages/twenty-apps/public/granola/src/logic-functions/types/granola-api.type.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { GRANOLA_NOTE_ID_PATTERN } from 'src/constants/granola-api.constant';
 
-const GRANOLA_DATE_TIME_SCHEMA = z.string().datetime({ offset: true });
+export const GRANOLA_DATE_TIME_SCHEMA = z.string().datetime({ offset: true });
 const GRANOLA_USER_SCHEMA = z.object({
   name: z.string().nullable(),
   email: z.string(),

--- a/packages/twenty-apps/public/granola/src/logic-functions/utils/is-granola-api-key-set.util.ts
+++ b/packages/twenty-apps/public/granola/src/logic-functions/utils/is-granola-api-key-set.util.ts
@@ -1,0 +1,6 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
+import { GRANOLA_API_KEY_ENV_VAR_NAME } from 'src/logic-functions/constants/granola-api-key-env-var-name';
+
+export const isGranolaApiKeySet = (): boolean =>
+  isNonEmptyString(process.env[GRANOLA_API_KEY_ENV_VAR_NAME]?.trim());


### PR DESCRIPTION
Exposes Granola notes to workflows and AI.

- `granola-sync-note` and `granola-list-notes` as workflow actions and AI tools, `granola-list-folders` as an AI tool, all validated with zod and bounded to 30 items per page.
- Actions return a structured "not connected" result when no key is saved instead of throwing.
- Deployed-function smoke tests for the stack's routes and actions.

Stack 6/8. Review against `ehco/granola-5-history`; merge in order and retain base branches until dependent PRs are retargeted.

Review order:

1. [Add the Granola application scaffold](https://github.com/twentyhq/twenty/pull/25570)
2. [Add Granola API access and credential settings](https://github.com/twentyhq/twenty/pull/25571)
3. [Map Granola notes into Call Recordings](https://github.com/twentyhq/twenty/pull/25572)
4. [Connect Granola webhooks and live synchronization](https://github.com/twentyhq/twenty/pull/25573)
5. [Import Granola history and recover missed updates](https://github.com/twentyhq/twenty/pull/25574)
6. [Expose Granola notes to workflows and AI](https://github.com/twentyhq/twenty/pull/25575)
7. [Filter Granola synchronization by folder](https://github.com/twentyhq/twenty/pull/25576)
8. [Add Granola listing copy and setup documentation](https://github.com/twentyhq/twenty/pull/25577)
