### PR TITLE
Add Input, InputGroup and Textarea to twenty-ui

### DIFF
--- a/packages/twenty-ui/src/input/Input/Input.module.scss
+++ b/packages/twenty-ui/src/input/Input/Input.module.scss
@@ -1,0 +1,58 @@
+.input {
+  --tw-input-block-size: 32px;
+  --tw-input-border-color: var(--t-border-color-medium);
+
+  appearance: none;
+  background-color: var(--t-background-transparent-lighter);
+  block-size: var(--tw-input-block-size);
+  border: 1px solid var(--tw-input-border-color);
+  border-radius: var(--t-border-radius-md);
+  color: var(--t-font-color-primary);
+  font-family: var(--t-font-family);
+  font-size: var(--t-font-size-md);
+  font-weight: var(--t-font-weight-regular);
+  inline-size: 100%;
+  margin: 0;
+  min-inline-size: 0;
+  outline: none;
+  padding-block: 0;
+  padding-inline: var(--t-spacing-2);
+  text-overflow: ellipsis;
+
+  &::placeholder {
+    color: var(--t-font-color-light);
+    font-weight: var(--t-font-weight-medium);
+  }
+
+  &:focus {
+    --tw-input-border-color: var(--t-color-blue);
+  }
+
+  &[aria-invalid='true'],
+  &[data-invalid] {
+    --tw-input-border-color: var(--t-border-color-danger);
+  }
+
+  &:disabled {
+    color: var(--t-font-color-tertiary);
+    cursor: not-allowed;
+  }
+
+  &[data-grouped] {
+    align-self: stretch;
+    background-color: transparent;
+    block-size: auto;
+    border: 0;
+    border-radius: 0;
+    flex: 1;
+    padding-inline: 0;
+  }
+}
+
+.sm {
+  --tw-input-block-size: 24px;
+}
+
+.md {
+  --tw-input-block-size: 32px;
+}

--- a/packages/twenty-ui/src/input/Input/Input.module.scss.d.ts
+++ b/packages/twenty-ui/src/input/Input/Input.module.scss.d.ts
@@ -1,0 +1,6 @@
+declare const classNames: {
+  readonly input: 'input';
+  readonly sm: 'sm';
+  readonly md: 'md';
+};
+export default classNames;

--- a/packages/twenty-ui/src/input/Input/Input.tsx
+++ b/packages/twenty-ui/src/input/Input/Input.tsx
@@ -1,0 +1,26 @@
+import { Input as InputPrimitive } from '@base-ui/react/input';
+import { clsx } from 'clsx';
+import { useContext } from 'react';
+
+import { mergeFieldPartClassName } from '@ui/input/Field/internal/mergeFieldPartClassName';
+import { InputGroupContext } from '@ui/input/InputGroup/internal/InputGroupContext';
+import { isDefined } from '@ui/utilities/utils/isDefined';
+
+import styles from './Input.module.scss';
+import { type InputProps } from './types/InputProps';
+
+export const Input = ({ size, className, ...props }: InputProps) => {
+  const inputGroup = useContext(InputGroupContext);
+  const resolvedSize = size ?? inputGroup?.size ?? 'md';
+
+  return (
+    <InputPrimitive
+      {...props}
+      className={mergeFieldPartClassName(
+        clsx(styles.input, styles[resolvedSize]),
+        className,
+      )}
+      data-grouped={isDefined(inputGroup) || undefined}
+    />
+  );
+};

--- a/packages/twenty-ui/src/input/Input/__stories__/Input.stories.tsx
+++ b/packages/twenty-ui/src/input/Input/__stories__/Input.stories.tsx
@@ -1,0 +1,99 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+
+import {
+  A11Y_DEFER_COLOR_CONTRAST,
+  CatalogDecorator,
+  type CatalogStory,
+  ComponentDecorator,
+} from '@ui/testing';
+
+import { Field } from '@ui/input/Field/Field';
+import { Input } from '@ui/input/Input/Input';
+import { type InputSize } from '@ui/input/types/InputSize';
+
+const meta: Meta<typeof Input> = {
+  title: 'UI/Input/Input',
+  component: Input,
+  args: {
+    'aria-label': 'Input',
+    placeholder: 'Placeholder',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  decorators: [ComponentDecorator],
+  parameters: { container: { width: 240 } },
+};
+
+export const WithField: Story = {
+  decorators: [ComponentDecorator],
+  parameters: {
+    a11y: A11Y_DEFER_COLOR_CONTRAST,
+    container: { width: 240 },
+  },
+  render: () => (
+    <Field.Root style={{ width: '100%' }}>
+      <Field.Label>Email</Field.Label>
+      <Input placeholder="you@example.com" />
+      <Field.Description>We never share it</Field.Description>
+    </Field.Root>
+  ),
+};
+
+type InputCatalogState = 'default' | 'focus' | 'invalid' | 'disabled';
+
+const getInputCatalogStateProps = (state: InputCatalogState) => {
+  if (state === 'focus') {
+    return { className: 'focus' };
+  }
+
+  if (state === 'invalid') {
+    return { 'aria-invalid': true };
+  }
+
+  if (state === 'disabled') {
+    return { disabled: true };
+  }
+
+  return {};
+};
+
+export const Catalog: CatalogStory<Story, typeof Input> = {
+  parameters: {
+    a11y: A11Y_DEFER_COLOR_CONTRAST,
+    pseudo: { focus: ['.focus'] },
+    catalog: {
+      dimensions: [
+        {
+          name: 'size',
+          values: ['sm', 'md'] satisfies InputSize[],
+          props: (size: InputSize) => ({ size }),
+        },
+        {
+          name: 'state',
+          values: [
+            'default',
+            'focus',
+            'invalid',
+            'disabled',
+          ] satisfies InputCatalogState[],
+          props: getInputCatalogStateProps,
+        },
+      ],
+      options: {
+        elementContainer: { style: { width: 160 } },
+      },
+    },
+  },
+  decorators: [CatalogDecorator],
+};
+
+export const CatalogDark: CatalogStory<Story, typeof Input> = {
+  ...Catalog,
+  tags: ['!autodocs'],
+  globals: { colorScheme: 'dark' },
+};

--- a/packages/twenty-ui/src/input/Input/__tests__/Input.test.tsx
+++ b/packages/twenty-ui/src/input/Input/__tests__/Input.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { runComponentConformance } from '@test-utilities/conformance/runComponentConformance';
+
+import { Field } from '@ui/input/Field/Field';
+
+import { Input } from '../Input';
+import styles from '../Input.module.scss';
+
+runComponentConformance({
+  name: 'Input',
+  element: <Input />,
+  refInstanceOf: HTMLInputElement,
+  ownClassName: styles.input,
+  renderPropTagName: 'input',
+});
+
+describe('Input', () => {
+  it('updates its value and reports it when uncontrolled', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <Input
+        defaultValue="a"
+        onValueChange={onValueChange}
+        aria-label="Name"
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Name' });
+
+    await user.type(input, 'b');
+
+    expect(input).toHaveValue('ab');
+    expect(onValueChange).toHaveBeenCalledWith(
+      'ab',
+      expect.objectContaining({ reason: 'none' }),
+    );
+  });
+
+  it('keeps the rendered value controlled by the value prop', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(<Input value="a" onValueChange={onValueChange} aria-label="Name" />);
+
+    const input = screen.getByRole('textbox', { name: 'Name' });
+
+    await user.type(input, 'b');
+
+    expect(onValueChange).toHaveBeenCalledWith('ab', expect.anything());
+    expect(input).toHaveValue('a');
+  });
+
+  it('applies the medium size by default and the small size on demand', () => {
+    const { rerender } = render(<Input aria-label="Name" />);
+
+    const input = screen.getByRole('textbox', { name: 'Name' });
+
+    expect(input).toHaveClass(styles.md);
+
+    rerender(<Input aria-label="Name" size="sm" />);
+
+    expect(input).toHaveClass(styles.sm);
+    expect(input).not.toHaveClass(styles.md);
+  });
+
+  it('is labelled and focused by Field.Label inside Field.Root', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Field.Root>
+        <Field.Label>Name</Field.Label>
+        <Input />
+      </Field.Root>,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Name' });
+
+    await user.click(screen.getByText('Name'));
+
+    expect(input).toHaveFocus();
+  });
+
+  it('reflects the invalid and disabled state of its Field.Root', () => {
+    render(
+      <Field.Root invalid disabled>
+        <Input aria-label="Name" />
+      </Field.Root>,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Name' });
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('data-invalid');
+    expect(input).toBeDisabled();
+  });
+});

--- a/packages/twenty-ui/src/input/Input/types/InputProps.ts
+++ b/packages/twenty-ui/src/input/Input/types/InputProps.ts
@@ -1,0 +1,7 @@
+import { type Input as InputPrimitive } from '@base-ui/react/input';
+
+import { type InputSize } from '@ui/input/types/InputSize';
+
+export type InputProps = Omit<InputPrimitive.Props, 'size'> & {
+  size?: InputSize;
+};

--- a/packages/twenty-ui/src/input/InputGroup/InputGroup.module.scss
+++ b/packages/twenty-ui/src/input/InputGroup/InputGroup.module.scss
@@ -1,0 +1,45 @@
+.root {
+  --tw-input-group-block-size: 32px;
+  --tw-input-group-border-color: var(--t-border-color-medium);
+
+  align-items: center;
+  background-color: var(--t-background-transparent-lighter);
+  block-size: var(--tw-input-group-block-size);
+  border: 1px solid var(--tw-input-group-border-color);
+  border-radius: var(--t-border-radius-md);
+  color: var(--t-font-color-tertiary);
+  display: flex;
+  gap: var(--t-spacing-1);
+  inline-size: 100%;
+  padding-inline: var(--t-spacing-2);
+
+  &:focus-within {
+    --tw-input-group-border-color: var(--t-color-blue);
+
+    color: var(--t-font-color-secondary);
+  }
+
+  &:has([aria-invalid='true'], [data-invalid]) {
+    --tw-input-group-border-color: var(--t-border-color-danger);
+  }
+
+  &:has(:disabled) {
+    color: var(--t-font-color-light);
+    cursor: not-allowed;
+  }
+}
+
+.sm {
+  --tw-input-group-block-size: 24px;
+}
+
+.md {
+  --tw-input-group-block-size: 32px;
+}
+
+.startElement,
+.endElement {
+  align-items: center;
+  display: inline-flex;
+  flex: none;
+}

--- a/packages/twenty-ui/src/input/InputGroup/InputGroup.module.scss.d.ts
+++ b/packages/twenty-ui/src/input/InputGroup/InputGroup.module.scss.d.ts
@@ -1,0 +1,8 @@
+declare const classNames: {
+  readonly root: 'root';
+  readonly sm: 'sm';
+  readonly md: 'md';
+  readonly startElement: 'startElement';
+  readonly endElement: 'endElement';
+};
+export default classNames;

--- a/packages/twenty-ui/src/input/InputGroup/InputGroup.tsx
+++ b/packages/twenty-ui/src/input/InputGroup/InputGroup.tsx
@@ -1,0 +1,45 @@
+import { useRender } from '@base-ui/react/use-render';
+import { clsx } from 'clsx';
+
+import { isDefined } from '@ui/utilities/utils/isDefined';
+
+import styles from './InputGroup.module.scss';
+import { InputGroupContext } from './internal/InputGroupContext';
+import { type InputGroupProps } from './types/InputGroupProps';
+
+export const InputGroup = ({
+  size = 'md',
+  startElement,
+  endElement,
+  className,
+  children,
+  render,
+  ref,
+  ...props
+}: InputGroupProps) => {
+  const element = useRender({
+    render,
+    ref,
+    props: {
+      ...props,
+      className: clsx(styles.root, styles[size], className),
+      children: (
+        <>
+          {isDefined(startElement) && (
+            <span className={styles.startElement}>{startElement}</span>
+          )}
+          {children}
+          {isDefined(endElement) && (
+            <span className={styles.endElement}>{endElement}</span>
+          )}
+        </>
+      ),
+    },
+  });
+
+  return (
+    <InputGroupContext.Provider value={{ size }}>
+      {element}
+    </InputGroupContext.Provider>
+  );
+};

--- a/packages/twenty-ui/src/input/InputGroup/InputGroup.tsx
+++ b/packages/twenty-ui/src/input/InputGroup/InputGroup.tsx
@@ -1,10 +1,9 @@
 import { useRender } from '@base-ui/react/use-render';
 import { clsx } from 'clsx';
 
-import { isDefined } from '@ui/utilities/utils/isDefined';
-
 import styles from './InputGroup.module.scss';
 import { InputGroupContext } from './internal/InputGroupContext';
+import { isRenderableAdornment } from './internal/isRenderableAdornment';
 import { type InputGroupProps } from './types/InputGroupProps';
 
 export const InputGroup = ({
@@ -25,11 +24,11 @@ export const InputGroup = ({
       className: clsx(styles.root, styles[size], className),
       children: (
         <>
-          {isDefined(startElement) && (
+          {isRenderableAdornment(startElement) && (
             <span className={styles.startElement}>{startElement}</span>
           )}
           {children}
-          {isDefined(endElement) && (
+          {isRenderableAdornment(endElement) && (
             <span className={styles.endElement}>{endElement}</span>
           )}
         </>

--- a/packages/twenty-ui/src/input/InputGroup/__stories__/InputGroup.stories.tsx
+++ b/packages/twenty-ui/src/input/InputGroup/__stories__/InputGroup.stories.tsx
@@ -1,0 +1,89 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+
+import {
+  A11Y_DEFER_COLOR_CONTRAST,
+  CatalogDecorator,
+  type CatalogStory,
+  ComponentDecorator,
+} from '@ui/testing';
+
+import { IconSearch } from '@ui/icon';
+import { Input } from '@ui/input/Input/Input';
+import { InputGroup } from '@ui/input/InputGroup/InputGroup';
+import { type InputSize } from '@ui/input/types/InputSize';
+
+const meta: Meta<typeof InputGroup> = {
+  title: 'UI/Input/InputGroup',
+  component: InputGroup,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InputGroup>;
+
+const SEARCH_ICON = <IconSearch size={16} />;
+
+export const Default: Story = {
+  decorators: [ComponentDecorator],
+  parameters: { container: { width: 240 } },
+  args: {
+    startElement: SEARCH_ICON,
+    children: <Input placeholder="Search" />,
+  },
+};
+
+export const WithEndElement: Story = {
+  decorators: [ComponentDecorator],
+  parameters: {
+    a11y: A11Y_DEFER_COLOR_CONTRAST,
+    container: { width: 240 },
+  },
+  args: {
+    endElement: 'USD',
+    children: <Input placeholder="0.00" />,
+  },
+};
+
+type InputGroupCatalogAdornment = 'start' | 'end' | 'both';
+
+const getInputGroupCatalogAdornmentProps = (
+  adornment: InputGroupCatalogAdornment,
+) => ({
+  startElement: adornment === 'end' ? undefined : SEARCH_ICON,
+  endElement: adornment === 'start' ? undefined : 'USD',
+});
+
+export const Catalog: CatalogStory<Story, typeof InputGroup> = {
+  args: { children: <Input placeholder="Search" /> },
+  parameters: {
+    a11y: A11Y_DEFER_COLOR_CONTRAST,
+    catalog: {
+      dimensions: [
+        {
+          name: 'size',
+          values: ['sm', 'md'] satisfies InputSize[],
+          props: (size: InputSize) => ({ size }),
+        },
+        {
+          name: 'adornment',
+          values: [
+            'start',
+            'end',
+            'both',
+          ] satisfies InputGroupCatalogAdornment[],
+          props: getInputGroupCatalogAdornmentProps,
+        },
+      ],
+      options: {
+        elementContainer: { style: { width: 160 } },
+      },
+    },
+  },
+  decorators: [CatalogDecorator],
+};
+
+export const CatalogDark: CatalogStory<Story, typeof InputGroup> = {
+  ...Catalog,
+  tags: ['!autodocs'],
+  globals: { colorScheme: 'dark' },
+};

--- a/packages/twenty-ui/src/input/InputGroup/__tests__/InputGroup.test.tsx
+++ b/packages/twenty-ui/src/input/InputGroup/__tests__/InputGroup.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+
+import { runComponentConformance } from '@test-utilities/conformance/runComponentConformance';
+
+import { Input } from '@ui/input/Input/Input';
+import inputStyles from '@ui/input/Input/Input.module.scss';
+
+import { InputGroup } from '../InputGroup';
+import styles from '../InputGroup.module.scss';
+
+runComponentConformance({
+  name: 'InputGroup',
+  element: (
+    <InputGroup>
+      <Input aria-label="Grouped" />
+    </InputGroup>
+  ),
+  refInstanceOf: HTMLDivElement,
+  ownClassName: styles.root,
+});
+
+describe('InputGroup', () => {
+  it('renders the start and end elements around the input', () => {
+    render(
+      <InputGroup startElement="$" endElement="USD">
+        <Input aria-label="Amount" />
+      </InputGroup>,
+    );
+
+    expect(screen.getByText('$')).toBeInTheDocument();
+    expect(screen.getByText('USD')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Amount' })).toBeInTheDocument();
+  });
+
+  it('renders only the input when no element is given', () => {
+    render(
+      <InputGroup>
+        <Input aria-label="Amount" />
+      </InputGroup>,
+    );
+
+    expect(
+      screen.getByRole('textbox', { name: 'Amount' }).parentElement?.children,
+    ).toHaveLength(1);
+  });
+
+  it('passes its size to the input and marks it as grouped', () => {
+    render(
+      <InputGroup size="sm">
+        <Input aria-label="Amount" />
+      </InputGroup>,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Amount' });
+
+    expect(input).toHaveClass(inputStyles.sm);
+    expect(input).toHaveAttribute('data-grouped');
+  });
+
+  it('lets an explicit input size win over the group size', () => {
+    render(
+      <InputGroup size="sm">
+        <Input aria-label="Amount" size="md" />
+      </InputGroup>,
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Amount' })).toHaveClass(
+      inputStyles.md,
+    );
+  });
+});

--- a/packages/twenty-ui/src/input/InputGroup/__tests__/InputGroup.test.tsx
+++ b/packages/twenty-ui/src/input/InputGroup/__tests__/InputGroup.test.tsx
@@ -32,6 +32,18 @@ describe('InputGroup', () => {
     expect(screen.getByRole('textbox', { name: 'Amount' })).toBeInTheDocument();
   });
 
+  it('renders no wrapper for a boolean or empty adornment', () => {
+    render(
+      <InputGroup startElement={false} endElement="">
+        <Input aria-label="Amount" />
+      </InputGroup>,
+    );
+
+    expect(
+      screen.getByRole('textbox', { name: 'Amount' }).parentElement?.children,
+    ).toHaveLength(1);
+  });
+
   it('renders only the input when no element is given', () => {
     render(
       <InputGroup>

--- a/packages/twenty-ui/src/input/InputGroup/internal/InputGroupContext.ts
+++ b/packages/twenty-ui/src/input/InputGroup/internal/InputGroupContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+import { type InputSize } from '@ui/input/types/InputSize';
+
+export const InputGroupContext = createContext<{ size: InputSize } | null>(
+  null,
+);

--- a/packages/twenty-ui/src/input/InputGroup/internal/isRenderableAdornment.ts
+++ b/packages/twenty-ui/src/input/InputGroup/internal/isRenderableAdornment.ts
@@ -1,0 +1,7 @@
+import { isBoolean } from '@sniptt/guards';
+import { type ReactNode } from 'react';
+
+import { isDefined } from '@ui/utilities/utils/isDefined';
+
+export const isRenderableAdornment = (adornment: ReactNode) =>
+  isDefined(adornment) && !isBoolean(adornment) && adornment !== '';

--- a/packages/twenty-ui/src/input/InputGroup/types/InputGroupProps.ts
+++ b/packages/twenty-ui/src/input/InputGroup/types/InputGroupProps.ts
@@ -1,0 +1,10 @@
+import { type useRender } from '@base-ui/react/use-render';
+import { type ReactNode } from 'react';
+
+import { type InputSize } from '@ui/input/types/InputSize';
+
+export type InputGroupProps = useRender.ComponentProps<'div'> & {
+  size?: InputSize;
+  startElement?: ReactNode;
+  endElement?: ReactNode;
+};

--- a/packages/twenty-ui/src/input/Textarea/Textarea.module.scss
+++ b/packages/twenty-ui/src/input/Textarea/Textarea.module.scss
@@ -1,0 +1,53 @@
+.textarea {
+  --tw-textarea-border-color: var(--t-border-color-medium);
+  --tw-textarea-padding-block: var(--t-spacing-2);
+
+  appearance: none;
+  background-color: var(--t-background-transparent-lighter);
+  border: 1px solid var(--tw-textarea-border-color);
+  border-radius: var(--t-border-radius-md);
+  color: var(--t-font-color-primary);
+  display: block;
+  font-family: var(--t-font-family);
+  font-size: var(--t-font-size-md);
+  font-weight: var(--t-font-weight-regular);
+  inline-size: 100%;
+  line-height: 16px;
+  margin: 0;
+  max-block-size: calc(
+    var(--tw-textarea-max-rows) * 1lh + 2 * var(--tw-textarea-padding-block) +
+      2px
+  );
+  outline: none;
+  overflow: auto;
+  padding-block: var(--tw-textarea-padding-block);
+  padding-inline: var(--t-spacing-2);
+  resize: none;
+
+  &::placeholder {
+    color: var(--t-font-color-light);
+    font-weight: var(--t-font-weight-medium);
+  }
+
+  &:focus {
+    --tw-textarea-border-color: var(--t-color-blue);
+  }
+
+  &[aria-invalid='true'],
+  &[data-invalid] {
+    --tw-textarea-border-color: var(--t-border-color-danger);
+  }
+
+  &:disabled {
+    color: var(--t-font-color-tertiary);
+    cursor: not-allowed;
+  }
+}
+
+.sm {
+  --tw-textarea-padding-block: var(--t-spacing-1);
+}
+
+.md {
+  --tw-textarea-padding-block: var(--t-spacing-2);
+}

--- a/packages/twenty-ui/src/input/Textarea/Textarea.module.scss.d.ts
+++ b/packages/twenty-ui/src/input/Textarea/Textarea.module.scss.d.ts
@@ -1,0 +1,6 @@
+declare const classNames: {
+  readonly textarea: 'textarea';
+  readonly sm: 'sm';
+  readonly md: 'md';
+};
+export default classNames;

--- a/packages/twenty-ui/src/input/Textarea/Textarea.tsx
+++ b/packages/twenty-ui/src/input/Textarea/Textarea.tsx
@@ -1,0 +1,73 @@
+import { Input as InputPrimitive } from '@base-ui/react/input';
+import { clsx } from 'clsx';
+import {
+  type ChangeEvent,
+  type CSSProperties,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
+
+import { isDefined } from '@ui/utilities/utils/isDefined';
+
+import { mergeRefs } from './internal/mergeRefs';
+import { resizeTextareaToContent } from './internal/resizeTextareaToContent';
+import styles from './Textarea.module.scss';
+import { type TextareaProps } from './types/TextareaProps';
+
+const TEXTAREA_RENDER_ELEMENT = <textarea />;
+
+export const Textarea = ({
+  size = 'md',
+  autoResize = false,
+  maxRows,
+  className,
+  style,
+  ref,
+  render = TEXTAREA_RENDER_ELEMENT,
+  onChange,
+  value,
+  ...props
+}: TextareaProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Base UI re-forks a merged ref whenever its identity changes, which would detach and reattach it on every render.
+  const mergedRef = useMemo(() => mergeRefs(ref, textareaRef), [ref]);
+
+  useLayoutEffect(() => {
+    if (!autoResize || !isDefined(textareaRef.current)) {
+      return;
+    }
+
+    resizeTextareaToContent(textareaRef.current);
+  }, [autoResize, value, maxRows]);
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    if (autoResize) {
+      resizeTextareaToContent(event.currentTarget);
+    }
+
+    onChange?.(event);
+  };
+
+  const resolvedStyle = isDefined(maxRows)
+    ? ({ ...style, '--tw-textarea-max-rows': maxRows } as CSSProperties)
+    : style;
+
+  // Base UI types its control for <input> but only reads currentTarget.value, so rendering a textarea through it is safe.
+  const primitiveProps = {
+    ...props,
+    onChange: handleChange,
+  } as unknown as InputPrimitive.Props;
+
+  return (
+    <InputPrimitive
+      {...primitiveProps}
+      ref={mergedRef}
+      render={render}
+      value={value}
+      className={clsx(styles.textarea, styles[size], className)}
+      style={resolvedStyle}
+      data-auto-resize={autoResize || undefined}
+    />
+  );
+};

--- a/packages/twenty-ui/src/input/Textarea/Textarea.tsx
+++ b/packages/twenty-ui/src/input/Textarea/Textarea.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
 } from 'react';
 
+import { mergeFieldPartClassName } from '@ui/input/Field/internal/mergeFieldPartClassName';
 import { isDefined } from '@ui/utilities/utils/isDefined';
 
 import { mergeRefs } from './internal/mergeRefs';
@@ -27,22 +28,31 @@ export const Textarea = ({
   render = TEXTAREA_RENDER_ELEMENT,
   onChange,
   value,
+  rows,
   ...props
 }: TextareaProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Base UI re-forks a merged ref whenever its identity changes, which would detach and reattach it on every render.
   const mergedRef = useMemo(() => mergeRefs(ref, textareaRef), [ref]);
+  const isControlled = isDefined(value);
 
   useLayoutEffect(() => {
-    if (!autoResize || !isDefined(textareaRef.current)) {
+    const textarea = textareaRef.current;
+
+    if (!autoResize || !isDefined(textarea)) {
       return;
     }
 
-    resizeTextareaToContent(textareaRef.current);
-  }, [autoResize, value, maxRows]);
+    resizeTextareaToContent(textarea);
+
+    return () => {
+      textarea.style.blockSize = '';
+    };
+  }, [autoResize, value, maxRows, rows]);
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    if (autoResize) {
+    // A controlled parent may reject the edit, so the layout effect measures the committed value instead.
+    if (autoResize && !isControlled) {
       resizeTextareaToContent(event.currentTarget);
     }
 
@@ -56,6 +66,7 @@ export const Textarea = ({
   // Base UI types its control for <input> but only reads currentTarget.value, so rendering a textarea through it is safe.
   const primitiveProps = {
     ...props,
+    rows,
     onChange: handleChange,
   } as unknown as InputPrimitive.Props;
 
@@ -65,7 +76,10 @@ export const Textarea = ({
       ref={mergedRef}
       render={render}
       value={value}
-      className={clsx(styles.textarea, styles[size], className)}
+      className={mergeFieldPartClassName(
+        clsx(styles.textarea, styles[size]),
+        className,
+      )}
       style={resolvedStyle}
       data-auto-resize={autoResize || undefined}
     />

--- a/packages/twenty-ui/src/input/Textarea/Textarea.tsx
+++ b/packages/twenty-ui/src/input/Textarea/Textarea.tsx
@@ -41,15 +41,16 @@ export const Textarea = ({
   useLayoutEffect(() => {
     const textarea = textareaRef.current;
 
-    if (!autoResize || !isDefined(textarea)) {
+    if (!isDefined(textarea)) {
+      return;
+    }
+
+    if (!autoResize) {
+      textarea.style.blockSize = formatInlineBlockSize(consumerBlockSize);
       return;
     }
 
     resizeTextareaToContent(textarea);
-
-    return () => {
-      textarea.style.blockSize = formatInlineBlockSize(consumerBlockSize);
-    };
   }, [autoResize, value, maxRows, rows, consumerBlockSize]);
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/twenty-ui/src/input/Textarea/Textarea.tsx
+++ b/packages/twenty-ui/src/input/Textarea/Textarea.tsx
@@ -11,6 +11,7 @@ import {
 import { mergeFieldPartClassName } from '@ui/input/Field/internal/mergeFieldPartClassName';
 import { isDefined } from '@ui/utilities/utils/isDefined';
 
+import { formatInlineBlockSize } from './internal/formatInlineBlockSize';
 import { mergeRefs } from './internal/mergeRefs';
 import { resizeTextareaToContent } from './internal/resizeTextareaToContent';
 import styles from './Textarea.module.scss';
@@ -35,6 +36,7 @@ export const Textarea = ({
   // Base UI re-forks a merged ref whenever its identity changes, which would detach and reattach it on every render.
   const mergedRef = useMemo(() => mergeRefs(ref, textareaRef), [ref]);
   const isControlled = isDefined(value);
+  const consumerBlockSize = style?.blockSize;
 
   useLayoutEffect(() => {
     const textarea = textareaRef.current;
@@ -46,9 +48,9 @@ export const Textarea = ({
     resizeTextareaToContent(textarea);
 
     return () => {
-      textarea.style.blockSize = '';
+      textarea.style.blockSize = formatInlineBlockSize(consumerBlockSize);
     };
-  }, [autoResize, value, maxRows, rows]);
+  }, [autoResize, value, maxRows, rows, consumerBlockSize]);
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     // A controlled parent may reject the edit, so the layout effect measures the committed value instead.

--- a/packages/twenty-ui/src/input/Textarea/__stories__/Textarea.stories.tsx
+++ b/packages/twenty-ui/src/input/Textarea/__stories__/Textarea.stories.tsx
@@ -1,0 +1,109 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+
+import {
+  A11Y_DEFER_COLOR_CONTRAST,
+  CatalogDecorator,
+  type CatalogStory,
+  ComponentDecorator,
+} from '@ui/testing';
+
+import { Textarea } from '@ui/input/Textarea/Textarea';
+import { type InputSize } from '@ui/input/types/InputSize';
+
+const meta: Meta<typeof Textarea> = {
+  title: 'UI/Input/Textarea',
+  component: Textarea,
+  args: {
+    'aria-label': 'Textarea',
+    placeholder: 'Placeholder',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Textarea>;
+
+export const Default: Story = {
+  decorators: [ComponentDecorator],
+  parameters: { container: { width: 240 } },
+  args: { rows: 3 },
+};
+
+export const AutoResize: Story = {
+  decorators: [ComponentDecorator],
+  parameters: { container: { width: 240 } },
+  args: { autoResize: true, rows: 1, maxRows: 4 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const textarea = canvas.getByRole('textbox', { name: 'Textarea' });
+    const initialHeight = textarea.clientHeight;
+
+    await userEvent.type(textarea, 'one{enter}two{enter}three');
+
+    await expect(textarea.clientHeight).toBeGreaterThan(initialHeight);
+
+    await userEvent.type(
+      textarea,
+      '{enter}four{enter}five{enter}six{enter}seven{enter}eight',
+    );
+
+    await expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
+  },
+};
+
+type TextareaCatalogState = 'default' | 'focus' | 'invalid' | 'disabled';
+
+const getTextareaCatalogStateProps = (state: TextareaCatalogState) => {
+  if (state === 'focus') {
+    return { className: 'focus' };
+  }
+
+  if (state === 'invalid') {
+    return { 'aria-invalid': true };
+  }
+
+  if (state === 'disabled') {
+    return { disabled: true };
+  }
+
+  return {};
+};
+
+export const Catalog: CatalogStory<Story, typeof Textarea> = {
+  args: { rows: 2 },
+  parameters: {
+    a11y: A11Y_DEFER_COLOR_CONTRAST,
+    pseudo: { focus: ['.focus'] },
+    catalog: {
+      dimensions: [
+        {
+          name: 'size',
+          values: ['sm', 'md'] satisfies InputSize[],
+          props: (size: InputSize) => ({ size }),
+        },
+        {
+          name: 'state',
+          values: [
+            'default',
+            'focus',
+            'invalid',
+            'disabled',
+          ] satisfies TextareaCatalogState[],
+          props: getTextareaCatalogStateProps,
+        },
+      ],
+      options: {
+        elementContainer: { style: { width: 160 } },
+      },
+    },
+  },
+  decorators: [CatalogDecorator],
+};
+
+export const CatalogDark: CatalogStory<Story, typeof Textarea> = {
+  ...Catalog,
+  tags: ['!autodocs'],
+  globals: { colorScheme: 'dark' },
+};

--- a/packages/twenty-ui/src/input/Textarea/__tests__/Textarea.test.tsx
+++ b/packages/twenty-ui/src/input/Textarea/__tests__/Textarea.test.tsx
@@ -234,6 +234,24 @@ describe('Textarea', () => {
 
       expect(textarea.style.blockSize).toBe('80px');
     });
+
+    it('applies a block size changed in the same render that turns autoResize off', () => {
+      const { rerender } = render(
+        <Textarea aria-label="Notes" autoResize style={{ blockSize: 80 }} />,
+      );
+
+      rerender(
+        <Textarea
+          aria-label="Notes"
+          autoResize={false}
+          style={{ blockSize: 120 }}
+        />,
+      );
+
+      expect(
+        screen.getByRole('textbox', { name: 'Notes' }).style.blockSize,
+      ).toBe('120px');
+    });
   });
 
   it('is labelled and focused by Field.Label inside Field.Root', async () => {

--- a/packages/twenty-ui/src/input/Textarea/__tests__/Textarea.test.tsx
+++ b/packages/twenty-ui/src/input/Textarea/__tests__/Textarea.test.tsx
@@ -66,6 +66,22 @@ describe('Textarea', () => {
     expect(textarea).toHaveClass(styles.sm);
   });
 
+  it('resolves a function className against the field state', () => {
+    render(
+      <Field.Root invalid>
+        <Textarea
+          aria-label="Notes"
+          className={(state) => (state.valid === false ? 'invalid' : 'valid')}
+        />
+      </Field.Root>,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+    expect(textarea).toHaveClass(styles.textarea, 'invalid');
+    expect(textarea).not.toHaveClass('valid');
+  });
+
   it('exposes maxRows as a custom property', () => {
     render(<Textarea aria-label="Notes" maxRows={4} />);
 
@@ -74,6 +90,24 @@ describe('Textarea', () => {
         .getByRole('textbox', { name: 'Notes' })
         .style.getPropertyValue('--tw-textarea-max-rows'),
     ).toBe('4');
+  });
+
+  it('runs the cleanup of a callback ref on unmount', () => {
+    const refCleanup = vi.fn();
+    const callbackRef = vi.fn(() => refCleanup);
+
+    const { unmount } = render(
+      <Textarea aria-label="Notes" ref={callbackRef} />,
+    );
+
+    expect(callbackRef).toHaveBeenCalledWith(
+      screen.getByRole('textbox', { name: 'Notes' }),
+    );
+
+    unmount();
+
+    expect(refCleanup).toHaveBeenCalledTimes(1);
+    expect(callbackRef).toHaveBeenCalledTimes(1);
   });
 
   describe('autoResize', () => {
@@ -131,6 +165,54 @@ describe('Textarea', () => {
       expect(
         screen.getByRole('textbox', { name: 'Notes' }).style.blockSize,
       ).toBe('72px');
+    });
+
+    it('keeps the height when a controlled parent rejects the edit', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Textarea
+          aria-label="Notes"
+          autoResize
+          value="a"
+          onValueChange={() => undefined}
+        />,
+      );
+
+      const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+      scrollHeightSpy.mockReturnValue(56);
+
+      await user.type(textarea, 'b');
+
+      expect(textarea).toHaveValue('a');
+      expect(textarea.style.blockSize).toBe('40px');
+    });
+
+    it('measures again when rows changes', () => {
+      const { rerender } = render(
+        <Textarea aria-label="Notes" autoResize rows={1} />,
+      );
+
+      scrollHeightSpy.mockReturnValue(56);
+
+      rerender(<Textarea aria-label="Notes" autoResize rows={3} />);
+
+      expect(
+        screen.getByRole('textbox', { name: 'Notes' }).style.blockSize,
+      ).toBe('56px');
+    });
+
+    it('clears the inline height when autoResize is turned off', () => {
+      const { rerender } = render(<Textarea aria-label="Notes" autoResize />);
+
+      const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+      expect(textarea.style.blockSize).toBe('40px');
+
+      rerender(<Textarea aria-label="Notes" autoResize={false} />);
+
+      expect(textarea.style.blockSize).toBe('');
     });
   });
 

--- a/packages/twenty-ui/src/input/Textarea/__tests__/Textarea.test.tsx
+++ b/packages/twenty-ui/src/input/Textarea/__tests__/Textarea.test.tsx
@@ -214,6 +214,26 @@ describe('Textarea', () => {
 
       expect(textarea.style.blockSize).toBe('');
     });
+
+    it('restores the consumer block size when autoResize is turned off', () => {
+      const { rerender } = render(
+        <Textarea aria-label="Notes" autoResize style={{ blockSize: 80 }} />,
+      );
+
+      const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+      expect(textarea.style.blockSize).toBe('40px');
+
+      rerender(
+        <Textarea
+          aria-label="Notes"
+          autoResize={false}
+          style={{ blockSize: 80 }}
+        />,
+      );
+
+      expect(textarea.style.blockSize).toBe('80px');
+    });
   });
 
   it('is labelled and focused by Field.Label inside Field.Root', async () => {

--- a/packages/twenty-ui/src/input/Textarea/__tests__/Textarea.test.tsx
+++ b/packages/twenty-ui/src/input/Textarea/__tests__/Textarea.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type MockInstance, vi } from 'vitest';
+
+import { runComponentConformance } from '@test-utilities/conformance/runComponentConformance';
+
+import { Field } from '@ui/input/Field/Field';
+
+import { Textarea } from '../Textarea';
+import styles from '../Textarea.module.scss';
+
+runComponentConformance({
+  name: 'Textarea',
+  element: <Textarea />,
+  refInstanceOf: HTMLTextAreaElement,
+  ownClassName: styles.textarea,
+  renderPropTagName: 'textarea',
+});
+
+describe('Textarea', () => {
+  it('updates its value and reports it when uncontrolled', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <Textarea
+        defaultValue="a"
+        onValueChange={onValueChange}
+        aria-label="Notes"
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+    await user.type(textarea, 'b');
+
+    expect(textarea).toHaveValue('ab');
+    expect(onValueChange).toHaveBeenCalledWith(
+      'ab',
+      expect.objectContaining({ reason: 'none' }),
+    );
+  });
+
+  it('keeps the rendered value controlled by the value prop', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <Textarea value="a" onValueChange={onValueChange} aria-label="Notes" />,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+    await user.type(textarea, 'b');
+
+    expect(onValueChange).toHaveBeenCalledWith('ab', expect.anything());
+    expect(textarea).toHaveValue('a');
+  });
+
+  it('passes rows through and applies the size', () => {
+    render(<Textarea aria-label="Notes" rows={5} size="sm" />);
+
+    const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+    expect(textarea).toHaveAttribute('rows', '5');
+    expect(textarea).toHaveClass(styles.sm);
+  });
+
+  it('exposes maxRows as a custom property', () => {
+    render(<Textarea aria-label="Notes" maxRows={4} />);
+
+    expect(
+      screen
+        .getByRole('textbox', { name: 'Notes' })
+        .style.getPropertyValue('--tw-textarea-max-rows'),
+    ).toBe('4');
+  });
+
+  describe('autoResize', () => {
+    let scrollHeightSpy: MockInstance<() => number>;
+
+    beforeEach(() => {
+      scrollHeightSpy = vi
+        .spyOn(Element.prototype, 'scrollHeight', 'get')
+        .mockReturnValue(40);
+    });
+
+    afterEach(() => {
+      scrollHeightSpy.mockRestore();
+    });
+
+    it('sizes the textarea to its content on mount and while typing', async () => {
+      const user = userEvent.setup();
+
+      render(<Textarea aria-label="Notes" autoResize />);
+
+      const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+      expect(textarea).toHaveAttribute('data-auto-resize');
+      expect(textarea.style.blockSize).toBe('40px');
+
+      scrollHeightSpy.mockReturnValue(56);
+
+      await user.type(textarea, 'a');
+
+      expect(textarea.style.blockSize).toBe('56px');
+    });
+
+    it('resizes when a controlled value changes', () => {
+      const onValueChange = vi.fn();
+      const { rerender } = render(
+        <Textarea
+          aria-label="Notes"
+          autoResize
+          value="a"
+          onValueChange={onValueChange}
+        />,
+      );
+
+      scrollHeightSpy.mockReturnValue(72);
+
+      rerender(
+        <Textarea
+          aria-label="Notes"
+          autoResize
+          value={'a\nb'}
+          onValueChange={onValueChange}
+        />,
+      );
+
+      expect(
+        screen.getByRole('textbox', { name: 'Notes' }).style.blockSize,
+      ).toBe('72px');
+    });
+  });
+
+  it('is labelled and focused by Field.Label inside Field.Root', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Field.Root>
+        <Field.Label>Notes</Field.Label>
+        <Textarea />
+      </Field.Root>,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+    await user.click(screen.getByText('Notes'));
+
+    expect(textarea).toHaveFocus();
+  });
+
+  it('reflects the invalid state of its Field.Root', () => {
+    render(
+      <Field.Root invalid>
+        <Textarea aria-label="Notes" />
+      </Field.Root>,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Notes' });
+
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(textarea).toHaveAttribute('data-invalid');
+  });
+});

--- a/packages/twenty-ui/src/input/Textarea/__tests__/mergeRefs.test.ts
+++ b/packages/twenty-ui/src/input/Textarea/__tests__/mergeRefs.test.ts
@@ -1,0 +1,49 @@
+import { isFunction } from '@sniptt/guards';
+import { createRef } from 'react';
+import { vi } from 'vitest';
+
+import { mergeRefs } from '../internal/mergeRefs';
+
+const runCleanup = (cleanup: unknown) => {
+  expect(cleanup).toBeTypeOf('function');
+
+  if (isFunction(cleanup)) {
+    cleanup();
+  }
+};
+
+describe('mergeRefs', () => {
+  it('assigns the node to every ref and clears them on cleanup', () => {
+    const objectRef = createRef<HTMLDivElement>();
+    const callbackRef = vi.fn();
+    const node = document.createElement('div');
+
+    const cleanup = mergeRefs<HTMLDivElement>(
+      objectRef,
+      undefined,
+      null,
+      callbackRef,
+    )(node);
+
+    expect(objectRef.current).toBe(node);
+    expect(callbackRef).toHaveBeenCalledWith(node);
+
+    runCleanup(cleanup);
+
+    expect(objectRef.current).toBeNull();
+    expect(callbackRef).toHaveBeenLastCalledWith(null);
+  });
+
+  it('runs the cleanup returned by a callback ref instead of calling it with null', () => {
+    const refCleanup = vi.fn();
+    const callbackRef = vi.fn(() => refCleanup);
+    const node = document.createElement('div');
+
+    const cleanup = mergeRefs<HTMLDivElement>(callbackRef)(node);
+
+    runCleanup(cleanup);
+
+    expect(refCleanup).toHaveBeenCalledTimes(1);
+    expect(callbackRef).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/twenty-ui/src/input/Textarea/internal/formatInlineBlockSize.ts
+++ b/packages/twenty-ui/src/input/Textarea/internal/formatInlineBlockSize.ts
@@ -1,0 +1,14 @@
+import { isNumber } from '@sniptt/guards';
+import { type CSSProperties } from 'react';
+
+import { isDefined } from '@ui/utilities/utils/isDefined';
+
+export const formatInlineBlockSize = (
+  blockSize: CSSProperties['blockSize'],
+): string => {
+  if (!isDefined(blockSize)) {
+    return '';
+  }
+
+  return isNumber(blockSize) ? `${blockSize}px` : String(blockSize);
+};

--- a/packages/twenty-ui/src/input/Textarea/internal/mergeRefs.ts
+++ b/packages/twenty-ui/src/input/Textarea/internal/mergeRefs.ts
@@ -3,19 +3,35 @@ import { type Ref, type RefCallback } from 'react';
 
 import { isDefined } from '@ui/utilities/utils/isDefined';
 
+const assignRef = <TElement>(
+  ref: Ref<TElement> | undefined,
+  node: TElement | null,
+) => {
+  if (!isDefined(ref)) {
+    return undefined;
+  }
+
+  if (isFunction(ref)) {
+    return ref(node);
+  }
+
+  ref.current = node;
+
+  return undefined;
+};
+
 export const mergeRefs =
   <TElement>(...refs: (Ref<TElement> | undefined)[]): RefCallback<TElement> =>
   (node) => {
-    for (const ref of refs) {
-      if (!isDefined(ref)) {
-        continue;
-      }
+    const cleanups = refs.map((ref) => {
+      const cleanup = assignRef(ref, node);
 
-      if (isFunction(ref)) {
-        ref(node);
-        continue;
-      }
+      return isFunction(cleanup) ? cleanup : () => assignRef(ref, null);
+    });
 
-      ref.current = node;
-    }
+    return () => {
+      for (const cleanup of cleanups) {
+        cleanup();
+      }
+    };
   };

--- a/packages/twenty-ui/src/input/Textarea/internal/mergeRefs.ts
+++ b/packages/twenty-ui/src/input/Textarea/internal/mergeRefs.ts
@@ -1,0 +1,21 @@
+import { isFunction } from '@sniptt/guards';
+import { type Ref, type RefCallback } from 'react';
+
+import { isDefined } from '@ui/utilities/utils/isDefined';
+
+export const mergeRefs =
+  <TElement>(...refs: (Ref<TElement> | undefined)[]): RefCallback<TElement> =>
+  (node) => {
+    for (const ref of refs) {
+      if (!isDefined(ref)) {
+        continue;
+      }
+
+      if (isFunction(ref)) {
+        ref(node);
+        continue;
+      }
+
+      ref.current = node;
+    }
+  };

--- a/packages/twenty-ui/src/input/Textarea/internal/resizeTextareaToContent.ts
+++ b/packages/twenty-ui/src/input/Textarea/internal/resizeTextareaToContent.ts
@@ -1,0 +1,7 @@
+export const resizeTextareaToContent = (textarea: HTMLTextAreaElement) => {
+  textarea.style.blockSize = 'auto';
+
+  const borderBlockSize = textarea.offsetHeight - textarea.clientHeight;
+
+  textarea.style.blockSize = `${textarea.scrollHeight + borderBlockSize}px`;
+};

--- a/packages/twenty-ui/src/input/Textarea/types/TextareaProps.ts
+++ b/packages/twenty-ui/src/input/Textarea/types/TextareaProps.ts
@@ -3,7 +3,11 @@ import { type useRender } from '@base-ui/react/use-render';
 
 import { type InputSize } from '@ui/input/types/InputSize';
 
-export type TextareaProps = useRender.ComponentProps<'textarea'> & {
+export type TextareaProps = Omit<
+  useRender.ComponentProps<'textarea'>,
+  'className'
+> & {
+  className?: string | ((state: InputPrimitive.State) => string | undefined);
   onValueChange?: (
     value: string,
     eventDetails: InputPrimitive.ChangeEventDetails,

--- a/packages/twenty-ui/src/input/Textarea/types/TextareaProps.ts
+++ b/packages/twenty-ui/src/input/Textarea/types/TextareaProps.ts
@@ -1,0 +1,14 @@
+import { type Input as InputPrimitive } from '@base-ui/react/input';
+import { type useRender } from '@base-ui/react/use-render';
+
+import { type InputSize } from '@ui/input/types/InputSize';
+
+export type TextareaProps = useRender.ComponentProps<'textarea'> & {
+  onValueChange?: (
+    value: string,
+    eventDetails: InputPrimitive.ChangeEventDetails,
+  ) => void;
+  size?: InputSize;
+  autoResize?: boolean;
+  maxRows?: number;
+};

--- a/packages/twenty-ui/src/input/index.ts
+++ b/packages/twenty-ui/src/input/index.ts
@@ -74,6 +74,10 @@ export { IconButtonGroup } from './IconButtonGroup/IconButtonGroup';
 export type { IconButtonWithTooltipProps } from './IconButtonWithTooltip/IconButtonWithTooltip';
 export { IconButtonWithTooltip } from './IconButtonWithTooltip/IconButtonWithTooltip';
 export { IconListViewGrip } from './IconListViewGrip/IconListViewGrip';
+export { Input } from './Input/Input';
+export type { InputProps } from './Input/types/InputProps';
+export { InputGroup } from './InputGroup/InputGroup';
+export type { InputGroupProps } from './InputGroup/types/InputGroupProps';
 export { InputHint } from './InputHint/InputHint';
 export { InputLabel } from './InputLabel/InputLabel';
 export type { InsideButtonProps } from './InsideButton/InsideButton';
@@ -113,7 +117,10 @@ export {
   TabContent,
   TabButton,
 } from './TabButton/TabButton';
+export { Textarea } from './Textarea/Textarea';
+export type { TextareaProps } from './Textarea/types/TextareaProps';
 export type { ToggleSize, ToggleProps } from './Toggle/Toggle';
 export { Toggle } from './Toggle/Toggle';
 export type { ColorScheme } from './types/ColorScheme';
+export type { InputSize } from './types/InputSize';
 export type { SelectOption } from './types/SelectOption';

--- a/packages/twenty-ui/src/input/types/InputSize.ts
+++ b/packages/twenty-ui/src/input/types/InputSize.ts
@@ -1,0 +1,1 @@
+export type InputSize = 'sm' | 'md';


### PR DESCRIPTION
Adds the first Phase 1 form-control family of the twenty-ui standalone-library plan: `Input`, `InputGroup` and `Textarea`. They are built on Base UI's `Input`, so they wire into the existing `Field` compound (label, description, error, validation, disabled) with the `value` / `defaultValue` / `onValueChange` contract, `render` polymorphism and native prop passthrough.

- `Input`: bare styled `<input>` with `size: 'sm' | 'md'`.
- `InputGroup`: owns the box and lays out `startElement` / `endElement` as flex siblings (the SearchInput layout, generalized); the Input inside goes borderless and inherits the group size.
- `Textarea`: same contract plus `autoResize` and `maxRows`.

Each part ships with conformance and behavior tests on the vitest unit project and `Catalog` / `CatalogDark` stories. Additive only, no twenty-front change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

