### PR TITLE
Stop calling a local file unknown to the workspace when the export reported it

### DIFF
--- a/packages/twenty-sdk/src/cli/operations/pull.ts
+++ b/packages/twenty-sdk/src/cli/operations/pull.ts
@@ -180,7 +180,16 @@ const innerAppPull = async (
     applicationUniversalIdentifier: manifest.application.universalIdentifier,
   });
 
-  const plan = planPullWrites({ manifest, baseManifest, scannedFiles });
+  const plan = planPullWrites({
+    manifest,
+    baseManifest,
+    scannedFiles,
+    workspaceUniversalIdentifiers: new Set(
+      applicationExport.coverage.map(
+        ({ universalIdentifier }) => universalIdentifier,
+      ),
+    ),
+  });
   const translationPlan = await planTranslationWrites({
     appPath,
     manifest,

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
@@ -232,6 +232,7 @@ describe('planPullWrites', () => {
     const plan = planPullWrites({
       manifest: MANIFEST,
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -254,6 +255,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: MANIFEST,
       baseManifest: null,
       scannedFiles,
@@ -283,6 +285,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: MANIFEST,
       baseManifest: MANIFEST,
       scannedFiles,
@@ -309,6 +312,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: buildManifest([
         buildObject({
           universalIdentifier: PET_UID,
@@ -339,6 +343,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: MANIFEST,
       baseManifest: buildManifest([
         buildObject({
@@ -375,6 +380,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: MANIFEST,
       baseManifest: null,
       scannedFiles,
@@ -384,6 +390,28 @@ describe('planPullWrites', () => {
       'src/objects/unpushed.object.ts',
     ]);
     expect(plan.deletions).toEqual([]);
+  });
+
+  it('should not call a local entity unknown to the workspace when the export reported it', () => {
+    const scannedFiles: ScannedDefineFile[] = [
+      {
+        relativePath: 'src/roles/guest.role.ts',
+        entityKey: ManifestEntityKey.Roles,
+        universalIdentifier: 'a-role-the-writer-cannot-write',
+        isReadable: true,
+      },
+    ];
+
+    const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set([
+        'a-role-the-writer-cannot-write',
+      ]),
+      manifest: MANIFEST,
+      baseManifest: null,
+      scannedFiles,
+    });
+
+    expect(plan.localOnlyRelativePaths).toEqual([]);
   });
 
   it('should place a new entity beside existing files of its kind', () => {
@@ -397,6 +425,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: MANIFEST,
       baseManifest: null,
       scannedFiles,
@@ -442,6 +471,7 @@ describe('planPullWrites', () => {
         ],
       } as unknown as Manifest,
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -460,6 +490,7 @@ describe('planPullWrites', () => {
     const plan = planPullWrites({
       manifest: MANIFEST,
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [
         {
           relativePath: 'src/objects/pet.object.ts',
@@ -482,6 +513,7 @@ describe('planPullWrites', () => {
     const plan = planPullWrites({
       manifest: MANIFEST,
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [
         {
           relativePath: 'src/objects/Pet.object.ts',
@@ -503,6 +535,7 @@ describe('planPullWrites', () => {
     const plan = planPullWrites({
       manifest: MANIFEST,
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [
         {
           relativePath: 'src/objects/pet.object.ts',
@@ -531,6 +564,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [
         {
           relativePath: 'app/screens/overview.view.ts',
@@ -574,6 +608,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [
         {
           relativePath: 'app/screens/overview.view.ts',
@@ -626,6 +661,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -650,6 +686,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -690,6 +727,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -732,6 +770,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -775,6 +814,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: buildManifestWithFilteredView('Max'),
       baseManifest: buildManifestWithFilteredView('Rex'),
       scannedFiles,
@@ -804,6 +844,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [
         {
           relativePath: 'app/screens/overview.page-layout.ts',
@@ -837,6 +878,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [
         {
           relativePath: 'app/screens/tabs/extra.page-layout-tab.ts',
@@ -883,6 +925,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -912,6 +955,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -936,6 +980,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -985,6 +1030,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: buildManifestWithDocsPageLayout('https://example.com/new'),
       baseManifest: buildManifestWithDocsPageLayout('https://example.com/old'),
       scannedFiles,
@@ -1024,6 +1070,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [
         {
           relativePath: 'app/navigation/pet-care.navigation-menu-item.ts',
@@ -1072,6 +1119,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -1119,6 +1167,7 @@ describe('planPullWrites', () => {
         ],
       },
       baseManifest: null,
+      workspaceUniversalIdentifiers: new Set(),
       scannedFiles: [],
     });
 
@@ -1163,6 +1212,7 @@ describe('planPullWrites', () => {
     ];
 
     const plan = planPullWrites({
+      workspaceUniversalIdentifiers: new Set(),
       manifest: buildManifestWithNavigationMenu('https://example.com/new'),
       baseManifest: buildManifestWithNavigationMenu('https://example.com/old'),
       scannedFiles,

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/plan-pull-writes.spec.ts
@@ -392,8 +392,8 @@ describe('planPullWrites', () => {
     expect(plan.deletions).toEqual([]);
   });
 
-  it('should not call a local entity unknown to the workspace when the export reported it', () => {
-    const scannedFiles: ScannedDefineFile[] = [
+  it('should not report a local file as local-only when the export reported its entity', () => {
+    const scannedFiles: ScannedSourceFile[] = [
       {
         relativePath: 'src/roles/guest.role.ts',
         entityKey: ManifestEntityKey.Roles,

--- a/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/plan-pull-writes.ts
@@ -200,10 +200,12 @@ export const planPullWrites = ({
   manifest,
   baseManifest,
   scannedFiles,
+  workspaceUniversalIdentifiers,
 }: {
   manifest: Manifest;
   baseManifest: Manifest | null;
   scannedFiles: ScannedSourceFile[];
+  workspaceUniversalIdentifiers: ReadonlySet<string>;
 }): PullWritePlan & {
   skipped: ReturnType<typeof buildPullEntities>['skipped'];
 } => {
@@ -317,6 +319,7 @@ export const planPullWrites = ({
         isDefined(scannedFile.universalIdentifier) &&
         !exportedUniversalIdentifiers.has(scannedFile.universalIdentifier) &&
         !baseConfigByUniversalIdentifier.has(scannedFile.universalIdentifier) &&
+        !workspaceUniversalIdentifiers.has(scannedFile.universalIdentifier) &&
         !usedRelativePaths.has(toPosixPath(scannedFile.relativePath)),
     )
     .map((scannedFile) => toPosixPath(scannedFile.relativePath));


### PR DESCRIPTION
## What

The pull report contradicted itself. A define file for an entity the workspace really has, but that this version of pull cannot write, was listed under "Local entities the workspace does not have (left untouched)" while the same report said the workspace has those entities.

Pulling the Custom application into a tree holding a `defineRole()` file for one of its real roles printed both of these, a few lines apart:

```
Local entities the workspace does not have (left untouched):
  src/roles/guest.role.ts

Not written, unsupported by this version (19 row(s)):
  ...
  role                              4
```

Read literally, the first line invites you to delete a file that describes a role the workspace is using.

## How

The local-only list was everything scanned that the writer did not write and the base did not know. Since roles, command menu items, logic functions and front components are not written by this version, every file for them qualified.

`planPullWrites` now also receives the universal identifiers the export reported in its coverage, which is every row the workspace holds for this application whatever its status, and excludes them. What remains in the list is what the heading claims: a file whose entity the workspace genuinely does not have, such as one authored locally and never pushed.

Files for kinds pull cannot write yet stay untouched on disk, as before, and the coverage section keeps reporting their entities.

## Verification

- A new case asserts a scanned file whose identifier the export reported is not listed as local-only. It fails against the previous code.
- The existing case for a genuinely unknown local entity still reports it.
- Verified live: the reproduction above no longer prints the "Local entities" section at all.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

