### PR TITLE
Compare a record relation to the current member's relation in row-level permissions

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useBuildRecordInputFromRLSPredicates.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useBuildRecordInputFromRLSPredicates.ts
@@ -72,7 +72,9 @@ export const useBuildRecordInputFromRLSPredicates = ({
     }
 
     let workspaceMemberFieldValue =
-      currentWorkspaceMemberRecord?.[workspaceMemberFieldMetadataItem.name];
+      currentWorkspaceMemberRecord?.[
+        getRecordInputFieldName(workspaceMemberFieldMetadataItem)
+      ];
 
     if (isCompositeFieldType(workspaceMemberFieldMetadataItem.type)) {
       if (!workspaceMemberSubFieldName) {

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelPermissionFieldSelectFieldMenu.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelPermissionFieldSelectFieldMenu.tsx
@@ -4,6 +4,7 @@ import { useLingui } from '@lingui/react/macro';
 import { getFilterTypeFromFieldType } from 'twenty-shared/utils';
 
 import { CoreObjectNameSingular, FieldMetadataType } from 'twenty-shared/types';
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { AdvancedFilterFieldSelectSearchInput } from '@/object-record/advanced-filter/components/AdvancedFilterFieldSelectSearchInput';
 import { useAdvancedFilterFieldSelectDropdown } from '@/object-record/advanced-filter/hooks/useAdvancedFilterFieldSelectDropdown';
@@ -18,6 +19,7 @@ import { objectFilterDropdownSubMenuFieldTypeComponentState } from '@/object-rec
 import { isCompositeFilterableFieldType } from '@/object-record/object-filter-dropdown/utils/isCompositeFilterableFieldType';
 import { useFilterableFieldMetadataItems } from '@/object-record/record-filter/hooks/useFilterableFieldMetadataItems';
 import { RECORD_LEVEL_PERMISSION_PREDICATE_FIELD_TYPES } from '@/settings/roles/role-permissions/object-level-permissions/record-level-permissions/constants/RecordLevelPermissionPredicateFieldTypes';
+import { getComparableWorkspaceMemberRelationFields } from '@/settings/roles/role-permissions/object-level-permissions/record-level-permissions/utils/getComparableWorkspaceMemberRelationFields';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSectionLabel } from '@/ui/layout/dropdown/components/DropdownMenuSectionLabel';
@@ -55,18 +57,50 @@ export const SettingsRolePermissionsObjectLevelRecordLevelPermissionFieldSelectF
       objectMetadataItem.id,
     );
 
+    const { objectMetadataItem: workspaceMemberObjectMetadataItem } =
+      useObjectMetadataItem({
+        objectNameSingular: CoreObjectNameSingular.WorkspaceMember,
+      });
+
+    const isPredicateFieldMetadataItem = (
+      fieldMetadataItem: FieldMetadataItem,
+    ) => {
+      if (
+        RECORD_LEVEL_PERMISSION_PREDICATE_FIELD_TYPES.includes(
+          fieldMetadataItem.type,
+        )
+      ) {
+        return true;
+      }
+
+      if (fieldMetadataItem.type !== FieldMetadataType.RELATION) {
+        return false;
+      }
+
+      if (
+        fieldMetadataItem.relation?.targetObjectMetadata.nameSingular ===
+        CoreObjectNameSingular.WorkspaceMember
+      ) {
+        return true;
+      }
+
+      return (
+        getComparableWorkspaceMemberRelationFields({
+          workspaceMemberFieldMetadataItems:
+            workspaceMemberObjectMetadataItem?.fields ?? [],
+          targetObjectMetadataId:
+            fieldMetadataItem.relation?.targetObjectMetadata.id,
+        }).length > 0
+      );
+    };
+
     const filteredFieldMetadataItems = filterableFieldMetadataItems
       .filter(
         (fieldMetadataItem) =>
           fieldMetadataItem.label
             .toLocaleLowerCase()
             .includes(objectFilterDropdownSearchInput.toLocaleLowerCase()) &&
-          (RECORD_LEVEL_PERMISSION_PREDICATE_FIELD_TYPES.includes(
-            fieldMetadataItem.type,
-          ) ||
-            (fieldMetadataItem.type === FieldMetadataType.RELATION &&
-              fieldMetadataItem.relation?.targetObjectMetadata.nameSingular ===
-                CoreObjectNameSingular.WorkspaceMember)),
+          isPredicateFieldMetadataItem(fieldMetadataItem),
       )
       .sort((a, b) => a.label.localeCompare(b.label));
 

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelPermissionMeValueSelect.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelPermissionMeValueSelect.tsx
@@ -24,6 +24,7 @@ import { SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS } from '@/settings/data-model/con
 import { type CompositeFieldSubFieldName } from '@/settings/data-model/types/CompositeFieldSubFieldName';
 import { type CompositeFieldType } from '@/settings/data-model/types/CompositeFieldType';
 import { RECORD_LEVEL_PERMISSION_PREDICATE_FIELD_TYPES } from '@/settings/roles/role-permissions/object-level-permissions/record-level-permissions/constants/RecordLevelPermissionPredicateFieldTypes';
+import { getComparableWorkspaceMemberRelationFields } from '@/settings/roles/role-permissions/object-level-permissions/record-level-permissions/utils/getComparableWorkspaceMemberRelationFields';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
 import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
@@ -110,48 +111,66 @@ export const SettingsRolePermissionsObjectLevelRecordLevelPermissionMeValueSelec
       }
     }
 
-    const compatibleWorkspaceMemberFields = !isDefined(
-      workspaceMemberMetadataItem,
-    )
-      ? []
-      : workspaceMemberMetadataItem.fields.filter((field) => {
-          if (
-            field.name === 'createdAt' ||
-            field.name === 'updatedAt' ||
-            field.name === 'deletedAt' ||
-            field.name === 'id'
-          ) {
-            return false;
-          }
+    const isRelationToWorkspaceMember =
+      selectedFieldMetadataItem?.type === FieldMetadataType.RELATION &&
+      selectedFieldMetadataItem.relation?.targetObjectMetadata.nameSingular ===
+        CoreObjectNameSingular.WorkspaceMember;
 
-          if (!targetFieldType) {
-            return true;
-          }
+    const getCompatibleWorkspaceMemberFields = () => {
+      if (!isDefined(workspaceMemberMetadataItem)) {
+        return [];
+      }
 
-          if (
-            !RECORD_LEVEL_PERMISSION_PREDICATE_FIELD_TYPES.includes(
-              targetFieldType,
-            )
-          ) {
-            return false;
-          }
-
-          if (field.type === targetFieldType) {
-            return true;
-          }
-
-          if (isCompositeFieldType(field.type)) {
-            const fieldCompositeType = compositeTypeDefinitions.get(field.type);
-
-            if (isDefined(fieldCompositeType)) {
-              return fieldCompositeType.properties.some(
-                (property) => property.type === targetFieldType,
-              );
-            }
-          }
-
-          return false;
+      if (selectedFieldMetadataItem?.type === FieldMetadataType.RELATION) {
+        return getComparableWorkspaceMemberRelationFields({
+          workspaceMemberFieldMetadataItems: workspaceMemberMetadataItem.fields,
+          targetObjectMetadataId:
+            selectedFieldMetadataItem.relation?.targetObjectMetadata.id,
         });
+      }
+
+      return workspaceMemberMetadataItem.fields.filter((field) => {
+        if (
+          field.name === 'createdAt' ||
+          field.name === 'updatedAt' ||
+          field.name === 'deletedAt' ||
+          field.name === 'id'
+        ) {
+          return false;
+        }
+
+        if (!targetFieldType) {
+          return true;
+        }
+
+        if (
+          !RECORD_LEVEL_PERMISSION_PREDICATE_FIELD_TYPES.includes(
+            targetFieldType,
+          )
+        ) {
+          return false;
+        }
+
+        if (field.type === targetFieldType) {
+          return true;
+        }
+
+        if (isCompositeFieldType(field.type)) {
+          const fieldCompositeType = compositeTypeDefinitions.get(field.type);
+
+          if (isDefined(fieldCompositeType)) {
+            return fieldCompositeType.properties.some(
+              (property) => property.type === targetFieldType,
+            );
+          }
+        }
+
+        return false;
+      });
+    };
+
+    const compatibleWorkspaceMemberFields =
+      getCompatibleWorkspaceMemberFields();
 
     const handleSelectField = (
       fieldMetadataId: string,
@@ -160,11 +179,6 @@ export const SettingsRolePermissionsObjectLevelRecordLevelPermissionMeValueSelec
       onSelect(fieldMetadataId, subFieldName);
       closeDropdown();
     };
-
-    const isRelationToWorkspaceMember =
-      selectedFieldMetadataItem?.type === FieldMetadataType.RELATION &&
-      selectedFieldMetadataItem.relation?.targetObjectMetadata.nameSingular ===
-        CoreObjectNameSingular.WorkspaceMember;
 
     const menuItems: Array<{
       id: string;

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/utils/__tests__/getComparableWorkspaceMemberRelationFields.test.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/utils/__tests__/getComparableWorkspaceMemberRelationFields.test.ts
@@ -1,0 +1,97 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { getComparableWorkspaceMemberRelationFields } from '@/settings/roles/role-permissions/object-level-permissions/record-level-permissions/utils/getComparableWorkspaceMemberRelationFields';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { RelationType } from '~/generated-metadata/graphql';
+
+const REGION_OBJECT_ID = '20202020-0000-4000-8000-000000000001';
+const TEAM_OBJECT_ID = '20202020-0000-4000-8000-000000000002';
+
+const buildRelationField = ({
+  name,
+  targetObjectMetadataId,
+  relationType,
+}: {
+  name: string;
+  targetObjectMetadataId: string;
+  relationType: RelationType;
+}) =>
+  ({
+    id: `field-${name}`,
+    name,
+    label: name,
+    type: FieldMetadataType.RELATION,
+    relation: {
+      type: relationType,
+      targetObjectMetadata: { id: targetObjectMetadataId },
+    },
+  }) as FieldMetadataItem;
+
+const regionField = buildRelationField({
+  name: 'region',
+  targetObjectMetadataId: REGION_OBJECT_ID,
+  relationType: RelationType.MANY_TO_ONE,
+});
+
+const teamField = buildRelationField({
+  name: 'team',
+  targetObjectMetadataId: TEAM_OBJECT_ID,
+  relationType: RelationType.MANY_TO_ONE,
+});
+
+const regionsField = buildRelationField({
+  name: 'regions',
+  targetObjectMetadataId: REGION_OBJECT_ID,
+  relationType: RelationType.ONE_TO_MANY,
+});
+
+const jobTitleField = {
+  id: 'field-jobTitle',
+  name: 'jobTitle',
+  label: 'Job Title',
+  type: FieldMetadataType.TEXT,
+} as FieldMetadataItem;
+
+const workspaceMemberFieldMetadataItems = [
+  regionField,
+  teamField,
+  regionsField,
+  jobTitleField,
+];
+
+describe('getComparableWorkspaceMemberRelationFields', () => {
+  it('returns the many-to-one relations pointing to the target object', () => {
+    const result = getComparableWorkspaceMemberRelationFields({
+      workspaceMemberFieldMetadataItems,
+      targetObjectMetadataId: REGION_OBJECT_ID,
+    });
+
+    expect(result).toEqual([regionField]);
+  });
+
+  it('excludes relations pointing to another object', () => {
+    const result = getComparableWorkspaceMemberRelationFields({
+      workspaceMemberFieldMetadataItems,
+      targetObjectMetadataId: TEAM_OBJECT_ID,
+    });
+
+    expect(result).toEqual([teamField]);
+  });
+
+  it('returns nothing when the target object is unknown', () => {
+    const result = getComparableWorkspaceMemberRelationFields({
+      workspaceMemberFieldMetadataItems,
+      targetObjectMetadataId: undefined,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns nothing when no relation matches', () => {
+    const result = getComparableWorkspaceMemberRelationFields({
+      workspaceMemberFieldMetadataItems: [jobTitleField, regionsField],
+      targetObjectMetadataId: TEAM_OBJECT_ID,
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/utils/getComparableWorkspaceMemberRelationFields.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/utils/getComparableWorkspaceMemberRelationFields.ts
@@ -1,0 +1,26 @@
+/* @license Enterprise */
+
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { RelationType } from '~/generated-metadata/graphql';
+
+export const getComparableWorkspaceMemberRelationFields = ({
+  workspaceMemberFieldMetadataItems,
+  targetObjectMetadataId,
+}: {
+  workspaceMemberFieldMetadataItems: FieldMetadataItem[];
+  targetObjectMetadataId: string | undefined;
+}): FieldMetadataItem[] => {
+  if (!isDefined(targetObjectMetadataId)) {
+    return [];
+  }
+
+  return workspaceMemberFieldMetadataItems.filter(
+    (fieldMetadataItem) =>
+      fieldMetadataItem.type === FieldMetadataType.RELATION &&
+      fieldMetadataItem.relation?.type === RelationType.MANY_TO_ONE &&
+      fieldMetadataItem.relation.targetObjectMetadata.id ===
+        targetObjectMetadataId,
+  );
+};

--- a/packages/twenty-server/src/engine/metadata-modules/role/tools/upsert-row-level-permission-rules.tool.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/role/tools/upsert-row-level-permission-rules.tool.ts
@@ -48,7 +48,7 @@ const rowLevelPermissionPredicateSchema = z.object({
     .nullable()
     .optional()
     .describe(
-      'Dynamic comparison: id of a field on the workspaceMember object whose value for the CURRENT user is substituted at query time. Use the workspaceMember "id" field to express "matches the current user".',
+      'Dynamic comparison: id of a field on the workspaceMember object whose value for the CURRENT user is substituted at query time. Use the workspaceMember "id" field to express "matches the current user", or a many-to-one relation field to compare against a relation on the record pointing at the same object.',
     ),
   workspaceMemberSubFieldName: z
     .string()
@@ -118,6 +118,7 @@ export const createUpsertRowLevelPermissionRulesTool = (
   description: `Set row-level permission rules restricting which records members with a role can see on a given object (enterprise feature).
 
 Example, "members with this role only see records where the owner field matches the current user": pass one predicate with fieldMetadataId = the owner field on the object, operand = IS, and workspaceMemberFieldMetadataId = the "id" field of the workspaceMember object (resolved to the current user at query time). Use metadata tools to look up field ids.
+The same works between relations: for "only records in my region", pass fieldMetadataId = a many-to-one relation on the object and workspaceMemberFieldMetadataId = a many-to-one relation on workspaceMember pointing at the same object, with operand IS.
 Combine several predicates with predicateGroups (AND / OR): give each new group a client-generated UUID and reference it from predicates via rowLevelPermissionPredicateGroupId.
 IMPORTANT: this replaces the full rule set for the role + object. Predicates or groups omitted from the lists are deleted; empty lists clear all rules. System-managed roles (like Admin) cannot be changed.`,
   inputSchema: upsertRowLevelPermissionRulesSchema,

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/resolve-workspace-member-predicate-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/resolve-workspace-member-predicate-value.util.spec.ts
@@ -1,0 +1,118 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { type OrmFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/orm-flat-field-metadata.type';
+import { resolveWorkspaceMemberPredicateValue } from 'src/engine/twenty-orm/utils/resolve-workspace-member-predicate-value.util';
+import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+const REGION_ID = '20202020-0000-4000-8000-000000000001';
+
+const buildFieldMetadata = (
+  fieldMetadata: Partial<OrmFlatFieldMetadata>,
+): OrmFlatFieldMetadata =>
+  ({
+    id: 'field-id',
+    name: 'region',
+    ...fieldMetadata,
+  }) as OrmFlatFieldMetadata;
+
+const buildWorkspaceMember = (properties: Record<string, unknown>) =>
+  properties as unknown as WorkspaceMemberWorkspaceEntity;
+
+describe('resolveWorkspaceMemberPredicateValue', () => {
+  it('should read a many-to-one relation from its join column', () => {
+    const result = resolveWorkspaceMemberPredicateValue({
+      workspaceMember: buildWorkspaceMember({ regionId: REGION_ID }),
+      workspaceMemberFieldMetadata: buildFieldMetadata({
+        type: FieldMetadataType.RELATION,
+        settings: { relationType: RelationType.MANY_TO_ONE },
+      }),
+      workspaceMemberSubFieldName: null,
+    });
+
+    expect(result).toBe(REGION_ID);
+  });
+
+  it('should return null when the relation is not set on the workspace member', () => {
+    const result = resolveWorkspaceMemberPredicateValue({
+      workspaceMember: buildWorkspaceMember({ regionId: null }),
+      workspaceMemberFieldMetadata: buildFieldMetadata({
+        type: FieldMetadataType.RELATION,
+        settings: { relationType: RelationType.MANY_TO_ONE },
+      }),
+      workspaceMemberSubFieldName: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for a one-to-many relation, which has no join column', () => {
+    const result = resolveWorkspaceMemberPredicateValue({
+      workspaceMember: buildWorkspaceMember({ regions: [{ id: REGION_ID }] }),
+      workspaceMemberFieldMetadata: buildFieldMetadata({
+        name: 'regions',
+        type: FieldMetadataType.RELATION,
+        settings: { relationType: RelationType.ONE_TO_MANY },
+      }),
+      workspaceMemberSubFieldName: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('should read a subfield of a composite field', () => {
+    const result = resolveWorkspaceMemberPredicateValue({
+      workspaceMember: buildWorkspaceMember({
+        name: { firstName: 'Jony', lastName: 'Ive' },
+      }),
+      workspaceMemberFieldMetadata: buildFieldMetadata({
+        name: 'name',
+        type: FieldMetadataType.FULL_NAME,
+      }),
+      workspaceMemberSubFieldName: 'firstName',
+    });
+
+    expect(result).toBe('Jony');
+  });
+
+  it('should return null when the composite subfield is empty', () => {
+    const result = resolveWorkspaceMemberPredicateValue({
+      workspaceMember: buildWorkspaceMember({
+        name: { firstName: null, lastName: 'Ive' },
+      }),
+      workspaceMemberFieldMetadata: buildFieldMetadata({
+        name: 'name',
+        type: FieldMetadataType.FULL_NAME,
+      }),
+      workspaceMemberSubFieldName: 'firstName',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('should wrap a select value in an array to match the multi-select filter format', () => {
+    const result = resolveWorkspaceMemberPredicateValue({
+      workspaceMember: buildWorkspaceMember({ area: 'EMEA' }),
+      workspaceMemberFieldMetadata: buildFieldMetadata({
+        name: 'area',
+        type: FieldMetadataType.SELECT,
+      }),
+      workspaceMemberSubFieldName: null,
+    });
+
+    expect(result).toEqual(['EMEA']);
+  });
+
+  it('should return a scalar value as is', () => {
+    const result = resolveWorkspaceMemberPredicateValue({
+      workspaceMember: buildWorkspaceMember({ jobTitle: 'Designer' }),
+      workspaceMemberFieldMetadata: buildFieldMetadata({
+        name: 'jobTitle',
+        type: FieldMetadataType.TEXT,
+      }),
+      workspaceMemberSubFieldName: null,
+    });
+
+    expect(result).toBe('Designer');
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/validate-predicate-value-compatibility.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/validate-predicate-value-compatibility.util.spec.ts
@@ -1,9 +1,9 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { validateEnumValueCompatibility } from 'src/engine/twenty-orm/utils/validate-enum-value-compatibility.util';
+import { validatePredicateValueCompatibility } from 'src/engine/twenty-orm/utils/validate-predicate-value-compatibility.util';
 
-describe('validateEnumValueCompatibility', () => {
+describe('validatePredicateValueCompatibility', () => {
   const createMockFieldMetadata = (
     type: FieldMetadataType,
     options?: Array<{ value: string; label: string }>,
@@ -32,7 +32,7 @@ describe('validateEnumValueCompatibility', () => {
         { value: 'option3', label: 'Option 3' },
       ]);
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: 'option1',
@@ -55,7 +55,7 @@ describe('validateEnumValueCompatibility', () => {
         { value: 'option4', label: 'Option 4' },
       ]);
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: 'option1',
@@ -82,7 +82,7 @@ describe('validateEnumValueCompatibility', () => {
         ],
       );
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: ['option1', 'option2'],
@@ -108,7 +108,7 @@ describe('validateEnumValueCompatibility', () => {
         ],
       );
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: ['option1', 'option2'],
@@ -125,7 +125,7 @@ describe('validateEnumValueCompatibility', () => {
 
       const targetField = createMockFieldMetadata(FieldMetadataType.SELECT, []);
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: 'option1',
@@ -148,7 +148,7 @@ describe('validateEnumValueCompatibility', () => {
         ],
       );
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: 'option1',
@@ -168,7 +168,7 @@ describe('validateEnumValueCompatibility', () => {
         { value: 'option1', label: 'Option 1' },
       ]);
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: 'some text',
@@ -185,7 +185,7 @@ describe('validateEnumValueCompatibility', () => {
 
       const targetField = createMockFieldMetadata(FieldMetadataType.TEXT);
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: 'option1',
@@ -201,7 +201,7 @@ describe('validateEnumValueCompatibility', () => {
 
       const targetField = createMockFieldMetadata(FieldMetadataType.TEXT);
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: 'some text',
@@ -222,7 +222,7 @@ describe('validateEnumValueCompatibility', () => {
         { value: 'option1', label: 'Option 1' },
       ]);
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: undefined,
@@ -241,7 +241,7 @@ describe('validateEnumValueCompatibility', () => {
         { value: 'option1', label: 'Option 1' },
       ]);
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: null,
@@ -261,10 +261,70 @@ describe('validateEnumValueCompatibility', () => {
         [{ value: 'option1', label: 'Option 1' }],
       );
 
-      const result = validateEnumValueCompatibility({
+      const result = validatePredicateValueCompatibility({
         workspaceMemberFieldMetadata: workspaceMemberField,
         targetFieldMetadata: targetField,
         predicateValue: [],
+      });
+
+      expect(result).toBe(true);
+    });
+  });
+  describe('when the workspace member field is a relation', () => {
+    const createMockRelationFieldMetadata = (
+      relationTargetObjectMetadataId: string,
+    ): FlatFieldMetadata => {
+      return {
+        id: 'mock-relation-id',
+        name: 'region',
+        type: FieldMetadataType.RELATION,
+        relationTargetObjectMetadataId,
+      } as FlatFieldMetadata;
+    };
+
+    it('should return true when both relations target the same object', () => {
+      const result = validatePredicateValueCompatibility({
+        workspaceMemberFieldMetadata:
+          createMockRelationFieldMetadata('region-object-id'),
+        targetFieldMetadata:
+          createMockRelationFieldMetadata('region-object-id'),
+        predicateValue: '20202020-0000-0000-0000-000000000001',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when the relations target different objects', () => {
+      const result = validatePredicateValueCompatibility({
+        workspaceMemberFieldMetadata:
+          createMockRelationFieldMetadata('region-object-id'),
+        targetFieldMetadata: createMockRelationFieldMetadata('team-object-id'),
+        predicateValue: '20202020-0000-0000-0000-000000000001',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when the target field is not a relation', () => {
+      const result = validatePredicateValueCompatibility({
+        workspaceMemberFieldMetadata:
+          createMockRelationFieldMetadata('region-object-id'),
+        targetFieldMetadata: createMockFieldMetadata(FieldMetadataType.TEXT),
+        predicateValue: '20202020-0000-0000-0000-000000000001',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should keep allowing the workspace member id against a relation field', () => {
+      const result = validatePredicateValueCompatibility({
+        workspaceMemberFieldMetadata: createMockFieldMetadata(
+          FieldMetadataType.UUID,
+        ),
+        targetFieldMetadata: createMockRelationFieldMetadata(
+          'workspace-member-object-id',
+        ),
+        predicateValue: '20202020-0000-0000-0000-000000000001',
       });
 
       expect(result).toBe(true);

--- a/packages/twenty-server/src/engine/twenty-orm/utils/build-row-level-permission-record-filter.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/build-row-level-permission-record-filter.util.ts
@@ -1,7 +1,6 @@
 /* @license Enterprise */
 
 import {
-  FieldMetadataType,
   RecordFilterGroupLogicalOperator,
   RowLevelPermissionPredicateGroupLogicalOperator,
   type CompositeFieldSubFieldName,
@@ -18,7 +17,6 @@ import {
 } from 'twenty-shared/utils';
 
 import { type UserWorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
-import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { type OrmFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/orm-flat-field-metadata.type';
@@ -29,7 +27,8 @@ import {
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { type FlatRowLevelPermissionPredicateGroupMaps } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate-group-maps.type';
 import { type FlatRowLevelPermissionPredicateMaps } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate-maps.type';
-import { validateEnumValueCompatibility } from 'src/engine/twenty-orm/utils/validate-enum-value-compatibility.util';
+import { resolveWorkspaceMemberPredicateValue } from 'src/engine/twenty-orm/utils/resolve-workspace-member-predicate-value.util';
+import { validatePredicateValueCompatibility } from 'src/engine/twenty-orm/utils/validate-predicate-value-compatibility.util';
 
 type BuildRecordFilterForRoleArgs = {
   flatRowLevelPermissionPredicateMaps: FlatRowLevelPermissionPredicateMaps;
@@ -100,51 +99,28 @@ const buildRecordFilterForRole = ({
           return null;
         }
 
-        const rawWorkspaceMemberValue = Object.entries(workspaceMember).find(
-          ([key]) => key === workspaceMemberFieldMetadata.name,
-        )?.[1];
+        const resolvedWorkspaceMemberValue =
+          resolveWorkspaceMemberPredicateValue({
+            workspaceMember,
+            workspaceMemberFieldMetadata,
+            workspaceMemberSubFieldName: predicate.workspaceMemberSubFieldName,
+          });
 
-        const workspaceMemberSubFieldName =
-          predicate.workspaceMemberSubFieldName;
-
-        if (!isDefined(rawWorkspaceMemberValue)) {
+        if (!isDefined(resolvedWorkspaceMemberValue)) {
           return null;
         }
 
-        if (
-          isDefined(workspaceMemberSubFieldName) &&
-          isCompositeFieldMetadataType(workspaceMemberFieldMetadata.type) &&
-          typeof rawWorkspaceMemberValue === 'object'
-        ) {
-          predicateValue = rawWorkspaceMemberValue[workspaceMemberSubFieldName];
-        } else {
-          predicateValue = rawWorkspaceMemberValue;
-        }
-
-        if (!isDefined(predicateValue)) {
-          return null;
-        }
-
-        const isEnumValueCompatible = validateEnumValueCompatibility({
+        const isPredicateValueCompatible = validatePredicateValueCompatibility({
           workspaceMemberFieldMetadata,
           targetFieldMetadata: fieldMetadata,
-          predicateValue,
+          predicateValue: resolvedWorkspaceMemberValue,
         });
 
-        if (!isEnumValueCompatible) {
+        if (!isPredicateValueCompatible) {
           return null;
         }
 
-        // When workspace member field is SELECT or MULTI_SELECT and value is a string,
-        // wrap it in an array to match the frontend format (which uses multi-select UI)
-        if (
-          (workspaceMemberFieldMetadata.type === FieldMetadataType.SELECT ||
-            workspaceMemberFieldMetadata.type ===
-              FieldMetadataType.MULTI_SELECT) &&
-          typeof predicateValue === 'string'
-        ) {
-          predicateValue = [predicateValue];
-        }
+        predicateValue = resolvedWorkspaceMemberValue;
       }
 
       const effectiveSubFieldName = predicate.subFieldName as

--- a/packages/twenty-server/src/engine/twenty-orm/utils/resolve-workspace-member-predicate-value.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/resolve-workspace-member-predicate-value.util.ts
@@ -4,7 +4,8 @@ import {
   FieldMetadataType,
   type RowLevelPermissionPredicateValue,
 } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
+import { isNonEmptyString } from '@sniptt/guards';
+import { isDefined, isPlainObject } from 'twenty-shared/utils';
 
 import { type UserWorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
@@ -22,8 +23,8 @@ type ResolveWorkspaceMemberPredicateValueArgs = {
 const isOwningRelationFlatFieldMetadata = (
   flatFieldMetadata: OrmFlatFieldMetadata,
 ): boolean =>
-  isMorphOrRelationFlatFieldMetadata(flatFieldMetadata) &&
   flatFieldMetadata.type === FieldMetadataType.RELATION &&
+  isMorphOrRelationFlatFieldMetadata(flatFieldMetadata) &&
   flatFieldMetadata.settings?.relationType === RelationType.MANY_TO_ONE;
 
 export const resolveWorkspaceMemberPredicateValue = ({
@@ -31,17 +32,28 @@ export const resolveWorkspaceMemberPredicateValue = ({
   workspaceMemberFieldMetadata,
   workspaceMemberSubFieldName,
 }: ResolveWorkspaceMemberPredicateValueArgs): RowLevelPermissionPredicateValue | null => {
-  const workspaceMemberPropertyName = isOwningRelationFlatFieldMetadata(
-    workspaceMemberFieldMetadata,
-  )
-    ? computeMorphOrRelationFieldJoinColumnName({
-        name: workspaceMemberFieldMetadata.name,
-      })
-    : workspaceMemberFieldMetadata.name;
+  const workspaceMemberValues = workspaceMember as unknown as Record<
+    string,
+    unknown
+  >;
 
-  const rawWorkspaceMemberValue = Object.entries(workspaceMember).find(
-    ([key]) => key === workspaceMemberPropertyName,
-  )?.[1];
+  if (isMorphOrRelationFlatFieldMetadata(workspaceMemberFieldMetadata)) {
+    if (!isOwningRelationFlatFieldMetadata(workspaceMemberFieldMetadata)) {
+      return null;
+    }
+
+    const relatedRecordId =
+      workspaceMemberValues[
+        computeMorphOrRelationFieldJoinColumnName({
+          name: workspaceMemberFieldMetadata.name,
+        })
+      ];
+
+    return isNonEmptyString(relatedRecordId) ? relatedRecordId : null;
+  }
+
+  const rawWorkspaceMemberValue =
+    workspaceMemberValues[workspaceMemberFieldMetadata.name];
 
   if (!isDefined(rawWorkspaceMemberValue)) {
     return null;
@@ -50,7 +62,7 @@ export const resolveWorkspaceMemberPredicateValue = ({
   const workspaceMemberValue =
     isDefined(workspaceMemberSubFieldName) &&
     isCompositeFieldMetadataType(workspaceMemberFieldMetadata.type) &&
-    typeof rawWorkspaceMemberValue === 'object'
+    isPlainObject(rawWorkspaceMemberValue)
       ? rawWorkspaceMemberValue[workspaceMemberSubFieldName]
       : rawWorkspaceMemberValue;
 
@@ -66,5 +78,5 @@ export const resolveWorkspaceMemberPredicateValue = ({
     return [workspaceMemberValue];
   }
 
-  return workspaceMemberValue;
+  return workspaceMemberValue as RowLevelPermissionPredicateValue;
 };

--- a/packages/twenty-server/src/engine/twenty-orm/utils/resolve-workspace-member-predicate-value.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/resolve-workspace-member-predicate-value.util.ts
@@ -1,0 +1,70 @@
+/* @license Enterprise */
+
+import {
+  FieldMetadataType,
+  type RowLevelPermissionPredicateValue,
+} from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type UserWorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
+import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
+import { type OrmFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/orm-flat-field-metadata.type';
+import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
+
+type ResolveWorkspaceMemberPredicateValueArgs = {
+  workspaceMember: NonNullable<UserWorkspaceAuthContext['workspaceMember']>;
+  workspaceMemberFieldMetadata: OrmFlatFieldMetadata;
+  workspaceMemberSubFieldName: string | null;
+};
+
+const isOwningRelationFlatFieldMetadata = (
+  flatFieldMetadata: OrmFlatFieldMetadata,
+): boolean =>
+  isMorphOrRelationFlatFieldMetadata(flatFieldMetadata) &&
+  flatFieldMetadata.type === FieldMetadataType.RELATION &&
+  flatFieldMetadata.settings?.relationType === RelationType.MANY_TO_ONE;
+
+export const resolveWorkspaceMemberPredicateValue = ({
+  workspaceMember,
+  workspaceMemberFieldMetadata,
+  workspaceMemberSubFieldName,
+}: ResolveWorkspaceMemberPredicateValueArgs): RowLevelPermissionPredicateValue | null => {
+  const workspaceMemberPropertyName = isOwningRelationFlatFieldMetadata(
+    workspaceMemberFieldMetadata,
+  )
+    ? computeMorphOrRelationFieldJoinColumnName({
+        name: workspaceMemberFieldMetadata.name,
+      })
+    : workspaceMemberFieldMetadata.name;
+
+  const rawWorkspaceMemberValue = Object.entries(workspaceMember).find(
+    ([key]) => key === workspaceMemberPropertyName,
+  )?.[1];
+
+  if (!isDefined(rawWorkspaceMemberValue)) {
+    return null;
+  }
+
+  const workspaceMemberValue =
+    isDefined(workspaceMemberSubFieldName) &&
+    isCompositeFieldMetadataType(workspaceMemberFieldMetadata.type) &&
+    typeof rawWorkspaceMemberValue === 'object'
+      ? rawWorkspaceMemberValue[workspaceMemberSubFieldName]
+      : rawWorkspaceMemberValue;
+
+  if (!isDefined(workspaceMemberValue)) {
+    return null;
+  }
+
+  if (
+    (workspaceMemberFieldMetadata.type === FieldMetadataType.SELECT ||
+      workspaceMemberFieldMetadata.type === FieldMetadataType.MULTI_SELECT) &&
+    typeof workspaceMemberValue === 'string'
+  ) {
+    return [workspaceMemberValue];
+  }
+
+  return workspaceMemberValue;
+};

--- a/packages/twenty-server/src/engine/twenty-orm/utils/validate-predicate-value-compatibility.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/validate-predicate-value-compatibility.util.ts
@@ -3,17 +3,39 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type OrmFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/orm-flat-field-metadata.type';
 
-type ValidateEnumValueCompatibilityArgs = {
+type ValidatePredicateValueCompatibilityArgs = {
   workspaceMemberFieldMetadata: OrmFlatFieldMetadata;
   targetFieldMetadata: OrmFlatFieldMetadata;
   predicateValue: unknown;
 };
 
-export const validateEnumValueCompatibility = ({
+const validateRelationTargetCompatibility = ({
+  workspaceMemberFieldMetadata,
+  targetFieldMetadata,
+}: Omit<
+  ValidatePredicateValueCompatibilityArgs,
+  'predicateValue'
+>): boolean => {
+  if (workspaceMemberFieldMetadata.type !== FieldMetadataType.RELATION) {
+    return true;
+  }
+
+  const workspaceMemberRelationTargetObjectMetadataId =
+    workspaceMemberFieldMetadata.relationTargetObjectMetadataId;
+
+  return (
+    targetFieldMetadata.type === FieldMetadataType.RELATION &&
+    isDefined(workspaceMemberRelationTargetObjectMetadataId) &&
+    workspaceMemberRelationTargetObjectMetadataId ===
+      targetFieldMetadata.relationTargetObjectMetadataId
+  );
+};
+
+const validateEnumValueCompatibility = ({
   workspaceMemberFieldMetadata,
   targetFieldMetadata,
   predicateValue,
-}: ValidateEnumValueCompatibilityArgs): boolean => {
+}: ValidatePredicateValueCompatibilityArgs): boolean => {
   const isWorkspaceMemberFieldEnum =
     workspaceMemberFieldMetadata.type === FieldMetadataType.SELECT ||
     workspaceMemberFieldMetadata.type === FieldMetadataType.MULTI_SELECT;
@@ -45,3 +67,18 @@ export const validateEnumValueCompatibility = ({
 
   return allValuesAreValid;
 };
+
+export const validatePredicateValueCompatibility = ({
+  workspaceMemberFieldMetadata,
+  targetFieldMetadata,
+  predicateValue,
+}: ValidatePredicateValueCompatibilityArgs): boolean =>
+  validateRelationTargetCompatibility({
+    workspaceMemberFieldMetadata,
+    targetFieldMetadata,
+  }) &&
+  validateEnumValueCompatibility({
+    workspaceMemberFieldMetadata,
+    targetFieldMetadata,
+    predicateValue,
+  });

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
@@ -3,6 +3,8 @@ import {
   RowLevelPermissionPredicateOperand,
 } from 'twenty-shared/types';
 
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { FlatRowLevelPermissionPredicateValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service';
 
@@ -66,6 +68,8 @@ const relatedMaps = (fieldType: FieldMetadataType) => ({
       type: FieldMetadataType.UUID,
       name: 'id',
       label: 'Id',
+      objectMetadataUniversalIdentifier:
+        STANDARD_OBJECTS.workspaceMember.universalIdentifier,
     },
     {
       universalIdentifier: WORKSPACE_MEMBER_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
@@ -75,6 +79,8 @@ const relatedMaps = (fieldType: FieldMetadataType) => ({
       universalSettings: { relationType: RelationType.MANY_TO_ONE },
       relationTargetObjectMetadataUniversalIdentifier:
         RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+      objectMetadataUniversalIdentifier:
+        STANDARD_OBJECTS.workspaceMember.universalIdentifier,
     },
     {
       universalIdentifier:
@@ -85,6 +91,8 @@ const relatedMaps = (fieldType: FieldMetadataType) => ({
       universalSettings: { relationType: RelationType.MANY_TO_ONE },
       relationTargetObjectMetadataUniversalIdentifier:
         OTHER_RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+      objectMetadataUniversalIdentifier:
+        STANDARD_OBJECTS.workspaceMember.universalIdentifier,
     },
   ]),
   flatObjectMetadataMaps: mapsFrom([
@@ -278,6 +286,23 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0].message).toContain(
         'must be relations pointing to the same object',
+      );
+    });
+
+    it('should reject a member field that belongs to another object', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: null,
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain(
+        'is not a field of the workspaceMember object',
       );
     });
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
@@ -18,6 +18,10 @@ const WORKSPACE_MEMBER_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
   '00000000-0000-4000-8000-0000000000b3';
 const WORKSPACE_MEMBER_OTHER_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
   '00000000-0000-4000-8000-0000000000b4';
+const ONE_TO_MANY_FIELD_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-0000000000b5';
+const WORKSPACE_MEMBER_MORPH_FIELD_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-0000000000b6';
 const RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER =
   '00000000-0000-4000-8000-0000000000c2';
 const OTHER_RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER =
@@ -36,13 +40,15 @@ const buildPredicate = ({
   operand,
   value,
   workspaceMemberFieldMetadataUniversalIdentifier = null,
+  fieldMetadataUniversalIdentifier = FIELD_UNIVERSAL_IDENTIFIER,
 }: {
   operand: RowLevelPermissionPredicateOperand;
   value: unknown;
   workspaceMemberFieldMetadataUniversalIdentifier?: string | null;
+  fieldMetadataUniversalIdentifier?: string;
 }) => ({
   universalIdentifier: PREDICATE_UNIVERSAL_IDENTIFIER,
-  fieldMetadataUniversalIdentifier: FIELD_UNIVERSAL_IDENTIFIER,
+  fieldMetadataUniversalIdentifier,
   objectMetadataUniversalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER,
   roleUniversalIdentifier: ROLE_UNIVERSAL_IDENTIFIER,
   rowLevelPermissionPredicateGroupUniversalIdentifier: null,
@@ -60,8 +66,29 @@ const relatedMaps = (fieldType: FieldMetadataType) => ({
       type: fieldType,
       name: 'accountOwner',
       label: 'Account Owner',
+      universalSettings: { relationType: RelationType.MANY_TO_ONE },
       relationTargetObjectMetadataUniversalIdentifier:
         RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+    },
+    {
+      universalIdentifier: ONE_TO_MANY_FIELD_UNIVERSAL_IDENTIFIER,
+      type: FieldMetadataType.RELATION,
+      name: 'people',
+      label: 'People',
+      universalSettings: { relationType: RelationType.ONE_TO_MANY },
+      relationTargetObjectMetadataUniversalIdentifier:
+        RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+    },
+    {
+      universalIdentifier: WORKSPACE_MEMBER_MORPH_FIELD_UNIVERSAL_IDENTIFIER,
+      type: FieldMetadataType.MORPH_RELATION,
+      name: 'target',
+      label: 'Target',
+      universalSettings: { relationType: RelationType.MANY_TO_ONE },
+      relationTargetObjectMetadataUniversalIdentifier:
+        RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+      objectMetadataUniversalIdentifier:
+        STANDARD_OBJECTS.workspaceMember.universalIdentifier,
     },
     {
       universalIdentifier: WORKSPACE_MEMBER_ID_FIELD_UNIVERSAL_IDENTIFIER,
@@ -106,17 +133,20 @@ const buildCreationArgs = ({
   operand,
   value,
   workspaceMemberFieldMetadataUniversalIdentifier = null,
+  fieldMetadataUniversalIdentifier,
 }: {
   fieldType: FieldMetadataType;
   operand: RowLevelPermissionPredicateOperand;
   value: unknown;
   workspaceMemberFieldMetadataUniversalIdentifier?: string | null;
+  fieldMetadataUniversalIdentifier?: string;
 }) =>
   ({
     flatEntityToValidate: buildPredicate({
       operand,
       value,
       workspaceMemberFieldMetadataUniversalIdentifier,
+      fieldMetadataUniversalIdentifier,
     }),
     optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
       flatRowLevelPermissionPredicateMaps: mapsFrom([]),
@@ -304,6 +334,40 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
       expect(result.errors[0].message).toContain(
         'is not a field of the workspaceMember object',
       );
+    });
+
+    it('should reject a morph relation on the workspace member', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: null,
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            WORKSPACE_MEMBER_MORPH_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain(
+        'is not a many-to-one relation, its value cannot be resolved',
+      );
+    });
+
+    it('should reject a record field that is not a many-to-one relation', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: null,
+          fieldMetadataUniversalIdentifier:
+            ONE_TO_MANY_FIELD_UNIVERSAL_IDENTIFIER,
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            WORKSPACE_MEMBER_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('has no join column');
     });
 
     it('should reject an operand the relation query filter cannot express', () => {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
@@ -3,12 +3,23 @@ import {
   RowLevelPermissionPredicateOperand,
 } from 'twenty-shared/types';
 
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { FlatRowLevelPermissionPredicateValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service';
 
 const PREDICATE_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000a1';
 const FIELD_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000b1';
 const OBJECT_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000c1';
 const ROLE_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000d1';
+const WORKSPACE_MEMBER_ID_FIELD_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-0000000000b2';
+const WORKSPACE_MEMBER_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-0000000000b3';
+const WORKSPACE_MEMBER_OTHER_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-0000000000b4';
+const RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-0000000000c2';
+const OTHER_RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER =
+  '00000000-0000-4000-8000-0000000000c3';
 const RECORD_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
 
 const mapsFrom = (
@@ -45,7 +56,35 @@ const relatedMaps = (fieldType: FieldMetadataType) => ({
     {
       universalIdentifier: FIELD_UNIVERSAL_IDENTIFIER,
       type: fieldType,
+      name: 'accountOwner',
       label: 'Account Owner',
+      relationTargetObjectMetadataUniversalIdentifier:
+        RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+    },
+    {
+      universalIdentifier: WORKSPACE_MEMBER_ID_FIELD_UNIVERSAL_IDENTIFIER,
+      type: FieldMetadataType.UUID,
+      name: 'id',
+      label: 'Id',
+    },
+    {
+      universalIdentifier: WORKSPACE_MEMBER_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+      type: FieldMetadataType.RELATION,
+      name: 'region',
+      label: 'Region',
+      universalSettings: { relationType: RelationType.MANY_TO_ONE },
+      relationTargetObjectMetadataUniversalIdentifier:
+        RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
+    },
+    {
+      universalIdentifier:
+        WORKSPACE_MEMBER_OTHER_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+      type: FieldMetadataType.RELATION,
+      name: 'team',
+      label: 'Team',
+      universalSettings: { relationType: RelationType.MANY_TO_ONE },
+      relationTargetObjectMetadataUniversalIdentifier:
+        OTHER_RELATION_TARGET_OBJECT_UNIVERSAL_IDENTIFIER,
     },
   ]),
   flatObjectMetadataMaps: mapsFrom([
@@ -204,11 +243,57 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
           operand: RowLevelPermissionPredicateOperand.IS,
           value: null,
           workspaceMemberFieldMetadataUniversalIdentifier:
-            FIELD_UNIVERSAL_IDENTIFIER,
+            WORKSPACE_MEMBER_ID_FIELD_UNIVERSAL_IDENTIFIER,
         }),
       );
 
       expect(result.errors).toEqual([]);
+    });
+
+    it('should accept two relations pointing to the same object', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: null,
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            WORKSPACE_MEMBER_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should reject two relations pointing to different objects', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: null,
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            WORKSPACE_MEMBER_OTHER_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain(
+        'must be relations pointing to the same object',
+      );
+    });
+
+    it('should reject an operand the relation query filter cannot express', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.CONTAINS,
+          value: null,
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            WORKSPACE_MEMBER_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('use IS or IS_NOT');
     });
   });
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -6,8 +6,8 @@ import { msg, t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import {
-  type FieldMetadataType,
-  type RowLevelPermissionPredicateOperand,
+  FieldMetadataType,
+  RowLevelPermissionPredicateOperand,
   type ViewFilterOperand,
 } from 'twenty-shared/types';
 import {
@@ -20,8 +20,12 @@ import {
   jsonRelationFilterValueSchema,
 } from 'twenty-shared/utils';
 
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { isMorphOrRelationUniversalFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { RowLevelPermissionPredicateExceptionCode } from 'src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate.exception';
+import { type UniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-maps.type';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
 import { FailedFlatEntityValidation } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
 import { FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/universal-flat-entity-update-validation-args.type';
@@ -90,6 +94,22 @@ export class FlatRowLevelPermissionPredicateValidatorService {
 
       if (isDefined(invalidValueError)) {
         validationResult.errors.push(invalidValueError);
+      }
+
+      const workspaceMemberFieldError = this.getWorkspaceMemberFieldError({
+        fieldMetadata,
+        operand: flatPredicateToValidate.operand,
+        workspaceMemberFieldMetadata: this.findWorkspaceMemberFieldMetadata({
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            flatPredicateToValidate.workspaceMemberFieldMetadataUniversalIdentifier,
+          flatFieldMetadataMaps,
+        }),
+        workspaceMemberFieldMetadataUniversalIdentifier:
+          flatPredicateToValidate.workspaceMemberFieldMetadataUniversalIdentifier,
+      });
+
+      if (isDefined(workspaceMemberFieldError)) {
+        validationResult.errors.push(workspaceMemberFieldError);
       }
     }
 
@@ -286,6 +306,22 @@ export class FlatRowLevelPermissionPredicateValidatorService {
       if (isDefined(invalidValueError)) {
         validationResult.errors.push(invalidValueError);
       }
+
+      const workspaceMemberFieldError = this.getWorkspaceMemberFieldError({
+        fieldMetadata,
+        operand: updatedPredicate.operand,
+        workspaceMemberFieldMetadata: this.findWorkspaceMemberFieldMetadata({
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            updatedPredicate.workspaceMemberFieldMetadataUniversalIdentifier,
+          flatFieldMetadataMaps,
+        }),
+        workspaceMemberFieldMetadataUniversalIdentifier:
+          updatedPredicate.workspaceMemberFieldMetadataUniversalIdentifier,
+      });
+
+      if (isDefined(workspaceMemberFieldError)) {
+        validationResult.errors.push(workspaceMemberFieldError);
+      }
     }
 
     const objectMetadata = flatObjectMetadataMaps
@@ -378,6 +414,106 @@ export class FlatRowLevelPermissionPredicateValidatorService {
       message: t`Value "${stringifiedValue}" resolves to no record for operand "${operand}", the current record is not available to a row level permission predicate`,
       userFriendlyMessage: msg`Predicate value is not valid for this operand`,
     };
+  }
+
+  private findWorkspaceMemberFieldMetadata({
+    workspaceMemberFieldMetadataUniversalIdentifier,
+    flatFieldMetadataMaps,
+  }: {
+    workspaceMemberFieldMetadataUniversalIdentifier: string | null | undefined;
+    flatFieldMetadataMaps:
+      | UniversalFlatEntityMaps<UniversalFlatFieldMetadata>
+      | undefined;
+  }): UniversalFlatFieldMetadata | undefined {
+    if (
+      !isDefined(workspaceMemberFieldMetadataUniversalIdentifier) ||
+      !isDefined(flatFieldMetadataMaps)
+    ) {
+      return undefined;
+    }
+
+    return findFlatEntityByUniversalIdentifier({
+      universalIdentifier: workspaceMemberFieldMetadataUniversalIdentifier,
+      flatEntityMaps: flatFieldMetadataMaps,
+    });
+  }
+
+  private getWorkspaceMemberFieldError({
+    fieldMetadata,
+    operand,
+    workspaceMemberFieldMetadata,
+    workspaceMemberFieldMetadataUniversalIdentifier,
+  }: {
+    fieldMetadata: UniversalFlatFieldMetadata;
+    operand: RowLevelPermissionPredicateOperand;
+    workspaceMemberFieldMetadata: UniversalFlatFieldMetadata | undefined;
+    workspaceMemberFieldMetadataUniversalIdentifier: string | null | undefined;
+  }) {
+    if (!isDefined(workspaceMemberFieldMetadataUniversalIdentifier)) {
+      return undefined;
+    }
+
+    if (!isDefined(workspaceMemberFieldMetadata)) {
+      return {
+        code: RowLevelPermissionPredicateExceptionCode.FIELD_METADATA_NOT_FOUND,
+        message: t`Workspace member field metadata not found`,
+        userFriendlyMessage: msg`Workspace member field metadata not found`,
+      };
+    }
+
+    if (
+      getFilterTypeFromFieldType(fieldMetadata.type) === 'RELATION' &&
+      operand !== RowLevelPermissionPredicateOperand.IS &&
+      operand !== RowLevelPermissionPredicateOperand.IS_NOT
+    ) {
+      return {
+        code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
+        message: t`Operand "${operand}" is not supported on a relation field, use IS or IS_NOT`,
+        userFriendlyMessage: msg`This operand is not supported on a relation field`,
+      };
+    }
+
+    if (
+      !isMorphOrRelationUniversalFlatFieldMetadata(
+        workspaceMemberFieldMetadata,
+      ) ||
+      workspaceMemberFieldMetadata.type !== FieldMetadataType.RELATION
+    ) {
+      return undefined;
+    }
+
+    if (
+      workspaceMemberFieldMetadata.universalSettings?.relationType !==
+      RelationType.MANY_TO_ONE
+    ) {
+      const workspaceMemberFieldName = workspaceMemberFieldMetadata.name;
+
+      return {
+        code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
+        message: t`Workspace member field "${workspaceMemberFieldName}" holds several records, only a many-to-one relation can be compared`,
+        userFriendlyMessage: msg`This workspace member field holds several records and cannot be compared`,
+      };
+    }
+
+    if (
+      fieldMetadata.type !== FieldMetadataType.RELATION ||
+      !isDefined(
+        workspaceMemberFieldMetadata.relationTargetObjectMetadataUniversalIdentifier,
+      ) ||
+      workspaceMemberFieldMetadata.relationTargetObjectMetadataUniversalIdentifier !==
+        fieldMetadata.relationTargetObjectMetadataUniversalIdentifier
+    ) {
+      const workspaceMemberFieldName = workspaceMemberFieldMetadata.name;
+      const fieldName = fieldMetadata.name;
+
+      return {
+        code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
+        message: t`Fields "${fieldName}" and "${workspaceMemberFieldName}" must be relations pointing to the same object to be compared`,
+        userFriendlyMessage: msg`These two relation fields do not point to the same object`,
+      };
+    }
+
+    return undefined;
   }
 
   private getInvalidValueError({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -438,6 +438,17 @@ export class FlatRowLevelPermissionPredicateValidatorService {
     });
   }
 
+  private isOwningRelationFlatFieldMetadata(
+    flatFieldMetadata: UniversalFlatFieldMetadata,
+  ): boolean {
+    return (
+      flatFieldMetadata.type === FieldMetadataType.RELATION &&
+      isMorphOrRelationUniversalFlatFieldMetadata(flatFieldMetadata) &&
+      flatFieldMetadata.universalSettings?.relationType ===
+        RelationType.MANY_TO_ONE
+    );
+  }
+
   private getWorkspaceMemberFieldError({
     fieldMetadata,
     operand,
@@ -474,8 +485,11 @@ export class FlatRowLevelPermissionPredicateValidatorService {
       };
     }
 
+    const isRecordFieldFilteredAsRelation =
+      getFilterTypeFromFieldType(fieldMetadata.type) === 'RELATION';
+
     if (
-      getFilterTypeFromFieldType(fieldMetadata.type) === 'RELATION' &&
+      isRecordFieldFilteredAsRelation &&
       operand !== RowLevelPermissionPredicateOperand.IS &&
       operand !== RowLevelPermissionPredicateOperand.IS_NOT
     ) {
@@ -487,24 +501,31 @@ export class FlatRowLevelPermissionPredicateValidatorService {
     }
 
     if (
-      !isMorphOrRelationUniversalFlatFieldMetadata(
-        workspaceMemberFieldMetadata,
-      ) ||
-      workspaceMemberFieldMetadata.type !== FieldMetadataType.RELATION
+      isRecordFieldFilteredAsRelation &&
+      !this.isOwningRelationFlatFieldMetadata(fieldMetadata)
+    ) {
+      const fieldName = fieldMetadata.name;
+
+      return {
+        code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
+        message: t`Field "${fieldName}" is not a many-to-one relation, it has no join column to compare against`,
+        userFriendlyMessage: msg`This relation field cannot be used in a record rule`,
+      };
+    }
+
+    if (
+      !isMorphOrRelationUniversalFlatFieldMetadata(workspaceMemberFieldMetadata)
     ) {
       return undefined;
     }
 
-    if (
-      workspaceMemberFieldMetadata.universalSettings?.relationType !==
-      RelationType.MANY_TO_ONE
-    ) {
+    if (!this.isOwningRelationFlatFieldMetadata(workspaceMemberFieldMetadata)) {
       const workspaceMemberFieldName = workspaceMemberFieldMetadata.name;
 
       return {
         code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
-        message: t`Workspace member field "${workspaceMemberFieldName}" holds several records, only a many-to-one relation can be compared`,
-        userFriendlyMessage: msg`This workspace member field holds several records and cannot be compared`,
+        message: t`Workspace member field "${workspaceMemberFieldName}" is not a many-to-one relation, its value cannot be resolved for the current user`,
+        userFriendlyMessage: msg`This workspace member field cannot be compared`,
       };
     }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@nestjs/common';
 
 import { msg, t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
-import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+import { ALL_METADATA_NAME, STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   FieldMetadataType,
   RowLevelPermissionPredicateOperand,
@@ -458,6 +458,19 @@ export class FlatRowLevelPermissionPredicateValidatorService {
         code: RowLevelPermissionPredicateExceptionCode.FIELD_METADATA_NOT_FOUND,
         message: t`Workspace member field metadata not found`,
         userFriendlyMessage: msg`Workspace member field metadata not found`,
+      };
+    }
+
+    if (
+      workspaceMemberFieldMetadata.objectMetadataUniversalIdentifier !==
+      STANDARD_OBJECTS.workspaceMember.universalIdentifier
+    ) {
+      const workspaceMemberFieldName = workspaceMemberFieldMetadata.name;
+
+      return {
+        code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
+        message: t`Field "${workspaceMemberFieldName}" is not a field of the workspaceMember object, the predicate would never apply`,
+        userFriendlyMessage: msg`This field does not belong to the workspace member object`,
       };
     }
 

--- a/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/record-level-permissions-on-relation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/record-level-permissions-on-relation.integration-spec.ts
@@ -1,0 +1,414 @@
+import { randomUUID } from 'node:crypto';
+
+import { COMPANY_GQL_FIELDS } from 'test/integration/constants/company-gql-fields.constants';
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { destroyManyOperationFactory } from 'test/integration/graphql/utils/destroy-many-operation-factory.util';
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { updateOneOperationFactory } from 'test/integration/graphql/utils/update-one-operation-factory.util';
+import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
+import { deleteOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/delete-one-field-metadata.util';
+import { createOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/create-one-object-metadata.util';
+import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { upsertRowLevelPermissionPredicates } from 'test/integration/metadata/suites/row-level-permission-predicate/utils/upsert-row-level-permission-predicates.util';
+import { createOneRole } from 'test/integration/metadata/suites/role/utils/create-one-role.util';
+import { deleteOneRole } from 'test/integration/metadata/suites/role/utils/delete-one-role.util';
+import { findOneRoleByLabel } from 'test/integration/metadata/suites/role/utils/find-one-role-by-label.util';
+import { updateWorkspaceMemberRole } from 'test/integration/metadata/suites/role/utils/update-workspace-member-role.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import { jestExpectToBeDefined } from 'test/utils/jest-expect-to-be-defined.util.test';
+import {
+  FieldMetadataType,
+  RowLevelPermissionPredicateOperand,
+} from 'twenty-shared/types';
+
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+const REGION_OBJECT_SINGULAR = 'rlsRegion';
+const REGION_OBJECT_PLURAL = 'rlsRegions';
+const REGION_FIELD_NAME = 'rlsRegion';
+const COMPANY_FIELD_NAME = 'rlsCompany';
+
+const MEMBER_REGION_ID = randomUUID();
+const OTHER_REGION_ID = randomUUID();
+
+const MEMBER_REGION_COMPANY_ID = randomUUID();
+const OTHER_REGION_COMPANY_ID = randomUUID();
+const CREATED_IN_MEMBER_REGION_COMPANY_ID = randomUUID();
+const CREATED_IN_OTHER_REGION_COMPANY_ID = randomUUID();
+
+const PREDICATE_ID = randomUUID();
+
+const ALL_COMPANY_IDS = [
+  MEMBER_REGION_COMPANY_ID,
+  OTHER_REGION_COMPANY_ID,
+  CREATED_IN_MEMBER_REGION_COMPANY_ID,
+  CREATED_IN_OTHER_REGION_COMPANY_ID,
+];
+
+const findSeededCompanyIdsAsRestrictedMember = async (): Promise<string[]> => {
+  const response = await makeGraphqlAPIRequest(
+    findManyOperationFactory({
+      objectMetadataSingularName: 'company',
+      objectMetadataPluralName: 'companies',
+      gqlFields: 'id',
+      filter: {
+        id: { in: [MEMBER_REGION_COMPANY_ID, OTHER_REGION_COMPANY_ID] },
+      },
+    }),
+    APPLE_JONY_MEMBER_ACCESS_TOKEN,
+  );
+
+  expect(response.body.errors).toBeUndefined();
+
+  return response.body.data.companies.edges.map(
+    (edge: { node: { id: string } }) => edge.node.id,
+  );
+};
+
+const createCompanyInRegionAsRestrictedMember = (
+  companyId: string,
+  regionId: string,
+) =>
+  makeGraphqlAPIRequest(
+    createOneOperationFactory({
+      objectMetadataSingularName: 'company',
+      gqlFields: COMPANY_GQL_FIELDS,
+      data: {
+        id: companyId,
+        name: `RLS Relation Company ${companyId}`,
+        [`${REGION_FIELD_NAME}Id`]: regionId,
+      },
+    }),
+    APPLE_JONY_MEMBER_ACCESS_TOKEN,
+  );
+
+describe('row-level permission predicates comparing two relation fields', () => {
+  let customRoleId: string;
+  let originalMemberRoleId: string;
+  let regionObjectMetadataId: string;
+  let companyRegionFieldMetadataId: string;
+  let workspaceMemberRegionFieldMetadataId: string;
+  let workspaceMemberCompanyFieldMetadataId: string;
+  let companyObjectMetadataId: string;
+
+  beforeAll(async () => {
+    const { data: regionObjectData } = await createOneObjectMetadata({
+      input: {
+        nameSingular: REGION_OBJECT_SINGULAR,
+        namePlural: REGION_OBJECT_PLURAL,
+        labelSingular: 'RLS Region',
+        labelPlural: 'RLS Regions',
+        icon: 'IconMap',
+        isLabelSyncedWithName: false,
+      },
+    });
+
+    regionObjectMetadataId = regionObjectData.createOneObject.id;
+
+    await createOneFieldMetadata({
+      input: {
+        name: 'name',
+        label: 'Name',
+        type: FieldMetadataType.TEXT,
+        objectMetadataId: regionObjectMetadataId,
+        isLabelSyncedWithName: false,
+      },
+    });
+
+    const objectMetadataRepository =
+      getCoreRepository<ObjectMetadataEntity>(ObjectMetadataEntity);
+
+    const companyObjectMetadata = await objectMetadataRepository.findOneOrFail({
+      where: { workspaceId: SEED_APPLE_WORKSPACE_ID, nameSingular: 'company' },
+    });
+
+    companyObjectMetadataId = companyObjectMetadata.id;
+
+    const workspaceMemberObjectMetadata =
+      await objectMetadataRepository.findOneOrFail({
+        where: {
+          workspaceId: SEED_APPLE_WORKSPACE_ID,
+          nameSingular: 'workspaceMember',
+        },
+      });
+
+    const { data: companyRegionFieldData } = await createOneFieldMetadata({
+      input: {
+        name: REGION_FIELD_NAME,
+        label: 'RLS Region',
+        type: FieldMetadataType.RELATION,
+        objectMetadataId: companyObjectMetadataId,
+        isLabelSyncedWithName: false,
+        relationCreationPayload: {
+          targetObjectMetadataId: regionObjectMetadataId,
+          targetFieldLabel: 'Companies',
+          targetFieldIcon: 'IconBuildingSkyscraper',
+          type: RelationType.MANY_TO_ONE,
+        },
+      },
+    });
+
+    companyRegionFieldMetadataId = companyRegionFieldData.createOneField.id;
+
+    const { data: workspaceMemberRegionFieldData } =
+      await createOneFieldMetadata({
+        input: {
+          name: REGION_FIELD_NAME,
+          label: 'RLS Region',
+          type: FieldMetadataType.RELATION,
+          objectMetadataId: workspaceMemberObjectMetadata.id,
+          isLabelSyncedWithName: false,
+          relationCreationPayload: {
+            targetObjectMetadataId: regionObjectMetadataId,
+            targetFieldLabel: 'Workspace Members',
+            targetFieldIcon: 'IconUser',
+            type: RelationType.MANY_TO_ONE,
+          },
+        },
+      });
+
+    workspaceMemberRegionFieldMetadataId =
+      workspaceMemberRegionFieldData.createOneField.id;
+
+    const { data: workspaceMemberCompanyFieldData } =
+      await createOneFieldMetadata({
+        input: {
+          name: COMPANY_FIELD_NAME,
+          label: 'RLS Company',
+          type: FieldMetadataType.RELATION,
+          objectMetadataId: workspaceMemberObjectMetadata.id,
+          isLabelSyncedWithName: false,
+          relationCreationPayload: {
+            targetObjectMetadataId: companyObjectMetadataId,
+            targetFieldLabel: 'RLS Workspace Members',
+            targetFieldIcon: 'IconUser',
+            type: RelationType.MANY_TO_ONE,
+          },
+        },
+      });
+
+    workspaceMemberCompanyFieldMetadataId =
+      workspaceMemberCompanyFieldData.createOneField.id;
+
+    for (const [regionId, name] of [
+      [MEMBER_REGION_ID, 'Member Region'],
+      [OTHER_REGION_ID, 'Other Region'],
+    ]) {
+      await makeGraphqlAPIRequest(
+        createOneOperationFactory({
+          objectMetadataSingularName: REGION_OBJECT_SINGULAR,
+          gqlFields: 'id',
+          data: { id: regionId, name },
+        }),
+      );
+    }
+
+    for (const [companyId, regionId] of [
+      [MEMBER_REGION_COMPANY_ID, MEMBER_REGION_ID],
+      [OTHER_REGION_COMPANY_ID, OTHER_REGION_ID],
+    ]) {
+      await makeGraphqlAPIRequest(
+        createOneOperationFactory({
+          objectMetadataSingularName: 'company',
+          gqlFields: COMPANY_GQL_FIELDS,
+          data: {
+            id: companyId,
+            name: `RLS Relation Company ${companyId}`,
+            [`${REGION_FIELD_NAME}Id`]: regionId,
+          },
+        }),
+      );
+    }
+
+    await makeGraphqlAPIRequest(
+      updateOneOperationFactory({
+        objectMetadataSingularName: 'workspaceMember',
+        gqlFields: 'id',
+        recordId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+        data: { [`${REGION_FIELD_NAME}Id`]: MEMBER_REGION_ID },
+      }),
+    );
+
+    const memberRole = await findOneRoleByLabel({ label: 'Member' });
+
+    originalMemberRoleId = memberRole.id;
+
+    const { data: roleData } = await createOneRole({
+      expectToFail: false,
+      input: {
+        label: 'RLS Relation Predicate Test Role',
+        description: 'Role comparing a company relation to a member relation',
+        icon: 'IconSettings',
+        canUpdateAllSettings: false,
+        canAccessAllTools: true,
+        canReadAllObjectRecords: true,
+        canUpdateAllObjectRecords: true,
+        canSoftDeleteAllObjectRecords: false,
+        canDestroyAllObjectRecords: false,
+        canBeAssignedToUsers: true,
+        canBeAssignedToAgents: false,
+        canBeAssignedToApiKeys: false,
+      },
+    });
+
+    const roleId = roleData?.createOneRole?.id;
+
+    jestExpectToBeDefined(roleId);
+
+    customRoleId = roleId;
+
+    await upsertRowLevelPermissionPredicates({
+      expectToFail: false,
+      input: {
+        roleId: customRoleId,
+        objectMetadataId: companyObjectMetadataId,
+        predicates: [
+          {
+            id: PREDICATE_ID,
+            fieldMetadataId: companyRegionFieldMetadataId,
+            operand: RowLevelPermissionPredicateOperand.IS,
+            workspaceMemberFieldMetadataId:
+              workspaceMemberRegionFieldMetadataId,
+          },
+        ],
+        predicateGroups: [],
+      },
+    });
+
+    await updateWorkspaceMemberRole({
+      expectToFail: false,
+      input: {
+        roleId: customRoleId,
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await updateWorkspaceMemberRole({
+      expectToFail: false,
+      input: {
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+        roleId: originalMemberRoleId,
+      },
+    });
+
+    await deleteOneRole({
+      expectToFail: false,
+      input: { idToDelete: customRoleId },
+    });
+
+    await makeGraphqlAPIRequest(
+      destroyManyOperationFactory({
+        objectMetadataSingularName: 'company',
+        objectMetadataPluralName: 'companies',
+        gqlFields: 'id',
+        filter: { id: { in: ALL_COMPANY_IDS } },
+      }),
+    );
+
+    await makeGraphqlAPIRequest(
+      updateOneOperationFactory({
+        objectMetadataSingularName: 'workspaceMember',
+        gqlFields: 'id',
+        recordId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+        data: { [`${REGION_FIELD_NAME}Id`]: null },
+      }),
+    );
+
+    for (const fieldMetadataId of [
+      companyRegionFieldMetadataId,
+      workspaceMemberRegionFieldMetadataId,
+      workspaceMemberCompanyFieldMetadataId,
+    ]) {
+      await deleteOneFieldMetadata({
+        expectToFail: false,
+        input: { idToDelete: fieldMetadataId },
+      });
+    }
+
+    await updateOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        idToUpdate: regionObjectMetadataId,
+        updatePayload: { isActive: false },
+      },
+    });
+
+    await deleteOneObjectMetadata({
+      input: { idToDelete: regionObjectMetadataId },
+    });
+  });
+
+  it('returns only the records sharing the current member relation', async () => {
+    expect(await findSeededCompanyIdsAsRestrictedMember()).toEqual([
+      MEMBER_REGION_COMPANY_ID,
+    ]);
+  });
+
+  it('allows creating a record in the current member region', async () => {
+    const response = await createCompanyInRegionAsRestrictedMember(
+      CREATED_IN_MEMBER_REGION_COMPANY_ID,
+      MEMBER_REGION_ID,
+    );
+
+    expect(response.body.errors).toBeUndefined();
+    expect(response.body.data.createCompany.id).toBe(
+      CREATED_IN_MEMBER_REGION_COMPANY_ID,
+    );
+  });
+
+  it('rejects creating a record in another region', async () => {
+    const response = await createCompanyInRegionAsRestrictedMember(
+      CREATED_IN_OTHER_REGION_COMPANY_ID,
+      OTHER_REGION_ID,
+    );
+
+    expect(response.body.errors).toBeDefined();
+  });
+
+  it('rejects a predicate whose relations point to different objects', async () => {
+    await upsertRowLevelPermissionPredicates({
+      expectToFail: true,
+      input: {
+        roleId: customRoleId,
+        objectMetadataId: companyObjectMetadataId,
+        predicates: [
+          {
+            id: PREDICATE_ID,
+            fieldMetadataId: companyRegionFieldMetadataId,
+            operand: RowLevelPermissionPredicateOperand.IS,
+            workspaceMemberFieldMetadataId:
+              workspaceMemberCompanyFieldMetadataId,
+          },
+        ],
+        predicateGroups: [],
+      },
+    });
+  });
+
+  it('rejects a relation predicate with an operand the query filter cannot express', async () => {
+    await upsertRowLevelPermissionPredicates({
+      expectToFail: true,
+      input: {
+        roleId: customRoleId,
+        objectMetadataId: companyObjectMetadataId,
+        predicates: [
+          {
+            id: PREDICATE_ID,
+            fieldMetadataId: companyRegionFieldMetadataId,
+            operand: RowLevelPermissionPredicateOperand.CONTAINS,
+            workspaceMemberFieldMetadataId:
+              workspaceMemberRegionFieldMetadataId,
+          },
+        ],
+        predicateGroups: [],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Why

A role could already restrict records by comparing a field to a value taken from the acting workspace member, but only for scalar and composite fields. Relations were out of reach, so a rule like *"a manager sees the companies of their region"*, where `region` is a relation on both `company` and `workspaceMember`, could not be expressed.

The value was not merely unsupported, it failed quietly: a many-to-one relation stores its value on the join column, so reading it by field name returned `undefined`, the predicate was dropped, and the role saw everything on that object.

## What changed

**Resolution.** `resolveWorkspaceMemberPredicateValue` reads the join column (`regionId`) when the member field is a many-to-one relation, and keeps the existing composite and select handling. The resolved id flows through the relation filter branch that already exists, which compiles to a join-column `in` filter, so no new SQL shape is introduced.

**Compatibility.** `validateEnumValueCompatibility` becomes `validatePredicateValueCompatibility` and additionally requires both fields to point at the same target object when the member field is a relation. Comparing the workspace member `id` against a relation field, which is how "owned by me" rules are written today, is unaffected.

**Validation at save time.** Predicates backed by a member field were not validated at all. They now report a member field that belongs to another object, an unknown member field, a member field holding several records, mismatched relation targets, and operands the relation query filter cannot express. These used to be silent drops at query time, which widened access instead of narrowing it. The owning-object check already existed on the direct upsert path but not on the application manifest path, which reaches the flat validator directly.

**Settings UI.** The predicate field picker offers a relation field when the workspace member has a many-to-one relation to the same object, and the value picker lists those member relations. Relations to `workspaceMember` keep their existing "Me (User ID)" entry.

**New-record prefill.** The prefill wrote to `regionId` but read the member value by field name, so creating a record under a relation rule sent the nested record where a uuid was expected and the mutation was rejected. It now reads through the same helper it writes with.

**Tool description.** `upsert_row_level_permission_rules` already accepted a relation on both sides, but described only the workspace member id case, so a model had no reason to reach for it.

Application manifests need no change: `RoleManifest` already carries `workspaceMemberFieldUniversalIdentifier`, and manifest-declared predicates go through the same server-side validation.

## Behaviour left as is

A predicate that cannot resolve, because the member's field is empty or the caller is an API key with no workspace member, is still dropped rather than compiled to a never-matching condition. That is today's behaviour for scalar predicates and this PR does not change it. Worth revisiting on its own.

Covering several regions is expressed as several predicates in an OR group. Traversing a relation, or a member holding many related records, still needs the id-set work that is not part of this change.

## Tests

New integration suite `record-level-permissions-on-relation.integration-spec.ts` builds a `Region` object with a relation on both `company` and `workspaceMember`, then covers read filtering, create allowed inside the member's region, create rejected outside it, and the save-time rejections. Unit specs cover the value resolver, the compatibility rules, the validator and the front-end field matching. The existing row-level permission suites, including the app manifest sync, still pass.

Also checked by hand in the app: the rule reads `Where Region Is Me / Region` in the role settings, and a member restricted by it sees only the companies of their own region.
