### PR TITLE
Refuse to pull an application into a project that already defines another

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
+++ b/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
@@ -107,7 +107,7 @@ A plan only previews **metadata** changes. It also works for an app that was nev
 yarn twenty pull -u <universalIdentifier>
 ```
 
-Pull needs an existing project — scaffold one with `npx create-twenty-app@latest` first, then pull into it. Without `-u`, pull targets the application your local `defineApplication()` file declares. If `-u` names a different application than the one your project declares, pull refuses rather than leaving two applications in one tree: pull that one into its own directory. Add `-v` to expand the coverage sections of the report, which then name up to 20 identifiers per metadata type instead of only the totals.
+Pull needs an existing project — scaffold one with `npx create-twenty-app@latest` first, then pull into it. Without `-u`, pull targets the application your local `defineApplication()` file declares. If `-u` names a different application than the one your project declares, pull refuses rather than leaving two applications in one tree: pull that one into its own directory. If the project has an application file whose identifier cannot be read, usually because dependencies are not installed, pull refuses too and asks you to run `yarn install` first. Add `-v` to expand the coverage sections of the report, which then name up to 20 identifiers per metadata type instead of only the totals.
 
 **What it writes:**
 

--- a/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
+++ b/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
@@ -107,7 +107,7 @@ A plan only previews **metadata** changes. It also works for an app that was nev
 yarn twenty pull -u <universalIdentifier>
 ```
 
-Pull needs an existing project — scaffold one with `npx create-twenty-app@latest` first, then pull into it. Without `-u`, pull targets the application your local `defineApplication()` file declares. Add `-v` to expand the coverage sections of the report, which then name up to 20 identifiers per metadata type instead of only the totals.
+Pull needs an existing project — scaffold one with `npx create-twenty-app@latest` first, then pull into it. Without `-u`, pull targets the application your local `defineApplication()` file declares. If `-u` names a different application than the one your project declares, pull refuses rather than leaving two applications in one tree: pull that one into its own directory. Add `-v` to expand the coverage sections of the report, which then name up to 20 identifiers per metadata type instead of only the totals.
 
 **What it writes:**
 

--- a/packages/twenty-sdk/src/cli/operations/pull.ts
+++ b/packages/twenty-sdk/src/cli/operations/pull.ts
@@ -21,6 +21,7 @@ import {
   readPullBaseManifest,
   writePullBaseManifest,
 } from '@/cli/utilities/pull/pull-base-file';
+import { getApplicationMismatchMessage } from '@/cli/utilities/pull/get-application-mismatch-message';
 import { scanProjectSourceFiles } from '@/cli/utilities/pull/scan-project-source-files';
 import { runSafe } from '@/cli/utilities/run-safe';
 import { join } from 'node:path';
@@ -126,6 +127,21 @@ const innerAppPull = async (
           'Could not tell which application to pull.\n\n' +
           '  Pass the identifier explicitly:\n' +
           '    yarn twenty pull -u <universalIdentifier>',
+      },
+    };
+  }
+
+  const applicationMismatchMessage = getApplicationMismatchMessage({
+    requestedUniversalIdentifier: options.universalIdentifier,
+    localApplicationUniversalIdentifier,
+  });
+
+  if (isDefined(applicationMismatchMessage)) {
+    return {
+      success: false,
+      error: {
+        code: APP_ERROR_CODES.PULL_FAILED,
+        message: applicationMismatchMessage,
       },
     };
   }

--- a/packages/twenty-sdk/src/cli/operations/pull.ts
+++ b/packages/twenty-sdk/src/cli/operations/pull.ts
@@ -111,9 +111,11 @@ const innerAppPull = async (
   onProgress?.('Reading local source files...');
 
   const scannedFiles = await scanProjectSourceFiles(appPath);
-  const localApplicationUniversalIdentifier = scannedFiles.find(
+  const localApplicationFile = scannedFiles.find(
     (scannedFile) => scannedFile.entityKey === ManifestEntityKey.Application,
-  )?.universalIdentifier;
+  );
+  const localApplicationUniversalIdentifier =
+    localApplicationFile?.universalIdentifier;
 
   const universalIdentifier =
     options.universalIdentifier ?? localApplicationUniversalIdentifier;
@@ -134,6 +136,7 @@ const innerAppPull = async (
   const applicationMismatchMessage = getApplicationMismatchMessage({
     requestedUniversalIdentifier: options.universalIdentifier,
     localApplicationUniversalIdentifier,
+    hasLocalApplicationFile: isDefined(localApplicationFile),
   });
 
   if (isDefined(applicationMismatchMessage)) {

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/get-application-mismatch-message.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/get-application-mismatch-message.spec.ts
@@ -1,0 +1,43 @@
+import { getApplicationMismatchMessage } from '@/cli/utilities/pull/get-application-mismatch-message';
+
+const LOCAL_UID = 'b30a4560-fedb-4ccd-904a-3788762c7d33';
+const OTHER_UID = '5b1e7c2a-3d4f-4e5a-9b6c-7d8e9f0a1b2c';
+
+describe('getApplicationMismatchMessage', () => {
+  it('should refuse a pull that would bring another application into the tree', () => {
+    const message = getApplicationMismatchMessage({
+      requestedUniversalIdentifier: OTHER_UID,
+      localApplicationUniversalIdentifier: LOCAL_UID,
+    });
+
+    expect(message).toContain(LOCAL_UID);
+    expect(message).toContain(OTHER_UID);
+  });
+
+  it('should allow a pull of the application the tree already defines', () => {
+    expect(
+      getApplicationMismatchMessage({
+        requestedUniversalIdentifier: LOCAL_UID,
+        localApplicationUniversalIdentifier: LOCAL_UID,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('should allow a pull into a tree that defines no application yet', () => {
+    expect(
+      getApplicationMismatchMessage({
+        requestedUniversalIdentifier: OTHER_UID,
+        localApplicationUniversalIdentifier: null,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('should allow a pull that names no application, so the tree decides', () => {
+    expect(
+      getApplicationMismatchMessage({
+        requestedUniversalIdentifier: undefined,
+        localApplicationUniversalIdentifier: LOCAL_UID,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/get-application-mismatch-message.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/get-application-mismatch-message.spec.ts
@@ -8,9 +8,21 @@ describe('getApplicationMismatchMessage', () => {
     const message = getApplicationMismatchMessage({
       requestedUniversalIdentifier: OTHER_UID,
       localApplicationUniversalIdentifier: LOCAL_UID,
+      hasLocalApplicationFile: true,
     });
 
     expect(message).toContain(LOCAL_UID);
+    expect(message).toContain(OTHER_UID);
+  });
+
+  it('should refuse a pull when the declaration exists but could not be read', () => {
+    const message = getApplicationMismatchMessage({
+      requestedUniversalIdentifier: OTHER_UID,
+      localApplicationUniversalIdentifier: null,
+      hasLocalApplicationFile: true,
+    });
+
+    expect(message).toContain('could not be read');
     expect(message).toContain(OTHER_UID);
   });
 
@@ -19,6 +31,7 @@ describe('getApplicationMismatchMessage', () => {
       getApplicationMismatchMessage({
         requestedUniversalIdentifier: LOCAL_UID,
         localApplicationUniversalIdentifier: LOCAL_UID,
+        hasLocalApplicationFile: true,
       }),
     ).toBeUndefined();
   });
@@ -28,6 +41,7 @@ describe('getApplicationMismatchMessage', () => {
       getApplicationMismatchMessage({
         requestedUniversalIdentifier: OTHER_UID,
         localApplicationUniversalIdentifier: null,
+        hasLocalApplicationFile: false,
       }),
     ).toBeUndefined();
   });
@@ -37,6 +51,7 @@ describe('getApplicationMismatchMessage', () => {
       getApplicationMismatchMessage({
         requestedUniversalIdentifier: undefined,
         localApplicationUniversalIdentifier: LOCAL_UID,
+        hasLocalApplicationFile: true,
       }),
     ).toBeUndefined();
   });

--- a/packages/twenty-sdk/src/cli/utilities/pull/get-application-mismatch-message.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/get-application-mismatch-message.ts
@@ -1,0 +1,23 @@
+import { isDefined } from 'twenty-shared/utils';
+
+export const getApplicationMismatchMessage = ({
+  requestedUniversalIdentifier,
+  localApplicationUniversalIdentifier,
+}: {
+  requestedUniversalIdentifier: string | undefined;
+  localApplicationUniversalIdentifier: string | null | undefined;
+}): string | undefined => {
+  if (
+    !isDefined(requestedUniversalIdentifier) ||
+    !isDefined(localApplicationUniversalIdentifier) ||
+    requestedUniversalIdentifier === localApplicationUniversalIdentifier
+  ) {
+    return undefined;
+  }
+
+  return (
+    `This project already defines application ${localApplicationUniversalIdentifier}.\n\n` +
+    `  Pulling ${requestedUniversalIdentifier} here would leave two applications in one tree.\n` +
+    '  Pull it into a different directory instead.'
+  );
+};

--- a/packages/twenty-sdk/src/cli/utilities/pull/get-application-mismatch-message.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/get-application-mismatch-message.ts
@@ -3,15 +3,25 @@ import { isDefined } from 'twenty-shared/utils';
 export const getApplicationMismatchMessage = ({
   requestedUniversalIdentifier,
   localApplicationUniversalIdentifier,
+  hasLocalApplicationFile,
 }: {
   requestedUniversalIdentifier: string | undefined;
   localApplicationUniversalIdentifier: string | null | undefined;
+  hasLocalApplicationFile: boolean;
 }): string | undefined => {
-  if (
-    !isDefined(requestedUniversalIdentifier) ||
-    !isDefined(localApplicationUniversalIdentifier) ||
-    requestedUniversalIdentifier === localApplicationUniversalIdentifier
-  ) {
+  if (!isDefined(requestedUniversalIdentifier) || !hasLocalApplicationFile) {
+    return undefined;
+  }
+
+  if (!isDefined(localApplicationUniversalIdentifier)) {
+    return (
+      'This project declares an application, but its identifier could not be read.\n\n' +
+      `  Pulling ${requestedUniversalIdentifier} here could overwrite that declaration.\n` +
+      '  Run `yarn install` so the file can be evaluated, then pull again.'
+    );
+  }
+
+  if (requestedUniversalIdentifier === localApplicationUniversalIdentifier) {
     return undefined;
   }
 


### PR DESCRIPTION
## What

`yarn twenty pull -u <other application>` in a project that already defines one silently repointed the project at the other application and left both applications' entities in the same tree. `src/application.config.ts` was rewritten to the new identity, the previous application's objects stayed where they were, and the report said nothing.

The damage only surfaced later, on the next plan, as a wall of raw errors:

```
3. ENTITY_ALREADY_EXISTS: Cannot create navigationMenuItem: universalIdentifier "b80b9e60-…"
   already exists in navigationMenuItem maps from application "b30a4560-…"
```

## How

Pull refuses when `-u` names an application other than the one the project's `defineApplication()` file declares:

```
This project already defines application b30a4560-fedb-4ccd-904a-3788762c7d33.

  Pulling 5b1e7c2a-3d4f-4e5a-9b6c-7d8e9f0a1b2c here would leave two applications in one tree.
  Pull it into a different directory instead.
```

The check runs before the export, so a mistyped or mistaken identifier costs nothing and touches neither the tree nor the server.

It also refuses when the project declares an application whose identifier cannot be read, which the scanner records the same way as no declaration at all. Left alone, that case would have let the pull through and written the new application over the very file it could not evaluate:

```
This project declares an application, but its identifier could not be read.

  Pulling 5b1e7c2a-3d4f-4e5a-9b6c-7d8e9f0a1b2c here could overwrite that declaration.
  Run `yarn install` so the file can be evaluated, then pull again.
```

Everything else is unchanged: `-u` naming the application the tree already declares still pulls, a project that declares no application yet still accepts any `-u`, and pull with no `-u` still reads the identity from the tree.

No flag is added to force the old behaviour. Re-pointing a tree at a different application is not something to do in place, and a fresh directory is both the safe and the obvious way to get it.

## Verification

- New spec on the check: refuses a different identifier and names both applications, refuses an unreadable declaration, and allows the matching identifier, a tree with no application, and a pull that passes no identifier.
- The pull page documents the restriction.
- Verified live against a dev workspace: pulling the SDK app into a tree pulled from Custom is refused with the message above, `application.config.ts` still holds the Custom identifier afterwards, and pulling Custom again into the same tree still succeeds.
