### PR TITLE
fix(caldav): accept calendars when supported-calendar-component-set is omitted (fixes #25683)

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.ts
@@ -42,8 +42,10 @@ export class CalDavFetchEventsService {
   async listEventCalendars(client: DAVClient): Promise<DAVCalendar[]> {
     const calendars = await client.fetchCalendars();
 
-    return calendars.filter((calendar) =>
-      calendar.components?.includes('VEVENT'),
+    return calendars.filter(
+      (calendar) =>
+        !calendar.components?.length ||
+        calendar.components.includes('VEVENT'),
     );
   }
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.ts
@@ -42,10 +42,8 @@ export class CalDavFetchEventsService {
   async listEventCalendars(client: DAVClient): Promise<DAVCalendar[]> {
     const calendars = await client.fetchCalendars();
 
-    return calendars.filter(
-      (calendar) =>
-        !calendar.components?.length ||
-        calendar.components.includes('VEVENT'),
+    return calendars.filter((calendar) =>
+      !calendar.components?.length || calendar.components.includes('VEVENT'),
     );
   }
 


### PR DESCRIPTION
Fixes #25683.

### Description

Per [RFC 4791 §5.2.3](https://www.rfc-editor.org/rfc/rfc4791.html#section-5.2.3), the `supported-calendar-component-set` property is optional (`MAY be defined`). When a CalDAV server (such as Purelymail) omits this property, the server accepts all calendar component types, including `VEVENT`.

Previously, `CalDavFetchEventsService.listEventCalendars` strictly required `calendar.components?.includes('VEVENT')`. When `components` was empty or undefined, valid RFC-compliant calendars were discarded, causing CalDAV connection tests and event synchronization to fail with `No calendar with event support found`.

This PR updates the filter so that:
- Calendars with omitted or empty `components` are accepted as per the CalDAV specification.
- Calendars with explicitly declared components that do not include `VEVENT` (e.g. `['VTODO']` or `['VJOURNAL']`) continue to be correctly filtered out.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

