### PR TITLE
feat(slack): point the channel welcome at the DM as the private path

### DIFF
--- a/packages/twenty-apps/public/slack/SETUP.md
+++ b/packages/twenty-apps/public/slack/SETUP.md
@@ -362,10 +362,11 @@ configured.
   gets an ephemeral nudge (only that member sees it) to mention the bot again.
 - **Channel welcome.** With `member_joined_channel` subscribed, the bot posts a
   short introduction the first time it is added to a channel, with the details
-  in a thread reply so the channel itself stays quiet. It fires once per channel
-  for 30 days, and only for the bot's own join — humans joining afterwards
-  trigger nothing. Skip the subscription if you would rather it arrived
-  silently.
+  in a thread reply so the channel itself stays quiet. It names both ways to
+  reach the bot: mention it in the channel, or DM it to keep a question and its
+  answer out of the channel. It fires once per channel for 30 days, and only for
+  the bot's own join — humans joining afterwards trigger nothing. Skip the
+  subscription if you would rather it arrived silently.
 - **One Slack workspace per Twenty workspace.** Connecting Slack claims that
   Slack team for the connecting Twenty workspace, and on the same server a
   second Twenty workspace connecting the same team is rejected. Removing the last

--- a/packages/twenty-apps/public/slack/package.json
+++ b/packages/twenty-apps/public/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/slack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Slack assistant and workflow steps for Twenty",
   "license": "MIT",
   "engines": {

--- a/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-channel-welcome-text.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-channel-welcome-text.ts
@@ -1,5 +1,5 @@
 export const SLACK_CHANNEL_WELCOME_TEXT = [
   ":wave: Hi! I'm Twenty, your CRM in this channel.",
-  "Mention me here or send me a DM and I'll answer in the thread: pipeline questions, company and contact lookups, creating and updating records, capturing notes and tasks.",
-  'Details on how I work and what I can see are in the thread. Ask me anything.',
+  "Mention me here and I'll answer in the thread: pipeline questions, company and contact lookups, creating and updating records, capturing notes and tasks.",
+  'Or DM me to keep a question and its answer out of the channel. Details on how I work and what I can see are in the thread. Ask me anything.',
 ].join('\n\n');

--- a/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-channel-welcome-thread-text.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-channel-welcome-thread-text.ts
@@ -7,7 +7,7 @@ export const SLACK_CHANNEL_WELCOME_THREAD_TEXT = [
   ].join('\n'),
   '**How I work with your data**',
   [
-    "- I only act when you mention me, or in a thread I've already replied in. Channel threads stay open to me for 24 hours after my last reply, DM threads never expire",
+    "- I only act when you mention me, or in a thread I've already replied in. Channel threads stay open to me for 24 hours after my last reply. DM threads never expire",
     '- When you mention me I read recent messages in that thread for context',
     "- I can read, create, update and archive people, companies, opportunities, notes and tasks. I can't permanently delete anything and I can't change workspace settings",
     "- If your Slack email matches your Twenty account, I act as you and can't see or change anything you couldn't yourself. Otherwise I fall back to the shared **Slack Assistant** role",

--- a/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-channel-welcome-thread-text.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-channel-welcome-thread-text.ts
@@ -7,7 +7,7 @@ export const SLACK_CHANNEL_WELCOME_THREAD_TEXT = [
   ].join('\n'),
   '**How I work with your data**',
   [
-    "- I only act when you mention me, or in a thread I've already replied in. Channel threads stay open to me for 24 hours after my last reply",
+    "- I only act when you mention me, or in a thread I've already replied in. Channel threads stay open to me for 24 hours after my last reply, DM threads never expire",
     '- When you mention me I read recent messages in that thread for context',
     "- I can read, create, update and archive people, companies, opportunities, notes and tasks. I can't permanently delete anything and I can't change workspace settings",
     "- If your Slack email matches your Twenty account, I act as you and can't see or change anything you couldn't yourself. Otherwise I fall back to the shared **Slack Assistant** role",


### PR DESCRIPTION
## Why

This started as an evaluation of a proposed `/twenty` slash command: let a member ask a question in a channel and get an ephemeral answer only they can see, instead of choosing between a public `@mention` and a DM.

The conclusion was not to build it. Summary of what the evaluation turned up:

- **A DM already gives a private answer**, and gives it better: native thinking status, an auto-titled thread, and thread memory that never expires. A slash command has no thread, so it loses all three and every follow-up means retyping the question with no history.
- **The 3-second ack is not reliably met.** #25304 states it directly: "a cold logic-function sandbox can push the ack past 3s", and the resolver p95 is unmeasured. For events that is invisible (Slack retries, and the unique index on `(slackChannelId, slackMessageTimestamp)` dedupes). Slash commands have no retry mechanism, so the user sees `operation_timeout` in the channel while the job may still answer later.
- **The run-as path cannot be reused.** `resolveSlackRunAsForRequest` makes four assertions that all require a real Slack message (it exists, its author matches the identity, it is addressed to the bot, its live text matches the stored `requestText`). A slash command creates no message, so all four fail, run-as returns `undefined`, and the agent falls back to the Slack Assistant role, which is workspace-wide read/update/soft-delete on the CRM objects. For a member with narrower Twenty permissions that is a silent escalation, and it would break the "nobody gets more access through Slack than they have in Twenty" guarantee on exactly that path.
- **Migration is the deciding factor.** Slash commands need the `commands` bot scope, and SETUP.md's own rule is that a new scope means every existing install must disconnect and re-add the connection, which releases and re-claims the Slack team. On top of that the manifest is only read at creation, so each admin would also hand-create the command against a third Request URL. Until they do, `/twenty` is an unknown command in their workspace.

What is left of the original want is discoverability: people reach for a public mention because the DM is not presented as the private option. The channel welcome is where that can be fixed, with no scope change and nothing for existing installers to do.

## What

Copy only, two constants and one docs bullet, plus a version bump.

- `SLACK_CHANNEL_WELCOME_TEXT`: the DM was already named, but only as another address for the bot, never with a reason to pick it. Split the two paths so the DM carries the privacy reason ("Or DM me to keep a question and its answer out of the channel"). Still three paragraphs, so the channel stays as quiet as before.
- `SLACK_CHANNEL_WELCOME_THREAD_TEXT`: the lifetime bullet described channel behaviour only, so a reader had no way to know the DM path differs. Added "DM threads never expire" next to the 24-hour channel window.
- `SETUP.md`: the channel welcome behaviour note said when the introduction fires but not what it says, so an admin deciding whether to subscribe `member_joined_channel` could not tell it is what surfaces the DM as the private path.
- `package.json`: 1.0.0 to 1.0.1. The copy is user-visible in Slack, so it only reaches installs through a publish. Patch rather than minor since there is no new capability and no manifest or scope change; SETUP.md's upgrade notes cover changes that need admin action, and this needs none. The release also picks up #25304, which landed unbumped.

No behaviour change, no manifest change, no new scopes or subscriptions, nothing for existing installs to do.

## Test plan

- `yarn lint`, `yarn typecheck` clean
- `yarn test:unit` 616 passed across 87 files
- `yarn test` (integration) needs a running server at `localhost:2020` and was not run. Its two welcome assertions (`slack-connection-lifecycle.integration-test.ts:161,164`) compare posted text against these same constants, so they cannot detect a copy change either way.
