### PR TITLE
Skip workflow status update when the workflow no longer exists

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -1,6 +1,7 @@
 import { Logger, Scope } from '@nestjs/common';
 
 import isEqual from 'lodash.isequal';
+import { isDefined } from 'twenty-shared/utils';
 import { In } from 'typeorm';
 
 import { computeCoreWorkflowStatuses } from 'src/engine/core-modules/workflow/utils/compute-core-workflow-statuses.util';
@@ -112,14 +113,17 @@ export class WorkflowStatusesUpdateJob {
       workflowVersionRepository,
     });
 
-    const previousWorkflow = await workflowRepository.findOneOrFail({
+    const previousWorkflow = await workflowRepository.findOne({
       where: {
         id: workflowId,
       },
       withDeleted: true,
     });
 
-    if (isEqual(newWorkflowStatuses, previousWorkflow.statuses)) {
+    if (
+      !isDefined(previousWorkflow) ||
+      isEqual(newWorkflowStatuses, previousWorkflow.statuses)
+    ) {
       return;
     }
 
@@ -150,11 +154,15 @@ export class WorkflowStatusesUpdateJob {
         { shouldBypassPermissionChecks: true },
       );
 
-    const workflow = await workflowRepository.findOneOrFail({
+    const workflow = await workflowRepository.findOne({
       where: {
         id: statusUpdate.workflowId,
       },
     });
+
+    if (!isDefined(workflow)) {
+      return;
+    }
 
     const newWorkflowStatuses = await this.getWorkflowStatuses({
       workflowId: statusUpdate.workflowId,


### PR DESCRIPTION
### Problem

`WorkflowStatusesUpdateJob` looks the workflow up with `findOneOrFail`, so a workflow that is gone by the time the job runs throws `ENTITY_NOT_FOUND` instead of the job simply having nothing to update. Deleting a workflow shortly after creating one is enough to hit it: the create enqueues the status job, the destroy removes the row, the job then fails.

Sentry: TWENTY-SERVER-CVE, 3640 occurrences across 100 workspaces since October 2025.

### Fix

Both handlers now read with `findOne` and return early when the workflow is missing:

- `handleWorkflowVersionCreatedOrDeleted` already passed `withDeleted: true`, so only a hard destroy could make it throw.
- `handleWorkflowVersionStatusUpdated` had no `withDeleted`, so a soft delete was enough. Left as is on purpose - changing it to read deleted rows would make the job write statuses onto deleted workflows, which is a behaviour change rather than a bug fix.

There is nothing to update in either case, so returning is the correct outcome, and the job stops reporting a user-triggerable race as an error.

Fixes TWENTY-SERVER-CVE

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

