### PR TITLE
fix(server): stop upgrade-pending columns from breaking repository updates

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-repository.proxy.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-repository.proxy.spec.ts
@@ -155,6 +155,8 @@ describe('wrapRepositoryWithUpgradeAwareProxy', () => {
       const result = await wrapped.update({ id: 1 }, { introducedColumn: {} });
 
       expect(update).not.toHaveBeenCalled();
+      expect(result.affected).toBe(0);
+      expect(result.raw).toEqual([]);
       expect(result.generatedMaps).toEqual([]);
     });
 

--- a/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-repository.proxy.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-repository.proxy.spec.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata';
 import { Test } from '@nestjs/testing';
 import { getDataSourceToken } from '@nestjs/typeorm';
 
-import { type DataSource, type Repository } from 'typeorm';
+import { type DataSource, type Repository, type UpdateResult } from 'typeorm';
 import { type EntityMetadata } from 'typeorm/metadata/EntityMetadata';
 
 import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorators/was-introduced-in-upgrade.decorator';
@@ -105,6 +105,67 @@ describe('wrapRepositoryWithUpgradeAwareProxy', () => {
 
     expect(find).toHaveBeenCalledWith({
       select: ['id', 'unknownTypo'],
+    });
+  });
+
+  describe('update', () => {
+    const buildWrappedRepository = (hiddenColumnPropertyNames: string[]) => {
+      const update = jest.fn().mockResolvedValue({ affected: 1 });
+      const repository = {
+        update,
+        metadata: {
+          relations: [],
+          targetName: EntityWithHiddenColumn.name,
+        },
+      } as unknown as Repository<EntityWithHiddenColumn>;
+      const state = {
+        getHiddenColumnPropertyNames: jest
+          .fn()
+          .mockReturnValue(new Set(hiddenColumnPropertyNames)),
+        isEntityAvailable: jest.fn().mockReturnValue(true),
+      } as unknown as UpgradeAwareRepositoryState;
+
+      return {
+        update,
+        wrapped: wrapRepositoryWithUpgradeAwareProxy({
+          repository,
+          entityClass: EntityWithHiddenColumn,
+          state,
+        }) as unknown as {
+          update: (
+            criteria: unknown,
+            values: Record<string, unknown>,
+          ) => Promise<UpdateResult>;
+        },
+      };
+    };
+
+    it('strips hidden columns from the values so a lagging cursor cannot reject the write', async () => {
+      const { update, wrapped } = buildWrappedRepository(['introducedColumn']);
+
+      await wrapped.update({ id: 1 }, { name: 'app', introducedColumn: {} });
+
+      expect(update).toHaveBeenCalledWith({ id: 1 }, { name: 'app' });
+    });
+
+    it('skips the query when every value is a hidden column', async () => {
+      const { update, wrapped } = buildWrappedRepository(['introducedColumn']);
+
+      const result = await wrapped.update({ id: 1 }, { introducedColumn: {} });
+
+      expect(update).not.toHaveBeenCalled();
+      expect(result.generatedMaps).toEqual([]);
+    });
+
+    it('leaves the values untouched when no column is hidden', async () => {
+      const { update, wrapped } = buildWrappedRepository([]);
+
+      await wrapped.update({ id: 1 }, { name: 'app', introducedColumn: {} });
+
+      expect(update).toHaveBeenCalledWith(
+        { id: 1 },
+        { name: 'app', introducedColumn: {} },
+      );
     });
   });
 

--- a/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-repository.proxy.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-repository.proxy.spec.ts
@@ -145,6 +145,7 @@ describe('wrapRepositoryWithUpgradeAwareProxy', () => {
 
       await wrapped.update({ id: 1 }, { name: 'app', introducedColumn: {} });
 
+      expect(update).toHaveBeenCalledTimes(1);
       expect(update).toHaveBeenCalledWith({ id: 1 }, { name: 'app' });
     });
 
@@ -162,6 +163,7 @@ describe('wrapRepositoryWithUpgradeAwareProxy', () => {
 
       await wrapped.update({ id: 1 }, { name: 'app', introducedColumn: {} });
 
+      expect(update).toHaveBeenCalledTimes(1);
       expect(update).toHaveBeenCalledWith(
         { id: 1 },
         { name: 'app', introducedColumn: {} },

--- a/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/upgrade-aware-repository.proxy.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/upgrade-aware-repository.proxy.ts
@@ -164,6 +164,17 @@ const stripUnavailableSelect = (
   return options;
 };
 
+// A skipped update never reaches the driver, so the counts TypeORM would have
+// filled in have to be stated rather than left undefined: no rows matched.
+const buildSkippedUpdateResult = (): UpdateResult => {
+  const updateResult = new UpdateResult();
+
+  updateResult.raw = [];
+  updateResult.affected = 0;
+
+  return updateResult;
+};
+
 const stripUnavailableUpdateValues = (
   entityClass: Function,
   state: UpgradeAwareRepositoryState,
@@ -366,7 +377,7 @@ const handleRepositoryMethodCall = <Entity extends object>({
       updateValues !== args[1] &&
       Object.keys(updateValues as Record<string, unknown>).length === 0
     ) {
-      return Promise.resolve(new UpdateResult());
+      return Promise.resolve(buildSkippedUpdateResult());
     }
 
     return callRepositoryMethod({

--- a/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/upgrade-aware-repository.proxy.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/upgrade-aware-repository.proxy.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 
-import { type Repository } from 'typeorm';
+import { UpdateResult, type Repository } from 'typeorm';
 import { EntityNotFoundError } from 'typeorm/error/EntityNotFoundError';
 import { type EntityMetadata } from 'typeorm/metadata/EntityMetadata';
 import { isDefined } from 'twenty-shared/utils';
@@ -164,6 +164,45 @@ const stripUnavailableSelect = (
   return options;
 };
 
+const stripUnavailableUpdateValues = (
+  entityClass: Function,
+  state: UpgradeAwareRepositoryState,
+  values: unknown,
+): unknown => {
+  if (
+    !isDefined(values) ||
+    typeof values !== 'object' ||
+    Array.isArray(values)
+  ) {
+    return values;
+  }
+
+  const hiddenColumnPropertyNames =
+    state.getHiddenColumnPropertyNames(entityClass);
+
+  if (hiddenColumnPropertyNames.size === 0) {
+    return values;
+  }
+
+  const entries = Object.entries(values as Record<string, unknown>);
+  const keptEntries = entries.filter(
+    ([propertyName]) => !hiddenColumnPropertyNames.has(propertyName),
+  );
+
+  if (keptEntries.length === entries.length) {
+    return values;
+  }
+
+  logger.log(
+    `[upgrade-proxy] strip update values on ${entityClass.name}: ${entries
+      .filter(([propertyName]) => hiddenColumnPropertyNames.has(propertyName))
+      .map(([propertyName]) => propertyName)
+      .join(',')}`,
+  );
+
+  return Object.fromEntries(keptEntries);
+};
+
 const stripUnavailableRelations = (
   metadata: EntityMetadata,
   state: UpgradeAwareRepositoryState,
@@ -314,6 +353,29 @@ const handleRepositoryMethodCall = <Entity extends object>({
     return behavior.produceEmpty(entityClass);
   }
 
+  if (methodName === 'update' && args.length > 1) {
+    const updateValues = stripUnavailableUpdateValues(
+      entityClass,
+      state,
+      args[1],
+    );
+
+    // Nothing the caller asked to write exists at this cursor, and TypeORM
+    // rejects an empty value set, so report the no-op instead of running it.
+    if (
+      updateValues !== args[1] &&
+      Object.keys(updateValues as Record<string, unknown>).length === 0
+    ) {
+      return Promise.resolve(new UpdateResult());
+    }
+
+    return callRepositoryMethod({
+      target,
+      methodName,
+      args: [args[0], updateValues, ...args.slice(2)],
+    });
+  }
+
   const rewrittenArgs =
     METHODS_THAT_ACCEPT_FIND_OPTIONS.has(methodName) && args.length > 0
       ? [
@@ -326,9 +388,20 @@ const handleRepositoryMethodCall = <Entity extends object>({
         ]
       : args;
 
-  return (
+  return callRepositoryMethod({ target, methodName, args: rewrittenArgs });
+};
+
+const callRepositoryMethod = <Entity extends object>({
+  target,
+  methodName,
+  args,
+}: {
+  target: Repository<Entity>;
+  methodName: string;
+  args: unknown[];
+}): unknown =>
+  (
     target[methodName as keyof Repository<Entity>] as unknown as (
       ...callArgs: unknown[]
     ) => unknown
-  ).apply(target, rewrittenArgs);
-};
+  ).apply(target, args);


### PR DESCRIPTION
Fixes app sync failing with `Sync failed with error: Property "billing" was not found in "ApplicationEntity". Make sure your query is correct.` on a fresh app created with `npx create-twenty-app`.

## Root cause

Not a manifest problem: `billing` is already optional on `ApplicationManifest`, and the scaffolded `application-config.ts` declares none.

When an instance's upgrade cursor sits before a column's introducing command, `UpgradeAwareEntityMetadataAdapter` hides that column: it drops it from `metadata.columns` and forces `isSelect` / `isInsert` / `isUpdate` to `false`. Reads honour that. Writes don't: TypeORM's `UpdateQueryBuilder.createUpdateExpression` resolves every key of its value set against `metadata.columns` and throws `EntityPropertyNotFoundError` before it ever looks at `isUpdate`.

`ApplicationSyncService.syncApplication` writes `billing: manifest.application.billing ?? {}` unconditionally, so on an instance migrated past 2.31 but not past `2.38.0_AddBillingToApplicationFastInstanceCommand_1788340843000`, every sync dies, including for an app that declares no billing. The error naming `billing` rather than `logo` (2.2.0, earlier in the same payload) pins the cursor to that window.

## Fix

Strip hidden columns from `update` value sets in the upgrade-aware repository proxy, the same way `select` and `relations` are already stripped, and report a no-op `UpdateResult` when nothing is left to write (TypeORM rejects an empty value set). This is what `isInsert` / `isUpdate = false` already declares the intent to be. It also covers transaction-scoped repositories, since the proxy patches `EntityManager.prototype.getRepository`.

## Siblings this also fixes

Same class of bug, same mechanism:

- `ApplicationRegistrationEntity.pricingDescription` (2.38.0, from the same billing PR). `fromManifestApplicationToDisplayFields` returns it unconditionally into the `.update()` in `application-registration.service.ts`. This is the next error you would hit after a billing-only fix, on the same `yarn twenty dev` flow.
- `ConnectedAccountEntity.authFailedReason` (2.40.0). Written by `application-connection-auth-failure.service.ts` and `update-connected-account-on-reconnect.service.ts`; any instance not yet upgraded to 2.40 throws on an auth-failure report or a reconnect.
- Older, lower-risk cases: `autoUpgrade`, `uninstallHookCompletedForRequestedAt`, `logoFileId`.

## Deliberately not covered

- `where` / `order` clauses naming a hidden column throw the same error, but stripping them is unsafe: dropping a `where` on an `update` would silently widen it to every row. No live occurrence found.
- `EntityManager.update(Entity, criteria, values)` and raw query builders bypass the proxy (only `getRepository` is patched). I checked every such call; none currently writes an upgrade-introduced column.

## Test plan

- 3 new cases in `upgrade-aware-repository.proxy.spec.ts`; 2 of them fail without the source change.
- `npx jest src/engine/twenty-orm src/engine/core-modules/application src/engine/core-modules/upgrade` -> 733 passed. The 5 erroring suites fail identically on a clean tree (`twenty-client-sdk/generate` not built in this workspace).
- `tsgo --noEmit`, oxlint `--type-aware` and oxfmt clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSpCgqHMoUUsAykGm1Tm6X)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

