### PR TITLE
Tell pull users their project cannot build what pull just wrote

### DIFF
--- a/packages/twenty-sdk/src/cli/commands/dev/pull.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/pull.ts
@@ -62,6 +62,20 @@ export class AppPullCommand {
       ),
     );
     console.log(chalk.gray(`Base recorded in ${PULL_BASE_FILE_PATH}`));
-    console.log(chalk.gray('Next: yarn twenty plan --no-delete'));
+
+    if (result.data.isSdkResolvable) {
+      console.log(chalk.gray('Next: yarn twenty plan --no-delete'));
+    } else {
+      console.log(
+        chalk.yellow(
+          'twenty-sdk is not installed here, so the written files cannot build yet.',
+        ),
+      );
+      console.log(
+        chalk.gray(
+          'Next: install your dependencies, then yarn twenty plan --no-delete',
+        ),
+      );
+    }
   }
 }

--- a/packages/twenty-sdk/src/cli/operations/pull.ts
+++ b/packages/twenty-sdk/src/cli/operations/pull.ts
@@ -22,6 +22,7 @@ import {
   writePullBaseManifest,
 } from '@/cli/utilities/pull/pull-base-file';
 import { getApplicationMismatchMessage } from '@/cli/utilities/pull/get-application-mismatch-message';
+import { isSdkResolvable } from '@/cli/utilities/pull/is-sdk-resolvable';
 import { scanProjectSourceFiles } from '@/cli/utilities/pull/scan-project-source-files';
 import { runSafe } from '@/cli/utilities/run-safe';
 import { join } from 'node:path';
@@ -45,6 +46,7 @@ export type AppPullResult = {
   unreadableRelativePaths: string[];
   compiledTranslationEntryCountByLocale: Record<string, number>;
   hadBase: boolean;
+  isSdkResolvable: boolean;
 };
 
 const EXPORT_REFUSAL_SUB_CODES = [
@@ -228,6 +230,7 @@ const innerAppPull = async (
       compiledTranslationEntryCountByLocale:
         translationPlan.compiledEntryCountByLocale,
       hadBase: isDefined(baseManifest),
+      isSdkResolvable: isSdkResolvable(appPath),
     },
   };
 };

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/is-sdk-resolvable.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/is-sdk-resolvable.spec.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { isSdkResolvable } from '@/cli/utilities/pull/is-sdk-resolvable';
+
+describe('isSdkResolvable', () => {
+  let appPath: string;
+
+  beforeEach(async () => {
+    appPath = await mkdtemp(join(tmpdir(), 'is-sdk-resolvable-'));
+    await writeFile(
+      join(appPath, 'package.json'),
+      JSON.stringify({ name: 'app', version: '1.0.0', private: true }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(appPath, { recursive: true, force: true });
+  });
+
+  it('should be false when the project has no twenty-sdk installed', () => {
+    expect(isSdkResolvable(appPath)).toBe(false);
+  });
+
+  it('should be true when twenty-sdk exposes its define entry point', async () => {
+    const sdkPath = join(appPath, 'node_modules', 'twenty-sdk');
+
+    await mkdir(sdkPath, { recursive: true });
+    await writeFile(
+      join(sdkPath, 'package.json'),
+      JSON.stringify({
+        name: 'twenty-sdk',
+        version: '0.0.0',
+        exports: { './define': './define.js' },
+      }),
+    );
+    await writeFile(join(sdkPath, 'define.js'), 'module.exports = {};\n');
+
+    expect(isSdkResolvable(appPath)).toBe(true);
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/pull/is-sdk-resolvable.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/is-sdk-resolvable.ts
@@ -1,0 +1,12 @@
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+export const isSdkResolvable = (appPath: string): boolean => {
+  try {
+    createRequire(join(appPath, 'package.json')).resolve('twenty-sdk/define');
+
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## What

`yarn twenty pull` into a project that has a `package.json` but no installed `twenty-sdk` wrote the whole tree, declared success and then pointed at a command that cannot work:

```
✓ Pulled Custom into /path/to/my-app
Base recorded in .twenty/pull-base.json
Next: yarn twenty plan --no-delete
```

Running that next step fails immediately with `Could not resolve "twenty-sdk/define"`, because nothing in the project provides the definers the written files import. Pull's only precondition is that a `package.json` exists, so a project assembled by hand rather than scaffolded lands here.

## How

Pull now checks whether `twenty-sdk/define` resolves from the project, and says so instead of pretending the next step will work:

```
✓ Pulled Custom into /path/to/my-app
Base recorded in .twenty/pull-base.json
twenty-sdk is not installed here, so the written files cannot build yet.
Next: install your dependencies, then yarn twenty plan --no-delete
```

A project with the SDK installed is unchanged and still prints the plain next step.

The check resolves the `./define` subpath rather than the package root, because `twenty-sdk` has no root export and resolving the bare name fails even when it is installed. It follows normal Node resolution from the project, so a workspace that hoists its dependencies is detected correctly.

Pull still writes the files. They are the point of the command, and they are what you want on disk before installing.

## Verification

- New spec on the check: false for a project with only a package.json, true for one that exposes the define entry point. It builds its own fixture, so it does not depend on twenty-sdk being built.
- Verified live against a dev workspace, both branches: a hand-made project gets the warning and the corrected next step, a scaffolded one is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

