### PR TITLE
Restore workflowRun.updated webhooks for explicit subscriptions

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
@@ -88,34 +88,24 @@ export class EntityEventsToDbListener {
         workspaceId: batchEvent.workspaceId,
       }));
 
-    const isWorkflowRunUpdate =
-      action === DatabaseEventAction.UPDATED &&
-      batchEvent.objectMetadata.universalIdentifier ===
-        STANDARD_OBJECTS.workflowRun.universalIdentifier;
+    const batchEventForWebhook = {
+      ...batchEvent,
+      objectMetadata: {
+        id: batchEvent.objectMetadata.id,
+        nameSingular: batchEvent.objectMetadata.nameSingular,
+      },
+    };
 
-    const promises: Promise<void | string | undefined>[] = [
+    const promises = [
       this.objectRecordEventPublisher.publish(batchEvent),
-    ];
-
-    if (!isWorkflowRunUpdate) {
-      const batchEventForWebhook = {
-        ...batchEvent,
-        objectMetadata: {
-          id: batchEvent.objectMetadata.id,
-          nameSingular: batchEvent.objectMetadata.nameSingular,
+      this.webhookQueueService.add<WorkspaceEventBatchForWebhook<T>>(
+        CallWebhookJobsJob.name,
+        batchEventForWebhook,
+        {
+          retryLimit: 3,
         },
-      };
-
-      promises.push(
-        this.webhookQueueService.add<WorkspaceEventBatchForWebhook<T>>(
-          CallWebhookJobsJob.name,
-          batchEventForWebhook,
-          {
-            retryLimit: 3,
-          },
-        ),
-      );
-    }
+      ),
+    ];
 
     promises.push(
       this.triggerQueueService.add<WorkspaceEventBatch<T>>(

--- a/packages/twenty-server/src/engine/metadata-modules/webhook/jobs/call-webhook-jobs.job.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/webhook/jobs/call-webhook-jobs.job.ts
@@ -12,6 +12,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { CallWebhookJob } from 'src/engine/metadata-modules/webhook/jobs/call-webhook.job';
 import { type CallWebhookJobData } from 'src/engine/metadata-modules/webhook/types/webhook-job-data.type';
+import { computeWebhookOperationsToMatch } from 'src/engine/metadata-modules/webhook/utils/compute-webhook-operations-to-match.util';
 import { transformEventBatchToWebhookEvents } from 'src/engine/metadata-modules/webhook/utils/transform-event-batch-to-webhook-events';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
@@ -38,12 +39,10 @@ export class CallWebhookJobsJob {
 
     const [nameSingular, operation] = workspaceEventBatch.name.split('.');
 
-    const operationsToMatch = [
-      `${nameSingular}.${operation}`,
-      `*.${operation}`,
-      `${nameSingular}.*`,
-      '*.*',
-    ];
+    const operationsToMatch = computeWebhookOperationsToMatch({
+      nameSingular,
+      operation,
+    });
 
     const { flatWebhookMaps } = await this.workspaceCacheService.getOrRecompute(
       workspaceEventBatch.workspaceId,

--- a/packages/twenty-server/src/engine/metadata-modules/webhook/tools/create-webhook.tool.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/webhook/tools/create-webhook.tool.ts
@@ -34,7 +34,7 @@ export const createCreateWebhookTool = (
 
 Operations are structured entries discriminated by 'kind':
 - {kind:'record', object:'person', event:'created'} → fires when a person is created (compiles to 'person.created').
-- {kind:'record', object:'*', event:'*'} → fires on every record event.
+- {kind:'record', object:'*', event:'*'} → fires on every record event except 'workflowRun.updated', which only matches an explicit {kind:'record', object:'workflowRun', event:'updated'} entry.
 - {kind:'metadata', metadataName:'workflow', operation:'updated'} → fires when a workflow definition is updated (compiles to 'metadata.workflow.updated').
 - {kind:'metadata', metadataName:'*', operation:'*'} → fires on every metadata change.
 

--- a/packages/twenty-server/src/engine/metadata-modules/webhook/tools/schemas/webhook-operation.schema.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/webhook/tools/schemas/webhook-operation.schema.ts
@@ -41,5 +41,5 @@ export const webhookOperationSchema = z
   )
   .min(1)
   .describe(
-    "Events that trigger the webhook. Record events compile to '<object>.<event>' (e.g. 'person.created'). Metadata events compile to 'metadata.<metadataName>.<operation>' (e.g. 'metadata.workflow.updated'). Use [{kind:'record',object:'*',event:'*'}] to subscribe to all record events.",
+    "Events that trigger the webhook. Record events compile to '<object>.<event>' (e.g. 'person.created'). Metadata events compile to 'metadata.<metadataName>.<operation>' (e.g. 'metadata.workflow.updated'). Use [{kind:'record',object:'*',event:'*'}] to subscribe to all record events. Exception: 'workflowRun.updated' never matches wildcards and requires an explicit {kind:'record',object:'workflowRun',event:'updated'} entry.",
   );

--- a/packages/twenty-server/src/engine/metadata-modules/webhook/utils/__tests__/compute-webhook-operations-to-match.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/webhook/utils/__tests__/compute-webhook-operations-to-match.spec.ts
@@ -1,0 +1,30 @@
+import { computeWebhookOperationsToMatch } from 'src/engine/metadata-modules/webhook/utils/compute-webhook-operations-to-match.util';
+
+describe('computeWebhookOperationsToMatch', () => {
+  it('matches exact and wildcard operations for a regular object event', () => {
+    expect(
+      computeWebhookOperationsToMatch({
+        nameSingular: 'company',
+        operation: 'updated',
+      }),
+    ).toEqual(['company.updated', '*.updated', 'company.*', '*.*']);
+  });
+
+  it('matches only the exact operation for workflowRun.updated', () => {
+    expect(
+      computeWebhookOperationsToMatch({
+        nameSingular: 'workflowRun',
+        operation: 'updated',
+      }),
+    ).toEqual(['workflowRun.updated']);
+  });
+
+  it('keeps wildcard matching for other workflowRun operations', () => {
+    expect(
+      computeWebhookOperationsToMatch({
+        nameSingular: 'workflowRun',
+        operation: 'created',
+      }),
+    ).toEqual(['workflowRun.created', '*.created', 'workflowRun.*', '*.*']);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/webhook/utils/compute-webhook-operations-to-match.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/webhook/utils/compute-webhook-operations-to-match.util.ts
@@ -1,0 +1,21 @@
+import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
+
+const WILDCARD_EXCLUDED_EVENT_NAMES = [
+  `workflowRun.${DatabaseEventAction.UPDATED}`,
+];
+
+export const computeWebhookOperationsToMatch = ({
+  nameSingular,
+  operation,
+}: {
+  nameSingular: string;
+  operation: string;
+}): string[] => {
+  const exactOperation = `${nameSingular}.${operation}`;
+
+  if (WILDCARD_EXCLUDED_EVENT_NAMES.includes(exactOperation)) {
+    return [exactOperation];
+  }
+
+  return [exactOperation, `*.${operation}`, `${nameSingular}.*`, '*.*'];
+};


### PR DESCRIPTION
## Context

Follow-up to #25599, which merged the emergency version of the mitigation: the webhook fan-out enqueue is skipped entirely for `workflowRun.updated`, so even webhooks explicitly subscribed to that operation receive nothing.

## Change

Replaces the blanket skip with an opt-in matching rule:

- The listener enqueues webhook fan-out jobs for `workflowRun.updated` batches again (revert of the #25599 listener change).
- Operation matching for `workflowRun.updated` is restricted to the exact subscription string via the new `computeWebhookOperationsToMatch` util: explicit subscribers (settings UI picking Workflow Runs + Updated, Zapier workflow-run zaps) receive events; wildcard subscriptions (`*.*`, `*.updated`, `workflowRun.*`) do not match it.
- The MCP webhook tool descriptions document the wildcard exception.

Verified surfaces: Zapier subscribes with exact strings only (`triggers.utils.ts` builds `<object>.<operation>`), and the settings UI stores `workflowRun.updated` for an explicit pick. Sharp edge kept deliberately: Workflow Runs + "All events" stores `workflowRun.*` and therefore loses updated events while keeping created/deleted.

## Cost note

Fan-out jobs for run-update batches return to the webhook queue (they were zero-traffic under #25599). For workspaces with no explicit subscriber they no-op after a cached webhook-map lookup and enqueue zero deliveries.

## Tests

`compute-webhook-operations-to-match.spec.ts` pins the rule: regular objects keep all four match patterns, `workflowRun.updated` matches exactly only, other `workflowRun` operations keep wildcards.

## E2E verification

Ran on a local instance of this branch (fresh DB, seeded "Create company when adding a new person" workflow, two webhooks pointing at a local sink). One `createPerson`:

- webhook subscribed to `workflowRun.updated`: received `workflowRun.updated` x3 (one per step transition), nothing else.
- webhook subscribed to `*.*`: received `person.created`, `workflowRun.created`, and metadata events - zero `workflowRun.updated`.