### PR TITLE
Fix Menu imports after class-name helper rename

### DIFF
--- a/packages/twenty-ui/src/surfaces/Menu/internal/MenuGroup.tsx
+++ b/packages/twenty-ui/src/surfaces/Menu/internal/MenuGroup.tsx
@@ -1,6 +1,6 @@
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 
-import { mergeFieldPartClassName } from '@ui/input/Field/internal/mergeFieldPartClassName';
+import { mergeClassNames } from '@ui/utilities/internal/mergeClassNames';
 
 import styles from '../Menu.module.scss';
 import { type MenuGroupProps } from '../types/MenuGroupProps';
@@ -8,6 +8,6 @@ import { type MenuGroupProps } from '../types/MenuGroupProps';
 export const MenuGroup = ({ className, ...props }: MenuGroupProps) => (
   <MenuPrimitive.Group
     {...props}
-    className={mergeFieldPartClassName(styles.group, className)}
+    className={mergeClassNames(styles.group, className)}
   />
 );

--- a/packages/twenty-ui/src/surfaces/Menu/internal/MenuGroupLabel.tsx
+++ b/packages/twenty-ui/src/surfaces/Menu/internal/MenuGroupLabel.tsx
@@ -1,6 +1,6 @@
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 
-import { mergeFieldPartClassName } from '@ui/input/Field/internal/mergeFieldPartClassName';
+import { mergeClassNames } from '@ui/utilities/internal/mergeClassNames';
 
 import styles from '../Menu.module.scss';
 import { type MenuGroupLabelProps } from '../types/MenuGroupLabelProps';
@@ -11,6 +11,6 @@ export const MenuGroupLabel = ({
 }: MenuGroupLabelProps) => (
   <MenuPrimitive.GroupLabel
     {...props}
-    className={mergeFieldPartClassName(styles.groupLabel, className)}
+    className={mergeClassNames(styles.groupLabel, className)}
   />
 );

--- a/packages/twenty-ui/src/surfaces/Menu/internal/MenuPopup.tsx
+++ b/packages/twenty-ui/src/surfaces/Menu/internal/MenuPopup.tsx
@@ -1,8 +1,8 @@
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 import { useContext } from 'react';
 
-import { mergeFieldPartClassName } from '@ui/input/Field/internal/mergeFieldPartClassName';
 import { useThemeContainer } from '@ui/theme-constants';
+import { mergeClassNames } from '@ui/utilities/internal/mergeClassNames';
 
 import styles from '../Menu.module.scss';
 import { type MenuPopupProps } from '../types/MenuPopupProps';
@@ -37,7 +37,7 @@ export const MenuPopup = ({
       >
         <MenuPrimitive.Popup
           {...popupProps}
-          className={mergeFieldPartClassName(styles.popup, className)}
+          className={mergeClassNames(styles.popup, className)}
         >
           {children}
         </MenuPrimitive.Popup>

--- a/packages/twenty-ui/src/surfaces/Menu/internal/MenuRadioGroup.tsx
+++ b/packages/twenty-ui/src/surfaces/Menu/internal/MenuRadioGroup.tsx
@@ -1,6 +1,6 @@
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 
-import { mergeFieldPartClassName } from '@ui/input/Field/internal/mergeFieldPartClassName';
+import { mergeClassNames } from '@ui/utilities/internal/mergeClassNames';
 
 import styles from '../Menu.module.scss';
 import { type MenuRadioGroupProps } from '../types/MenuRadioGroupProps';
@@ -11,6 +11,6 @@ export const MenuRadioGroup = ({
 }: MenuRadioGroupProps) => (
   <MenuPrimitive.RadioGroup
     {...props}
-    className={mergeFieldPartClassName(styles.group, className)}
+    className={mergeClassNames(styles.group, className)}
   />
 );

--- a/packages/twenty-ui/src/surfaces/Menu/internal/MenuSeparator.tsx
+++ b/packages/twenty-ui/src/surfaces/Menu/internal/MenuSeparator.tsx
@@ -1,6 +1,6 @@
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 
-import { mergeFieldPartClassName } from '@ui/input/Field/internal/mergeFieldPartClassName';
+import { mergeClassNames } from '@ui/utilities/internal/mergeClassNames';
 
 import styles from '../Menu.module.scss';
 import { type MenuSeparatorProps } from '../types/MenuSeparatorProps';
@@ -8,6 +8,6 @@ import { type MenuSeparatorProps } from '../types/MenuSeparatorProps';
 export const MenuSeparator = ({ className, ...props }: MenuSeparatorProps) => (
   <MenuPrimitive.Separator
     {...props}
-    className={mergeFieldPartClassName(styles.separator, className)}
+    className={mergeClassNames(styles.separator, className)}
   />
 );


### PR DESCRIPTION
Fix main CI's five TS2307 errors introduced when #25610 merged after #25621 had renamed and moved the class-name helper.

Update Menu Group, GroupLabel, Popup, RadioGroup, and Separator to use `utilities/internal/mergeClassNames`.

Validation: both twenty-ui TypeScript configurations pass with `--noEmit --preserveSymlinks`, all 100 Menu tests pass, and lint and formatting pass for the changed files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

