### PR TITLE
Fix empty relation card vertical padding

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/WidgetCardContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/WidgetCardContent.tsx
@@ -43,6 +43,10 @@ const StyledWidgetCardContent = styled.div<WidgetCardContentStyledProps>`
   &:empty {
     margin-top: 0;
     padding: 0;
+    padding-bottom: ${({ hasHeader, variant }) =>
+      hasHeader && variant === 'flush'
+        ? 'var(--widget-card-title-padding-top)'
+        : '0'};
   }
 `;
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/__stories__/WidgetCard.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/__stories__/WidgetCard.stories.tsx
@@ -2,8 +2,12 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { type CSSProperties } from 'react';
 import { expect, within } from 'storybook/test';
 
+import { PageLayoutTestWrapper } from '@/page-layout/hooks/__tests__/PageLayoutTestWrapper';
 import { WidgetCard } from '@/page-layout/widgets/widget-card/components/WidgetCard';
+import { WidgetCardContent } from '@/page-layout/widgets/widget-card/components/WidgetCardContent';
+import { WidgetCardHeader } from '@/page-layout/widgets/widget-card/components/WidgetCardHeader';
 import { ComponentDecorator } from 'twenty-ui/testing';
+import { MemoryRouterDecorator } from '~/testing/decorators/MemoryRouterDecorator';
 
 const meta: Meta<typeof WidgetCard> = {
   title: 'Modules/PageLayout/Widgets/WidgetCard',
@@ -86,5 +90,56 @@ export const FlushWhileDragging: Story = {
     ).toBe(cardStyle.getPropertyValue('--t-background-secondary').trim());
     await expect(cardStyle.backgroundImage).toContain('linear-gradient');
     await expect(cardStyle.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  },
+};
+
+export const EmptyFlush: Story = {
+  args: {
+    variant: 'flush',
+  },
+  decorators: [MemoryRouterDecorator],
+  render: (args) => (
+    <PageLayoutTestWrapper>
+      <div style={{ width: 320, '--widget-height': 'auto' } as CSSProperties}>
+        {/* oxlint-disable-next-line react/jsx-props-no-spreading */}
+        <WidgetCard {...args}>
+          <WidgetCardHeader
+            widgetId="empty-widget-card"
+            variant={args.variant}
+            isInEditMode={args.isEditable}
+            title="Calendar Event"
+          />
+          <WidgetCardContent
+            variant={args.variant}
+            hasHeader
+            isEditable={args.isEditable}
+          />
+        </WidgetCard>
+      </div>
+    </PageLayoutTestWrapper>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = canvas.getByTestId('widget-card');
+    const title = canvas.getByText('Calendar Event');
+
+    await expect(title).toBeVisible();
+
+    const cardBounds = card.getBoundingClientRect();
+    const titleBounds = title.getBoundingClientRect();
+    const topInset = titleBounds.top - cardBounds.top;
+    const bottomInset = cardBounds.bottom - titleBounds.bottom;
+
+    await expect(bottomInset).toBeGreaterThan(0);
+    await expect(bottomInset).toBeCloseTo(topInset, 1);
+  },
+};
+
+export const EmptyFlushInEditMode: Story = {
+  ...EmptyFlush,
+  args: {
+    variant: 'flush',
+    isEditable: true,
+    isEditing: true,
   },
 };


### PR DESCRIPTION
## Summary

Empty relation cards keep the header's top inset but remove all body padding, leaving the title too close to the bottom edge. Reuse the header's spacing variable as bottom padding when a flush card has a header and an empty body.

Populated cards, framed cards, and cards without a header retain their existing spacing.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

