### PR TITLE
Fix AWS region validation across partitions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/__tests__/is-aws-region.decorator.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/__tests__/is-aws-region.decorator.spec.ts
@@ -1,0 +1,56 @@
+import { validateSync } from 'class-validator';
+
+import { IsAWSRegion } from 'src/engine/core-modules/twenty-config/decorators/is-aws-region.decorator';
+
+describe('IsAWSRegion', () => {
+  class ConfigVariables {
+    @IsAWSRegion()
+    region: string;
+  }
+
+  // AWS partitions use different region naming formats:
+  // https://github.com/boto/botocore/blob/e3ae2081184335ff69687f8dacc798e58715af1d/botocore/data/partitions.json
+  it.each([
+    'eu-west-1',
+    'cn-north-1',
+    'eusc-de-east-1',
+    'us-gov-west-1',
+    'us-iso-east-1',
+    'us-isob-east-1',
+    'eu-isoe-west-1',
+    'us-isof-east-1',
+  ])('should accept region %s', (region) => {
+    const config = Object.assign(new ConfigVariables(), { region });
+
+    expect(validateSync(config)).toHaveLength(0);
+  });
+
+  it('should accept multi-digit region numbers', () => {
+    const config = Object.assign(new ConfigVariables(), {
+      region: 'eu-west-10',
+    });
+
+    expect(validateSync(config)).toHaveLength(0);
+  });
+
+  it.each([
+    '',
+    'eu-west',
+    'eu_west_1',
+    'eu-west-1a',
+    'eu-west-1-2',
+    'us-gov--west-1',
+    'eusc-de-east',
+    'eusc-de-east-1a',
+    'eusc-de-east-1-2',
+    'eusc-de--east-1',
+    'EUSC-de-east-1',
+    ' eusc-de-east-1',
+    'eusc-de-east-1 ',
+    'aws-global',
+  ])('should reject invalid region %s', (region) => {
+    const config = Object.assign(new ConfigVariables(), { region });
+
+    expect(validateSync(config)).toHaveLength(1);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/is-aws-region.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/is-aws-region.decorator.ts
@@ -8,9 +8,9 @@ import {
 @ValidatorConstraint({ async: false })
 export class IsAWSRegionConstraint implements ValidatorConstraintInterface {
   validate(region: string) {
-    const regex = /^[a-z]{2}-[a-z]+-\d{1}$/;
+    const regex = /^[a-z]{2,4}(?:-[a-z]+){1,2}-\d+$/;
 
-    return regex.test(region); // Returns true if region matches regex
+    return regex.test(region);
   }
 }
 


### PR DESCRIPTION
Twenty rejects valid region names such as `eusc-de-east-1` and `us-gov-west-1` during configuration validation. The existing regex rejects 10 of the 46 regions listed in AWS's partition data, including European Sovereign Cloud, GovCloud, and ISO regions.

Expand the format check to accept longer prefixes and an extra name segment. Allow multi-digit region numbers to match AWS's own format rules. The shared decorator covers Lambda, Lambda layer bucket, and SES region settings.

Add inline regression cases for one region from each of the eight partitions in [AWS's partitions.json](https://github.com/boto/botocore/blob/e3ae2081184335ff69687f8dacc798e58715af1d/botocore/data/partitions.json), plus tests for malformed names and multi-digit numbers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

