### PR TITLE
fix(rls): handle SQL wildcards in in-memory ilike filter evaluation (#25652)

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/is-record-matching-rls-row-level-permission-predicate.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/is-record-matching-rls-row-level-permission-predicate.util.spec.ts
@@ -127,6 +127,11 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
       FieldMetadataType.ADDRESS,
     ),
     createMockFlatFieldMetadata(
+      'description-id',
+      'description',
+      FieldMetadataType.RICH_TEXT,
+    ),
+    createMockFlatFieldMetadata(
       'company-id',
       'company',
       FieldMetadataType.RELATION,
@@ -150,6 +155,9 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
     address: {
       addressStreet1: 'Main Street',
       addressCity: 'Paris',
+    },
+    description: {
+      markdown: 'Lead developer on CRM core modules',
     },
     companyId: 'company-1',
     deletedAt: null,
@@ -337,6 +345,38 @@ describe('isRecordMatchingRLSRowLevelPermissionPredicate', () => {
       isRecordMatchingRLSRowLevelPermissionPredicate({
         record: { ...baseRecord, company: { id: 'company-1' } } as ObjectRecord,
         filter: { company: { is: 'NULL' } },
+        flatObjectMetadata,
+        flatFieldMetadataMaps,
+      }),
+    ).toBe(false);
+  });
+
+  it('matches rich text fields with SQL wildcards in ILIKE filter', () => {
+    expect(
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: baseRecord,
+        filter: {
+          description: {
+            markdown: {
+              ilike: '%dev_loper%core%',
+            },
+          },
+        },
+        flatObjectMetadata,
+        flatFieldMetadataMaps,
+      }),
+    ).toBe(true);
+
+    expect(
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: baseRecord,
+        filter: {
+          description: {
+            markdown: {
+              ilike: '%manager%',
+            },
+          },
+        },
         flatObjectMetadata,
         flatFieldMetadataMaps,
       }),

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts
@@ -28,6 +28,74 @@ describe('isMatchingRichTextFilter', () => {
         }),
       ).toBe(true);
     });
+
+    it('should handle SQL single-character wildcard (_)', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'h_llo' } },
+          value: 'hello',
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: 'h_llo' } },
+          value: 'hllo',
+        }),
+      ).toBe(false);
+
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '%h_llo%' } },
+          value: 'prefix hillo suffix',
+        }),
+      ).toBe(true);
+    });
+
+    it('should match across newlines in multiline markdown', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '%first%second%' } },
+          value: '# Title\nfirst paragraph\nsome text\nsecond paragraph',
+        }),
+      ).toBe(true);
+    });
+
+    it('should escape regex special characters while preserving SQL wildcards', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '%price: $10.00 (tax incl.)%' } },
+          value: 'Total price: $10.00 (tax incl.) for the item',
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '%price: $10_00%' } },
+          value: 'Total price: $10.00 for the item',
+        }),
+      ).toBe(true);
+    });
+
+    it('should support object value with markdown property', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '%note%' } },
+          value: { markdown: 'This is a note', blocknote: '{"root":{}}' },
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('blocknote ilike', () => {
+    it('should match blocknote content with wildcards', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { blocknote: { ilike: '%content%' } },
+          value: { blocknote: 'rich text content here', markdown: 'other' },
+        }),
+      ).toBe(true);
+    });
   });
 
   describe('default', () => {

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingRichTextFilter.test.ts
@@ -98,6 +98,42 @@ describe('isMatchingRichTextFilter', () => {
     });
   });
 
+  describe('direct ilike and like predicates', () => {
+    it('should support direct ilike predicate on string value', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { ilike: '%direct%' } as any,
+          value: 'direct content',
+        }),
+      ).toBe(true);
+    });
+
+    it('should support direct ilike predicate on object value', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { ilike: '%direct%' } as any,
+          value: { markdown: 'some direct text' },
+        }),
+      ).toBe(true);
+    });
+
+    it('should support escaped wildcards in markdown ilike', () => {
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '%100\\%%' } },
+          value: 'Coverage is 100% complete',
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingRichTextFilter({
+          richTextFilter: { markdown: { ilike: '%100\\%%' } },
+          value: 'Coverage is 1000 complete',
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe('default', () => {
     it('should throw for unexpected filter', () => {
       expect(() =>
@@ -109,3 +145,4 @@ describe('isMatchingRichTextFilter', () => {
     });
   });
 });
+

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingStringFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingStringFilter.test.ts
@@ -209,4 +209,39 @@ describe('isMatchingStringFilter', () => {
       ).toBe(false);
     });
   });
+
+  describe('escaped wildcards', () => {
+    it('should match escaped underscore literally', () => {
+      expect(
+        isMatchingStringFilter({
+          stringFilter: { like: 't\\_st' },
+          value: 't_st',
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingStringFilter({
+          stringFilter: { like: 't\\_st' },
+          value: 'test',
+        }),
+      ).toBe(false);
+    });
+
+    it('should match escaped percent sign literally', () => {
+      expect(
+        isMatchingStringFilter({
+          stringFilter: { like: '100\\%' },
+          value: '100%',
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingStringFilter({
+          stringFilter: { like: '100\\%' },
+          value: '1000',
+        }),
+      ).toBe(false);
+    });
+  });
 });
+

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingStringFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingStringFilter.test.ts
@@ -56,6 +56,22 @@ describe('isMatchingStringFilter', () => {
         }),
       ).toBe(false);
     });
+
+    it('value matches like pattern with underscore wildcard', () => {
+      expect(
+        isMatchingStringFilter({
+          stringFilter: { like: 't_st' },
+          value: 'test',
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingStringFilter({
+          stringFilter: { like: 't_st' },
+          value: 'toast',
+        }),
+      ).toBe(false);
+    });
   });
 
   describe('ilike', () => {
@@ -73,6 +89,22 @@ describe('isMatchingStringFilter', () => {
         isMatchingStringFilter({
           stringFilter: { ilike: 'AB%' },
           value: 'test',
+        }),
+      ).toBe(false);
+    });
+
+    it('value matches ilike pattern with underscore wildcard', () => {
+      expect(
+        isMatchingStringFilter({
+          stringFilter: { ilike: 'T_ST' },
+          value: 'test',
+        }),
+      ).toBe(true);
+
+      expect(
+        isMatchingStringFilter({
+          stringFilter: { ilike: 'T_ST' },
+          value: 'toast',
         }),
       ).toBe(false);
     });

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingFilesFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingFilesFilter.ts
@@ -13,7 +13,9 @@ export const isMatchingFilesFilter = ({
         /[.*+?^${}()|[\]\\]/g,
         '\\$&',
       );
-      const regexPattern = escapedPattern.replace(/%/g, '.*');
+      const regexPattern = escapedPattern
+        .replace(/%/g, '.*')
+        .replace(/_/g, '.');
       const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'is');
 
       const stringValue = JSON.stringify(value, null, 1);

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingRichTextFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingRichTextFilter.ts
@@ -1,6 +1,34 @@
 import { type RichTextFilter } from '@/types';
 import escapeRegExp from 'lodash.escaperegexp';
 
+const sqlWildcardToRegex = (pattern: string): string => {
+  let result = '';
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+
+    if (char === '\\' && i + 1 < pattern.length) {
+      const nextChar = pattern[i + 1];
+
+      if (nextChar === '%' || nextChar === '_' || nextChar === '\\') {
+        result += escapeRegExp(nextChar);
+        i++;
+        continue;
+      }
+    }
+
+    if (char === '%') {
+      result += '[\\s\\S]*';
+    } else if (char === '_') {
+      result += '[\\s\\S]';
+    } else {
+      result += escapeRegExp(char);
+    }
+  }
+
+  return result;
+};
+
 export const isMatchingRichTextFilter = ({
   richTextFilter,
   value,
@@ -19,11 +47,10 @@ export const isMatchingRichTextFilter = ({
         return false;
       }
 
-      const escapedPattern = escapeRegExp(richTextFilter.markdown.ilike ?? '');
-      const regexPattern = escapedPattern
-        .replace(/%/g, '.*')
-        .replace(/_/g, '.');
-      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'is');
+      const regexPattern = sqlWildcardToRegex(
+        richTextFilter.markdown.ilike ?? '',
+      );
+      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'iu');
 
       return regexCaseInsensitive.test(targetValue);
     }
@@ -37,13 +64,46 @@ export const isMatchingRichTextFilter = ({
         return false;
       }
 
-      const escapedPattern = escapeRegExp(richTextFilter.blocknote.ilike ?? '');
-      const regexPattern = escapedPattern
-        .replace(/%/g, '.*')
-        .replace(/_/g, '.');
-      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'is');
+      const regexPattern = sqlWildcardToRegex(
+        richTextFilter.blocknote.ilike ?? '',
+      );
+      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'iu');
 
       return regexCaseInsensitive.test(targetValue);
+    }
+    case (richTextFilter as { ilike?: string }).ilike !== undefined: {
+      const targetValue =
+        typeof value === 'object' && value !== null
+          ? (value.markdown ?? value.blocknote ?? '')
+          : value;
+
+      if (typeof targetValue !== 'string') {
+        return false;
+      }
+
+      const regexPattern = sqlWildcardToRegex(
+        (richTextFilter as { ilike: string }).ilike ?? '',
+      );
+      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'iu');
+
+      return regexCaseInsensitive.test(targetValue);
+    }
+    case (richTextFilter as { like?: string }).like !== undefined: {
+      const targetValue =
+        typeof value === 'object' && value !== null
+          ? (value.markdown ?? value.blocknote ?? '')
+          : value;
+
+      if (typeof targetValue !== 'string') {
+        return false;
+      }
+
+      const regexPattern = sqlWildcardToRegex(
+        (richTextFilter as { like: string }).like ?? '',
+      );
+      const regexCaseSensitive = new RegExp(`^${regexPattern}$`, 'u');
+
+      return regexCaseSensitive.test(targetValue);
     }
     default: {
       throw new Error(

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingRichTextFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingRichTextFilter.ts
@@ -6,15 +6,44 @@ export const isMatchingRichTextFilter = ({
   value,
 }: {
   richTextFilter: RichTextFilter;
-  value: string;
+  value: string | { markdown?: string; blocknote?: string } | null;
 }) => {
   switch (true) {
     case richTextFilter.markdown !== undefined: {
-      const escapedPattern = escapeRegExp(richTextFilter.markdown.ilike);
-      const regexPattern = escapedPattern.replace(/%/g, '.*');
-      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'i');
+      const targetValue =
+        typeof value === 'object' && value !== null
+          ? (value.markdown ?? '')
+          : value;
 
-      return regexCaseInsensitive.test(value);
+      if (typeof targetValue !== 'string') {
+        return false;
+      }
+
+      const escapedPattern = escapeRegExp(richTextFilter.markdown.ilike ?? '');
+      const regexPattern = escapedPattern
+        .replace(/%/g, '.*')
+        .replace(/_/g, '.');
+      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'is');
+
+      return regexCaseInsensitive.test(targetValue);
+    }
+    case richTextFilter.blocknote !== undefined: {
+      const targetValue =
+        typeof value === 'object' && value !== null
+          ? (value.blocknote ?? '')
+          : value;
+
+      if (typeof targetValue !== 'string') {
+        return false;
+      }
+
+      const escapedPattern = escapeRegExp(richTextFilter.blocknote.ilike ?? '');
+      const regexPattern = escapedPattern
+        .replace(/%/g, '.*')
+        .replace(/_/g, '.');
+      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'is');
+
+      return regexCaseInsensitive.test(targetValue);
     }
     default: {
       throw new Error(

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingStringFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingStringFilter.ts
@@ -29,15 +29,19 @@ export const isMatchingStringFilter = ({
     }
     case stringFilter.like !== undefined: {
       const escapedPattern = escapeRegExp(stringFilter.like);
-      const regexPattern = escapedPattern.replace(/%/g, '.*');
-      const regexCaseSensitive = new RegExp(`^${regexPattern}$`);
+      const regexPattern = escapedPattern
+        .replace(/%/g, '.*')
+        .replace(/_/g, '.');
+      const regexCaseSensitive = new RegExp(`^${regexPattern}$`, 's');
 
       return regexCaseSensitive.test(value);
     }
     case stringFilter.ilike !== undefined: {
       const escapedPattern = escapeRegExp(stringFilter.ilike);
-      const regexPattern = escapedPattern.replace(/%/g, '.*');
-      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'i');
+      const regexPattern = escapedPattern
+        .replace(/%/g, '.*')
+        .replace(/_/g, '.');
+      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'is');
 
       return regexCaseInsensitive.test(value);
     }

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingStringFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingStringFilter.ts
@@ -1,6 +1,34 @@
 import { type StringFilter } from '@/types';
 import escapeRegExp from 'lodash.escaperegexp';
 
+const sqlWildcardToRegex = (pattern: string): string => {
+  let result = '';
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+
+    if (char === '\\' && i + 1 < pattern.length) {
+      const nextChar = pattern[i + 1];
+
+      if (nextChar === '%' || nextChar === '_' || nextChar === '\\') {
+        result += escapeRegExp(nextChar);
+        i++;
+        continue;
+      }
+    }
+
+    if (char === '%') {
+      result += '[\\s\\S]*';
+    } else if (char === '_') {
+      result += '[\\s\\S]';
+    } else {
+      result += escapeRegExp(char);
+    }
+  }
+
+  return result;
+};
+
 export const isMatchingStringFilter = ({
   stringFilter,
   value,
@@ -28,20 +56,14 @@ export const isMatchingStringFilter = ({
       return value <= stringFilter.lte;
     }
     case stringFilter.like !== undefined: {
-      const escapedPattern = escapeRegExp(stringFilter.like);
-      const regexPattern = escapedPattern
-        .replace(/%/g, '.*')
-        .replace(/_/g, '.');
-      const regexCaseSensitive = new RegExp(`^${regexPattern}$`, 's');
+      const regexPattern = sqlWildcardToRegex(stringFilter.like);
+      const regexCaseSensitive = new RegExp(`^${regexPattern}$`, 'u');
 
       return regexCaseSensitive.test(value);
     }
     case stringFilter.ilike !== undefined: {
-      const escapedPattern = escapeRegExp(stringFilter.ilike);
-      const regexPattern = escapedPattern
-        .replace(/%/g, '.*')
-        .replace(/_/g, '.');
-      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'is');
+      const regexPattern = sqlWildcardToRegex(stringFilter.ilike);
+      const regexCaseInsensitive = new RegExp(`^${regexPattern}$`, 'iu');
 
       return regexCaseInsensitive.test(value);
     }


### PR DESCRIPTION
## Description

During row-level security (RLS) predicate evaluation, in-memory filter matching for \iLike\ and \like\ operators on rich text (and string/file) fields did not properly convert all SQL wildcards (\%\ and \_\) into regular expression equivalents, or account for multiline text in rich text fields. Specifically:
- SQL single-character wildcard \_\ was not converted to \.\ in regular expression patterns.
- \isMatchingRichTextFilter\ now properly escapes special regex characters while replacing \%\ with \.*\ and \_\ with \.\, enabling multiline \is\ matching across blocknote and markdown contents.
- Both string-based and object-based rich text values (\{ markdown: '...', blocknote: '...' }\) are properly extracted and evaluated.
- Added comprehensive unit test coverage for \isMatchingRichTextFilter\, \isMatchingStringFilter\, and \isRecordMatchingRLSRowLevelPermissionPredicate\.

## Changes
- \packages/twenty-shared/src/utils/filter/utils/isMatchingRichTextFilter.ts\: Properly transform \%\ to \.*\ and \_\ to \.\, support case-insensitive and dotAll matching (\'is'\), extract text from \markdown\ / \locknote\ values or string values.
- \packages/twenty-shared/src/utils/filter/utils/isMatchingStringFilter.ts\: Support \_\ wildcard replacement to \.\ in \like\ and \ilike\ filters.
- \packages/twenty-shared/src/utils/filter/utils/isMatchingFilesFilter.ts\: Support \_\ wildcard replacement to \.\.
- Test suites updated with test cases covering SQL wildcards (\%\, \_\), multiline markdown matching, and RLS predicate evaluation for \FieldMetadataType.RICH_TEXT\.

Fixes #25652

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

