### PR TITLE
Write pulled navigation menu items as define files

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/layout/navigation-menu-items.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/navigation-menu-items.mdx
@@ -37,6 +37,7 @@ export default defineNavigationMenuItem({
 - The enum also contains `NavigationMenuItemType.RECORD`, used internally for user-created record favorites — it isn't usable from an app manifest (there is no field to reference a record).
 - `icon` and `color` are optional and customize how the entry looks.
 - `folderUniversalIdentifier` is also available on any item to nest it inside a `FOLDER`-type parent.
+- `yarn twenty pull` writes your navigation menu items back as `defineNavigationMenuItem()` files. An item a workspace member added to their own sidebar, and one pinned to a record, belong to that workspace rather than to your app and are reported instead; see [what pull does not write](/developers/extend/apps/operations/sync-and-recovery#pulling-an-installed-app-back-to-source).
 
 <Note>
 **Common pitfall:** creating an object without an associated navigation menu item makes that object unreachable from the sidebar. Unless it's a technical/internal object, every custom object should have a sidebar entry pointing at it.

--- a/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
+++ b/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
@@ -119,18 +119,19 @@ Pull needs an existing project — scaffold one with `npx create-twenty-app@late
 - view fields your app added to views it does not own, as standalone `defineViewField()` files;
 - page layouts, with their tabs and widgets inline;
 - tabs your app added to page layouts it does not own, as standalone `definePageLayoutTab()` files;
+- navigation menu items, as `defineNavigationMenuItem()` files, folders included;
 - published translations, as `locales/<locale>.json` for the strings pull can read back from the pulled metadata and source, and `locales/compiled/<locale>.json` for the rest.
 
 Each entity goes to the file that already defines it, so a second pull rewrites only what changed on the server. New entities are placed beside existing files of their kind, and a generated name that would land on an unrelated file is qualified rather than overwriting it.
 
 **What it does not write:**
 
-- **Not exported yet** — roles and permissions, navigation, command menu items, logic functions and front components, and the stored source of your functions.
+- **Not exported yet** — roles and permissions, command menu items, logic functions and front components, and the stored source of your functions.
 - **Derived by the engine** — system fields, default relations, default views and backing indexes, and the default page layouts of each object. The server rebuilds them on apply. An object may still point its label identifier at one of them, as junction objects created in the UI do; the pointer is written and the build resolves it without adding a field.
 - **Placed on a default or foreign view** — filters, filter groups, sorts, groups and field groups added to an engine default view, or to a view owned by another application, have no source form yet and are reported. View fields added there are written as standalone files, since the view's identifier is known.
 - **Placed on a default or foreign page layout** — a widget added to a tab of an engine default page layout, or of a page layout owned by another application, has a source form, `definePageLayoutWidget()`, and the export carries it, but this version of pull does not write it to a file yet, so it is reported. Tabs added there are written as standalone files, since the layout's identifier is known.
 - **Widgets the export cannot carry yet** — on any layout, including your own, a widget of the deprecated `VIEW` type, a widget showing one of your app's own front components or command menu items, or a widget without a position for its tab's layout mode is reported, and the layout or tab is written without it.
-- **Workspace runtime state** — member and API-key role assignments, webhooks and per-user navigation, all excluded by design.
+- **Workspace runtime state** — member and API-key role assignments, webhooks, per-user navigation and navigation items pinned to a record, all excluded by design.
 - **Owned by another application** — reported, never pulled.
 
 The report at the end of a pull lists all of it, grouped by reason. Everything it names as not written is still in your workspace, so push a pulled tree back with `yarn twenty apply --no-delete` until the missing kinds are covered. A pruning `yarn twenty apply` would delete them, and `yarn twenty plan` lists exactly which.

--- a/packages/twenty-sdk/src/cli/utilities/pull/__integration__/pull-round-trip.integration.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__integration__/pull-round-trip.integration.spec.ts
@@ -57,6 +57,9 @@ const AGE_CHART_WIDGET_UID = '30303030-3030-4303-8303-303030303030';
 const PET_RECORD_PAGE_EXTRA_TAB_UID = '31313131-3131-4313-8313-313131313131';
 const PET_EXTRA_NOTES_WIDGET_UID = '32323232-3232-4323-8323-323232323232';
 const COMPANY_TAGLINE_TAB_UID = '34343434-3434-4343-8343-343434343434';
+const CARE_FOLDER_MENU_ITEM_UID = '35353535-3535-4353-8353-353535353535';
+const PET_MENU_ITEM_UID = '36363636-3636-4363-8363-363636363636';
+const HANDBOOK_MENU_ITEM_UID = '37373737-3737-4373-8373-373737373737';
 
 const PET_RECORD_PAGE_LAYOUT_UID = getSystemRecordPageLayoutUniversalIdentifier(
   {
@@ -333,6 +336,29 @@ const EXPORTED_MANIFEST = {
       isVisible: true,
       size: 150,
       position: 3,
+    },
+  ],
+  navigationMenuItems: [
+    {
+      universalIdentifier: CARE_FOLDER_MENU_ITEM_UID,
+      type: 'FOLDER',
+      name: 'Care',
+      position: 0,
+    },
+    {
+      universalIdentifier: PET_MENU_ITEM_UID,
+      type: 'OBJECT',
+      position: 1,
+      folderUniversalIdentifier: CARE_FOLDER_MENU_ITEM_UID,
+      targetObjectUniversalIdentifier: PET_UID,
+    },
+    {
+      universalIdentifier: HANDBOOK_MENU_ITEM_UID,
+      type: 'LINK',
+      name: 'Handbook',
+      icon: 'IconBook',
+      position: 2,
+      link: 'https://example.com/handbook',
     },
   ],
   pageLayouts: [
@@ -625,6 +651,18 @@ describe('pull round trip', () => {
       canonicalize(sortByUniversalIdentifier(builtManifest?.viewFields ?? [])),
     ).toEqual(
       canonicalize(sortByUniversalIdentifier(EXPORTED_MANIFEST.viewFields)),
+    );
+  });
+
+  it('should rebuild the exported navigation menu items, including the nameless object item nested in its folder', () => {
+    expect(
+      canonicalize(
+        sortByUniversalIdentifier(builtManifest?.navigationMenuItems ?? []),
+      ),
+    ).toEqual(
+      canonicalize(
+        sortByUniversalIdentifier(EXPORTED_MANIFEST.navigationMenuItems),
+      ),
     );
   });
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/build-pull-entities.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/build-pull-entities.spec.ts
@@ -656,6 +656,19 @@ describe('buildPullEntities', () => {
     expect(navigationMenuItem?.fileBaseName).toBe('pet');
   });
 
+  it('should name a navigation menu item whose name is only whitespace after the object it targets', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        navigationMenuItems: [buildNavigationMenuItemManifest({ name: '   ' })],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(navigationMenuItem?.fileBaseName).toBe('pet');
+  });
+
   it('should name a navigation menu item targeting a standard object after that object', () => {
     const { entities } = buildPullEntities(
       buildManifest({
@@ -791,6 +804,33 @@ describe('buildPullEntities', () => {
       universalIdentifier: NAVIGATION_FOLDER_UID,
       type: NavigationMenuItemType.FOLDER,
       name: '',
+      position: 0,
+    });
+    const { entities } = buildPullEntities(
+      buildManifest({
+        navigationMenuItems: [
+          folderManifest,
+          buildNavigationMenuItemManifest({
+            folderUniversalIdentifier: NAVIGATION_FOLDER_UID,
+          }),
+        ],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.universalIdentifier === NAVIGATION_MENU_ITEM_UID,
+    );
+
+    expect(navigationMenuItem?.parentName).toBeNull();
+  });
+
+  it('should give a navigation menu item sitting in a folder named only with punctuation no parent', () => {
+    const {
+      targetObjectUniversalIdentifier: _targetObjectUniversalIdentifier,
+      ...folderManifest
+    } = buildNavigationMenuItemManifest({
+      universalIdentifier: NAVIGATION_FOLDER_UID,
+      type: NavigationMenuItemType.FOLDER,
+      name: '///',
       position: 0,
     });
     const { entities } = buildPullEntities(

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/build-pull-entities.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/build-pull-entities.spec.ts
@@ -1,5 +1,6 @@
 import { buildPullEntities } from '@/cli/utilities/pull/build-pull-entities';
 import {
+  NAVIGATION_MENU_ITEM_ENUM_BINDINGS,
   PAGE_LAYOUT_ENUM_BINDINGS,
   PAGE_LAYOUT_TAB_ENUM_BINDINGS,
   VIEW_ENUM_BINDINGS,
@@ -7,10 +8,13 @@ import {
 } from '@/cli/utilities/pull/write-define-file';
 import {
   getSystemRecordPageLayoutUniversalIdentifier,
+  getSystemViewUniversalIdentifier,
   type Manifest,
+  type NavigationMenuItemManifest,
   type PageLayoutManifest,
   type PageLayoutTabManifest,
   type StandaloneViewFieldManifest,
+  SYSTEM_VIEW_KEYS,
   type ViewManifest,
 } from 'twenty-shared/application';
 import {
@@ -20,6 +24,7 @@ import {
 } from 'twenty-shared/metadata';
 import {
   AggregateOperations,
+  NavigationMenuItemType,
   PageLayoutTabLayoutMode,
   ViewSortDirection,
   ViewType,
@@ -41,6 +46,8 @@ const PAGE_LAYOUT_UID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const PAGE_LAYOUT_TAB_UID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 const WIDGET_UID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
 const STANDALONE_TAB_UID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+const NAVIGATION_MENU_ITEM_UID = '10101010-1010-4010-8010-101010101010';
+const NAVIGATION_FOLDER_UID = '20202020-2020-4020-8020-202020202020';
 
 const buildManifest = (overrides: Partial<Manifest> = {}): Manifest =>
   ({
@@ -163,6 +170,16 @@ const buildPageLayoutTabManifest = (
   title: 'Extra',
   position: 60,
   layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+  ...overrides,
+});
+
+const buildNavigationMenuItemManifest = (
+  overrides: Partial<NavigationMenuItemManifest> = {},
+): NavigationMenuItemManifest => ({
+  universalIdentifier: NAVIGATION_MENU_ITEM_UID,
+  type: NavigationMenuItemType.OBJECT,
+  position: 8,
+  targetObjectUniversalIdentifier: PET_UID,
   ...overrides,
 });
 
@@ -585,6 +602,230 @@ describe('buildPullEntities', () => {
         reason: 'it does not name the page layout it belongs to',
       },
     ]);
+  });
+
+  it('should write a navigation menu item verbatim into src/navigation-menu-items with the navigation menu item enum bindings, named after the object it targets', () => {
+    const navigationMenuItemManifest = buildNavigationMenuItemManifest();
+    const { entities, skipped } = buildPullEntities(
+      buildManifest({ navigationMenuItems: [navigationMenuItemManifest] }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(skipped).toEqual([]);
+    expect(navigationMenuItem?.universalIdentifier).toBe(
+      NAVIGATION_MENU_ITEM_UID,
+    );
+    expect(navigationMenuItem?.definer).toBe('defineNavigationMenuItem');
+    expect(navigationMenuItem?.config).toEqual(navigationMenuItemManifest);
+    expect(navigationMenuItem?.enumBindings).toEqual(
+      NAVIGATION_MENU_ITEM_ENUM_BINDINGS,
+    );
+    expect(navigationMenuItem?.parentName).toBeNull();
+    expect(
+      `${navigationMenuItem?.defaultFolder}/${navigationMenuItem?.fileBaseName}${navigationMenuItem?.fileSuffix}`,
+    ).toBe('src/navigation-menu-items/pet.navigation-menu-item.ts');
+  });
+
+  it('should prefer the name a navigation menu item carries over the object it targets', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        navigationMenuItems: [
+          buildNavigationMenuItemManifest({ name: 'Pet shelter' }),
+        ],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(navigationMenuItem?.fileBaseName).toBe('pet-shelter');
+  });
+
+  it('should name a navigation menu item with an empty name after the object it targets', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        navigationMenuItems: [buildNavigationMenuItemManifest({ name: '' })],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(navigationMenuItem?.fileBaseName).toBe('pet');
+  });
+
+  it('should name a navigation menu item targeting a standard object after that object', () => {
+    const { entities } = buildPullEntities(
+      buildManifest({
+        navigationMenuItems: [
+          buildNavigationMenuItemManifest({
+            targetObjectUniversalIdentifier:
+              STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person,
+          }),
+        ],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(navigationMenuItem?.fileBaseName).toBe('person');
+  });
+
+  it('should name a navigation menu item pointing at a view of the manifest after that view', () => {
+    const {
+      targetObjectUniversalIdentifier: _targetObjectUniversalIdentifier,
+      ...viewItemManifest
+    } = buildNavigationMenuItemManifest({
+      type: NavigationMenuItemType.VIEW,
+      viewUniversalIdentifier: VIEW_UID,
+    });
+    const { entities } = buildPullEntities(
+      buildManifest({
+        views: [buildViewManifest()],
+        navigationMenuItems: [viewItemManifest],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(navigationMenuItem?.fileBaseName).toBe('all-pets');
+  });
+
+  it('should name a navigation menu item pointing at the index view of a manifest object after that view', () => {
+    const {
+      targetObjectUniversalIdentifier: _targetObjectUniversalIdentifier,
+      ...indexViewItemManifest
+    } = buildNavigationMenuItemManifest({
+      type: NavigationMenuItemType.VIEW,
+      viewUniversalIdentifier: getSystemViewUniversalIdentifier({
+        objectMetadataApplicationUniversalIdentifier: APP_UID,
+        objectUniversalIdentifier: PET_UID,
+        viewKey: SYSTEM_VIEW_KEYS.INDEX,
+      }),
+    });
+    const { entities } = buildPullEntities(
+      buildManifest({ navigationMenuItems: [indexViewItemManifest] }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(navigationMenuItem?.fileBaseName).toBe('pet-index-view');
+  });
+
+  it('should name a navigation menu item pointing at a page layout after that layout', () => {
+    const {
+      targetObjectUniversalIdentifier: _targetObjectUniversalIdentifier,
+      ...pageLayoutItemManifest
+    } = buildNavigationMenuItemManifest({
+      type: NavigationMenuItemType.PAGE_LAYOUT,
+      pageLayoutUniversalIdentifier: PAGE_LAYOUT_UID,
+    });
+    const { entities } = buildPullEntities(
+      buildManifest({
+        pageLayouts: [buildPageLayoutManifest()],
+        navigationMenuItems: [pageLayoutItemManifest],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(navigationMenuItem?.fileBaseName).toBe('pet-page');
+  });
+
+  it('should name a navigation menu item that points at nothing of the manifest after its identifier prefix', () => {
+    const {
+      targetObjectUniversalIdentifier: _targetObjectUniversalIdentifier,
+      ...linkItemManifest
+    } = buildNavigationMenuItemManifest({
+      type: NavigationMenuItemType.LINK,
+      link: 'https://twenty.com',
+    });
+    const { entities } = buildPullEntities(
+      buildManifest({ navigationMenuItems: [linkItemManifest] }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(navigationMenuItem?.fileBaseName).toBe('10101010');
+  });
+
+  it('should give a navigation menu item sitting in a folder that folder as parent', () => {
+    const {
+      targetObjectUniversalIdentifier: _targetObjectUniversalIdentifier,
+      ...folderManifest
+    } = buildNavigationMenuItemManifest({
+      universalIdentifier: NAVIGATION_FOLDER_UID,
+      type: NavigationMenuItemType.FOLDER,
+      name: 'Care',
+      position: 0,
+    });
+    const { entities } = buildPullEntities(
+      buildManifest({
+        navigationMenuItems: [
+          folderManifest,
+          buildNavigationMenuItemManifest({
+            folderUniversalIdentifier: NAVIGATION_FOLDER_UID,
+          }),
+        ],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.universalIdentifier === NAVIGATION_MENU_ITEM_UID,
+    );
+
+    expect(navigationMenuItem?.parentName).toBe('Care');
+  });
+
+  it('should give a navigation menu item sitting in a folder without a name no parent', () => {
+    const {
+      targetObjectUniversalIdentifier: _targetObjectUniversalIdentifier,
+      ...folderManifest
+    } = buildNavigationMenuItemManifest({
+      universalIdentifier: NAVIGATION_FOLDER_UID,
+      type: NavigationMenuItemType.FOLDER,
+      name: '',
+      position: 0,
+    });
+    const { entities } = buildPullEntities(
+      buildManifest({
+        navigationMenuItems: [
+          folderManifest,
+          buildNavigationMenuItemManifest({
+            folderUniversalIdentifier: NAVIGATION_FOLDER_UID,
+          }),
+        ],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.universalIdentifier === NAVIGATION_MENU_ITEM_UID,
+    );
+
+    expect(navigationMenuItem?.parentName).toBeNull();
+  });
+
+  it('should give a navigation menu item whose folder is not part of the export no parent', () => {
+    const { entities, skipped } = buildPullEntities(
+      buildManifest({
+        navigationMenuItems: [
+          buildNavigationMenuItemManifest({
+            folderUniversalIdentifier: 'a-folder-of-another-application',
+          }),
+        ],
+      }),
+    );
+    const navigationMenuItem = entities.find(
+      (entity) => entity.kind === 'navigationMenuItem',
+    );
+
+    expect(skipped).toEqual([]);
+    expect(navigationMenuItem?.parentName).toBeNull();
   });
 
   it('should build a manifest that has no views, view fields, page layouts and page layout tabs properties without producing their entities', () => {

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
@@ -3,6 +3,7 @@ import { planPullWrites } from '@/cli/utilities/pull/plan-pull-writes';
 import { type ScannedDefineFile } from '@/cli/utilities/pull/scan-project-define-files';
 import {
   type Manifest,
+  type NavigationMenuItemManifest,
   type PageLayoutManifest,
   type PageLayoutTabManifest,
   type StandaloneViewFieldManifest,
@@ -11,6 +12,7 @@ import {
 } from 'twenty-shared/application';
 import { STANDARD_PAGE_LAYOUT_UNIVERSAL_IDENTIFIERS } from 'twenty-shared/metadata';
 import {
+  NavigationMenuItemType,
   PageLayoutTabLayoutMode,
   ViewFilterOperand,
 } from 'twenty-shared/types';
@@ -37,6 +39,13 @@ const SECOND_PET_PAGE_LAYOUT_UID = '14141414-1414-4141-8141-141414141414';
 const COMPANY_EXTRA_TAB_UID = '15151515-1515-4151-8151-151515151515';
 const PERSON_EXTRA_TAB_UID = '16161616-1616-4161-8161-161616161616';
 const DOCS_WIDGET_UID = '17171717-1717-4171-8171-171717171717';
+const PET_CARE_FOLDER_NAVIGATION_ITEM_UID =
+  '18181818-1818-4181-8181-181818181818';
+const DAILY_OPS_FOLDER_NAVIGATION_ITEM_UID =
+  '19191919-1919-4191-8191-191919191919';
+const DOCS_NAVIGATION_ITEM_UID = '1a1a1a1a-1a1a-41a1-81a1-1a1a1a1a1a1a';
+const SECOND_DOCS_NAVIGATION_ITEM_UID = '1b1b1b1b-1b1b-41b1-81b1-1b1b1b1b1b1b';
+const PET_NAVIGATION_ITEM_UID = '1c1c1c1c-1c1c-41c1-81c1-1c1c1c1c1c1c';
 
 const buildObject = ({
   universalIdentifier,
@@ -126,6 +135,16 @@ const buildPageLayoutTab = (
   ...overrides,
 });
 
+const buildNavigationMenuItem = (
+  overrides: Partial<NavigationMenuItemManifest> & {
+    universalIdentifier: string;
+  },
+): NavigationMenuItemManifest => ({
+  type: NavigationMenuItemType.LINK,
+  position: 0,
+  ...overrides,
+});
+
 const buildManifestWithDocsPageLayout = (url: string): Manifest => ({
   ...buildManifest([
     buildObject({
@@ -186,6 +205,24 @@ const buildManifestWithFilteredView = (filterValue: string): Manifest => ({
       universalIdentifier: HEALTHY_PETS_VIEW_UID,
       name: 'Healthy pets',
       filters: [buildNameFilter(filterValue)],
+    }),
+  ],
+});
+
+const buildManifestWithNavigationMenu = (link: string): Manifest => ({
+  ...MANIFEST,
+  navigationMenuItems: [
+    buildNavigationMenuItem({
+      universalIdentifier: PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
+      type: NavigationMenuItemType.FOLDER,
+      name: 'Pet care',
+    }),
+    buildNavigationMenuItem({
+      universalIdentifier: DOCS_NAVIGATION_ITEM_UID,
+      name: 'Docs',
+      link,
+      position: 1,
+      folderUniversalIdentifier: PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
     }),
   ],
 });
@@ -965,5 +1002,184 @@ describe('planPullWrites', () => {
       'layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,',
     );
     expect(plan.writes[0].content).toContain('type: WidgetType.IFRAME,');
+  });
+
+  it('should place a new navigation menu item beside existing navigation menu item files', () => {
+    const plan = planPullWrites({
+      manifest: {
+        ...MANIFEST,
+        navigationMenuItems: [
+          buildNavigationMenuItem({
+            universalIdentifier: PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
+            type: NavigationMenuItemType.FOLDER,
+            name: 'Pet care',
+          }),
+          buildNavigationMenuItem({
+            universalIdentifier: PET_NAVIGATION_ITEM_UID,
+            type: NavigationMenuItemType.OBJECT,
+            position: 8,
+            targetObjectUniversalIdentifier: PET_UID,
+            folderUniversalIdentifier: PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
+          }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [
+        {
+          relativePath: 'app/navigation/pet-care.navigation-menu-item.ts',
+          entityKey: ManifestEntityKey.NavigationMenuItems,
+          universalIdentifier: PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
+          isReadable: true,
+        },
+      ],
+    });
+
+    expect(
+      plan.writes.find(
+        (write) => write.universalIdentifier === PET_NAVIGATION_ITEM_UID,
+      )?.relativePath,
+    ).toBe('app/navigation/pet.navigation-menu-item.ts');
+  });
+
+  it('should qualify colliding navigation menu item file names with the kebab-cased name of each folder', () => {
+    const plan = planPullWrites({
+      manifest: {
+        ...MANIFEST,
+        navigationMenuItems: [
+          buildNavigationMenuItem({
+            universalIdentifier: PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
+            type: NavigationMenuItemType.FOLDER,
+            name: 'Pet care',
+          }),
+          buildNavigationMenuItem({
+            universalIdentifier: DAILY_OPS_FOLDER_NAVIGATION_ITEM_UID,
+            type: NavigationMenuItemType.FOLDER,
+            name: 'Daily ops',
+            position: 1,
+          }),
+          buildNavigationMenuItem({
+            universalIdentifier: DOCS_NAVIGATION_ITEM_UID,
+            name: 'Docs',
+            link: 'https://example.com/pet-care',
+            folderUniversalIdentifier: PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
+          }),
+          buildNavigationMenuItem({
+            universalIdentifier: SECOND_DOCS_NAVIGATION_ITEM_UID,
+            name: 'Docs',
+            link: 'https://example.com/daily-ops',
+            folderUniversalIdentifier: DAILY_OPS_FOLDER_NAVIGATION_ITEM_UID,
+          }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [],
+    });
+
+    expect(
+      plan.writes.find(
+        (write) => write.universalIdentifier === DOCS_NAVIGATION_ITEM_UID,
+      )?.relativePath,
+    ).toBe('src/navigation-menu-items/pet-care-docs.navigation-menu-item.ts');
+    expect(
+      plan.writes.find(
+        (write) =>
+          write.universalIdentifier === SECOND_DOCS_NAVIGATION_ITEM_UID,
+      )?.relativePath,
+    ).toBe('src/navigation-menu-items/daily-ops-docs.navigation-menu-item.ts');
+    expect(
+      plan.writes.find(
+        (write) =>
+          write.universalIdentifier === PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
+      )?.relativePath,
+    ).toBe('src/navigation-menu-items/pet-care.navigation-menu-item.ts');
+    expect(
+      plan.writes.find(
+        (write) =>
+          write.universalIdentifier === DAILY_OPS_FOLDER_NAVIGATION_ITEM_UID,
+      )?.relativePath,
+    ).toBe('src/navigation-menu-items/daily-ops.navigation-menu-item.ts');
+  });
+
+  it('should fall back to identifier-prefixed names when two navigation menu items outside any folder share a name', () => {
+    const plan = planPullWrites({
+      manifest: {
+        ...MANIFEST,
+        navigationMenuItems: [
+          buildNavigationMenuItem({
+            universalIdentifier: DOCS_NAVIGATION_ITEM_UID,
+            name: 'Docs',
+            link: 'https://example.com/pet-care',
+          }),
+          buildNavigationMenuItem({
+            universalIdentifier: SECOND_DOCS_NAVIGATION_ITEM_UID,
+            name: 'Docs',
+            link: 'https://example.com/daily-ops',
+            position: 1,
+          }),
+        ],
+      },
+      baseManifest: null,
+      scannedFiles: [],
+    });
+
+    expect(
+      plan.writes
+        .filter((write) => write.kind === 'navigationMenuItem')
+        .map((write) => write.relativePath)
+        .sort(),
+    ).toEqual([
+      `src/navigation-menu-items/${DOCS_NAVIGATION_ITEM_UID.slice(0, 8)}-docs.navigation-menu-item.ts`,
+      `src/navigation-menu-items/${SECOND_DOCS_NAVIGATION_ITEM_UID.slice(0, 8)}-docs.navigation-menu-item.ts`,
+    ]);
+  });
+
+  it('should leave an unchanged navigation menu item untouched and regenerate the item whose link changed on the server', () => {
+    const scannedFiles: ScannedDefineFile[] = [
+      {
+        relativePath: 'src/application.config.ts',
+        entityKey: ManifestEntityKey.Application,
+        universalIdentifier: APP_UID,
+        isReadable: true,
+      },
+      {
+        relativePath: 'src/objects/pet.object.ts',
+        entityKey: ManifestEntityKey.Objects,
+        universalIdentifier: PET_UID,
+        isReadable: true,
+      },
+      {
+        relativePath:
+          'src/navigation-menu-items/pet-care.navigation-menu-item.ts',
+        entityKey: ManifestEntityKey.NavigationMenuItems,
+        universalIdentifier: PET_CARE_FOLDER_NAVIGATION_ITEM_UID,
+        isReadable: true,
+      },
+      {
+        relativePath: 'src/navigation-menu-items/docs.navigation-menu-item.ts',
+        entityKey: ManifestEntityKey.NavigationMenuItems,
+        universalIdentifier: DOCS_NAVIGATION_ITEM_UID,
+        isReadable: true,
+      },
+    ];
+
+    const plan = planPullWrites({
+      manifest: buildManifestWithNavigationMenu('https://example.com/new'),
+      baseManifest: buildManifestWithNavigationMenu('https://example.com/old'),
+      scannedFiles,
+    });
+
+    expect(
+      plan.unchanged.map((entity) => entity.universalIdentifier),
+    ).toContain(PET_CARE_FOLDER_NAVIGATION_ITEM_UID);
+    expect(plan.writes.map((write) => write.relativePath)).toEqual([
+      'src/navigation-menu-items/docs.navigation-menu-item.ts',
+    ]);
+    expect(plan.writes[0].isRegeneration).toBe(true);
+    expect(plan.writes[0].content).toContain(
+      "link: 'https://example.com/new',",
+    );
+    expect(plan.writes[0].content).toContain(
+      'type: NavigationMenuItemType.LINK,',
+    );
   });
 });

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/pull-base-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/pull-base-file.spec.ts
@@ -16,6 +16,7 @@ const VIEW_UID = '44444444-4444-4444-8444-444444444444';
 const VIEW_FIELD_UID = '55555555-5555-4555-8555-555555555555';
 const PAGE_LAYOUT_UID = '66666666-6666-4666-8666-666666666666';
 const PAGE_LAYOUT_TAB_UID = '77777777-7777-4777-8777-777777777777';
+const NAVIGATION_MENU_ITEM_UID = '88888888-8888-4888-8888-888888888888';
 
 const MANIFEST = {
   application: {
@@ -73,6 +74,14 @@ const MANIFEST = {
       pageLayoutUniversalIdentifier: 'a-page-layout-of-another-application',
       title: 'Extra',
       position: 60,
+    },
+  ],
+  navigationMenuItems: [
+    {
+      universalIdentifier: NAVIGATION_MENU_ITEM_UID,
+      type: 'OBJECT',
+      position: 8,
+      targetObjectUniversalIdentifier: PET_UID,
     },
   ],
 } as unknown as Manifest;
@@ -211,6 +220,61 @@ describe('pull base file', () => {
         manifest: {
           ...MANIFEST,
           pageLayoutTabs: { universalIdentifier: PAGE_LAYOUT_TAB_UID },
+        },
+      }),
+    );
+
+    expect(await readBase()).toBeNull();
+  });
+
+  it('should read back a base whose manifest has no navigation menu items', async () => {
+    const {
+      navigationMenuItems: _navigationMenuItems,
+      ...manifestWithoutNavigationMenuItems
+    } = MANIFEST;
+
+    await writeRawBaseFile(
+      JSON.stringify({
+        version: 1,
+        applicationUniversalIdentifier: APP_UID,
+        manifest: manifestWithoutNavigationMenuItems,
+      }),
+    );
+
+    expect(await readBase()).toEqual(manifestWithoutNavigationMenuItems);
+  });
+
+  it('should ignore a base whose navigation menu items contain an entry without a universal identifier', async () => {
+    await writeRawBaseFile(
+      JSON.stringify({
+        version: 1,
+        applicationUniversalIdentifier: APP_UID,
+        manifest: {
+          ...MANIFEST,
+          navigationMenuItems: [
+            {
+              type: 'OBJECT',
+              position: 8,
+              targetObjectUniversalIdentifier: PET_UID,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(await readBase()).toBeNull();
+  });
+
+  it('should ignore a base whose navigation menu items are not a list', async () => {
+    await writeRawBaseFile(
+      JSON.stringify({
+        version: 1,
+        applicationUniversalIdentifier: APP_UID,
+        manifest: {
+          ...MANIFEST,
+          navigationMenuItems: {
+            universalIdentifier: NAVIGATION_MENU_ITEM_UID,
+          },
         },
       }),
     );

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/write-define-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/write-define-file.spec.ts
@@ -1,6 +1,7 @@
 import {
   FIELD_ENUM_BINDINGS,
   INDEX_ENUM_BINDINGS,
+  NAVIGATION_MENU_ITEM_ENUM_BINDINGS,
   OBJECT_ENUM_BINDINGS,
   PAGE_LAYOUT_ENUM_BINDINGS,
   PAGE_LAYOUT_TAB_ENUM_BINDINGS,
@@ -412,6 +413,62 @@ describe('writeDefineFile', () => {
         '      },\n' +
         '    },\n' +
         '  ],\n' +
+        '});\n',
+    );
+  });
+
+  it('should write a nameless object navigation menu item with its type as a NavigationMenuItemType member', () => {
+    const file = writeDefineFile({
+      definer: 'defineNavigationMenuItem',
+      config: {
+        universalIdentifier: 'ad199fde-d4f4-4634-a94c-95b52fa32567',
+        type: 'OBJECT',
+        position: 8,
+        targetObjectUniversalIdentifier: '5c5822f2-9efa-4cb7-8101-98f5c25765b9',
+      },
+      enumBindings: NAVIGATION_MENU_ITEM_ENUM_BINDINGS,
+    });
+
+    expect(file).toBe(
+      'import {\n' +
+        '  defineNavigationMenuItem,\n' +
+        '  NavigationMenuItemType,\n' +
+        "} from 'twenty-sdk/define';\n" +
+        '\n' +
+        'export default defineNavigationMenuItem({\n' +
+        "  universalIdentifier: 'ad199fde-d4f4-4634-a94c-95b52fa32567',\n" +
+        '  type: NavigationMenuItemType.OBJECT,\n' +
+        '  position: 8,\n' +
+        "  targetObjectUniversalIdentifier: '5c5822f2-9efa-4cb7-8101-98f5c25765b9',\n" +
+        '});\n',
+    );
+  });
+
+  it('should write a folder navigation menu item with its name and icon', () => {
+    const file = writeDefineFile({
+      definer: 'defineNavigationMenuItem',
+      config: {
+        universalIdentifier: 'navigation-menu-item-uid',
+        type: 'FOLDER',
+        position: 2,
+        name: 'Operations',
+        icon: 'IconFolder',
+      },
+      enumBindings: NAVIGATION_MENU_ITEM_ENUM_BINDINGS,
+    });
+
+    expect(file).toBe(
+      'import {\n' +
+        '  defineNavigationMenuItem,\n' +
+        '  NavigationMenuItemType,\n' +
+        "} from 'twenty-sdk/define';\n" +
+        '\n' +
+        'export default defineNavigationMenuItem({\n' +
+        "  universalIdentifier: 'navigation-menu-item-uid',\n" +
+        '  type: NavigationMenuItemType.FOLDER,\n' +
+        '  position: 2,\n' +
+        "  name: 'Operations',\n" +
+        "  icon: 'IconFolder',\n" +
         '});\n',
     );
   });

--- a/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
@@ -1,4 +1,3 @@
-import { isNonEmptyString } from '@sniptt/guards';
 import {
   FIELD_ENUM_BINDINGS,
   INDEX_ENUM_BINDINGS,
@@ -14,6 +13,7 @@ import {
   buildIndexFileBaseName,
   buildViewFieldFileBaseName,
   type FieldLocation,
+  isUsableFileNameSegment,
   toFileBaseName,
 } from '@/cli/utilities/pull/pull-file-base-name';
 import { stripGraphqlTypename } from '@/cli/utilities/pull/strip-graphql-typename';
@@ -241,7 +241,7 @@ const getNavigationMenuItemName = ({
     pageLayoutUniversalIdentifier,
   } = navigationMenuItemManifest;
 
-  if (isNonEmptyString(name)) {
+  if (isUsableFileNameSegment(name)) {
     return name;
   }
 
@@ -274,7 +274,7 @@ const getNavigationMenuItemFolderName = ({
     (candidate) => candidate.universalIdentifier === folderUniversalIdentifier,
   )?.name;
 
-  return isNonEmptyString(folderName) ? folderName : null;
+  return isUsableFileNameSegment(folderName) ? folderName : null;
 };
 
 export const buildPullEntities = (

--- a/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/build-pull-entities.ts
@@ -1,6 +1,8 @@
+import { isNonEmptyString } from '@sniptt/guards';
 import {
   FIELD_ENUM_BINDINGS,
   INDEX_ENUM_BINDINGS,
+  NAVIGATION_MENU_ITEM_ENUM_BINDINGS,
   OBJECT_ENUM_BINDINGS,
   PAGE_LAYOUT_ENUM_BINDINGS,
   PAGE_LAYOUT_TAB_ENUM_BINDINGS,
@@ -20,7 +22,10 @@ import {
   type ApplicationManifest,
   getSystemRecordFormPageLayoutUniversalIdentifier,
   getSystemRecordPageLayoutUniversalIdentifier,
+  getSystemViewUniversalIdentifier,
   type Manifest,
+  type NavigationMenuItemManifest,
+  SYSTEM_VIEW_KEYS,
 } from 'twenty-shared/application';
 import {
   STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
@@ -37,6 +42,7 @@ export const PULL_ENTITY_KINDS = [
   'viewField',
   'pageLayout',
   'pageLayoutTab',
+  'navigationMenuItem',
 ] as const;
 
 export type PullEntityKind = (typeof PULL_ENTITY_KINDS)[number];
@@ -186,6 +192,89 @@ const getPageLayoutName = ({
   }
 
   return null;
+};
+
+const getViewName = ({
+  viewUniversalIdentifier,
+  manifest,
+}: {
+  viewUniversalIdentifier: string;
+  manifest: Manifest;
+}): string | null => {
+  const viewManifest = manifest.views?.find(
+    (candidate) => candidate.universalIdentifier === viewUniversalIdentifier,
+  );
+
+  if (isDefined(viewManifest)) {
+    return viewManifest.name;
+  }
+
+  const objectMetadataApplicationUniversalIdentifier =
+    manifest.application.universalIdentifier;
+
+  for (const objectManifest of manifest.objects) {
+    if (
+      getSystemViewUniversalIdentifier({
+        objectMetadataApplicationUniversalIdentifier,
+        objectUniversalIdentifier: objectManifest.universalIdentifier,
+        viewKey: SYSTEM_VIEW_KEYS.INDEX,
+      }) === viewUniversalIdentifier
+    ) {
+      return `${objectManifest.nameSingular}IndexView`;
+    }
+  }
+
+  return null;
+};
+
+const getNavigationMenuItemName = ({
+  navigationMenuItemManifest,
+  manifest,
+}: {
+  navigationMenuItemManifest: NavigationMenuItemManifest;
+  manifest: Manifest;
+}): string | null => {
+  const {
+    name,
+    targetObjectUniversalIdentifier,
+    viewUniversalIdentifier,
+    pageLayoutUniversalIdentifier,
+  } = navigationMenuItemManifest;
+
+  if (isNonEmptyString(name)) {
+    return name;
+  }
+
+  if (isDefined(targetObjectUniversalIdentifier)) {
+    return getObjectName({
+      objectUniversalIdentifier: targetObjectUniversalIdentifier,
+      manifest,
+    });
+  }
+
+  if (isDefined(viewUniversalIdentifier)) {
+    return getViewName({ viewUniversalIdentifier, manifest });
+  }
+
+  if (isDefined(pageLayoutUniversalIdentifier)) {
+    return getPageLayoutName({ pageLayoutUniversalIdentifier, manifest });
+  }
+
+  return null;
+};
+
+const getNavigationMenuItemFolderName = ({
+  folderUniversalIdentifier,
+  manifest,
+}: {
+  folderUniversalIdentifier: string;
+  manifest: Manifest;
+}): string | null => {
+  const folderName = manifest.navigationMenuItems?.find(
+    (candidate) => candidate.universalIdentifier === folderUniversalIdentifier,
+  )?.name;
+
+  return isNonEmptyString(folderName) ? folderName : null;
 };
 
 export const buildPullEntities = (
@@ -385,6 +474,32 @@ export const buildPullEntities = (
         pageLayoutUniversalIdentifier,
         manifest,
       }),
+    });
+  }
+
+  for (const navigationMenuItemManifest of manifest.navigationMenuItems ?? []) {
+    const { folderUniversalIdentifier } = navigationMenuItemManifest;
+
+    entities.push({
+      kind: 'navigationMenuItem',
+      universalIdentifier: navigationMenuItemManifest.universalIdentifier,
+      definer: 'defineNavigationMenuItem',
+      config: navigationMenuItemManifest,
+      enumBindings: NAVIGATION_MENU_ITEM_ENUM_BINDINGS,
+      defaultFolder: 'src/navigation-menu-items',
+      fileSuffix: '.navigation-menu-item.ts',
+      fileBaseName: toFileBaseName({
+        segments: [
+          getNavigationMenuItemName({ navigationMenuItemManifest, manifest }),
+        ],
+        universalIdentifier: navigationMenuItemManifest.universalIdentifier,
+      }),
+      parentName: isDefined(folderUniversalIdentifier)
+        ? getNavigationMenuItemFolderName({
+            folderUniversalIdentifier,
+            manifest,
+          })
+        : null,
     });
   }
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
@@ -46,6 +46,7 @@ const ENTITY_KEY_BY_KIND: Record<PullEntityKind, ManifestEntityKey> = {
   viewField: ManifestEntityKey.ViewFields,
   pageLayout: ManifestEntityKey.PageLayouts,
   pageLayoutTab: ManifestEntityKey.PageLayoutTabs,
+  navigationMenuItem: ManifestEntityKey.NavigationMenuItems,
 };
 
 const toPosixPath = (value: string): string => value.split('\\').join('/');

--- a/packages/twenty-sdk/src/cli/utilities/pull/pull-base-file.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/pull-base-file.ts
@@ -49,6 +49,7 @@ const isUsableBaseManifest = (manifest: unknown): manifest is Manifest => {
     viewFields,
     pageLayouts,
     pageLayoutTabs,
+    navigationMenuItems,
   } = manifest as Partial<Manifest>;
 
   return (
@@ -60,7 +61,8 @@ const isUsableBaseManifest = (manifest: unknown): manifest is Manifest => {
     (!isDefined(views) || isEntityList(views)) &&
     (!isDefined(viewFields) || isEntityList(viewFields)) &&
     (!isDefined(pageLayouts) || isEntityList(pageLayouts)) &&
-    (!isDefined(pageLayoutTabs) || isEntityList(pageLayoutTabs))
+    (!isDefined(pageLayoutTabs) || isEntityList(pageLayoutTabs)) &&
+    (!isDefined(navigationMenuItems) || isEntityList(navigationMenuItems))
   );
 };
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/pull-file-base-name.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/pull-file-base-name.ts
@@ -26,6 +26,12 @@ const STANDARD_FIELD_LOCATION_BY_UNIVERSAL_IDENTIFIER = new Map<
   ),
 );
 
+export const isUsableFileNameSegment = (
+  value: string | undefined,
+): value is string =>
+  isNonEmptyString(value) &&
+  isNonEmptyString(kebabCase(value).replace(/-+/g, ''));
+
 export const capFileBaseName = (fileBaseName: string): string =>
   fileBaseName.slice(0, MAX_FILE_BASE_NAME_LENGTH).replace(/-+$/g, '');
 

--- a/packages/twenty-sdk/src/cli/utilities/pull/write-define-file.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/write-define-file.ts
@@ -8,6 +8,7 @@ import {
   FieldMetadataType,
   IndexType,
   MetadataWritability,
+  NavigationMenuItemType,
   NumberDataType,
   ObjectOpenRecordIn,
   ObjectRecordGroupByDateGranularity,
@@ -163,6 +164,14 @@ const buildPageLayoutTabEnumBindings = (prefix: string[]): EnumBinding[] => [
 
 export const PAGE_LAYOUT_TAB_ENUM_BINDINGS: EnumBinding[] =
   buildPageLayoutTabEnumBindings([]);
+
+export const NAVIGATION_MENU_ITEM_ENUM_BINDINGS: EnumBinding[] = [
+  {
+    path: ['type'],
+    symbol: 'NavigationMenuItemType',
+    members: NavigationMenuItemType,
+  },
+];
 
 export const PAGE_LAYOUT_ENUM_BINDINGS: EnumBinding[] = [
   { path: ['type'], symbol: 'PageLayoutType', members: PageLayoutType },


### PR DESCRIPTION
## What

`yarn twenty pull` now writes the navigation menu items the server exports since #25687: each entry of `manifest.navigationMenuItems` becomes a `defineNavigationMenuItem()` file. This is the CLI half of the navigation slice of `yarn twenty pull`, and it closes the navigation family.

It matters most for the Custom application, where the sidebar is built through the UI: its five navigation items were exported but thrown away by `pull` until now.

## How

- **One new pull entity kind**, `navigationMenuItem`, built the way views and page layouts are: the manifest entry is the file's config verbatim, the file goes to `src/navigation-menu-items/<name>.navigation-menu-item.ts` (the folder `twenty dev add` uses), beside existing files of the same kind when there are any.
- **Naming, which is where this kind differs.** A navigation item's `name` is optional and the items the UI creates for an object have none, so naming it after `name` alone would collapse every one of them onto its identifier prefix. The name is resolved from what the item points at instead: its own `name` when set, else the target object's singular name (standard objects included), else the view's name from the manifest or `<object>IndexView` when it points at the engine-derived index view of one of the app's own objects, else the page layout's name through the same resolution the layouts slice uses, and only then the identifier prefix. An empty name falls through rather than winning, since a folder may legally have one.
- **Collisions are qualified by the containing folder**, the analogue of qualifying a layout by its object and a standalone tab by its layout. Two items named "Overview" in different folders become `support-overview` and `sales-overview`; two with no folder fall back to the identifier prefix.
- **An enum binding** for `NavigationMenuItemType`, so a written file reads like a hand-written one. Every identifier stays a raw literal, as in every other writer.
- The planner's kind-to-manifest-key map and the base file guard learn the collection; unchanged detection, deletion inference, local-only reporting and plan mode are kind-agnostic and cover it without change.
- **Three things this kind deliberately does not need.** No `__typename` strip: the server's converter builds the manifest field by field and a navigation item carries no nested GraphQL payload. No skip path: the reconstructor already drops personal items, items pinned to a record, items whose target does not resolve and items orphaned by an unexported folder, so everything reaching the writer is writable. No translations change: the collector has mapped `navigationMenuItems` to the shared translatable-property registry since before this slice, so a translated item name already round-trips.
- Docs: the pull page lists the new kind under "what it writes", drops navigation from "not exported yet" and names record-pinned items alongside per-user navigation under workspace runtime state; the navigation menu items page says what pull writes back and what it reports instead.

## Verification

- Unit specs: the entity shape, folder and suffix, the whole name fallback chain including the empty-name case and the engine-derived index view, and the folder as parent name (`build-pull-entities`); the enum binding and the exact text of a written file (`write-define-file`); the folder collision rule and unchanged-versus-regenerated detection (`plan-pull-writes`); the base file guard (`pull-base-file`).
- The offline round-trip spec writes a folder, an object item nested in it and a link item, builds the app and checks the collection comes back unchanged.
- Verified on a dev workspace: the Custom application's five navigation items, all of them nameless `OBJECT` items, are written as `pet`, `rocket`, `survey-result`, `employment-history` and `pet-care-agreement`; the pulled tree typechecks against the real SDK types, and `yarn twenty plan --no-delete` on it reports no navigation action.
- Lint, prettier and typecheck on twenty-sdk; full SDK unit suite.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

