### PR TITLE
fix(calendar): fall back to href as pseudo-etag when server omits getetag (#25648)

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.spec.ts
@@ -8,6 +8,16 @@ import {
 
 import { CalDavFetchEventsService } from './caldav-fetch-events.service';
 
+const davResponse = (
+  response: Pick<DAVResponse, 'href' | 'props'> &
+    Partial<Pick<DAVResponse, 'status'>>,
+): DAVResponse => ({
+  status: 200,
+  statusText: 'OK',
+  ok: true,
+  ...response,
+});
+
 describe('CalDavFetchEventsService', () => {
   let service: CalDavFetchEventsService;
 
@@ -33,26 +43,22 @@ describe('CalDavFetchEventsService', () => {
 
     it('falls back to href as pseudo-etag when getetag is missing or empty (e.g. SmarterMail)', async () => {
       const mockResponses: DAVResponse[] = [
-        {
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/',
           props: {},
-          status: 200,
-        },
-        {
+        }),
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/event-no-etag.ics',
           props: {},
-          status: 200,
-        },
-        {
+        }),
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/event-empty-etag.ics',
           props: { getetag: '' },
-          status: 200,
-        },
-        {
+        }),
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/event-with-etag.ics',
           props: { getetag: '"real-etag-123"' },
-          status: 200,
-        },
+        }),
       ];
 
       const mockClient = {
@@ -90,21 +96,18 @@ describe('CalDavFetchEventsService', () => {
 
     it('ignores collection href and non-caldav file extensions', async () => {
       const mockResponses: DAVResponse[] = [
-        {
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/',
           props: {},
-          status: 200,
-        },
-        {
+        }),
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/readme.txt',
           props: {},
-          status: 200,
-        },
-        {
+        }),
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/valid-event.ics',
           props: {},
-          status: 200,
-        },
+        }),
       ];
 
       const mockClient = {
@@ -168,16 +171,14 @@ describe('CalDavFetchEventsService', () => {
       };
 
       const mockResponses: DAVResponse[] = [
-        {
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/kept-event.ics',
           props: {},
-          status: 200,
-        },
-        {
+        }),
+        davResponse({
           href: 'https://caldav.example.com/calendars/user/default/new-event.ics',
           props: {},
-          status: 200,
-        },
+        }),
       ];
 
       const mockClient = {
@@ -220,19 +221,17 @@ describe('CalDavFetchEventsService', () => {
         propfind: jest.fn().mockImplementation(({ url }: { url: string }) => {
           if (url === cal1.url) {
             return [
-              {
+              davResponse({
                 href: 'https://caldav.example.com/cal1/event1.ics',
                 props: {},
-                status: 200,
-              },
+              }),
             ];
           }
           return [
-            {
+            davResponse({
               href: 'https://caldav.example.com/cal2/event2.ics',
               props: { getetag: '"cal2-etag"' },
-              status: 200,
-            },
+            }),
           ];
         }),
       } as unknown as DAVClient;

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.spec.ts
@@ -1,0 +1,263 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import {
+  type DAVCalendar,
+  type DAVClient,
+  type DAVResponse,
+  DAVNamespaceShort,
+} from 'tsdav';
+
+import { CalDavFetchEventsService } from './caldav-fetch-events.service';
+
+describe('CalDavFetchEventsService', () => {
+  let service: CalDavFetchEventsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CalDavFetchEventsService],
+    }).compile();
+
+    service = module.get<CalDavFetchEventsService>(CalDavFetchEventsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('syncCalendar via fetchHrefsViaCtagEtag', () => {
+    const mockCalendar: DAVCalendar = {
+      url: 'https://caldav.example.com/calendars/user/default/',
+      ctag: 'ctag-1',
+      reports: [],
+      components: ['VEVENT'],
+    };
+
+    it('falls back to href as pseudo-etag when getetag is missing or empty (e.g. SmarterMail)', async () => {
+      const mockResponses: DAVResponse[] = [
+        {
+          href: 'https://caldav.example.com/calendars/user/default/',
+          props: {},
+          status: 200,
+        },
+        {
+          href: 'https://caldav.example.com/calendars/user/default/event-no-etag.ics',
+          props: {},
+          status: 200,
+        },
+        {
+          href: 'https://caldav.example.com/calendars/user/default/event-empty-etag.ics',
+          props: { getetag: '' },
+          status: 200,
+        },
+        {
+          href: 'https://caldav.example.com/calendars/user/default/event-with-etag.ics',
+          props: { getetag: '"real-etag-123"' },
+          status: 200,
+        },
+      ];
+
+      const mockClient = {
+        propfind: jest.fn().mockResolvedValue(mockResponses),
+      } as unknown as DAVClient;
+
+      const result = await (service as any).syncCalendar(
+        mockClient,
+        mockCalendar,
+      );
+
+      expect(mockClient.propfind).toHaveBeenCalledWith({
+        url: mockCalendar.url,
+        props: { [`${DAVNamespaceShort.DAV}:getetag`]: {} },
+        depth: '1',
+      });
+
+      // Events without getetag must not be dropped; they should fall back to href as pseudo-etag
+      expect(result.changedHrefs).toEqual([
+        'https://caldav.example.com/calendars/user/default/event-no-etag.ics',
+        'https://caldav.example.com/calendars/user/default/event-empty-etag.ics',
+        'https://caldav.example.com/calendars/user/default/event-with-etag.ics',
+      ]);
+      expect(result.cancelledHrefs).toEqual([]);
+      expect(result.newCtag).toBe('ctag-1');
+      expect(result.newEtags).toEqual({
+        'https://caldav.example.com/calendars/user/default/event-no-etag.ics':
+          'https://caldav.example.com/calendars/user/default/event-no-etag.ics',
+        'https://caldav.example.com/calendars/user/default/event-empty-etag.ics':
+          'https://caldav.example.com/calendars/user/default/event-empty-etag.ics',
+        'https://caldav.example.com/calendars/user/default/event-with-etag.ics':
+          '"real-etag-123"',
+      });
+    });
+
+    it('ignores collection href and non-caldav file extensions', async () => {
+      const mockResponses: DAVResponse[] = [
+        {
+          href: 'https://caldav.example.com/calendars/user/default/',
+          props: {},
+          status: 200,
+        },
+        {
+          href: 'https://caldav.example.com/calendars/user/default/readme.txt',
+          props: {},
+          status: 200,
+        },
+        {
+          href: 'https://caldav.example.com/calendars/user/default/valid-event.ics',
+          props: {},
+          status: 200,
+        },
+      ];
+
+      const mockClient = {
+        propfind: jest.fn().mockResolvedValue(mockResponses),
+      } as unknown as DAVClient;
+
+      const result = await (service as any).syncCalendar(
+        mockClient,
+        mockCalendar,
+      );
+
+      expect(result.changedHrefs).toEqual([
+        'https://caldav.example.com/calendars/user/default/valid-event.ics',
+      ]);
+    });
+
+    it('short-circuits when ctag is unchanged', async () => {
+      const storedEtags = {
+        'https://caldav.example.com/calendars/user/default/event1.ics':
+          'https://caldav.example.com/calendars/user/default/event1.ics',
+      };
+      const syncCursor = {
+        syncTokens: {},
+        ctags: { [mockCalendar.url]: 'ctag-1' },
+        etags: { [mockCalendar.url]: storedEtags },
+      };
+
+      const mockClient = {
+        propfind: jest.fn(),
+      } as unknown as DAVClient;
+
+      const result = await (service as any).syncCalendar(
+        mockClient,
+        mockCalendar,
+        syncCursor,
+      );
+
+      expect(mockClient.propfind).not.toHaveBeenCalled();
+      expect(result.changedHrefs).toEqual([]);
+      expect(result.cancelledHrefs).toEqual([]);
+      expect(result.newCtag).toBe('ctag-1');
+      expect(result.newEtags).toEqual(storedEtags);
+    });
+
+    it('detects new and cancelled events when ctag changes on server without getetag', async () => {
+      const storedEtags = {
+        'https://caldav.example.com/calendars/user/default/kept-event.ics':
+          'https://caldav.example.com/calendars/user/default/kept-event.ics',
+        'https://caldav.example.com/calendars/user/default/deleted-event.ics':
+          'https://caldav.example.com/calendars/user/default/deleted-event.ics',
+      };
+      const syncCursor = {
+        syncTokens: {},
+        ctags: { [mockCalendar.url]: 'ctag-1' },
+        etags: { [mockCalendar.url]: storedEtags },
+      };
+
+      const updatedCalendar: DAVCalendar = {
+        ...mockCalendar,
+        ctag: 'ctag-2',
+      };
+
+      const mockResponses: DAVResponse[] = [
+        {
+          href: 'https://caldav.example.com/calendars/user/default/kept-event.ics',
+          props: {},
+          status: 200,
+        },
+        {
+          href: 'https://caldav.example.com/calendars/user/default/new-event.ics',
+          props: {},
+          status: 200,
+        },
+      ];
+
+      const mockClient = {
+        propfind: jest.fn().mockResolvedValue(mockResponses),
+      } as unknown as DAVClient;
+
+      const result = await (service as any).syncCalendar(
+        mockClient,
+        updatedCalendar,
+        syncCursor,
+      );
+
+      expect(result.changedHrefs).toEqual([
+        'https://caldav.example.com/calendars/user/default/new-event.ics',
+      ]);
+      expect(result.cancelledHrefs).toEqual([
+        'https://caldav.example.com/calendars/user/default/deleted-event.ics',
+      ]);
+      expect(result.newCtag).toBe('ctag-2');
+    });
+  });
+
+  describe('fetchChangedEventHrefs', () => {
+    it('aggregates changed and cancelled hrefs across multiple calendars', async () => {
+      const cal1: DAVCalendar = {
+        url: 'https://caldav.example.com/cal1/',
+        ctag: '1',
+        reports: [],
+        components: ['VEVENT'],
+      };
+      const cal2: DAVCalendar = {
+        url: 'https://caldav.example.com/cal2/',
+        ctag: '1',
+        reports: [],
+        components: ['VEVENT'],
+      };
+
+      const mockClient = {
+        fetchCalendars: jest.fn().mockResolvedValue([cal1, cal2]),
+        propfind: jest.fn().mockImplementation(({ url }: { url: string }) => {
+          if (url === cal1.url) {
+            return [
+              {
+                href: 'https://caldav.example.com/cal1/event1.ics',
+                props: {},
+                status: 200,
+              },
+            ];
+          }
+          return [
+            {
+              href: 'https://caldav.example.com/cal2/event2.ics',
+              props: { getetag: '"cal2-etag"' },
+              status: 200,
+            },
+          ];
+        }),
+      } as unknown as DAVClient;
+
+      const { changedHrefs, cancelledHrefs, syncCursor } =
+        await service.fetchChangedEventHrefs(mockClient);
+
+      expect(changedHrefs).toEqual([
+        'https://caldav.example.com/cal1/event1.ics',
+        'https://caldav.example.com/cal2/event2.ics',
+      ]);
+      expect(cancelledHrefs).toEqual([]);
+      expect(syncCursor.ctags).toEqual({
+        'https://caldav.example.com/cal1/': '1',
+        'https://caldav.example.com/cal2/': '1',
+      });
+      expect(syncCursor.etags).toEqual({
+        'https://caldav.example.com/cal1/': {
+          'https://caldav.example.com/cal1/event1.ics':
+            'https://caldav.example.com/cal1/event1.ics',
+        },
+        'https://caldav.example.com/cal2/': {
+          'https://caldav.example.com/cal2/event2.ics': '"cal2-etag"',
+        },
+      });
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.ts
@@ -362,16 +362,18 @@ export class CalDavFetchEventsService {
 
     return responses.reduce<Record<string, string>>((map, response) => {
       const href = response.href;
-      const etag = response.props?.getetag;
 
       if (
         !isNonEmptyString(href) ||
-        !isNonEmptyString(etag) ||
         !isValidCalDavHref(href) ||
         isCalDavCollectionHref(href, calendarUrl)
       ) {
         return map;
       }
+
+      const etag = isNonEmptyString(response.props?.getetag)
+        ? response.props.getetag
+        : href;
 
       map[href] = etag;
 


### PR DESCRIPTION
Fixes #25648

## Problem

CalDAV calendar sync silently discovers zero events forever — with no error logged — when the CalDAV server (such as SmarterMail or other servers without WebDAV-Sync `sync-collection` support) returns calendar object resources without a `getetag` property in `depth: 1` `PROPFIND` responses.

This causes two compounding failures:

1. **All valid events are silently dropped**: In `CalDavFetchEventsService.fetchEtagsByHref`, any PROPFIND response missing `getetag` or with an empty `getetag` was unconditionally filtered out (`!isNonEmptyString(etag)`). Servers like SmarterMail return valid `href`s and `status: 207` for every calendar object but omit `getetag` on the collection-level PROPFIND, resulting in 100% of events being discarded.
2. **Permanent, undetectable lock-out**: `fetchHrefsViaCtagEtag` persists the collection's current `ctag` even when `currentEtags` is `{}`. On the next sync cycle, `storedCtag === newCtag` evaluates to true, short-circuiting immediately with 0 changes before ever invoking `fetchEtagsByHref` again. `storedEtags` remains `{}` indefinitely without any error or log output.

## Solution

In `CalDavFetchEventsService.fetchEtagsByHref`:
- When `response.props?.getetag` is present and non-empty, use it as before (preserving full RFC-standard etag behavior for Apple, Google, Nextcloud, Radicale, Fastmail, etc.).
- When `response.props?.getetag` is missing or empty, fall back to using `response.href` as a pseudo-etag rather than discarding the resource.
- On initial sync (`storedEtags` empty), all events are recognized as changed and imported via `fetchEventsByHrefs`.
- On subsequent syncs where `ctag` advances (e.g. event added or deleted), newly added events are imported, and deleted events (whose href is absent from `currentEtags`) are cancelled via `cancelledHrefs`.

## Tests

- Added comprehensive unit test suite in `packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.spec.ts`:
  - `falls back to href as pseudo-etag when getetag is missing or empty (e.g. SmarterMail)`
  - `ignores collection href and non-caldav file extensions`
  - `short-circuits when ctag is unchanged`
  - `detects new and cancelled events when ctag changes on server without getetag`
  - `fetchChangedEventHrefs aggregates changed and cancelled hrefs across multiple calendars`
- Verified:
  - All 5 unit tests pass in `caldav-fetch-events.service.spec.ts`.
  - All 12 CalDAV test suites (107 tests) in `packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav` pass.
  - Code formatted with `oxfmt`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

