### PR TITLE
fix(messaging): don't delete messages still present in another folder's delta sync

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -240,9 +240,7 @@ export class MessagingMessageListFetchService {
               await this.messagingMessageCleanerService.deleteMessagesChannelMessageAssociationsAndRelatedOrphans(
                 {
                   workspaceId,
-                  messageExternalIds: toDeleteChunk.filter(
-                    (messageExternalId) => isNonEmptyString(messageExternalId),
-                  ),
+                  messageExternalIds: toDeleteChunk,
                   messageChannelId: freshMessageChannel.id,
                 },
               );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -33,6 +33,7 @@ import {
 } from 'src/modules/messaging/message-import-manager/services/messaging-process-folder-actions.service';
 import { MessagingProcessGroupEmailActionsService } from 'src/modules/messaging/message-import-manager/services/messaging-process-group-email-actions.service';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { filterMessageExternalIdsToDelete } from 'src/modules/messaging/message-import-manager/utils/filter-message-external-ids-to-delete.util';
 
 const ONE_WEEK_IN_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
 
@@ -212,13 +213,17 @@ export class MessagingMessageListFetchService {
               )
             : [];
 
-          const allMessageExternalIdsToDelete = [
-            ...messageExternalIdsToDelete,
-            ...fullSyncMessageChannelMessageAssociationsToDelete.map(
-              (messageChannelMessageAssociation) =>
-                messageChannelMessageAssociation.messageExternalId,
-            ),
-          ];
+          const allMessageExternalIdsToDelete =
+            filterMessageExternalIdsToDelete({
+              messageExternalIds,
+              messageExternalIdsToDelete: [
+                ...messageExternalIdsToDelete,
+                ...fullSyncMessageChannelMessageAssociationsToDelete.map(
+                  (messageChannelMessageAssociation) =>
+                    messageChannelMessageAssociation.messageExternalId,
+                ),
+              ],
+            });
 
           if (allMessageExternalIdsToDelete.length) {
             this.logger.log(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/filter-message-external-ids-to-delete.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/filter-message-external-ids-to-delete.util.spec.ts
@@ -1,0 +1,21 @@
+import { filterMessageExternalIdsToDelete } from 'src/modules/messaging/message-import-manager/utils/filter-message-external-ids-to-delete.util';
+
+describe('filterMessageExternalIdsToDelete', () => {
+  it('keeps a message when one folder removes it while another still returns it', () => {
+    expect(
+      filterMessageExternalIdsToDelete({
+        messageExternalIds: ['moved-message', 'current-message'],
+        messageExternalIdsToDelete: ['moved-message', 'deleted-message'],
+      }),
+    ).toEqual(['deleted-message']);
+  });
+
+  it('deduplicates deletion events returned by multiple folders', () => {
+    expect(
+      filterMessageExternalIdsToDelete({
+        messageExternalIds: [],
+        messageExternalIdsToDelete: ['deleted-message', 'deleted-message'],
+      }),
+    ).toEqual(['deleted-message']);
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/filter-message-external-ids-to-delete.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/filter-message-external-ids-to-delete.util.ts
@@ -1,17 +1,22 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
 export const filterMessageExternalIdsToDelete = ({
   messageExternalIds,
   messageExternalIdsToDelete,
 }: {
   messageExternalIds: string[];
-  messageExternalIdsToDelete: string[];
+  messageExternalIdsToDelete: (string | null)[];
 }): string[] => {
   const presentMessageExternalIds = new Set(messageExternalIds);
 
   return [
     ...new Set(
-      messageExternalIdsToDelete.filter(
-        (messageExternalId) => !presentMessageExternalIds.has(messageExternalId),
-      ),
+      messageExternalIdsToDelete
+        .filter(isNonEmptyString)
+        .filter(
+          (messageExternalId) =>
+            !presentMessageExternalIds.has(messageExternalId),
+        ),
     ),
   ];
 };

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/filter-message-external-ids-to-delete.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/filter-message-external-ids-to-delete.util.ts
@@ -1,0 +1,17 @@
+export const filterMessageExternalIdsToDelete = ({
+  messageExternalIds,
+  messageExternalIdsToDelete,
+}: {
+  messageExternalIds: string[];
+  messageExternalIdsToDelete: string[];
+}): string[] => {
+  const presentMessageExternalIds = new Set(messageExternalIds);
+
+  return [
+    ...new Set(
+      messageExternalIdsToDelete.filter(
+        (messageExternalId) => !presentMessageExternalIds.has(messageExternalId),
+      ),
+    ),
+  ];
+};

--- a/packages/twenty-server/test/integration/microsoft/messaging/cross-folder-move.integration-spec.ts
+++ b/packages/twenty-server/test/integration/microsoft/messaging/cross-folder-move.integration-spec.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from 'node:crypto';
+
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+import { setupMicrosoftMock } from 'test/integration/microsoft/mocks/setup-microsoft-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { findImportedMessageSubjects } from 'test/integration/utils/find-imported-records.util';
+import { runMessageChannelSync } from 'test/integration/utils/run-message-channel-sync.util';
+
+const HANDLE = 'microsoft-cross-folder-move@apple.dev';
+
+const MOVED_SUBJECT = `Microsoft moved message ${randomUUID()}`;
+const DELETED_SUBJECT = `Microsoft deleted message ${randomUUID()}`;
+
+const FOLDERS = [
+  { id: 'inbox', displayName: 'Inbox' },
+  { id: 'sentitems', displayName: 'Sent Items' },
+  { id: 'archive', displayName: 'Archive' },
+];
+
+const inboxMessage = (id: string, subject: string) => ({
+  id,
+  subject,
+  body: { contentType: 'text', content: subject },
+  receivedDateTime: '2026-08-13T00:00:00.000Z',
+  internetMessageId: `<${id}@example.com>`,
+  conversationId: `${id}-conversation`,
+  parentFolderId: 'inbox',
+  isDraft: false,
+  from: { emailAddress: { address: 'sender@external.test' } },
+  toRecipients: [{ emailAddress: { address: HANDLE } }],
+});
+
+const MOVED_MESSAGE = inboxMessage(
+  'microsoft-cross-folder-moved-message',
+  MOVED_SUBJECT,
+);
+const DELETED_MESSAGE = inboxMessage(
+  'microsoft-cross-folder-deleted-message',
+  DELETED_SUBJECT,
+);
+
+describe('Microsoft cross-folder move (integration)', () => {
+  const microsoftMock = setupMicrosoftMock({
+    handle: HANDLE,
+    folders: FOLDERS,
+    messages: [MOVED_MESSAGE, DELETED_MESSAGE],
+  });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+  let subjectsAfterInitialSync: string[];
+  let subjectsAfterMoveAndDelete: string[];
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.MICROSOFT,
+      handle: HANDLE,
+    });
+
+    await runMessageChannelSync(channel.channelId);
+
+    subjectsAfterInitialSync = await findImportedMessageSubjects([
+      MOVED_SUBJECT,
+      DELETED_SUBJECT,
+    ]);
+
+    microsoftMock.moveMessageToFolder(MOVED_MESSAGE.id, 'archive');
+    microsoftMock.deleteMessage(DELETED_MESSAGE.id);
+
+    await runMessageChannelSync(channel.channelId);
+
+    subjectsAfterMoveAndDelete = await findImportedMessageSubjects([
+      MOVED_SUBJECT,
+      DELETED_SUBJECT,
+    ]);
+  }, 180000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('imports both inbox messages on the first sync', () => {
+    expect(subjectsAfterInitialSync).toEqual(
+      [MOVED_SUBJECT, DELETED_SUBJECT].sort(),
+    );
+  });
+
+  it('keeps the moved message the archive delta still returns and deletes the one no folder returns', () => {
+    expect(subjectsAfterMoveAndDelete).toEqual([MOVED_SUBJECT]);
+  });
+});

--- a/packages/twenty-server/test/integration/microsoft/mocks/microsoft-mailbox-handlers.util.ts
+++ b/packages/twenty-server/test/integration/microsoft/mocks/microsoft-mailbox-handlers.util.ts
@@ -8,6 +8,7 @@ import { type MockEntityStore } from 'test/integration/utils/mock-entity-store.u
 export const microsoftMailboxHandlers = (
   folderStore: MockEntityStore<MailFolder>,
   messages: Array<Record<string, unknown>> = [],
+  removedMessageIdsByFolderId: Record<string, string[]> = {},
 ): MswHandler[] => [
   http.get('*/me/mailFolders', () =>
     HttpResponse.json<{ value: MailFolder[] }>({ value: folderStore.list() }),
@@ -33,9 +34,17 @@ export const microsoftMailboxHandlers = (
             id,
             status: 200,
             body: {
-              value: messages
-                .filter((message) => message.parentFolderId === folderId)
-                .map((message) => ({ id: message.id })),
+              value: [
+                ...messages
+                  .filter((message) => message.parentFolderId === folderId)
+                  .map((message) => ({ id: message.id })),
+                ...(removedMessageIdsByFolderId[folderId ?? ''] ?? []).map(
+                  (removedMessageId) => ({
+                    id: removedMessageId,
+                    '@removed': { reason: 'deleted' },
+                  }),
+                ),
+              ],
               '@odata.deltaLink': `https://graph.microsoft.com/beta${url}`,
             },
           };

--- a/packages/twenty-server/test/integration/microsoft/mocks/setup-microsoft-mock.util.ts
+++ b/packages/twenty-server/test/integration/microsoft/mocks/setup-microsoft-mock.util.ts
@@ -1,5 +1,7 @@
 import { type Event, type MailFolder } from '@microsoft/microsoft-graph-types';
+import { isNonEmptyString } from '@sniptt/guards';
 import { http, HttpResponse } from 'msw';
+import { isDefined } from 'twenty-shared/utils';
 
 import { setupHttpMock } from 'test/integration/utils/http-mock.util';
 import {
@@ -34,6 +36,8 @@ export type MicrosoftMock = {
     events: Event[],
     options?: { deltaToken?: string; removedEventIds?: string[] },
   ) => void;
+  moveMessageToFolder: (messageId: string, targetFolderId: string) => void;
+  deleteMessage: (messageId: string) => void;
   failSubscriptionRenewal: () => void;
   failMessageDelta: (failure: MicrosoftGraphFailure) => void;
   failCalendarDelta: (failure: MicrosoftGraphFailure) => void;
@@ -74,10 +78,38 @@ export const setupMicrosoftMock = ({
   const patchedMessages: Array<Record<string, unknown>> = [];
   const sentMessageIds: string[] = [];
   const createdCalendarEvents: Event[] = [];
+  const removedMessageIdsByFolderId: Record<string, string[]> = {};
+
+  const recordFolderRemoval = (messageId: string) => {
+    const message = messages.find((candidate) => candidate.id === messageId);
+
+    if (!isDefined(message)) {
+      throw new Error(`No mocked Microsoft message with id ${messageId}`);
+    }
+
+    const folderId = message.parentFolderId;
+
+    if (!isNonEmptyString(folderId)) {
+      throw new Error(
+        `Mocked Microsoft message ${messageId} has no parentFolderId`,
+      );
+    }
+
+    removedMessageIdsByFolderId[folderId] = [
+      ...(removedMessageIdsByFolderId[folderId] ?? []),
+      messageId,
+    ];
+
+    return message;
+  };
 
   const httpMock = setupHttpMock(
     ...microsoftAuthHandlers(handle, aliases),
-    ...microsoftMailboxHandlers(folderStore, messages),
+    ...microsoftMailboxHandlers(
+      folderStore,
+      messages,
+      removedMessageIdsByFolderId,
+    ),
     ...microsoftWebhookSubscriptionHandlers(subscriptionStore),
     http.post('*/me/messages', async ({ request }) => {
       const message = (await request.json()) as Record<string, unknown>;
@@ -159,6 +191,16 @@ export const setupMicrosoftMock = ({
       httpMock.use(
         ...microsoftCalendarEventsHandlers(events, deltaToken, removedEventIds),
       ),
+    moveMessageToFolder: (messageId, targetFolderId) => {
+      const message = recordFolderRemoval(messageId);
+
+      message.parentFolderId = targetFolderId;
+    },
+    deleteMessage: (messageId) => {
+      const message = recordFolderRemoval(messageId);
+
+      messages.splice(messages.indexOf(message), 1);
+    },
     failSubscriptionRenewal: () =>
       httpMock.use(
         ...microsoftWebhookSubscriptionHandlers(subscriptionStore, {


### PR DESCRIPTION
Related: #25749 (and possibly the still-unresolved "Synced but missing" reports #16679, #13397, #13884, #16284)

## Mechanism

Microsoft delta sync runs per folder. When a message is moved between folders, the old folder's delta returns `@removed` for the message's immutable Graph ID while the new folder's delta returns that same ID as present. `MessagingMessageListFetchService.processMessageListFetch` flattens all folders' present IDs into `messageExternalIds` and all folders' deletion IDs into `messageExternalIdsToDelete`, then passes the deletion union unchanged to `deleteMessagesChannelMessageAssociationsAndRelatedOrphans` - which deletes the association and hard-deletes the now-orphaned `message` row, even though another folder returned that same message as present in the same sync cycle.

That produces exactly the reported shape: the message imports successfully (message + participants + `messageLinked` timelineActivity all created), then disappears on a later sync with no user-visible error, leaving orphaned `timelineActivity` rows and contact timestamps behind. Any folder move (archive, mailbox rules, conversation-history moves) can trigger it, and how often depends on each user's mailbox behavior - which fits the "some messages, not others" distribution.

This is a concrete, reproducible mechanism consistent with the data in #25749; we did not verify each of the 56 reported orphans individually.

## Fix

New util `filterMessageExternalIdsToDelete`: subtracts the sync cycle's present-ID set from the combined deletion candidates, and dedupes deletion events returned by multiple folders. A message any folder still reports as present is never sent to the orphan cleaner in that cycle.

## Tests

New spec `filter-message-external-ids-to-delete.util.spec.ts`:
- keeps a message when one folder removes it while another still returns it (the moved-message case)
- deduplicates deletion events returned by multiple folders

Red/green verified against the actual logic (pre-fix the deletion set retains `moved-message`; post-fix it contains only `deleted-message`). Full TS suite not run (no local install); the change is a pure exported helper plus a call-site swap, and the spec exercises both paths.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

