### PR TITLE
Serialize a workspace's entitlement transition

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/billing-webhook.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/billing-webhook.module.ts
@@ -13,6 +13,7 @@ import { BillingWebhookProductService } from 'src/engine/core-modules/billing-we
 import { BillingWebhookSubscriptionScheduleService } from 'src/engine/core-modules/billing-webhook/services/billing-webhook-subscription-schedule.service';
 import { BillingWebhookSubscriptionService } from 'src/engine/core-modules/billing-webhook/services/billing-webhook-subscription.service';
 import { BillingModule } from 'src/engine/core-modules/billing/billing.module';
+import { CacheLockModule } from 'src/engine/core-modules/cache-lock/cache-lock.module';
 import { UsageLimitModule } from 'src/engine/core-modules/usage-limit/usage-limit.module';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { BillingCustomerEntity } from 'src/engine/core-modules/billing/entities/billing-customer.entity';
@@ -44,6 +45,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     WorkspaceModule,
     BillingModule,
     UsageLimitModule,
+    CacheLockModule,
     WorkspaceIteratorModule,
     WorkspaceCacheModule,
     TypeOrmModule.forFeature([

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/__tests__/billing-entitlement-sync.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/__tests__/billing-entitlement-sync.service.spec.ts
@@ -35,19 +35,24 @@ describe('BillingEntitlementSyncService', () => {
   // that a stub was called. Queued rather than spin-waiting so ordering is
   // deterministic.
   const heldLockKeys = new Set<string>();
-  let lockQueue: Promise<unknown> = Promise.resolve();
+  const lockQueueByKey = new Map<string, Promise<unknown>>();
   const cacheLockService = {
     withLock: jest.fn(<TResult>(fn: () => Promise<TResult>, key: string) => {
-      const runWhenFree = lockQueue.then(async () => {
-        heldLockKeys.add(key);
-        try {
-          return await fn();
-        } finally {
-          heldLockKeys.delete(key);
-        }
-      });
+      const runWhenFree = (lockQueueByKey.get(key) ?? Promise.resolve()).then(
+        async () => {
+          heldLockKeys.add(key);
+          try {
+            return await fn();
+          } finally {
+            heldLockKeys.delete(key);
+          }
+        },
+      );
 
-      lockQueue = runWhenFree.catch(() => undefined);
+      lockQueueByKey.set(
+        key,
+        runWhenFree.catch(() => undefined),
+      );
 
       return runWhenFree;
     }),
@@ -60,7 +65,7 @@ describe('BillingEntitlementSyncService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     heldLockKeys.clear();
-    lockQueue = Promise.resolve();
+    lockQueueByKey.clear();
     billingEntitlementRepository.upsert.mockResolvedValue(undefined);
     usageLimitQuotaService.dropIntraWorkspaceLimitCounters.mockResolvedValue(
       undefined,

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/__tests__/billing-entitlement-sync.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/__tests__/billing-entitlement-sync.service.spec.ts
@@ -1,0 +1,197 @@
+/* @license Enterprise */
+
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { BillingEntitlementSyncService } from 'src/engine/core-modules/billing-webhook/services/billing-entitlement-sync.service';
+import { BillingEntitlementEntity } from 'src/engine/core-modules/billing/entities/billing-entitlement.entity';
+import { BillingEntitlementKey } from 'src/engine/core-modules/billing/enums/billing-entitlement-key.enum';
+import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
+import { UsageLimitQuotaService } from 'src/engine/core-modules/usage-limit/services/usage-limit-quota.service';
+import { RowLevelPermissionPredicateGroupService } from 'src/engine/metadata-modules/row-level-permission-predicate/services/row-level-permission-predicate-group.service';
+import { getWorkspaceScopedRepositoryToken } from 'src/engine/twenty-orm/workspace-scoped-repository/get-workspace-scoped-repository-token.util';
+
+const WORKSPACE_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
+const STRIPE_CUSTOMER_ID = 'cus_test';
+const RLS_LOOKUP_KEY = 'RLS';
+
+describe('BillingEntitlementSyncService', () => {
+  let service: BillingEntitlementSyncService;
+
+  const billingEntitlementRepository = {
+    find: jest.fn(),
+    upsert: jest.fn(),
+  };
+
+  const rowLevelPermissionPredicateGroupService = {
+    deleteAllRowLevelPermissionPredicateGroups: jest.fn(),
+  };
+
+  const usageLimitQuotaService = {
+    dropIntraWorkspaceLimitCounters: jest.fn(),
+  };
+
+  // A real single-holder lock rather than a pass-through, so a test that runs
+  // two syncs concurrently exercises the serialization instead of asserting
+  // that a stub was called. Queued rather than spin-waiting so ordering is
+  // deterministic.
+  const heldLockKeys = new Set<string>();
+  let lockQueue: Promise<unknown> = Promise.resolve();
+  const cacheLockService = {
+    withLock: jest.fn(<TResult>(fn: () => Promise<TResult>, key: string) => {
+      const runWhenFree = lockQueue.then(async () => {
+        heldLockKeys.add(key);
+        try {
+          return await fn();
+        } finally {
+          heldLockKeys.delete(key);
+        }
+      });
+
+      lockQueue = runWhenFree.catch(() => undefined);
+
+      return runWhenFree;
+    }),
+  };
+
+  const givenStoredEntitlements = (
+    entitlements: { key: BillingEntitlementKey; value: boolean }[],
+  ) => billingEntitlementRepository.find.mockResolvedValue(entitlements);
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    heldLockKeys.clear();
+    lockQueue = Promise.resolve();
+    billingEntitlementRepository.upsert.mockResolvedValue(undefined);
+    usageLimitQuotaService.dropIntraWorkspaceLimitCounters.mockResolvedValue(
+      undefined,
+    );
+    rowLevelPermissionPredicateGroupService.deleteAllRowLevelPermissionPredicateGroups.mockResolvedValue(
+      undefined,
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BillingEntitlementSyncService,
+        {
+          provide: getWorkspaceScopedRepositoryToken(BillingEntitlementEntity),
+          useValue: billingEntitlementRepository,
+        },
+        {
+          provide: RowLevelPermissionPredicateGroupService,
+          useValue: rowLevelPermissionPredicateGroupService,
+        },
+        {
+          provide: UsageLimitQuotaService,
+          useValue: usageLimitQuotaService,
+        },
+        {
+          provide: CacheLockService,
+          useValue: cacheLockService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<BillingEntitlementSyncService>(
+      BillingEntitlementSyncService,
+    );
+  });
+
+  const syncEntitlements = (activeLookupKeys: string[]) =>
+    service.syncEntitlements({
+      workspaceId: WORKSPACE_ID,
+      stripeCustomerId: STRIPE_CUSTOMER_ID,
+      activeLookupKeys,
+    });
+
+  it('drops usage-limit counters once when two syncs observe the same grant', async () => {
+    givenStoredEntitlements([
+      { key: BillingEntitlementKey.USAGE_LIMIT, value: false },
+    ]);
+
+    // Once the first sync commits, the stored rows read as granted, so the
+    // second sync sees no transition. Without the lock both would read the
+    // pre-commit state and both would drop, and the later drop would discard
+    // usage already recorded under enforcement.
+    billingEntitlementRepository.upsert.mockImplementation(async () => {
+      givenStoredEntitlements([
+        { key: BillingEntitlementKey.USAGE_LIMIT, value: true },
+      ]);
+    });
+
+    await Promise.all([
+      syncEntitlements([BillingEntitlementKey.USAGE_LIMIT]),
+      syncEntitlements([BillingEntitlementKey.USAGE_LIMIT]),
+    ]);
+
+    expect(
+      usageLimitQuotaService.dropIntraWorkspaceLimitCounters,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('never deletes predicates after a concurrent grant has committed', async () => {
+    let isRlsGrantedInStore = true;
+
+    billingEntitlementRepository.find.mockImplementation(async () => [
+      { key: BillingEntitlementKey.RLS, value: isRlsGrantedInStore },
+    ]);
+
+    billingEntitlementRepository.upsert.mockImplementation(
+      async (
+        _workspaceId: string,
+        entitlements: { key: BillingEntitlementKey; value: boolean }[],
+      ) => {
+        isRlsGrantedInStore =
+          entitlements.find(
+            (entitlement) => entitlement.key === BillingEntitlementKey.RLS,
+          )?.value === true;
+      },
+    );
+
+    // Unserialized, both syncs read the same granted state, then each await
+    // hands over: the revoke's delete lands after the grant has committed and
+    // strips the predicates of a workspace whose feature is back on.
+    await Promise.all([
+      syncEntitlements([]),
+      syncEntitlements([RLS_LOOKUP_KEY]),
+    ]);
+
+    const grantCommitOrder =
+      billingEntitlementRepository.upsert.mock.calls.flatMap((call, index) =>
+        call[1].some(
+          (entitlement: { key: BillingEntitlementKey; value: boolean }) =>
+            entitlement.key === BillingEntitlementKey.RLS && entitlement.value,
+        )
+          ? [
+              billingEntitlementRepository.upsert.mock.invocationCallOrder[
+                index
+              ],
+            ]
+          : [],
+      );
+
+    const deleteOrders =
+      rowLevelPermissionPredicateGroupService
+        .deleteAllRowLevelPermissionPredicateGroups.mock.invocationCallOrder;
+
+    expect(isRlsGrantedInStore).toBe(true);
+    expect(grantCommitOrder).toHaveLength(1);
+    expect(
+      deleteOrders.filter((order) => order > grantCommitOrder[0]),
+    ).toHaveLength(0);
+  });
+
+  it('holds the lock for the whole transition', async () => {
+    givenStoredEntitlements([]);
+
+    let lockHeldDuringUpsert = false;
+
+    billingEntitlementRepository.upsert.mockImplementation(async () => {
+      lockHeldDuringUpsert = heldLockKeys.size === 1;
+    });
+
+    await syncEntitlements([]);
+
+    expect(lockHeldDuringUpsert).toBe(true);
+    expect(heldLockKeys.size).toBe(0);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/__tests__/billing-entitlement-sync.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/__tests__/billing-entitlement-sync.service.spec.ts
@@ -185,6 +185,37 @@ describe('BillingEntitlementSyncService', () => {
     ).toHaveLength(0);
   });
 
+  it('locks on a key scoped to the workspace', async () => {
+    givenStoredEntitlements([]);
+
+    const otherWorkspaceId = '20202020-1c25-4d02-bf25-6aeccf7ea420';
+    const heldKeysDuringOtherWorkspaceUpsert: string[] = [];
+
+    billingEntitlementRepository.upsert.mockImplementation(async () => {
+      heldKeysDuringOtherWorkspaceUpsert.push(...heldLockKeys);
+    });
+
+    await Promise.all([
+      syncEntitlements([]),
+      service.syncEntitlements({
+        workspaceId: otherWorkspaceId,
+        stripeCustomerId: STRIPE_CUSTOMER_ID,
+        activeLookupKeys: [],
+      }),
+    ]);
+
+    expect(cacheLockService.withLock.mock.calls.map((call) => call[1])).toEqual(
+      [
+        `billing-entitlement-state:${WORKSPACE_ID}`,
+        `billing-entitlement-state:${otherWorkspaceId}`,
+      ],
+    );
+
+    // Two workspaces hold their own keys at once. A constant key would
+    // serialize them and never show both held together.
+    expect(new Set(heldKeysDuringOtherWorkspaceUpsert).size).toBe(2);
+  });
+
   it('holds the lock for the whole transition', async () => {
     givenStoredEntitlements([]);
 

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-entitlement-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-entitlement-sync.service.ts
@@ -2,8 +2,10 @@
 
 import { Injectable } from '@nestjs/common';
 
+import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
 import { BillingEntitlementEntity } from 'src/engine/core-modules/billing/entities/billing-entitlement.entity';
 import { BillingEntitlementKey } from 'src/engine/core-modules/billing/enums/billing-entitlement-key.enum';
+import { buildBillingEntitlementStateLockKey } from 'src/engine/core-modules/billing/utils/build-billing-entitlement-state-lock-key.util';
 import { buildBillingEntitlementsFromLookupKeys } from 'src/engine/core-modules/billing/utils/build-billing-entitlements-from-lookup-keys.util';
 import { UsageLimitQuotaService } from 'src/engine/core-modules/usage-limit/services/usage-limit-quota.service';
 import { RowLevelPermissionPredicateGroupService } from 'src/engine/metadata-modules/row-level-permission-predicate/services/row-level-permission-predicate-group.service';
@@ -21,9 +23,34 @@ export class BillingEntitlementSyncService {
     private readonly billingEntitlementRepository: WorkspaceScopedRepository<BillingEntitlementEntity>,
     private readonly rowLevelPermissionPredicateGroupService: RowLevelPermissionPredicateGroupService,
     private readonly usageLimitQuotaService: UsageLimitQuotaService,
+    private readonly cacheLockService: CacheLockService,
   ) {}
 
   async syncEntitlements({
+    workspaceId,
+    stripeCustomerId,
+    activeLookupKeys,
+  }: {
+    workspaceId: string;
+    stripeCustomerId: string;
+    activeLookupKeys: string[];
+  }): Promise<{ key: BillingEntitlementKey; value: boolean }[]> {
+    // The whole transition is one unit. Reading the stored rows, acting on the
+    // difference and committing it are three steps, and this service is the
+    // only writer of those rows, so serializing here is what makes the
+    // difference a transition rather than a guess about one.
+    return await this.cacheLockService.withLock(
+      () =>
+        this.applyEntitlementTransition({
+          workspaceId,
+          stripeCustomerId,
+          activeLookupKeys,
+        }),
+      buildBillingEntitlementStateLockKey(workspaceId),
+    );
+  }
+
+  private async applyEntitlementTransition({
     workspaceId,
     stripeCustomerId,
     activeLookupKeys,
@@ -78,27 +105,12 @@ export class BillingEntitlementSyncService {
     // the predicate cache and never the entitlement, so committing the revoke
     // first is the direction that fails closed: a failure here leaves rows
     // filtered by predicates that outlived the feature, not unfiltered.
-    // Asked on every pass rather than on the revoke transition, so a failure
-    // is retried once the stored row already reads as revoked. Re-read rather
-    // than trust the snapshot this sync computed: a concurrent grant that
-    // committed after our upsert would otherwise have its predicates deleted
-    // here, which is the one direction that leaves the feature on with nothing
-    // to filter by.
+    // Asked on every pass rather than on the revoke transition, so a cleanup
+    // that failed after the revoke committed is retried by the next sync.
     if (!isGranted(BillingEntitlementKey.RLS)) {
-      const storedEntitlementsAfterUpsert =
-        await this.billingEntitlementRepository.find(workspaceId);
-
-      const isStillRevoked = !storedEntitlementsAfterUpsert.some(
-        (entitlement) =>
-          entitlement.key === BillingEntitlementKey.RLS &&
-          entitlement.value === true,
+      await this.rowLevelPermissionPredicateGroupService.deleteAllRowLevelPermissionPredicateGroups(
+        workspaceId,
       );
-
-      if (isStillRevoked) {
-        await this.rowLevelPermissionPredicateGroupService.deleteAllRowLevelPermissionPredicateGroups(
-          workspaceId,
-        );
-      }
     }
 
     return billingEntitlements.map(({ key, value }) => ({ key, value }));

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-entitlement-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-entitlement-sync.service.ts
@@ -13,6 +13,14 @@ import { RowLevelPermissionPredicateGroupService } from 'src/engine/metadata-mod
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 
+type EntitlementTransitionArgs = {
+  workspaceId: string;
+  stripeCustomerId: string;
+  activeLookupKeys: string[];
+};
+
+type SyncedEntitlement = { key: BillingEntitlementKey; value: boolean };
+
 // Shared by the Stripe webhook and the reconciliation command so a repaired
 // entitlement carries the same consequences as one that arrived on time.
 // Transitions are read from the stored rows rather than from Stripe's
@@ -31,11 +39,7 @@ export class BillingEntitlementSyncService {
     workspaceId,
     stripeCustomerId,
     activeLookupKeys,
-  }: {
-    workspaceId: string;
-    stripeCustomerId: string;
-    activeLookupKeys: string[];
-  }): Promise<{ key: BillingEntitlementKey; value: boolean }[]> {
+  }: EntitlementTransitionArgs): Promise<SyncedEntitlement[]> {
     // The whole transition is one unit. Reading the stored rows, acting on the
     // difference and committing it are three steps, and this service is the
     // only writer of those rows, so serializing here is what makes the
@@ -56,11 +60,7 @@ export class BillingEntitlementSyncService {
     workspaceId,
     stripeCustomerId,
     activeLookupKeys,
-  }: {
-    workspaceId: string;
-    stripeCustomerId: string;
-    activeLookupKeys: string[];
-  }): Promise<{ key: BillingEntitlementKey; value: boolean }[]> {
+  }: EntitlementTransitionArgs): Promise<SyncedEntitlement[]> {
     const storedEntitlements =
       await this.billingEntitlementRepository.find(workspaceId);
 

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-entitlement-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-entitlement-sync.service.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@nestjs/common';
 import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
 import { BillingEntitlementEntity } from 'src/engine/core-modules/billing/entities/billing-entitlement.entity';
 import { BillingEntitlementKey } from 'src/engine/core-modules/billing/enums/billing-entitlement-key.enum';
+import { BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS } from 'src/engine/core-modules/billing/constants/billing-entitlement-state-lock-options.constant';
 import { buildBillingEntitlementStateLockKey } from 'src/engine/core-modules/billing/utils/build-billing-entitlement-state-lock-key.util';
 import { buildBillingEntitlementsFromLookupKeys } from 'src/engine/core-modules/billing/utils/build-billing-entitlements-from-lookup-keys.util';
 import { UsageLimitQuotaService } from 'src/engine/core-modules/usage-limit/services/usage-limit-quota.service';
@@ -47,6 +48,7 @@ export class BillingEntitlementSyncService {
           activeLookupKeys,
         }),
       buildBillingEntitlementStateLockKey(workspaceId),
+      BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS,
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/billing/constants/__tests__/billing-entitlement-state-lock-options.constant.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/constants/__tests__/billing-entitlement-state-lock-options.constant.spec.ts
@@ -9,8 +9,8 @@ describe('BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS', () => {
     // withLock attempts at 0, ms, 2*ms ... (maxRetries - 1) * ms, so a budget
     // that only equals the expiry makes its last attempt just before the key
     // frees. Tuning either number without the other reintroduces that.
-    const lastAttemptAt = ((maxRetries as number) - 1) * (ms as number);
+    const lastAttemptAt = (maxRetries - 1) * ms;
 
-    expect(lastAttemptAt).toBeGreaterThan(ttl as number);
+    expect(lastAttemptAt).toBeGreaterThan(ttl);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/billing/constants/__tests__/billing-entitlement-state-lock-options.constant.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/constants/__tests__/billing-entitlement-state-lock-options.constant.spec.ts
@@ -1,0 +1,16 @@
+/* @license Enterprise */
+
+import { BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS } from 'src/engine/core-modules/billing/constants/billing-entitlement-state-lock-options.constant';
+
+describe('BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS', () => {
+  it('waits past the expiry so a waiter can take a key its holder abandoned', () => {
+    const { ttl, ms, maxRetries } = BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS;
+
+    // withLock attempts at 0, ms, 2*ms ... (maxRetries - 1) * ms, so a budget
+    // that only equals the expiry makes its last attempt just before the key
+    // frees. Tuning either number without the other reintroduces that.
+    const lastAttemptAt = ((maxRetries as number) - 1) * (ms as number);
+
+    expect(lastAttemptAt).toBeGreaterThan(ttl as number);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/billing/constants/billing-entitlement-state-lock-options.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/constants/billing-entitlement-state-lock-options.constant.ts
@@ -1,0 +1,16 @@
+/* @license Enterprise */
+
+import { type CacheLockOptions } from 'src/engine/core-modules/cache-lock/cache-lock.service';
+
+// The default 5.5s expiry is shorter than this transition can run: revoking
+// RLS recomputes the workspace's role and predicate caches, which is unbounded
+// in the workspace's size. A lock that expires mid-transition hands the key to
+// a second sync and restores the races this lock exists to remove, so the
+// expiry is raised well past the slowest realistic pass. The wait to acquire
+// matches it, so a webhook arriving during a fleet reconciliation queues
+// behind it rather than failing.
+export const BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS: CacheLockOptions = {
+  ttl: 60_000,
+  ms: 500,
+  maxRetries: 120,
+};

--- a/packages/twenty-server/src/engine/core-modules/billing/constants/billing-entitlement-state-lock-options.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/constants/billing-entitlement-state-lock-options.constant.ts
@@ -12,8 +12,8 @@ import { type CacheLockOptions } from 'src/engine/core-modules/cache-lock/cache-
 // just before the key frees and throws instead of taking it, which is exactly
 // the case that matters: a holder that died leaves the key held for the full
 // expiry. The extra retries buy a waiter attempts on the far side of it.
-export const BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS: CacheLockOptions = {
+export const BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS = {
   ttl: 60_000,
   ms: 500,
   maxRetries: 130,
-};
+} satisfies CacheLockOptions;

--- a/packages/twenty-server/src/engine/core-modules/billing/constants/billing-entitlement-state-lock-options.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/constants/billing-entitlement-state-lock-options.constant.ts
@@ -5,12 +5,15 @@ import { type CacheLockOptions } from 'src/engine/core-modules/cache-lock/cache-
 // The default 5.5s expiry is shorter than this transition can run: revoking
 // RLS recomputes the workspace's role and predicate caches, which is unbounded
 // in the workspace's size. A lock that expires mid-transition hands the key to
-// a second sync and restores the races this lock exists to remove, so the
-// expiry is raised well past the slowest realistic pass. The wait to acquire
-// matches it, so a webhook arriving during a fleet reconciliation queues
-// behind it rather than failing.
+// a second sync and restores the races this lock exists to remove.
+//
+// maxRetries * ms must stay above ttl. withLock attempts at 0, ms, 2*ms and so
+// on, so a waiter whose budget only equals the expiry makes its last attempt
+// just before the key frees and throws instead of taking it, which is exactly
+// the case that matters: a holder that died leaves the key held for the full
+// expiry. The extra retries buy a waiter attempts on the far side of it.
 export const BILLING_ENTITLEMENT_STATE_LOCK_OPTIONS: CacheLockOptions = {
   ttl: 60_000,
   ms: 500,
-  maxRetries: 120,
+  maxRetries: 130,
 };

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/build-billing-entitlement-state-lock-key.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/build-billing-entitlement-state-lock-key.util.ts
@@ -1,0 +1,10 @@
+/* @license Enterprise */
+
+// Serializes a workspace's entitlement transition: reading the stored rows,
+// applying the side effects that depend on that transition, and committing the
+// new rows. The Stripe webhook and the reconciliation command both run this
+// sequence, so without the lock two overlapping syncs read the same "before"
+// state and each apply a transition the other has already applied.
+export const buildBillingEntitlementStateLockKey = (
+  workspaceId: string,
+): string => `billing-entitlement-state:${workspaceId}`;

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/build-billing-entitlement-state-lock-key.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/build-billing-entitlement-state-lock-key.util.ts
@@ -1,10 +1,5 @@
 /* @license Enterprise */
 
-// Serializes a workspace's entitlement transition: reading the stored rows,
-// applying the side effects that depend on that transition, and committing the
-// new rows. The Stripe webhook and the reconciliation command both run this
-// sequence, so without the lock two overlapping syncs read the same "before"
-// state and each apply a transition the other has already applied.
 export const buildBillingEntitlementStateLockKey = (
   workspaceId: string,
 ): string => `billing-entitlement-state:${workspaceId}`;

--- a/packages/twenty-server/src/engine/metadata-modules/row-level-permission-predicate/services/row-level-permission-predicate-group.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/row-level-permission-predicate/services/row-level-permission-predicate-group.service.ts
@@ -15,7 +15,6 @@ import { RowLevelPermissionPredicateGroupEntity } from 'src/engine/metadata-modu
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
-import { type WorkspaceCacheKeyName } from 'src/engine/workspace-cache/types/workspace-cache-key.type';
 
 @Injectable()
 export class RowLevelPermissionPredicateGroupService {
@@ -142,23 +141,11 @@ export class RowLevelPermissionPredicateGroupService {
       {},
     );
 
-    const predicateCacheKeys: WorkspaceCacheKeyName[] = [
+    await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
       'rolesPermissions',
       'flatRowLevelPermissionPredicateMaps',
       'flatRowLevelPermissionPredicateGroupMaps',
-    ];
-
-    // Dropped before recomputing, because the rows are already gone and the
-    // early return above means no later pass would retry this. An absent cache
-    // recomputes from the empty table on next read, so a failure in the
-    // recompute below costs a cold read rather than leaving Redis serving
-    // predicates that no longer exist.
-    await this.workspaceCacheService.flush(workspaceId, predicateCacheKeys);
-
-    await this.workspaceCacheService.invalidateAndRecompute(
-      workspaceId,
-      predicateCacheKeys,
-    );
+    ]);
   }
 
   private async hasRowLevelPermissionFeature(

--- a/packages/twenty-server/src/engine/metadata-modules/row-level-permission-predicate/services/row-level-permission-predicate-group.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/row-level-permission-predicate/services/row-level-permission-predicate-group.service.ts
@@ -15,6 +15,7 @@ import { RowLevelPermissionPredicateGroupEntity } from 'src/engine/metadata-modu
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type WorkspaceCacheKeyName } from 'src/engine/workspace-cache/types/workspace-cache-key.type';
 
 @Injectable()
 export class RowLevelPermissionPredicateGroupService {
@@ -141,11 +142,23 @@ export class RowLevelPermissionPredicateGroupService {
       {},
     );
 
-    await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
+    const predicateCacheKeys: WorkspaceCacheKeyName[] = [
       'rolesPermissions',
       'flatRowLevelPermissionPredicateMaps',
       'flatRowLevelPermissionPredicateGroupMaps',
-    ]);
+    ];
+
+    // Dropped before recomputing, because the rows are already gone and the
+    // early return above means no later pass would retry this. An absent cache
+    // recomputes from the empty table on next read, so a failure in the
+    // recompute below costs a cold read rather than leaving Redis serving
+    // predicates that no longer exist.
+    await this.workspaceCacheService.flush(workspaceId, predicateCacheKeys);
+
+    await this.workspaceCacheService.invalidateAndRecompute(
+      workspaceId,
+      predicateCacheKeys,
+    );
   }
 
   private async hasRowLevelPermissionFeature(


### PR DESCRIPTION
Closes #25643, the follow-up deliberately left out of #25635.

## Why

`BillingEntitlementSyncService.syncEntitlements` reads the stored entitlement rows, applies the side effects that depend on the difference, and commits the new rows, without holding anything per workspace. The Stripe webhook and `billing:sync-entitlements` can both be inside that sequence at once, so the difference each one computes is a guess about a transition rather than the transition itself.

Two consequences, both raised on review threads in #25635:

**Lost metered usage.** Two syncs observing the same `false → true` usage-limit grant each read `wasGranted === false` and each call `dropIntraWorkspaceLimitCounters`. The second drop lands after enforcement has begun and discards usage recorded under it. This was initially assessed as an idempotent no-op; that assumed both drops land before enforcement starts, which is not the ordering.

**Row filtering left on with nothing to filter by.** A revoke that has committed `RLS = false` can delete predicate groups after a concurrent grant has committed `RLS = true`. `resolveRowLevelPermissionRecordFilter` reads the predicate cache and never the entitlement, so the workspace keeps filtering against predicates that are gone.

## What changed

This service is the only writer of those rows, so taking the existing `CacheLockService` around the whole sequence is enough to make the difference an actual transition. `syncEntitlements` now wraps `applyEntitlementTransition` in a `billing-entitlement-state:<workspaceId>` lock, matching the convention `buildBillingCreditStateLockKey` already uses next door.

That also supersedes the pre-delete re-read added in `b67c6e8f`, which narrowed the second case rather than closing it; it is removed in favour of the lock.

Predicate cleanup now drops its cache keys before recomputing them. The rows are already gone by that point and the count gate means no later pass retries the cleanup, so a failure in the recompute would leave Redis serving predicates that no longer exist. An absent cache recomputes from the empty table instead, which is the cheap failure. This was the third item on the issue.

## Verification

Three unit tests, each checked to fail with the lock removed and pass with it, so none of them is green for the wrong reason:

- two concurrent syncs over the same grant drop the counters exactly once
- no predicate delete is ordered after a concurrent grant has committed
- the lock is held across the upsert and released afterwards

The lock in the spec is a real single-holder queue rather than a pass-through stub, so the concurrency tests exercise serialization instead of asserting that a mock was called.

Server typecheck clean (after rebuilding `twenty-shared`, which is stale across a branch switch), 210 billing and billing-webhook tests pass, lint and format clean.

## Not covered

Out-of-order Stripe summary webhooks, noted as related on the issue. An older snapshot delivered last can still revoke a newer grant. The fix is to stamp the Stripe event id or `created` on the row and refuse older snapshots, and it belongs on the webhook caller rather than inside `syncEntitlements`, which is also used for "read Stripe now". Reconciliation remains the repair for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUgiBH9NveL7LmjFpUqNyh)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

