### PR TITLE
Resolve the side panel context store object from the panel location

### DIFF
--- a/packages/twenty-front/src/modules/context-store/components/RouteContextStoreProvider.tsx
+++ b/packages/twenty-front/src/modules/context-store/components/RouteContextStoreProvider.tsx
@@ -6,9 +6,9 @@ import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMeta
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { viewsSelector } from '@/views/states/selectors/viewsSelector';
-import { useLocation, useParams, useSearchParams } from 'react-router-dom';
-import { AppPath } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
+import { useLocation, useMatch, useSearchParams } from 'react-router-dom';
+import { AppPath, SettingsPath } from 'twenty-shared/types';
+import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { ViewKey, ViewType } from '~/generated-metadata/graphql';
 import { isMatchingLocation } from '~/utils/isMatchingLocation';
 
@@ -39,17 +39,22 @@ const getViewId = (
 
 export const RouteContextStoreProvider = () => {
   const location = useLocation();
-  const isRecordIndexPage = isMatchingLocation(
-    location,
-    AppPath.RecordIndexPage,
-  );
-  const isRecordShowPage = isMatchingLocation(location, AppPath.RecordShowPage);
+  const recordIndexPageMatch = useMatch(AppPath.RecordIndexPage);
+  const recordShowPageMatch = useMatch(AppPath.RecordShowPage);
+  const settingsObjectPageMatch = useMatch({
+    path: getSettingsPath(SettingsPath.ObjectDetail),
+    end: false,
+  });
+  const isRecordIndexPage = isDefined(recordIndexPageMatch);
+  const isRecordShowPage = isDefined(recordShowPageMatch);
   const isStandalonePage = isMatchingLocation(location, AppPath.PageLayoutPage);
   const isAiChatPage = isMatchingLocation(location, AppPath.AiChat);
   const isSettingsPage = useIsSettingsPage();
 
-  const objectNamePlural = useParams().objectNamePlural ?? '';
-  const objectNameSingular = useParams().objectNameSingular ?? '';
+  const objectNamePlural =
+    recordIndexPageMatch?.params.objectNamePlural ??
+    settingsObjectPageMatch?.params.objectNamePlural;
+  const objectNameSingular = recordShowPageMatch?.params.objectNameSingular;
 
   const [searchParams] = useSearchParams();
   const viewIdQueryParamRaw = searchParams.get('viewId');

--- a/packages/twenty-front/src/modules/context-store/components/RouteContextStoreProvider.tsx
+++ b/packages/twenty-front/src/modules/context-store/components/RouteContextStoreProvider.tsx
@@ -1,3 +1,4 @@
+import { useWorkspaceRouteObjects } from '@/app/routing/components/WorkspaceRouteObjectsProvider';
 import { RouteContextStoreProviderEffect } from '@/context-store/components/RouteContextStoreProviderEffect';
 import { metadataStoreState } from '@/metadata-store/states/metadataStoreState';
 import { useIsSettingsPage } from '@/navigation/hooks/useIsSettingsPage';
@@ -6,9 +7,9 @@ import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMeta
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { viewsSelector } from '@/views/states/selectors/viewsSelector';
-import { useLocation, useMatch, useSearchParams } from 'react-router-dom';
-import { AppPath, SettingsPath } from 'twenty-shared/types';
-import { getSettingsPath, isDefined } from 'twenty-shared/utils';
+import { matchRoutes, useLocation, useSearchParams } from 'react-router-dom';
+import { AppPath } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 import { ViewKey, ViewType } from '~/generated-metadata/graphql';
 import { isMatchingLocation } from '~/utils/isMatchingLocation';
 
@@ -39,22 +40,19 @@ const getViewId = (
 
 export const RouteContextStoreProvider = () => {
   const location = useLocation();
-  const recordIndexPageMatch = useMatch(AppPath.RecordIndexPage);
-  const recordShowPageMatch = useMatch(AppPath.RecordShowPage);
-  const settingsObjectPageMatch = useMatch({
-    path: getSettingsPath(SettingsPath.ObjectDetail),
-    end: false,
-  });
-  const isRecordIndexPage = isDefined(recordIndexPageMatch);
-  const isRecordShowPage = isDefined(recordShowPageMatch);
+  const routeObjects = useWorkspaceRouteObjects();
+  const isRecordIndexPage = isMatchingLocation(
+    location,
+    AppPath.RecordIndexPage,
+  );
+  const isRecordShowPage = isMatchingLocation(location, AppPath.RecordShowPage);
   const isStandalonePage = isMatchingLocation(location, AppPath.PageLayoutPage);
   const isAiChatPage = isMatchingLocation(location, AppPath.AiChat);
   const isSettingsPage = useIsSettingsPage();
 
-  const objectNamePlural =
-    recordIndexPageMatch?.params.objectNamePlural ??
-    settingsObjectPageMatch?.params.objectNamePlural;
-  const objectNameSingular = recordShowPageMatch?.params.objectNameSingular;
+  const routeParams = matchRoutes(routeObjects, location)?.at(-1)?.params;
+  const objectNamePlural = routeParams?.objectNamePlural;
+  const objectNameSingular = routeParams?.objectNameSingular;
 
   const [searchParams] = useSearchParams();
   const viewIdQueryParamRaw = searchParams.get('viewId');

--- a/packages/twenty-front/src/modules/context-store/components/__tests__/RouteContextStoreProvider.test.tsx
+++ b/packages/twenty-front/src/modules/context-store/components/__tests__/RouteContextStoreProvider.test.tsx
@@ -1,6 +1,10 @@
+import { WorkspaceRouteObjectsContext } from '@/app/routing/components/WorkspaceRouteObjectsProvider';
+import { type WorkspaceRouteObject } from '@/app/routing/types/WorkspaceRouteObject';
+import { getWorkspaceRouteObjectsForSurface } from '@/app/routing/utils/getWorkspaceRouteObjectsForSurface';
 import { RouteContextStoreProvider } from '@/context-store/components/RouteContextStoreProvider';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { type ReactNode } from 'react';
+import { MemoryRouter, Outlet, useRoutes } from 'react-router-dom';
 import { AppPath, SettingsPath } from 'twenty-shared/types';
 
 jest.mock('@/navigation/hooks/useLastVisitedView', () => ({
@@ -30,6 +34,11 @@ jest.mock('@/ui/utilities/state/jotai/hooks/useAtomStateValue', () => ({
             id: 'person-object',
             namePlural: 'people',
             nameSingular: 'person',
+          },
+          {
+            id: 'new-object',
+            namePlural: 'new',
+            nameSingular: 'new',
           },
         ]
       : [
@@ -72,6 +81,39 @@ jest.mock('@/context-store/components/RouteContextStoreProviderEffect', () => ({
   ),
 }));
 
+const MAIN_AND_SIDE_PANEL = ['main', 'side-panel'] as const;
+
+const routeObjects: WorkspaceRouteObject[] = [
+  {
+    path: AppPath.RecordIndexPage,
+    element: null,
+    handle: { workspaceSurfaces: MAIN_AND_SIDE_PANEL },
+  },
+  {
+    path: AppPath.RecordShowPage,
+    element: null,
+    handle: { workspaceSurfaces: MAIN_AND_SIDE_PANEL },
+  },
+  {
+    path: `/${AppPath.Settings}`,
+    element: <Outlet />,
+    children: [
+      { path: SettingsPath.NewObject, element: null },
+      { path: SettingsPath.ObjectNewFieldSelect, element: null },
+    ],
+  },
+];
+
+const mainSurfaceRouteObjects = getWorkspaceRouteObjectsForSurface(
+  routeObjects,
+  'main',
+);
+
+const sidePanelRouteObjects = getWorkspaceRouteObjectsForSurface(
+  routeObjects,
+  'side-panel',
+);
+
 const MainSurfaceLayout = () => (
   <>
     <RouteContextStoreProvider />
@@ -79,35 +121,33 @@ const MainSurfaceLayout = () => (
   </>
 );
 
-const renderOnMainSurface = (initialEntry: string) =>
-  render(
-    <MemoryRouter initialEntries={[initialEntry]}>
-      <Routes>
-        <Route element={<MainSurfaceLayout />}>
-          <Route path={AppPath.RecordIndexPage} element={null} />
-          <Route path={AppPath.Settings}>
-            <Route path={SettingsPath.ObjectNewFieldSelect} element={null} />
-          </Route>
-        </Route>
-      </Routes>
-    </MemoryRouter>,
-  );
+const MainSurfaceRoutes = () =>
+  useRoutes([
+    { element: <MainSurfaceLayout />, children: mainSurfaceRouteObjects },
+  ]);
 
 const SidePanelHostLayout = () => (
   <>
     <Outlet />
-    <Routes location="/object/person/record-1">
-      <Route
-        path={AppPath.RecordShowPage}
-        element={<RouteContextStoreProvider />}
-      />
-    </Routes>
+    {useRoutes(sidePanelRouteObjects, '/object/person/record-1')}
   </>
 );
 
+const SidePanelHostRoutes = () =>
+  useRoutes([
+    { element: <SidePanelHostLayout />, children: mainSurfaceRouteObjects },
+  ]);
+
+const renderAt = (initialEntry: string, children: ReactNode) =>
+  render(
+    <WorkspaceRouteObjectsContext.Provider value={routeObjects}>
+      <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>
+    </WorkspaceRouteObjectsContext.Provider>,
+  );
+
 describe('RouteContextStoreProvider', () => {
   it('accepts a query-param view owned by the route object', () => {
-    renderOnMainSurface('/objects/companies?viewId=company-view');
+    renderAt('/objects/companies?viewId=company-view', <MainSurfaceRoutes />);
 
     expect(screen.getByTestId('route-context-store')).toHaveAttribute(
       'data-view-id',
@@ -116,7 +156,7 @@ describe('RouteContextStoreProvider', () => {
   });
 
   it('falls back when the query-param view belongs to another object', () => {
-    renderOnMainSurface('/objects/companies?viewId=person-view');
+    renderAt('/objects/companies?viewId=person-view', <MainSurfaceRoutes />);
 
     expect(screen.getByTestId('route-context-store')).toHaveAttribute(
       'data-view-id',
@@ -125,7 +165,10 @@ describe('RouteContextStoreProvider', () => {
   });
 
   it('resolves the object on settings object pages', () => {
-    renderOnMainSurface('/settings/objects/companies/new-field/select');
+    renderAt(
+      '/settings/objects/companies/new-field/select',
+      <MainSurfaceRoutes />,
+    );
 
     expect(screen.getByTestId('route-context-store')).toHaveAttribute(
       'data-object-metadata-id',
@@ -133,16 +176,16 @@ describe('RouteContextStoreProvider', () => {
     );
   });
 
-  it('resolves the side panel object from the panel location rather than the main surface route params', () => {
-    render(
-      <MemoryRouter initialEntries={['/objects/companies']}>
-        <Routes>
-          <Route element={<SidePanelHostLayout />}>
-            <Route path={AppPath.RecordIndexPage} element={null} />
-          </Route>
-        </Routes>
-      </MemoryRouter>,
+  it('does not read a static settings segment as an object name', () => {
+    renderAt('/settings/objects/new', <MainSurfaceRoutes />);
+
+    expect(screen.getByTestId('route-context-store')).not.toHaveAttribute(
+      'data-object-metadata-id',
     );
+  });
+
+  it('resolves the side panel object from the panel location rather than the main surface route params', () => {
+    renderAt('/objects/companies', <SidePanelHostRoutes />);
 
     expect(screen.getByTestId('route-context-store')).toHaveAttribute(
       'data-object-metadata-id',

--- a/packages/twenty-front/src/modules/context-store/components/__tests__/RouteContextStoreProvider.test.tsx
+++ b/packages/twenty-front/src/modules/context-store/components/__tests__/RouteContextStoreProvider.test.tsx
@@ -1,26 +1,7 @@
 import { RouteContextStoreProvider } from '@/context-store/components/RouteContextStoreProvider';
 import { render, screen } from '@testing-library/react';
-
-let mockViewIdQueryParam = 'company-view';
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: () => ({
-    pathname: '/objects/companies',
-    search: `?viewId=${mockViewIdQueryParam}`,
-    hash: '',
-    state: null,
-    key: 'test',
-  }),
-  useParams: () => ({ objectNamePlural: 'companies' }),
-  useSearchParams: () => [
-    new URLSearchParams(`viewId=${mockViewIdQueryParam}`),
-  ],
-}));
-
-jest.mock('@/navigation/hooks/useIsSettingsPage', () => ({
-  useIsSettingsPage: () => false,
-}));
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { AppPath, SettingsPath } from 'twenty-shared/types';
 
 jest.mock('@/navigation/hooks/useLastVisitedView', () => ({
   useLastVisitedView: () => ({
@@ -44,6 +25,11 @@ jest.mock('@/ui/utilities/state/jotai/hooks/useAtomStateValue', () => ({
             id: 'company-object',
             namePlural: 'companies',
             nameSingular: 'company',
+          },
+          {
+            id: 'person-object',
+            namePlural: 'people',
+            nameSingular: 'person',
           },
         ]
       : [
@@ -71,33 +57,96 @@ jest.mock('@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue', () => ({
 }));
 
 jest.mock('@/context-store/components/RouteContextStoreProviderEffect', () => ({
-  RouteContextStoreProviderEffect: ({ viewId }: { viewId?: string }) => (
-    <div data-testid="context-view" data-view-id={viewId} />
+  RouteContextStoreProviderEffect: ({
+    viewId,
+    objectMetadataItem,
+  }: {
+    viewId?: string;
+    objectMetadataItem?: { id: string };
+  }) => (
+    <div
+      data-testid="route-context-store"
+      data-view-id={viewId}
+      data-object-metadata-id={objectMetadataItem?.id}
+    />
   ),
 }));
 
-describe('RouteContextStoreProvider view selection', () => {
-  beforeEach(() => {
-    mockViewIdQueryParam = 'company-view';
-  });
+const MainSurfaceLayout = () => (
+  <>
+    <RouteContextStoreProvider />
+    <Outlet />
+  </>
+);
 
+const renderOnMainSurface = (initialEntry: string) =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route element={<MainSurfaceLayout />}>
+          <Route path={AppPath.RecordIndexPage} element={null} />
+          <Route path={AppPath.Settings}>
+            <Route path={SettingsPath.ObjectNewFieldSelect} element={null} />
+          </Route>
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+
+const SidePanelHostLayout = () => (
+  <>
+    <Outlet />
+    <Routes location="/object/person/record-1">
+      <Route
+        path={AppPath.RecordShowPage}
+        element={<RouteContextStoreProvider />}
+      />
+    </Routes>
+  </>
+);
+
+describe('RouteContextStoreProvider', () => {
   it('accepts a query-param view owned by the route object', () => {
-    render(<RouteContextStoreProvider />);
+    renderOnMainSurface('/objects/companies?viewId=company-view');
 
-    expect(screen.getByTestId('context-view')).toHaveAttribute(
+    expect(screen.getByTestId('route-context-store')).toHaveAttribute(
       'data-view-id',
       'company-view',
     );
   });
 
   it('falls back when the query-param view belongs to another object', () => {
-    mockViewIdQueryParam = 'person-view';
+    renderOnMainSurface('/objects/companies?viewId=person-view');
 
-    render(<RouteContextStoreProvider />);
-
-    expect(screen.getByTestId('context-view')).toHaveAttribute(
+    expect(screen.getByTestId('route-context-store')).toHaveAttribute(
       'data-view-id',
       'company-index-view',
+    );
+  });
+
+  it('resolves the object on settings object pages', () => {
+    renderOnMainSurface('/settings/objects/companies/new-field/select');
+
+    expect(screen.getByTestId('route-context-store')).toHaveAttribute(
+      'data-object-metadata-id',
+      'company-object',
+    );
+  });
+
+  it('resolves the side panel object from the panel location rather than the main surface route params', () => {
+    render(
+      <MemoryRouter initialEntries={['/objects/companies']}>
+        <Routes>
+          <Route element={<SidePanelHostLayout />}>
+            <Route path={AppPath.RecordIndexPage} element={null} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('route-context-store')).toHaveAttribute(
+      'data-object-metadata-id',
+      'person-object',
     );
   });
 });

--- a/packages/twenty-front/src/testing/decorators/PageDecorator.tsx
+++ b/packages/twenty-front/src/testing/decorators/PageDecorator.tsx
@@ -3,12 +3,9 @@ import { loadDevMessages } from '@apollo/client/dev';
 import { type Decorator } from '@storybook/react-vite';
 import { Provider as JotaiProvider } from 'jotai';
 import { HelmetProvider } from '@dr.pogodin/react-helmet';
-import {
-  createMemoryRouter,
-  createRoutesFromElements,
-  Route,
-  RouterProvider,
-} from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { WorkspaceRouteObjectsProvider } from '@/app/routing/components/WorkspaceRouteObjectsProvider';
+import { type WorkspaceRouteObject } from '@/app/routing/types/WorkspaceRouteObject';
 import { ClientConfigProviderEffect } from '@/client-config/components/ClientConfigProviderEffect';
 import { MinimalMetadataGate } from '@/metadata-store/components/MinimalMetadataGate';
 import { ApolloCoreClientMockedProvider } from '@/object-metadata/hooks/__mocks__/ApolloCoreClientMockedProvider';
@@ -141,24 +138,30 @@ const createRouter = ({
     pathname: string;
   }[];
   initialIndex?: number;
-}) =>
-  createMemoryRouter(
-    createRoutesFromElements(
-      <Route element={<Providers />}>
-        <Route element={<DefaultLayout />}>
-          <Route path={args.routePath} element={<Story />} />
-          {args.additionalRoutes?.map((route) => (
-            <Route
-              key={route}
-              path={route}
-              element={<div>Navigated to {route}</div>}
-            />
-          ))}
-        </Route>
-      </Route>,
-    ),
+}) => {
+  const routeObjects: WorkspaceRouteObject[] = [
+    { path: args.routePath, element: <Story /> },
+    ...(args.additionalRoutes ?? []).map((route) => ({
+      path: route,
+      element: <div>Navigated to {route}</div>,
+    })),
+  ];
+
+  return createMemoryRouter(
+    [
+      {
+        element: <WorkspaceRouteObjectsProvider routeObjects={routeObjects} />,
+        children: [
+          {
+            element: <Providers />,
+            children: [{ element: <DefaultLayout />, children: routeObjects }],
+          },
+        ],
+      },
+    ],
     { initialEntries, initialIndex },
   );
+};
 
 export const PageDecorator: Decorator<{
   routePath: string;


### PR DESCRIPTION
## Problem

When the side panel navigates from one record to a related record of a different object, the footer actions keep targeting the object of the page the panel came from. The action labels name the wrong object, and the commands behind them, delete included, act on that wrong object, because the labels and the commands read the same context store value.

The bug only appears when the main surface is on an index page and the panel shows a record of another object, which is the common case for navigating relations from a side panel opened from a list.

## Cause

`RouteContextStoreProvider` resolved the object from `useParams()`. The side panel renders its routes with `useRoutes(routes, location)` inside the main layout route, and React Router merges the enclosing route's params into every nested match. As a result, a panel page sees the main page's `objectNamePlural` alongside its own `objectNameSingular`, and the lookup, which accepts either name, returns whichever object comes first in the metadata list.

## Fix

The provider now matches the surface's own location against the workspace route table with `matchRoutes` and reads the params of the leaf match. This is what `useParams()` was approximating, without the parent-branch merge, and React Router's ranking keeps static settings routes such as `objects/new` above `objects/:objectNamePlural`. The main surface is unchanged. The test renders both surfaces from one miniature route table, so the side panel case fails on the previous code.

## Follow-ups

This change is correct on its own, but the underlying design has three weaknesses worth separate work:

1. Effects store derived data. The object, view ID, view type, and page type are pure functions of the location, yet an effect writes them into atoms, which caused #25233 and leaves stale values behind. Computing them from the location and keeping atoms only for selection and filters would remove both classes of bugs.
2. Surface identity is split between `WorkspaceSurfaceContext` and `ContextStoreComponentInstanceContext`, and reads without a provider fall back to `MAIN`. Deriving one from the other and throwing on a missing provider would expose wrong-instance reads.
3. The panel is a nested router, so `useParams()` in any panel page still inherits main-surface params for names its own route doesn't define. A location-based params helper with a lint rule closes this cheaply; a memory router per panel page closes it completely.
