### PR TITLE
Skip non-actionable Slack message events in the events resolver

### DIFF
--- a/packages/twenty-apps/public/slack/README.md
+++ b/packages/twenty-apps/public/slack/README.md
@@ -14,7 +14,7 @@
 
 No per-seat or per-message charge. The app's runs are metered like any other app's, at **$0.0001 per logic function invocation** plus runtime, and answers use AI credits on the model's token usage.
 
-Every Slack event the bot subscribes to costs an invocation, including messages it never answers. Drop the `message.channels` and `message.groups` subscriptions to limit it to explicit mentions and DMs.
+Every Slack event the bot subscribes to costs one invocation for the events route, including messages it never answers. Channel and group messages that cannot become a request are dropped there, so they never cost the second invocation an answered event pays in the target workspace. Dropping the `message.channels` and `message.groups` subscriptions removes the first invocation too, at the cost of unmentioned thread follow-ups.
 
 ## 📌 Heads up
 

--- a/packages/twenty-apps/public/slack/src/__tests__/slack-inbound-events.integration-test.ts
+++ b/packages/twenty-apps/public/slack/src/__tests__/slack-inbound-events.integration-test.ts
@@ -182,6 +182,103 @@ describe('Slack inbound events', () => {
       );
     });
 
+    it('should skip a plain channel message without dispatching to a workspace', async () => {
+      const result = await slackEventsResolverHandler(
+        buildSlackRoutePayload(
+          buildSlackMessageEventBody({
+            channelId: CHANNEL_ID,
+            channelType: 'channel',
+            text: 'unrelated team chatter',
+            messageTimestamp: nextMessageTimestamp(),
+            teamId: slack.teamId,
+          }),
+        ),
+      );
+
+      if (!(result instanceof Response)) {
+        throw new Error('A plain channel message was dispatched');
+      }
+
+      expect(result.body).toEqual({
+        ok: true,
+        skipped: 'Unhandled event type: message',
+      });
+    });
+
+    it('should skip a channel message posted by another bot', async () => {
+      const result = await slackEventsResolverHandler(
+        buildSlackRoutePayload(
+          buildSlackMessageEventBody({
+            channelId: CHANNEL_ID,
+            channelType: 'channel',
+            text: 'a bot is talking in a thread',
+            messageTimestamp: nextMessageTimestamp(),
+            threadTimestamp: '1700000000.000004',
+            botId: 'B0OTHERBOT',
+            teamId: slack.teamId,
+          }),
+        ),
+      );
+
+      if (!(result instanceof Response)) {
+        throw new Error('A bot message was dispatched');
+      }
+
+      expect(result.body).toEqual({
+        ok: true,
+        skipped: 'Not a plain user message',
+      });
+    });
+
+    it('should route an unmentioned thread follow-up to the assistant enqueue function', async () => {
+      claimSlackTeamForThisWorkspace();
+
+      const result = await slackEventsResolverHandler(
+        buildSlackRoutePayload(
+          buildSlackMessageEventBody({
+            channelId: CHANNEL_ID,
+            channelType: 'channel',
+            text: 'and what about last month?',
+            messageTimestamp: nextMessageTimestamp(),
+            threadTimestamp: '1700000000.000005',
+            teamId: slack.teamId,
+          }),
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          workspaceId,
+          targetLogicFunctionUniversalIdentifier:
+            SLACK_EVENTS_ENQUEUE_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+    });
+
+    it('should route a direct message to the assistant enqueue function', async () => {
+      claimSlackTeamForThisWorkspace();
+
+      const result = await slackEventsResolverHandler(
+        buildSlackRoutePayload(
+          buildSlackMessageEventBody({
+            channelId: DIRECT_MESSAGE_CHANNEL_ID,
+            channelType: 'im',
+            text: 'how many companies do we have?',
+            messageTimestamp: nextMessageTimestamp(),
+            teamId: slack.teamId,
+          }),
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          workspaceId,
+          targetLogicFunctionUniversalIdentifier:
+            SLACK_EVENTS_ENQUEUE_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+    });
+
     it('should route a channel join to the welcome function', async () => {
       claimSlackTeamForThisWorkspace();
 

--- a/packages/twenty-apps/public/slack/src/logic-functions/slack-events-resolver.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/slack-events-resolver.ts
@@ -13,6 +13,7 @@ import {
   SLACK_LINK_UNFURL_UNIVERSAL_IDENTIFIER,
 } from 'src/constants/universal-identifiers';
 import { type SlackEventsRequestBody } from 'src/logic-functions/types/slack-events-request-body.type';
+import { classifySlackAssistantEventBody } from 'src/logic-functions/utils/classify-slack-assistant-event-body';
 import { findClaimedWorkspaceId } from 'src/logic-functions/utils/find-claimed-workspace-id';
 import { resolveTargetWorkspaceId } from 'src/logic-functions/utils/resolve-target-workspace-id';
 import { logSlackRetryDelivery } from 'src/logic-functions/utils/log-slack-retry-delivery';
@@ -70,6 +71,17 @@ export const slackEventsResolverHandler = async (
       targetLogicFunctionUniversalIdentifier,
       payload: body,
     };
+  }
+
+  if (
+    targetLogicFunctionUniversalIdentifier ===
+    SLACK_EVENTS_ENQUEUE_UNIVERSAL_IDENTIFIER
+  ) {
+    const classification = classifySlackAssistantEventBody(body);
+
+    if (classification.kind === null) {
+      return new Response({ ok: true, skipped: classification.skipReason });
+    }
   }
 
   return {

--- a/packages/twenty-apps/public/slack/src/logic-functions/types/slack-assistant-event-classification.type.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/types/slack-assistant-event-classification.type.ts
@@ -1,0 +1,8 @@
+export type SlackAssistantEventKind =
+  | 'mention'
+  | 'directMessage'
+  | 'threadFollowUp';
+
+export type SlackAssistantEventClassification =
+  | { kind: SlackAssistantEventKind }
+  | { kind: null; skipReason: string };

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/classify-slack-assistant-event-body.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/classify-slack-assistant-event-body.ts
@@ -1,0 +1,63 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
+import {
+  type SlackAssistantEventClassification,
+  type SlackAssistantEventKind,
+} from 'src/logic-functions/types/slack-assistant-event-classification.type';
+import { type SlackEventsRequestBody } from 'src/logic-functions/types/slack-events-request-body.type';
+
+type SlackInboundEvent = NonNullable<SlackEventsRequestBody['event']>;
+
+const classifySlackAssistantEvent = (
+  event: SlackInboundEvent,
+): SlackAssistantEventKind | null => {
+  if (event.type === 'app_mention') {
+    return 'mention';
+  }
+
+  if (event.type !== 'message') {
+    return null;
+  }
+
+  if (event.channel_type === 'im') {
+    return 'directMessage';
+  }
+
+  const isChannelOrGroupMessage =
+    event.channel_type === 'channel' || event.channel_type === 'group';
+
+  if (isChannelOrGroupMessage && isNonEmptyString(event.thread_ts)) {
+    return 'threadFollowUp';
+  }
+
+  return null;
+};
+
+// Decides from the event body alone, with no workspace state, so the events
+// resolver can answer Slack without dispatching a second billed invocation
+// into the target workspace for an event the enqueue would only discard.
+export const classifySlackAssistantEventBody = (
+  body: SlackEventsRequestBody,
+): SlackAssistantEventClassification => {
+  if (body.type !== 'event_callback') {
+    return { kind: null, skipReason: `Unhandled body type: ${body.type}` };
+  }
+
+  const event = body.event;
+
+  if (!event) {
+    return { kind: null, skipReason: 'Missing event payload' };
+  }
+
+  const kind = classifySlackAssistantEvent(event);
+
+  if (kind === null) {
+    return { kind: null, skipReason: `Unhandled event type: ${event.type}` };
+  }
+
+  if (isNonEmptyString(event.bot_id) || isNonEmptyString(event.subtype)) {
+    return { kind: null, skipReason: 'Not a plain user message' };
+  }
+
+  return { kind };
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/parse-slack-assistant-request.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/parse-slack-assistant-request.ts
@@ -1,17 +1,15 @@
 import { isNonEmptyString } from '@sniptt/guards';
 
 import { type SlackAssistantEmptyRequest } from 'src/logic-functions/types/slack-assistant-empty-request.type';
+import { type SlackAssistantEventKind } from 'src/logic-functions/types/slack-assistant-event-classification.type';
 import { type SlackAssistantRequestDraft } from 'src/logic-functions/types/slack-assistant-request-draft.type';
 import { type SlackEventsRequestBody } from 'src/logic-functions/types/slack-events-request-body.type';
+import { classifySlackAssistantEventBody } from 'src/logic-functions/utils/classify-slack-assistant-event-body';
 import { getSlackAssistantParentMessageTimestamp } from 'src/logic-functions/utils/get-slack-assistant-parent-message-timestamp';
 import { getSlackBotUserIdFromEventBody } from 'src/logic-functions/utils/get-slack-bot-user-id-from-event-body';
 import { normalizeSlackRequestText } from 'src/logic-functions/utils/normalize-slack-request-text';
 
 const LEADING_MENTION_PATTERN = /^<@([A-Z0-9]+)(\|[^>]*)?>/;
-
-type SlackInboundEvent = NonNullable<SlackEventsRequestBody['event']>;
-
-type SlackAssistantEventKind = 'mention' | 'directMessage' | 'threadFollowUp';
 
 type ParsedSlackAssistantRequest =
   | {
@@ -23,31 +21,6 @@ type ParsedSlackAssistantRequest =
       skipReason: string;
       emptyRequest?: SlackAssistantEmptyRequest;
     };
-
-const classifySlackAssistantEvent = (
-  event: SlackInboundEvent,
-): SlackAssistantEventKind | null => {
-  if (event.type === 'app_mention') {
-    return 'mention';
-  }
-
-  if (event.type !== 'message') {
-    return null;
-  }
-
-  if (event.channel_type === 'im') {
-    return 'directMessage';
-  }
-
-  const isChannelOrGroupMessage =
-    event.channel_type === 'channel' || event.channel_type === 'group';
-
-  if (isChannelOrGroupMessage && isNonEmptyString(event.thread_ts)) {
-    return 'threadFollowUp';
-  }
-
-  return null;
-};
 
 const getBotUserIdFromLeadingMention = (text: string): string | undefined =>
   text.trimStart().match(LEADING_MENTION_PATTERN)?.[1];
@@ -67,27 +40,17 @@ const resolveRequestBotUserId = ({
 export const parseSlackAssistantRequest = (
   body: SlackEventsRequestBody,
 ): ParsedSlackAssistantRequest => {
-  if (body.type !== 'event_callback') {
-    return { request: null, skipReason: `Unhandled body type: ${body.type}` };
+  const classification = classifySlackAssistantEventBody(body);
+
+  if (classification.kind === null) {
+    return { request: null, skipReason: classification.skipReason };
   }
 
+  const kind = classification.kind;
   const event = body.event;
 
-  if (!event) {
-    return { request: null, skipReason: 'Missing event payload' };
-  }
-
-  const kind = classifySlackAssistantEvent(event);
-
-  if (kind === null) {
-    return { request: null, skipReason: `Unhandled event type: ${event.type}` };
-  }
-
-  if (isNonEmptyString(event.bot_id) || isNonEmptyString(event.subtype)) {
-    return { request: null, skipReason: 'Not a plain user message' };
-  }
-
   if (
+    !event ||
     !isNonEmptyString(body.event_id) ||
     !isNonEmptyString(event.channel) ||
     !isNonEmptyString(event.ts) ||


### PR DESCRIPTION
## Problem

The Slack app subscribes to `message.channels`, `message.groups` and `message.im`. `slackEventsResolverHandler` has no `message` case in its switch, so every one of those events falls through to the `default` and is dispatched to `SLACK_EVENTS_ENQUEUE_UNIVERSAL_IDENTIFIER`.

Both halves of that round trip are separately metered. Billing happens in `LogicFunctionExecutorService.handleExecutionResult`, which calls `computeLogicFunctionExecutionCreditsMicro` and then `consumeUsageQuota` + `usageRecorderService.record`. The resolver reaches it via `ServerRouteTriggerService.runFunction → execute`, and the queued target reaches it via `LogicFunctionTriggerJob.handle → execute`. Each charges `LOGIC_FUNCTION_INVOCATION_CREDITS_MICRO` (100 micro-credits, $0.0001) plus `0.1` micro-credits per ms of runtime. The only escape is `isBillingExemptApplication`, and the Slack app's universal identifier is not in `MARKETPLACE_BILLING_EXEMPT_UNIVERSAL_IDENTIFIERS`.

So a plain channel message cost two billed invocations, and `classifySlackAssistantEvent` in the enqueue then discarded most of them anyway: bot messages, messages carrying a subtype, and channel/group messages with no `thread_ts`. Those checks read the event body only and need no workspace state.

## Change

The body-only screening moves into the resolver. A message event that cannot become a request now returns `new Response({ ok: true, skipped })` instead of dispatching.

The classification is extracted into one util, `classifySlackAssistantEventBody`, called by both the resolver and `parseSlackAssistantRequest`, which now takes its skip reasons from it rather than carrying a second copy. The two cannot drift.

Nothing that would have produced a request is dropped:

- `app_mention` still dispatches
- DMs (`channel_type: 'im'`) still dispatch
- channel and group messages carrying a `thread_ts` still dispatch, so unmentioned thread follow-ups keep working for the full 24 hours

The empty-text branch stays in `parseSlackAssistantRequest`, since replying to an empty mention is a real side effect and needs the target workspace.

The skip branch sits before `resolveTargetWorkspaceId`, so skipped events also no longer perform the team key-value lookup. Slack retries an event it cannot ack within 3 seconds; for these events the resolver now does signature verification and nothing else, no key-value read, no queue write, no second execution.

## Impact

Honest sizing: the resolver invocation is the webhook entry point and is unavoidable, so this saves one of the two invocations, not both. A workspace with the bot in ~5 busy channels at ~200 messages/day is roughly 850 non-actionable events/day, about $0.09/day or $2.70/month at $0.0001 plus a few ms of runtime each. Small in dollars. The change is worth it because it is contained behind a single shared predicate, it halves worker queue traffic for those events, and the README's previous advice for this problem was to drop the `message.channels` and `message.groups` subscriptions, which would silently disable unmentioned thread follow-ups. This keeps the feature.

The README billing paragraph described the old behavior and has been updated.

## Tests

Added to `slack-inbound-events.integration-test.ts`:

- a plain channel message is skipped without dispatch
- a bot-authored thread message is skipped
- a threaded follow-up still dispatches
- a DM still dispatches

The existing `app_mention` routing test covers the fourth required case.

`yarn lint` and `yarn typecheck` are clean and `yarn test:unit` passes 616/616. For the integration suite I brought up Postgres, Redis, migrations, the dev seed and the server; `slack-inbound-events.integration-test.ts` passes 20/20.

One caveat, stated plainly: `slack-deployed-functions.integration-test.ts` fails 4 tests locally with `Authentication failed: GraphQL auth error`. I confirmed these are pre-existing by stashing the changes and reproducing the identical 4 failures on a clean tree. They come from the local dev server's `APP_SECRET` not matching the hardcoded `DEV_API_KEY`, which is only valid against the `twenty-app-dev` Docker image, and are unrelated to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_0194fnjHNk3Apfghp7VWq7to)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

