### PR TITLE
feat: make record group page size configurable

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -2175,6 +2175,7 @@ type ClientConfig {
   isClickHouseConfigured: Boolean!
   isWorkspaceSchemaDDLLocked: Boolean!
   isOnboardingAiChatEnabled: Boolean!
+  recordGroupPageSize: Int!
   enterpriseInstanceType: String!
   maintenance: ClientConfigMaintenanceMode
 }

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -1784,6 +1784,7 @@ export interface ClientConfig {
     isClickHouseConfigured: Scalars['Boolean']
     isWorkspaceSchemaDDLLocked: Scalars['Boolean']
     isOnboardingAiChatEnabled: Scalars['Boolean']
+    recordGroupPageSize: Scalars['Int']
     enterpriseInstanceType: Scalars['String']
     maintenance?: ClientConfigMaintenanceMode
     __typename: 'ClientConfig'
@@ -5354,6 +5355,7 @@ export interface ClientConfigGenqlSelection{
     isClickHouseConfigured?: boolean | number
     isWorkspaceSchemaDDLLocked?: boolean | number
     isOnboardingAiChatEnabled?: boolean | number
+    recordGroupPageSize?: boolean | number
     enterpriseInstanceType?: boolean | number
     maintenance?: ClientConfigMaintenanceModeGenqlSelection
     __typename?: boolean | number

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -4217,6 +4217,9 @@ export default {
             "isOnboardingAiChatEnabled": [
                 8
             ],
+            "recordGroupPageSize": [
+                28
+            ],
             "enterpriseInstanceType": [
                 1
             ],

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1106,6 +1106,7 @@ export type ClientConfig = {
   maintenance?: Maybe<ClientConfigMaintenanceMode>;
   publicFeatureFlags: Array<PublicFeatureFlag>;
   publicFunctionDomain?: Maybe<Scalars['String']['output']>;
+  recordGroupPageSize: Scalars['Int']['output'];
   sentry: Sentry;
   signInPrefilled: Scalars['Boolean']['output'];
   support: Support;

--- a/packages/twenty-front/src/modules/client-config/hooks/useClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/hooks/useClientConfig.ts
@@ -29,6 +29,7 @@ import { isMicrosoftMessagingEnabledState } from '@/client-config/states/isMicro
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
 import { isOnboardingAiChatEnabledState } from '@/client-config/states/isOnboardingAiChatEnabledState';
 import { labPublicFeatureFlagsState } from '@/client-config/states/labPublicFeatureFlagsState';
+import { recordGroupPageSizeState } from '@/client-config/states/recordGroupPageSizeState';
 import { sentryConfigState } from '@/client-config/states/sentryConfigState';
 import { supportChatState } from '@/client-config/states/supportChatState';
 import { type ClientConfig } from '@/client-config/types/ClientConfig';
@@ -151,6 +152,8 @@ export const useClientConfig = (): UseClientConfigResult => {
 
   const setAppVersion = useSetAtomState(appVersionState);
 
+  const setRecordGroupPageSize = useSetAtomState(recordGroupPageSizeState);
+
   const fetchClientConfig = useCallback(async () => {
     setClientConfigApiStatus((prev) => ({
       ...prev,
@@ -243,6 +246,7 @@ export const useClientConfig = (): UseClientConfigResult => {
       setIsOnboardingAiChatEnabled(
         clientConfig?.isOnboardingAiChatEnabled ?? false,
       );
+      setRecordGroupPageSize(clientConfig?.recordGroupPageSize ?? null);
       setMaintenanceMode(clientConfig?.maintenance ?? null);
       setEnterpriseInstanceType(
         clientConfig?.enterpriseInstanceType ??
@@ -290,6 +294,7 @@ export const useClientConfig = (): UseClientConfigResult => {
     setIsOnboardingAiChatEnabled,
     setLabPublicFeatureFlags,
     setMaintenanceMode,
+    setRecordGroupPageSize,
     setEnterpriseInstanceType,
     setIsMicrosoftCalendarEnabled,
     setIsMicrosoftMessagingEnabled,

--- a/packages/twenty-front/src/modules/client-config/states/recordGroupPageSizeState.ts
+++ b/packages/twenty-front/src/modules/client-config/states/recordGroupPageSizeState.ts
@@ -1,0 +1,6 @@
+import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
+
+export const recordGroupPageSizeState = createAtomState<number | null>({
+  key: 'recordGroupPageSizeState',
+  defaultValue: null,
+});

--- a/packages/twenty-front/src/modules/client-config/types/ClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/types/ClientConfig.ts
@@ -45,6 +45,7 @@ export type ClientConfig = {
   isOnboardingAiChatEnabled: boolean;
   onboarding: OnboardingConfig | null;
   publicFeatureFlags: Array<PublicFeatureFlag>;
+  recordGroupPageSize: number;
   sentry: Sentry;
   signInPrefilled: boolean;
   support: Support;

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
@@ -1,3 +1,4 @@
+import { recordGroupPageSizeState } from '@/client-config/states/recordGroupPageSizeState';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
@@ -11,6 +12,7 @@ import { useRecordGroupFilter } from '@/object-record/record-group/hooks/useReco
 import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { DEFAULT_RECORD_GROUP_PAGE_SIZE } from 'twenty-shared/constants';
 import {
   combineFilters,
   computeRecordGqlOperationFilter,
@@ -31,6 +33,8 @@ export const useFindManyRecordIndexTableParams = (
   );
 
   const currentRecordGroupDefinition = useCurrentRecordGroupDefinition();
+
+  const recordGroupPageSize = useAtomStateValue(recordGroupPageSizeState);
 
   const currentRecordFilterGroups = useAtomComponentStateValue(
     currentRecordFilterGroupsComponentState,
@@ -87,7 +91,10 @@ export const useFindManyRecordIndexTableParams = (
     objectNameSingular,
     filter: combinedFilter,
     orderBy,
-    // If we have a current record group definition, we only want to fetch 8 records by page
-    ...(currentRecordGroupDefinition ? { limit: 8 } : {}),
+    // Grouped tables paginate behind a "Load more" button instead of scrolling
+    // infinitely, so each group fetches a small page rather than the table one
+    ...(currentRecordGroupDefinition
+      ? { limit: recordGroupPageSize ?? DEFAULT_RECORD_GROUP_PAGE_SIZE }
+      : {}),
   };
 };

--- a/packages/twenty-front/src/testing/mock-data/config.ts
+++ b/packages/twenty-front/src/testing/mock-data/config.ts
@@ -54,6 +54,7 @@ export const mockedClientConfig: ClientConfig = {
   },
   canManageFeatureFlags: true,
   publicFeatureFlags: [],
+  recordGroupPageSize: 8,
   isMicrosoftMessagingEnabled: true,
   isMicrosoftCalendarEnabled: true,
   isGoogleMessagingEnabled: true,

--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -88,6 +88,7 @@ FRONTEND_URL=http://localhost:3001
 # CLICKHOUSE_URL=http://default:clickhousePassword@localhost:8123/twenty
 # HTTP_TOOL_SAFE_MODE_ENABLED=true
 # ALLOW_REQUESTS_TO_TWENTY_ICONS=true
+# RECORD_GROUP_PAGE_SIZE=8
 
 # ———————— ONBOARDING AI CHAT ————————
 # Opens an AI chat at the end of onboarding to help set up the workspace.

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.controller.spec.ts
@@ -115,6 +115,7 @@ describe('ClientConfigController', () => {
         isClickHouseConfigured: false,
         isWorkspaceSchemaDDLLocked: false,
         isOnboardingAiChatEnabled: false,
+        recordGroupPageSize: 8,
         enterpriseInstanceType: ENTERPRISE_INSTANCE_TYPE.PRODUCTION,
       };
 

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.entity.ts
@@ -1,6 +1,7 @@
 import {
   Field,
   GraphQLISODateTime,
+  Int,
   ObjectType,
   registerEnumType,
 } from '@nestjs/graphql';
@@ -398,6 +399,9 @@ export class ClientConfig {
 
   @Field(() => Boolean)
   isOnboardingAiChatEnabled: boolean;
+
+  @Field(() => Int)
+  recordGroupPageSize: number;
 
   @Field(() => String)
   enterpriseInstanceType: string;

--- a/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.ts
@@ -26,6 +26,7 @@ import { getNativeModelCapabilities } from 'src/engine/metadata-modules/ai/ai-mo
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
 import { type AiModelBenchmark } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-benchmark.type';
 import { type AiModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-config.type';
+import { getRecordGroupPageSize } from 'src/engine/core-modules/client-config/utils/get-record-group-page-size.util';
 
 @Injectable()
 export class ClientConfigService {
@@ -278,6 +279,9 @@ export class ClientConfigService {
       ),
       isOnboardingAiChatEnabled: this.twentyConfigService.get(
         'IS_ONBOARDING_AI_CHAT_ENABLED',
+      ),
+      recordGroupPageSize: getRecordGroupPageSize(
+        this.twentyConfigService.get('RECORD_GROUP_PAGE_SIZE'),
       ),
       enterpriseInstanceType:
         this.twentyConfigService.get('ENTERPRISE_INSTANCE_TYPE') ??

--- a/packages/twenty-server/src/engine/core-modules/client-config/utils/__tests__/get-record-group-page-size.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/utils/__tests__/get-record-group-page-size.util.spec.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_RECORD_GROUP_PAGE_SIZE } from 'twenty-shared/constants';
+
+import { getRecordGroupPageSize } from 'src/engine/core-modules/client-config/utils/get-record-group-page-size.util';
+
+describe('getRecordGroupPageSize', () => {
+  it('should return a positive integer page size as is', () => {
+    expect(getRecordGroupPageSize(50)).toBe(50);
+  });
+
+  it('should accept the smallest valid page size', () => {
+    expect(getRecordGroupPageSize(1)).toBe(1);
+  });
+
+  it('should fall back to the default when unset', () => {
+    expect(getRecordGroupPageSize(undefined)).toBe(
+      DEFAULT_RECORD_GROUP_PAGE_SIZE,
+    );
+  });
+
+  it('should fall back to the default for zero', () => {
+    expect(getRecordGroupPageSize(0)).toBe(DEFAULT_RECORD_GROUP_PAGE_SIZE);
+  });
+
+  it('should fall back to the default for a negative value', () => {
+    expect(getRecordGroupPageSize(-8)).toBe(DEFAULT_RECORD_GROUP_PAGE_SIZE);
+  });
+
+  it('should fall back to the default for a fractional value', () => {
+    expect(getRecordGroupPageSize(8.5)).toBe(DEFAULT_RECORD_GROUP_PAGE_SIZE);
+  });
+
+  it('should fall back to the default for a NaN value', () => {
+    expect(getRecordGroupPageSize(Number.NaN)).toBe(
+      DEFAULT_RECORD_GROUP_PAGE_SIZE,
+    );
+  });
+
+  it('should fall back to the default above the GraphQL Int range', () => {
+    expect(getRecordGroupPageSize(2_147_483_648)).toBe(
+      DEFAULT_RECORD_GROUP_PAGE_SIZE,
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/client-config/utils/get-record-group-page-size.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/utils/get-record-group-page-size.util.ts
@@ -1,0 +1,22 @@
+import { isNumber } from '@sniptt/guards';
+import { DEFAULT_RECORD_GROUP_PAGE_SIZE } from 'twenty-shared/constants';
+
+// GraphQL Int is a signed 32-bit integer
+const GRAPHQL_INT_MAX_VALUE = 2_147_483_647;
+
+// Admin panel edits bypass the class-validator decorators on ConfigVariables,
+// so the value is normalized here before it is exposed on ClientConfig as Int
+export const getRecordGroupPageSize = (
+  configuredPageSize: number | undefined,
+): number => {
+  if (
+    !isNumber(configuredPageSize) ||
+    !Number.isInteger(configuredPageSize) ||
+    configuredPageSize <= 0 ||
+    configuredPageSize > GRAPHQL_INT_MAX_VALUE
+  ) {
+    return DEFAULT_RECORD_GROUP_PAGE_SIZE;
+  }
+
+  return configuredPageSize;
+};

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -17,6 +17,7 @@ import {
   validateSync,
 } from 'class-validator';
 import {
+  DEFAULT_RECORD_GROUP_PAGE_SIZE,
   ENTERPRISE_INSTANCE_TYPE,
   type EnterpriseInstanceType,
 } from 'twenty-shared/constants';
@@ -253,6 +254,17 @@ export class ConfigVariables {
     type: ConfigVariableType.BOOLEAN,
   })
   ALLOW_REQUESTS_TO_TWENTY_ICONS = true;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.ADVANCED_SETTINGS,
+    description:
+      'Number of records fetched per page in each group of a record table grouped by a field. Groups keep their "Load more" button, this only changes how many records one page holds.',
+    type: ConfigVariableType.NUMBER,
+  })
+  @CastToPositiveNumber()
+  @IsInt()
+  @IsOptional()
+  RECORD_GROUP_PAGE_SIZE = DEFAULT_RECORD_GROUP_PAGE_SIZE;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.MICROSOFT_AUTH,

--- a/packages/twenty-shared/src/constants/DefaultRecordGroupPageSize.ts
+++ b/packages/twenty-shared/src/constants/DefaultRecordGroupPageSize.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_RECORD_GROUP_PAGE_SIZE = 8;

--- a/packages/twenty-shared/src/constants/index.ts
+++ b/packages/twenty-shared/src/constants/index.ts
@@ -18,6 +18,7 @@ export { CurrencyCode } from './CurrencyCode';
 export { CURRENCY_CODE_LABELS } from './CurrencyCodeLabels';
 export { DATE_TYPE_FORMAT } from './DateTypeFormat';
 export { DEFAULT_NUMBER_OF_GROUPS_LIMIT } from './DefaultNumberOfGroupsLimit';
+export { DEFAULT_RECORD_GROUP_PAGE_SIZE } from './DefaultRecordGroupPageSize';
 export { DEFAULT_RELATIVE_DATE_FILTER_VALUE } from './DefaultRelativeDateFilterValue';
 export { DEFAULT_VISIBLE_ADDRESS_SUBFIELDS } from './DefaultVisibleAddressSubfields';
 export { DEFAULT_WIDGET_SIZE } from './DefaultWidgetSize';


### PR DESCRIPTION
Closes #25770

## Problem

When a record table or list is grouped by a field, each group fetches a hardcoded 8 records and shows a "Load more" button below them (#8756). Self-hosted instances whose workflow relies on grouped views have no way to see groups expanded by default, so users click "Load more" on every group every time they open the view.

## Solution

Add a `RECORD_GROUP_PAGE_SIZE` config variable (default 8) so an instance can choose how many records each group loads per page.

**Server**
- New config variable in the `ADVANCED_SETTINGS` group, using the same `@CastToPositiveNumber() @IsInt() @IsOptional()` combination as the other integer variables, and listed in `.env.example`.
- Exposed on `ClientConfig` as `recordGroupPageSize: Int!`.
- Admin panel edits are written straight to the database and do not go through the class-validator decorators, so `getRecordGroupPageSize` normalizes the value before it is exposed: anything that is not a positive integer within the GraphQL `Int` range falls back to the default. Covered by unit tests (zero, negative, fractional, NaN, above 2^31-1).

**Front**
- `recordGroupPageSizeState` is populated from client config, and `useFindManyRecordIndexTableParams` uses it as the per-group `limit` with a `DEFAULT_RECORD_GROUP_PAGE_SIZE` fallback.

**Shared**
- `DEFAULT_RECORD_GROUP_PAGE_SIZE = 8` lives in `twenty-shared/constants` so the server default and the client fallback cannot drift apart.

**Generated**
- `twenty-client-sdk` metadata contracts and `twenty-front` generated metadata regenerated for the new field (verified by re-running both codegens against a local server: no diff).

## Behaviour

- An instance that does not set the variable behaves exactly as before, 8 records per group.
- "Load more" is unchanged and subsequent pages use the same configured size.
- The variable is editable from the admin panel; a new value applies once the client reloads its config.
- The same hook backs the grouped list view, so that view picks up the setting too.

## Test plan

- [x] `nx typecheck twenty-server` / `nx typecheck twenty-front`
- [x] `nx lint twenty-server` / `nx lint twenty-front` / `nx lint twenty-shared`
- [x] `jest src/engine/core-modules/client-config` (3 suites, 13 tests, including the new normalization tests)
- [x] Re-ran `nx generate-metadata-client twenty-client-sdk` and the front metadata codegen against a local server; generated files match this branch exactly

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



