### PR TITLE
Let the e2e local registry accept twenty-ui

### DIFF
--- a/.github/verdaccio-config.yaml
+++ b/.github/verdaccio-config.yaml
@@ -13,6 +13,9 @@ packages:
   'twenty-client-sdk':
     access: $all
     publish: $all
+  'twenty-ui':
+    access: $all
+    publish: $all
   'create-twenty-app':
     access: $all
     publish: $all


### PR DESCRIPTION
## What

`create-app-e2e-minimal` fails for every pull request that runs it, at the "Publish packages to local registry" step:

```
➤ YN0041: Invalid authentication (as an unknown user)
➤ YN0000: Failed with errors in 0s 813ms
Error: Process completed with exit code 1
```

The workflow publishes `twenty-client-sdk twenty-ui twenty-sdk create-twenty-app`, but `.github/verdaccio-config.yaml` grants `publish` to only three of them. `twenty-ui` falls through to the `'**'` entry, which sets `access` and a proxy but no `publish`, and verdaccio defaults publish to `$authenticated`. The job authenticates with a placeholder `npmAuthToken` and no htpasswd user, so the request is rejected as an unknown user.

This has been failing since `twenty-ui` joined the publishable set. It is not intermittent: retries fail identically, because nothing about it depends on timing.

Main looks unaffected only because the job is gated on changes under `packages/create-twenty-app/**`, `packages/twenty-sdk/**`, `packages/twenty-client-sdk/**` and `packages/twenty-shared/**`. Most pushes to main touch none of those, so the job is skipped and the run is green. On the runs where main did execute it, it failed with this same error.

## How

`twenty-ui` gets the same rule the other published packages already have, so the local registry accepts it without authentication like its siblings.

Adding the rule rather than dropping `twenty-ui` from `PUBLISHABLE_PACKAGES`, because its version is aligned with the SDK's, so the scaffolded app resolves `twenty-ui` at the CI version from this registry. Removing it from the list would move the failure to the install step instead of fixing it.

## Verification

- Reproduced and fixed locally, running verdaccio exactly as the job does. Publishing a package named `twenty-ui` against the current config fails with `E401 Unable to authenticate`, which is this failure; against the config in this PR the same publish succeeds with `+ twenty-ui@0.0.0-authtest`.
- The config parses, and every package the workflow publishes now has a publish rule.
- The failure and its cause were read from the job logs of a run that executed the step, and confirmed identical on a run from `main`.
- Size is not a concern for this registry's default 10 MB body limit: a clean `twenty-ui` build is about 11 MB across 872 artifacts before compression, so the tarball lands well under it.
