### PR TITLE
fix(server): scope API-key default connected account to workspace visibility

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
@@ -112,10 +112,6 @@ export class EmailComposerService {
         );
       }
 
-      if (!isDefined(userWorkspaceId)) {
-        return allAccounts[0].id;
-      }
-
       const connectedAccountId = selectConnectedAccountIdForCaller({
         connectedAccounts: allAccounts,
         userWorkspaceId,
@@ -123,7 +119,9 @@ export class EmailComposerService {
 
       if (!isDefined(connectedAccountId)) {
         throw new EmailToolException(
-          `No connected account available for user workspace '${userWorkspaceId}'`,
+          isDefined(userWorkspaceId)
+            ? `No connected account available for user workspace '${userWorkspaceId}'`
+            : 'No connected account shared with the workspace is available for this API key',
           EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
         );
       }

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/__tests__/select-connected-account-id-for-caller.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/__tests__/select-connected-account-id-for-caller.util.spec.ts
@@ -66,4 +66,28 @@ describe('selectConnectedAccountIdForCaller', () => {
       }),
     ).toBeUndefined();
   });
+
+  describe('without a user workspace, as an API key', () => {
+    it('returns an account shared with the whole workspace', () => {
+      expect(
+        selectConnectedAccountIdForCaller({
+          connectedAccounts: [ownAccount, colleagueAccount, sharedAccount],
+        }),
+      ).toBe('shared-account-id');
+    });
+
+    it('returns undefined rather than a private account owned by a member', () => {
+      expect(
+        selectConnectedAccountIdForCaller({
+          connectedAccounts: [ownAccount, colleagueAccount],
+        }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when there is no account at all', () => {
+      expect(
+        selectConnectedAccountIdForCaller({ connectedAccounts: [] }),
+      ).toBeUndefined();
+    });
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-for-caller.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-for-caller.util.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { isConnectedAccountUsableByCaller } from 'src/engine/metadata-modules/connected-account/utils/is-connected-account-usable-by-caller.util';
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 
@@ -9,8 +11,14 @@ export const selectConnectedAccountIdForCaller = ({
     ConnectedAccountEntity,
     'id' | 'visibility' | 'userWorkspaceId'
   >[];
-  userWorkspaceId: string;
+  userWorkspaceId?: string;
 }): string | undefined => {
+  if (!isDefined(userWorkspaceId)) {
+    return connectedAccounts.find(
+      (connectedAccount) => connectedAccount.visibility === 'workspace',
+    )?.id;
+  }
+
   const ownAccount = connectedAccounts.find(
     (connectedAccount) => connectedAccount.userWorkspaceId === userWorkspaceId,
   );


### PR DESCRIPTION
## Problem

`EmailComposerService.composeEmail` resolves a default connected account whenever the caller omits `connectedAccountId`. For a caller with no user identity (an API key), that resolution returned the workspace's first non-archived account regardless of its visibility:

```ts
if (!isDefined(userWorkspaceId)) {
  return allAccounts[0].id;
}
```

So an API key could send or draft from a member's `visibility: 'user'` account belonging to someone else. Every other connected-account surface applies `isConnectedAccountUsableByCaller`, which only ever grants access to the caller's own account or one shared with the workspace.

This affects the `send_email` and `draft_email` MCP tools. The GraphQL `sendEmail` mutation is not affected: `connectedAccountId` is required on `SendEmailInput` and the resolver calls `verifyOwnership` on it first, so the default-resolution path is never reached there.

Surfaced while reviewing #25658, which scopes the new `find_connected_accounts` tool to workspace-visibility accounts for API-key callers. Without this change, discovery and sending disagree: an API key can send from an account it is not allowed to enumerate.

## Fix

`selectConnectedAccountIdForCaller` now owns the API-key case and returns only accounts shared with the workspace, so the composer no longer needs its own unscoped branch. The exception message distinguishes the two cases, since an operator hitting the API-key path needs to know the remedy is to mark an account workspace-visible.

## Breaking change

An API key that omits `connectedAccountId` in a workspace with no `visibility: 'workspace'` account now gets `CONNECTED_ACCOUNT_NOT_FOUND` where it previously sent from an arbitrary private account. That is the intended tightening, but it is a behaviour change for existing integrations. Two ways out for an affected workspace, both already supported: pass an explicit `connectedAccountId`, or set the intended account's visibility to `workspace`.

## Test plan

- [x] Regression cases added to `select-connected-account-id-for-caller.util.spec.ts` covering the API-key path: picks a workspace-shared account, refuses a member's private account, handles the empty list
- [x] `npx tsgo -p tsconfig.json --noEmit` clean in `packages/twenty-server`
- [x] `npx nx lint:diff-with-main twenty-server` clean
- [x] 26 tests pass across `tools/email-tool` and `metadata-modules/connected-account`
- [ ] CI on this PR

Related: #25658, #20407


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

