### PR TITLE
fix(sso): require IMPERSONATE permission to create/edit SSO identity providers

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/sso/__tests__/sso.resolver.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/__tests__/sso.resolver.spec.ts
@@ -9,7 +9,6 @@ import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 
 import { EnterpriseFeaturesEnabledGuard } from 'src/engine/core-modules/auth/guards/enterprise-features-enabled.guard';
 import { SsoResolver } from 'src/engine/core-modules/sso/sso.resolver';
-import { type SsoService } from 'src/engine/core-modules/sso/services/sso.service';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionsException } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { type PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
@@ -139,9 +138,9 @@ describe('SsoResolver', () => {
           Promise.resolve(setting === PermissionFlagType.IMPERSONATE),
       );
 
-      await expect(
-        runGuardsFor('deleteSSOIdentityProvider'),
-      ).rejects.toThrow(PermissionsException);
+      await expect(runGuardsFor('deleteSSOIdentityProvider')).rejects.toThrow(
+        PermissionsException,
+      );
     });
 
     it('only requires SECURITY permission (unchanged)', async () => {

--- a/packages/twenty-server/src/engine/core-modules/sso/__tests__/sso.resolver.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/__tests__/sso.resolver.spec.ts
@@ -1,5 +1,6 @@
 /* @license Enterprise */
 
+import { type ExecutionContext } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { GqlExecutionContext } from '@nestjs/graphql';
 
@@ -24,7 +25,7 @@ const NON_PERMISSION_GUARDS: unknown[] = [
 describe('SsoResolver', () => {
   let mockPermissionsService: jest.Mocked<PermissionsService>;
   let mockGqlContext: any;
-  let mockExecutionContext: any;
+  let mockExecutionContext: ExecutionContext;
 
   const buildGuardsFor = (methodName: keyof SsoResolver) => {
     const classGuards = Reflect.getMetadata(GUARDS_METADATA, SsoResolver) ?? [];
@@ -61,7 +62,7 @@ describe('SsoResolver', () => {
       },
     };
 
-    mockExecutionContext = {};
+    mockExecutionContext = {} as ExecutionContext;
 
     jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
       getContext: () => mockGqlContext,
@@ -77,10 +78,21 @@ describe('SsoResolver', () => {
     'createSAMLIdentityProvider',
     'editSSOIdentityProvider',
   ] as const)('%s', (methodName) => {
-    it('requires SECURITY permission', async () => {
-      const guards = buildGuardsFor(methodName);
+    it('rejects an actor who has IMPERSONATE but not SECURITY permission', async () => {
+      mockPermissionsService.userHasWorkspaceSettingPermission.mockImplementation(
+        ({ setting }) =>
+          Promise.resolve(setting === PermissionFlagType.IMPERSONATE),
+      );
 
-      expect(guards.length).toBeGreaterThan(0);
+      await expect(runGuardsFor(methodName)).rejects.toThrow(
+        PermissionsException,
+      );
+
+      expect(
+        mockPermissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ setting: PermissionFlagType.SECURITY }),
+      );
     });
 
     it('rejects an actor who has SECURITY but not IMPERSONATE permission', async () => {
@@ -121,6 +133,17 @@ describe('SsoResolver', () => {
   });
 
   describe('deleteSSOIdentityProvider', () => {
+    it('rejects an actor who has IMPERSONATE but not SECURITY permission', async () => {
+      mockPermissionsService.userHasWorkspaceSettingPermission.mockImplementation(
+        ({ setting }) =>
+          Promise.resolve(setting === PermissionFlagType.IMPERSONATE),
+      );
+
+      await expect(
+        runGuardsFor('deleteSSOIdentityProvider'),
+      ).rejects.toThrow(PermissionsException);
+    });
+
     it('only requires SECURITY permission (unchanged)', async () => {
       mockPermissionsService.userHasWorkspaceSettingPermission.mockImplementation(
         ({ setting }) =>

--- a/packages/twenty-server/src/engine/core-modules/sso/__tests__/sso.resolver.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/__tests__/sso.resolver.spec.ts
@@ -1,0 +1,141 @@
+/* @license Enterprise */
+
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+import { PermissionFlagType } from 'twenty-shared/constants';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+
+import { EnterpriseFeaturesEnabledGuard } from 'src/engine/core-modules/auth/guards/enterprise-features-enabled.guard';
+import { SsoResolver } from 'src/engine/core-modules/sso/sso.resolver';
+import { type SsoService } from 'src/engine/core-modules/sso/services/sso.service';
+import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
+import { PermissionsException } from 'src/engine/metadata-modules/permissions/permissions.exception';
+import { type PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
+
+// Guards unrelated to permission-flag checks (auth/entitlement) are excluded
+// so tests focus purely on which PermissionFlagType each mutation requires,
+// without having to fake a full ExecutionContext for them.
+const NON_PERMISSION_GUARDS: unknown[] = [
+  WorkspaceAuthGuard,
+  EnterpriseFeaturesEnabledGuard,
+];
+
+describe('SsoResolver', () => {
+  let mockPermissionsService: jest.Mocked<PermissionsService>;
+  let mockGqlContext: any;
+  let mockExecutionContext: any;
+
+  const buildGuardsFor = (methodName: keyof SsoResolver) => {
+    const classGuards = Reflect.getMetadata(GUARDS_METADATA, SsoResolver) ?? [];
+    const methodGuards =
+      Reflect.getMetadata(GUARDS_METADATA, SsoResolver.prototype[methodName]) ??
+      [];
+
+    return [...classGuards, ...methodGuards]
+      .filter((GuardClass) => !NON_PERMISSION_GUARDS.includes(GuardClass))
+      .map((GuardClass) => new GuardClass(mockPermissionsService));
+  };
+
+  const runGuardsFor = async (methodName: keyof SsoResolver) => {
+    for (const guard of buildGuardsFor(methodName)) {
+      // Mirrors Nest's own semantics: every applicable guard must allow the
+      // request (logical AND), so a rejection from any of them short-circuits.
+      await guard.canActivate(mockExecutionContext);
+    }
+  };
+
+  beforeEach(() => {
+    mockPermissionsService = {
+      userHasWorkspaceSettingPermission: jest.fn(),
+    } as any;
+
+    mockGqlContext = {
+      req: {
+        workspace: {
+          id: 'workspace-id',
+          activationStatus: WorkspaceActivationStatus.ACTIVE,
+        },
+        userWorkspaceId: 'user-workspace-id',
+        apiKey: null,
+      },
+    };
+
+    mockExecutionContext = {};
+
+    jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+      getContext: () => mockGqlContext,
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe.each([
+    'createOIDCIdentityProvider',
+    'createSAMLIdentityProvider',
+    'editSSOIdentityProvider',
+  ] as const)('%s', (methodName) => {
+    it('requires SECURITY permission', async () => {
+      const guards = buildGuardsFor(methodName);
+
+      expect(guards.length).toBeGreaterThan(0);
+    });
+
+    it('rejects an actor who has SECURITY but not IMPERSONATE permission', async () => {
+      mockPermissionsService.userHasWorkspaceSettingPermission.mockImplementation(
+        ({ setting }) =>
+          Promise.resolve(setting === PermissionFlagType.SECURITY),
+      );
+
+      await expect(runGuardsFor(methodName)).rejects.toThrow(
+        PermissionsException,
+      );
+
+      expect(
+        mockPermissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ setting: PermissionFlagType.IMPERSONATE }),
+      );
+    });
+
+    it('allows an actor who has both SECURITY and IMPERSONATE permission', async () => {
+      mockPermissionsService.userHasWorkspaceSettingPermission.mockResolvedValue(
+        true,
+      );
+
+      await expect(runGuardsFor(methodName)).resolves.not.toThrow();
+
+      expect(
+        mockPermissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ setting: PermissionFlagType.SECURITY }),
+      );
+      expect(
+        mockPermissionsService.userHasWorkspaceSettingPermission,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ setting: PermissionFlagType.IMPERSONATE }),
+      );
+    });
+  });
+
+  describe('deleteSSOIdentityProvider', () => {
+    it('only requires SECURITY permission (unchanged)', async () => {
+      mockPermissionsService.userHasWorkspaceSettingPermission.mockImplementation(
+        ({ setting }) =>
+          Promise.resolve(setting === PermissionFlagType.SECURITY),
+      );
+
+      await expect(
+        runGuardsFor('deleteSSOIdentityProvider'),
+      ).resolves.not.toThrow();
+
+      expect(
+        mockPermissionsService.userHasWorkspaceSettingPermission,
+      ).not.toHaveBeenCalledWith(
+        expect.objectContaining({ setting: PermissionFlagType.IMPERSONATE }),
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/sso/sso.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/sso.resolver.ts
@@ -37,7 +37,11 @@ import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-module
 export class SsoResolver {
   constructor(private readonly ssoService: SsoService) {}
 
-  @UseGuards(WorkspaceAuthGuard, EnterpriseFeaturesEnabledGuard)
+  @UseGuards(
+    WorkspaceAuthGuard,
+    EnterpriseFeaturesEnabledGuard,
+    SettingsPermissionGuard(PermissionFlagType.IMPERSONATE),
+  )
   @Mutation(() => SetupSsoDTO)
   async createOIDCIdentityProvider(
     @Args('input') setupSsoInput: SetupOidcSsoInput,
@@ -57,7 +61,11 @@ export class SsoResolver {
     return this.ssoService.getSsoIdentityProviders(workspaceId);
   }
 
-  @UseGuards(WorkspaceAuthGuard, EnterpriseFeaturesEnabledGuard)
+  @UseGuards(
+    WorkspaceAuthGuard,
+    EnterpriseFeaturesEnabledGuard,
+    SettingsPermissionGuard(PermissionFlagType.IMPERSONATE),
+  )
   @Mutation(() => SetupSsoDTO)
   async createSAMLIdentityProvider(
     @Args('input') setupSsoInput: SetupSamlSsoInput,
@@ -81,7 +89,11 @@ export class SsoResolver {
     );
   }
 
-  @UseGuards(WorkspaceAuthGuard, EnterpriseFeaturesEnabledGuard)
+  @UseGuards(
+    WorkspaceAuthGuard,
+    EnterpriseFeaturesEnabledGuard,
+    SettingsPermissionGuard(PermissionFlagType.IMPERSONATE),
+  )
   @Mutation(() => EditSsoDTO)
   async editSSOIdentityProvider(
     @Args('input') input: EditSsoInput,


### PR DESCRIPTION
Fixes #25594

Creating or editing a SAML/OIDC identity provider lets its owner sign in as any existing workspace member whose email the IdP asserts with none of impersonation's safeguards (2FA, admin-target check, audit log). That capability only required the SECURITY permission flag, which is independently assignable from IMPERSONATE, so a lower-privileged actor (e.g. a custom role with SECURITY but not IMPERSONATE) could configure a rogue IdP and take over any member's account, including Admins, entirely bypassing the impersonation feature's authorization path.

This gates createOIDCIdentityProvider, createSAMLIdentityProvider, and editSSOIdentityProvider behind IMPERSONATE in addition to SECURITY, since establishing or repointing a workspace's trusted identity provider is at least as powerful as impersonating its members directly. The default Admin role already carries both flags, so this doesn't affect normal SSO setup. deleteSSOIdentityProvider is unchanged since revoking access grants no new capability.

Added sso.resolver.spec.ts covering both the rejection (SECURITY-only) and success (SECURITY + IMPERSONATE) paths for all three affected mutations.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

