### PR TITLE
Stop reporting handled webhook subscription failures to Sentry

### DIFF
--- a/packages/twenty-server/src/modules/connected-account-sync-webhooks/drivers/microsoft/microsoft-calendar-notification.handler.ts
+++ b/packages/twenty-server/src/modules/connected-account-sync-webhooks/drivers/microsoft/microsoft-calendar-notification.handler.ts
@@ -9,6 +9,7 @@ import { type AssertUnreachable } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { In, Repository } from 'typeorm';
 
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
@@ -31,6 +32,7 @@ export class MicrosoftCalendarNotificationHandler implements WebhookNotification
     private readonly calendarWebhookSubscriptionService: CalendarWebhookSubscriptionService,
     private readonly webhookSyncTriggerService: WebhookSyncTriggerService,
     private readonly metricsService: MetricsService,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
   ) {}
 
   async handle(notifications: MicrosoftGraphNotification[]): Promise<void> {
@@ -99,12 +101,15 @@ export class MicrosoftCalendarNotificationHandler implements WebhookNotification
           lifecycleEvent: notification.lifecycleEvent,
           removedSubscriptionId: notification.subscriptionId,
           calendarChannel,
-        }).catch((error) =>
+        }).catch((error) => {
           this.logger.error(
             `Failed to handle ${notification.lifecycleEvent} lifecycle event for calendar channel ${calendarChannel.id}`,
             error,
-          ),
-        );
+          );
+          this.exceptionHandlerService.captureExceptions([error], {
+            workspace: { id: calendarChannel.workspaceId },
+          });
+        });
         continue;
       }
 

--- a/packages/twenty-server/src/modules/connected-account-sync-webhooks/drivers/microsoft/microsoft-messaging-notification.handler.ts
+++ b/packages/twenty-server/src/modules/connected-account-sync-webhooks/drivers/microsoft/microsoft-messaging-notification.handler.ts
@@ -9,6 +9,7 @@ import { type AssertUnreachable } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { In, Repository } from 'typeorm';
 
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
@@ -31,6 +32,7 @@ export class MicrosoftMessagingNotificationHandler implements WebhookNotificatio
     private readonly messagingWebhookSubscriptionService: MessagingWebhookSubscriptionService,
     private readonly webhookSyncTriggerService: WebhookSyncTriggerService,
     private readonly metricsService: MetricsService,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
   ) {}
 
   async handle(notifications: MicrosoftGraphNotification[]): Promise<void> {
@@ -98,12 +100,15 @@ export class MicrosoftMessagingNotificationHandler implements WebhookNotificatio
           lifecycleEvent: notification.lifecycleEvent,
           removedSubscriptionId: notification.subscriptionId,
           messageChannel,
-        }).catch((error) =>
+        }).catch((error) => {
           this.logger.error(
             `Failed to handle ${notification.lifecycleEvent} lifecycle event for message channel ${messageChannel.id}`,
             error,
-          ),
-        );
+          );
+          this.exceptionHandlerService.captureExceptions([error], {
+            workspace: { id: messageChannel.workspaceId },
+          });
+        });
         continue;
       }
 

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-exception-handler.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 
 import { type WebhookSubscriptionChannelType } from 'twenty-shared/types';
 
-import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import {
   ConnectedAccountRefreshAccessTokenException,
   ConnectedAccountRefreshAccessTokenExceptionCode,
@@ -27,7 +26,6 @@ type WebhookSubscribableChannelReference = Pick<
 export class WebhookSubscriptionExceptionHandlerService {
   constructor(
     private readonly webhookSubscriptionStatusService: WebhookSubscriptionStatusService,
-    private readonly exceptionHandlerService: ExceptionHandlerService,
   ) {}
 
   public async handleDriverException(
@@ -49,11 +47,8 @@ export class WebhookSubscriptionExceptionHandlerService {
           );
         case WebhookSubscriptionDriverExceptionCode.INSUFFICIENT_PERMISSIONS:
           return await this.handleInsufficientPermissionsException(
-            exception,
-            operation,
             channelType,
             channel,
-            workspaceId,
           );
         case WebhookSubscriptionDriverExceptionCode.TEMPORARY_ERROR:
           return await this.handleTemporaryException(
@@ -80,11 +75,8 @@ export class WebhookSubscriptionExceptionHandlerService {
         case ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND:
         case ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN:
           return await this.handleInsufficientPermissionsException(
-            exception,
-            operation,
             channelType,
             channel,
-            workspaceId,
           );
         case ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR:
           return await this.handleTemporaryException(
@@ -121,11 +113,8 @@ export class WebhookSubscriptionExceptionHandlerService {
   ): Promise<WebhookSubscriptionRecoveryAction> {
     if (operation === 'CREATE') {
       return await this.handleInsufficientPermissionsException(
-        exception,
-        operation,
         channelType,
         channel,
-        workspaceId,
       );
     }
 
@@ -141,22 +130,9 @@ export class WebhookSubscriptionExceptionHandlerService {
   }
 
   private async handleInsufficientPermissionsException(
-    exception: unknown,
-    operation: WebhookSubscriptionOperation,
     channelType: WebhookSubscriptionChannelType,
     channel: WebhookSubscribableChannelReference,
-    workspaceId: string,
   ): Promise<WebhookSubscriptionRecoveryAction> {
-    this.exceptionHandlerService.captureExceptions([exception], {
-      additionalData: {
-        channelId: channel.id,
-        channelType,
-        connectedAccountId: channel.connectedAccountId,
-        operation,
-      },
-      workspace: { id: workspaceId },
-    });
-
     await this.webhookSubscriptionStatusService.markAsExpired(
       channelType,
       channel.id,
@@ -190,10 +166,6 @@ export class WebhookSubscriptionExceptionHandlerService {
       channelType,
       channel.id,
     );
-
-    this.exceptionHandlerService.captureExceptions([exception], {
-      workspace: { id: workspaceId },
-    });
 
     throw exception;
   }


### PR DESCRIPTION
`handleInsufficientPermissionsException` is the branch for the failures we already understand — a revoked token, or a mailbox the provider will not watch. It marks the channel expired, returns `NONE` and lets the sync carry on, yet it also raised a Sentry event, so every one of these paged us with nothing to act on beyond what the channel status already says.

`handleUnknownException` raised its own event and then rethrew, so an unclassified failure was reported twice: once here, and again by the queue explorer once it escaped the job. Rethrowing alone keeps the single report at the boundary and still fails the job for retry.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

