### PR TITLE
Stop fanning workflowRun.updated events out to webhooks

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
@@ -88,24 +88,34 @@ export class EntityEventsToDbListener {
         workspaceId: batchEvent.workspaceId,
       }));
 
-    const batchEventForWebhook = {
-      ...batchEvent,
-      objectMetadata: {
-        id: batchEvent.objectMetadata.id,
-        nameSingular: batchEvent.objectMetadata.nameSingular,
-      },
-    };
+    const isWorkflowRunUpdate =
+      action === DatabaseEventAction.UPDATED &&
+      batchEvent.objectMetadata.universalIdentifier ===
+        STANDARD_OBJECTS.workflowRun.universalIdentifier;
 
-    const promises = [
+    const promises: Promise<unknown>[] = [
       this.objectRecordEventPublisher.publish(batchEvent),
-      this.webhookQueueService.add<WorkspaceEventBatchForWebhook<T>>(
-        CallWebhookJobsJob.name,
-        batchEventForWebhook,
-        {
-          retryLimit: 3,
-        },
-      ),
     ];
+
+    if (!isWorkflowRunUpdate) {
+      const batchEventForWebhook = {
+        ...batchEvent,
+        objectMetadata: {
+          id: batchEvent.objectMetadata.id,
+          nameSingular: batchEvent.objectMetadata.nameSingular,
+        },
+      };
+
+      promises.push(
+        this.webhookQueueService.add<WorkspaceEventBatchForWebhook<T>>(
+          CallWebhookJobsJob.name,
+          batchEventForWebhook,
+          {
+            retryLimit: 3,
+          },
+        ),
+      );
+    }
 
     promises.push(
       this.triggerQueueService.add<WorkspaceEventBatch<T>>(

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
@@ -93,7 +93,7 @@ export class EntityEventsToDbListener {
       batchEvent.objectMetadata.universalIdentifier ===
         STANDARD_OBJECTS.workflowRun.universalIdentifier;
 
-    const promises: Promise<unknown>[] = [
+    const promises: Promise<void | string | undefined>[] = [
       this.objectRecordEventPublisher.publish(batchEvent),
     ];
 


### PR DESCRIPTION
## Context

During the v2.39 incident the webhook queue backlogged up to 100K jobs with delivery latency reaching ~1 hour. A large share of deliveries were `workflowRun.updated` events: a workflow run is updated on every step transition, so one triggering record event fans out into several run-update deliveries per subscribed webhook. Webhook delivery runs at concurrency 1 per worker pod, so a single workflow-heavy workspace with slow endpoints can consume most of the fleet's delivery capacity.

## Change (as merged)

`EntityEventsToDbListener` no longer enqueues the webhook fan-out job (`CallWebhookJobsJob`) for `workflowRun` UPDATED event batches, so those jobs never reach the webhook queue. Everything else is untouched: other `workflowRun` operations, and the batch's other consumers (SSE record-event publisher, database-event triggers, timeline activities, audit logs).

This suppresses `workflowRun.updated` for ALL subscribers, explicit ones included. That blanket behavior is deliberate for the incident; #25601 follows up by restoring delivery to explicit `workflowRun.updated` subscriptions while keeping wildcards excluded.

Note: a rework commit (782016322a) was pushed to this branch minutes after the merge and is NOT part of the merged change; it landed via #25601 instead.