### PR TITLE
Allow automation and AI agents in the terms of service

### DIFF
--- a/packages/twenty-website/public/llms.txt
+++ b/packages/twenty-website/public/llms.txt
@@ -8,7 +8,7 @@ Twenty is multi-tenant, so there is no single global API host: each workspace ha
 
 ## Signing up
 
-Agent-driven signup is allowed: an agent acting openly for an identified person may create an account, create a workspace, and complete onboarding for them, per section 10 of the [Terms of Service](https://twenty.com/terms). The account holder stays responsible for what the agent does under the account. Creating accounts in bulk, working around usage limits, and collecting data you are not entitled to are not allowed.
+Agent-driven signup is allowed: an agent acting openly for an identified person or organization may create an account, create a workspace, and complete onboarding for them, per section 10 of the [Terms of Service](https://twenty.com/terms). The account holder stays responsible for what the agent does under the account. Creating accounts in bulk, working around usage limits, and collecting data you are not entitled to are not allowed.
 
 Signup runs through the web app at `https://app.twenty.com`: account creation is CAPTCHA-protected, so a browser-driving agent completes it the way a person would, including email verification. Everything after that is available over the API, and an agent should move to its own API key or OAuth connection rather than keep using the account password.
 

--- a/packages/twenty-website/public/llms.txt
+++ b/packages/twenty-website/public/llms.txt
@@ -6,6 +6,12 @@ Every endpoint is workspace-scoped: replace `{your-workspace-url}` with your wor
 
 Twenty is multi-tenant, so there is no single global API host: each workspace has its own base URL, and the REST OpenAPI is generated per workspace, so it includes any custom objects and fields you have created. Prefer the MCP server for agents — it exposes typed tools with header-based auth and discovers your workspace's tools at runtime, so it does not depend on the per-workspace OpenAPI document.
 
+## Signing up
+
+Agent-driven signup is allowed: an agent acting openly for an identified person may create an account, create a workspace, and complete onboarding for them, per section 10 of the [Terms of Service](https://twenty.com/terms). The account holder stays responsible for what the agent does under the account. Creating accounts in bulk, working around usage limits, and collecting data you are not entitled to are not allowed.
+
+Signup runs through the web app at `https://app.twenty.com`: account creation is CAPTCHA-protected, so a browser-driving agent completes it the way a person would, including email verification. Everything after that is available over the API, and an agent should move to its own API key or OAuth connection rather than keep using the account password.
+
 ## Connect an AI assistant
 
 - [MCP server guide](https://docs.twenty.com/user-guide/ai/capabilities/mcp): connect Claude, Cursor, ChatGPT and others.

--- a/packages/twenty-website/public/llms.txt
+++ b/packages/twenty-website/public/llms.txt
@@ -10,7 +10,7 @@ Twenty is multi-tenant, so there is no single global API host: each workspace ha
 
 Agent-driven signup is allowed: an agent acting openly for an identified person or organization may create an account, create a workspace, and complete onboarding for them, per section 10 of the [Terms of Service](https://twenty.com/terms). The account holder stays responsible for what the agent does under the account. Creating accounts in bulk, working around usage limits, and collecting data you are not entitled to are not allowed.
 
-Signup runs through the web app at `https://app.twenty.com`: account creation is CAPTCHA-protected, so a browser-driving agent completes it the way a person would, including email verification. Everything after that is available over the API, and an agent should move to its own API key or OAuth connection rather than keep using the account password.
+Signup runs through the web app at `https://app.twenty.com`: account creation is CAPTCHA-protected, so a browser-driving agent completes it the way a person would, including email verification. Once the workspace exists, the MCP server is the easier path for most agents, and connecting over OAuth or an API key keeps the account password out of the loop. Continuing to drive the app in a browser is allowed too.
 
 ## Connect an AI assistant
 

--- a/packages/twenty-website/src/sections/legal/TermsDocument.tsx
+++ b/packages/twenty-website/src/sections/legal/TermsDocument.tsx
@@ -402,10 +402,11 @@ export function TermsDocument() {
         AI agents to work with your workspace, whether they call our APIs or use
         the app in a browser as you would, and an agent may act for you,
         including when signing up, as long as it acts openly on behalf of an
-        identified customer. The rules in this section apply to automated use
-        exactly as they do to a person clicking in the app: creating accounts in
-        bulk, working around usage limits, and collecting data you are not
-        entitled to are not allowed, whoever or whatever does them.
+        identified person or organization. The rules in this section apply to
+        automated use exactly as they do to a person clicking in the app:
+        creating accounts in bulk, working around usage limits, and collecting
+        data you are not entitled to are not allowed, whoever or whatever does
+        them.
       </p>
       <p>
         Plans include usage limits, described on the pricing page or in your

--- a/packages/twenty-website/src/sections/legal/TermsDocument.tsx
+++ b/packages/twenty-website/src/sections/legal/TermsDocument.tsx
@@ -36,6 +36,11 @@ export function TermsDocument() {
           terms.
         </li>
         <li>
+          You can automate your use of the Service and have AI agents act for
+          you, including when signing up. You stay responsible for what they do
+          under your account.
+        </li>
+        <li>
           Subscriptions renew automatically. You can cancel at any time,
           effective at the end of your current billing period.
         </li>
@@ -141,7 +146,11 @@ export function TermsDocument() {
         date, to keep your credentials confidential, and to notify us promptly
         at <a href="mailto:contact@twenty.com">contact@twenty.com</a> if you
         suspect unauthorized use of your account. You are responsible for
-        activity that occurs under your account.
+        activity that occurs under your account, including activity by software
+        or AI agents you authorize to act for you, whether they call our APIs or
+        use the app the way you would. For ongoing automated access, we
+        recommend giving an agent its own API key or OAuth connection, scoped to
+        a role with only the access it needs.
       </p>
       <p>
         Data in Twenty lives in workspaces. Workspace administrators control who
@@ -377,8 +386,8 @@ export function TermsDocument() {
           rate limits, or usage limits;
         </li>
         <li>
-          access the Cloud Service by automated means other than our documented
-          APIs;
+          scrape or bulk-extract content from the Site, or data from workspaces
+          you are not authorized to access;
         </li>
         <li>misrepresent who you are or your affiliation with anyone; or</li>
         <li>
@@ -388,6 +397,16 @@ export function TermsDocument() {
           give you, including hosting the software yourself.
         </li>
       </ol>
+      <p>
+        Automation is allowed. You may use our APIs, our MCP server, scripts, or
+        AI agents to work with your workspace, whether they call our APIs or use
+        the app in a browser as you would, and an agent may act for you,
+        including when signing up, as long as it acts openly on behalf of an
+        identified customer. The rules in this section apply to automated use
+        exactly as they do to a person clicking in the app: creating accounts in
+        bulk, working around usage limits, and collecting data you are not
+        entitled to are not allowed, whoever or whatever does them.
+      </p>
       <p>
         Plans include usage limits, described on the pricing page or in your
         order form, and the Service is subject to fair use so one

--- a/packages/twenty-website/src/sections/legal/TermsDocument.tsx
+++ b/packages/twenty-website/src/sections/legal/TermsDocument.tsx
@@ -386,8 +386,8 @@ export function TermsDocument() {
           rate limits, or usage limits;
         </li>
         <li>
-          scrape or bulk-extract content from the Site, or data from workspaces
-          you are not authorized to access;
+          bulk-extract data from workspaces you are not authorized to access, or
+          scrape the Site in a way that burdens it;
         </li>
         <li>misrepresent who you are or your affiliation with anyone; or</li>
         <li>


### PR DESCRIPTION
## Summary

Section 10 of the terms banned accessing the Cloud Service "by automated means other than our documented APIs". That clause is inherited from the generic template the terms replaced, which had the classic "robot, spider, or other automatic device" wording, and it reads as a ban on using Twenty with an agent. That is the opposite of what we ship: an MCP server with OAuth 2.1 and dynamic client registration, agent-facing metadata in `llms.txt` and the MCP server card, and AI agents in the product. A prospect read it that way this week and paused their signup over it.

Changes:

- Section 10.6 replaced with the harm it was aimed at: bulk-extracting data from workspaces you are not authorized to access, or scraping the Site in a way that burdens it. The test is burden and authorization, not automation, so a customer exporting their own workspace is not caught by it and the public pages stay crawlable as `llms.txt` and `robots.txt` invite.
- New paragraph in section 10 stating automation is allowed, whether an agent calls our APIs or drives the app in a browser the way a person would, including at signup, as long as it acts openly for an identified person or organization. Creating accounts in bulk, working around usage limits, and collecting data you are not entitled to stay prohibited.
- Section 3 extends responsibility for account activity to agents you authorize, and recommends rather than requires a scoped API key or OAuth connection for ongoing automated access. Account creation is CAPTCHA-protected and runs through the front end, so a computer-use agent necessarily signs up the way a person does.
- A short-version bullet, since that summary is where the impression gets formed.
- `llms.txt` gains a "Signing up" section. It described how to use a workspace but not how to get one.

## Notes

- Content-only change: no routes, styling, or i18n (legal pages are not translated).
- Effective date left at the August 7, 2026 placeholder; set it when this ships. Section 20 requires at least 30 days' notice for a material change, so the date depends on the publication schedule. Tracked in an open review thread rather than guessed here.
- Needs legal review. The change only widens what is permitted, so it should not count as a material adverse change under section 20, but that is a call for review rather than mine.
- `oxlint`, `oxfmt --check` and `check-conventions` pass on the changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture>``&lt;source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;&lt;source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"&gt;&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</picture></a>
<!-- End of auto-generated description by cubic. -->
