### PR TITLE
Fix column resize dragging the widget in layout edit mode

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordColumnResizeHandle.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordColumnResizeHandle.tsx
@@ -43,6 +43,7 @@ export const RecordColumnResizeHandle = ({
     className="cursor-col-resize"
     role="separator"
     aria-orientation="vertical"
+    data-dnd-drag-disable
     isResizing={isResizing}
     position={position}
     onPointerDown={onPointerDown}

--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/__tests__/shouldPreventDragActivation.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/__tests__/shouldPreventDragActivation.test.ts
@@ -1,7 +1,6 @@
 import { shouldPreventDragActivation } from '@/ui/utilities/drag-and-drop/utils/shouldPreventDragActivation';
 
-const createPointerEvent = (target: Element) =>
-  ({ target }) as unknown as PointerEvent;
+const createPointerEvent = (target: Element) => ({ target });
 
 describe('shouldPreventDragActivation', () => {
   it('should prevent activation when the target opts out of dragging', () => {

--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/__tests__/shouldPreventDragActivation.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/__tests__/shouldPreventDragActivation.test.ts
@@ -1,0 +1,56 @@
+import { shouldPreventDragActivation } from '@/ui/utilities/drag-and-drop/utils/shouldPreventDragActivation';
+
+const createPointerEvent = (target: Element) =>
+  ({ target }) as unknown as PointerEvent;
+
+describe('shouldPreventDragActivation', () => {
+  it('should prevent activation when the target opts out of dragging', () => {
+    const sourceElement = document.createElement('div');
+    const resizeHandle = document.createElement('div');
+    resizeHandle.setAttribute('data-dnd-drag-disable', '');
+    sourceElement.appendChild(resizeHandle);
+
+    expect(
+      shouldPreventDragActivation(createPointerEvent(resizeHandle), {
+        element: sourceElement,
+      }),
+    ).toBe(true);
+  });
+
+  it('should prevent activation when the target is inside an element that opts out of dragging', () => {
+    const sourceElement = document.createElement('div');
+    const optedOutContainer = document.createElement('div');
+    optedOutContainer.setAttribute('data-dnd-drag-disable', '');
+    const nestedTarget = document.createElement('span');
+    optedOutContainer.appendChild(nestedTarget);
+    sourceElement.appendChild(optedOutContainer);
+
+    expect(
+      shouldPreventDragActivation(createPointerEvent(nestedTarget), {
+        element: sourceElement,
+      }),
+    ).toBe(true);
+  });
+
+  it('should not prevent activation when the target is the source element', () => {
+    const sourceElement = document.createElement('div');
+
+    expect(
+      shouldPreventDragActivation(createPointerEvent(sourceElement), {
+        element: sourceElement,
+      }),
+    ).toBe(false);
+  });
+
+  it('should not prevent activation for a plain descendant of the source element', () => {
+    const sourceElement = document.createElement('div');
+    const plainDescendant = document.createElement('span');
+    sourceElement.appendChild(plainDescendant);
+
+    expect(
+      shouldPreventDragActivation(createPointerEvent(plainDescendant), {
+        element: sourceElement,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/shouldPreventDragActivation.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/shouldPreventDragActivation.ts
@@ -12,13 +12,15 @@ const NON_DRAGGABLE_TARGET_SELECTOR = [
   '[data-dnd-drag-disable]',
 ].join(', ');
 
+type DragActivationEvent = Pick<PointerEvent, 'target'>;
+
 type DragActivationSource = {
   element?: Element | null;
   handle?: Element | null;
 };
 
 export const shouldPreventDragActivation = (
-  event: PointerEvent,
+  event: DragActivationEvent,
   source: DragActivationSource,
 ): boolean => {
   const target = event.target;

--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/shouldPreventDragActivation.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/shouldPreventDragActivation.ts
@@ -9,6 +9,7 @@ const NON_DRAGGABLE_TARGET_SELECTOR = [
   'textarea:not([disabled])',
   'button:not([disabled])',
   '[contenteditable]:not([contenteditable="false"])',
+  '[data-dnd-drag-disable]',
 ].join(', ');
 
 type DragActivationSource = {


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/5a70b40b-f237-4dd7-80ff-bb91ef0a0f3f


## After

https://github.com/user-attachments/assets/7efae66c-3d24-4ee8-9d87-52329c33692b


In page layout edit mode, dragging a column resize handle inside a table or kanban widget also dragged the widget in vertical-list tabs. Those widgets are whole-card dnd-kit sortables, and the resize handle was not excluded from drag activation.

Adds a `data-dnd-drag-disable` opt-out to `shouldPreventDragActivation` and sets it on the shared column resize handle.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

