### PR TITLE
fix(sso): route OIDC issuer discovery through the SSRF-safe agent

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/sso/services/__tests__/sso.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/services/__tests__/sso.service.spec.ts
@@ -18,7 +18,7 @@ describe('SsoService', () => {
 
     return new SsoService(
       {} as any,
-      mockTwentyConfigService as TwentyConfigService,
+      mockTwentyConfigService as unknown as TwentyConfigService,
       {} as BillingService,
       {} as ExceptionHandlerService,
     );
@@ -66,8 +66,10 @@ describe('SsoService', () => {
         {} as any,
       );
 
+      const agent = httpOptions.agent as http.Agent;
+
       expect(() => {
-        httpOptions.agent!.createConnection(
+        agent.createConnection(
           { host: '169.254.169.254' } as any,
           jest.fn() as any,
         );

--- a/packages/twenty-server/src/engine/core-modules/sso/services/__tests__/sso.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/services/__tests__/sso.service.spec.ts
@@ -1,0 +1,91 @@
+/* @license Enterprise */
+
+import * as http from 'http';
+import * as https from 'https';
+
+import { custom, Issuer } from 'openid-client';
+
+import { type BillingService } from 'src/engine/core-modules/billing/services/billing.service';
+import { type ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { SsoService } from 'src/engine/core-modules/sso/services/sso.service';
+import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+
+describe('SsoService', () => {
+  let mockTwentyConfigService: jest.Mocked<Pick<TwentyConfigService, 'get'>>;
+
+  const buildSsoService = () => {
+    mockTwentyConfigService = { get: jest.fn() };
+
+    return new SsoService(
+      {} as any,
+      mockTwentyConfigService as TwentyConfigService,
+      {} as BillingService,
+      {} as ExceptionHandlerService,
+    );
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Issuer.discover() SSRF protection', () => {
+    it('routes discovery requests through an SSRF-safe https agent when safe mode is enabled', () => {
+      buildSsoService();
+      mockTwentyConfigService.get.mockReturnValue(true);
+
+      const httpOptions = Issuer[custom.http_options](
+        new URL('https://attacker-controlled-idp.example'),
+        {} as any,
+      );
+
+      expect(mockTwentyConfigService.get).toHaveBeenCalledWith(
+        'OUTBOUND_HTTP_SAFE_MODE_ENABLED',
+      );
+      expect(httpOptions.agent).toBeInstanceOf(https.Agent);
+    });
+
+    it('routes discovery requests through an SSRF-safe http agent when safe mode is enabled', () => {
+      buildSsoService();
+      mockTwentyConfigService.get.mockReturnValue(true);
+
+      const httpOptions = Issuer[custom.http_options](
+        new URL('http://169.254.169.254/latest/meta-data/'),
+        {} as any,
+      );
+
+      expect(httpOptions.agent).toBeInstanceOf(http.Agent);
+      expect(httpOptions.agent).not.toBeInstanceOf(https.Agent);
+    });
+
+    it('blocks a private/metadata address via the returned agent', () => {
+      buildSsoService();
+      mockTwentyConfigService.get.mockReturnValue(true);
+
+      const httpOptions = Issuer[custom.http_options](
+        new URL('http://169.254.169.254/latest/meta-data/'),
+        {} as any,
+      );
+
+      expect(() => {
+        httpOptions.agent!.createConnection(
+          { host: '169.254.169.254' } as any,
+          jest.fn() as any,
+        );
+      }).toThrow(
+        'Request to internal IP address 169.254.169.254 is not allowed.',
+      );
+    });
+
+    it('does not override the agent when safe mode is disabled', () => {
+      buildSsoService();
+      mockTwentyConfigService.get.mockReturnValue(false);
+
+      const httpOptions = Issuer[custom.http_options](
+        new URL('https://issuer.example.com'),
+        {} as any,
+      );
+
+      expect(httpOptions).toStrictEqual({});
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/sso/services/sso.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/services/sso.service.ts
@@ -3,7 +3,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Issuer } from 'openid-client';
+import { custom, Issuer } from 'openid-client';
 import { Repository } from 'typeorm';
 
 import {
@@ -14,6 +14,7 @@ import {
 import { BillingEntitlementKey } from 'src/engine/core-modules/billing/enums/billing-entitlement-key.enum';
 import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { createSsrfSafeAgent } from 'src/engine/core-modules/secure-http-client/utils/create-ssrf-safe-agent.util';
 import {
   SsoException,
   SsoExceptionCode,
@@ -34,7 +35,24 @@ export class SsoService {
     private readonly twentyConfigService: TwentyConfigService,
     private readonly billingService: BillingService,
     private readonly exceptionHandlerService: ExceptionHandlerService,
-  ) {}
+  ) {
+    // Issuer.discover() makes its own outbound request to an admin-supplied
+    // URL, outside SecureHttpClientService. This is openid-client's only
+    // hook to route it through the same SSRF-safe agents, and it's static
+    // on Issuer, so setting it once here also covers the Issuer.discover()
+    // call in OidcAuthGuard.
+    Issuer[custom.http_options] = (url) => {
+      if (!this.twentyConfigService.get('OUTBOUND_HTTP_SAFE_MODE_ENABLED')) {
+        return {};
+      }
+
+      return {
+        agent: createSsrfSafeAgent(
+          url.protocol === 'https:' ? 'https' : 'http',
+        ),
+      };
+    };
+  }
 
   private async isSsoEnabled(workspaceId: string) {
     const isSsoBillingEnabled = await this.billingService.hasEntitlement(


### PR DESCRIPTION
Fixes #25638

Issuer.discover([issuerUrl](https://github.com/twentyhq/twenty/issues/25638)) called in SsoService.getIssuerForOidc and again on every login in OidcAuthGuard — makes its own outbound request via openid-client's internal HTTP client, not SecureHttpClientService, the SSRF-safe client used consistently everywhere else outbound requests are made (webhooks, workflow HTTP actions, CalDAV, IMAP/SMTP, avatar fetching). Since issuerUrl is admin-supplied, an actor with only the SECURITY permission (not an instance admin) could point discovery at internal-only network targets, including the cloud metadata service, from the shared backend process — and repeat it on every subsequent login through that IdP.

openid-client exposes a single hook for customizing the HTTP client behind Issuer.discover(): a static Issuer[custom.http_options] provider. This wires it to the same SSRF-safe connection-level agent SecureHttpClientService uses elsewhere (blocks private/link-local/metadata IPs, validates DNS-resolved addresses to close rebinding), respecting the existing OUTBOUND_HTTP_SAFE_MODE_ENABLED toggle. Because the hook is static on the Issuer class, setting it once in SsoService's constructor also protects OidcAuthGuard's Issuer.discover() call.

Added sso.service.spec.ts covering: correct agent selected by protocol, the agent actually rejecting a metadata-service address, and the hook being a no-op when safe mode is off.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

