### PR TITLE
fix(messaging): recycle the html-to-text converter to bound jsdom retention

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/create-html-to-text-converter.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/create-html-to-text-converter.util.spec.ts
@@ -1,7 +1,7 @@
 import { createHtmlToTextConverter } from 'src/modules/messaging/message-import-manager/utils/create-html-to-text-converter.util';
 
 describe('createHtmlToTextConverter', () => {
-  const convertHtmlToText = createHtmlToTextConverter();
+  const { convert: convertHtmlToText } = createHtmlToTextConverter();
 
   it('should convert basic HTML to plain text', () => {
     expect(convertHtmlToText('<p>Hello world</p>')).toBe('Hello world');

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-message-body-text.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/extract-message-body-text.util.spec.ts
@@ -1,6 +1,9 @@
 import { type Email as ParsedMail } from 'postal-mime';
 
-import { extractMessageBodyText } from 'src/modules/messaging/message-import-manager/utils/extract-message-body-text.util';
+import {
+  extractMessageBodyText,
+  MAX_CONVERSIONS_PER_CONVERTER,
+} from 'src/modules/messaging/message-import-manager/utils/extract-message-body-text.util';
 
 describe('extractMessageBodyText', () => {
   it('should extract text from plain text emails with lot of reply quotations', () => {
@@ -347,5 +350,24 @@ Developer Support`);
     expect(result).toBe(
       'See https://example.com/path%2Fto%2Ffile and a 100%20 budget cut',
     );
+  });
+});
+
+describe('extractMessageBodyText converter recycling', () => {
+  it('should keep converting correctly across the recycle boundary', () => {
+    const iterations = MAX_CONVERSIONS_PER_CONVERTER * 2 + 5;
+
+    for (let i = 0; i < iterations; i++) {
+      expect(extractMessageBodyText({ html: `<p>Message ${i}</p>` })).toBe(
+        `Message ${i}`,
+      );
+    }
+  });
+
+  it('should not leak documents from one converted message into the next', () => {
+    extractMessageBodyText({ html: '<p id="first">First body</p>' });
+
+    expect(extractMessageBodyText({ html: '<p id="second">Second body</p>' }))
+      .toBe('Second body');
   });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/create-html-to-text-converter.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/create-html-to-text-converter.util.ts
@@ -11,24 +11,32 @@ const CONVERT_OPTIONS = {
   preserveNewlines: true,
 } satisfies HtmlToTextOptions;
 
-export const createHtmlToTextConverter = (): ((html: string) => string) => {
+export type HtmlToTextConverter = {
+  convert: (html: string) => string;
+  close: () => void;
+};
+
+export const createHtmlToTextConverter = (): HtmlToTextConverter => {
   const jsdom = new JSDOM('');
   const purify = createDOMPurify(jsdom.window);
 
-  return (html: string): string => {
-    const sanitizedHtml = purify.sanitize(html);
+  return {
+    convert: (html: string): string => {
+      const sanitizedHtml = purify.sanitize(html);
 
-    const cleanedHtml = planer.extractFromHtml(
-      sanitizedHtml,
-      jsdom.window.document,
-    );
+      const cleanedHtml = planer.extractFromHtml(
+        sanitizedHtml,
+        jsdom.window.document,
+      );
 
-    const text = normalizeMessageText(convert(cleanedHtml, CONVERT_OPTIONS));
+      const text = normalizeMessageText(convert(cleanedHtml, CONVERT_OPTIONS));
 
-    // planer can strip an entirely-quoted (e.g. forwarded) body to nothing;
-    // fall back to the un-stripped sanitized html so the body is not lost.
-    return isNonEmptyString(text)
-      ? text
-      : normalizeMessageText(convert(sanitizedHtml, CONVERT_OPTIONS));
+      // planer can strip an entirely-quoted (e.g. forwarded) body to nothing;
+      // fall back to the un-stripped sanitized html so the body is not lost.
+      return isNonEmptyString(text)
+        ? text
+        : normalizeMessageText(convert(sanitizedHtml, CONVERT_OPTIONS));
+    },
+    close: () => jsdom.window.close(),
   };
 };

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-message-body-text.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/extract-message-body-text.util.ts
@@ -1,6 +1,9 @@
 import { isNonEmptyString } from '@sniptt/guards';
 
-import { createHtmlToTextConverter } from 'src/modules/messaging/message-import-manager/utils/create-html-to-text-converter.util';
+import {
+  createHtmlToTextConverter,
+  type HtmlToTextConverter,
+} from 'src/modules/messaging/message-import-manager/utils/create-html-to-text-converter.util';
 import { extractTextWithoutReplyQuotations } from 'src/modules/messaging/message-import-manager/utils/extract-text-without-reply-quotations.util';
 import { normalizeMessageText } from 'src/modules/messaging/message-import-manager/utils/normalize-message-text.util';
 import { sanitizeString } from 'src/modules/messaging/message-import-manager/utils/sanitize-string.util';
@@ -8,11 +11,32 @@ import { sanitizeString } from 'src/modules/messaging/message-import-manager/uti
 // createHtmlToTextConverter builds a JSDOM + DOMPurify instance, which is
 // expensive. extractMessageBodyText runs once per message, so an import batch
 // (hundreds of emails) would build hundreds of JSDOMs on the worker event loop.
-// The converter is stateless across calls, so build it once and reuse it.
-let htmlToTextConverter: ((html: string) => string) | undefined;
+//
+// It cannot be reused indefinitely either: jsdom records every id/name-bearing
+// element in a named-properties map keyed by the window, and only drops entries
+// when an element is detached. Documents built per message are discarded whole,
+// never detached, so each converted email stays pinned to the window for as long
+// as it lives. Recycling the converter bounds that retention.
+export const MAX_CONVERSIONS_PER_CONVERTER = 100;
 
-const getHtmlToTextConverter = (): ((html: string) => string) => {
-  htmlToTextConverter ??= createHtmlToTextConverter();
+let htmlToTextConverter: HtmlToTextConverter | undefined;
+let conversionsSinceRecycle = 0;
+
+const getHtmlToTextConverter = (): HtmlToTextConverter => {
+  if (
+    htmlToTextConverter !== undefined &&
+    conversionsSinceRecycle >= MAX_CONVERSIONS_PER_CONVERTER
+  ) {
+    htmlToTextConverter.close();
+    htmlToTextConverter = undefined;
+  }
+
+  if (htmlToTextConverter === undefined) {
+    htmlToTextConverter = createHtmlToTextConverter();
+    conversionsSinceRecycle = 0;
+  }
+
+  conversionsSinceRecycle += 1;
 
   return htmlToTextConverter;
 };
@@ -27,7 +51,7 @@ export const extractMessageBodyText = ({
   const candidate = isNonEmptyString(text)
     ? text
     : isNonEmptyString(html)
-      ? getHtmlToTextConverter()(html)
+      ? getHtmlToTextConverter().convert(html)
       : '';
 
   const textWithoutReplyQuotations =


### PR DESCRIPTION
## Summary

`extractMessageBodyText` caches one JSDOM window for the lifetime of the worker. jsdom
retains every email document ever converted through that window, so worker memory grows
until the process dies. This recycles the converter every 100 conversions.

Local repro, heap retained after GC over 500 emails:

| | retained | behaviour |
|---|---|---|
| never recycle (main today) | **814 MB** | scales linearly with message count |
| recycle every 100 (this PR) | **201 MB** | flat |
| JSDOM per message (pre Aug 28) | 51 MB | flat |

## What I measured on prod-eu

Two heap snapshots taken from the **same** `twenty-server-worker` process, 28 minutes
apart, on v2.39.1. Live heap means the sum of `self_size` over all nodes, i.e. only
objects that survived a full mark-compact GC.

| | at 26 min | at 54 min | delta |
|---|---|---|---|
| Live heap | 1.202 GiB | 1.725 GiB | **+535.6 MiB (+43.5%)** |
| Live nodes | 15,928,372 | 23,876,499 | +7,948,127 (+49.9%) |

That is roughly 1.1 GiB/hour of permanently retained data. The equivalent measurement on
v2.39.0 gave ~1.7 GiB/hour, so this is not specific to one release.

Object counts across the same interval:

```
JSDOM                     4 ->      4     (constant)
Window                    6 ->      6     (constant)
DOMPurify                 4 ->      4     (constant)
DocumentImpl            213 ->    423     (+210)
HTMLHtmlElementImpl     209 ->    419     (+210)
HTMLBodyElementImpl     209 ->    419     (+210)
SymbolTreeNode      229,179 -> 387,531
AttrImpl            115,562 -> 185,603
```

The cached JSDOM instances stay pinned at 4, exactly as intended. What grows is the
per-message documents created off them: +210 in 28 minutes, each carrying a full email
DOM. `HTMLHtmlElementImpl` and `HTMLBodyElementImpl` track `DocumentImpl` one for one,
which is whole documents being retained rather than loose fragments.

## Why jsdom is at fault

Retaining path, computed from the snapshot as a shortest path from GC roots and identical
across every sampled `DocumentImpl`:

```
(GC roots) -> (Global handles) -> code
  -> Window                                  the cached JSDOM window
  -> WeakMap `trackers`                      jsdom/lib/jsdom/living/window-properties.js:12
  -> Map<string, Set<Element>>
  -> Set
  -> HTMLSpanElementImpl / HTMLDivElementImpl
     via _ownerDocument
  -> DocumentImpl                            the per-message email document
```

`window-properties.js` implements named properties on `window`, so `window.foo` resolves
to `<div id="foo">`. It registers every element carrying `id` or `name`:

```js
exports.elementAttached = element => {
  const window = element._ownerDocument._globalObject;
  ...
  const idAttr = element.getAttributeNS(null, "id");
  if (idAttr !== null) upsert(tracker, idAttr, element);
};
```

The tracker is keyed on `_ownerDocument._globalObject`. Documents that planer creates via
`dom.implementation.createHTMLDocument()` inherit the shared cached window as their global
object, so every id-bearing element of every inbound email registers into that one tracker.

`elementDetached` is the only thing that removes entries, and it only fires when an element
is removed from its tree. The per-message document is simply dropped: no teardown, no
detach. The entries stay forever, and each retained element pins its `_ownerDocument`,
which pins the entire email DOM. HTML emails are full of `id=` attributes, so this scales
directly with import volume.

I confirmed the tracker's identity by reading the closure slots straight out of the heap
(`trackers`, `upsert`, `remove`, `getNamedObject`, `nameAttributeElementLocalNames`), which
match `window-properties.js` exactly.

jsdom assumes a window has a document lifecycle. Reusing one window for thousands of
throwaway documents breaks that assumption.

## History

| date | change |
|---|---|
| 2024-01-25 | `planer` added, "remove reply quotations from emails" (#3630) |
| 2024-04-02 | jsdom added to server deps (#4740) |
| 2026-04-27 | converter extracted to its own file (#19989) |
| 2026-06-04 | quote-stripping fix (#21118) |
| **2026-08-28** | **converter cached across messages (#25004)** |

jsdom has been on this path since 2024 without leaking, because until #25004 the code built
a fresh JSDOM per message. Each window accumulated one email's elements, then became
garbage and was collected. Self-cleaning. The local repro confirms it: per-message JSDOM
holds flat at 51 MB regardless of message count.

#25004 made the window permanent, for good and well-evidenced reasons:

> A live V8 CPU profile of a worker that was actively stalling attributes ~29% of all worker
> CPU to jsdom

That was a real problem, 400 messages per batch each building a JSDOM synchronously on the
event loop, and the fix worked. But an immortal window means an immortal named-properties
tracker, which turned a CPU problem into a memory leak.

This PR keeps #25004's benefit and removes its side effect.

## Why 100

Two independent numbers agree.

From prod: +535.6 MiB of live heap across +210 documents is about **2.5 MiB retained per
email document**. At N=100 that bounds retention around 250 MiB, comfortably under the
3500 MB `--max-old-space-size` ceiling and the 4096Mi container limit on the default
worker pool.

From the local repro: retention is flat at ~201 MB whether you convert 200 or 500 messages,
versus 354 MB then 814 MB with no recycling.

Recycling **per import batch would not work**: `MESSAGING_MESSAGES_GET_BATCH_SIZE = 400`
puts the bound near 1 GiB. Count-based at 100 is the right shape.

On CPU, N=100 means one window construction per 100 messages instead of one per message
before #25004, so it gives back roughly 1% of what #25004 saved.

## What this does not fix

This bounds the leak, it does not remove the cause. jsdom stays in the hot path, and every
message still parses HTML twice, once in `DOMPurify.sanitize()` and once in
`planer.createEmailDocument()`. That per-message parsing is untouched by caching and by
recycling, and it is part of the 29% CPU figure above.

The deeper fix is dropping jsdom from this path entirely. `html-to-text` uses `htmlparser2`
and `extractTextWithoutReplyQuotations` uses `email-reply-parser`, neither of which needs a
DOM. jsdom is carried only for DOMPurify and planer, and both look questionable here: the
output of this function is plain text, and quote stripping already happens twice. That is a
larger change needing validation against real emails, so it is not in this PR.

Worth an upstream jsdom issue too: `createHTMLDocument` inheriting the global object means
any long-lived window plus repeated document creation leaks, independent of the caller.

## Test plan

- `create-html-to-text-converter.util.spec.ts` and `extract-message-body-text.util.spec.ts` pass, 15 tests
- Added a test that conversion stays correct across the recycle boundary (250 conversions)
- Added a test that one message's document does not leak into the next
- Local memory repro above, reproducible to 0.1 MB across runs

Timings in the local microbenchmark ranged 9-37s for identical configurations, so I am not
quoting a CPU number from it. The memory figures were stable to within 0.1 MB.
