### PR TITLE
Let an exception declare that it is expected, instead of inferring it from an HTTP status

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/billing.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.exception.ts
@@ -1,8 +1,10 @@
 /* @license Enterprise */
 
+import { HttpStatus } from '@nestjs/common';
+
 import { type MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
-import { assertUnreachable } from 'twenty-shared/utils';
+import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 
 import { getBillingExceptionStatusCode } from 'src/engine/core-modules/billing/utils/get-billing-exception-status-code.util';
 import { CustomException } from 'src/utils/custom-exception';
@@ -133,5 +135,8 @@ export class BillingException extends CustomException<BillingExceptionCode> {
         userFriendlyMessage ?? getBillingExceptionUserFriendlyMessage(code),
     });
     this.statusCode = getBillingExceptionStatusCode(this);
+    this.isExpected =
+      isDefined(this.statusCode) &&
+      this.statusCode < HttpStatus.INTERNAL_SERVER_ERROR;
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/throttler/throttler.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/throttler/throttler.exception.ts
@@ -31,6 +31,7 @@ export class ThrottlerException extends CustomException<ThrottlerExceptionCode> 
       userFriendlyMessage:
         userFriendlyMessage ?? getThrottlerExceptionUserFriendlyMessage(code),
       statusCode: HttpStatus.TOO_MANY_REQUESTS,
+      isExpected: true,
     });
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception.ts
@@ -31,6 +31,12 @@ const getConnectedAccountRefreshAccessTokenExceptionUserFriendlyMessage = (
   }
 };
 
+const EXPECTED_CONNECTED_ACCOUNT_REFRESH_ACCESS_TOKEN_EXCEPTION_CODES: readonly ConnectedAccountRefreshAccessTokenExceptionCode[] =
+  [
+    ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND,
+    ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+  ];
+
 export class ConnectedAccountRefreshAccessTokenException extends CustomException<ConnectedAccountRefreshAccessTokenExceptionCode> {
   cause?: unknown;
 
@@ -46,6 +52,10 @@ export class ConnectedAccountRefreshAccessTokenException extends CustomException
       userFriendlyMessage:
         userFriendlyMessage ??
         getConnectedAccountRefreshAccessTokenExceptionUserFriendlyMessage(code),
+      isExpected:
+        EXPECTED_CONNECTED_ACCOUNT_REFRESH_ACCESS_TOKEN_EXCEPTION_CODES.includes(
+          code,
+        ),
     });
 
     if (isDefined(cause)) {

--- a/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
@@ -70,11 +70,7 @@ export const shouldCaptureException = (
     return false;
   }
 
-  if (
-    exception instanceof CustomException &&
-    isDefined(exception.statusCode) &&
-    exception.statusCode < 500
-  ) {
+  if (exception instanceof CustomException && exception.isExpected) {
     return false;
   }
 

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception.ts
@@ -34,6 +34,12 @@ const getWebhookSubscriptionDriverExceptionUserFriendlyMessage = (
   }
 };
 
+const EXPECTED_WEBHOOK_SUBSCRIPTION_DRIVER_EXCEPTION_CODES: readonly WebhookSubscriptionDriverExceptionCode[] =
+  [
+    WebhookSubscriptionDriverExceptionCode.NOT_FOUND,
+    WebhookSubscriptionDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+  ];
+
 export class WebhookSubscriptionDriverException extends CustomException<WebhookSubscriptionDriverExceptionCode> {
   cause?: unknown;
 
@@ -49,6 +55,8 @@ export class WebhookSubscriptionDriverException extends CustomException<WebhookS
       userFriendlyMessage:
         userFriendlyMessage ??
         getWebhookSubscriptionDriverExceptionUserFriendlyMessage(code),
+      isExpected:
+        EXPECTED_WEBHOOK_SUBSCRIPTION_DRIVER_EXCEPTION_CODES.includes(code),
     });
 
     if (isDefined(cause)) {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/exceptions/microsoft-import-driver.exception.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/exceptions/microsoft-import-driver.exception.ts
@@ -1,3 +1,5 @@
+import { HttpStatus } from '@nestjs/common';
+
 import { type MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
 
@@ -16,5 +18,6 @@ export class MicrosoftImportDriverException extends CustomException<string> {
         userFriendlyMessage ?? msg`An error occurred during messages import`,
     });
     this.statusCode = statusCode;
+    this.isExpected = statusCode < HttpStatus.INTERNAL_SERVER_ERROR;
   }
 }

--- a/packages/twenty-server/src/utils/__test__/custom-exception.spec.ts
+++ b/packages/twenty-server/src/utils/__test__/custom-exception.spec.ts
@@ -48,6 +48,23 @@ describe('CustomException', () => {
     expect(exception.statusCode).toBeUndefined();
   });
 
+  it('should treat an exception as unexpected unless it opts in', () => {
+    const exception = new UnknownException('Boom', 'INTERNAL_SERVER_ERROR', {
+      userFriendlyMessage: msg`Boom`,
+    });
+
+    expect(exception.isExpected).toBe(false);
+  });
+
+  it('should mark an exception as expected when the option is provided', () => {
+    const exception = new UnknownException('Reconnect', 'INVALID_TOKEN', {
+      userFriendlyMessage: msg`Reconnect`,
+      isExpected: true,
+    });
+
+    expect(exception.isExpected).toBe(true);
+  });
+
   class TestException extends CustomException<string> {
     constructor(
       message: string,

--- a/packages/twenty-server/src/utils/custom-exception.ts
+++ b/packages/twenty-server/src/utils/custom-exception.ts
@@ -23,6 +23,7 @@ export abstract class CustomException<
   code: ExceptionCode;
   userFriendlyMessage: MessageDescriptor;
   statusCode?: number;
+  isExpected: boolean;
 
   constructor(
     message: ExceptionMessage,
@@ -30,12 +31,18 @@ export abstract class CustomException<
     {
       userFriendlyMessage,
       statusCode,
-    }: { userFriendlyMessage: MessageDescriptor; statusCode?: number },
+      isExpected = false,
+    }: {
+      userFriendlyMessage: MessageDescriptor;
+      statusCode?: number;
+      isExpected?: boolean;
+    },
   ) {
     super(message);
     this.code = code;
     this.userFriendlyMessage = userFriendlyMessage;
     this.statusCode = statusCode;
+    this.isExpected = isExpected;
   }
 }
 


### PR DESCRIPTION
`shouldCaptureException` decided whether to page a human by reading `CustomException.statusCode` and treating anything under 500 as expected. That field has exactly one consumer, so it was never an HTTP status in practice — it was an alerting flag wearing an HTTP name.

A queue job has no HTTP status to give, so **104 of the 109** exception classes leave it unset, and `isDefined(statusCode)` then sends every one of them to Sentry as if it were a server fault. A dead refresh token and a mailbox without Gmail enabled both page us, despite each already carrying a reconnect message for the user.

`CustomException` now has an explicit `isExpected`, defaulting to `false` so an exception still has to opt out of alerting, and `shouldCaptureException` reads that. The three classes that set `statusCode` keep it — `MicrosoftImportDriverException` carries a real Graph status — and derive `isExpected` from it, so their behaviour is unchanged. The connected account classes list their expected codes as data rather than restating the enum in a switch.