### PR TITLE
Fix dropdown anchoring at non-default interface scales

### DIFF
--- a/packages/twenty-front/src/index.css
+++ b/packages/twenty-front/src/index.css
@@ -47,15 +47,21 @@ form {
   /* dnd-kit can reuse the source node as its moving feedback. In that case,
      feedback opacity must win over the source fade applied by the component. */
   opacity: var(--dnd-drag-feedback-opacity) !important;
-  /* dnd-kit positions and sizes the feedback from visual-viewport pixel
+}
+
+/* dnd-kit positions and sizes the feedback from visual-viewport pixel
      measurements, so inside the zoomed root those inline values would be
      multiplied a second time. The inverse zoom makes them render one to one,
      and the child rule restores the interface scale for the dragged content
      so it keeps matching the rest of the page. */
+
+[data-dnd-dragging='true'],
+[data-floating-ui-viewport] {
   zoom: calc(1 / var(--t-zoom, 1));
 }
 
-[data-dnd-dragging='true'] > * {
+[data-dnd-dragging='true'] > *,
+[data-floating-ui-viewport] > * {
   zoom: var(--t-zoom, 1);
 }
 

--- a/packages/twenty-front/src/index.css
+++ b/packages/twenty-front/src/index.css
@@ -1,3 +1,5 @@
+@import './viewport-zoom.css';
+
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
@@ -47,22 +49,6 @@ form {
   /* dnd-kit can reuse the source node as its moving feedback. In that case,
      feedback opacity must win over the source fade applied by the component. */
   opacity: var(--dnd-drag-feedback-opacity) !important;
-}
-
-/* dnd-kit positions and sizes the feedback from visual-viewport pixel
-     measurements, so inside the zoomed root those inline values would be
-     multiplied a second time. The inverse zoom makes them render one to one,
-     and the child rule restores the interface scale for the dragged content
-     so it keeps matching the rest of the page. */
-
-[data-dnd-dragging='true'],
-[data-floating-ui-viewport] {
-  zoom: calc(1 / var(--t-zoom, 1));
-}
-
-[data-dnd-dragging='true'] > *,
-[data-floating-ui-viewport] > * {
-  zoom: var(--t-zoom, 1);
 }
 
 /* https://stackoverflow.com/questions/44543157/how-to-hide-the-google-invisible-recaptcha-badge */

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenuDropdown.tsx
@@ -77,7 +77,6 @@ export const RecordIndexCommandMenuDropdown = () => {
       dropdownId={dropdownId}
       data-select-disable
       dropdownPlacement="bottom-start"
-      dropdownStrategy="absolute"
       dropdownOffset={{
         x: recordIndexCommandMenuDropdownPosition.x ?? 0,
         y: recordIndexCommandMenuDropdownPosition.y ?? 0,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormDateFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormDateFieldInput.tsx
@@ -112,6 +112,7 @@ export const FormDateFieldInput = ({
   const { refs, floatingStyles } = useFloating({
     open: displayDatePicker,
     placement: 'bottom-start',
+    strategy: 'fixed',
     middleware: [offset(4), flip()],
     whileElementsMounted: autoUpdate,
   });
@@ -302,6 +303,7 @@ export const FormDateFieldInput = ({
         !readonly ? (
           <FloatingPortal>
             <div
+              data-floating-ui-viewport
               ref={refs.setFloating}
               style={floatingStyles}
               data-click-outside-id={FORM_DATE_FIELD_PICKER_CLICK_OUTSIDE_ID}

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormDateTimeFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormDateTimeFieldInput.tsx
@@ -108,6 +108,7 @@ export const FormDateTimeFieldInput = ({
   const { refs, floatingStyles } = useFloating({
     open: displayDatePicker,
     placement: 'bottom-start',
+    strategy: 'fixed',
     middleware: [offset(4), flip()],
     whileElementsMounted: autoUpdate,
   });
@@ -297,6 +298,7 @@ export const FormDateTimeFieldInput = ({
         {draftValue.type === 'static' && draftValue.mode === 'edit' ? (
           <FloatingPortal>
             <div
+              data-floating-ui-viewport
               ref={refs.setFloating}
               style={floatingStyles}
               data-click-outside-id={

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
@@ -3,6 +3,7 @@ import { recordFieldInputIsFieldInErrorComponentState } from '@/object-record/re
 import { recordFieldInputLayoutDirectionComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionComponentState';
 import { recordFieldInputLayoutDirectionLoadingComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionLoadingComponentState';
 import { RecordInlineCellContext } from '@/object-record/record-inline-cell/components/RecordInlineCellContext';
+import { StyledDropdownContentContainer } from '@/ui/layout/dropdown/components/internal/DropdownInternalContainer';
 import { OverlayContainer } from '@/ui/layout/overlay/components/OverlayContainer';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
@@ -70,19 +71,20 @@ export const RecordInlineCellEditMode = ({
 
   const { refs, floatingStyles } = useFloating({
     placement: isCentered ? 'bottom' : 'bottom-start',
+    strategy: 'fixed',
     middleware: [
       flip(),
-      offset(
-        isCentered
-          ? {
-              mainAxis: -26,
-              crossAxis: 0,
-            }
-          : {
-              mainAxis: -29,
-              crossAxis: -5,
-            },
-      ),
+      offset(({ rects, elements }) => {
+        const referenceScale =
+          elements.reference instanceof HTMLElement
+            ? rects.reference.width / elements.reference.offsetWidth
+            : 1;
+
+        return {
+          mainAxis: (isCentered ? -26 : -29) * referenceScale,
+          crossAxis: (isCentered ? 0 : -5) * referenceScale,
+        };
+      }),
       shift({ padding: 8 }),
       setFieldInputLayoutDirectionMiddleware,
     ],
@@ -96,14 +98,18 @@ export const RecordInlineCellEditMode = ({
     >
       <>
         {createPortal(
-          <OverlayContainer
+          <StyledDropdownContentContainer
+            data-floating-ui-viewport
             ref={refs.setFloating}
             style={floatingStyles}
-            borderRadius="sm"
-            hasDangerBorder={recordFieldInputIsFieldInError}
           >
-            {children}
-          </OverlayContainer>,
+            <OverlayContainer
+              borderRadius="sm"
+              hasDangerBorder={recordFieldInputIsFieldInError}
+            >
+              {children}
+            </OverlayContainer>
+          </StyledDropdownContentContainer>,
           document.body,
         )}
       </>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx
@@ -5,12 +5,14 @@ import { recordFieldInputLayoutDirectionComponentState } from '@/object-record/r
 import { recordFieldInputLayoutDirectionLoadingComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionLoadingComponentState';
 import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
 import { useFocusRecordTableCell } from '@/object-record/record-table/record-table-cell/hooks/useFocusRecordTableCell';
+import { StyledDropdownContentContainer } from '@/ui/layout/dropdown/components/internal/DropdownInternalContainer';
 import { OverlayContainer } from '@/ui/layout/overlay/components/OverlayContainer';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { styled } from '@linaria/react';
 import {
+  FloatingPortal,
   autoUpdate,
   flip,
   offset,
@@ -75,11 +77,19 @@ export const RecordTableCellEditMode = ({
 
   const { refs, floatingStyles } = useFloating({
     placement: 'bottom-start',
+    strategy: 'fixed',
     middleware: [
       flip(),
-      offset({
-        mainAxis: -33,
-        crossAxis: -3,
+      offset(({ rects, elements }) => {
+        const referenceScale =
+          elements.reference instanceof HTMLElement
+            ? rects.reference.width / elements.reference.offsetWidth
+            : 1;
+
+        return {
+          mainAxis: -33 * referenceScale,
+          crossAxis: -3 * referenceScale,
+        };
       }),
       setFieldInputLayoutDirectionMiddleware,
     ],
@@ -108,14 +118,20 @@ export const RecordTableCellEditMode = ({
           {children}
         </StyledInputModeOnlyContainer>
       ) : (
-        <OverlayContainer
-          ref={refs.setFloating}
-          style={floatingStyles}
-          borderRadius="sm"
-          hasDangerBorder={recordFieldInputIsFieldInError}
-        >
-          {children}
-        </OverlayContainer>
+        <FloatingPortal>
+          <StyledDropdownContentContainer
+            data-floating-ui-viewport
+            ref={refs.setFloating}
+            style={floatingStyles}
+          >
+            <OverlayContainer
+              borderRadius="sm"
+              hasDangerBorder={recordFieldInputIsFieldInError}
+            >
+              {children}
+            </OverlayContainer>
+          </StyledDropdownContentContainer>
+        </FloatingPortal>
       )}
     </StyledEditableCellEditModeContainer>
   );

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/Dropdown.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/Dropdown.tsx
@@ -56,7 +56,6 @@ export type DropdownProps = {
   dropdownId: string;
   dropdownPlacement?: Placement;
   dropdownOffset?: DropdownOffset;
-  dropdownStrategy?: 'fixed' | 'absolute';
   onClickOutside?: () => void;
   onClose?: () => void;
   onOpen?: () => void;
@@ -78,7 +77,6 @@ export const Dropdown = ({
   dropdownId,
   globalHotkeysConfig,
   dropdownPlacement = 'bottom-end',
-  dropdownStrategy = 'absolute',
   dropdownOffset,
   onClickOutside,
   onClose,
@@ -173,7 +171,8 @@ export const Dropdown = ({
       }),
     ],
     whileElementsMounted: autoUpdate,
-    strategy: dropdownStrategy,
+    // Portaled dropdowns use viewport coordinates, including under root zoom.
+    strategy: 'fixed',
   });
 
   const handleClickableComponentClick = useCallback(

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/Dropdown.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/Dropdown.tsx
@@ -171,7 +171,6 @@ export const Dropdown = ({
       }),
     ],
     whileElementsMounted: autoUpdate,
-    // Portaled dropdowns use viewport coordinates, including under root zoom.
     strategy: 'fixed',
   });
 

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/Dropdown.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/Dropdown.stories.tsx
@@ -114,7 +114,9 @@ export const InterfaceScale: Story = {
     clickableComponent: <span>Open Dropdown</span>,
     dropdownPlacement: 'bottom-start',
     dropdownOffset: { x: 0, y: 0 },
-    dropdownComponents: <DropdownContent>Scaled dropdown</DropdownContent>,
+    dropdownComponents: (
+      <div style={{ width: 200, height: 100 }}>Scaled dropdown</div>
+    ),
   },
   render: (args) => (
     <div style={{ paddingLeft: 200, paddingTop: 100 }}>
@@ -141,6 +143,12 @@ export const InterfaceScale: Story = {
           const anchorBounds = button.getBoundingClientRect();
           const menuBounds = menu.getBoundingClientRect();
 
+          const contentBounds = canvas
+            .getByText('Scaled dropdown')
+            .getBoundingClientRect();
+          expect(Math.abs(contentBounds.width - 200 * scale)).toBeLessThan(1);
+          expect(Math.abs(contentBounds.height - 100 * scale)).toBeLessThan(1);
+
           expect(Math.abs(menuBounds.left - anchorBounds.left)).toBeLessThan(1);
           expect(Math.abs(menuBounds.top - anchorBounds.bottom)).toBeLessThan(
             1,
@@ -154,11 +162,6 @@ export const InterfaceScale: Story = {
       rootStyle.setProperty('--t-zoom', previousScale);
     }
   },
-};
-
-export const InterfaceScaleFixed: Story = {
-  ...InterfaceScale,
-  args: { ...InterfaceScale.args, dropdownStrategy: 'fixed' },
 };
 
 const avatarUrl =

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/Dropdown.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/Dropdown.stories.tsx
@@ -109,6 +109,58 @@ export const Empty: Story = {
   },
 };
 
+export const InterfaceScale: Story = {
+  args: {
+    clickableComponent: <span>Open Dropdown</span>,
+    dropdownPlacement: 'bottom-start',
+    dropdownOffset: { x: 0, y: 0 },
+    dropdownComponents: <DropdownContent>Scaled dropdown</DropdownContent>,
+  },
+  render: (args) => (
+    <div style={{ paddingLeft: 200, paddingTop: 100 }}>
+      <Dropdown {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const document = canvasElement.ownerDocument;
+    const canvas = within(document.body);
+    const rootStyle = document.documentElement.style;
+    const previousZoom = rootStyle.getPropertyValue('zoom');
+    const previousScale = rootStyle.getPropertyValue('--t-zoom');
+
+    try {
+      for (const scale of [0.9, 1, 1.1, 1.25, 14 / 13]) {
+        rootStyle.setProperty('--t-zoom', String(scale));
+        rootStyle.setProperty('zoom', 'var(--t-zoom)');
+
+        const button = canvas.getByRole('button', { name: 'Open Dropdown' });
+        await userEvent.click(button);
+
+        const menu = await canvas.findByRole('listbox');
+        await waitFor(() => {
+          const anchorBounds = button.getBoundingClientRect();
+          const menuBounds = menu.getBoundingClientRect();
+
+          expect(Math.abs(menuBounds.left - anchorBounds.left)).toBeLessThan(1);
+          expect(Math.abs(menuBounds.top - anchorBounds.bottom)).toBeLessThan(
+            1,
+          );
+        });
+
+        await userEvent.click(button);
+      }
+    } finally {
+      rootStyle.setProperty('zoom', previousZoom);
+      rootStyle.setProperty('--t-zoom', previousScale);
+    }
+  },
+};
+
+export const InterfaceScaleFixed: Story = {
+  ...InterfaceScale,
+  args: { ...InterfaceScale.args, dropdownStrategy: 'fixed' },
+};
+
 const avatarUrl =
   'https://s3-alpha-sig.figma.com/img/bbb5/4905/f0a52cc2b9aaeb0a82a360d478dae8bf?Expires=1687132800&Signature=iVBr0BADa3LHoFVGbwqO-wxC51n1o~ZyFD-w7nyTyFP4yB-Y6zFawL-igewaFf6PrlumCyMJThDLAAc-s-Cu35SBL8BjzLQ6HymzCXbrblUADMB208PnMAvc1EEUDq8TyryFjRO~GggLBk5yR0EXzZ3zenqnDEGEoQZR~TRqS~uDF-GwQB3eX~VdnuiU2iittWJkajIDmZtpN3yWtl4H630A3opQvBnVHZjXAL5YPkdh87-a-H~6FusWvvfJxfNC2ZzbrARzXofo8dUFtH7zUXGCC~eUk~hIuLbLuz024lFQOjiWq2VKyB7dQQuGFpM-OZQEV8tSfkViP8uzDLTaCg__&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4';
 

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/internal/DropdownInternalContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/internal/DropdownInternalContainer.tsx
@@ -29,6 +29,13 @@ export const StyledDropdownContentContainer = styled.div<{
   isDropdownInModal?: boolean;
 }>`
   display: flex;
+  // Floating UI returns viewport pixels, which root zoom would scale again.
+  zoom: calc(1 / var(--t-zoom, 1));
+
+  > * {
+    zoom: var(--t-zoom, 1);
+  }
+
   z-index: ${({ isDropdownInModal }) =>
     isDropdownInModal
       ? RootStackingContextZIndices.DropdownPortalAboveModal

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/internal/DropdownInternalContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/internal/DropdownInternalContainer.tsx
@@ -33,11 +33,6 @@ export const StyledDropdownContentContainer = styled.div<{
     isDropdownInModal
       ? RootStackingContextZIndices.DropdownPortalAboveModal
       : RootStackingContextZIndices.DropdownPortalBelowModal};
-  zoom: calc(1 / var(--t-zoom, 1));
-
-  > * {
-    zoom: var(--t-zoom, 1);
-  }
 `;
 
 const StyledDropdownInsideContainer = styled.div`
@@ -161,6 +156,7 @@ export const DropdownInternalContainer = ({
 
       <FloatingPortal>
         <StyledDropdownContentContainer
+          data-floating-ui-viewport
           ref={floatingUiRefs.setFloating}
           style={dropdownMenuStyles}
           role="listbox"

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/internal/DropdownInternalContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/internal/DropdownInternalContainer.tsx
@@ -29,7 +29,6 @@ export const StyledDropdownContentContainer = styled.div<{
   isDropdownInModal?: boolean;
 }>`
   display: flex;
-  // Floating UI returns viewport pixels, which root zoom would scale again.
   zoom: calc(1 / var(--t-zoom, 1));
 
   > * {

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/internal/DropdownInternalContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/internal/DropdownInternalContainer.tsx
@@ -29,16 +29,15 @@ export const StyledDropdownContentContainer = styled.div<{
   isDropdownInModal?: boolean;
 }>`
   display: flex;
+  z-index: ${({ isDropdownInModal }) =>
+    isDropdownInModal
+      ? RootStackingContextZIndices.DropdownPortalAboveModal
+      : RootStackingContextZIndices.DropdownPortalBelowModal};
   zoom: calc(1 / var(--t-zoom, 1));
 
   > * {
     zoom: var(--t-zoom, 1);
   }
-
-  z-index: ${({ isDropdownInModal }) =>
-    isDropdownInModal
-      ? RootStackingContextZIndices.DropdownPortalAboveModal
-      : RootStackingContextZIndices.DropdownPortalBelowModal};
 `;
 
 const StyledDropdownInsideContainer = styled.div`

--- a/packages/twenty-front/src/modules/ui/layout/expandable-list/components/ExpandedListDropdown.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/expandable-list/components/ExpandedListDropdown.tsx
@@ -28,6 +28,7 @@ export const ExpandedListDropdown = ({
 }: ExpandedListDropdownProps) => {
   const { refs, floatingStyles } = useFloating({
     placement: 'bottom-start',
+    strategy: 'fixed',
     middleware: [offset({ mainAxis: -9, crossAxis: -7 }), shift()],
     elements: { reference: anchorElement },
   });

--- a/packages/twenty-front/src/modules/ui/layout/expandable-list/components/ExpandedListDropdown.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/expandable-list/components/ExpandedListDropdown.tsx
@@ -42,12 +42,13 @@ export const ExpandedListDropdown = ({
   });
 
   const dropdownContentWidth = anchorElement
-    ? Math.max(220, anchorElement.getBoundingClientRect().width)
+    ? Math.max(220, anchorElement.offsetWidth)
     : undefined;
 
   return (
     <FloatingPortal>
       <StyledDropdownContentContainer
+        data-floating-ui-viewport
         ref={refs.setFloating}
         style={floatingStyles}
       >

--- a/packages/twenty-front/src/testing/decorators/RootDecorator.tsx
+++ b/packages/twenty-front/src/testing/decorators/RootDecorator.tsx
@@ -1,4 +1,4 @@
-import '@/viewport-zoom.css';
+import '~/viewport-zoom.css';
 import { ApolloProvider } from '@apollo/client/react';
 import { type Decorator } from '@storybook/react-vite';
 import { Provider as JotaiProvider } from 'jotai';

--- a/packages/twenty-front/src/testing/decorators/RootDecorator.tsx
+++ b/packages/twenty-front/src/testing/decorators/RootDecorator.tsx
@@ -1,3 +1,4 @@
+import '@/viewport-zoom.css';
 import { ApolloProvider } from '@apollo/client/react';
 import { type Decorator } from '@storybook/react-vite';
 import { Provider as JotaiProvider } from 'jotai';

--- a/packages/twenty-front/src/viewport-zoom.css
+++ b/packages/twenty-front/src/viewport-zoom.css
@@ -1,0 +1,15 @@
+/* dnd-kit positions and sizes the feedback from visual-viewport pixel
+     measurements, so inside the zoomed root those inline values would be
+     multiplied a second time. The inverse zoom makes them render one to one,
+     and the child rule restores the interface scale for the dragged content
+     so it keeps matching the rest of the page. */
+
+[data-dnd-dragging='true'],
+[data-floating-ui-viewport] {
+  zoom: calc(1 / var(--t-zoom, 1));
+}
+
+[data-dnd-dragging='true'] > *,
+[data-floating-ui-viewport] > * {
+  zoom: var(--t-zoom, 1);
+}


### PR DESCRIPTION
## Summary

Fix dropdowns drifting offscreen when the interface scale differs from 100%. Use fixed viewport positioning for portaled dropdowns, cancel root zoom on the positioning wrapper, and restore the selected scale on its contents. This also covers expanded-list menus and removes the obsolete absolute-position override from the record command menu.

The regression story checks anchoring and scaled content dimensions at 90%, 100%, 110%, 125%, and the mobile base scale.

## Preview verification

Captured from the [deployed preview](https://harry-backed-chester-offerings.trycloudflare.com/settings/experience) at commit `f265a0c`. At both 90% and 125%, the open scale menu stays aligned beneath its selector and remains fully visible. Restored the preview to 100% afterward.

CI lint, typecheck, build, unit tests, and all Storybook test shards passed.

### 90% interface scale

![Dropdown anchored at 90% interface scale](https://github.com/user-attachments/assets/bf3b2687-87ba-4c4c-b9c9-ae438b241722)

### 125% interface scale

![Dropdown anchored at 125% interface scale](https://github.com/user-attachments/assets/7827135b-1d4f-44f6-93de-a1d1460dfb88)
