### PR TITLE
Accept CalDAV calendars that do not publish a component set

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -166,7 +166,7 @@
     "tar": "^7.5.9",
     "temporal-polyfill": "^0.3.0",
     "tsconfig-paths": "^4.2.0",
-    "tsdav": "^2.2.0",
+    "tsdav": "^2.2.1",
     "tslib": "2.8.1",
     "type-fest": "4.10.1",
     "typeorm": "patch:typeorm@0.3.31#./patches/typeorm+0.3.31.patch",

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service.ts
@@ -14,6 +14,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { type CalDavSyncCursor } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/types/caldav-sync-cursor';
 import { extractICalData } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/extract-ical-data.util';
 import { isCalDavCollectionHref } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-caldav-collection-href.util';
+import { isEventCalendar } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-event-calendar.util';
 import { isEventInTimeRange } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-event-in-time-range.util';
 import { isInvalidSyncTokenResponse } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-invalid-sync-token-response.util';
 import { isSameCalDavResource } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-same-caldav-resource.util';
@@ -42,9 +43,7 @@ export class CalDavFetchEventsService {
   async listEventCalendars(client: DAVClient): Promise<DAVCalendar[]> {
     const calendars = await client.fetchCalendars();
 
-    return calendars.filter((calendar) =>
-      calendar.components?.includes('VEVENT'),
-    );
+    return calendars.filter(isEventCalendar);
   }
 
   async fetchChangedEventHrefs(

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/is-event-calendar.util.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/is-event-calendar.util.spec.ts
@@ -2,11 +2,9 @@ import { type DAVCalendar } from 'tsdav';
 
 import { isEventCalendar } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-event-calendar.util';
 
-const calendar = (components?: string[]): DAVCalendar =>
-  ({
-    url: 'https://caldav.example.com/calendars/user/personal/',
-    components,
-  }) as DAVCalendar;
+const calendar = (
+  components?: DAVCalendar['components'],
+): Pick<DAVCalendar, 'components'> => ({ components });
 
 describe('isEventCalendar', () => {
   it('accepts a calendar declaring VEVENT', () => {

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/is-event-calendar.util.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/is-event-calendar.util.spec.ts
@@ -1,0 +1,27 @@
+import { type DAVCalendar } from 'tsdav';
+
+import { isEventCalendar } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-event-calendar.util';
+
+const calendar = (components?: string[]): DAVCalendar =>
+  ({
+    url: 'https://caldav.example.com/calendars/user/personal/',
+    components,
+  }) as DAVCalendar;
+
+describe('isEventCalendar', () => {
+  it('accepts a calendar declaring VEVENT', () => {
+    expect(isEventCalendar(calendar(['VEVENT', 'VTODO']))).toBe(true);
+  });
+
+  it('accepts a calendar that does not publish supported-calendar-component-set, which RFC 4791 defines as accepting every component type', () => {
+    expect(isEventCalendar(calendar(undefined))).toBe(true);
+  });
+
+  it('accepts a calendar whose published component set came back empty', () => {
+    expect(isEventCalendar(calendar([]))).toBe(true);
+  });
+
+  it('rejects a calendar restricted to components other than VEVENT', () => {
+    expect(isEventCalendar(calendar(['VTODO', 'VJOURNAL']))).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-event-calendar.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-event-calendar.util.ts
@@ -1,6 +1,8 @@
 import { isNonEmptyArray } from '@sniptt/guards';
 import { type DAVCalendar } from 'tsdav';
 
-export const isEventCalendar = (calendar: DAVCalendar): boolean =>
+export const isEventCalendar = (
+  calendar: Pick<DAVCalendar, 'components'>,
+): boolean =>
   !isNonEmptyArray(calendar.components) ||
   calendar.components.includes('VEVENT');

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-event-calendar.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/is-event-calendar.util.ts
@@ -1,0 +1,6 @@
+import { isNonEmptyArray } from '@sniptt/guards';
+import { type DAVCalendar } from 'tsdav';
+
+export const isEventCalendar = (calendar: DAVCalendar): boolean =>
+  !isNonEmptyArray(calendar.components) ||
+  calendar.components.includes('VEVENT');

--- a/packages/twenty-server/test/integration/caldav/suites/caldav-omitted-component-set.integration-spec.ts
+++ b/packages/twenty-server/test/integration/caldav/suites/caldav-omitted-component-set.integration-spec.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from 'node:crypto';
+
+import { isNonEmptyString } from '@sniptt/guards';
+
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+
+import { deleteConnectedAccount } from 'test/integration/metadata/suites/connected-account/utils/delete-connected-account.util';
+import { saveImapSmtpCaldavAccount } from 'test/integration/metadata/suites/connected-account/utils/save-imap-smtp-caldav-account.util';
+import { updateConfigVariable } from 'test/integration/twenty-config/utils/update-config-variable.util';
+import { findImportedCalendarEventTitles } from 'test/integration/utils/find-imported-records.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import { runCalendarChannelEventsImport } from 'test/integration/utils/run-calendar-channel-events-import.util';
+import { runCalendarChannelListFetch } from 'test/integration/utils/run-calendar-channel-list-fetch.util';
+import {
+  type CalDavProxy,
+  startCalDavProxyOmittingComponentSet,
+} from 'test/integration/utils/start-caldav-proxy-omitting-component-set.util';
+import {
+  type RadicaleServer,
+  startRadicaleContainer,
+} from 'test/integration/utils/start-radicale-container.util';
+
+const HANDLE = `caldav-omitted-component-set-${randomUUID()}@acme.test`;
+const COLLECTION = 'personal';
+const PASSWORD = 'radicale-password';
+
+const authorizationHeader = `Basic ${Buffer.from(`${HANDLE}:${PASSWORD}`).toString('base64')}`;
+
+const icalEvent = ({ uid, summary }: { uid: string; summary: string }) =>
+  [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Twenty//CalDAV integration test//EN',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    'DTSTAMP:20231101T000000Z',
+    'DTSTART:20231115T100000Z',
+    'DTEND:20231115T110000Z',
+    `SUMMARY:${summary}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+
+describe('CalDAV server omitting supported-calendar-component-set (integration)', () => {
+  let radicale: RadicaleServer;
+  let proxy: CalDavProxy;
+  let connectedAccountId: string;
+  let calendarChannelId: string;
+
+  const collectionUrl = () =>
+    `http://${radicale.host}:${radicale.port}/${HANDLE}/${COLLECTION}/`;
+
+  beforeAll(async () => {
+    await updateConfigVariable({
+      input: { key: 'OUTBOUND_HTTP_SAFE_MODE_ENABLED', value: false },
+    });
+
+    radicale = await startRadicaleContainer({
+      username: HANDLE,
+      password: PASSWORD,
+    });
+
+    await fetch(collectionUrl(), {
+      method: 'MKCOL',
+      headers: {
+        'Content-Type': 'application/xml; charset=utf-8',
+        Authorization: authorizationHeader,
+      },
+      body: `<?xml version="1.0" encoding="utf-8"?>
+        <mkcol xmlns="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+          <set><prop>
+            <resourcetype><collection/><c:calendar/></resourcetype>
+            <displayname>Personal</displayname>
+          </prop></set>
+        </mkcol>`,
+    });
+
+    proxy = await startCalDavProxyOmittingComponentSet({
+      targetHost: radicale.host,
+      targetPort: radicale.port,
+    });
+
+    const { data } = await saveImapSmtpCaldavAccount({
+      input: {
+        handle: HANDLE,
+        connectionParameters: {
+          CALDAV: {
+            host: proxy.url,
+            port: Number(new URL(proxy.url).port),
+            username: HANDLE,
+            password: PASSWORD,
+          },
+        },
+      },
+      expectToFail: false,
+    });
+
+    connectedAccountId = data.connectedAccountId;
+
+    calendarChannelId = (
+      await getCoreRepository<CalendarChannelEntity>(
+        CalendarChannelEntity,
+      ).findOneByOrFail({ connectedAccountId })
+    ).id;
+  }, 300000);
+
+  afterAll(async () => {
+    await updateConfigVariable({
+      input: { key: 'OUTBOUND_HTTP_SAFE_MODE_ENABLED', value: true },
+    }).catch(() => undefined);
+
+    if (isNonEmptyString(connectedAccountId)) {
+      await deleteConnectedAccount({
+        id: connectedAccountId,
+        expectToFail: false,
+      }).catch(() => undefined);
+    }
+
+    await proxy?.stop().catch(() => undefined);
+    await radicale?.stop().catch(() => undefined);
+  });
+
+  it('serves the calendar collection without a component set', async () => {
+    const response = await fetch(`${proxy.url}/${HANDLE}/`, {
+      method: 'PROPFIND',
+      headers: {
+        'Content-Type': 'application/xml; charset=utf-8',
+        Authorization: authorizationHeader,
+        Depth: '1',
+      },
+      body: `<?xml version="1.0" encoding="utf-8"?>
+        <propfind xmlns="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+          <prop><resourcetype/><c:supported-calendar-component-set/></prop>
+        </propfind>`,
+    });
+
+    const body = await response.text();
+
+    expect(body).toContain('calendar');
+    expect(body).not.toContain('supported-calendar-component-set');
+  }, 300000);
+
+  it('imports an event even though the component set is not published', async () => {
+    const summary = `CalDAV event ${randomUUID()}`;
+    const uid = `caldav-event-${randomUUID()}`;
+
+    await fetch(`${collectionUrl()}${uid}.ics`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'text/calendar; charset=utf-8',
+        Authorization: authorizationHeader,
+      },
+      body: icalEvent({ uid, summary }),
+    });
+
+    await runCalendarChannelListFetch(calendarChannelId);
+    await runCalendarChannelEventsImport(calendarChannelId);
+
+    expect(await findImportedCalendarEventTitles([summary])).toEqual([summary]);
+  }, 300000);
+});

--- a/packages/twenty-server/test/integration/utils/start-caldav-proxy-omitting-component-set.util.ts
+++ b/packages/twenty-server/test/integration/utils/start-caldav-proxy-omitting-component-set.util.ts
@@ -1,0 +1,72 @@
+import { createServer, request, type Server } from 'node:http';
+import { type AddressInfo } from 'node:net';
+
+const COMPONENT_SET_ELEMENT =
+  /<(\w+:)?supported-calendar-component-set\b[^>]*(\/>|>[\s\S]*?<\/(\w+:)?supported-calendar-component-set>)/g;
+
+export type CalDavProxy = {
+  url: string;
+  stop: () => Promise<void>;
+};
+
+// Radicale always publishes supported-calendar-component-set, so reproducing an
+// RFC 4791 server that leaves it out means stripping it off the wire.
+export const startCalDavProxyOmittingComponentSet = async ({
+  targetHost,
+  targetPort,
+}: {
+  targetHost: string;
+  targetPort: number;
+}): Promise<CalDavProxy> => {
+  const server: Server = createServer((incoming, outgoing) => {
+    const requestChunks: Buffer[] = [];
+
+    incoming.on('data', (chunk) => requestChunks.push(chunk));
+    incoming.on('end', () => {
+      const proxied = request(
+        {
+          host: targetHost,
+          port: targetPort,
+          path: incoming.url,
+          method: incoming.method,
+          headers: {
+            ...incoming.headers,
+            host: `${targetHost}:${targetPort}`,
+            'accept-encoding': 'identity',
+          },
+        },
+        (upstream) => {
+          const responseChunks: Buffer[] = [];
+
+          upstream.on('data', (chunk) => responseChunks.push(chunk));
+          upstream.on('end', () => {
+            const body = Buffer.concat(responseChunks)
+              .toString('utf-8')
+              .replace(COMPONENT_SET_ELEMENT, '');
+
+            const headers = { ...upstream.headers };
+
+            delete headers['content-length'];
+            delete headers['transfer-encoding'];
+
+            outgoing.writeHead(upstream.statusCode ?? 502, {
+              ...headers,
+              'content-length': Buffer.byteLength(body),
+            });
+            outgoing.end(body);
+          });
+        },
+      );
+
+      proxied.on('error', () => outgoing.destroy());
+      proxied.end(Buffer.concat(requestChunks));
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  return {
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    stop: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+};

--- a/packages/twenty-server/test/integration/utils/start-caldav-proxy-omitting-component-set.util.ts
+++ b/packages/twenty-server/test/integration/utils/start-caldav-proxy-omitting-component-set.util.ts
@@ -1,8 +1,11 @@
 import { createServer, request, type Server } from 'node:http';
 import { type AddressInfo } from 'node:net';
 
+// The self-closing form has to be matched on its own: sharing a branch with the
+// open tag lets a self-closing occurrence pair up with a later closing tag and
+// swallow every response in between.
 const COMPONENT_SET_ELEMENT =
-  /<(\w+:)?supported-calendar-component-set\b[^>]*(\/>|>[\s\S]*?<\/(\w+:)?supported-calendar-component-set>)/g;
+  /<(\w+:)?supported-calendar-component-set\b[^>]*\/>|<(\w+:)?supported-calendar-component-set\b[^>]*>[\s\S]*?<\/(\w+:)?supported-calendar-component-set>/g;
 
 export type CalDavProxy = {
   url: string;
@@ -44,10 +47,11 @@ export const startCalDavProxyOmittingComponentSet = async ({
               .toString('utf-8')
               .replace(COMPONENT_SET_ELEMENT, '');
 
-            const headers = { ...upstream.headers };
-
-            delete headers['content-length'];
-            delete headers['transfer-encoding'];
+            const {
+              'content-length': _staleContentLength,
+              'transfer-encoding': _staleTransferEncoding,
+              ...headers
+            } = upstream.headers;
 
             outgoing.writeHead(upstream.statusCode ?? 502, {
               ...headers,

--- a/yarn.lock
+++ b/yarn.lock
@@ -25488,13 +25488,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-64@npm:1.0.0":
-  version: 1.0.0
-  resolution: "base-64@npm:1.0.0"
-  checksum: 10c0/d886cb3236cee0bed9f7075675748b59b32fad623ddb8ce1793c790306aa0f76a03238cad4b3fb398abda6527ce08a5588388533a4ccade0b97e82b9da660e28
-  languageName: node
-  linkType: hard
-
 "base-64@npm:^0.1.0":
   version: 0.1.0
   resolution: "base-64@npm:0.1.0"
@@ -49284,14 +49277,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsdav@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "tsdav@npm:2.2.0"
+"tsdav@npm:^2.2.1":
+  version: 2.3.2
+  resolution: "tsdav@npm:2.3.2"
   dependencies:
-    base-64: "npm:1.0.0"
     debug: "npm:4.4.3"
     xml-js: "npm:1.6.11"
-  checksum: 10c0/39dbe70c7e0bb1e5d48d776a15221d1f43c0e8165c7a1af3679e1c0517474ad133daf34763e19f79b7e365e54e3ff24b777f2198d2aedb6422c127a9841bf91c
+  checksum: 10c0/2306214178f738b58bdd6fc40ad8e98faef96bec93b599050cdbd5c8c99cde599a30055ec9920b25c94fc914e7c7cf0a1778115b3dc23e07a2b5fa6aaf0e7e47
   languageName: node
   linkType: hard
 
@@ -49913,7 +49905,7 @@ __metadata:
     ts-jest: "npm:^29.1.1"
     ts-node: "npm:10.9.1"
     tsconfig-paths: "npm:^4.2.0"
-    tsdav: "npm:^2.2.0"
+    tsdav: "npm:^2.2.1"
     tslib: "npm:2.8.1"
     twenty-client-sdk: "workspace:*"
     twenty-emails: "workspace:*"


### PR DESCRIPTION
Fixes #25683

RFC 4791 §5.2.3 makes `supported-calendar-component-set` optional, and states that in its absence the server accepts every component type. Twenty read an absent set as "VEVENT unsupported", so connecting a Purelymail account failed with `No calendar with event support found`.

tsdav ran the same stricter filter inside `fetchCalendars` until 2.2.1, so the calendar never reached our filter — the range is bumped past that fix. A calendar that does publish a set without VEVENT is still skipped.

Integration coverage proxies Radicale (which always publishes the property) to strip it off the wire.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

