### PR TITLE
fix: republish twenty-ui as MIT (1.0.0-alpha.2) to resolve stale AGPL artifacts

### DIFF
--- a/packages/create-twenty-app/src/constants/template/package.json
+++ b/packages/create-twenty-app/src/constants/template/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^19.0.0",
     "twenty-client-sdk": "TO-BE-GENERATED",
     "twenty-sdk": "TO-BE-GENERATED",
-    "twenty-ui": "1.0.0-alpha.1",
+    "twenty-ui": "1.0.0-alpha.2",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.0.0"

--- a/packages/twenty-codex-plugin/references/concepts/how-apps-work.md
+++ b/packages/twenty-codex-plugin/references/concepts/how-apps-work.md
@@ -21,7 +21,7 @@ A Twenty app depends on two SDK packages:
 
 `twenty-sdk/front-component` provides runtime APIs available inside front components: `navigate`, `enqueueSnackbar`, `openSidePanelPage`, `useSelectedRecordIds`, `getApplicationVariable`, and others.
 
-Twenty UI components (`Button`, `Chip`, `Tag`, `Status`, `H2Title`, `ThemeProvider`, icons, `themeCssVariables`) live in the `twenty-ui` package. Install `twenty-ui@1.0.0-alpha.1` from npm and import from its subpaths (`twenty-ui/input`, `twenty-ui/data-display`, `twenty-ui/icon`, `twenty-ui/typography`, `twenty-ui/theme-constants`, and others).
+Twenty UI components (`Button`, `Chip`, `Tag`, `Status`, `H2Title`, `ThemeProvider`, icons, `themeCssVariables`) live in the `twenty-ui` package. Install `twenty-ui@1.0.0-alpha.2` from npm and import from its subpaths (`twenty-ui/input`, `twenty-ui/data-display`, `twenty-ui/icon`, `twenty-ui/typography`, `twenty-ui/theme-constants`, and others).
 
 `twenty-client-sdk/core` provides `CoreApiClient` for querying and mutating workspace records (companies, people, custom objects). `twenty-client-sdk/metadata` provides access to workspace metadata (object definitions, field definitions).
 

--- a/packages/twenty-codex-plugin/references/develop-app/front-components.md
+++ b/packages/twenty-codex-plugin/references/develop-app/front-components.md
@@ -33,7 +33,7 @@ Keep imports narrow:
 
 - Use `twenty-sdk/front-component` for front component hooks and host APIs.
 - Use `twenty-client-sdk/core` or `twenty-client-sdk/metadata` for data access.
-- Install `twenty-ui@1.0.0-alpha.1` from npm and import Twenty UI components, icons, and theme tokens from its subpaths (`twenty-ui/input`, `twenty-ui/data-display`, `twenty-ui/icon`, `twenty-ui/typography`, `twenty-ui/theme-constants`, and others) before adding external UI libraries.
+- Install `twenty-ui@1.0.0-alpha.2` from npm and import Twenty UI components, icons, and theme tokens from its subpaths (`twenty-ui/input`, `twenty-ui/data-display`, `twenty-ui/icon`, `twenty-ui/typography`, `twenty-ui/theme-constants`, and others) before adding external UI libraries.
 
 The front component renderer provides a Twenty `ThemeProvider` around the remote root. For isolated examples or local story-style verification, wrapping the component in `ThemeProvider` from `twenty-ui/theme-constants` is also acceptable.
 

--- a/packages/twenty-codex-plugin/scripts/validators/cross-doc-contracts.js
+++ b/packages/twenty-codex-plugin/scripts/validators/cross-doc-contracts.js
@@ -82,7 +82,7 @@ const assertFrontComponentGuidance = (fail) => {
     'defineFrontComponent',
     'Use `twenty-sdk/front-component`',
     'Use `twenty-client-sdk/core` or `twenty-client-sdk/metadata`',
-    'twenty-ui@1.0.0-alpha.1',
+    'twenty-ui@1.0.0-alpha.2',
     'import Twenty UI components, icons, and theme tokens from its subpaths',
     'ThemeProvider',
     'showcase/twenty-ui-example.front-component.tsx',

--- a/packages/twenty-docs/developers/extend/apps/getting-started/project-structure.mdx
+++ b/packages/twenty-docs/developers/extend/apps/getting-started/project-structure.mdx
@@ -67,7 +67,7 @@ Both Twenty SDK packages belong under `devDependencies`, not `dependencies`:
   "devDependencies": {
     "twenty-client-sdk": "2.20.0",
     "twenty-sdk": "2.20.0",
-    "twenty-ui": "1.0.0-alpha.1"
+    "twenty-ui": "1.0.0-alpha.2"
   }
 }
 ```

--- a/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
@@ -690,14 +690,14 @@ Front components support multiple styling approaches. You can use:
 
 ## Using Twenty UI components
 
-Twenty ships its component library as the [`twenty-ui`](https://www.npmjs.com/package/twenty-ui/v/1.0.0-alpha.1) package. Front components can use it for buttons, tags, status pills, chips, avatars, icons, typography, and theme tokens that automatically match the workspace's light and dark theme.
+Twenty ships its component library as the [`twenty-ui`](https://www.npmjs.com/package/twenty-ui/v/1.0.0-alpha.2) package. Front components can use it for buttons, tags, status pills, chips, avatars, icons, typography, and theme tokens that automatically match the workspace's light and dark theme.
 
 ### Installation
 
 Add the package to your app, pinned to the version your Twenty instance ships:
 
 ```bash
-yarn add twenty-ui@1.0.0-alpha.1
+yarn add twenty-ui@1.0.0-alpha.2
 ```
 
 `twenty-ui` is bundled into your front component at build time, so it only needs to be a dependency of your app — there is nothing to configure at runtime.

--- a/packages/twenty-ui/package.json
+++ b/packages/twenty-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-ui",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Twenty's shared React UI component library.",
   "license": "MIT",
   "repository": {
@@ -88,6 +88,7 @@
   },
   "files": [
     "dist",
+    "LICENSE",
     "!dist/individual",
     "!dist/individual/**",
     "!dist/**/*.map"


### PR DESCRIPTION
Fixes #25722.

## Problem
#23564 (merged 2026-07-30) relicensed the app-development packages to MIT, but npm still serves builds that predate the relicensing:

- twenty-ui@1.0.0-alpha.0 (latest) and 1.0.0-alpha.1 (alpha tag, both published 2026-06-24): AGPL-3.0 on the registry, old root LICENSE in the tarball.
- twenty-shared@0.41.0-canary (published 2025-01-24): AGPL-3.0.

Meanwhile twenty-sdk, twenty-client-sdk, and create-twenty-app (all published after 2026-07-30) are correctly MIT. The repo itself is already correct (license: MIT plus per-package MIT LICENSE).

In practice, create-twenty-app scaffolds apps pinning "twenty-ui": "1.0.0-alpha.1" and the generated front component imports from twenty-ui/data-display and twenty-ui/icon — the exact scenario #23564 was written to prevent.

## What this PR does
- Bumps packages/twenty-ui/package.json 1.0.0-alpha.1 to 1.0.0-alpha.2 so the next publish ships the post-#23564 package.json (license: MIT) and MIT LICENSE.
- Adds LICENSE explicitly to twenty-ui files so the MIT text is always in the tarball (verified: npm pack --dry-run lists package/LICENSE, 1.1 kB MIT, license=MIT).
- Points the create-twenty-app scaffold template at 1.0.0-alpha.2.
- Syncs English docs (front-components.mdx, project-structure.mdx), codex-plugin references, and the cross-doc-contracts.js validator.

## Why twenty-shared is intentionally untouched
packages/twenty-shared/package.json is private:true with no version — it is only consumed via workspace:* (bundled at build time; twenty-sdk and twenty-client-sdk list it under devDependencies, never via the registry) and the scaffold template does not depend on it. There is nothing to republish; republishing would mean making an internal package public again. Instead, a maintainer should run npm deprecate on twenty-shared@0.41.0-canary pointing at this issue. The in-repo state (license: MIT plus MIT LICENSE) is already correct.

## Maintainer follow-up needed (cannot be done in a PR)
1. Publish 1.0.0-alpha.2 from packages/twenty-ui, then promote it to latest (currently latest still points at the stale 1.0.0-alpha.0; alpha points at 1.0.0-alpha.1).
2. npm deprecate the stale artifacts: twenty-ui@1.0.0-alpha.0, twenty-ui@1.0.0-alpha.1, and twenty-shared@0.41.0-canary.
3. Confirm npm view twenty-ui@1.0.0-alpha.2 license returns MIT and package/LICENSE in the tarball is the MIT text.

## Verification done
- npm view confirms both published twenty-ui versions are AGPL-3.0 and predate #23564; repo is MIT.
- npm pack --dry-run on the bumped package includes package/LICENSE (MIT) with license=MIT.
- No test pins the old version (only the template literal, docs, and validator — all updated); twenty-apps examples use caret ranges that resolve forward to alpha.2 automatically, and root yarn.lock uses workspace:*, so no lockfile churn is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

