### PR TITLE
feat(server): run server route dispatch jobs ahead of the trigger fan-out

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/constants/server-route-dispatch-job-priority.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/constants/server-route-dispatch-job-priority.constant.ts
@@ -1,0 +1,4 @@
+// A server route dispatch answers an inbound webhook someone is waiting on,
+// so it runs ahead of the database-event fan-out (queue default) and the
+// application-enqueued jobs (ENQUEUE_JOB_PRIORITY) sharing the same queue.
+export const SERVER_ROUTE_DISPATCH_JOB_PRIORITY = 1;

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -25,6 +25,7 @@ import {
   type RouteTriggerResponse,
 } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/route-trigger-response.util';
 import { DEFAULT_SERVER_ROUTE_HTTP_METHODS } from 'src/engine/core-modules/server-route-trigger/constants/default-server-route-http-methods.constant';
+import { SERVER_ROUTE_DISPATCH_JOB_PRIORITY } from 'src/engine/core-modules/server-route-trigger/constants/server-route-dispatch-job-priority.constant';
 import {
   ServerRouteTriggerException,
   ServerRouteTriggerExceptionCode,
@@ -188,6 +189,7 @@ export class ServerRouteTriggerService {
       {
         retryLimit: QUEUED_TARGET_RETRY_LIMIT,
         backoff: LOGIC_FUNCTION_QUEUE_RETRY_BACKOFF,
+        priority: SERVER_ROUTE_DISPATCH_JOB_PRIORITY,
       },
     );
 


### PR DESCRIPTION
## Why

When a server route resolver dispatches to a target logic function, `ServerRouteTriggerService.enqueueTargetFunction` adds one job to the logic function queue at the queue's default priority. That is the same priority as the database-event trigger fan-out, which puts every subscribed logic function of every workspace on the same queue: Last Contact on `person.updated`, `messageParticipant.updated` and `calendarEventParticipant.updated`, Call Recorder on `calendarEvent.*`. During a mailbox or calendar import that line is thousands of Lambda executions long, and the per-app enqueue throttle still lets through 500 jobs a minute per install and 2,000 a minute per app.

A route dispatch is different from that fan-out: it is the tail of an inbound webhook that someone is waiting on. For the Slack assistant it is the step that creates the Slack Assistant Request record, and in production that record has been showing up minutes after the message, before the assistant worker even starts. The Slack app side of this was addressed in #25676; this is the server side.

## What

- Route dispatch jobs are enqueued with `SERVER_ROUTE_DISPATCH_JOB_PRIORITY` (1). Lower runs first in BullMQ, so they go ahead of the trigger fan-out (queue default 4) and of application-enqueued jobs (`ENQUEUE_JOB_PRIORITY`, 10) on the same queue.
- Nothing else changes: same queue, same retry limit and backoff, same job data.

## Test plan

- The change is two lines in `server-route-trigger.service.ts` plus the constant. The job options type already declares `priority`, and the BullMQ driver already forwards an explicit priority over the queue default (`bullmq.driver.ts`, `options?.priority ?? MESSAGE_QUEUE_WORKER_CONFIG[queueName].priority`).
- No behavioural test exists for this service (its unit spec was removed in #24094); CI lint and typecheck cover the change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GWwrhW5s8bR2TVtKsQdSu2)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

