### PR TITLE
fix(front): reset confirmation modal input when reopened

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -100,7 +100,15 @@ export const ConfirmationModal = ({
     useState<string>('');
   const [isValidValue, setIsValidValue] = useState(!confirmationValue);
 
+  const isValueMatchingInput = useDebouncedCallback(
+    (value?: string, inputValue?: string) => {
+      setIsValidValue(Boolean(value && inputValue && value === inputValue));
+    },
+    250,
+  );
+
   const resetConfirmationState = () => {
+    isValueMatchingInput.cancel();
     setInputConfirmationValue('');
     setIsValidValue(!confirmationValue);
   };
@@ -109,13 +117,6 @@ export const ConfirmationModal = ({
     setInputConfirmationValue(value);
     isValueMatchingInput(confirmationValue, value);
   };
-
-  const isValueMatchingInput = useDebouncedCallback(
-    (value?: string, inputValue?: string) => {
-      setIsValidValue(Boolean(value && inputValue && value === inputValue));
-    },
-    250,
-  );
 
   const { closeModal } = useModal();
 

--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -100,6 +100,11 @@ export const ConfirmationModal = ({
     useState<string>('');
   const [isValidValue, setIsValidValue] = useState(!confirmationValue);
 
+  const resetConfirmationState = () => {
+    setInputConfirmationValue('');
+    setIsValidValue(!confirmationValue);
+  };
+
   const handleInputConfimrationValueChange = (value: string) => {
     setInputConfirmationValue(value);
     isValueMatchingInput(confirmationValue, value);
@@ -115,11 +120,13 @@ export const ConfirmationModal = ({
   const { closeModal } = useModal();
 
   const handleConfirmClick = () => {
+    resetConfirmationState();
     closeModal(modalInstanceId);
     onConfirmClick();
   };
 
   const handleCancelClick = () => {
+    resetConfirmationState();
     closeModal(modalInstanceId);
     onClose?.();
   };
@@ -134,6 +141,7 @@ export const ConfirmationModal = ({
     <ModalStatefulWrapper
       modalInstanceId={modalInstanceId}
       onClose={() => {
+        resetConfirmationState();
         onClose?.();
       }}
       onEnter={handleEnter}

--- a/packages/twenty-front/src/modules/ui/layout/modal/components/__stories__/ConfirmationModal.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/__stories__/ConfirmationModal.stories.tsx
@@ -202,20 +202,14 @@ export const ResetsInputWhenReopened: Story = {
   },
   play: async ({ canvasElement }) => {
     const body = within(canvasElement.ownerDocument.body);
-    const input = await body.findByTestId('confirmation-modal-input');
-    const confirmButton = await body.findByTestId(
-      'confirmation-modal-confirm-button',
-    );
+    const input = await body.findByPlaceholderText('yes');
+    const confirmButton = await body.findByRole('button', { name: /Delete/ });
 
     expect(confirmButton).toBeDisabled();
 
     await userEvent.type(input, 'yes');
-    await waitFor(() => {
-      expect(confirmButton).toBeEnabled();
-    });
-
     await userEvent.click(
-      await body.findByTestId('confirmation-modal-cancel-button'),
+      await body.findByRole('button', { name: /Cancel/ }),
     );
 
     jotaiStore.set(
@@ -225,11 +219,11 @@ export const ResetsInputWhenReopened: Story = {
       true,
     );
 
+    await sleep(400);
+
     await waitFor(() => {
-      expect(
-        body.getByTestId('confirmation-modal-confirm-button'),
-      ).toBeDisabled();
+      expect(body.getByRole('button', { name: /Delete/ })).toBeDisabled();
     });
-    expect(body.getByTestId('confirmation-modal-input')).toHaveValue('');
+    expect(body.getByPlaceholderText('yes')).toHaveValue('');
   },
 };

--- a/packages/twenty-front/src/modules/ui/layout/modal/components/__stories__/ConfirmationModal.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/__stories__/ConfirmationModal.stories.tsx
@@ -203,14 +203,17 @@ export const ResetsInputWhenReopened: Story = {
   play: async ({ canvasElement }) => {
     const body = within(canvasElement.ownerDocument.body);
     const input = await body.findByPlaceholderText('yes');
-    const confirmButton = await body.findByRole('button', { name: /Delete/ });
+    const confirmButton = await body.findByRole('button', {
+      name: /Delete/,
+    });
 
     expect(confirmButton).toBeDisabled();
 
     await userEvent.type(input, 'yes');
-    await userEvent.click(
-      await body.findByRole('button', { name: /Cancel/ }),
-    );
+    const cancelButton = await body.findByRole('button', {
+      name: /Cancel/,
+    });
+    await userEvent.click(cancelButton);
 
     jotaiStore.set(
       isModalOpenedComponentState.atomFamily({
@@ -222,7 +225,11 @@ export const ResetsInputWhenReopened: Story = {
     await sleep(400);
 
     await waitFor(() => {
-      expect(body.getByRole('button', { name: /Delete/ })).toBeDisabled();
+      expect(
+        body.getByRole('button', {
+          name: /Delete/,
+        }),
+      ).toBeDisabled();
     });
     expect(body.getByPlaceholderText('yes')).toHaveValue('');
   },

--- a/packages/twenty-front/src/modules/ui/layout/modal/components/__stories__/ConfirmationModal.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/__stories__/ConfirmationModal.stories.tsx
@@ -188,3 +188,48 @@ export const ConfirmButtonClick: Story = {
     });
   },
 };
+
+export const ResetsInputWhenReopened: Story = {
+  args: {
+    confirmationValue: 'yes',
+    confirmationPlaceholder: 'yes',
+    modalInstanceId: 'confirmation-modal',
+    title: 'Delete API key',
+    subtitle:
+      'Please type "yes" to confirm you want to delete this API Key. Be aware that any script using this key will stop working.',
+    confirmButtonText: 'Delete',
+    onConfirmClick: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    const input = await body.findByTestId('confirmation-modal-input');
+    const confirmButton = await body.findByTestId(
+      'confirmation-modal-confirm-button',
+    );
+
+    expect(confirmButton).toBeDisabled();
+
+    await userEvent.type(input, 'yes');
+    await waitFor(() => {
+      expect(confirmButton).toBeEnabled();
+    });
+
+    await userEvent.click(
+      await body.findByTestId('confirmation-modal-cancel-button'),
+    );
+
+    jotaiStore.set(
+      isModalOpenedComponentState.atomFamily({
+        instanceId: 'confirmation-modal',
+      }),
+      true,
+    );
+
+    await waitFor(() => {
+      expect(
+        body.getByTestId('confirmation-modal-confirm-button'),
+      ).toBeDisabled();
+    });
+    expect(body.getByTestId('confirmation-modal-input')).toHaveValue('');
+  },
+};


### PR DESCRIPTION
Closes #25628

### Type of change

- [x] Bug fix

### What does this PR do?

ConfirmationModal stays mounted. Type the confirm string, Cancel, open it again: input is empty but Delete is still enabled.

Reset the input + validity on close, and cancel the 250ms debounce so it can't flip the button back on.

### How did you verify your code works?

Story `ResetsInputWhenReopened`. Repro: Settings → API key → Delete → type yes → Cancel → Delete again.

### Screenshots

**Before (reopen):** empty input, Delete enabled

![before](https://raw.githubusercontent.com/mydd7/twenty/screens-25564/before.png)

**After (reopen):** empty input, Delete disabled

![after](https://raw.githubusercontent.com/mydd7/twenty/screens-25564/after.png)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

