### PR TITLE
Write pulled views and standalone view fields as define files

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
+++ b/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
@@ -115,14 +115,17 @@ Pull needs an existing project — scaffold one with `npx create-twenty-app@late
 - objects, with their fields inline;
 - fields your app added to objects it does not own;
 - authored indexes;
+- views, with their fields, field groups, filters, filter groups, sorts and groups inline;
+- view fields your app added to views it does not own, as standalone `defineViewField()` files;
 - published translations, as `locales/<locale>.json` for the strings pull can read back from the pulled metadata and source, and `locales/compiled/<locale>.json` for the rest.
 
 Each entity goes to the file that already defines it, so a second pull rewrites only what changed on the server. New entities are placed beside existing files of their kind, and a generated name that would land on an unrelated file is qualified rather than overwriting it.
 
 **What it does not write:**
 
-- **Not exported yet** — roles and permissions, views, page layouts, navigation, command menu items, logic functions and front components, and the stored source of your functions.
+- **Not exported yet** — roles and permissions, page layouts, navigation, command menu items, logic functions and front components, and the stored source of your functions.
 - **Derived by the engine** — system fields, default relations, default views and backing indexes. The server rebuilds them on apply. An object may still point its label identifier at one of them, as junction objects created in the UI do; the pointer is written and the build resolves it without adding a field.
+- **Placed on a default or foreign view** — filters, filter groups, sorts, groups and field groups added to an engine default view, or to a view owned by another application, have no source form yet and are reported. View fields added there are written as standalone files, since the view's identifier is known.
 - **Workspace runtime state** — member and API-key role assignments, webhooks and per-user navigation, all excluded by design.
 - **Owned by another application** — reported, never pulled.
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/__integration__/pull-round-trip.integration.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__integration__/pull-round-trip.integration.spec.ts
@@ -7,7 +7,10 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import {
   getFieldUniversalIdentifier,
+  getSystemViewUniversalIdentifier,
   type Manifest,
+  SYSTEM_VIEW_KEYS,
+  TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
 } from 'twenty-shared/application';
 import { generateMessageId } from 'twenty-shared/i18n';
 import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
@@ -28,6 +31,22 @@ const INDEX_FIELD_UID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const JUNCTION_UID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 const JUNCTION_PET_FIELD_UID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const PET_AGREEMENTS_FIELD_UID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const VIEW_UID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+const VIEW_NAME_FIELD_UID = '13131313-1313-4131-8131-131313131313';
+const VIEW_AGE_FIELD_UID = '12121212-1212-4121-8121-121212121212';
+const VIEW_FILTER_GROUP_UID = '14141414-1414-4141-8141-141414141414';
+const VIEW_FILTER_UID = '15151515-1515-4151-8151-151515151515';
+const VIEW_SORT_UID = '16161616-1616-4161-8161-161616161616';
+const VIEW_GROUP_UID = '17171717-1717-4171-8171-171717171717';
+const VIEW_FIELD_GROUP_UID = '18181818-1818-4181-8181-181818181818';
+const COMPANY_INDEX_VIEW_FIELD_UID = '19191919-1919-4191-8191-191919191919';
+
+const COMPANY_INDEX_VIEW_UID = getSystemViewUniversalIdentifier({
+  objectMetadataApplicationUniversalIdentifier:
+    TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+  objectUniversalIdentifier: STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.company,
+  viewKey: SYSTEM_VIEW_KEYS.INDEX,
+});
 
 const EXPORTED_TRANSLATIONS = {
   'fr-FR': {
@@ -209,6 +228,89 @@ const EXPORTED_MANIFEST = {
       ],
     },
   ],
+  views: [
+    {
+      universalIdentifier: VIEW_UID,
+      name: 'Senior pets',
+      objectUniversalIdentifier: PET_UID,
+      type: 'TABLE',
+      icon: 'IconPaw',
+      position: 1,
+      isCompact: false,
+      visibility: 'WORKSPACE',
+      openRecordIn: 'SIDE_PANEL',
+      mainGroupByFieldMetadataUniversalIdentifier: PET_STATUS_FIELD_UID,
+      shouldHideEmptyGroups: false,
+      anyFieldFilterValue: null,
+      fields: [
+        {
+          universalIdentifier: VIEW_NAME_FIELD_UID,
+          fieldMetadataUniversalIdentifier: PET_NAME_FIELD_UID,
+          isVisible: true,
+          size: 180,
+          position: 0,
+        },
+        {
+          universalIdentifier: VIEW_AGE_FIELD_UID,
+          fieldMetadataUniversalIdentifier: PET_AGE_FIELD_UID,
+          isVisible: true,
+          size: 100,
+          position: 1,
+          aggregateOperation: 'AVG',
+        },
+      ],
+      filterGroups: [
+        {
+          universalIdentifier: VIEW_FILTER_GROUP_UID,
+          logicalOperator: 'NOT',
+          positionInViewFilterGroup: 0,
+        },
+      ],
+      filters: [
+        {
+          universalIdentifier: VIEW_FILTER_UID,
+          fieldMetadataUniversalIdentifier: PET_NAME_FIELD_UID,
+          operand: 'CONTAINS',
+          value: 'Rex',
+          viewFilterGroupUniversalIdentifier: VIEW_FILTER_GROUP_UID,
+          positionInViewFilterGroup: 0,
+        },
+      ],
+      sorts: [
+        {
+          universalIdentifier: VIEW_SORT_UID,
+          fieldMetadataUniversalIdentifier: PET_AGE_FIELD_UID,
+          direction: 'DESC',
+        },
+      ],
+      groups: [
+        {
+          universalIdentifier: VIEW_GROUP_UID,
+          fieldValue: 'HEALTHY',
+          isVisible: true,
+          position: 0,
+        },
+      ],
+      fieldGroups: [
+        {
+          universalIdentifier: VIEW_FIELD_GROUP_UID,
+          name: 'Details',
+          position: 0,
+          isVisible: true,
+        },
+      ],
+    },
+  ],
+  viewFields: [
+    {
+      universalIdentifier: COMPANY_INDEX_VIEW_FIELD_UID,
+      viewUniversalIdentifier: COMPANY_INDEX_VIEW_UID,
+      fieldMetadataUniversalIdentifier: COMPANY_TAGLINE_FIELD_UID,
+      isVisible: true,
+      size: 150,
+      position: 3,
+    },
+  ],
 } as unknown as Manifest;
 
 const canonicalize = (value: unknown): unknown =>
@@ -346,6 +448,20 @@ describe('pull round trip', () => {
       canonicalize(sortByUniversalIdentifier(builtManifest?.indexes ?? [])),
     ).toEqual(
       canonicalize(sortByUniversalIdentifier(EXPORTED_MANIFEST.indexes ?? [])),
+    );
+  });
+
+  it('should rebuild the exported view with its fields, filters, groups and sorts in order', () => {
+    expect(
+      canonicalize(sortByUniversalIdentifier(builtManifest?.views ?? [])),
+    ).toEqual(canonicalize(sortByUniversalIdentifier(EXPORTED_MANIFEST.views)));
+  });
+
+  it('should rebuild the standalone view field on the company index view unchanged', () => {
+    expect(
+      canonicalize(sortByUniversalIdentifier(builtManifest?.viewFields ?? [])),
+    ).toEqual(
+      canonicalize(sortByUniversalIdentifier(EXPORTED_MANIFEST.viewFields)),
     );
   });
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/build-pull-entities.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/build-pull-entities.spec.ts
@@ -1,6 +1,22 @@
 import { buildPullEntities } from '@/cli/utilities/pull/build-pull-entities';
-import { type Manifest } from 'twenty-shared/application';
-import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
+import {
+  VIEW_ENUM_BINDINGS,
+  VIEW_FIELD_ENUM_BINDINGS,
+} from '@/cli/utilities/pull/write-define-file';
+import {
+  type Manifest,
+  type StandaloneViewFieldManifest,
+  type ViewManifest,
+} from 'twenty-shared/application';
+import {
+  STANDARD_OBJECT_FIELDS,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
+} from 'twenty-shared/metadata';
+import {
+  AggregateOperations,
+  ViewSortDirection,
+  ViewType,
+} from 'twenty-shared/types';
 import { describe, expect, it } from 'vitest';
 
 const APP_UID = '11111111-1111-4111-8111-111111111111';
@@ -10,6 +26,10 @@ const COMPANY_FIELD_UID = '44444444-4444-4444-8444-444444444444';
 const INDEX_UID = '55555555-5555-4555-8555-555555555555';
 const JUNCTION_UID = '66666666-6666-4666-8666-666666666666';
 const JUNCTION_ID_FIELD_UID = '77777777-7777-4777-8777-777777777777';
+const VIEW_UID = '88888888-8888-4888-8888-888888888888';
+const VIEW_FIELD_UID = '99999999-9999-4999-8999-999999999999';
+const VIEW_SORT_UID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const INLINE_VIEW_FIELD_UID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 
 const buildManifest = (overrides: Partial<Manifest> = {}): Manifest =>
   ({
@@ -53,6 +73,43 @@ const buildManifest = (overrides: Partial<Manifest> = {}): Manifest =>
     indexes: [],
     ...overrides,
   }) as unknown as Manifest;
+
+const buildViewManifest = (
+  overrides: Partial<ViewManifest> = {},
+): ViewManifest => ({
+  universalIdentifier: VIEW_UID,
+  name: 'All pets',
+  objectUniversalIdentifier: PET_UID,
+  type: ViewType.TABLE,
+  kanbanAggregateOperation: AggregateOperations.COUNT,
+  fields: [
+    {
+      universalIdentifier: INLINE_VIEW_FIELD_UID,
+      fieldMetadataUniversalIdentifier: PET_NAME_FIELD_UID,
+      position: 0,
+      aggregateOperation: AggregateOperations.COUNT,
+    },
+  ],
+  sorts: [
+    {
+      universalIdentifier: VIEW_SORT_UID,
+      fieldMetadataUniversalIdentifier: PET_NAME_FIELD_UID,
+      direction: ViewSortDirection.ASC,
+    },
+  ],
+  ...overrides,
+});
+
+const buildViewFieldManifest = (
+  overrides: Partial<StandaloneViewFieldManifest> = {},
+): StandaloneViewFieldManifest => ({
+  universalIdentifier: VIEW_FIELD_UID,
+  viewUniversalIdentifier: VIEW_UID,
+  fieldMetadataUniversalIdentifier: PET_NAME_FIELD_UID,
+  position: 1,
+  aggregateOperation: AggregateOperations.COUNT,
+  ...overrides,
+});
 
 describe('buildPullEntities', () => {
   it('should strip the checksums the build recomputes from the application config', () => {
@@ -158,5 +215,188 @@ describe('buildPullEntities', () => {
     expect(
       skipped.find((entry) => entry.universalIdentifier === INDEX_UID)?.reason,
     ).toBe('its object is not part of the written source');
+  });
+
+  it('should write a view verbatim into src/views with the view enum bindings and its object as parent', () => {
+    const viewManifest = buildViewManifest();
+    const { entities, skipped } = buildPullEntities(
+      buildManifest({ views: [viewManifest] }),
+    );
+    const view = entities.find((entity) => entity.kind === 'view');
+
+    expect(skipped).toEqual([]);
+    expect(view?.universalIdentifier).toBe(VIEW_UID);
+    expect(view?.definer).toBe('defineView');
+    expect(view?.config).toEqual(viewManifest);
+    expect(view?.enumBindings).toEqual(VIEW_ENUM_BINDINGS);
+    expect(view?.parentName).toBe('pet');
+    expect(
+      `${view?.defaultFolder}/${view?.fileBaseName}${view?.fileSuffix}`,
+    ).toBe('src/views/all-pets.view.ts');
+  });
+
+  it('should give a view on a standard object that object as parent', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        views: [
+          buildViewManifest({
+            objectUniversalIdentifier:
+              STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person,
+          }),
+        ],
+      }),
+    );
+    const view = entities.find((entity) => entity.kind === 'view');
+
+    expect(view?.parentName).toBe('person');
+  });
+
+  it('should name a view whose name has no kebab-case form after its identifier prefix', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({ views: [buildViewManifest({ name: '!!!' })] }),
+    );
+    const view = entities.find((entity) => entity.kind === 'view');
+
+    expect(view?.fileBaseName).toBe('88888888');
+  });
+
+  it('should cap the file name of a view with an overlong name', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        views: [
+          buildViewManifest({ name: `${'Ab'.repeat(39)} ${'c'.repeat(300)}` }),
+        ],
+      }),
+    );
+    const view = entities.find((entity) => entity.kind === 'view');
+
+    expect(view?.fileBaseName).toBe(`${'ab-'.repeat(26)}ab`);
+    expect(view?.fileBaseName).toHaveLength(80);
+  });
+
+  it('should prefix a view named after a Windows reserved device name with its identifier', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({ views: [buildViewManifest({ name: 'Con' })] }),
+    );
+    const view = entities.find((entity) => entity.kind === 'view');
+
+    expect(view?.fileBaseName).toBe('88888888-con');
+  });
+
+  it('should write a standalone view field into src/view-fields named after the manifest object and field it points to', () => {
+    const viewFieldManifest = buildViewFieldManifest();
+    const { entities, skipped } = buildPullEntities(
+      buildManifest({
+        views: [buildViewManifest()],
+        viewFields: [viewFieldManifest],
+      }),
+    );
+    const viewField = entities.find((entity) => entity.kind === 'viewField');
+
+    expect(skipped).toEqual([]);
+    expect(viewField?.universalIdentifier).toBe(VIEW_FIELD_UID);
+    expect(viewField?.definer).toBe('defineViewField');
+    expect(viewField?.config).toEqual(viewFieldManifest);
+    expect(viewField?.enumBindings).toEqual(VIEW_FIELD_ENUM_BINDINGS);
+    expect(viewField?.parentName).toBeNull();
+    expect(
+      `${viewField?.defaultFolder}/${viewField?.fileBaseName}${viewField?.fileSuffix}`,
+    ).toBe('src/view-fields/pet-name.view-field.ts');
+  });
+
+  it('should name a standalone view field pointing at a manifest field on a standard object after that object', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        views: [buildViewManifest()],
+        viewFields: [
+          buildViewFieldManifest({
+            fieldMetadataUniversalIdentifier: COMPANY_FIELD_UID,
+          }),
+        ],
+      }),
+    );
+    const viewField = entities.find((entity) => entity.kind === 'viewField');
+
+    expect(viewField?.fileBaseName).toBe('company-cared-for-pets');
+  });
+
+  it('should name a standalone view field pointing at a standard field after the standard object and field', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        views: [buildViewManifest()],
+        viewFields: [
+          buildViewFieldManifest({
+            fieldMetadataUniversalIdentifier:
+              STANDARD_OBJECT_FIELDS.person.jobTitle.universalIdentifier,
+          }),
+        ],
+      }),
+    );
+    const viewField = entities.find((entity) => entity.kind === 'viewField');
+
+    expect(viewField?.fileBaseName).toBe('person-job-title');
+  });
+
+  it('should name a standalone view field pointing at an unknown field after its identifier prefix', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        views: [buildViewManifest()],
+        viewFields: [
+          buildViewFieldManifest({
+            fieldMetadataUniversalIdentifier: 'a-field-of-another-application',
+          }),
+        ],
+      }),
+    );
+    const viewField = entities.find((entity) => entity.kind === 'viewField');
+
+    expect(viewField?.fileBaseName).toBe('99999999');
+  });
+
+  it('should build a manifest that has no views and viewFields properties without producing view entities', () => {
+    const {
+      views: _views,
+      viewFields: _viewFields,
+      ...manifestWithoutViews
+    } = buildManifest({
+      views: [buildViewManifest()],
+      viewFields: [buildViewFieldManifest()],
+    });
+
+    const { entities, skipped } = buildPullEntities(
+      manifestWithoutViews as unknown as Manifest,
+    );
+
+    expect(skipped).toEqual([]);
+    expect(entities.map((entity) => entity.kind)).toEqual([
+      'application',
+      'object',
+      'field',
+    ]);
+  });
+
+  it('should never skip a view or a view field, even when their object or field is unknown', () => {
+    const { entities, skipped } = buildPullEntities(
+      buildManifest({
+        objects: [],
+        views: [
+          buildViewManifest({
+            objectUniversalIdentifier: 'an-object-of-another-application',
+          }),
+        ],
+        viewFields: [
+          buildViewFieldManifest({
+            fieldMetadataUniversalIdentifier: 'a-field-of-another-application',
+          }),
+        ],
+      }),
+    );
+    const view = entities.find((entity) => entity.kind === 'view');
+
+    expect(skipped).toEqual([]);
+    expect(entities.map((entity) => entity.kind)).toEqual(
+      expect.arrayContaining(['view', 'viewField']),
+    );
+    expect(view?.parentName).toBeNull();
   });
 });

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/build-pull-entities.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/build-pull-entities.spec.ts
@@ -274,15 +274,6 @@ describe('buildPullEntities', () => {
     expect(view?.fileBaseName).toHaveLength(80);
   });
 
-  it('should prefix a view named after a Windows reserved device name with its identifier', () => {
-    const { entities } = buildPullEntities(
-      buildManifest({ views: [buildViewManifest({ name: 'Con' })] }),
-    );
-    const view = entities.find((entity) => entity.kind === 'view');
-
-    expect(view?.fileBaseName).toBe('88888888-con');
-  });
-
   it('should write a standalone view field into src/view-fields named after the manifest object and field it points to', () => {
     const viewFieldManifest = buildViewFieldManifest();
     const { entities, skipped } = buildPullEntities(

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
@@ -1,7 +1,13 @@
 import { ManifestEntityKey } from '@/cli/utilities/build/manifest/manifest-extract-config';
 import { planPullWrites } from '@/cli/utilities/pull/plan-pull-writes';
 import { type ScannedDefineFile } from '@/cli/utilities/pull/scan-project-define-files';
-import { type Manifest } from 'twenty-shared/application';
+import {
+  type Manifest,
+  type StandaloneViewFieldManifest,
+  type ViewFilterManifest,
+  type ViewManifest,
+} from 'twenty-shared/application';
+import { ViewFilterOperand } from 'twenty-shared/types';
 import { describe, expect, it } from 'vitest';
 
 const APP_UID = '11111111-1111-4111-8111-111111111111';
@@ -9,6 +15,15 @@ const PET_UID = '22222222-2222-4222-8222-222222222222';
 const NAME_FIELD_UID = '33333333-3333-4333-8333-333333333333';
 const ROCKET_UID = '44444444-4444-4444-8444-444444444444';
 const ROCKET_NAME_FIELD_UID = '55555555-5555-4555-8555-555555555555';
+const JUNCTION_UID = '66666666-6666-4666-8666-666666666666';
+const JUNCTION_ID_FIELD_UID = '77777777-7777-4777-8777-777777777777';
+const ALL_PETS_VIEW_UID = '88888888-8888-4888-8888-888888888888';
+const HEALTHY_PETS_VIEW_UID = '99999999-9999-4999-8999-999999999999';
+const OVERVIEW_VIEW_UID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SECOND_OVERVIEW_VIEW_UID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const HEALTHY_PETS_FILTER_UID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const PET_NAME_VIEW_FIELD_UID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const ROCKET_NAME_VIEW_FIELD_UID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
 
 const buildObject = ({
   universalIdentifier,
@@ -57,6 +72,44 @@ const MANIFEST = buildManifest([
     labelIdentifierFieldMetadataUniversalIdentifier: NAME_FIELD_UID,
   }),
 ]);
+
+const buildView = (
+  overrides: Partial<ViewManifest> & { universalIdentifier: string },
+): ViewManifest => ({
+  name: 'Overview',
+  objectUniversalIdentifier: PET_UID,
+  ...overrides,
+});
+
+const buildViewField = (
+  overrides: Partial<StandaloneViewFieldManifest> & {
+    universalIdentifier: string;
+  },
+): StandaloneViewFieldManifest => ({
+  viewUniversalIdentifier: OVERVIEW_VIEW_UID,
+  fieldMetadataUniversalIdentifier: NAME_FIELD_UID,
+  position: 0,
+  ...overrides,
+});
+
+const buildNameFilter = (value: string): ViewFilterManifest => ({
+  universalIdentifier: HEALTHY_PETS_FILTER_UID,
+  fieldMetadataUniversalIdentifier: NAME_FIELD_UID,
+  operand: ViewFilterOperand.IS,
+  value,
+});
+
+const buildManifestWithFilteredView = (filterValue: string): Manifest => ({
+  ...MANIFEST,
+  views: [
+    buildView({ universalIdentifier: ALL_PETS_VIEW_UID, name: 'All pets' }),
+    buildView({
+      universalIdentifier: HEALTHY_PETS_VIEW_UID,
+      name: 'Healthy pets',
+      filters: [buildNameFilter(filterValue)],
+    }),
+  ],
+});
 
 describe('planPullWrites', () => {
   it('should write every entity when the project has no source and no base', () => {
@@ -347,5 +400,196 @@ describe('planPullWrites', () => {
     expect(plan.writes.map((write) => write.relativePath)).not.toContain(
       'src/objects/pet.object.ts',
     );
+  });
+
+  it('should place a new view beside existing view files', () => {
+    const plan = planPullWrites({
+      manifest: {
+        ...MANIFEST,
+        views: [
+          buildView({ universalIdentifier: OVERVIEW_VIEW_UID }),
+          buildView({
+            universalIdentifier: ALL_PETS_VIEW_UID,
+            name: 'All pets',
+          }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [
+        {
+          relativePath: 'app/screens/overview.view.ts',
+          entityKey: ManifestEntityKey.Views,
+          universalIdentifier: OVERVIEW_VIEW_UID,
+          isReadable: true,
+        },
+      ],
+    });
+
+    expect(
+      plan.writes.find(
+        (write) => write.universalIdentifier === ALL_PETS_VIEW_UID,
+      )?.relativePath,
+    ).toBe('app/screens/all-pets.view.ts');
+  });
+
+  it('should place a new standalone view field beside existing view field files', () => {
+    const plan = planPullWrites({
+      manifest: {
+        ...buildManifest([
+          buildObject({
+            universalIdentifier: PET_UID,
+            nameSingular: 'pet',
+            labelIdentifierFieldMetadataUniversalIdentifier: NAME_FIELD_UID,
+          }),
+          buildObject({
+            universalIdentifier: ROCKET_UID,
+            nameSingular: 'rocket',
+            labelIdentifierFieldMetadataUniversalIdentifier:
+              ROCKET_NAME_FIELD_UID,
+          }),
+        ]),
+        views: [buildView({ universalIdentifier: OVERVIEW_VIEW_UID })],
+        viewFields: [
+          buildViewField({
+            universalIdentifier: ROCKET_NAME_VIEW_FIELD_UID,
+            fieldMetadataUniversalIdentifier: ROCKET_NAME_FIELD_UID,
+          }),
+          buildViewField({ universalIdentifier: PET_NAME_VIEW_FIELD_UID }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [
+        {
+          relativePath: 'app/screens/overview.view.ts',
+          entityKey: ManifestEntityKey.Views,
+          universalIdentifier: OVERVIEW_VIEW_UID,
+          isReadable: true,
+        },
+        {
+          relativePath: 'app/screens/columns/rocket-name.view-field.ts',
+          entityKey: ManifestEntityKey.ViewFields,
+          universalIdentifier: ROCKET_NAME_VIEW_FIELD_UID,
+          isReadable: true,
+        },
+      ],
+    });
+
+    expect(
+      plan.writes.find(
+        (write) => write.universalIdentifier === PET_NAME_VIEW_FIELD_UID,
+      )?.relativePath,
+    ).toBe('app/screens/columns/pet-name.view-field.ts');
+  });
+
+  it('should qualify colliding view file names with the kebab-cased name of each object', () => {
+    const plan = planPullWrites({
+      manifest: {
+        ...buildManifest([
+          buildObject({
+            universalIdentifier: JUNCTION_UID,
+            nameSingular: 'petCareAgreement',
+            labelIdentifierFieldMetadataUniversalIdentifier:
+              JUNCTION_ID_FIELD_UID,
+          }),
+          buildObject({
+            universalIdentifier: ROCKET_UID,
+            nameSingular: 'rocket',
+            labelIdentifierFieldMetadataUniversalIdentifier:
+              ROCKET_NAME_FIELD_UID,
+          }),
+        ]),
+        views: [
+          buildView({
+            universalIdentifier: OVERVIEW_VIEW_UID,
+            objectUniversalIdentifier: JUNCTION_UID,
+          }),
+          buildView({
+            universalIdentifier: SECOND_OVERVIEW_VIEW_UID,
+            objectUniversalIdentifier: ROCKET_UID,
+          }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [],
+    });
+
+    expect(
+      plan.writes
+        .filter((write) => write.kind === 'view')
+        .map((write) => write.relativePath)
+        .sort(),
+    ).toEqual([
+      'src/views/pet-care-agreement-overview.view.ts',
+      'src/views/rocket-overview.view.ts',
+    ]);
+  });
+
+  it('should fall back to identifier-prefixed names when two views of one object share a name', () => {
+    const plan = planPullWrites({
+      manifest: {
+        ...MANIFEST,
+        views: [
+          buildView({ universalIdentifier: OVERVIEW_VIEW_UID }),
+          buildView({ universalIdentifier: SECOND_OVERVIEW_VIEW_UID }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [],
+    });
+
+    expect(
+      plan.writes
+        .filter((write) => write.kind === 'view')
+        .map((write) => write.relativePath)
+        .sort(),
+    ).toEqual([
+      `src/views/${OVERVIEW_VIEW_UID.slice(0, 8)}-overview.view.ts`,
+      `src/views/${SECOND_OVERVIEW_VIEW_UID.slice(0, 8)}-overview.view.ts`,
+    ]);
+  });
+
+  it('should leave an unchanged view untouched and regenerate the view whose filter changed on the server', () => {
+    const scannedFiles: ScannedDefineFile[] = [
+      {
+        relativePath: 'src/application.config.ts',
+        entityKey: ManifestEntityKey.Application,
+        universalIdentifier: APP_UID,
+        isReadable: true,
+      },
+      {
+        relativePath: 'src/objects/pet.object.ts',
+        entityKey: ManifestEntityKey.Objects,
+        universalIdentifier: PET_UID,
+        isReadable: true,
+      },
+      {
+        relativePath: 'src/views/all-pets.view.ts',
+        entityKey: ManifestEntityKey.Views,
+        universalIdentifier: ALL_PETS_VIEW_UID,
+        isReadable: true,
+      },
+      {
+        relativePath: 'src/views/healthy-pets.view.ts',
+        entityKey: ManifestEntityKey.Views,
+        universalIdentifier: HEALTHY_PETS_VIEW_UID,
+        isReadable: true,
+      },
+    ];
+
+    const plan = planPullWrites({
+      manifest: buildManifestWithFilteredView('Max'),
+      baseManifest: buildManifestWithFilteredView('Rex'),
+      scannedFiles,
+    });
+
+    expect(
+      plan.unchanged.map((entity) => entity.universalIdentifier),
+    ).toContain(ALL_PETS_VIEW_UID);
+    expect(plan.writes.map((write) => write.relativePath)).toEqual([
+      'src/views/healthy-pets.view.ts',
+    ]);
+    expect(plan.writes[0].isRegeneration).toBe(true);
+    expect(plan.writes[0].content).toContain("value: 'Max',");
+    expect(plan.writes[0].content).toContain('operand: ViewFilterOperand.IS,');
   });
 });

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
@@ -21,6 +21,7 @@ const ALL_PETS_VIEW_UID = '88888888-8888-4888-8888-888888888888';
 const HEALTHY_PETS_VIEW_UID = '99999999-9999-4999-8999-999999999999';
 const OVERVIEW_VIEW_UID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const SECOND_OVERVIEW_VIEW_UID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const THIRD_OVERVIEW_VIEW_UID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
 const HEALTHY_PETS_FILTER_UID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const PET_NAME_VIEW_FIELD_UID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 const ROCKET_NAME_VIEW_FIELD_UID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
@@ -543,8 +544,49 @@ describe('planPullWrites', () => {
         .map((write) => write.relativePath)
         .sort(),
     ).toEqual([
-      `src/views/${OVERVIEW_VIEW_UID.slice(0, 8)}-overview.view.ts`,
-      `src/views/${SECOND_OVERVIEW_VIEW_UID.slice(0, 8)}-overview.view.ts`,
+      `src/views/${OVERVIEW_VIEW_UID.slice(0, 8)}-pet-overview.view.ts`,
+      `src/views/${SECOND_OVERVIEW_VIEW_UID.slice(0, 8)}-pet-overview.view.ts`,
+    ]);
+  });
+
+  it('should prefix only the views whose qualified names still collide', () => {
+    const plan = planPullWrites({
+      manifest: {
+        ...buildManifest([
+          buildObject({
+            universalIdentifier: PET_UID,
+            nameSingular: 'pet',
+            labelIdentifierFieldMetadataUniversalIdentifier: NAME_FIELD_UID,
+          }),
+          buildObject({
+            universalIdentifier: ROCKET_UID,
+            nameSingular: 'rocket',
+            labelIdentifierFieldMetadataUniversalIdentifier:
+              ROCKET_NAME_FIELD_UID,
+          }),
+        ]),
+        views: [
+          buildView({ universalIdentifier: OVERVIEW_VIEW_UID }),
+          buildView({ universalIdentifier: SECOND_OVERVIEW_VIEW_UID }),
+          buildView({
+            universalIdentifier: THIRD_OVERVIEW_VIEW_UID,
+            objectUniversalIdentifier: ROCKET_UID,
+          }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [],
+    });
+
+    expect(
+      plan.writes
+        .filter((write) => write.kind === 'view')
+        .map((write) => write.relativePath)
+        .sort(),
+    ).toEqual([
+      `src/views/${OVERVIEW_VIEW_UID.slice(0, 8)}-pet-overview.view.ts`,
+      `src/views/${SECOND_OVERVIEW_VIEW_UID.slice(0, 8)}-pet-overview.view.ts`,
+      'src/views/rocket-overview.view.ts',
     ]);
   });
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
@@ -590,6 +590,47 @@ describe('planPullWrites', () => {
     ]);
   });
 
+  it('should keep a qualified file name within the length cap', () => {
+    const longName = 'x'.repeat(100);
+    const plan = planPullWrites({
+      manifest: {
+        ...buildManifest([
+          buildObject({
+            universalIdentifier: PET_UID,
+            nameSingular: 'pet',
+            labelIdentifierFieldMetadataUniversalIdentifier: NAME_FIELD_UID,
+          }),
+          buildObject({
+            universalIdentifier: ROCKET_UID,
+            nameSingular: 'rocket',
+            labelIdentifierFieldMetadataUniversalIdentifier:
+              ROCKET_NAME_FIELD_UID,
+          }),
+        ]),
+        views: [
+          buildView({ universalIdentifier: OVERVIEW_VIEW_UID, name: longName }),
+          buildView({
+            universalIdentifier: SECOND_OVERVIEW_VIEW_UID,
+            name: longName,
+            objectUniversalIdentifier: ROCKET_UID,
+          }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [],
+    });
+
+    expect(
+      plan.writes
+        .filter((write) => write.kind === 'view')
+        .map((write) => write.relativePath)
+        .sort(),
+    ).toEqual([
+      `src/views/pet-${'x'.repeat(76)}.view.ts`,
+      `src/views/rocket-${'x'.repeat(73)}.view.ts`,
+    ]);
+  });
+
   it('should leave an unchanged view untouched and regenerate the view whose filter changed on the server', () => {
     const scannedFiles: ScannedDefineFile[] = [
       {

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/pull-base-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/pull-base-file.spec.ts
@@ -1,0 +1,164 @@
+import {
+  PULL_BASE_FILE_PATH,
+  readPullBaseManifest,
+  writePullBaseManifest,
+} from '@/cli/utilities/pull/pull-base-file';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { type Manifest } from 'twenty-shared/application';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const APP_UID = '11111111-1111-4111-8111-111111111111';
+const PET_UID = '22222222-2222-4222-8222-222222222222';
+const NAME_FIELD_UID = '33333333-3333-4333-8333-333333333333';
+const VIEW_UID = '44444444-4444-4444-8444-444444444444';
+const VIEW_FIELD_UID = '55555555-5555-4555-8555-555555555555';
+
+const MANIFEST = {
+  application: {
+    universalIdentifier: APP_UID,
+    displayName: 'Pets',
+    description: '',
+    defaultRoleUniversalIdentifier: 'role-uid',
+  },
+  objects: [
+    {
+      universalIdentifier: PET_UID,
+      nameSingular: 'pet',
+      namePlural: 'pets',
+      labelSingular: 'Pet',
+      labelPlural: 'Pets',
+      labelIdentifierFieldMetadataUniversalIdentifier: NAME_FIELD_UID,
+      fields: [
+        {
+          universalIdentifier: NAME_FIELD_UID,
+          name: 'name',
+          label: 'Name',
+          type: 'TEXT',
+        },
+      ],
+    },
+  ],
+  fields: [],
+  indexes: [],
+  views: [
+    {
+      universalIdentifier: VIEW_UID,
+      name: 'Overview',
+      objectUniversalIdentifier: PET_UID,
+    },
+  ],
+  viewFields: [
+    {
+      universalIdentifier: VIEW_FIELD_UID,
+      viewUniversalIdentifier: VIEW_UID,
+      fieldMetadataUniversalIdentifier: NAME_FIELD_UID,
+      position: 0,
+    },
+  ],
+} as unknown as Manifest;
+
+describe('pull base file', () => {
+  let appPath: string;
+
+  beforeEach(async () => {
+    appPath = await mkdtemp(join(tmpdir(), 'pull-base-file-'));
+  });
+
+  afterEach(async () => {
+    await rm(appPath, { recursive: true, force: true });
+  });
+
+  const readBase = (applicationUniversalIdentifier = APP_UID) =>
+    readPullBaseManifest({ appPath, applicationUniversalIdentifier });
+
+  const writeRawBaseFile = async (content: string) => {
+    const baseFilePath = join(appPath, PULL_BASE_FILE_PATH);
+
+    await mkdir(dirname(baseFilePath), { recursive: true });
+    await writeFile(baseFilePath, content);
+  };
+
+  it('should read back the manifest it wrote', async () => {
+    await writePullBaseManifest({ appPath, manifest: MANIFEST });
+
+    expect(await readBase()).toEqual(MANIFEST);
+  });
+
+  it('should ignore a base written for another application', async () => {
+    await writePullBaseManifest({ appPath, manifest: MANIFEST });
+
+    expect(await readBase('another-application-identifier')).toBeNull();
+  });
+
+  it('should ignore a base written with another file version', async () => {
+    await writeRawBaseFile(
+      JSON.stringify({
+        version: 999,
+        applicationUniversalIdentifier: APP_UID,
+        manifest: MANIFEST,
+      }),
+    );
+
+    expect(await readBase()).toBeNull();
+  });
+
+  it('should read back a base whose manifest has no views and no view fields', async () => {
+    const {
+      views: _views,
+      viewFields: _viewFields,
+      ...manifestWithoutViews
+    } = MANIFEST;
+
+    await writeRawBaseFile(
+      JSON.stringify({
+        version: 1,
+        applicationUniversalIdentifier: APP_UID,
+        manifest: manifestWithoutViews,
+      }),
+    );
+
+    expect(await readBase()).toEqual(manifestWithoutViews);
+  });
+
+  it('should ignore a base whose views contain an entry without a universal identifier', async () => {
+    await writeRawBaseFile(
+      JSON.stringify({
+        version: 1,
+        applicationUniversalIdentifier: APP_UID,
+        manifest: {
+          ...MANIFEST,
+          views: [{ name: 'Overview', objectUniversalIdentifier: PET_UID }],
+        },
+      }),
+    );
+
+    expect(await readBase()).toBeNull();
+  });
+
+  it('should ignore a base whose view fields are not a list', async () => {
+    await writeRawBaseFile(
+      JSON.stringify({
+        version: 1,
+        applicationUniversalIdentifier: APP_UID,
+        manifest: {
+          ...MANIFEST,
+          viewFields: { universalIdentifier: VIEW_FIELD_UID },
+        },
+      }),
+    );
+
+    expect(await readBase()).toBeNull();
+  });
+
+  it('should return null when no base file has been written', async () => {
+    expect(await readBase()).toBeNull();
+  });
+
+  it('should return null when the base file is not valid JSON', async () => {
+    await writeRawBaseFile('{ "version": 1, ');
+
+    expect(await readBase()).toBeNull();
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/write-define-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/write-define-file.spec.ts
@@ -2,6 +2,8 @@ import {
   FIELD_ENUM_BINDINGS,
   INDEX_ENUM_BINDINGS,
   OBJECT_ENUM_BINDINGS,
+  VIEW_ENUM_BINDINGS,
+  VIEW_FIELD_ENUM_BINDINGS,
   writeDefineFile,
 } from '@/cli/utilities/pull/write-define-file';
 import { describe, expect, it } from 'vitest';
@@ -120,6 +122,138 @@ describe('writeDefineFile', () => {
         'export default defineObject({\n' +
         "  nameSingular: 'pet',\n" +
         '});\n',
+    );
+  });
+
+  it('should write every bound view property as its enum symbol and import each symbol on its own line', () => {
+    const file = writeDefineFile({
+      definer: 'defineView',
+      config: {
+        universalIdentifier: 'view-uid',
+        name: 'Companies by owner',
+        objectUniversalIdentifier: 'object-uid',
+        type: 'TABLE_WIDGET',
+        visibility: 'WORKSPACE',
+        openRecordIn: 'SIDE_PANEL',
+        calendarLayout: 'MONTH',
+        kanbanAggregateOperation: 'COUNT',
+        fields: [
+          {
+            universalIdentifier: 'view-field-uid',
+            fieldMetadataUniversalIdentifier: 'field-uid',
+            position: 0,
+            aggregateOperation: 'COUNT_UNIQUE_VALUES',
+          },
+        ],
+        filters: [
+          {
+            universalIdentifier: 'view-filter-uid',
+            fieldMetadataUniversalIdentifier: 'field-uid',
+            operand: 'CONTAINS',
+            value: 'acme',
+          },
+        ],
+        filterGroups: [
+          {
+            universalIdentifier: 'view-filter-group-uid',
+            logicalOperator: 'NOT',
+          },
+        ],
+        sorts: [
+          {
+            universalIdentifier: 'view-sort-uid',
+            fieldMetadataUniversalIdentifier: 'field-uid',
+            direction: 'DESC',
+          },
+        ],
+      },
+      enumBindings: VIEW_ENUM_BINDINGS,
+    });
+
+    expect(
+      file.startsWith(
+        'import {\n' +
+          '  defineView,\n' +
+          '  AggregateOperations,\n' +
+          '  ViewCalendarLayout,\n' +
+          '  ViewFilterGroupLogicalOperator,\n' +
+          '  ViewFilterOperand,\n' +
+          '  ViewOpenRecordIn,\n' +
+          '  ViewSortDirection,\n' +
+          '  ViewType,\n' +
+          '  ViewVisibility,\n' +
+          "} from 'twenty-sdk/define';\n",
+      ),
+    ).toBe(true);
+    expect(file).toContain('type: ViewType.TABLE_WIDGET,');
+    expect(file).toContain('visibility: ViewVisibility.WORKSPACE,');
+    expect(file).toContain('openRecordIn: ViewOpenRecordIn.SIDE_PANEL,');
+    expect(file).toContain('calendarLayout: ViewCalendarLayout.MONTH,');
+    expect(file).toContain(
+      'kanbanAggregateOperation: AggregateOperations.COUNT,',
+    );
+    expect(file).toContain(
+      'aggregateOperation: AggregateOperations.COUNT_UNIQUE_VALUES,',
+    );
+    expect(file).toContain('operand: ViewFilterOperand.CONTAINS,');
+    expect(file).toContain(
+      'logicalOperator: ViewFilterGroupLogicalOperator.NOT,',
+    );
+    expect(file).toContain('direction: ViewSortDirection.DESC,');
+  });
+
+  it('should leave a filter operand that is not a member of ViewFilterOperand as a literal', () => {
+    const file = writeDefineFile({
+      definer: 'defineView',
+      config: {
+        universalIdentifier: 'view-uid',
+        filters: [
+          {
+            universalIdentifier: 'view-filter-uid',
+            fieldMetadataUniversalIdentifier: 'field-uid',
+            operand: 'contains',
+            value: 'acme',
+          },
+        ],
+      },
+      enumBindings: VIEW_ENUM_BINDINGS,
+    });
+
+    expect(file).toContain("operand: 'contains',");
+    expect(file).toContain("import { defineView } from 'twenty-sdk/define';");
+  });
+
+  it('should not bind an operand that sits on the view itself rather than inside its filters', () => {
+    const file = writeDefineFile({
+      definer: 'defineView',
+      config: {
+        universalIdentifier: 'view-uid',
+        operand: 'CONTAINS',
+      },
+      enumBindings: VIEW_ENUM_BINDINGS,
+    });
+
+    expect(file).toContain("operand: 'CONTAINS',");
+    expect(file).toContain("import { defineView } from 'twenty-sdk/define';");
+  });
+
+  it('should write a standalone view field aggregate operation as an AggregateOperations member', () => {
+    const file = writeDefineFile({
+      definer: 'defineViewField',
+      config: {
+        universalIdentifier: 'view-field-uid',
+        viewUniversalIdentifier: 'view-uid',
+        fieldMetadataUniversalIdentifier: 'field-uid',
+        position: 0,
+        isVisible: true,
+        aggregateOperation: 'MIN',
+      },
+      enumBindings: VIEW_FIELD_ENUM_BINDINGS,
+    });
+
+    expect(file).toContain('aggregateOperation: AggregateOperations.MIN,');
+    expect(file).toContain(
+      "import { defineViewField, AggregateOperations } from 'twenty-sdk/define';",
     );
   });
 });

--- a/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
@@ -1,7 +1,10 @@
+import { isNonEmptyString } from '@sniptt/guards';
 import {
   FIELD_ENUM_BINDINGS,
   INDEX_ENUM_BINDINGS,
   OBJECT_ENUM_BINDINGS,
+  VIEW_ENUM_BINDINGS,
+  VIEW_FIELD_ENUM_BINDINGS,
   type EnumBinding,
 } from '@/cli/utilities/pull/write-define-file';
 import { kebabCase } from '@/cli/utilities/string/kebab-case';
@@ -9,8 +12,12 @@ import {
   type ApplicationManifest,
   type IndexManifest,
   type Manifest,
+  type StandaloneViewFieldManifest,
 } from 'twenty-shared/application';
-import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
+import {
+  STANDARD_OBJECT_FIELDS,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
+} from 'twenty-shared/metadata';
 import { isDefined } from 'twenty-shared/utils';
 
 export const PULL_ENTITY_KINDS = [
@@ -18,6 +25,8 @@ export const PULL_ENTITY_KINDS = [
   'object',
   'field',
   'index',
+  'view',
+  'viewField',
 ] as const;
 
 export type PullEntityKind = (typeof PULL_ENTITY_KINDS)[number];
@@ -38,6 +47,11 @@ export type SkippedPullEntity = {
   kind: PullEntityKind;
   universalIdentifier: string;
   reason: string;
+};
+
+type FieldLocation = {
+  objectName: string | null;
+  fieldName: string;
 };
 
 const APPLICATION_PROPERTIES_TO_STRIP = [
@@ -66,6 +80,48 @@ const STANDARD_OBJECT_NAME_BY_UNIVERSAL_IDENTIFIER = new Map<string, string>(
     ([name, universalIdentifier]) => [universalIdentifier, name] as const,
   ),
 );
+
+const STANDARD_FIELD_LOCATION_BY_UNIVERSAL_IDENTIFIER = new Map<
+  string,
+  FieldLocation
+>(
+  Object.entries(STANDARD_OBJECT_FIELDS).flatMap(([objectName, fields]) =>
+    Object.entries(fields).map(
+      ([fieldName, { universalIdentifier }]) =>
+        [universalIdentifier, { objectName, fieldName }] as const,
+    ),
+  ),
+);
+
+const MAX_FILE_BASE_NAME_LENGTH = 80;
+
+const WINDOWS_RESERVED_FILE_BASE_NAMES = new Set(['con', 'prn', 'aux', 'nul']);
+
+const toFileBaseName = ({
+  segments,
+  universalIdentifier,
+}: {
+  segments: (string | null)[];
+  universalIdentifier: string;
+}): string => {
+  const identifierPrefix = universalIdentifier.slice(0, 8);
+  const fileBaseName = segments
+    .filter(isDefined)
+    .map(kebabCase)
+    .join('-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_FILE_BASE_NAME_LENGTH)
+    .replace(/-+$/g, '');
+
+  if (!isNonEmptyString(fileBaseName)) {
+    return identifierPrefix;
+  }
+
+  return WINDOWS_RESERVED_FILE_BASE_NAMES.has(fileBaseName)
+    ? `${identifierPrefix}-${fileBaseName}`
+    : fileBaseName;
+};
 
 const buildApplicationConfig = (
   manifest: Manifest,
@@ -109,23 +165,45 @@ const getObjectName = ({
 const buildIndexFileBaseName = ({
   indexManifest,
   objectName,
-  fieldNameByUniversalIdentifier,
+  fieldLocationByUniversalIdentifier,
 }: {
   indexManifest: IndexManifest;
   objectName: string | null;
-  fieldNameByUniversalIdentifier: Map<string, string>;
+  fieldLocationByUniversalIdentifier: Map<string, FieldLocation>;
+}): string =>
+  toFileBaseName({
+    segments: [
+      objectName,
+      ...indexManifest.fields.map(
+        ({ fieldUniversalIdentifier }) =>
+          fieldLocationByUniversalIdentifier.get(fieldUniversalIdentifier)
+            ?.fieldName ?? null,
+      ),
+    ],
+    universalIdentifier: indexManifest.universalIdentifier,
+  });
+
+const buildViewFieldFileBaseName = ({
+  viewFieldManifest,
+  fieldLocationByUniversalIdentifier,
+}: {
+  viewFieldManifest: StandaloneViewFieldManifest;
+  fieldLocationByUniversalIdentifier: Map<string, FieldLocation>;
 }): string => {
-  const fieldNames = indexManifest.fields
-    .map(({ fieldUniversalIdentifier }) =>
-      fieldNameByUniversalIdentifier.get(fieldUniversalIdentifier),
-    )
-    .filter(isDefined);
+  const fieldLocation =
+    fieldLocationByUniversalIdentifier.get(
+      viewFieldManifest.fieldMetadataUniversalIdentifier,
+    ) ??
+    STANDARD_FIELD_LOCATION_BY_UNIVERSAL_IDENTIFIER.get(
+      viewFieldManifest.fieldMetadataUniversalIdentifier,
+    );
 
-  const segments = [objectName, ...fieldNames].filter(isDefined);
-
-  return segments.length > 0
-    ? segments.map(kebabCase).join('-')
-    : indexManifest.universalIdentifier.slice(0, 8);
+  return toFileBaseName({
+    segments: isDefined(fieldLocation)
+      ? [fieldLocation.objectName, fieldLocation.fieldName]
+      : [],
+    universalIdentifier: viewFieldManifest.universalIdentifier,
+  });
 };
 
 export const buildPullEntities = (
@@ -149,11 +227,14 @@ export const buildPullEntities = (
   });
 
   const writtenObjectUniversalIdentifiers = new Set<string>();
-  const fieldNameByUniversalIdentifier = new Map<string, string>();
+  const fieldLocationByUniversalIdentifier = new Map<string, FieldLocation>();
 
   for (const objectManifest of manifest.objects) {
     for (const field of objectManifest.fields) {
-      fieldNameByUniversalIdentifier.set(field.universalIdentifier, field.name);
+      fieldLocationByUniversalIdentifier.set(field.universalIdentifier, {
+        objectName: objectManifest.nameSingular,
+        fieldName: field.name,
+      });
     }
 
     writtenObjectUniversalIdentifiers.add(objectManifest.universalIdentifier);
@@ -172,14 +253,14 @@ export const buildPullEntities = (
   }
 
   for (const fieldManifest of manifest.fields) {
-    fieldNameByUniversalIdentifier.set(
-      fieldManifest.universalIdentifier,
-      fieldManifest.name,
-    );
-
     const objectName = getObjectName({
       objectUniversalIdentifier: fieldManifest.objectUniversalIdentifier,
       manifest,
+    });
+
+    fieldLocationByUniversalIdentifier.set(fieldManifest.universalIdentifier, {
+      objectName,
+      fieldName: fieldManifest.name,
     });
 
     entities.push({
@@ -190,9 +271,10 @@ export const buildPullEntities = (
       enumBindings: FIELD_ENUM_BINDINGS,
       defaultFolder: 'src/fields',
       fileSuffix: '.field.ts',
-      fileBaseName: isDefined(objectName)
-        ? `${kebabCase(objectName)}-${kebabCase(fieldManifest.name)}`
-        : kebabCase(fieldManifest.name),
+      fileBaseName: toFileBaseName({
+        segments: [objectName, fieldManifest.name],
+        universalIdentifier: fieldManifest.universalIdentifier,
+      }),
       parentName: objectName,
     });
   }
@@ -227,9 +309,46 @@ export const buildPullEntities = (
       fileBaseName: buildIndexFileBaseName({
         indexManifest,
         objectName,
-        fieldNameByUniversalIdentifier,
+        fieldLocationByUniversalIdentifier,
       }),
       parentName: objectName,
+    });
+  }
+
+  for (const viewManifest of manifest.views ?? []) {
+    entities.push({
+      kind: 'view',
+      universalIdentifier: viewManifest.universalIdentifier,
+      definer: 'defineView',
+      config: viewManifest,
+      enumBindings: VIEW_ENUM_BINDINGS,
+      defaultFolder: 'src/views',
+      fileSuffix: '.view.ts',
+      fileBaseName: toFileBaseName({
+        segments: [viewManifest.name],
+        universalIdentifier: viewManifest.universalIdentifier,
+      }),
+      parentName: getObjectName({
+        objectUniversalIdentifier: viewManifest.objectUniversalIdentifier,
+        manifest,
+      }),
+    });
+  }
+
+  for (const viewFieldManifest of manifest.viewFields ?? []) {
+    entities.push({
+      kind: 'viewField',
+      universalIdentifier: viewFieldManifest.universalIdentifier,
+      definer: 'defineViewField',
+      config: viewFieldManifest,
+      enumBindings: VIEW_FIELD_ENUM_BINDINGS,
+      defaultFolder: 'src/view-fields',
+      fileSuffix: '.view-field.ts',
+      fileBaseName: buildViewFieldFileBaseName({
+        viewFieldManifest,
+        fieldLocationByUniversalIdentifier,
+      }),
+      parentName: null,
     });
   }
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
@@ -1,4 +1,3 @@
-import { isNonEmptyString } from '@sniptt/guards';
 import {
   FIELD_ENUM_BINDINGS,
   INDEX_ENUM_BINDINGS,
@@ -7,18 +6,18 @@ import {
   VIEW_FIELD_ENUM_BINDINGS,
   type EnumBinding,
 } from '@/cli/utilities/pull/write-define-file';
+import {
+  buildIndexFileBaseName,
+  buildViewFieldFileBaseName,
+  type FieldLocation,
+  toFileBaseName,
+} from '@/cli/utilities/pull/pull-file-base-name';
 import { kebabCase } from '@/cli/utilities/string/kebab-case';
 import {
   type ApplicationManifest,
-  type IndexManifest,
   type Manifest,
-  type StandaloneViewFieldManifest,
 } from 'twenty-shared/application';
-import {
-  STANDARD_OBJECT_FIELDS,
-  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
-} from 'twenty-shared/metadata';
-import { isDefined } from 'twenty-shared/utils';
+import { STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
 
 export const PULL_ENTITY_KINDS = [
   'application',
@@ -49,11 +48,6 @@ export type SkippedPullEntity = {
   reason: string;
 };
 
-type FieldLocation = {
-  objectName: string | null;
-  fieldName: string;
-};
-
 const APPLICATION_PROPERTIES_TO_STRIP = [
   'packageJsonChecksum',
   'yarnLockChecksum',
@@ -80,41 +74,6 @@ const STANDARD_OBJECT_NAME_BY_UNIVERSAL_IDENTIFIER = new Map<string, string>(
     ([name, universalIdentifier]) => [universalIdentifier, name] as const,
   ),
 );
-
-const STANDARD_FIELD_LOCATION_BY_UNIVERSAL_IDENTIFIER = new Map<
-  string,
-  FieldLocation
->(
-  Object.entries(STANDARD_OBJECT_FIELDS).flatMap(([objectName, fields]) =>
-    Object.entries(fields).map(
-      ([fieldName, { universalIdentifier }]) =>
-        [universalIdentifier, { objectName, fieldName }] as const,
-    ),
-  ),
-);
-
-const MAX_FILE_BASE_NAME_LENGTH = 80;
-
-const toFileBaseName = ({
-  segments,
-  universalIdentifier,
-}: {
-  segments: (string | null)[];
-  universalIdentifier: string;
-}): string => {
-  const fileBaseName = segments
-    .filter(isDefined)
-    .map(kebabCase)
-    .join('-')
-    .replace(/-{2,}/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, MAX_FILE_BASE_NAME_LENGTH)
-    .replace(/-+$/g, '');
-
-  return isNonEmptyString(fileBaseName)
-    ? fileBaseName
-    : universalIdentifier.slice(0, 8);
-};
 
 const buildApplicationConfig = (
   manifest: Manifest,
@@ -154,50 +113,6 @@ const getObjectName = ({
   )?.nameSingular ??
   STANDARD_OBJECT_NAME_BY_UNIVERSAL_IDENTIFIER.get(objectUniversalIdentifier) ??
   null;
-
-const buildIndexFileBaseName = ({
-  indexManifest,
-  objectName,
-  fieldLocationByUniversalIdentifier,
-}: {
-  indexManifest: IndexManifest;
-  objectName: string | null;
-  fieldLocationByUniversalIdentifier: Map<string, FieldLocation>;
-}): string =>
-  toFileBaseName({
-    segments: [
-      objectName,
-      ...indexManifest.fields.map(
-        ({ fieldUniversalIdentifier }) =>
-          fieldLocationByUniversalIdentifier.get(fieldUniversalIdentifier)
-            ?.fieldName ?? null,
-      ),
-    ],
-    universalIdentifier: indexManifest.universalIdentifier,
-  });
-
-const buildViewFieldFileBaseName = ({
-  viewFieldManifest,
-  fieldLocationByUniversalIdentifier,
-}: {
-  viewFieldManifest: StandaloneViewFieldManifest;
-  fieldLocationByUniversalIdentifier: Map<string, FieldLocation>;
-}): string => {
-  const fieldLocation =
-    fieldLocationByUniversalIdentifier.get(
-      viewFieldManifest.fieldMetadataUniversalIdentifier,
-    ) ??
-    STANDARD_FIELD_LOCATION_BY_UNIVERSAL_IDENTIFIER.get(
-      viewFieldManifest.fieldMetadataUniversalIdentifier,
-    );
-
-  return toFileBaseName({
-    segments: isDefined(fieldLocation)
-      ? [fieldLocation.objectName, fieldLocation.fieldName]
-      : [],
-    universalIdentifier: viewFieldManifest.universalIdentifier,
-  });
-};
 
 export const buildPullEntities = (
   manifest: Manifest,

--- a/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
@@ -95,8 +95,6 @@ const STANDARD_FIELD_LOCATION_BY_UNIVERSAL_IDENTIFIER = new Map<
 
 const MAX_FILE_BASE_NAME_LENGTH = 80;
 
-const WINDOWS_RESERVED_FILE_BASE_NAMES = new Set(['con', 'prn', 'aux', 'nul']);
-
 const toFileBaseName = ({
   segments,
   universalIdentifier,
@@ -104,7 +102,6 @@ const toFileBaseName = ({
   segments: (string | null)[];
   universalIdentifier: string;
 }): string => {
-  const identifierPrefix = universalIdentifier.slice(0, 8);
   const fileBaseName = segments
     .filter(isDefined)
     .map(kebabCase)
@@ -114,13 +111,9 @@ const toFileBaseName = ({
     .slice(0, MAX_FILE_BASE_NAME_LENGTH)
     .replace(/-+$/g, '');
 
-  if (!isNonEmptyString(fileBaseName)) {
-    return identifierPrefix;
-  }
-
-  return WINDOWS_RESERVED_FILE_BASE_NAMES.has(fileBaseName)
-    ? `${identifierPrefix}-${fileBaseName}`
-    : fileBaseName;
+  return isNonEmptyString(fileBaseName)
+    ? fileBaseName
+    : universalIdentifier.slice(0, 8);
 };
 
 const buildApplicationConfig = (

--- a/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
@@ -4,6 +4,7 @@ import {
   type PullEntity,
   type PullEntityKind,
 } from '@/cli/utilities/pull/build-pull-entities';
+import { capFileBaseName } from '@/cli/utilities/pull/pull-file-base-name';
 import { type ScannedDefineFile } from '@/cli/utilities/pull/scan-project-define-files';
 import { writeDefineFile } from '@/cli/utilities/pull/write-define-file';
 import { kebabCase } from '@/cli/utilities/string/kebab-case';
@@ -97,7 +98,9 @@ const resolveFileBaseNames = (entities: PullEntity[]): Map<string, string> => {
 
     const qualifiedNames = collidingEntities.map((entity) =>
       isDefined(entity.parentName)
-        ? `${kebabCase(entity.parentName)}-${entity.fileBaseName}`
+        ? capFileBaseName(
+            `${kebabCase(entity.parentName)}-${entity.fileBaseName}`,
+          )
         : entity.fileBaseName,
     );
 
@@ -111,7 +114,9 @@ const resolveFileBaseNames = (entities: PullEntity[]): Map<string, string> => {
         entity.universalIdentifier,
         isQualifiedNameUnique
           ? qualifiedName
-          : `${entity.universalIdentifier.slice(0, 8)}-${qualifiedName}`,
+          : capFileBaseName(
+              `${entity.universalIdentifier.slice(0, 8)}-${qualifiedName}`,
+            ),
       );
     });
   }

--- a/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
@@ -100,15 +100,18 @@ const resolveFileBaseNames = (entities: PullEntity[]): Map<string, string> => {
         ? `${kebabCase(entity.parentName)}-${entity.fileBaseName}`
         : entity.fileBaseName,
     );
-    const hasUniqueQualifiedNames =
-      new Set(qualifiedNames).size === qualifiedNames.length;
 
     collidingEntities.forEach((entity, index) => {
+      const qualifiedName = qualifiedNames[index];
+      const isQualifiedNameUnique =
+        qualifiedNames.indexOf(qualifiedName) ===
+        qualifiedNames.lastIndexOf(qualifiedName);
+
       fileBaseNameByUniversalIdentifier.set(
         entity.universalIdentifier,
-        hasUniqueQualifiedNames
-          ? qualifiedNames[index]
-          : `${entity.universalIdentifier.slice(0, 8)}-${entity.fileBaseName}`,
+        isQualifiedNameUnique
+          ? qualifiedName
+          : `${entity.universalIdentifier.slice(0, 8)}-${qualifiedName}`,
       );
     });
   }

--- a/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
@@ -6,6 +6,7 @@ import {
 } from '@/cli/utilities/pull/build-pull-entities';
 import { type ScannedDefineFile } from '@/cli/utilities/pull/scan-project-define-files';
 import { writeDefineFile } from '@/cli/utilities/pull/write-define-file';
+import { kebabCase } from '@/cli/utilities/string/kebab-case';
 import { dirname, posix } from 'node:path';
 import { type Manifest } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
@@ -40,6 +41,8 @@ const ENTITY_KEY_BY_KIND: Record<PullEntityKind, ManifestEntityKey> = {
   object: ManifestEntityKey.Objects,
   field: ManifestEntityKey.Fields,
   index: ManifestEntityKey.Indexes,
+  view: ManifestEntityKey.Views,
+  viewField: ManifestEntityKey.ViewFields,
 };
 
 const toPosixPath = (value: string): string => value.split('\\').join('/');
@@ -94,7 +97,7 @@ const resolveFileBaseNames = (entities: PullEntity[]): Map<string, string> => {
 
     const qualifiedNames = collidingEntities.map((entity) =>
       isDefined(entity.parentName)
-        ? `${entity.parentName}-${entity.fileBaseName}`
+        ? `${kebabCase(entity.parentName)}-${entity.fileBaseName}`
         : entity.fileBaseName,
     );
     const hasUniqueQualifiedNames =

--- a/packages/twenty-sdk/src/cli/utilities/pull/pull-base-file.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/pull-base-file.ts
@@ -24,6 +24,9 @@ const hasUniversalIdentifier = (value: unknown): boolean =>
   typeof (value as { universalIdentifier?: unknown }).universalIdentifier ===
     'string';
 
+const isEntityList = (value: unknown): boolean =>
+  Array.isArray(value) && value.every(hasUniversalIdentifier);
+
 const isEntityListWithFields = (value: unknown): boolean =>
   Array.isArray(value) &&
   value.every(
@@ -37,7 +40,7 @@ const isUsableBaseManifest = (manifest: unknown): manifest is Manifest => {
     return false;
   }
 
-  const { application, objects, fields, indexes } =
+  const { application, objects, fields, indexes, views, viewFields } =
     manifest as Partial<Manifest>;
 
   return (
@@ -45,7 +48,9 @@ const isUsableBaseManifest = (manifest: unknown): manifest is Manifest => {
     isEntityListWithFields(objects) &&
     Array.isArray(fields) &&
     fields.every(hasUniversalIdentifier) &&
-    (!isDefined(indexes) || isEntityListWithFields(indexes))
+    (!isDefined(indexes) || isEntityListWithFields(indexes)) &&
+    (!isDefined(views) || isEntityList(views)) &&
+    (!isDefined(viewFields) || isEntityList(viewFields))
   );
 };
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/pull-file-base-name.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/pull-file-base-name.ts
@@ -1,0 +1,95 @@
+import { isNonEmptyString } from '@sniptt/guards';
+import { kebabCase } from '@/cli/utilities/string/kebab-case';
+import {
+  type IndexManifest,
+  type StandaloneViewFieldManifest,
+} from 'twenty-shared/application';
+import { STANDARD_OBJECT_FIELDS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+export type FieldLocation = {
+  objectName: string | null;
+  fieldName: string;
+};
+
+const MAX_FILE_BASE_NAME_LENGTH = 80;
+
+const STANDARD_FIELD_LOCATION_BY_UNIVERSAL_IDENTIFIER = new Map<
+  string,
+  FieldLocation
+>(
+  Object.entries(STANDARD_OBJECT_FIELDS).flatMap(([objectName, fields]) =>
+    Object.entries(fields).map(
+      ([fieldName, { universalIdentifier }]) =>
+        [universalIdentifier, { objectName, fieldName }] as const,
+    ),
+  ),
+);
+
+export const capFileBaseName = (fileBaseName: string): string =>
+  fileBaseName.slice(0, MAX_FILE_BASE_NAME_LENGTH).replace(/-+$/g, '');
+
+export const toFileBaseName = ({
+  segments,
+  universalIdentifier,
+}: {
+  segments: (string | null)[];
+  universalIdentifier: string;
+}): string => {
+  const fileBaseName = capFileBaseName(
+    segments
+      .filter(isDefined)
+      .map(kebabCase)
+      .join('-')
+      .replace(/-{2,}/g, '-')
+      .replace(/^-+|-+$/g, ''),
+  );
+
+  return isNonEmptyString(fileBaseName)
+    ? fileBaseName
+    : universalIdentifier.slice(0, 8);
+};
+
+export const buildIndexFileBaseName = ({
+  indexManifest,
+  objectName,
+  fieldLocationByUniversalIdentifier,
+}: {
+  indexManifest: IndexManifest;
+  objectName: string | null;
+  fieldLocationByUniversalIdentifier: Map<string, FieldLocation>;
+}): string =>
+  toFileBaseName({
+    segments: [
+      objectName,
+      ...indexManifest.fields.map(
+        ({ fieldUniversalIdentifier }) =>
+          fieldLocationByUniversalIdentifier.get(fieldUniversalIdentifier)
+            ?.fieldName ?? null,
+      ),
+    ],
+    universalIdentifier: indexManifest.universalIdentifier,
+  });
+
+export const buildViewFieldFileBaseName = ({
+  viewFieldManifest,
+  fieldLocationByUniversalIdentifier,
+}: {
+  viewFieldManifest: StandaloneViewFieldManifest;
+  fieldLocationByUniversalIdentifier: Map<string, FieldLocation>;
+}): string => {
+  const fieldLocation =
+    fieldLocationByUniversalIdentifier.get(
+      viewFieldManifest.fieldMetadataUniversalIdentifier,
+    ) ??
+    STANDARD_FIELD_LOCATION_BY_UNIVERSAL_IDENTIFIER.get(
+      viewFieldManifest.fieldMetadataUniversalIdentifier,
+    );
+
+  return toFileBaseName({
+    segments: isDefined(fieldLocation)
+      ? [fieldLocation.objectName, fieldLocation.fieldName]
+      : [],
+    universalIdentifier: viewFieldManifest.universalIdentifier,
+  });
+};

--- a/packages/twenty-sdk/src/cli/utilities/pull/write-define-file.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/write-define-file.ts
@@ -3,6 +3,7 @@ import {
   printTypescriptValue,
 } from '@/cli/utilities/pull/print-typescript-value';
 import {
+  AggregateOperations,
   DateDisplayFormat,
   FieldMetadataType,
   IndexType,
@@ -11,6 +12,13 @@ import {
   ObjectOpenRecordIn,
   RelationOnDeleteAction,
   RelationType,
+  ViewCalendarLayout,
+  ViewFilterGroupLogicalOperator,
+  ViewFilterOperand,
+  ViewOpenRecordIn,
+  ViewSortDirection,
+  ViewType,
+  ViewVisibility,
 } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -73,6 +81,48 @@ export const OBJECT_ENUM_BINDINGS: EnumBinding[] = [
 
 export const INDEX_ENUM_BINDINGS: EnumBinding[] = [
   { path: ['indexType'], symbol: 'IndexType', members: IndexType },
+];
+
+const buildAggregateOperationBinding = (path: string[]): EnumBinding => ({
+  path,
+  symbol: 'AggregateOperations',
+  members: AggregateOperations,
+});
+
+export const VIEW_FIELD_ENUM_BINDINGS: EnumBinding[] = [
+  buildAggregateOperationBinding(['aggregateOperation']),
+];
+
+export const VIEW_ENUM_BINDINGS: EnumBinding[] = [
+  { path: ['type'], symbol: 'ViewType', members: ViewType },
+  { path: ['visibility'], symbol: 'ViewVisibility', members: ViewVisibility },
+  {
+    path: ['openRecordIn'],
+    symbol: 'ViewOpenRecordIn',
+    members: ViewOpenRecordIn,
+  },
+  buildAggregateOperationBinding(['kanbanAggregateOperation']),
+  {
+    path: ['calendarLayout'],
+    symbol: 'ViewCalendarLayout',
+    members: ViewCalendarLayout,
+  },
+  buildAggregateOperationBinding(['fields', '[]', 'aggregateOperation']),
+  {
+    path: ['filters', '[]', 'operand'],
+    symbol: 'ViewFilterOperand',
+    members: ViewFilterOperand,
+  },
+  {
+    path: ['filterGroups', '[]', 'logicalOperator'],
+    symbol: 'ViewFilterGroupLogicalOperator',
+    members: ViewFilterGroupLogicalOperator,
+  },
+  {
+    path: ['sorts', '[]', 'direction'],
+    symbol: 'ViewSortDirection',
+    members: ViewSortDirection,
+  },
 ];
 
 const isSamePath = (left: string[], right: string[]): boolean =>


### PR DESCRIPTION
## What

`yarn twenty pull` now writes views and standalone view fields, the CLI half of the views slice whose server half is #25600.

## How

- Two new pull kinds: a view becomes `src/views/<name>.view.ts` (`defineView`, children inline), a standalone view field becomes `src/view-fields/<object>-<field>.view-field.ts` (`defineViewField`), with the field name resolved from the manifest or the standard object fields. Names that kebab-case to nothing fall back to the identifier prefix. Colliding names are qualified with the kebab-cased parent name (which also fixes a latent bug: the qualifier used the raw camelCase object name), and a name that still collides after that gets the identifier prefix on its qualified form, member by member: two "Overview" views on `pet` and one on `rocket` become `<id>-pet-overview`, `<id>-pet-overview` and `rocket-overview`, where the whole group used to be prefixed.
- Enum bindings for the eight view enums (`ViewType`, `ViewVisibility`, `ViewOpenRecordIn`, `ViewCalendarLayout`, `AggregateOperations` on both the view and its fields, `ViewFilterOperand`, `ViewFilterGroupLogicalOperator`, `ViewSortDirection`, nested under fields, filters, filter groups and sorts) so the written files typecheck against the real TypeScript enums.
- The planner infers folders for the new kinds, and the base file accepts `views`/`viewFields` as optional so bases written by the previous release still compare.
- Docs: `sync-and-recovery.mdx` lists what pull writes for views and the cases with no source form (filters, filter groups, sorts, groups and field groups placed on an engine default view or on a view owned by another application).
- File names are capped at 80 characters, since view names are free text and a single overlong name would otherwise fail the whole pull.

## Verification

- Round trip on a dev workspace against the merged server: an application assembled from the rich-app fixture's objects, fields, indexes and views (five views including a kanban with groups and a standalone view field on the app's own view) pushed with `apply` (172 rows), pulled into a fresh project (13 files, locales included), and `plan --no-delete` reports "No changes". On the earlier build of this branch, `apply --no-delete` pushed the pulled tree back with no actions and a second pull left every file unchanged; the workspace's own Custom application with three UI-created views on `person` behaved the same, and a pruning plan never touched a view.
- Unit specs for the entity builder, enum bindings, planner and base file; the offline round-trip spec now builds a view with every child kind and a standalone view field back to the exported manifest.

## Notes

- A standalone view field declared on one of the application's own views is pulled inline into that view: the flat row is identical either way.
- A view name that kebab-cases to nothing (punctuation or emoji only) falls back to the identifier prefix rather than an empty segment; `toFileBaseName` normalises field and index file names the same way.
