### PR TITLE
fix(apps): preserve vetted status during catalog sync

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -783,12 +783,6 @@ export class ApplicationRegistrationService {
       params.universalIdentifier,
     );
 
-    const vettedIdentifiers = new Set(
-      MARKETPLACE_VETTED_APPLICATIONS.map((entry) => entry.universalIdentifier),
-    );
-
-    const isVetted = vettedIdentifiers.has(params.universalIdentifier);
-
     if (isDefined(existing) && isDefined(params.manifest)) {
       const isNewVersion = await this.setLatestAvailableVersionIfChanged(
         existing.id,
@@ -805,7 +799,6 @@ export class ApplicationRegistrationService {
         additionalFields: {
           name: params.name,
           sourcePackage: params.sourcePackage,
-          isVetted,
         },
       });
 
@@ -846,7 +839,6 @@ export class ApplicationRegistrationService {
         sourcePackage: params.sourcePackage,
         latestAvailableVersion: params.latestAvailableVersion,
         isListed: existing.isListed || isRelistedFromLocalSource,
-        isVetted,
         manifest: params.manifest,
         ...fromManifestApplicationToDisplayFields(params.manifest?.application),
       });
@@ -880,7 +872,10 @@ export class ApplicationRegistrationService {
       sourcePackage: params.sourcePackage,
       latestAvailableVersion: params.latestAvailableVersion,
       isListed: true,
-      isVetted,
+      isVetted: MARKETPLACE_VETTED_APPLICATIONS.some(
+        ({ universalIdentifier }) =>
+          universalIdentifier === params.universalIdentifier,
+      ),
       manifest: params.manifest,
       ...fromManifestApplicationToDisplayFields(params.manifest?.application),
       oAuthClientId: v4(),

--- a/packages/twenty-server/test/integration/metadata/suites/application/marketplace-catalog-sync.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/marketplace-catalog-sync.integration-spec.ts
@@ -3,11 +3,18 @@ import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
+import { gql } from 'graphql-tag';
 import request from 'supertest';
 import * as tar from 'tar';
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
 import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { makeAdminPanelAPIRequest } from 'test/integration/twenty-config/utils/make-admin-panel-api-request.util';
+import { getAppProviderByClassName } from 'test/integration/utils/get-app-provider-by-class-name.util';
 import { type DataSource } from 'typeorm';
 
+import { MARKETPLACE_VETTED_APPLICATIONS } from 'src/engine/core-modules/application/application-marketplace/constants/marketplace-vetted-applications.constant';
+import { type ApplicationRegistrationService } from 'src/engine/core-modules/application/application-registration/application-registration.service';
+import { ApplicationRegistrationSourceType } from 'src/engine/core-modules/application/application-registration/enums/application-registration-source-type.enum';
 import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
 const TEST_WORKSPACE_ID = SEED_APPLE_WORKSPACE_ID;
@@ -187,6 +194,103 @@ describe('Marketplace Catalog Sync (integration)', () => {
       expect(curatedApp.category).toBe('Data');
     });
   });
+
+  describe.each([true, false])(
+    'catalog sync with manifest: %s',
+    (hasManifest) => {
+      it.each([true, false])(
+        'preserves the admin choice isVetted=%s',
+        async (isVetted) => {
+          const applicationRegistrationService =
+            getAppProviderByClassName<ApplicationRegistrationService>(
+              'ApplicationRegistrationService',
+            );
+          const universalIdentifier = isVetted
+            ? crypto.randomUUID()
+            : MARKETPLACE_VETTED_APPLICATIONS[0].universalIdentifier;
+          const catalogParams = {
+            universalIdentifier,
+            name: 'Vetted catalog sync test',
+            sourceType: ApplicationRegistrationSourceType.NPM,
+            sourcePackage: '@test/vetted-catalog-sync',
+            latestAvailableVersion: '1.0.0',
+            manifest: hasManifest
+              ? buildBaseManifest({
+                  appId: universalIdentifier,
+                  roleId: crypto.randomUUID(),
+                })
+              : null,
+          };
+
+          expect(
+            await applicationRegistrationService.findOneByUniversalIdentifierGlobal(
+              universalIdentifier,
+            ),
+          ).toBeNull();
+
+          try {
+            await applicationRegistrationService.upsertFromCatalog(
+              catalogParams,
+            );
+
+            const registration =
+              await applicationRegistrationService.findOneByUniversalIdentifierGlobal(
+                universalIdentifier,
+              );
+
+            expect(registration).toMatchObject({ isVetted: !isVetted });
+
+            const updateResponse = await makeAdminPanelAPIRequest({
+              query: gql`
+                mutation UpdateAdminApplicationRegistration(
+                  $input: UpdateApplicationRegistrationInput!
+                ) {
+                  updateAdminApplicationRegistration(input: $input) {
+                    id
+                    isVetted
+                  }
+                }
+              `,
+              variables: {
+                input: { id: registration?.id, update: { isVetted } },
+              },
+            });
+
+            expect(updateResponse.body.errors).toBeUndefined();
+            expect(
+              updateResponse.body.data.updateAdminApplicationRegistration,
+            ).toMatchObject({ isVetted });
+
+            await applicationRegistrationService.upsertFromCatalog(
+              catalogParams,
+            );
+
+            const refreshedResponse = await makeAdminPanelAPIRequest({
+              query: gql`
+                query FindOneAdminApplicationRegistration($id: String!) {
+                  findOneAdminApplicationRegistration(id: $id) {
+                    id
+                    isVetted
+                  }
+                }
+              `,
+              variables: { id: registration?.id },
+            });
+
+            expect(refreshedResponse.body.errors).toBeUndefined();
+            expect(
+              refreshedResponse.body.data.findOneAdminApplicationRegistration,
+            ).toMatchObject({ isVetted });
+          } finally {
+            await ds.query(
+              `DELETE FROM core."applicationRegistration" WHERE "universalIdentifier" = $1`,
+              [universalIdentifier],
+            );
+          }
+        },
+      );
+    },
+  );
 
   describe('installApplication', () => {
     it('should fail if registration does not exist', async () => {


### PR DESCRIPTION
Catalog sync currently resets an admin's Vetted choice to match the hardcoded marketplace list. For example, manually vetting an app outside that list succeeds, but a later sync clears the setting.

Preserve the stored `isVetted` value in both existing-registration update paths, and apply the hardcoded default only when creating a registration. No UI changes or database migration are needed.

Adds four integration cases to the existing catalog suite covering vetting and unvetting, with and without a manifest. Each case verifies the initial default, changes the setting through the admin API, runs the real registration service's catalog upsert, and reads the setting back through the admin API. No mocks are added.

Validation:
- Formatting, non-type-aware lint, and `git diff --check` pass.
- Integration execution was attempted but stopped while loading the Jest configuration because this worktree cannot resolve `dotenv` and `ts-jest`; no test cases ran.
- Full type validation remains incomplete: type-aware lint could not locate `tsgolint`, and the direct type check was stopped after producing no output.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

