### PR TITLE
Enforce role object permissions on writes to system objects

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -127,6 +127,7 @@ export class TimelineCalendarEventService {
       const callRecordingRepository =
         this.workspaceOrmManager.getRepository<CallRecordingWorkspaceEntity>(
           'callRecording',
+          { shouldBypassPermissionChecks: true },
         );
 
       const callRecordings = await callRecordingRepository.find({

--- a/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
@@ -57,6 +57,7 @@ export class TimelineMessagingService {
       const messageThreadRepository =
         this.workspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
           'messageThread',
+          { shouldBypassPermissionChecks: true },
         );
 
       const totalQueryBuilder = messageThreadRepository
@@ -149,6 +150,7 @@ export class TimelineMessagingService {
       const messageParticipantRepository =
         this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
           'messageParticipant',
+          { shouldBypassPermissionChecks: true },
         );
 
       const threadParticipants = await messageParticipantRepository
@@ -285,6 +287,7 @@ export class TimelineMessagingService {
       const messageThreadRepository =
         this.workspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
           'messageThread',
+          { shouldBypassPermissionChecks: true },
         );
 
       const threadChannelRows = await messageThreadRepository

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
@@ -277,6 +277,7 @@ export class EmailComposerService {
       const messageRepository =
         this.workspaceOrmManager.getRepository<MessageWorkspaceEntity>(
           'message',
+          { shouldBypassPermissionChecks: true },
         );
 
       const parentMessage = await messageRepository.findOne({
@@ -294,6 +295,7 @@ export class EmailComposerService {
       const associationRepository =
         this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
           'messageChannelMessageAssociation',
+          { shouldBypassPermissionChecks: true },
         );
 
       const [association, ancestorMessages] = await Promise.all([

--- a/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
@@ -1,6 +1,5 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import isEmpty from 'lodash.isempty';
-import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   type ObjectsPermissions,
   type RestrictedFieldsPermissions,
@@ -20,9 +19,6 @@ import {
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { validateWritabilityOrThrow } from 'src/engine/twenty-orm/repository/validate-writability-or-throw.util';
 import { getColumnNameToFieldMetadataIdMap } from 'src/engine/twenty-orm/utils/get-column-name-to-field-metadata-id.util';
-
-const WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER =
-  STANDARD_OBJECTS.workspaceMember.universalIdentifier;
 
 export type OperationType =
   | 'select'
@@ -91,16 +87,6 @@ export const validateOperationIsPermittedOrThrow = ({
     flatFieldMetadataMaps,
     authContext,
   });
-
-  const objectMetadataIsSystem = objectMetadata.isSystem === true;
-  const isWorkspaceMemberObject =
-    objectMetadata.universalIdentifier ===
-    WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER;
-
-  // TODO: this should be improved, we may have more complex permission configuration for is system objects
-  if (objectMetadataIsSystem && !isWorkspaceMemberObject) {
-    return;
-  }
 
   const permissionsForEntity = objectsPermissions[objectMetadataIdForEntity];
 

--- a/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
+++ b/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
@@ -37,6 +37,9 @@ export class BlocklistRepository {
     return this.workspaceOrmManager.executeInWorkspaceContext(async () => {
       const blockListRepository = this.workspaceOrmManager.getRepository(
         BlocklistWorkspaceEntity,
+        {
+          shouldBypassPermissionChecks: true,
+        },
       );
 
       return blockListRepository.find({

--- a/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-cleaner/services/calendar-event-cleaner.service.ts
@@ -32,6 +32,7 @@ export class CalendarEventCleanerService {
             const calendarChannelEventAssociationRepository =
               transactionScope.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
                 'calendarChannelEventAssociation',
+                { shouldBypassPermissionChecks: true },
               );
 
             for (;;) {
@@ -82,10 +83,12 @@ export class CalendarEventCleanerService {
             const calendarEventRepository =
               transactionScope.getRepository<CalendarEventWorkspaceEntity>(
                 'calendarEvent',
+                { shouldBypassPermissionChecks: true },
               );
             const calendarChannelEventAssociationRepository =
               transactionScope.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
                 'calendarChannelEventAssociation',
+                { shouldBypassPermissionChecks: true },
               );
 
             for (
@@ -134,10 +137,12 @@ export class CalendarEventCleanerService {
             const calendarEventRepository =
               transactionScope.getRepository<CalendarEventWorkspaceEntity>(
                 'calendarEvent',
+                { shouldBypassPermissionChecks: true },
               );
             const calendarChannelEventAssociationRepository =
               transactionScope.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
                 'calendarChannelEventAssociation',
+                { shouldBypassPermissionChecks: true },
               );
 
             let cursor: string | undefined;

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-events-import.service.ts
@@ -154,6 +154,7 @@ export class CalendarEventsImportService {
             const calendarChannelEventAssociationRepository =
               this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
                 'calendarChannelEventAssociation',
+                { shouldBypassPermissionChecks: true },
               );
 
             const associationsToDelete =

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -63,6 +63,7 @@ export class CalendarFetchEventsService {
             const calendarChannelEventAssociationRepository =
               this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
                 'calendarChannelEventAssociation',
+                { shouldBypassPermissionChecks: true },
               );
 
             const associationsToDelete =

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
@@ -34,6 +34,7 @@ export class CalendarSaveEventsService {
           const calendarChannelEventAssociationRepository =
             this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
               'calendarChannelEventAssociation',
+              { shouldBypassPermissionChecks: true },
             );
 
           const existingAssociations =
@@ -79,11 +80,13 @@ export class CalendarSaveEventsService {
               const calendarEventRepository =
                 transactionScope.getRepository<CalendarEventWorkspaceEntity>(
                   'calendarEvent',
+                  { shouldBypassPermissionChecks: true },
                 );
 
               const associationRepository =
                 transactionScope.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
                   'calendarChannelEventAssociation',
+                  { shouldBypassPermissionChecks: true },
                 );
 
               if (saveOperations.calendarEventsToInsert.length > 0) {

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/services/calendar-event-participant.service.ts
@@ -38,6 +38,7 @@ export class CalendarEventParticipantService {
     const calendarEventParticipantRepository =
       this.workspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
         'calendarEventParticipant',
+        { shouldBypassPermissionChecks: true },
       );
 
     return calendarEventParticipantRepository.find({
@@ -55,6 +56,7 @@ export class CalendarEventParticipantService {
     const calendarEventParticipantRepository =
       transactionScope.getRepository<CalendarEventParticipantWorkspaceEntity>(
         'calendarEventParticipant',
+        { shouldBypassPermissionChecks: true },
       );
 
     if (operations.participantIdsToDelete.length > 0) {
@@ -98,6 +100,7 @@ export class CalendarEventParticipantService {
         const calendarEventParticipantRepository =
           this.workspaceOrmManager.getRepository<CalendarEventParticipantWorkspaceEntity>(
             'calendarEventParticipant',
+            { shouldBypassPermissionChecks: true },
           );
 
         const savedParticipants: CalendarEventParticipantWorkspaceEntity[] = [];

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -39,6 +39,7 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
         const calendarChannelEventAssociationRepository =
           this.workspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
             'calendarChannelEventAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         const calendarChannelCalendarEventsAssociations =

--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -78,6 +78,7 @@ export class MatchParticipantService<
         objectMetadataName,
         transactionScope,
         workspaceOrmManager: this.workspaceOrmManager,
+        rolePermissionConfig: { shouldBypassPermissionChecks: true },
       },
     );
   }

--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
@@ -56,6 +56,7 @@ export class BlocklistItemDeleteMessagesJob {
         const blocklistRepository =
           this.workspaceOrmManager.getRepository<BlocklistWorkspaceEntity>(
             'blocklist',
+            { shouldBypassPermissionChecks: true },
           );
 
         const blocklist = await blocklistRepository.find({
@@ -90,6 +91,7 @@ export class BlocklistItemDeleteMessagesJob {
         const messageChannelMessageAssociationRepository =
           this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         const workspaceMemberRepository =

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -40,6 +40,7 @@ export class ApplyMessagesVisibilityRestrictionsService {
         const messageChannelMessageAssociationRepository =
           this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         const messageChannelMessagesAssociations =

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -38,14 +38,19 @@ export class MessagingMessageCleanerService {
         await this.workspaceOrmManager.runInWorkspaceTransaction(
           async (transactionScope) => {
             const messageRepository =
-              transactionScope.getRepository<MessageWorkspaceEntity>('message');
+              transactionScope.getRepository<MessageWorkspaceEntity>(
+                'message',
+                { shouldBypassPermissionChecks: true },
+              );
             const messageChannelMessageAssociationRepository =
               transactionScope.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
                 'messageChannelMessageAssociation',
+                { shouldBypassPermissionChecks: true },
               );
             const messageThreadRepository =
               transactionScope.getRepository<MessageThreadWorkspaceEntity>(
                 'messageThread',
+                { shouldBypassPermissionChecks: true },
               );
 
             for (const messageExternalIdsChunk of chunk(
@@ -148,6 +153,7 @@ export class MessagingMessageCleanerService {
             const messageChannelMessageAssociationRepository =
               transactionScope.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
                 'messageChannelMessageAssociation',
+                { shouldBypassPermissionChecks: true },
               );
 
             for (;;) {
@@ -188,12 +194,17 @@ export class MessagingMessageCleanerService {
             const messageThreadRepository =
               transactionScope.getRepository<MessageThreadWorkspaceEntity>(
                 'messageThread',
+                { shouldBypassPermissionChecks: true },
               );
             const messageRepository =
-              transactionScope.getRepository<MessageWorkspaceEntity>('message');
+              transactionScope.getRepository<MessageWorkspaceEntity>(
+                'message',
+                { shouldBypassPermissionChecks: true },
+              );
             const messageChannelMessageAssociationRepository =
               transactionScope.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
                 'messageChannelMessageAssociation',
+                { shouldBypassPermissionChecks: true },
               );
 
             await this.deleteOrphansByKeyset(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-folder-messages.service.ts
@@ -42,11 +42,13 @@ export class MessagingDeleteFolderMessagesService {
         const messageFolderAssociationRepository =
           this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
             'messageChannelMessageAssociationMessageFolder',
+            { shouldBypassPermissionChecks: true },
           );
 
         const messageChannelMessageAssociationRepository =
           this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         let hasMoreData = true;

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
@@ -42,11 +42,13 @@ export class MessagingDeleteGroupEmailMessagesService {
         const messageChannelMessageAssociationRepository =
           this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         const messageParticipantRepository =
           this.workspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
             'messageParticipant',
+            { shouldBypassPermissionChecks: true },
           );
 
         let cursorId: string | undefined;

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-folder-association.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-folder-association.service.ts
@@ -37,6 +37,7 @@ export class MessagingMessageFolderAssociationService {
         const repository =
           transactionScope.getRepository<MessageChannelMessageAssociationMessageFolderWorkspaceEntity>(
             'messageChannelMessageAssociationMessageFolder',
+            { shouldBypassPermissionChecks: true },
           );
 
         const existingRecords = await repository.find({

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -150,6 +150,7 @@ export class MessagingMessageListFetchService {
           const messageChannelMessageAssociationRepository =
             this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
               'messageChannelMessageAssociation',
+              { shouldBypassPermissionChecks: true },
             );
 
           const messageExternalIdsChunks = chunk(messageExternalIds, 200);
@@ -346,6 +347,7 @@ export class MessagingMessageListFetchService {
     const messageChannelMessageAssociationRepository =
       this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
         'messageChannelMessageAssociation',
+        { shouldBypassPermissionChecks: true },
       );
 
     const fullSyncMessageChannelMessageAssociationsToDelete = [];

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
@@ -64,14 +64,18 @@ export class MessagingMessageService {
         const messageChannelMessageAssociationRepository =
           transactionScope.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         const messageRepository =
-          transactionScope.getRepository<MessageWorkspaceEntity>('message');
+          transactionScope.getRepository<MessageWorkspaceEntity>('message', {
+            shouldBypassPermissionChecks: true,
+          });
 
         const messageThreadRepository =
           transactionScope.getRepository<MessageThreadWorkspaceEntity>(
             'messageThread',
+            { shouldBypassPermissionChecks: true },
           );
 
         const messageAccumulatorMap = new Map<string, MessageAccumulator>();

--- a/packages/twenty-server/src/modules/messaging/message-outbound-manager/services/messaging-draft-send.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-outbound-manager/services/messaging-draft-send.service.ts
@@ -69,6 +69,7 @@ export class MessagingDraftSendService {
         const messageChannelMessageAssociationRepository =
           this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
             'messageChannelMessageAssociation',
+            { shouldBypassPermissionChecks: true },
           );
 
         const association =
@@ -137,6 +138,7 @@ export class MessagingDraftSendService {
           const messageChannelMessageAssociationRepository =
             this.workspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
               'messageChannelMessageAssociation',
+              { shouldBypassPermissionChecks: true },
             );
 
           return messageChannelMessageAssociationRepository.find({

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/services/messaging-message-participant.service.ts
@@ -28,6 +28,7 @@ export class MessagingMessageParticipantService {
         const messageParticipantRepository =
           transactionScope.getRepository<MessageParticipantWorkspaceEntity>(
             'messageParticipant',
+            { shouldBypassPermissionChecks: true },
           );
 
         const existingParticipantsBasedOnMessageIds =

--- a/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
@@ -29,6 +29,7 @@ export class NotePostQueryHookService {
       const noteTargetRepository =
         this.workspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
           'noteTarget',
+          { shouldBypassPermissionChecks: true },
         );
 
       await noteTargetRepository.softDelete({
@@ -53,6 +54,7 @@ export class NotePostQueryHookService {
       const noteTargetRepository =
         this.workspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
           'noteTarget',
+          { shouldBypassPermissionChecks: true },
         );
 
       await noteTargetRepository.restore({

--- a/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
@@ -29,6 +29,7 @@ export class TaskPostQueryHookService {
       const taskTargetRepository =
         this.workspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
           'taskTarget',
+          { shouldBypassPermissionChecks: true },
         );
 
       await taskTargetRepository.softDelete({
@@ -53,6 +54,7 @@ export class TaskPostQueryHookService {
       const taskTargetRepository =
         this.workspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
           'taskTarget',
+          { shouldBypassPermissionChecks: true },
         );
 
       await taskTargetRepository.restore({

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
@@ -31,6 +31,7 @@ export class AutomatedTriggerWorkspaceService {
       await transactionScope
         .getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
+          { shouldBypassPermissionChecks: true },
         )
         .insert({ type, settings, workflowId });
 
@@ -43,6 +44,7 @@ export class AutomatedTriggerWorkspaceService {
       const workflowAutomatedTriggerRepository =
         this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
+          { shouldBypassPermissionChecks: true },
         );
 
       await workflowAutomatedTriggerRepository.insert({
@@ -66,6 +68,7 @@ export class AutomatedTriggerWorkspaceService {
       await transactionScope
         .getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
+          { shouldBypassPermissionChecks: true },
         )
         .delete({ workflowId });
 
@@ -78,6 +81,7 @@ export class AutomatedTriggerWorkspaceService {
       const workflowAutomatedTriggerRepository =
         this.workspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           'workflowAutomatedTrigger',
+          { shouldBypassPermissionChecks: true },
         );
 
       await workflowAutomatedTriggerRepository.delete({ workflowId });

--- a/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/system-object-records-permissions.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/system-object-records-permissions.integration-spec.ts
@@ -1,0 +1,327 @@
+import { randomUUID } from 'node:crypto';
+
+import gql from 'graphql-tag';
+import { MESSAGE_GQL_FIELDS } from 'test/integration/constants/message-gql-fields.constants';
+import { PERSON_GQL_FIELDS } from 'test/integration/constants/person-gql-fields.constants';
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { deleteOneOperationFactory } from 'test/integration/graphql/utils/delete-one-operation-factory.util';
+import { destroyOneOperationFactory } from 'test/integration/graphql/utils/destroy-one-operation-factory.util';
+import { findOneOperationFactory } from 'test/integration/graphql/utils/find-one-operation-factory.util';
+import { generateApiKeyToken } from 'test/integration/graphql/utils/generate-api-key-token.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { updateOneOperationFactory } from 'test/integration/graphql/utils/update-one-operation-factory.util';
+import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
+import { upsertObjectPermissions } from 'test/integration/metadata/suites/object-permission/utils/upsert-object-permissions.util';
+import { createOneRole } from 'test/integration/metadata/suites/role/utils/create-one-role.util';
+import { deleteOneRole } from 'test/integration/metadata/suites/role/utils/delete-one-role.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { deleteRecordsByIds } from 'test/integration/utils/delete-records-by-ids';
+import { jestExpectToBeDefined } from 'test/utils/jest-expect-to-be-defined.util.test';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { PermissionsExceptionMessage } from 'src/engine/metadata-modules/permissions/permissions.exception';
+
+type GraphqlResponse = {
+  body: {
+    data: Record<string, unknown> | null;
+    errors?: { message: string; extensions: { code: string } }[];
+  };
+};
+
+const expectPermissionDenied = (response: GraphqlResponse) => {
+  expect(response.body.errors).toBeDefined();
+  expect(response.body.errors?.[0].message).toBe(
+    PermissionsExceptionMessage.PERMISSION_DENIED,
+  );
+  expect(response.body.errors?.[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+};
+
+const createApiKeyForRole = async ({
+  name,
+  roleId,
+}: {
+  name: string;
+  roleId: string;
+}) => {
+  const createApiKeyResponse = await makeMetadataAPIRequest({
+    query: gql`
+      mutation CreateApiKey($input: CreateApiKeyInput!) {
+        createApiKey(input: $input) {
+          id
+        }
+      }
+    `,
+    variables: {
+      input: {
+        name,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        roleId,
+      },
+    },
+  });
+
+  const apiKeyId: string | undefined =
+    createApiKeyResponse.body.data?.createApiKey?.id;
+
+  jestExpectToBeDefined(apiKeyId);
+
+  const tokenResponse = await generateApiKeyToken({
+    apiKeyId,
+    accessToken: APPLE_JANE_ADMIN_ACCESS_TOKEN,
+  });
+
+  const token: string | undefined =
+    tokenResponse.body.data?.generateApiKeyToken?.token;
+
+  jestExpectToBeDefined(token);
+
+  return { apiKeyId, token };
+};
+
+describe('systemObjectRecordsPermissions', () => {
+  const messageId = randomUUID();
+  const personId = randomUUID();
+
+  let readOnlyRoleId: string | undefined;
+  let readOnlyApiKeyId: string | undefined;
+  let readOnlyApiKeyToken: string;
+
+  let noOverrideRoleId: string | undefined;
+  let noOverrideApiKeyId: string | undefined;
+  let noOverrideApiKeyToken: string;
+
+  beforeAll(async () => {
+    const { objects } = await findManyObjectMetadata({
+      expectToFail: false,
+      input: { filter: {}, paging: { first: 1000 } },
+      gqlFields: 'id nameSingular',
+    });
+
+    const messageObjectMetadataId = objects.find(
+      (objectMetadata) => objectMetadata.nameSingular === 'message',
+    )?.id;
+    const messageThreadObjectMetadataId = objects.find(
+      (objectMetadata) => objectMetadata.nameSingular === 'messageThread',
+    )?.id;
+
+    jestExpectToBeDefined(messageObjectMetadataId);
+    jestExpectToBeDefined(messageThreadObjectMetadataId);
+
+    await makeGraphqlAPIRequest(
+      createOneOperationFactory({
+        objectMetadataSingularName: 'message',
+        gqlFields: MESSAGE_GQL_FIELDS,
+        data: {
+          id: messageId,
+          subject: 'System object permissions',
+          text: 'Original text',
+        },
+      }),
+    );
+
+    await makeGraphqlAPIRequest(
+      createOneOperationFactory({
+        objectMetadataSingularName: 'person',
+        gqlFields: PERSON_GQL_FIELDS,
+        data: { id: personId, jobTitle: 'Software Engineer' },
+      }),
+    );
+
+    const { data: readOnlyRoleData } = await createOneRole({
+      expectToFail: false,
+      input: {
+        label: 'Message read-only role',
+        description: 'API key role overriding messaging objects to read-only',
+        icon: 'IconKey',
+        canUpdateAllSettings: false,
+        canAccessAllTools: true,
+        canReadAllObjectRecords: true,
+        canUpdateAllObjectRecords: true,
+        canSoftDeleteAllObjectRecords: true,
+        canDestroyAllObjectRecords: true,
+        canBeAssignedToUsers: false,
+        canBeAssignedToAgents: false,
+        canBeAssignedToApiKeys: true,
+      },
+    });
+
+    readOnlyRoleId = readOnlyRoleData?.createOneRole?.id;
+    jestExpectToBeDefined(readOnlyRoleId);
+
+    await upsertObjectPermissions({
+      expectToFail: false,
+      input: {
+        roleId: readOnlyRoleId,
+        objectPermissions: [
+          messageObjectMetadataId,
+          messageThreadObjectMetadataId,
+        ].map((objectMetadataId) => ({
+          objectMetadataId,
+          canReadObjectRecords: true,
+          canUpdateObjectRecords: false,
+          canSoftDeleteObjectRecords: false,
+          canDestroyObjectRecords: false,
+        })),
+      },
+    });
+
+    ({ apiKeyId: readOnlyApiKeyId, token: readOnlyApiKeyToken } =
+      await createApiKeyForRole({
+        name: 'Message read-only key',
+        roleId: readOnlyRoleId,
+      }));
+
+    const { data: noOverrideRoleData } = await createOneRole({
+      expectToFail: false,
+      input: {
+        label: 'No write permissions role',
+        description: 'API key role with no override on system objects',
+        icon: 'IconKey',
+        canUpdateAllSettings: false,
+        canAccessAllTools: true,
+        canReadAllObjectRecords: true,
+        canUpdateAllObjectRecords: false,
+        canSoftDeleteAllObjectRecords: false,
+        canDestroyAllObjectRecords: false,
+        canBeAssignedToUsers: false,
+        canBeAssignedToAgents: false,
+        canBeAssignedToApiKeys: true,
+      },
+    });
+
+    noOverrideRoleId = noOverrideRoleData?.createOneRole?.id;
+    jestExpectToBeDefined(noOverrideRoleId);
+
+    ({ apiKeyId: noOverrideApiKeyId, token: noOverrideApiKeyToken } =
+      await createApiKeyForRole({
+        name: 'No write permissions key',
+        roleId: noOverrideRoleId,
+      }));
+  });
+
+  afterAll(async () => {
+    await deleteRecordsByIds('message', [messageId]);
+    await deleteRecordsByIds('person', [personId]);
+
+    for (const apiKeyId of [readOnlyApiKeyId, noOverrideApiKeyId]) {
+      if (isDefined(apiKeyId)) {
+        await global.testDataSource.query(
+          'DELETE FROM core."apiKey" WHERE id = $1',
+          [apiKeyId],
+        );
+      }
+    }
+
+    for (const roleId of [readOnlyRoleId, noOverrideRoleId]) {
+      if (isDefined(roleId)) {
+        await deleteOneRole({
+          expectToFail: false,
+          input: { idToDelete: roleId },
+        });
+      }
+    }
+  });
+
+  describe('API key whose role overrides message to read-only', () => {
+    it('should allow reading messages', async () => {
+      const response = await makeGraphqlAPIRequest(
+        findOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: MESSAGE_GQL_FIELDS,
+          filter: { subject: { eq: 'Meeting Request' } },
+        }),
+        readOnlyApiKeyToken,
+      );
+
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.message.subject).toBe('Meeting Request');
+    });
+
+    it('should deny updating a message', async () => {
+      const response = await makeGraphqlAPIRequest(
+        updateOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: MESSAGE_GQL_FIELDS,
+          recordId: messageId,
+          data: { text: 'Updated by a read-only key' },
+        }),
+        readOnlyApiKeyToken,
+      );
+
+      expectPermissionDenied(response);
+    });
+
+    it('should deny soft-deleting a message', async () => {
+      const response = await makeGraphqlAPIRequest(
+        deleteOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: 'id',
+          recordId: messageId,
+        }),
+        readOnlyApiKeyToken,
+      );
+
+      expectPermissionDenied(response);
+    });
+
+    it('should deny destroying a message', async () => {
+      const response = await makeGraphqlAPIRequest(
+        destroyOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: 'id',
+          recordId: messageId,
+        }),
+        readOnlyApiKeyToken,
+      );
+
+      expectPermissionDenied(response);
+    });
+
+    it('should deny creating a message thread', async () => {
+      const response = await makeGraphqlAPIRequest(
+        createOneOperationFactory({
+          objectMetadataSingularName: 'messageThread',
+          gqlFields: 'id',
+          data: { id: randomUUID() },
+        }),
+        readOnlyApiKeyToken,
+      );
+
+      expectPermissionDenied(response);
+    });
+  });
+
+  describe('API key whose role has no override on message', () => {
+    it('should allow updating a message through the system object default', async () => {
+      const response = await makeGraphqlAPIRequest(
+        updateOneOperationFactory({
+          objectMetadataSingularName: 'message',
+          gqlFields: MESSAGE_GQL_FIELDS,
+          recordId: messageId,
+          data: { text: 'Updated through the system object default' },
+        }),
+        noOverrideApiKeyToken,
+      );
+
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.updateMessage.text).toBe(
+        'Updated through the system object default',
+      );
+    });
+
+    it('should deny updating a standard object', async () => {
+      const response = await makeGraphqlAPIRequest(
+        updateOneOperationFactory({
+          objectMetadataSingularName: 'person',
+          gqlFields: PERSON_GQL_FIELDS,
+          recordId: personId,
+          data: { jobTitle: 'Senior Software Engineer' },
+        }),
+        noOverrideApiKeyToken,
+      );
+
+      expectPermissionDenied(response);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #24309

## Bug

A role holding read-only `objectPermissions` overrides on a system object (`message`, `messageThread`, `messageParticipant`, ...) could still update, soft-delete, destroy and create its records. With `canRead: true` and `canUpdate / canSoftDelete / canDestroy: false` on `message`, an API key assigned that role could still run `updateMessage`, `deleteMessage`, `destroyMessage` and `createMessageThread`. Reads behaved correctly, and the same override on a standard object denied writes as expected.

## Root cause

`validateOperationIsPermittedOrThrow` returned early for every system object except `workspaceMember`, before consulting the role's permissions. #23280 (d6c186a) already made explicit overrides win over the system-object default in `WorkspaceRolesPermissionsCacheService`, so the cache computed the right answer and the ORM validator threw it away.

## Fix

1. Delete the early return outright, along with the `STANDARD_OBJECTS` import and `WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER` constant it leaves unused, so the permissions cache stays the single source of truth for the system-object default. Roles that express no override still resolve to the permissive default through the cache, so nothing changes for them.

2. Declare the bypass explicitly on internal callers that were relying on the early return. `getRepository` without a `rolePermissionConfig` resolves to an empty, enforced permission map, which denies everything, so the 52 config-less calls on system objects (messaging and calendar import, cleaners, blocklist, visibility restriction hooks, note and task target hooks, timeline services, email composer, automated triggers) now pass `{ shouldBypassPermissionChecks: true }`. They all run under a system auth context or an internal query hook, so their behaviour is unchanged. `MatchParticipantService` reached the same shape through `getWorkspaceRepositoryWithOptionalTransaction` and got the same treatment, without it every message import batch failed with `PERMISSION_DENIED` during participant matching.

## Blast radius

- System objects with no role override: unchanged, the existing guest-role case in `update-one-object-records-permissions.integration-spec.ts` still passes.
- `workflowRun` and `workflowVersion` are system objects gated on the `WORKFLOWS` flag in the cache, so they move from never checked to checked at the ORM layer. This aligns them with `workflow`, which is not a system object and is already gated. The workflow engine writes `workflowRun` with `shouldBypassPermissionChecks: true` under a system context, and the AI workflow tools always carry a role config (the tool registry falls back to the role's own permissions), so a role without `WORKFLOWS` now sees consistent behaviour across the three objects.
- The API layer already required the matching settings permission on system objects, so nothing changes at that level.