### PR TITLE
Fix deterministic view sort priority in workspace cache

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-view/services/__tests__/workspace-flat-view-map-cache.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view/services/__tests__/workspace-flat-view-map-cache.service.spec.ts
@@ -1,0 +1,100 @@
+import {
+  type EntityTarget,
+  type FindManyOptions,
+  type ObjectLiteral,
+} from 'typeorm';
+
+import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { WorkspaceFlatViewMapCacheService } from 'src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { ViewSortEntity } from 'src/engine/metadata-modules/view-sort/entities/view-sort.entity';
+import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
+import { WorkspaceCacheRowsBatchLoader } from 'src/engine/workspace-cache/services/workspace-cache-rows-batch-loader';
+
+const WORKSPACE_ID = '20202020-0000-4000-8000-000000000000';
+
+describe('WorkspaceFlatViewMapCacheService', () => {
+  it('orders view sort identifiers by creation time and id without mutating shared rows', async () => {
+    const service = new WorkspaceFlatViewMapCacheService();
+    const viewSorts = [
+      { id: 'sort-a', createdAt: new Date('2026-01-02') },
+      { id: 'sort-c', createdAt: new Date('2026-01-01') },
+      { id: 'sort-b', createdAt: new Date('2026-01-01') },
+    ].map((viewSort) => ({
+      ...viewSort,
+      universalIdentifier: `universal-${viewSort.id}`,
+      viewId: 'view-1',
+    }));
+    const rowsByEntity = new Map<EntityTarget<ObjectLiteral>, ObjectLiteral[]>([
+      [
+        ViewEntity,
+        [
+          {
+            id: 'view-1',
+            universalIdentifier: 'universal-view-1',
+            applicationId: 'application-1',
+            objectMetadataId: 'object-1',
+          },
+        ],
+      ],
+      [
+        ApplicationEntity,
+        [
+          {
+            id: 'application-1',
+            universalIdentifier: 'universal-application-1',
+          },
+        ],
+      ],
+      [
+        ObjectMetadataEntity,
+        [{ id: 'object-1', universalIdentifier: 'universal-object-1' }],
+      ],
+      [ViewSortEntity, viewSorts],
+    ]);
+    const rowsBatchLoader = new WorkspaceCacheRowsBatchLoader(
+      {
+        getRepository: (entityTarget) => ({
+          find: jest.fn(async (options?: FindManyOptions<ObjectLiteral>) => {
+            const rows = rowsByEntity.get(entityTarget) ?? [];
+
+            return rows.map((row) =>
+              Array.isArray(options?.select)
+                ? Object.fromEntries(
+                    options.select.map((column: string) => [
+                      column,
+                      row[column],
+                    ]),
+                  )
+                : { ...row },
+            );
+          }),
+        }),
+      },
+      WORKSPACE_ID,
+    );
+
+    await rowsBatchLoader.loadRows([service.rowsRequirement]);
+
+    const rows = rowsBatchLoader.readRows(service.rowsRequirement);
+    const sharedViewSorts = [...(rows.viewSort.byViewId.get('view-1') ?? [])];
+    const flatViewMaps = service.computeForCache({
+      workspaceId: WORKSPACE_ID,
+      rows,
+    });
+    const flatView = flatViewMaps.byUniversalIdentifier['universal-view-1'];
+
+    expect(flatView?.viewSortIds).toEqual(['sort-b', 'sort-c', 'sort-a']);
+    expect(flatView?.viewSortUniversalIdentifiers).toEqual([
+      'universal-sort-b',
+      'universal-sort-c',
+      'universal-sort-a',
+    ]);
+    expect(rows.viewSort.byViewId.get('view-1')).toEqual(sharedViewSorts);
+    expect(rows.viewSort.rows.map(({ id }) => id)).toEqual([
+      'sort-a',
+      'sort-c',
+      'sort-b',
+    ]);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service.ts
@@ -32,7 +32,7 @@ const FLAT_VIEW_ROWS_REQUIREMENT = {
     groupBy: ['viewId'],
   },
   viewSort: {
-    columns: ['id', 'universalIdentifier'],
+    columns: ['id', 'universalIdentifier', 'createdAt'],
     groupBy: ['viewId'],
   },
   viewFieldGroup: {
@@ -81,7 +81,13 @@ export class WorkspaceFlatViewMapCacheService extends MetadataFlatEntityMapsCach
           viewFilters: viewFilters.byViewId.get(viewEntity.id) || [],
           viewGroups: viewGroups.byViewId.get(viewEntity.id) || [],
           viewFilterGroups: viewFilterGroups.byViewId.get(viewEntity.id) || [],
-          viewSorts: viewSorts.byViewId.get(viewEntity.id) || [],
+          // Array order defines multi-sort priority; grouped rows are shared across providers.
+          viewSorts: [...(viewSorts.byViewId.get(viewEntity.id) ?? [])].sort(
+            (firstViewSort, secondViewSort) =>
+              firstViewSort.createdAt.getTime() -
+                secondViewSort.createdAt.getTime() ||
+              firstViewSort.id.localeCompare(secondViewSort.id),
+          ),
           viewFieldGroups: viewFieldGroups.byViewId.get(viewEntity.id) || [],
         },
         applicationIdToUniversalIdentifierMap,


### PR DESCRIPTION
## Summary

Ensures view sort IDs are deterministic when building the flat view cache.

View sorts were previously preserved in database row order, which could change across cache rebuilds and alter multi-sort priority.

This change orders each view's sort rows by `createdAt`, with `id` as a stable tie-breaker, before mapping them to `viewSortIds`.

## Testing

- Added a regression test covering unordered view sort rows.
- Confirmed the regression test fails before the fix and passes after it.
- Ran the full `twenty-server` Jest suite:
  - 1167 test suites passed
  - 8273 tests passed

Closes #25262

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

