### PR TITLE
Let a relation field's bookkeeping properties be updated through a sync

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/__tests__/flat-field-metadata-relation-properties-to-compare.constant.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/__tests__/flat-field-metadata-relation-properties-to-compare.constant.spec.ts
@@ -17,8 +17,6 @@ const RELATION_UNSUPPORTED_COMPARED_PROPERTIES: Record<string, string> = {
     'isUnique is derived from the single field unique indexes a relation never has, so the stored value is always false',
   isSearchable:
     'validateSearchableFlatFieldMetadata already refuses a searchable relation, and it runs before this allow-list is consulted',
-  isLabelSyncedWithName:
-    'the field settings UI hides the label sync toggle for relation fields, so a relation is not expected to carry a value change',
 };
 
 describe('FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE', () => {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/__tests__/flat-field-metadata-relation-properties-to-compare.constant.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/__tests__/flat-field-metadata-relation-properties-to-compare.constant.spec.ts
@@ -1,0 +1,46 @@
+import { ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY } from 'src/engine/metadata-modules/flat-entity/constant/all-universal-flat-entity-properties-to-compare-and-stringify.constant';
+import { FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE } from 'src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-relation-properties-to-compare.constant';
+
+const COMPARED_PROPERTIES: readonly string[] =
+  ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY.fieldMetadata
+    .propertiesToCompare;
+
+const RELATION_UPDATABLE_PROPERTIES: readonly string[] =
+  FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE;
+
+const RELATION_UNSUPPORTED_COMPARED_PROPERTIES: Record<string, string> = {
+  defaultValue:
+    'RELATION and MORPH_RELATION are listed in FIELD_METADATA_TYPES_WITHOUT_DEFAULT_VALUE, so both sides of a comparison are always null',
+  options:
+    'options exist for RATING, SELECT and MULTI_SELECT only, so both sides of a comparison are always null',
+  isUnique:
+    'isUnique is derived from the single field unique indexes a relation never has, so the stored value is always false',
+  isSearchable:
+    'validateSearchableFlatFieldMetadata already refuses a searchable relation, and it runs before this allow-list is consulted',
+  isLabelSyncedWithName:
+    'the field settings UI hides the label sync toggle for relation fields, so a relation is not expected to carry a value change',
+};
+
+describe('FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE', () => {
+  it('should classify every compared field metadata property as relation updatable or explicitly unsupported', () => {
+    const unclassifiedProperties = COMPARED_PROPERTIES.filter(
+      (property) =>
+        !RELATION_UPDATABLE_PROPERTIES.includes(property) &&
+        !(property in RELATION_UNSUPPORTED_COMPARED_PROPERTIES),
+    );
+
+    expect(unclassifiedProperties).toEqual([]);
+  });
+
+  it('should not keep an unsupported reason for a property that became relation updatable or stopped being compared', () => {
+    const staleReasons = Object.keys(
+      RELATION_UNSUPPORTED_COMPARED_PROPERTIES,
+    ).filter(
+      (property) =>
+        RELATION_UPDATABLE_PROPERTIES.includes(property) ||
+        !COMPARED_PROPERTIES.includes(property),
+    );
+
+    expect(staleReasons).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-relation-properties-to-compare.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-relation-properties-to-compare.constant.ts
@@ -10,4 +10,6 @@ export const FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE = [
   'universalSettings',
   'isUIEditable',
   'isAuditLogged',
+  'isNullable',
+  'writability',
 ] as const satisfies (typeof ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY.fieldMetadata.propertiesToCompare)[number][];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-relation-properties-to-compare.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-relation-properties-to-compare.constant.ts
@@ -12,4 +12,5 @@ export const FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE = [
   'isAuditLogged',
   'isNullable',
   'writability',
+  'isLabelSyncedWithName',
 ] as const satisfies (typeof ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY.fieldMetadata.propertiesToCompare)[number][];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-relation-properties-to-compare.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-relation-properties-to-compare.constant.ts
@@ -9,4 +9,5 @@ export const FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE = [
   'name',
   'universalSettings',
   'isUIEditable',
+  'isAuditLogged',
 ] as const satisfies (typeof ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY.fieldMetadata.propertiesToCompare)[number][];


### PR DESCRIPTION
## What

A relation field could not be updated through the metadata sync when the change touched `isAuditLogged`, `isNullable`, `writability` or `isLabelSyncedWithName`: the whole sync failed with `FIELD_MUTATION_NOT_ALLOWED` instead of applying the update. This adds the four properties to the relation allow-list and adds a guard so the next property added to the compared set cannot be forgotten the same way.

## The bug

`FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE` is the allow-list `FlatFieldMetadataValidatorService` filters an update against when the field is a relation or a morph relation. Anything outside it aborts the sync. The list is consulted by the migration builder, so it gates every write source: the metadata API, an application manifest sync, an upgrade command and the standard application build alike.

Four compared properties were missing from it:

- **`isAuditLogged`**, added by #25641. An app can create a relation field with auditing off, then never change it. Non-audited relations are a supported state: the timeline builder has a dedicated branch that also excludes the `<name>Id` join column for a many-to-one relation, and `FieldManifest` can declare the flag.
- **`isNullable`**. `RelationFieldManifest` declares it and the converter resolves it for every relation, and three standard relation fields are built non-nullable today, so a release that flipped one would fail the standard sync on every existing workspace while a fresh-database CI run stayed green.
- **`writability`**. Inherited from the base field manifest and meaningful on a relation, since the join column of a many-to-one maps back to the relation field, so `APPLICATION` or `SYSTEM` genuinely locks that foreign key against API writes. That is how an app owns a link it maintains itself.
- **`isLabelSyncedWithName`**. Inherited from the base field manifest and copied into relation metadata by the converter. The label sync validation is type agnostic and simply requires the name to match the label, and both are already relation updatable, so keeping a relation's label in sync with its name is coherent.

Allowing the four costs nothing at the schema level. `handleFieldNullableUpdate` returns early for relation and morph fields, `writability` and `isLabelSyncedWithName` need no schema work at all, and `isAuditLogged` is metadata read by the timeline write path. All four are bookkeeping columns.

## Why it kept happening

A new field property has to land in three constants. The properties configuration is compiler-enforced exhaustive, through an equality assertion on the derived union, so it is always updated. The relation list is declared `as const satisfies (compared properties)[]`, which constrains membership but never completeness: widening the union only makes more arrays legal, so a list that omits the new property stays valid. The compiler asks about one list and is silent about the other, while the `satisfies` makes the file look checked.

No test covered it either. Nothing referenced the constant outside its own file, its type alias and the validator. The export round trip cannot reach it, because its pass condition is that the sync produces zero actions while the relation branch only runs on an update action. The manifest field update suite has a per-property update case but no relation fields at all, and the metadata API relation update suite only touches five properties, all allow-listed since 2025.

This is the third repair of the same omission. `icon` was added to the list in October 2025 as a bug fix, and `isUIEditable` in June 2026 as #21537, one day after the property was introduced, after it aborted the 1.22 to 2.13 upgrade on the activity target morph relations and left workspaces in a failed state.

## The guard

A constants spec asserts that every compared field metadata property is either relation updatable or carries a named reason for being excluded, and that no reason goes stale. Adding a compared property now forces a decision instead of silently defaulting to "the sync dies if anyone changes it".

It is keyed on the compared set rather than on `FLAT_FIELD_METADATA_EDITABLE_PROPERTIES`, which is the tempting choice: the editable list only covers the GraphQL path, so it is blind to `isNullable` and `writability`, the two most severe gaps here. The compared set is what the diff is built from, whichever door the write came through.

The four remaining exclusions carry their reason: `defaultValue` and `options` are null on both sides for a relation at the type level, `isUnique` is derived from single-field unique indexes a relation never has, and `isSearchable` is already refused by its own validator, which runs before this allow-list is consulted.

The spec runs in milliseconds with no database. It does not stop someone silencing it with a bad reason string, but it does force a written rationale a reviewer can argue with.

## Verification

- The guard is red on the defect and green on the fix. Removing any of the four properties from the list fails the spec and names it.
- End to end on a dev workspace, same input both ways: without the fix `yarn twenty plan` reports `FIELD_MUTATION_NOT_ALLOWED: Forbidden updated properties for relation field metadata: isAuditLogged`; with it, `~ isAuditLogged = true -> false`, one change, zero destroys.
- Server unit suites: 214 suites, 1290 tests. Metadata integration suites for field metadata and applications: 126 suites, 689 tests, 328 snapshots. Typecheck and diff lint clean.

## Follow-up, not in this PR

The constant is named `..._PROPERTIES_TO_COMPARE` but behaves as an updatable allow-list, and its sibling was renamed to `..._EDITABLE_PROPERTIES` back in 2025. Anyone grepping for "editable" while adding an editable property will not find it. Renaming it and stating the contract on the constant would remove the misdirection that has now cost three repairs.
