### PR TITLE
Fix two matcher defects the first populated benchmark sync exposed

### DIFF
--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/fetch-artificial-analysis.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/fetch-artificial-analysis.spec.ts
@@ -45,6 +45,43 @@ describe('fetchArtificialAnalysisBenchmarks', () => {
   });
 
   it.each([
+    ['best row first', true],
+    ['best row last', false],
+  ])(
+    'keeps the highest-scoring configuration whatever the order (%s)',
+    async (_label, bestFirst) => {
+      // The rows for one model are the same model at different reasoning
+      // efforts. Picking by how populated a row is scored Sonnet 4.6 at low
+      // effort against Sonnet 5 at max, and the gap read as capability.
+      const lowEffort = {
+        slug: 'claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6 (Non-reasoning, Low Effort)',
+        evaluations: { artificial_analysis_intelligence_index: 23.3 },
+        median_output_tokens_per_second: 120,
+        cost_per_task: { total_cost: 0.1 },
+      };
+      const maxEffort = {
+        slug: 'claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6 (Adaptive Reasoning, Max Effort)',
+        evaluations: { artificial_analysis_intelligence_index: 36.2 },
+        median_output_tokens_per_second: 80,
+      };
+
+      respondWith(bestFirst ? [maxEffort, lowEffort] : [lowEffort, maxEffort]);
+
+      const record = (await fetchArtificialAnalysisBenchmarks('key')).get(
+        'claudesonnet46',
+      );
+
+      expect(record?.intelligenceIndex).toBe(36.2);
+      // The whole row travels together, so speed and cost describe the same
+      // configuration the index was measured in.
+      expect(record?.outputTokensPerSecond).toBe(80);
+      expect(record?.costPerTask).toBeUndefined();
+    },
+  );
+
+  it.each([
     ['unmeasured row first', true],
     ['measured row first', false],
   ])(

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/match-benchmarks.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/match-benchmarks.spec.ts
@@ -106,6 +106,26 @@ describe('buildLookupCandidates', () => {
     expect(candidates).not.toContain('mistral-large');
   });
 
+  it('offers no undated spelling of a resolved full-date release either', () => {
+    // The publisher's undated row is whichever snapshot it last measured, which
+    // is the same trap as the bare rolling name in a longer date format.
+    const candidates = buildLookupCandidates({
+      modelName: 'claude-sonnet-5-latest',
+      siblingModels: {
+        'claude-sonnet-5-latest': modelsDevModel({
+          id: 'claude-sonnet-5-latest',
+        }),
+        'claude-sonnet-5-20260101': modelsDevModel({
+          id: 'claude-sonnet-5-20260101',
+          release_date: '2026-01-01',
+        }),
+      },
+    });
+
+    expect(candidates).toContain('claude-sonnet-5-20260101');
+    expect(candidates).not.toContain('claude-sonnet-5');
+  });
+
   it('falls back to the undated name when no release can be resolved', () => {
     const candidates = buildLookupCandidates({
       modelName: 'mistral-large-latest',

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/match-benchmarks.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/match-benchmarks.spec.ts
@@ -93,6 +93,30 @@ describe('buildLookupCandidates', () => {
     });
   });
 
+  it('does not offer the undated name once the alias resolves to a release', () => {
+    // The leaderboard's bare `mistral-large` row is the Feb '24 model. Letting
+    // it stand in for the release `-latest` currently points at published a
+    // two-year-old score as the current one.
+    const candidates = buildLookupCandidates({
+      modelName: 'mistral-large-latest',
+      siblingModels: MISTRAL_MODELS,
+    });
+
+    expect(candidates).toContain('mistral-large-2512');
+    expect(candidates).not.toContain('mistral-large');
+  });
+
+  it('falls back to the undated name when no release can be resolved', () => {
+    const candidates = buildLookupCandidates({
+      modelName: 'mistral-large-latest',
+      siblingModels: {
+        'mistral-large-latest': modelsDevModel({ id: 'mistral-large-latest' }),
+      },
+    });
+
+    expect(candidates).toContain('mistral-large');
+  });
+
   it('offers the undated name for a dated snapshot', () => {
     expect(
       buildLookupCandidates({

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/build-lookup-candidates.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/build-lookup-candidates.util.ts
@@ -55,13 +55,12 @@ export const buildLookupCandidates = ({
   const resolved = resolveRollingAlias(modelName, siblingModels);
 
   if (isDefined(resolved)) {
-    // Once the release an alias points at is known, an undated row is a
-    // different release and not a weaker spelling of this one. `mistral-large`
-    // on the leaderboard is the Feb '24 model; letting it stand in for
-    // `mistral-large-2512` published a two-year-old score as current.
-    return [
-      ...new Set([...candidates, resolved, resolved.replace(DATE_SUFFIX, '')]),
-    ];
+    // Once the release an alias points at is known, only a row naming that
+    // release will do. Every undated spelling is some other release the
+    // publisher happens to have measured: `mistral-large` on the leaderboard is
+    // the Feb '24 model, and standing in for `mistral-large-2512` it published a
+    // two-year-old score as current.
+    return [...new Set([...candidates, resolved])];
   }
 
   // No dated release to point at, so the bare name is the only thing left and

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/build-lookup-candidates.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/build-lookup-candidates.util.ts
@@ -55,13 +55,16 @@ export const buildLookupCandidates = ({
   const resolved = resolveRollingAlias(modelName, siblingModels);
 
   if (isDefined(resolved)) {
-    candidates.push(resolved, resolved.replace(DATE_SUFFIX, ''));
+    // Once the release an alias points at is known, an undated row is a
+    // different release and not a weaker spelling of this one. `mistral-large`
+    // on the leaderboard is the Feb '24 model; letting it stand in for
+    // `mistral-large-2512` published a two-year-old score as current.
+    return [
+      ...new Set([...candidates, resolved, resolved.replace(DATE_SUFFIX, '')]),
+    ];
   }
 
-  // Last: an undated `mistral-large` row in the index is whichever release the
-  // publisher last measured, so it must not win over the release the alias
-  // currently resolves to.
-  candidates.push(modelName.replace(ROLLING_SUFFIX, ''));
-
-  return [...new Set(candidates)];
+  // No dated release to point at, so the bare name is the only thing left and
+  // whichever release the publisher measured is the best answer available.
+  return [...new Set([...candidates, modelName.replace(ROLLING_SUFFIX, '')])];
 };

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/fetch-artificial-analysis-benchmarks.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/fetch-artificial-analysis-benchmarks.util.ts
@@ -58,6 +58,20 @@ const informationScore = (record: BenchmarkRecord): number =>
     record.costPerTask,
   ].filter(isDefined).length;
 
+// The rows for one model are the same model at different reasoning efforts, and
+// the publisher spells the effort only inside a display name. Taking the
+// best-scoring row gives every model its ceiling, measured the same way, which
+// is the whole reason for standing on one publisher. Picking by how populated a
+// row happened to be scored Sonnet 4.6 at low effort against Sonnet 5 at max,
+// and the gap read as a capability difference.
+const preferOver = (
+  candidate: BenchmarkRecord,
+  existing: BenchmarkRecord,
+): boolean =>
+  (candidate.intelligenceIndex ?? -1) !== (existing.intelligenceIndex ?? -1)
+    ? (candidate.intelligenceIndex ?? -1) > (existing.intelligenceIndex ?? -1)
+    : informationScore(candidate) > informationScore(existing);
+
 export const fetchArtificialAnalysisBenchmarks = async (
   apiKey: string,
 ): Promise<BenchmarkIndex> => {
@@ -120,8 +134,7 @@ export const fetchArtificialAnalysisBenchmarks = async (
 
       if (
         key.length > 0 &&
-        (!isDefined(existing) ||
-          informationScore(record) > informationScore(existing))
+        (!isDefined(existing) || preferOver(record, existing))
       ) {
         index.set(key, record);
       }

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/fetch-artificial-analysis-benchmarks.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/fetch-artificial-analysis-benchmarks.util.ts
@@ -67,10 +67,16 @@ const informationScore = (record: BenchmarkRecord): number =>
 const preferOver = (
   candidate: BenchmarkRecord,
   existing: BenchmarkRecord,
-): boolean =>
-  (candidate.intelligenceIndex ?? -1) !== (existing.intelligenceIndex ?? -1)
-    ? (candidate.intelligenceIndex ?? -1) > (existing.intelligenceIndex ?? -1)
-    : informationScore(candidate) > informationScore(existing);
+): boolean => {
+  const candidateIndex = candidate.intelligenceIndex ?? -1;
+  const existingIndex = existing.intelligenceIndex ?? -1;
+
+  if (candidateIndex !== existingIndex) {
+    return candidateIndex > existingIndex;
+  }
+
+  return informationScore(candidate) > informationScore(existing);
+};
 
 export const fetchArtificialAnalysisBenchmarks = async (
   apiKey: string,


### PR DESCRIPTION
The first sync with an API key configured landed as #25689 at 68% coverage. Reading what it actually matched turned up two defects, both now live on main.

## A stale row published as a current model's score

`mistral-large-latest` resolves to `mistral-large-2512`. Artificial Analysis has no row for that release, so the lookup fell through to its last candidate, the bare `mistral-large` — which is the leaderboard's **Feb '24** model. Main currently gives Mistral Large an intelligence index of **5.8**, below GPT-4.

Four aliases did this:

| model | row it was given | index |
|---|---|---|
| `mistral-large-latest` | Mistral Large (Feb '24) | 5.8 |
| `mistral-small-latest` | Mistral Small (Sep '24) | 5.8 |
| `mistral-medium-latest` | Mistral Medium | 5.5 |
| `devstral-medium-latest` | Devstral Medium | 9 |

The bare-name candidate was already ordered last, with a comment saying an undated row "must not win over the release the alias currently resolves to". Ordering was the wrong mechanism: last still means used when nothing before it hit. Now, once an alias resolves to a dated release, the undated row is not offered at all — it is a different release, not a weaker spelling of this one. When no release can be resolved, the bare name is still the best available answer and is still used.

Cost: those four models lose their benchmark, so coverage drops to roughly 50/80. Two of the four are provably stale from the publisher's own display name; the other two name no release at all. A missing index is a model nobody rated. A wrong one is a model ranked below GPT-4 in a picker.

## Rows compared at different reasoning efforts

The publisher carries several rows per model, and they are the same model at different efforts — the effort appears only inside the display name. The tie-break took whichever row had the most fields populated, which is arbitrary among complete rows. The result:

- `claude-sonnet-4-6` scored **23.3** from "(Non-reasoning, Low Effort)"
- `claude-sonnet-5` scored **38.4** from "(Adaptive Reasoning, Max Effort)"
- `gpt-5.4` from "(xhigh)", `gpt-5.4-mini` from "(medium)"

That gap reads as a capability difference and is partly a settings difference. It is the same error as mixing publishers, which this pipeline was built to avoid, one level down.

The highest-scoring row now wins. Every model is represented by its ceiling, measured the same way, and because the whole row travels together the speed and cost figures describe the configuration the index was measured in. Choosing a specific effort instead would need whatever field the API uses to name it; I could not inspect that without the key, so this is the rule that needs no field I have not seen.

## Verification

33 tests, 4 new. I reverted both fixes and confirmed 3 of the new tests fail on the old code — the effort-level test in both row orderings, and the alias test. Lint, format and typecheck clean.

The four dropped matches were measured by replaying the real models.dev payload through the new candidate builder against the merged overlay, not estimated.

## After this merges

The bad numbers stay on main until the sync runs again, so it is worth triggering `AI Catalog Sync` manually rather than waiting for 06:00, and checking the coverage summary on the PR it opens.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LWnxYvEvLR8VBEGA6uCKV)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

