### PR TITLE
Stop pull overwriting a source file that defines no entity

### DIFF
--- a/packages/twenty-sdk/src/cli/operations/pull.ts
+++ b/packages/twenty-sdk/src/cli/operations/pull.ts
@@ -21,7 +21,7 @@ import {
   readPullBaseManifest,
   writePullBaseManifest,
 } from '@/cli/utilities/pull/pull-base-file';
-import { scanProjectDefineFiles } from '@/cli/utilities/pull/scan-project-define-files';
+import { scanProjectSourceFiles } from '@/cli/utilities/pull/scan-project-source-files';
 import { runSafe } from '@/cli/utilities/run-safe';
 import { join } from 'node:path';
 import { isDefined } from 'twenty-shared/utils';
@@ -109,7 +109,7 @@ const innerAppPull = async (
 
   onProgress?.('Reading local source files...');
 
-  const scannedFiles = await scanProjectDefineFiles(appPath);
+  const scannedFiles = await scanProjectSourceFiles(appPath);
   const localApplicationUniversalIdentifier = scannedFiles.find(
     (scannedFile) => scannedFile.entityKey === ManifestEntityKey.Application,
   )?.universalIdentifier;

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
@@ -1,6 +1,6 @@
 import { ManifestEntityKey } from '@/cli/utilities/build/manifest/manifest-extract-config';
 import { planPullWrites } from '@/cli/utilities/pull/plan-pull-writes';
-import { type ScannedDefineFile } from '@/cli/utilities/pull/scan-project-define-files';
+import { type ScannedSourceFile } from '@/cli/utilities/pull/scan-project-source-files';
 import {
   type Manifest,
   type NavigationMenuItemManifest,
@@ -244,7 +244,7 @@ describe('planPullWrites', () => {
   });
 
   it('should regenerate the application config in the file that already declares one', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/application-config.ts',
         entityKey: ManifestEntityKey.Application,
@@ -267,7 +267,7 @@ describe('planPullWrites', () => {
   });
 
   it('should leave a file untouched when its entity has not changed since the base', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/application.config.ts',
         entityKey: ManifestEntityKey.Application,
@@ -293,7 +293,7 @@ describe('planPullWrites', () => {
   });
 
   it('should rewrite only the entity that changed on the server', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/application.config.ts',
         entityKey: ManifestEntityKey.Application,
@@ -329,7 +329,7 @@ describe('planPullWrites', () => {
   });
 
   it('should delete the file of an entity the base knew and the workspace no longer has', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/objects/rocket.object.ts',
         entityKey: ManifestEntityKey.Objects,
@@ -365,7 +365,7 @@ describe('planPullWrites', () => {
   });
 
   it('should report a local entity that neither the workspace nor the base knows', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/objects/unpushed.object.ts',
         entityKey: ManifestEntityKey.Objects,
@@ -387,7 +387,7 @@ describe('planPullWrites', () => {
   });
 
   it('should place a new entity beside existing files of its kind', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'app/data-model/rocket.object.ts',
         entityKey: ManifestEntityKey.Objects,
@@ -747,7 +747,7 @@ describe('planPullWrites', () => {
   });
 
   it('should leave an unchanged view untouched and regenerate the view whose filter changed on the server', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/application.config.ts',
         entityKey: ManifestEntityKey.Application,
@@ -951,7 +951,7 @@ describe('planPullWrites', () => {
   });
 
   it('should leave an unchanged page layout untouched and regenerate the page layout whose widget changed on the server', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/application.config.ts',
         entityKey: ManifestEntityKey.Application,
@@ -1134,7 +1134,7 @@ describe('planPullWrites', () => {
   });
 
   it('should leave an unchanged navigation menu item untouched and regenerate the item whose link changed on the server', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/application.config.ts',
         entityKey: ManifestEntityKey.Application,

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/scan-project-source-files.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/scan-project-source-files.spec.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { scanProjectSourceFiles } from '@/cli/utilities/pull/scan-project-source-files';
+
+describe('scanProjectSourceFiles', () => {
+  let appPath: string;
+
+  beforeEach(async () => {
+    appPath = await mkdtemp(join(tmpdir(), 'scan-project-source-files-'));
+    await mkdir(join(appPath, 'src', 'objects'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(appPath, { recursive: true, force: true });
+  });
+
+  it('should return a source file that defines no entity so its path stays reserved', async () => {
+    await writeFile(
+      join(appPath, 'src', 'objects', 'helpers.ts'),
+      "export const PET_LABEL = 'Pet';\n",
+    );
+
+    const scannedFiles = await scanProjectSourceFiles(appPath);
+
+    expect(scannedFiles).toEqual([
+      {
+        relativePath: join('src', 'objects', 'helpers.ts'),
+        entityKey: null,
+        universalIdentifier: null,
+        isReadable: true,
+      },
+    ]);
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
@@ -5,7 +5,7 @@ import {
   type PullEntityKind,
 } from '@/cli/utilities/pull/build-pull-entities';
 import { capFileBaseName } from '@/cli/utilities/pull/pull-file-base-name';
-import { type ScannedDefineFile } from '@/cli/utilities/pull/scan-project-define-files';
+import { type ScannedSourceFile } from '@/cli/utilities/pull/scan-project-source-files';
 import { writeDefineFile } from '@/cli/utilities/pull/write-define-file';
 import { kebabCase } from '@/cli/utilities/string/kebab-case';
 import { dirname, posix } from 'node:path';
@@ -55,7 +55,7 @@ const findExistingFolderForKind = ({
   scannedFiles,
   entityKey,
 }: {
-  scannedFiles: ScannedDefineFile[];
+  scannedFiles: ScannedSourceFile[];
   entityKey: ManifestEntityKey;
 }): string | null => {
   const folderCounts = new Map<string, number>();
@@ -169,7 +169,7 @@ const findExistingPath = ({
   pathByUniversalIdentifier,
 }: {
   entity: PullEntity;
-  applicationFile: ScannedDefineFile | undefined;
+  applicationFile: ScannedSourceFile | undefined;
   pathByUniversalIdentifier: Map<string, string>;
 }): string | undefined => {
   if (entity.kind !== 'application') {
@@ -203,7 +203,7 @@ export const planPullWrites = ({
 }: {
   manifest: Manifest;
   baseManifest: Manifest | null;
-  scannedFiles: ScannedDefineFile[];
+  scannedFiles: ScannedSourceFile[];
 }): PullWritePlan & {
   skipped: ReturnType<typeof buildPullEntities>['skipped'];
 } => {

--- a/packages/twenty-sdk/src/cli/utilities/pull/scan-project-source-files.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/scan-project-source-files.ts
@@ -9,7 +9,7 @@ import { readFile } from 'node:fs/promises';
 import { relative } from 'node:path';
 import { isDefined } from 'twenty-shared/utils';
 
-export type ScannedDefineFile = {
+export type ScannedSourceFile = {
   relativePath: string;
   entityKey: ManifestEntityKey | null;
   universalIdentifier: string | null;
@@ -20,9 +20,9 @@ type ExtractedConfig = {
   universalIdentifier?: unknown;
 };
 
-export const scanProjectDefineFiles = async (
+export const scanProjectSourceFiles = async (
   appPath: string,
-): Promise<ScannedDefineFile[]> => {
+): Promise<ScannedSourceFile[]> => {
   const filePaths = await glob(['**/*.ts', '**/*.tsx'], {
     cwd: appPath,
     absolute: true,
@@ -30,7 +30,7 @@ export const scanProjectDefineFiles = async (
     onlyFiles: true,
   });
 
-  const scannedFiles: ScannedDefineFile[] = [];
+  const scannedFiles: ScannedSourceFile[] = [];
 
   for (const filePath of filePaths) {
     const relativePath = relative(appPath, filePath);
@@ -52,6 +52,12 @@ export const scanProjectDefineFiles = async (
     const targetFunctionName = extractDefineEntity(fileContent);
 
     if (!isDefined(targetFunctionName)) {
+      scannedFiles.push({
+        relativePath,
+        entityKey: null,
+        universalIdentifier: null,
+        isReadable: true,
+      });
       continue;
     }
 


### PR DESCRIPTION
## What

`yarn twenty pull` could silently destroy a source file. If a generated file name landed on a path already holding something that is not a define file, pull overwrote it, reported the path as `written`, and exited 0. Nothing in the output said a file had been replaced.

Reproduced against a dev workspace: with `export const MY_PRECIOUS_HELPER = '...'` sitting at `src/objects/pet.object.ts`, a pull of the Custom application replaced the file with the generated `defineObject` for Pet and the helper was gone.

The docs promise the opposite: "a generated name that would land on an unrelated file is qualified rather than overwriting it".

## How

`planPullWrites` already reserves every path it is told about, and it is told about the result of the project scan. The scan was the hole: it globbed every `.ts` and `.tsx` file but kept only the ones whose content parsed as a `define*()` call with a default export, dropping everything else. Helpers, constants, type modules, and a define written as a named export were therefore invisible to the collision check, and their paths were free for the taking.

The scan now keeps those files too, with a null entity key and no universal identifier, which is the shape the reservation already understands. Every other consumer filters on fields that stay null for them, so they are unaffected: the local-only report requires a universal identifier, the front component collector requires its entity key, and the folder heuristic counts by entity key. The unreadable-file report is unaffected because these entries are readable.

The scan is renamed from `scanProjectDefineFiles` to `scanProjectSourceFiles`, and `ScannedDefineFile` to `ScannedSourceFile`, since the list is no longer only define files.

A colliding entity now falls through the existing ladder: the parent-qualified name first, then the identifier-prefixed one. In the reproduction above, Pet is written to `src/objects/5c5822f2-pet.object.ts` and the helper is left alone.

## Verification

- A new spec on the scan asserts a file defining no entity is returned rather than dropped. It fails against the previous code.
- The full pull suite passes, including the placement, collision and local-only cases that already covered define files.
- Verified live against a dev workspace: the reproduction above now preserves the helper and writes the object beside it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

