### PR TITLE
fix(cache-lock): fence Redis lock release with an ownership token

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/cache-lock/__tests__/cache-lock.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-lock/__tests__/cache-lock.service.spec.ts
@@ -1,0 +1,55 @@
+import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
+import { CacheLockException } from 'src/engine/core-modules/cache-lock/exceptions/cache-lock.exception';
+
+describe('CacheLockService', () => {
+  const acquireLock = jest.fn();
+  const releaseLock = jest.fn();
+
+  const cacheStorageService = {
+    acquireLock,
+    releaseLock,
+  };
+
+  let service: CacheLockService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    service = new CacheLockService(cacheStorageService as any);
+  });
+
+  it('releases the lock using the token returned by acquireLock', async () => {
+    acquireLock.mockResolvedValue('token-123');
+
+    const result = await service.withLock(async () => 'result', 'my-key');
+
+    expect(result).toBe('result');
+    expect(releaseLock).toHaveBeenCalledWith('my-key', 'token-123');
+  });
+
+  it('releases the token-fenced lock even when fn throws', async () => {
+    acquireLock.mockResolvedValue('token-123');
+
+    await expect(
+      service.withLock(async () => {
+        throw new Error('boom');
+      }, 'my-key'),
+    ).rejects.toThrow('boom');
+
+    expect(releaseLock).toHaveBeenCalledWith('my-key', 'token-123');
+  });
+
+  it('retries and throws without releasing when the lock cannot be acquired', async () => {
+    jest.useRealTimers();
+    acquireLock.mockResolvedValue(null);
+
+    await expect(
+      service.withLock(async () => 'result', 'my-key', {
+        maxRetries: 2,
+        ms: 0,
+      }),
+    ).rejects.toThrow(CacheLockException);
+
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/cache-lock/cache-lock.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-lock/cache-lock.service.ts
@@ -35,14 +35,14 @@ export class CacheLockService {
     const { ms = 100, maxRetries = 50, ttl = 5_500 } = options || {};
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
-      const acquired = await this.cacheStorageService.acquireLock(key, ttl);
+      const token = await this.cacheStorageService.acquireLock(key, ttl);
 
-      if (acquired) {
+      if (token !== null) {
         try {
           return await fn();
         } finally {
           try {
-            await this.cacheStorageService.releaseLock(key);
+            await this.cacheStorageService.releaseLock(key, token);
           } catch (releaseError) {
             this.logger.warn(
               `Failed to release lock for key "${key}": ${releaseError}`,

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/__tests__/cache-storage.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/__tests__/cache-storage.service.spec.ts
@@ -1,0 +1,82 @@
+import { type Cache } from '@nestjs/cache-manager';
+
+import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+
+describe('CacheStorageService locking', () => {
+  const set = jest.fn();
+  const del = jest.fn();
+  const evalMock = jest.fn();
+
+  const cache = {
+    store: {
+      name: 'redis',
+      client: {
+        set,
+        eval: evalMock,
+      },
+    },
+    del,
+  } as unknown as Cache;
+
+  let service: CacheStorageService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new CacheStorageService(cache, CacheStorageNamespace.EngineLock);
+  });
+
+  describe('acquireLock', () => {
+    it('stores a random token as the lock value and returns it', async () => {
+      set.mockResolvedValue('OK');
+
+      const token = await service.acquireLock('my-lock', 1000);
+
+      expect(token).toEqual(expect.any(String));
+      expect(set).toHaveBeenCalledWith(
+        expect.stringContaining('my-lock'),
+        token,
+        { NX: true, PX: 1000 },
+      );
+    });
+
+    it('returns a different token on each successful acquisition', async () => {
+      set.mockResolvedValue('OK');
+
+      const tokenA = await service.acquireLock('lock-a', 1000);
+      const tokenB = await service.acquireLock('lock-b', 1000);
+
+      expect(tokenA).not.toBe(tokenB);
+    });
+
+    it('returns null when the key is already locked', async () => {
+      set.mockResolvedValue(null);
+
+      const token = await service.acquireLock('my-lock', 1000);
+
+      expect(token).toBeNull();
+    });
+  });
+
+  describe('releaseLock', () => {
+    it('runs a compare-and-delete script when a token is provided', async () => {
+      await service.releaseLock('my-lock', 'token-1');
+
+      expect(evalMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          keys: [expect.stringContaining('my-lock')],
+          arguments: ['token-1'],
+        }),
+      );
+      expect(del).not.toHaveBeenCalled();
+    });
+
+    it('falls back to an unconditional delete when no token is provided', async () => {
+      await service.releaseLock('my-lock');
+
+      expect(del).toHaveBeenCalledWith(expect.stringContaining('my-lock'));
+      expect(evalMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -1,6 +1,8 @@
 import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { randomUUID } from 'crypto';
+
 import { type Milliseconds } from 'cache-manager';
 import { type RedisCache } from 'cache-manager-redis-yet';
 
@@ -296,27 +298,52 @@ export class CacheStorageService {
     return count as number;
   }
 
-  async acquireLock(key: string, ttl = 1000): Promise<boolean> {
+  // The stored value fences release: acquireLock returns it as a token so
+  // releaseLock can verify it still owns the key before deleting. Without
+  // this, a lock whose TTL expired mid-critical-section gets deleted by its
+  // original holder even after another caller has since acquired it.
+  async acquireLock(key: string, ttl = 1000): Promise<string | null> {
     if (!this.isRedisCache(this.cache)) {
       throw new Error('acquireLock is only supported with Redis cache');
     }
 
     const redisClient = this.cache.store.client;
+    const token = randomUUID();
 
-    const result = await redisClient.set(this.getKey(key), 'lock', {
+    const result = await redisClient.set(this.getKey(key), token, {
       NX: true,
       PX: ttl,
     });
 
-    return result === 'OK';
+    return result === 'OK' ? token : null;
   }
 
-  async releaseLock(key: string): Promise<void> {
+  // Passing the token from acquireLock makes the delete conditional on
+  // still owning the lock. Omitting it keeps the previous unconditional
+  // delete for callers that have not migrated to token-fenced release yet.
+  async releaseLock(key: string, token?: string): Promise<void> {
     if (!this.isRedisCache(this.cache)) {
       throw new Error('releaseLock is only supported with Redis cache');
     }
 
-    await this.del(key);
+    if (token === undefined) {
+      await this.del(key);
+
+      return;
+    }
+
+    const redisClient = this.cache.store.client;
+    const script = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+else
+  return 0
+end`;
+
+    await redisClient.eval(script, {
+      keys: [this.getKey(key)],
+      arguments: [token],
+    });
   }
 
   async incrBy(key: string, increment: number): Promise<number> {

--- a/packages/twenty-server/src/engine/core-modules/cron/services/cron-trigger-deduplication.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cron/services/cron-trigger-deduplication.service.ts
@@ -42,9 +42,11 @@ export class CronTriggerDeduplicationService {
 
     const dedupKey = `${keyPrefix}:${lastTriggerTimestamp}`;
 
-    return this.cacheStorageService.acquireLock(
-      dedupKey,
-      CRON_DISPATCH_DEDUP_TTL_MS,
+    return (
+      (await this.cacheStorageService.acquireLock(
+        dedupKey,
+        CRON_DISPATCH_DEDUP_TTL_MS,
+      )) !== null
     );
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
@@ -119,7 +119,7 @@ export class WorkflowThrottlingWorkspaceService {
   ): Promise<boolean> {
     const key = this.getWorkflowEnqueueRunningCacheKey(workspaceId);
 
-    return this.cacheStorage.acquireLock(key, ttlMs);
+    return (await this.cacheStorage.acquireLock(key, ttlMs)) !== null;
   }
 
   async releaseWorkflowEnqueueLock(workspaceId: string): Promise<void> {


### PR DESCRIPTION
Fixes #25661

CacheStorageService.acquireLock/releaseLock didn't fence release by ownership — the lock value was a constant, and release did an unconditional delete. If holder A's TTL expired while A was still in its critical section and B acquired the key, A's finally would delete B's lock, letting a third caller C acquire while B was still running. Mutual exclusion breaks for everyone after the first expiry, not just once.

Fix:

acquireLock(key, ttl) now stores a random token as the lock value and returns the token (or null) instead of a boolean.
releaseLock(key, token?) deletes the key only if its value still matches token, via a compare-and-delete Lua script. Called without a token, it falls back to the old unconditional delete.
CacheLockService.withLock (billing credit state, usage-limit quota warming, application install/uninstall, logic-function layer management, entitlement transitions, etc.) threads the token from acquire to release, so every caller through it is now fenced.
The three direct callers that haven't migrated (WorkflowThrottlingWorkspaceService, CronTriggerDeduplicationService, MessageCampaignStatisticsService) keep the tokenless fallback for now, per the issue they can migrate separately.
Lock renewal for critical sections that outrun their TTL is a separate follow-up mentioned in the issue, not addressed here.

Testing: unit tests for CacheStorageService.acquireLock/releaseLock (token generation, compare-and-delete script, tokenless fallback) and CacheLockService.withLock (token threading on success/failure, no release on failed acquisition) all passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

