### PR TITLE
fix(front): isolate side panel route params from the main index

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/routing/components/SidePanelRoutedPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/routing/components/SidePanelRoutedPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { UNSAFE_RouteContext } from 'react-router-dom';
 import { isDefined } from 'twenty-shared/utils';
 import { Trans } from '@lingui/react/macro';
 
@@ -12,6 +13,15 @@ import { SidePanelPageComponentInstanceContext } from '@/side-panel/states/conte
 import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
 import { useWorkspaceSurface } from '@/ui/layout/hooks/useWorkspaceSurface';
 import { useComponentInstanceStateContext } from '@/ui/utilities/state/component-state/hooks/useComponentInstanceStateContext';
+
+// The panel is a sibling of the main Outlet. React Router shares one params
+// object across that branch, so useRoutes(location) can match a Company record
+// while useParams still carries objectNamePlural from the People index.
+const SIDE_PANEL_ROUTE_CONTEXT = {
+  outlet: null,
+  matches: [],
+  isDataRoute: false,
+};
 
 const SidePanelRouteErrorFallback = () => (
   <WorkspaceRouteUnavailable>
@@ -48,10 +58,12 @@ export const SidePanelRoutedPage = () => {
           resetOnLocationChange={false}
         >
           <SidePanelRouteNavigatorProvider>
-            <WorkspaceRoutes
-              location={location}
-              fallback={<WorkspaceRouteUnavailable />}
-            />
+            <UNSAFE_RouteContext.Provider value={SIDE_PANEL_ROUTE_CONTEXT}>
+              <WorkspaceRoutes
+                location={location}
+                fallback={<WorkspaceRouteUnavailable />}
+              />
+            </UNSAFE_RouteContext.Provider>
           </SidePanelRouteNavigatorProvider>
         </AppErrorBoundary>
       </ContextStoreComponentInstanceContext.Provider>

--- a/packages/twenty-front/src/modules/side-panel/routing/components/__tests__/SidePanelRoutedPage.route-isolation.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/routing/components/__tests__/SidePanelRoutedPage.route-isolation.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '@testing-library/react';
+import { type FallbackProps } from 'react-error-boundary';
+import {
+  MemoryRouter,
+  Outlet,
+  useLocation,
+  useParams,
+  useRoutes,
+} from 'react-router-dom';
+import { AppPath } from 'twenty-shared/types';
+import { getAppPath } from 'twenty-shared/utils';
+
+import { WorkspaceRouteObjectsContext } from '@/app/routing/components/WorkspaceRouteObjectsProvider';
+import { type WorkspaceRouteObject } from '@/app/routing/types/WorkspaceRouteObject';
+import { SidePanelRoutedPage } from '@/side-panel/routing/components/SidePanelRoutedPage';
+import { SidePanelPageComponentInstanceContext } from '@/side-panel/states/contexts/SidePanelPageComponentInstanceContext';
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+
+const companyRecordPath = getAppPath(AppPath.RecordShowPage, {
+  objectNameSingular: 'company',
+  objectRecordId: 'company-1',
+});
+
+const panelLocation = {
+  pathname: companyRecordPath,
+  search: '',
+  hash: '',
+  state: null,
+  key: 'panel-company-1',
+};
+
+jest.mock('@/side-panel/routing/hooks/useCurrentSidePanelRoutedPath', () => ({
+  useCurrentSidePanelRoutedLocation: () => panelLocation,
+}));
+
+jest.mock(
+  '@/side-panel/routing/components/SidePanelRouteNavigatorProvider',
+  () => ({
+    SidePanelRouteNavigatorProvider: ({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) => children,
+  }),
+);
+
+jest.mock('@/context-store/components/RouteContextStoreProvider', () => ({
+  RouteContextStoreProvider: () => null,
+}));
+
+jest.mock('@/error-handler/components/AppErrorBoundary', () => {
+  const { ErrorBoundary: MockErrorBoundary } = jest.requireActual(
+    'react-error-boundary',
+  );
+
+  return {
+    AppErrorBoundary: ({
+      children,
+      FallbackComponent,
+    }: {
+      children: React.ReactNode;
+      FallbackComponent: React.ComponentType<FallbackProps>;
+    }) => (
+      <MockErrorBoundary FallbackComponent={FallbackComponent}>
+        {children}
+      </MockErrorBoundary>
+    ),
+  };
+});
+
+const PanelRecordProbe = () => {
+  const { pathname } = useLocation();
+  const params = useParams();
+
+  return (
+    <>
+      <output aria-label="Panel path">{pathname}</output>
+      <output aria-label="Panel object plural">
+        {params.objectNamePlural ?? ''}
+      </output>
+      <output aria-label="Panel object singular">
+        {params.objectNameSingular ?? ''}
+      </output>
+    </>
+  );
+};
+
+const routeObjects: WorkspaceRouteObject[] = [
+  {
+    path: AppPath.RecordIndexPage,
+    element: <div>panel index</div>,
+    handle: { workspaceSurfaces: ['main', 'side-panel'] },
+  },
+  {
+    path: AppPath.RecordShowPage,
+    element: <PanelRecordProbe />,
+    handle: { workspaceSurfaces: ['main', 'side-panel'] },
+  },
+];
+
+const MainLayoutWithSidePanel = () => {
+  const layout = useRoutes([
+    {
+      element: (
+        <>
+          <Outlet />
+          <WorkspaceSurfaceContext.Provider
+            value={{
+              type: 'side-panel',
+              instanceId: 'panel-page-1',
+              ownsRouteLocation: false,
+            }}
+          >
+            <SidePanelPageComponentInstanceContext.Provider
+              value={{ instanceId: 'panel-page-1' }}
+            >
+              <SidePanelRoutedPage />
+            </SidePanelPageComponentInstanceContext.Provider>
+          </WorkspaceSurfaceContext.Provider>
+        </>
+      ),
+      children: [
+        {
+          path: AppPath.RecordIndexPage,
+          element: <div>main people index</div>,
+        },
+      ],
+    },
+  ]);
+
+  return layout;
+};
+
+describe('SidePanelRoutedPage route isolation', () => {
+  it('keeps panel record params off the main People index after a company hop', () => {
+    render(
+      <MemoryRouter initialEntries={['/objects/people']}>
+        <WorkspaceRouteObjectsContext.Provider value={routeObjects}>
+          <MainLayoutWithSidePanel />
+        </WorkspaceRouteObjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('main people index')).toBeInTheDocument();
+    expect(screen.getByLabelText('Panel path')).toHaveTextContent(
+      companyRecordPath,
+    );
+    expect(screen.getByLabelText('Panel object singular')).toHaveTextContent(
+      'company',
+    );
+    expect(screen.getByLabelText('Panel object plural').textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Problem

https://github.com/twentyhq/twenty/issues/25580

Opening a Company in the side panel from the People list leaves the footer on Delete Person / Export Person.

The panel is a sibling of the main Outlet, so it shares one React Router params object with that branch. `useRoutes(location)` matches `/object/company/...`, but `useParams()` still carries `objectNamePlural=people` from the index. `RouteContextStoreProvider` checks plural OR singular, Person matches `people` first, and the page context store stays Person.

## Approach

Reset RouteContext around the panel `WorkspaceRoutes` so the panel match does not inherit the index params, same as the existing `UNSAFE_NavigationContext` override. The footer keeps reading the page context store; only the value written to it changes.

Preferring `objectNameSingular` inside `RouteContextStoreProvider` would patch one consumer of the merged params instead of the merge itself, so I did not go that way.

## Testing

`npx jest packages/twenty-front/src/modules/side-panel/routing/components/__tests__/SidePanelRoutedPage.route-isolation.test.tsx packages/twenty-front/src/modules/side-panel/routing/components/__tests__/SidePanelRoutedPage.test.tsx --config=packages/twenty-front/jest.config.mjs --no-coverage`

Both passed. With the RouteContext wrap removed, the isolation test failed: Expected `""`, Received `"people"`. Restored the wrap, both passed again.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

