### PR TITLE
[1/5] Desktop Recorder: support native OAuth

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/__tests__/desktop-oauth.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/__tests__/desktop-oauth.spec.ts
@@ -1,3 +1,4 @@
+import { OAUTH_INSTALL_SOURCE_PATH } from 'src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util';
 import { createHash } from 'crypto';
 
 import { OAuthService } from 'src/engine/core-modules/application/application-oauth/oauth.service';
@@ -89,6 +90,7 @@ describe('Desktop Recorder sign-in', () => {
     findApplication.mockResolvedValue({
       id: 'app',
       state: ApplicationState.INSTALLED,
+      version: '0.1.0',
     });
     for (const name of ['alice', 'bob']) {
       userId = name;
@@ -111,6 +113,18 @@ describe('Desktop Recorder sign-in', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
+  it('rejects an installed row before its first installation completes', async () => {
+    findApplication.mockResolvedValue({
+      id: 'app',
+      state: ApplicationState.INSTALLED,
+      version: null,
+    });
+    expect(await signIn()).toMatchObject({
+      error: 'application_not_installed',
+    });
+    expect(generateApplicationTokenPair).not.toHaveBeenCalled();
+  });
+
   it('requires PKCE for the desktop public client', async () => {
     expect(
       await service.exchangeAuthorizationCode({
@@ -123,15 +137,20 @@ describe('Desktop Recorder sign-in', () => {
   });
 
   it('accepts a packaged installation on an older instance without lifecycle state', async () => {
-    findApplication.mockResolvedValue({ id: 'app', sourcePath: 'tarball' });
+    findApplication.mockResolvedValue({
+      id: 'app',
+      sourcePath: 'tarball',
+      version: '0.1.0',
+    });
     expect(await signIn()).toMatchObject({ access_token: 'access' });
   });
 
   it('rejects a legacy OAuth-only entry even if marked installed', async () => {
     findApplication.mockResolvedValue({
       id: 'app',
-      sourcePath: 'oauth-install',
+      sourcePath: OAUTH_INSTALL_SOURCE_PATH,
       state: ApplicationState.INSTALLED,
+      version: '0.1.0',
     });
     expect(await signIn()).toMatchObject({
       error: 'application_not_installed',

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/__tests__/desktop-oauth.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/__tests__/desktop-oauth.spec.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'crypto';
+
+import { OAuthService } from 'src/engine/core-modules/application/application-oauth/oauth.service';
+import {
+  DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+  getDesktopRecorderOAuthFields,
+} from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
+import { ApplicationState } from 'src/engine/core-modules/application/enums/application-state.enum';
+
+type Dependencies = ConstructorParameters<typeof OAuthService>;
+
+describe('Desktop Recorder sign-in', () => {
+  const registration = {
+    id: 'registration',
+    universalIdentifier: DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+    oAuthScopes: ['api', 'profile'],
+  };
+  const codeVerifier = 'test-verifier';
+  const redirectUri = 'http://127.0.0.1:12345/callback';
+  const installApplication = jest.fn();
+  const create = jest.fn();
+  const findApplication = jest.fn();
+  const recordAuthorization = jest.fn();
+  const generateApplicationTokenPair = jest.fn();
+  let service: OAuthService;
+  let userId: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    userId = 'alice';
+    generateApplicationTokenPair.mockResolvedValue({
+      applicationAccessToken: { token: 'access' },
+      applicationRefreshToken: { token: 'refresh' },
+    });
+    service = new OAuthService(
+      {
+        findOne: async () => ({
+          id: 'code',
+          expiresAt: new Date(Date.now() + 60000),
+          userId,
+          workspaceId: 'workspace',
+          context: {
+            clientId: 'client',
+            redirectUri,
+            codeChallenge: createHash('sha256')
+              .update(codeVerifier)
+              .digest('base64url'),
+          },
+        }),
+        update: jest.fn(),
+      } as unknown as Dependencies[0],
+      { findOne: findApplication } as unknown as Dependencies[1],
+      {
+        findOne: async () => ({ id: `${userId}-workspace` }),
+      } as unknown as Dependencies[2],
+      { generateApplicationTokenPair } as unknown as Dependencies[3],
+      { recordAuthorization } as unknown as Dependencies[4],
+      {
+        findOneByClientId: async () => registration,
+      } as unknown as Dependencies[5],
+      { create } as unknown as Dependencies[6],
+      { installApplication } as unknown as Dependencies[7],
+      { get: () => '1h' } as unknown as Dependencies[8],
+    );
+  });
+
+  const signIn = () =>
+    service.exchangeAuthorizationCode({
+      authorizationCode: 'code',
+      clientId: 'client',
+      redirectUri,
+      codeVerifier,
+    });
+
+  it.each([null, ApplicationState.INSTALLING, ApplicationState.UNINSTALLING])(
+    'rejects unavailable installations (%s) without installing or creating an empty app',
+    async (state) => {
+      findApplication.mockResolvedValue(state ? { id: 'app', state } : null);
+      expect(await signIn()).toMatchObject({
+        error: 'application_not_installed',
+      });
+      expect(installApplication).not.toHaveBeenCalled();
+      expect(create).not.toHaveBeenCalled();
+      expect(generateApplicationTokenPair).not.toHaveBeenCalled();
+    },
+  );
+
+  it('authorizes two users on the same installed app with separate user identities', async () => {
+    findApplication.mockResolvedValue({
+      id: 'app',
+      state: ApplicationState.INSTALLED,
+    });
+    for (const name of ['alice', 'bob']) {
+      userId = name;
+      expect(await signIn()).toMatchObject({ access_token: 'access' });
+      expect(recordAuthorization).toHaveBeenLastCalledWith({
+        userId: name,
+        userWorkspaceId: `${name}-workspace`,
+        workspaceId: 'workspace',
+        applicationId: 'app',
+        scopes: ['api', 'profile'],
+      });
+      expect(generateApplicationTokenPair).toHaveBeenLastCalledWith({
+        userId: name,
+        userWorkspaceId: `${name}-workspace`,
+        workspaceId: 'workspace',
+        applicationId: 'app',
+      });
+    }
+    expect(installApplication).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('requires PKCE for the desktop public client', async () => {
+    expect(
+      await service.exchangeAuthorizationCode({
+        authorizationCode: 'code',
+        clientId: 'client',
+        redirectUri,
+      }),
+    ).toMatchObject({ error: 'invalid_request' });
+    expect(generateApplicationTokenPair).not.toHaveBeenCalled();
+  });
+
+  it('accepts a packaged installation on an older instance without lifecycle state', async () => {
+    findApplication.mockResolvedValue({ id: 'app', sourcePath: 'tarball' });
+    expect(await signIn()).toMatchObject({ access_token: 'access' });
+  });
+
+  it('rejects a legacy OAuth-only entry even if marked installed', async () => {
+    findApplication.mockResolvedValue({
+      id: 'app',
+      sourcePath: 'oauth-install',
+      state: ApplicationState.INSTALLED,
+    });
+    expect(await signIn()).toMatchObject({
+      error: 'application_not_installed',
+    });
+    expect(generateApplicationTokenPair).not.toHaveBeenCalled();
+  });
+
+  it('only configures the canonical desktop registration as a public client', () => {
+    expect(
+      getDesktopRecorderOAuthFields(DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER),
+    ).toEqual({
+      oAuthClientSecretHash: null,
+      oAuthRedirectUris: [],
+      oAuthScopes: ['api', 'profile'],
+    });
+    expect(getDesktopRecorderOAuthFields('other-app')).toEqual({});
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant.ts
@@ -11,3 +11,5 @@ export const getDesktopRecorderOAuthFields = (universalIdentifier: string) =>
         oAuthScopes: ['api', 'profile'],
       }
     : {};
+
+export const DESKTOP_RECORDER_PACKAGE = '@twentyhq/companion-app';

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant.ts
@@ -1,0 +1,13 @@
+export const DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER =
+  '8bdaaa9f-dc53-4247-a89b-aa386c9b3244';
+
+// Native clients cannot keep a secret. Empty redirect URIs enable Twenty's
+// loopback-only redirect validation, with PKCE required for every sign-in.
+export const getDesktopRecorderOAuthFields = (universalIdentifier: string) =>
+  universalIdentifier === DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER
+    ? {
+        oAuthClientSecretHash: null,
+        oAuthRedirectUris: [] as string[],
+        oAuthScopes: ['api', 'profile'],
+      }
+    : {};

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant.ts
@@ -1,15 +1,29 @@
+import { type ApplicationRegistrationEntity } from 'src/engine/core-modules/application/application-registration/application-registration.entity';
+
 export const DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER =
   '8bdaaa9f-dc53-4247-a89b-aa386c9b3244';
 
+export const DESKTOP_RECORDER_CATALOG_REQUIRED_MESSAGE =
+  'Desktop Recorder must be installed from its official catalog package';
+
+type DesktopRecorderOAuthFields = Pick<
+  ApplicationRegistrationEntity,
+  'oAuthClientSecretHash' | 'oAuthRedirectUris' | 'oAuthScopes'
+>;
+
 // Native clients cannot keep a secret. Empty redirect URIs enable Twenty's
 // loopback-only redirect validation, with PKCE required for every sign-in.
-export const getDesktopRecorderOAuthFields = (universalIdentifier: string) =>
+export const DESKTOP_RECORDER_OAUTH_FIELDS: DesktopRecorderOAuthFields = {
+  oAuthClientSecretHash: null,
+  oAuthRedirectUris: [],
+  oAuthScopes: ['api', 'profile'],
+};
+
+export const getDesktopRecorderOAuthFields = (
+  universalIdentifier: string,
+): Partial<DesktopRecorderOAuthFields> =>
   universalIdentifier === DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER
-    ? {
-        oAuthClientSecretHash: null,
-        oAuthRedirectUris: [] as string[],
-        oAuthScopes: ['api', 'profile'],
-      }
+    ? DESKTOP_RECORDER_OAUTH_FIELDS
     : {};
 
 export const DESKTOP_RECORDER_PACKAGE = '@twentyhq/companion-app';

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/__tests__/oauth-discovery.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/__tests__/oauth-discovery.controller.spec.ts
@@ -9,6 +9,7 @@ import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twent
 
 describe('OAuthDiscoveryController', () => {
   let controller: OAuthDiscoveryController;
+  const findRegistration = jest.fn();
 
   const buildMockRequest = (host: string, protocol = 'https') =>
     ({
@@ -18,6 +19,7 @@ describe('OAuthDiscoveryController', () => {
     }) as unknown as Request;
 
   beforeEach(async () => {
+    findRegistration.mockReset();
     const module: TestingModule = await Test.createTestingModule({
       controllers: [OAuthDiscoveryController],
       providers: [
@@ -37,7 +39,7 @@ describe('OAuthDiscoveryController', () => {
         },
         {
           provide: ApplicationRegistrationService,
-          useValue: { findOneByUniversalIdentifierGlobal: jest.fn() },
+          useValue: { findOneByUniversalIdentifierGlobal: findRegistration },
         },
       ],
     }).compile();
@@ -93,7 +95,7 @@ describe('OAuthDiscoveryController', () => {
           },
           {
             provide: ApplicationRegistrationService,
-            useValue: { findOneByUniversalIdentifierGlobal: jest.fn() },
+            useValue: { findOneByUniversalIdentifierGlobal: findRegistration },
           },
         ],
       }).compile();
@@ -134,4 +136,21 @@ describe('OAuthDiscoveryController', () => {
       });
     });
   });
+  it.each([{ redirects: [] }, { redirects: ['https://example.com/callback'] }])(
+    'advertises desktop sign-in only for loopback public clients (%j)',
+    async ({ redirects }) => {
+      findRegistration.mockResolvedValue({
+        oAuthClientId: 'desktop',
+        oAuthClientSecretHash: null,
+        oAuthScopes: ['api', 'profile'],
+        oAuthRedirectUris: redirects,
+      });
+      const metadata = await controller.getAuthorizationServerMetadata(
+        buildMockRequest('workspace.twenty.com'),
+      );
+      expect(metadata.desktop_client_id).toBe(
+        redirects.length === 0 ? 'desktop' : undefined,
+      );
+    },
+  );
 });

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/oauth-discovery.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/oauth-discovery.controller.ts
@@ -76,6 +76,7 @@ export class OAuthDiscoveryController {
         : {}),
       ...(desktopRegistration &&
       !desktopRegistration.oAuthClientSecretHash &&
+      desktopRegistration.oAuthRedirectUris.length === 0 &&
       ['api', 'profile'].every((scope) =>
         desktopRegistration.oAuthScopes.includes(scope),
       )

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/oauth-discovery.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/oauth-discovery.controller.ts
@@ -1,4 +1,7 @@
-import { DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
+import {
+  DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+  DESKTOP_RECORDER_OAUTH_FIELDS,
+} from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 
 import { type Request } from 'express';
@@ -75,9 +78,11 @@ export class OAuthDiscoveryController {
         ? { cli_client_id: cliRegistration.oAuthClientId }
         : {}),
       ...(desktopRegistration &&
-      !desktopRegistration.oAuthClientSecretHash &&
-      desktopRegistration.oAuthRedirectUris.length === 0 &&
-      ['api', 'profile'].every((scope) =>
+      desktopRegistration.oAuthClientSecretHash ===
+        DESKTOP_RECORDER_OAUTH_FIELDS.oAuthClientSecretHash &&
+      desktopRegistration.oAuthRedirectUris.length ===
+        DESKTOP_RECORDER_OAUTH_FIELDS.oAuthRedirectUris.length &&
+      DESKTOP_RECORDER_OAUTH_FIELDS.oAuthScopes.every((scope) =>
         desktopRegistration.oAuthScopes.includes(scope),
       )
         ? { desktop_client_id: desktopRegistration.oAuthClientId }

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/oauth-discovery.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/controllers/oauth-discovery.controller.ts
@@ -1,3 +1,4 @@
+import { DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 
 import { type Request } from 'express';
@@ -43,6 +44,11 @@ export class OAuthDiscoveryController {
         TWENTY_CLI_APPLICATION_REGISTRATION.universalIdentifier,
       );
 
+    const desktopRegistration =
+      await this.applicationRegistrationService.findOneByUniversalIdentifierGlobal(
+        DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+      );
+
     return {
       issuer,
       authorization_endpoint: authorizationEndpoint,
@@ -67,6 +73,13 @@ export class OAuthDiscoveryController {
       authorization_response_iss_parameter_supported: true,
       ...(cliRegistration
         ? { cli_client_id: cliRegistration.oAuthClientId }
+        : {}),
+      ...(desktopRegistration &&
+      !desktopRegistration.oAuthClientSecretHash &&
+      ['api', 'profile'].every((scope) =>
+        desktopRegistration.oAuthScopes.includes(scope),
+      )
+        ? { desktop_client_id: desktopRegistration.oAuthClientId }
         : {}),
     };
   }

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/oauth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/oauth.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
+import { isDesktopRecorderInstalled } from 'src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import crypto from 'crypto';
@@ -202,11 +204,6 @@ export class OAuthService {
       );
     }
 
-    const application = await this.findOrInstallApplication(
-      applicationRegistration,
-      authCodeToken.workspaceId,
-    );
-
     const userWorkspace = await this.userWorkspaceRepository.findOne({
       where: {
         userId: authCodeToken.userId,
@@ -218,6 +215,18 @@ export class OAuthService {
       return this.errorResponse(
         'invalid_grant',
         'User no longer has access to this workspace',
+      );
+    }
+
+    const application = await this.findOrInstallApplication(
+      applicationRegistration,
+      authCodeToken.workspaceId,
+    );
+
+    if (!application) {
+      return this.errorResponse(
+        'application_not_installed',
+        'Install Desktop Recorder in Settings > Apps, then connect again.',
       );
     }
 
@@ -729,13 +738,22 @@ export class OAuthService {
   private async findOrInstallApplication(
     applicationRegistration: ApplicationRegistrationEntity,
     workspaceId: string,
-  ): Promise<ApplicationEntity> {
+  ): Promise<ApplicationEntity | null> {
     const existingApplication = await this.applicationRepository.findOne({
       where: {
         applicationRegistrationId: applicationRegistration.id,
         workspaceId,
       },
     });
+
+    if (
+      applicationRegistration.universalIdentifier ===
+      DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER
+    ) {
+      return isDesktopRecorderInstalled(existingApplication)
+        ? existingApplication
+        : null;
+    }
 
     if (existingApplication) {
       return existingApplication;

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/oauth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/oauth.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
-import { isDesktopRecorderInstalled } from 'src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util';
+import {
+  isDesktopRecorderInstalled,
+  OAUTH_INSTALL_SOURCE_PATH,
+} from 'src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import crypto from 'crypto';
@@ -791,7 +794,7 @@ export class OAuthService {
       name: applicationRegistration.name,
       description: `OAuth application registered as "${applicationRegistration.name}"`,
       version: applicationRegistration.latestAvailableVersion ?? '1.0.0',
-      sourcePath: 'oauth-install',
+      sourcePath: OAUTH_INSTALL_SOURCE_PATH,
       applicationRegistrationId: applicationRegistration.id,
       workspaceId,
     });

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util.ts
@@ -1,11 +1,18 @@
 import { type ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { ApplicationState } from 'src/engine/core-modules/application/enums/application-state.enum';
 
+export const OAUTH_INSTALL_SOURCE_PATH = 'oauth-install';
+
 export const isDesktopRecorderInstalled = (
-  application: Pick<ApplicationEntity, 'state' | 'sourcePath'> | null,
+  application: Pick<
+    ApplicationEntity,
+    'state' | 'sourcePath' | 'version'
+  > | null,
 ): boolean =>
   application !== null &&
-  application.sourcePath !== 'oauth-install' &&
+  // The installer writes the version only after the first install finishes.
+  Boolean(application.version) &&
+  application.sourcePath !== OAUTH_INSTALL_SOURCE_PATH &&
   // Older instances do not have the lifecycle state column yet.
   (application.state ?? ApplicationState.INSTALLED) ===
     ApplicationState.INSTALLED;

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util.ts
@@ -1,0 +1,11 @@
+import { type ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { ApplicationState } from 'src/engine/core-modules/application/enums/application-state.enum';
+
+export const isDesktopRecorderInstalled = (
+  application: Pick<ApplicationEntity, 'state' | 'sourcePath'> | null,
+): boolean =>
+  application !== null &&
+  application.sourcePath !== 'oauth-install' &&
+  // Older instances do not have the lifecycle state column yet.
+  (application.state ?? ApplicationState.INSTALLED) ===
+    ApplicationState.INSTALLED;

--- a/packages/twenty-server/src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-oauth/utils/is-desktop-recorder-installed.util.ts
@@ -1,3 +1,6 @@
+import { isNonEmptyString } from '@sniptt/guards';
+import { isDefined } from 'twenty-shared/utils';
+
 import { type ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { ApplicationState } from 'src/engine/core-modules/application/enums/application-state.enum';
 
@@ -9,9 +12,9 @@ export const isDesktopRecorderInstalled = (
     'state' | 'sourcePath' | 'version'
   > | null,
 ): boolean =>
-  application !== null &&
+  isDefined(application) &&
   // The installer writes the version only after the first install finishes.
-  Boolean(application.version) &&
+  isNonEmptyString(application.version) &&
   application.sourcePath !== OAUTH_INSTALL_SOURCE_PATH &&
   // Older instances do not have the lifecycle state column yet.
   (application.state ?? ApplicationState.INSTALLED) ===

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/__tests__/application-registration-upsert-from-catalog.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/__tests__/application-registration-upsert-from-catalog.spec.ts
@@ -1,3 +1,7 @@
+import {
+  DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+  DESKTOP_RECORDER_PACKAGE,
+} from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
@@ -22,6 +26,7 @@ describe('ApplicationRegistrationService - upsertFromCatalog', () => {
     findOne: jest.Mock;
     save: jest.Mock;
     create: jest.Mock;
+    update: jest.Mock;
     createQueryBuilder: jest.Mock;
   };
 
@@ -50,6 +55,7 @@ describe('ApplicationRegistrationService - upsertFromCatalog', () => {
       findOne: jest.fn(),
       save: jest.fn(),
       create: jest.fn((entity) => entity),
+      update: jest.fn(),
       createQueryBuilder: jest.fn(() => ({
         update: jest.fn().mockReturnThis(),
         set: jest.fn().mockReturnThis(),
@@ -173,6 +179,79 @@ describe('ApplicationRegistrationService - upsertFromCatalog', () => {
 
     expect(applicationRegistrationRepository.save).toHaveBeenCalledWith(
       expect.objectContaining({ isListed: true }),
+    );
+  });
+  it('rejects a workspace claiming the reserved desktop identity', async () => {
+    await expect(
+      service.create(
+        {
+          name: 'Impersonator',
+          universalIdentifier: DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+        },
+        'workspace',
+        'user',
+      ),
+    ).rejects.toThrow('official catalog package');
+    expect(applicationRegistrationRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects a catalog package impersonating Desktop Recorder', async () => {
+    await expect(
+      service.upsertFromCatalog({
+        ...catalogParams,
+        universalIdentifier: DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+      }),
+    ).rejects.toThrow('official catalog package');
+    expect(applicationRegistrationRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('provisions the official package as a public client', async () => {
+    await service.upsertFromCatalog({
+      ...catalogParams,
+      universalIdentifier: DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+      sourcePackage: DESKTOP_RECORDER_PACKAGE,
+    });
+    expect(applicationRegistrationRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oAuthClientSecretHash: null,
+        oAuthRedirectUris: [],
+        oAuthScopes: ['api', 'profile'],
+      }),
+    );
+  });
+
+  it('does not rotate a secret for the desktop public client', async () => {
+    jest.spyOn(service, 'findOneById').mockResolvedValue(
+      buildExistingRegistration({
+        universalIdentifier: DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+      }),
+    );
+    await expect(
+      service.rotateClientSecret('registration-id', 'workspace'),
+    ).rejects.toThrow('public OAuth client');
+    expect(applicationRegistrationRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('preserves public client fields when registration settings change', async () => {
+    jest.spyOn(service, 'findOneByIdGlobal').mockResolvedValue(
+      buildExistingRegistration({
+        universalIdentifier: DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+      }),
+    );
+    await service.updateGlobal({
+      id: 'registration-id',
+      update: {
+        oAuthScopes: ['profile'],
+        oAuthRedirectUris: ['https://example.com/callback'],
+      },
+    });
+    expect(applicationRegistrationRepository.update).toHaveBeenCalledWith(
+      'registration-id',
+      expect.objectContaining({
+        oAuthClientSecretHash: null,
+        oAuthRedirectUris: [],
+        oAuthScopes: ['api', 'profile'],
+      }),
     );
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { getDesktopRecorderOAuthFields } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import crypto from 'crypto';
@@ -529,6 +530,7 @@ export class ApplicationRegistrationService {
         oAuthClientSecretHash: clientSecretHash,
         oAuthRedirectUris: input.oAuthRedirectUris ?? [],
         oAuthScopes: input.oAuthScopes ?? [],
+        ...getDesktopRecorderOAuthFields(universalIdentifier),
         createdByUserId,
         ownerWorkspaceId,
       });
@@ -684,6 +686,7 @@ export class ApplicationRegistrationService {
                   latestAvailableVersion,
                 }),
                 ...additionalFields,
+                ...getDesktopRecorderOAuthFields(existing.universalIdentifier),
               } as QueryDeepPartialEntity<ApplicationRegistrationEntity>);
 
             if (isDefined(manifest.application?.serverVariables)) {
@@ -849,6 +852,7 @@ export class ApplicationRegistrationService {
         isVetted,
         manifest: params.manifest,
         ...fromManifestApplicationToDisplayFields(params.manifest?.application),
+        ...getDesktopRecorderOAuthFields(params.universalIdentifier),
       });
 
       await this.invalidateMarketplaceAppsCache();
@@ -886,6 +890,7 @@ export class ApplicationRegistrationService {
       oAuthClientId: v4(),
       oAuthRedirectUris: [],
       oAuthScopes: [],
+      ...getDesktopRecorderOAuthFields(params.universalIdentifier),
       ownerWorkspaceId: null,
     });
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
   DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+  DESKTOP_RECORDER_CATALOG_REQUIRED_MESSAGE,
   DESKTOP_RECORDER_PACKAGE,
   getDesktopRecorderOAuthFields,
 } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
@@ -506,7 +507,7 @@ export class ApplicationRegistrationService {
 
     if (universalIdentifier === DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER) {
       throw new ApplicationRegistrationException(
-        'Desktop Recorder must be installed from its official catalog package',
+        DESKTOP_RECORDER_CATALOG_REQUIRED_MESSAGE,
         ApplicationRegistrationExceptionCode.INVALID_INPUT,
       );
     }
@@ -541,7 +542,6 @@ export class ApplicationRegistrationService {
         oAuthClientSecretHash: clientSecretHash,
         oAuthRedirectUris: input.oAuthRedirectUris ?? [],
         oAuthScopes: input.oAuthScopes ?? [],
-        ...getDesktopRecorderOAuthFields(universalIdentifier),
         createdByUserId,
         ownerWorkspaceId,
       });
@@ -590,7 +590,10 @@ export class ApplicationRegistrationService {
   }
 
   private async applyUpdate(
-    registration: ApplicationRegistrationEntity,
+    registration: Pick<
+      ApplicationRegistrationEntity,
+      'id' | 'universalIdentifier'
+    >,
     update: UpdateApplicationRegistrationPayload,
   ): Promise<void> {
     if (isDefined(update.oAuthRedirectUris)) {
@@ -814,7 +817,7 @@ export class ApplicationRegistrationService {
         params.sourcePackage !== DESKTOP_RECORDER_PACKAGE)
     ) {
       throw new ApplicationRegistrationException(
-        'Desktop Recorder must be installed from its official catalog package',
+        DESKTOP_RECORDER_CATALOG_REQUIRED_MESSAGE,
         ApplicationRegistrationExceptionCode.INVALID_INPUT,
       );
     }

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { getDesktopRecorderOAuthFields } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
+import {
+  DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+  DESKTOP_RECORDER_PACKAGE,
+  getDesktopRecorderOAuthFields,
+} from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import crypto from 'crypto';
@@ -500,6 +504,13 @@ export class ApplicationRegistrationService {
   }> {
     const universalIdentifier = input.universalIdentifier ?? v4();
 
+    if (universalIdentifier === DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER) {
+      throw new ApplicationRegistrationException(
+        'Desktop Recorder must be installed from its official catalog package',
+        ApplicationRegistrationExceptionCode.INVALID_INPUT,
+      );
+    }
+
     const existingByUid =
       await this.findOneByUniversalIdentifierGlobal(universalIdentifier);
 
@@ -557,7 +568,7 @@ export class ApplicationRegistrationService {
 
     const existingRegistration = await this.findOneById(id, ownerWorkspaceId);
 
-    await this.applyUpdate(id, update);
+    await this.applyUpdate(existingRegistration, update);
 
     await this.broadcastApplicationRegistrationUpdatedById(
       id,
@@ -572,14 +583,14 @@ export class ApplicationRegistrationService {
   ): Promise<ApplicationRegistrationEntity> {
     const { id, update } = input;
 
-    await this.findOneByIdGlobal(id);
-    await this.applyUpdate(id, update);
+    const existingRegistration = await this.findOneByIdGlobal(id);
+    await this.applyUpdate(existingRegistration, update);
 
     return this.findOneByIdGlobal(id);
   }
 
   private async applyUpdate(
-    id: string,
+    registration: ApplicationRegistrationEntity,
     update: UpdateApplicationRegistrationPayload,
   ): Promise<void> {
     if (isDefined(update.oAuthRedirectUris)) {
@@ -606,7 +617,14 @@ export class ApplicationRegistrationService {
       return;
     }
 
-    await this.applicationRegistrationRepository.update(id, updateData);
+    Object.assign(
+      updateData,
+      getDesktopRecorderOAuthFields(registration.universalIdentifier),
+    );
+    await this.applicationRegistrationRepository.update(
+      registration.id,
+      updateData,
+    );
     await this.invalidateMarketplaceAppsCache();
   }
 
@@ -746,7 +764,15 @@ export class ApplicationRegistrationService {
     id: string,
     ownerWorkspaceId: string,
   ): Promise<string> {
-    await this.findOneById(id, ownerWorkspaceId);
+    const registration = await this.findOneById(id, ownerWorkspaceId);
+    if (
+      registration.universalIdentifier === DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER
+    ) {
+      throw new ApplicationRegistrationException(
+        'Desktop Recorder is a public OAuth client and has no client secret',
+        ApplicationRegistrationExceptionCode.INVALID_INPUT,
+      );
+    }
 
     const { clientSecret, clientSecretHash } =
       await this.generateClientSecret();
@@ -782,6 +808,16 @@ export class ApplicationRegistrationService {
       | 'manifest'
     >,
   ): Promise<void> {
+    if (
+      params.universalIdentifier === DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER &&
+      (params.sourceType !== ApplicationRegistrationSourceType.NPM ||
+        params.sourcePackage !== DESKTOP_RECORDER_PACKAGE)
+    ) {
+      throw new ApplicationRegistrationException(
+        'Desktop Recorder must be installed from its official catalog package',
+        ApplicationRegistrationExceptionCode.INVALID_INPUT,
+      );
+    }
     const existing = await this.findOneByUniversalIdentifierGlobal(
       params.universalIdentifier,
     );

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-tarball.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-tarball.service.ts
@@ -1,4 +1,7 @@
-import { DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
+import {
+  DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER,
+  DESKTOP_RECORDER_CATALOG_REQUIRED_MESSAGE,
+} from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -71,7 +74,7 @@ export class ApplicationTarballService {
 
       if (universalIdentifier === DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER) {
         throw new ApplicationRegistrationException(
-          'Desktop Recorder must be installed from its official catalog package',
+          DESKTOP_RECORDER_CATALOG_REQUIRED_MESSAGE,
           ApplicationRegistrationExceptionCode.INVALID_INPUT,
         );
       }

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-tarball.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-tarball.service.ts
@@ -1,3 +1,4 @@
+import { DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER } from 'src/engine/core-modules/application/application-oauth/constants/desktop-recorder-oauth.constant';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -64,6 +65,13 @@ export class ApplicationTarballService {
       if (!isDefined(universalIdentifier)) {
         throw new ApplicationRegistrationException(
           'universalIdentifier is required (in body or manifest)',
+          ApplicationRegistrationExceptionCode.INVALID_INPUT,
+        );
+      }
+
+      if (universalIdentifier === DESKTOP_RECORDER_UNIVERSAL_IDENTIFIER) {
+        throw new ApplicationRegistrationException(
+          'Desktop Recorder must be installed from its official catalog package',
           ApplicationRegistrationExceptionCode.INVALID_INPUT,
         );
       }


### PR DESCRIPTION
Superseded: the desktop now reuses the existing CLI OAuth flow from `twenty remote:add`. No Desktop Recorder-specific OAuth changes are needed in Twenty core.

**Remaining stack:** #25631 → #25632 → #25633 → #25616.