### PR TITLE
Always create app connections at workspace level

### DIFF
--- a/packages/twenty-front/src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
@@ -129,7 +129,7 @@ export const SettingsApplicationConnectionDetail = () => {
       ? connection.name
       : (connection?.handle ?? t`Connection`);
   const deleteModalId = `delete-application-connection-modal-${connectedAccountId}`;
-  const changeVisibilityModalId = `change-application-connection-visibility-modal-${connectedAccountId}`;
+  const shareWithWorkspaceModalId = `share-application-connection-with-workspace-modal-${connectedAccountId}`;
   const applicationSettingsPath = getSettingsPath(
     SettingsPath.ApplicationDetail,
     { applicationId },
@@ -336,7 +336,7 @@ export const SettingsApplicationConnectionDetail = () => {
                     Icon={IconUsers}
                     variant="secondary"
                     accent="default"
-                    onClick={() => openModal(changeVisibilityModalId)}
+                    onClick={() => openModal(shareWithWorkspaceModalId)}
                   />
                 )}
                 <Button
@@ -388,7 +388,7 @@ export const SettingsApplicationConnectionDetail = () => {
               loading={isDeleting}
             />
             <ConfirmationModal
-              modalInstanceId={changeVisibilityModalId}
+              modalInstanceId={shareWithWorkspaceModalId}
               title={t`Share with workspace?`}
               subtitle={
                 <Trans>

--- a/packages/twenty-front/src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
@@ -389,7 +389,7 @@ export const SettingsApplicationConnectionDetail = () => {
             />
             <ConfirmationModal
               modalInstanceId={changeVisibilityModalId}
-              title={t`Change visibility?`}
+              title={t`Share with workspace?`}
               subtitle={
                 <Trans>
                   Sharing this connection with the workspace requires
@@ -397,7 +397,7 @@ export const SettingsApplicationConnectionDetail = () => {
                 </Trans>
               }
               onConfirmClick={handleShareWithWorkspace}
-              confirmButtonText={t`Reconnect and change visibility`}
+              confirmButtonText={t`Reconnect and share`}
               confirmButtonAccent="blue"
             />
           </>

--- a/packages/twenty-front/src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
@@ -7,7 +7,7 @@ import { useParams } from 'react-router-dom';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { Status, Tag } from 'twenty-ui/data-display';
-import { IconRefresh, IconTrash, IconUser, IconUsers } from 'twenty-ui/icon';
+import { IconRefresh, IconTrash, IconUsers } from 'twenty-ui/icon';
 import { H2Title } from 'twenty-ui/typography';
 import { Button } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
@@ -155,7 +155,7 @@ export const SettingsApplicationConnectionDetail = () => {
     });
   };
 
-  const handleChangeVisibility = () => {
+  const handleShareWithWorkspace = () => {
     if (connection === undefined || provider === undefined) {
       return;
     }
@@ -163,7 +163,7 @@ export const SettingsApplicationConnectionDetail = () => {
     triggerAppOAuth({
       applicationId,
       providerName: provider.name,
-      visibility: connection.visibility === 'workspace' ? 'user' : 'workspace',
+      visibility: 'workspace',
       reconnectingConnectedAccountId: connection.id,
       redirectLocation: detailPath,
     });
@@ -330,19 +330,15 @@ export const SettingsApplicationConnectionDetail = () => {
                     onClick={handleReconnect}
                   />
                 )}
-                <Button
-                  title={
-                    connection.visibility === 'workspace'
-                      ? t`Make private`
-                      : t`Share with workspace`
-                  }
-                  Icon={
-                    connection.visibility === 'workspace' ? IconUser : IconUsers
-                  }
-                  variant="secondary"
-                  accent="default"
-                  onClick={() => openModal(changeVisibilityModalId)}
-                />
+                {connection.visibility !== 'workspace' && (
+                  <Button
+                    title={t`Share with workspace`}
+                    Icon={IconUsers}
+                    variant="secondary"
+                    accent="default"
+                    onClick={() => openModal(changeVisibilityModalId)}
+                  />
+                )}
                 <Button
                   title={t`Disconnect`}
                   Icon={IconTrash}
@@ -396,11 +392,11 @@ export const SettingsApplicationConnectionDetail = () => {
               title={t`Change visibility?`}
               subtitle={
                 <Trans>
-                  Changing visibility requires reconnecting this OAuth
-                  connection. You will be redirected to authorize it again.
+                  Sharing this connection with the workspace requires
+                  reconnecting it. You will be redirected to authorize it again.
                 </Trans>
               }
-              onConfirmClick={handleChangeVisibility}
+              onConfirmClick={handleShareWithWorkspace}
               confirmButtonText={t`Reconnect and change visibility`}
               confirmButtonAccent="blue"
             />

--- a/packages/twenty-front/src/pages/settings/applications/__tests__/SettingsApplicationConnectionDetail.test.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/__tests__/SettingsApplicationConnectionDetail.test.tsx
@@ -176,7 +176,7 @@ describe('SettingsApplicationConnectionDetail', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'Reconnect and change visibility',
+        name: 'Reconnect and share',
       }),
     );
 

--- a/packages/twenty-front/src/pages/settings/applications/__tests__/SettingsApplicationConnectionDetail.test.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/__tests__/SettingsApplicationConnectionDetail.test.tsx
@@ -171,7 +171,7 @@ describe('SettingsApplicationConnectionDetail', () => {
     );
 
     expect(mockOpenModal).toHaveBeenCalledWith(
-      'change-application-connection-visibility-modal-account-1',
+      'share-application-connection-with-workspace-modal-account-1',
     );
 
     fireEvent.click(

--- a/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
@@ -4,31 +4,20 @@ import { useContext } from 'react';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 
-import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
-import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
-import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
-import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { Table } from '@/ui/layout/table/components/Table';
 import { TableCell } from '@/ui/layout/table/components/TableCell';
 import { TableHeader } from '@/ui/layout/table/components/TableHeader';
 import { TableRow } from '@/ui/layout/table/components/TableRow';
 import { Avatar, Status } from 'twenty-ui/data-display';
 import { Info } from 'twenty-ui/feedback';
-import {
-  IconChevronRight,
-  IconPlus,
-  IconUser,
-  IconUsers,
-} from 'twenty-ui/icon';
+import { IconChevronRight, IconPlus } from 'twenty-ui/icon';
 import { H2Title } from 'twenty-ui/typography';
 import { Button } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
-import { MenuItem } from 'twenty-ui/navigation';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 import { useFindApplicationConnectionProviders } from '~/pages/settings/applications/hooks/useFindApplicationConnectionProviders';
 import { useMyAppConnectedAccounts } from '~/pages/settings/applications/hooks/useMyAppConnectedAccounts';
 import { useTriggerAppOAuth } from '~/pages/settings/applications/hooks/useTriggerAppOAuth';
-import { type FrontendApplicationConnectionProvider } from '~/pages/settings/applications/types/FrontendApplicationConnectionProvider';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
 
 const CONNECTION_TABLE_ROW_GRID_TEMPLATE_COLUMNS =
@@ -44,55 +33,6 @@ const StyledTableRowsContainer = styled.div`
   border-bottom: 1px solid ${themeCssVariables.border.color.light};
   padding: ${themeCssVariables.spacing[2]} 0;
 `;
-
-const AddConnectionDropdown = ({
-  provider,
-  onPick,
-}: {
-  provider: FrontendApplicationConnectionProvider;
-  onPick: (visibility: 'user' | 'workspace') => void;
-}) => {
-  const { t } = useLingui();
-  const dropdownId = `app-connection-add-${provider.id}`;
-  const { closeDropdown } = useCloseDropdown();
-
-  const handleSelect = (visibility: 'user' | 'workspace') => {
-    closeDropdown(dropdownId);
-    onPick(visibility);
-  };
-
-  return (
-    <Dropdown
-      dropdownId={dropdownId}
-      dropdownPlacement="bottom-start"
-      clickableComponent={
-        <Button
-          title={t`Add connection`}
-          Icon={IconPlus}
-          variant="secondary"
-          accent="default"
-          size="small"
-        />
-      }
-      dropdownComponents={
-        <DropdownContent>
-          <DropdownMenuItemsContainer>
-            <MenuItem
-              text={t`Just for me`}
-              LeftIcon={IconUser}
-              onClick={() => handleSelect('user')}
-            />
-            <MenuItem
-              text={t`Workspace shared`}
-              LeftIcon={IconUsers}
-              onClick={() => handleSelect('workspace')}
-            />
-          </DropdownMenuItemsContainer>
-        </DropdownContent>
-      }
-    />
-  );
-};
 
 export const SettingsApplicationConnectionsSection = ({
   applicationId,
@@ -215,13 +155,17 @@ export const SettingsApplicationConnectionsSection = ({
             )}
             {isClientCredentialsConfigured && (
               <StyledFooter>
-                <AddConnectionDropdown
-                  provider={provider}
-                  onPick={(visibility) =>
+                <Button
+                  title={t`Add connection`}
+                  Icon={IconPlus}
+                  variant="secondary"
+                  accent="default"
+                  size="small"
+                  onClick={() =>
                     triggerAppOAuth({
                       applicationId,
                       providerName: provider.name,
-                      visibility,
+                      visibility: 'workspace',
                     })
                   }
                 />

--- a/packages/twenty-front/src/pages/settings/applications/tabs/__tests__/SettingsApplicationConnectionsSection.test.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/__tests__/SettingsApplicationConnectionsSection.test.tsx
@@ -153,6 +153,7 @@ describe('SettingsApplicationConnectionsSection', () => {
     );
 
     expect(screen.queryByText('Just for me')).not.toBeInTheDocument();
+    expect(mockTriggerAppOAuth).toHaveBeenCalledTimes(1);
     expect(mockTriggerAppOAuth).toHaveBeenCalledWith({
       applicationId: 'app-1',
       providerName: 'google-calendar',

--- a/packages/twenty-front/src/pages/settings/applications/tabs/__tests__/SettingsApplicationConnectionsSection.test.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/__tests__/SettingsApplicationConnectionsSection.test.tsx
@@ -1,6 +1,7 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
 import { SettingsApplicationConnectionsSection } from '~/pages/settings/applications/tabs/SettingsApplicationConnectionsSection';
@@ -111,5 +112,51 @@ describe('SettingsApplicationConnectionsSection', () => {
     expect(
       screen.queryByRole('button', { name: 'Delete' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('adds a workspace shared connection without asking for a visibility', async () => {
+    mockedUseFindApplicationConnectionProviders.mockReturnValue({
+      connectionProviders: [
+        {
+          id: 'provider-1',
+          applicationId: 'app-1',
+          type: 'oauth',
+          name: 'google-calendar',
+          displayName: 'Google Calendar',
+          logoUrl: null,
+          oauth: {
+            scopes: ['calendar.readonly'],
+            isClientCredentialsConfigured: true,
+          },
+        },
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    mockedUseMyAppConnectedAccounts.mockReturnValue({
+      accounts: [],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <MemoryRouter>
+          <SettingsApplicationConnectionsSection applicationId="app-1" />
+        </MemoryRouter>
+      </I18nProvider>,
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Add connection/i }),
+    );
+
+    expect(screen.queryByText('Just for me')).not.toBeInTheDocument();
+    expect(mockTriggerAppOAuth).toHaveBeenCalledWith({
+      applicationId: 'app-1',
+      providerName: 'google-calendar',
+      visibility: 'workspace',
+    });
   });
 });


### PR DESCRIPTION
The "Add connection" button on an application's settings opened a dropdown asking whether the connection should be personal ("Just for me") or workspace shared. Personal connections don't belong in application settings, they belong in a dedicated user-level settings section that doesn't exist yet.

## Changes

- `SettingsApplicationConnectionsSection`: the dropdown is gone. "Add connection" now goes straight to OAuth with `visibility: 'workspace'`.
- `SettingsApplicationConnectionDetail`: removed the "Make private" direction of the visibility toggle, since it was a second way to create a user-level connection from the same place. The button now only offers "Share with workspace", so an existing personal connection can still be promoted but nothing can be made private from here.

Reconnecting still preserves a connection's current visibility, so a personal connection isn't silently shared with the whole workspace. The "Just for me" label stays on the visibility column and detail row so pre-existing personal connections still display accurately.

## Test

- `yarn jest src/pages/settings/applications` passes, including a new case asserting the button triggers workspace visibility with no picker shown.
- oxlint and oxfmt clean on the changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VWC8JQyNBALo92VQK6Unyd)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

