### PR TITLE
Keep the workspace navigation section visible when it has no items

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/workspace/components/WorkspaceSectionContainer.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/workspace/components/WorkspaceSectionContainer.tsx
@@ -118,10 +118,6 @@ export const WorkspaceSectionContainer = ({
     };
   };
 
-  if (flatItems.length === 0 && !isAddToNavigationDropTargetVisible) {
-    return null;
-  }
-
   return (
     <NavigationMenuItemSection
       title={sectionTitle}

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/workspace/components/__tests__/WorkspaceSectionContainer.test.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/workspace/components/__tests__/WorkspaceSectionContainer.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { WorkspaceSectionContainer } from '@/navigation-menu-item/display/sections/workspace/components/WorkspaceSectionContainer';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+const BaseWrapper = getJestMetadataAndApolloMocksWrapper({ apolloMocks: [] });
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <BaseWrapper>
+    <MemoryRouter initialEntries={['/objects/companies']}>
+      {children}
+    </MemoryRouter>
+  </BaseWrapper>
+);
+
+describe('WorkspaceSectionContainer', () => {
+  it('keeps the section and its right icon reachable when there are no items', () => {
+    render(
+      <WorkspaceSectionContainer
+        sectionTitle="Workspace"
+        items={[]}
+        rightIcon={<button type="button">Customize</button>}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText('Workspace')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Customize' }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

`WorkspaceSectionContainer` returned `null` when the section had no top-level items and nothing was being dragged into it. That removed the whole section, including its title, and the customize button lives in that title. Once the last item was deleted there was no way back into layout customization mode to re-add items.

## Fix

Removed the early return so the section always renders.

- In read mode it shows the "Workspace" title with the customize button on hover, so users can re-enter customization mode.
- In customization mode it shows the "Add menu item" button, so items can be re-added directly.
- The empty read-only list adds no visible height, its top padding is cancelled by the existing negative margin wrapper.

## Test

Added `WorkspaceSectionContainer.test.tsx`, which renders the container with no items and asserts the title and right icon are still reachable. It fails on the old code and passes with the fix.

## Note

On mobile, and for users without the layouts permission, an empty section now shows a bare "Workspace" header since neither gets the customize button. Kept consistent rather than special-cased.
