### PR TITLE
Clear logoFileId when the workspace logo is removed

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -321,6 +321,7 @@ export class WorkspaceService {
       updatedWorkspace = await this.workspaceRepository.save({
         ...workspace,
         ...payload,
+        ...(payload.logo === null ? { logoFileId: null } : {}),
       });
     } catch (error) {
       if (payload.customDomain && customDomainRegistered) {

--- a/packages/twenty-server/test/integration/metadata/suites/file/successful-workspace-logo-removal.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/file/successful-workspace-logo-removal.integration-spec.ts
@@ -1,0 +1,50 @@
+import gql from 'graphql-tag';
+import { seedWorkspaceLogo } from 'test/integration/metadata/suites/file/utils/seed-workspace-logo.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+
+describe('Workspace logo removal should succeed', () => {
+  let workspaceId: string;
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    jest.useRealTimers();
+
+    const seeded = await seedWorkspaceLogo();
+
+    workspaceId = seeded.workspaceId;
+    cleanup = seeded.cleanup;
+
+    jest.useFakeTimers();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('should clear logoFileId so the resolver stops signing a deleted file', async () => {
+    jest.useRealTimers();
+
+    const response = await makeMetadataAPIRequest({
+      query: gql`
+        mutation UpdateWorkspace {
+          updateWorkspace(data: { logo: null }) {
+            id
+            logo
+          }
+        }
+      `,
+    });
+
+    jest.useFakeTimers();
+
+    expect(response.body.errors).toBeUndefined();
+    expect(response.body.data.updateWorkspace.logo).toBe('');
+
+    const [workspace] = await globalThis.testDataSource.query(
+      `SELECT "logoFileId" FROM core."workspace" WHERE id = $1`,
+      [workspaceId],
+    );
+
+    expect(workspace.logoFileId).toBeNull();
+  }, 30000);
+});


### PR DESCRIPTION
Removing a workspace logo left the workspace pointing at a deleted file.

## Bug

`updateWorkspace(data: { logo: null })` deletes the logo's storage object but never clears `logoFileId`. The `logo` resolver only checks `logoFileId`, so it keeps signing a URL for a file that no longer exists, and the UI shows a broken image.

| Step | Before | After |
|---|---|---|
| Storage object | deleted | deleted |
| `workspace.logoFileId` | **still set** | `null` |
| `logo` resolver returns | signed URL → 404 | `''` |

## Fix

When the payload removes the logo, the saved row also clears `logoFileId`:

```ts
...(payload.logo === null ? { logoFileId: null } : {}),
```

The storage deletion that already runs after the save is unchanged.

## Testing

New `successful-workspace-logo-removal.integration-spec.ts`: seeds a real logo with the existing `seedWorkspaceLogo` util, removes it, then checks that the mutation returns `logo: ''` and that `core.workspace.logoFileId` is `NULL`.

Typecheck, lint and format are clean. I couldn't run the integration suite locally (the in-process app ran out of heap at the default ~4 GB), so CI is its first run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

