### PR TITLE
Let app-driven agents reach dashboard and workflow tools

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/constants/__tests__/open-ended-agent-registry-tool-categories.const.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/constants/__tests__/open-ended-agent-registry-tool-categories.const.spec.ts
@@ -1,0 +1,33 @@
+import { ToolCategory } from 'twenty-shared/ai';
+
+import { OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES } from 'src/engine/metadata-modules/ai/ai-agent-execution/constants/open-ended-agent-registry-tool-categories.const';
+import { WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES } from 'src/engine/metadata-modules/ai/ai-agent-execution/constants/workflow-agent-registry-tool-categories.const';
+
+describe('OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES', () => {
+  it('exposes the permission-gated categories a member can reach in the app', () => {
+    expect(OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES).toContain(
+      ToolCategory.DASHBOARD,
+    );
+    expect(OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES).toContain(
+      ToolCategory.WORKFLOW,
+    );
+  });
+
+  it('keeps the categories that reshape the workspace out of reach', () => {
+    expect(OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES).toEqual(
+      expect.not.arrayContaining([
+        ToolCategory.METADATA,
+        ToolCategory.ROLE,
+        ToolCategory.WEBHOOK,
+        ToolCategory.LOGIC_FUNCTION,
+        ToolCategory.NAVIGATION_MENU_ITEM,
+      ]),
+    );
+  });
+
+  it('is a superset of the narrower workflow node categories', () => {
+    expect(OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES).toEqual(
+      expect.arrayContaining(WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/constants/open-ended-agent-registry-tool-categories.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/constants/open-ended-agent-registry-tool-categories.const.ts
@@ -1,0 +1,14 @@
+import { ToolCategory } from 'twenty-shared/ai';
+
+// Open-ended agents (runAgent / Slack) act for a resolved workspace member, so
+// their reach is bounded by that member's role, not by this list. DASHBOARD and
+// WORKFLOW are safe to expose because their providers gate on the LAYOUTS and
+// WORKFLOWS permission flags. The categories left out (METADATA, VIEW, ROLE,
+// WEBHOOK, NAVIGATION_MENU_ITEM, LOGIC_FUNCTION) have no such gate today, and
+// let a caller reshape the workspace rather than act on its records.
+export const OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES: ToolCategory[] = [
+  ToolCategory.DATABASE_CRUD,
+  ToolCategory.ACTION,
+  ToolCategory.DASHBOARD,
+  ToolCategory.WORKFLOW,
+];

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -43,6 +43,7 @@ import { isToolOutputSuccessful } from 'src/engine/core-modules/tool-provider/ut
 import { OUTPUT_NAVIGATION_TOOL_NAMES } from 'src/engine/core-modules/tool/tools/output-navigation-tool/constants/output-navigation-tool-names.constant';
 import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-operation-type.enum';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES } from 'src/engine/metadata-modules/ai/ai-agent-execution/constants/open-ended-agent-registry-tool-categories.const';
 import { WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES } from 'src/engine/metadata-modules/ai/ai-agent-execution/constants/workflow-agent-registry-tool-categories.const';
 import { type AgentExecutionResult } from 'src/engine/metadata-modules/ai/ai-agent-execution/types/agent-execution-result.type';
 import { type AgentToolLoadingStrategy } from 'src/engine/metadata-modules/ai/ai-agent-execution/types/agent-tool-loading-strategy.type';
@@ -215,7 +216,9 @@ export class AgentAsyncExecutorService {
       { userId, userWorkspaceId, rolePermissionConfig },
     );
 
-    const allowedCategories = new Set(WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES);
+    const allowedCategories = new Set(
+      OPEN_ENDED_AGENT_REGISTRY_TOOL_CATEGORIES,
+    );
     const excludedToolNames = new Set<string>(OUTPUT_NAVIGATION_TOOL_NAMES);
 
     const catalog = fullCatalog.filter(

--- a/packages/twenty-server/src/modules/dashboard/tools/__tests__/get-dashboard.tool.spec.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/__tests__/get-dashboard.tool.spec.ts
@@ -143,6 +143,7 @@ describe('get_dashboard tool', () => {
       >,
       {
         workspaceId: WORKSPACE_ID,
+        rolePermissionConfig: { shouldBypassPermissionChecks: true },
       },
     );
 

--- a/packages/twenty-server/src/modules/dashboard/tools/__tests__/list-dashboards.tool.spec.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/__tests__/list-dashboards.tool.spec.ts
@@ -1,0 +1,41 @@
+import { createListDashboardsTool } from 'src/modules/dashboard/tools/list-dashboards.tool';
+import { type DashboardToolDependencies } from 'src/modules/dashboard/tools/types/dashboard-tool-dependencies.type';
+
+const WORKSPACE_ID = '20202020-aaaa-4d02-bf25-6aeccf7ea419';
+const ROLE_ID = '20202020-bbbb-4d02-bf25-6aeccf7ea419';
+
+const buildDeps = () => {
+  const getRepository = jest.fn().mockReturnValue({
+    find: jest.fn().mockResolvedValue([]),
+  });
+
+  return {
+    getRepository,
+    deps: {
+      workspaceOrmManager: {
+        executeInWorkspaceContext: jest
+          .fn()
+          .mockImplementation(async (fn) => fn()),
+        getRepository,
+      },
+    } as unknown as Pick<DashboardToolDependencies, 'workspaceOrmManager'>,
+  };
+};
+
+describe('createListDashboardsTool', () => {
+  it('reads dashboards through the caller role rather than bypassing permissions', async () => {
+    const { deps, getRepository } = buildDeps();
+
+    const tool = createListDashboardsTool(deps, {
+      workspaceId: WORKSPACE_ID,
+      rolePermissionConfig: { intersectionOf: [ROLE_ID] },
+    });
+
+    const result = await tool.execute({});
+
+    expect(result.success).toBe(true);
+    expect(getRepository).toHaveBeenCalledWith('dashboard', {
+      intersectionOf: [ROLE_ID],
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
@@ -14,7 +14,7 @@ import {
   widgetTypeSchema,
 } from 'src/modules/dashboard/tools/schemas/widget.schema';
 import {
-  type DashboardToolContext,
+  type DashboardToolContextWithPermissions,
   type DashboardToolDependencies,
 } from 'src/modules/dashboard/tools/types/dashboard-tool-dependencies.type';
 import { type WidgetConfigurationInput } from 'src/modules/dashboard/tools/types/widget-configuration-input.type';
@@ -56,7 +56,7 @@ const createCompleteDashboardSchema = z.object({
 
 export const createCreateCompleteDashboardTool = (
   deps: DashboardToolDependencies,
-  context: DashboardToolContext,
+  context: DashboardToolContextWithPermissions,
 ) => ({
   name: 'create_complete_dashboard' as const,
   description: `Create a dashboard with layout, tab, and widgets.
@@ -232,7 +232,7 @@ AGGREGATION OPERATIONS: COUNT, SUM, AVG, MIN, MAX, COUNT_EMPTY, COUNT_NOT_EMPTY`
 
 const createDashboardRecord = async (
   deps: DashboardToolDependencies,
-  context: DashboardToolContext,
+  context: DashboardToolContextWithPermissions,
   title: string,
   pageLayoutId: string,
 ): Promise<string> => {
@@ -241,9 +241,7 @@ const createDashboardRecord = async (
   return deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
     const dashboardRepository = deps.workspaceOrmManager.getRepository(
       'dashboard',
-      {
-        shouldBypassPermissionChecks: true,
-      },
+      context.rolePermissionConfig,
     );
 
     const position = await deps.recordPositionService.buildRecordPosition({

--- a/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
@@ -8,7 +8,7 @@ import { findActiveFlatFieldMetadataById } from 'src/engine/metadata-modules/pag
 import { isChartReferencingFieldInConfiguration } from 'src/engine/metadata-modules/page-layout-widget/utils/is-chart-referencing-field-in-configuration.util';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
-  type DashboardToolContext,
+  type DashboardToolContextWithPermissions,
   type DashboardToolDependencies,
 } from 'src/modules/dashboard/tools/types/dashboard-tool-dependencies.type';
 import { buildResolvedGroupBy } from 'src/modules/dashboard/tools/utils/build-resolved-group-by.util';
@@ -22,7 +22,7 @@ export const createGetDashboardTool = (
     DashboardToolDependencies,
     'pageLayoutService' | 'workspaceOrmManager' | 'flatEntityMapsCacheService'
   >,
-  context: DashboardToolContext,
+  context: DashboardToolContextWithPermissions,
 ) => ({
   name: 'get_dashboard' as const,
   description: `Get a dashboard with its full layout structure including tabs and widgets.`,
@@ -70,9 +70,10 @@ export const createGetDashboardTool = (
 
       const dashboard =
         await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
-          const repo = deps.workspaceOrmManager.getRepository('dashboard', {
-            shouldBypassPermissionChecks: true,
-          });
+          const repo = deps.workspaceOrmManager.getRepository(
+            'dashboard',
+            context.rolePermissionConfig,
+          );
 
           return repo.findOne({ where: { id: parameters.dashboardId } });
         }, authContext);

--- a/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
-  type DashboardToolContext,
+  type DashboardToolContextWithPermissions,
   type DashboardToolDependencies,
 } from 'src/modules/dashboard/tools/types/dashboard-tool-dependencies.type';
 
@@ -18,7 +18,7 @@ const listDashboardsSchema = z.object({
 
 export const createListDashboardsTool = (
   deps: Pick<DashboardToolDependencies, 'workspaceOrmManager'>,
-  context: DashboardToolContext,
+  context: DashboardToolContextWithPermissions,
 ) => ({
   name: 'list_dashboards' as const,
   description: `List all dashboards in the workspace. Use get_dashboard to retrieve full layout structure.`,
@@ -30,9 +30,10 @@ export const createListDashboardsTool = (
 
       const dashboards =
         await deps.workspaceOrmManager.executeInWorkspaceContext(async () => {
-          const repo = deps.workspaceOrmManager.getRepository('dashboard', {
-            shouldBypassPermissionChecks: true,
-          });
+          const repo = deps.workspaceOrmManager.getRepository(
+            'dashboard',
+            context.rolePermissionConfig,
+          );
 
           return repo.find({ take: limit, order: { position: 'ASC' } });
         }, authContext);

--- a/packages/twenty-server/src/modules/dashboard/tools/services/dashboard-tool.workspace-service.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/services/dashboard-tool.workspace-service.ts
@@ -45,16 +45,23 @@ export class DashboardToolWorkspaceService {
 
   generateDashboardTools(
     workspaceId: string,
-    _rolePermissionConfig: RolePermissionConfig,
+    rolePermissionConfig: RolePermissionConfig,
   ): ToolSet {
     const context = { workspaceId };
+    const contextWithPermissions = { workspaceId, rolePermissionConfig };
 
     const createCompleteDashboard = createCreateCompleteDashboardTool(
       this.deps,
-      context,
+      contextWithPermissions,
     );
-    const listDashboards = createListDashboardsTool(this.deps, context);
-    const getDashboard = createGetDashboardTool(this.deps, context);
+    const listDashboards = createListDashboardsTool(
+      this.deps,
+      contextWithPermissions,
+    );
+    const getDashboard = createGetDashboardTool(
+      this.deps,
+      contextWithPermissions,
+    );
     const addDashboardTab = createAddDashboardTabTool(this.deps, context);
     const addDashboardWidget = createAddDashboardWidgetTool(this.deps, context);
     const updateDashboardWidget = createUpdateDashboardWidgetTool(


### PR DESCRIPTION
A workspace member with full permissions cannot create a dashboard or a workflow from the Slack assistant, and no permission grant changes that. Found while testing the Slack app on prod, but the defect is in the agent runtime, not in the Slack package.

## The bug

Agents started through `runAgent` build their tool catalog with `buildLazyRegistryTools`, which filtered it to `WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES`:

```ts
export const WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES: ToolCategory[] = [
  ToolCategory.DATABASE_CRUD,
  ToolCategory.ACTION,
];
```

`ToolCategory` has ten members. That constant exists for agent nodes inside a workflow, where a narrow scoped toolset is the point, and the open-ended path reused it. The filter runs *after* `provider.isAvailable` has already resolved the caller's permissions, so `DashboardToolProvider` correctly answers "this member holds `LAYOUTS`", and the result is then discarded. The comment above `buildLazyRegistryTools` says these agents "need broad object access", which is what the code was meant to do.

Record CRUD does not cover the gap:

- `dashboard` is in `OBJECTS_BLOCKED_FROM_AUTOMATION`, so `database-tool.provider.ts` never emits `create_one_dashboard`. Read tools are not gated, so the assistant can list dashboards but not create one, which is what made this look like a permissions problem.
- Workflow objects are dropped from the CRUD catalog outright by `isWorkflowRelatedObject`, so there is no read either.

`allowedToolNames` is derived from the filtered catalog and passed to `learn_tools` and `execute_tool` as `isToolAllowed`, enforced at call time, so there is no path to these tools even by name.

The in-app AI chat (`chat-execution.service.ts`) builds the index with no category filter, and MCP excludes by name list only. Same user, same role: works in the app, refused from Slack.

## The change

`buildLazyRegistryTools` gets its own category list with `DASHBOARD` and `WORKFLOW` added. `buildPreloadedRegistryTools` (workflow agent nodes) stays on the existing narrow constant.

Both added providers gate on permission flags (`LAYOUTS`, `WORKFLOWS`), so this grants nothing on its own. An unlinked Slack user still gets neither: they fall back to the Slack Assistant role, which carries only `SystemPermissionFlag.AI`. The categories that reshape the workspace rather than act on its records stay out.

`VIEW` was considered and left out. `ViewToolProvider.isAvailable` returns `true` unconditionally with no flag behind it, so including it would have handed view tools to unlinked Slack users. Whether that provider should be gated is a separate question.

## Dashboard tool permissions

`generateDashboardTools` took a `RolePermissionConfig` and ignored it (`_rolePermissionConfig`), and the three tools that touch dashboard records opened the repository with `shouldBypassPermissionChecks: true`. That was contained while the in-app chat was the only caller, since it already runs as the signed-in user, but not once an app token can reach these tools, which is exactly what the first half of this PR enables.

`create_complete_dashboard`, `get_dashboard` and `list_dashboards` now pass `context.rolePermissionConfig` through, as `create_complete_workflow` already does. `DashboardToolContextWithPermissions` already existed in the types file and was unused.

Layout metadata access is still gated only by the coarse `LAYOUTS` flag: the page-layout services do not take a role config. Tightening that reaches into `PageLayoutService` and friends and is better reviewed on its own.

## Test plan

- [x] `list-dashboards.tool.spec.ts` asserts the repository is opened with the caller's role config; fails against the previous bypass
- [x] A spec on the new constant pins `DASHBOARD` and `WORKFLOW` in, and `METADATA` / `ROLE` / `WEBHOOK` / `LOGIC_FUNCTION` / `NAVIGATION_MENU_ITEM` out
- [x] `tsgo -p tsconfig.json --noEmit` on twenty-server is clean
- [x] `nx lint:diff-with-main twenty-server`: 0 errors, formatting clean
- [x] Dashboard and tool-provider suites: 48 suites, 404 tests, all pass
- [ ] A linked admin asks the Slack assistant to create a dashboard and gets one
- [ ] An unlinked Slack user asking the same still gets refused
- [ ] Dashboards still list and open normally from the in-app AI chat under a non-admin role

The last three need a running stack against a real Slack workspace and are not covered by the unit tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVj51vPJYMhvfkRoppynJW)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

