### PR TITLE
Reactivate isSystemSideEffect view field groups stuck isActive=false

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-upgrade-version-command.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { SyncRecordShareObjectCommand } from 'src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788794677636-sync-record-share-object.command';
+import { ReactivateSystemSideEffectViewFieldGroupsCommand } from 'src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788902177727-reactivate-system-side-effect-view-field-groups.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { ViewFieldGroupEntity } from 'src/engine/metadata-modules/view-field-group/entities/view-field-group.entity';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
@@ -10,6 +13,7 @@ import { WorkspaceSchemaMigrationRunnerActionHandlersModule } from 'src/engine/w
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([ViewFieldGroupEntity]),
     ApplicationModule,
     WorkspaceCacheModule,
     WorkspaceIteratorModule,
@@ -17,6 +21,9 @@ import { WorkspaceSchemaMigrationRunnerActionHandlersModule } from 'src/engine/w
     WorkspaceMigrationRunnerModule,
     WorkspaceSchemaMigrationRunnerActionHandlersModule,
   ],
-  providers: [SyncRecordShareObjectCommand],
+  providers: [
+    SyncRecordShareObjectCommand,
+    ReactivateSystemSideEffectViewFieldGroupsCommand,
+  ],
 })
 export class V2_40_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-upgrade-version-command.module.ts
@@ -5,6 +5,7 @@ import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/w
 import { SyncRecordShareObjectCommand } from 'src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788794677636-sync-record-share-object.command';
 import { ReactivateSystemSideEffectViewFieldGroupsCommand } from 'src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788902177727-reactivate-system-side-effect-view-field-groups.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { UpgradeMigrationEntity } from 'src/engine/core-modules/upgrade/upgrade-migration.entity';
 import { ViewFieldGroupEntity } from 'src/engine/metadata-modules/view-field-group/entities/view-field-group.entity';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
@@ -13,7 +14,7 @@ import { WorkspaceSchemaMigrationRunnerActionHandlersModule } from 'src/engine/w
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ViewFieldGroupEntity]),
+    TypeOrmModule.forFeature([ViewFieldGroupEntity, UpgradeMigrationEntity]),
     ApplicationModule,
     WorkspaceCacheModule,
     WorkspaceIteratorModule,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788902177727-reactivate-system-side-effect-view-field-groups.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788902177727-reactivate-system-side-effect-view-field-groups.command.ts
@@ -1,0 +1,86 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+import { In, Repository } from 'typeorm';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { computeRecordPageReconcileFlatEntityMapsKeys } from 'src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-reconcile-flat-entity-maps-keys.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { ViewFieldGroupEntity } from 'src/engine/metadata-modules/view-field-group/entities/view-field-group.entity';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+@RegisteredWorkspaceCommand('2.40.0', 1788902177727)
+@Command({
+  name: 'upgrade:2-40:reactivate-system-side-effect-view-field-groups',
+  description:
+    'Reactivate isSystemSideEffect view field groups left isActive=false from before the 2-31 record-page reconcile existed, which hides their fields-widget section instead of just renaming/flagging it',
+})
+export class ReactivateSystemSideEffectViewFieldGroupsCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
+    // eslint-disable-next-line twenty/prefer-workspace-scoped-repository
+    @InjectRepository(ViewFieldGroupEntity)
+    private readonly viewFieldGroupRepository: Repository<ViewFieldGroupEntity>,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const { flatViewFieldGroupMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatViewFieldGroupMaps',
+      ]);
+
+    const inactiveSystemGroups = Object.values(
+      flatViewFieldGroupMaps.byUniversalIdentifier,
+    )
+      .filter(isDefined)
+      .filter(
+        (group) =>
+          group.isSystemSideEffect &&
+          !group.isActive &&
+          group.deletedAt === null,
+      );
+
+    if (inactiveSystemGroups.length === 0) {
+      this.logger.log(
+        `No inactive system-owned view field groups to reactivate for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    if (isDryRun) {
+      this.logger.log(
+        `[DRY RUN] Would reactivate ${inactiveSystemGroups.length} view field group(s) for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    await this.viewFieldGroupRepository.update(
+      { id: In(inactiveSystemGroups.map((group) => group.id)), workspaceId },
+      { isActive: true },
+    );
+
+    await this.workspaceMigrationRunnerService.invalidateCache({
+      allFlatEntityMapsKeys: computeRecordPageReconcileFlatEntityMapsKeys(),
+      workspaceId,
+    });
+
+    this.logger.log(
+      `Reactivated ${inactiveSystemGroups.length} view field group(s) for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788902177727-reactivate-system-side-effect-view-field-groups.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788902177727-reactivate-system-side-effect-view-field-groups.command.ts
@@ -1,5 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
+import chunk from 'lodash.chunk';
 import { Command } from 'nest-commander';
 import { isDefined } from 'twenty-shared/utils';
 import { In, Repository } from 'typeorm';
@@ -9,15 +10,28 @@ import { WorkspaceIteratorService } from 'src/database/commands/command-runners/
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
 import { computeRecordPageReconcileFlatEntityMapsKeys } from 'src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-reconcile-flat-entity-maps-keys.util';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { UpgradeMigrationEntity } from 'src/engine/core-modules/upgrade/upgrade-migration.entity';
 import { ViewFieldGroupEntity } from 'src/engine/metadata-modules/view-field-group/entities/view-field-group.entity';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+// Must match ReconcileStandardRecordPageCommand's @Command name.
+const RECONCILE_STANDARD_RECORD_PAGE_COMMAND_NAME =
+  'upgrade:2-31:reconcile-standard-record-page';
+
+// A group updated no later than shortly after the 2-31 reconcile ran was
+// never touched again afterward: any deliberate deactivation through
+// upsertFieldsWidget (removing a section in the fields widget) bumps
+// updatedAt past this point, so it is excluded and left alone.
+const REACTIVATION_SAFETY_MARGIN_MS = 5 * 60 * 1000;
+
+const REACTIVATION_BATCH_SIZE = 200;
 
 @RegisteredWorkspaceCommand('2.40.0', 1788902177727)
 @Command({
   name: 'upgrade:2-40:reactivate-system-side-effect-view-field-groups',
   description:
-    'Reactivate isSystemSideEffect view field groups left isActive=false from before the 2-31 record-page reconcile existed, which hides their fields-widget section instead of just renaming/flagging it',
+    'Reactivate isSystemSideEffect view field groups left isActive=false since before the 2-31 record-page reconcile ran, without touching groups deactivated on purpose afterward through the fields widget',
 })
 export class ReactivateSystemSideEffectViewFieldGroupsCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
@@ -27,6 +41,9 @@ export class ReactivateSystemSideEffectViewFieldGroupsCommand extends Provisione
     // eslint-disable-next-line twenty/prefer-workspace-scoped-repository
     @InjectRepository(ViewFieldGroupEntity)
     private readonly viewFieldGroupRepository: Repository<ViewFieldGroupEntity>,
+    // eslint-disable-next-line twenty/prefer-workspace-scoped-repository
+    @InjectRepository(UpgradeMigrationEntity)
+    private readonly upgradeMigrationRepository: Repository<UpgradeMigrationEntity>,
   ) {
     super(workspaceIteratorService);
   }
@@ -36,6 +53,30 @@ export class ReactivateSystemSideEffectViewFieldGroupsCommand extends Provisione
     options,
   }: RunOnWorkspaceArgs): Promise<void> {
     const isDryRun = options.dryRun ?? false;
+
+    const reconcileRun = await this.upgradeMigrationRepository.findOne({
+      where: {
+        name: RECONCILE_STANDARD_RECORD_PAGE_COMMAND_NAME,
+        workspaceId,
+        status: 'completed',
+      },
+      order: { attempt: 'DESC' },
+    });
+
+    if (!isDefined(reconcileRun)) {
+      // Workspace was created after 2.31 became current: its groups are
+      // created isActive=true from the start, so isActive=false here can
+      // only be a deliberate deactivation, never leave that alone.
+      this.logger.log(
+        `Workspace ${workspaceId} never ran the 2-31 record-page reconcile, skipping`,
+      );
+
+      return;
+    }
+
+    const reactivationCutoff = new Date(
+      reconcileRun.createdAt.getTime() + REACTIVATION_SAFETY_MARGIN_MS,
+    );
 
     const { flatViewFieldGroupMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
@@ -50,7 +91,8 @@ export class ReactivateSystemSideEffectViewFieldGroupsCommand extends Provisione
         (group) =>
           group.isSystemSideEffect &&
           !group.isActive &&
-          group.deletedAt === null,
+          group.deletedAt === null &&
+          new Date(group.updatedAt) <= reactivationCutoff,
       );
 
     if (inactiveSystemGroups.length === 0) {
@@ -69,10 +111,14 @@ export class ReactivateSystemSideEffectViewFieldGroupsCommand extends Provisione
       return;
     }
 
-    await this.viewFieldGroupRepository.update(
-      { id: In(inactiveSystemGroups.map((group) => group.id)), workspaceId },
-      { isActive: true },
-    );
+    const groupIds = inactiveSystemGroups.map((group) => group.id);
+
+    for (const idsBatch of chunk(groupIds, REACTIVATION_BATCH_SIZE)) {
+      await this.viewFieldGroupRepository.update(
+        { id: In(idsBatch), workspaceId },
+        { isActive: true },
+      );
+    }
 
     await this.workspaceMigrationRunnerService.invalidateCache({
       allFlatEntityMapsKeys: computeRecordPageReconcileFlatEntityMapsKeys(),

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788902177727-reactivate-system-side-effect-view-field-groups.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-40/2-40-workspace-command-1788902177727-reactivate-system-side-effect-view-field-groups.command.ts
@@ -19,12 +19,6 @@ import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/wo
 const RECONCILE_STANDARD_RECORD_PAGE_COMMAND_NAME =
   'upgrade:2-31:reconcile-standard-record-page';
 
-// A group updated no later than shortly after the 2-31 reconcile ran was
-// never touched again afterward: any deliberate deactivation through
-// upsertFieldsWidget (removing a section in the fields widget) bumps
-// updatedAt past this point, so it is excluded and left alone.
-const REACTIVATION_SAFETY_MARGIN_MS = 5 * 60 * 1000;
-
 const REACTIVATION_BATCH_SIZE = 200;
 
 @RegisteredWorkspaceCommand('2.40.0', 1788902177727)
@@ -74,9 +68,13 @@ export class ReactivateSystemSideEffectViewFieldGroupsCommand extends Provisione
       return;
     }
 
-    const reactivationCutoff = new Date(
-      reconcileRun.createdAt.getTime() + REACTIVATION_SAFETY_MARGIN_MS,
-    );
+    // recordUpgradeMigration only writes this row after runOnWorkspace's own
+    // transaction (applyRecordPageReownUpdates) has committed, so this
+    // timestamp is already guaranteed to be >= every row the reconcile
+    // itself touched - no extra margin needed, and none should be added:
+    // it would let a fields-widget removal made shortly after the reconcile
+    // slip through and get wrongly reactivated.
+    const reactivationCutoff = reconcileRun.createdAt;
 
     const { flatViewFieldGroupMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [


### PR DESCRIPTION
## Problem

Fixes #25653.

Workspaces that had record-page `viewFieldGroup` rows before the 2-31 `reconcile-standard-record-page` command existed (i.e. rows created by the pre-2.20 provisioning path or the 1-23 backfill) keep those rows `isActive=false` forever. Every subsequent upgrade touches them - the reconcile pass re-owns the row onto the derived `universalIdentifier` scheme and flags `isSystemSideEffect: true` - but nothing in that pipeline ever sets `isActive` back to `true`.

`createViewFieldGroupsByViewIdLoader` filters on `deletedAt === null && isActive`, so these groups silently disappear from the FIELDS widget: the record page's field sidebar renders as one flat, ungrouped list instead of the sectioned "Business", "Additional info", etc. groups - with no error, and no underlying field/data loss (confirmed via direct SQL: the rows are present and correct in every other column).

Root cause and repro details, plus why the row lands on `isActive=false` in the first place, are in #25653.

## Why not fix the 2-31 command itself

`docs/UPGRADE_COMMANDS.md` and the repo's own convention are explicit: upgrade commands are never rewritten once shipped, since the sequence runner tracks what already ran per workspace. `reconcile-standard-record-page` has already executed for every workspace that is currently on >= 2.31, so editing its logic in place would not touch already-affected workspaces at all, while still being a change to previously-committed command logic.

## Fix

A small forward-fixing workspace command under the current version (`2-40`), following the same shape as the neighboring 2-31 commands (`ProvisionedWorkspaceCommandRunner`, `WorkspaceCacheService.getOrRecompute`, direct repository update + `WorkspaceMigrationRunnerService.invalidateCache` with the existing `computeRecordPageReconcileFlatEntityMapsKeys()` closure that the 2-31 reconcile command already uses for the same cache domain):

- Loads `flatViewFieldGroupMaps` per workspace.
- Selects `isSystemSideEffect === true && isActive === false && deletedAt === null` groups - i.e. exactly the population the 2-31 reconcile pass already claims ownership of by flagging `isSystemSideEffect`, so this can't touch a genuinely user-deactivated custom group (those never get `isSystemSideEffect: true`).
- Sets `isActive: true` on them in one batched update, then invalidates the record-page flat cache closure.

No existing files are modified other than registering the new command as a provider in `2-40-upgrade-version-command.module.ts` (same pattern as the existing `SyncRecordShareObjectCommand`).

## Test plan

- [ ] `npx nx run twenty-server:database:migrate:generate`-style review of the new command against `docs/UPGRADE_COMMANDS.md` conventions (timestamp, `up`/registration pattern)
- [ ] Manually verified the equivalent fix (direct `UPDATE ... SET "isActive" = true` + `cache:flat-cache-invalidate`) against a real affected workspace: previously-flat Company/Opportunity field sidebars render sectioned again, no data changed
- [ ] `--dry-run` path logs the would-be reactivation count without writing

Happy to add a `.spec.ts` for the command if maintainers want one - I didn't see one on the sibling `SyncRecordShareObjectCommand` in the same version directory so followed that precedent, but can match whichever convention is preferred.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

