### PR TITLE
refactor: share floating reference scale calculation

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
@@ -1,3 +1,4 @@
+import { getFloatingReferenceScale } from '@/ui/layout/overlay/utils/getFloatingReferenceScale';
 import { RecordFieldComponentInstanceContext } from '@/object-record/record-field/ui/states/contexts/RecordFieldComponentInstanceContext';
 import { recordFieldInputIsFieldInErrorComponentState } from '@/object-record/record-field/ui/states/recordFieldInputIsFieldInErrorComponentState';
 import { recordFieldInputLayoutDirectionComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionComponentState';
@@ -74,11 +75,8 @@ export const RecordInlineCellEditMode = ({
     strategy: 'fixed',
     middleware: [
       flip(),
-      offset(({ rects, elements }) => {
-        const referenceScale =
-          elements.reference instanceof HTMLElement
-            ? rects.reference.width / elements.reference.offsetWidth
-            : 1;
+      offset((state) => {
+        const referenceScale = getFloatingReferenceScale(state);
 
         return {
           mainAxis: (isCentered ? -26 : -29) * referenceScale,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx
@@ -1,3 +1,4 @@
+import { getFloatingReferenceScale } from '@/ui/layout/overlay/utils/getFloatingReferenceScale';
 import { useIsFieldInputOnly } from '@/object-record/record-field/ui/hooks/useIsFieldInputOnly';
 import { RecordFieldComponentInstanceContext } from '@/object-record/record-field/ui/states/contexts/RecordFieldComponentInstanceContext';
 import { recordFieldInputIsFieldInErrorComponentState } from '@/object-record/record-field/ui/states/recordFieldInputIsFieldInErrorComponentState';
@@ -80,11 +81,8 @@ export const RecordTableCellEditMode = ({
     strategy: 'fixed',
     middleware: [
       flip(),
-      offset(({ rects, elements }) => {
-        const referenceScale =
-          elements.reference instanceof HTMLElement
-            ? rects.reference.width / elements.reference.offsetWidth
-            : 1;
+      offset((state) => {
+        const referenceScale = getFloatingReferenceScale(state);
 
         return {
           mainAxis: -33 * referenceScale,

--- a/packages/twenty-front/src/modules/ui/layout/overlay/utils/getFloatingReferenceScale.ts
+++ b/packages/twenty-front/src/modules/ui/layout/overlay/utils/getFloatingReferenceScale.ts
@@ -1,0 +1,9 @@
+import { type MiddlewareState } from '@floating-ui/react';
+
+export const getFloatingReferenceScale = ({
+  rects,
+  elements,
+}: Pick<MiddlewareState, 'rects' | 'elements'>) =>
+  elements.reference instanceof HTMLElement
+    ? rects.reference.width / elements.reference.offsetWidth
+    : 1;


### PR DESCRIPTION
The table and record-detail inline editors duplicated the same reference-scale calculation. Extract it into `getFloatingReferenceScale` and reuse it from both offset callbacks, preserving their existing behavior.

Addresses the final cleanup comment on #25667, which merged while this change was being prepared.

Validation: targeted lint and formatting pass. The unchanged positioning behavior was verified in the #25667 preview at 125%, including table editors and the record-detail date picker. No additional tests are needed for this extraction.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

