### PR TITLE
Read the deprecated flag from the model config when picking a tier default

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts
@@ -449,8 +449,9 @@ export class AiModelRegistryService {
     const allowedModels = this.getAdminFilteredModels();
 
     return (
-      allowedModels.find((model) => model.isDeprecated !== true) ??
-      allowedModels[0]
+      allowedModels.find(
+        (model) => this.getModelConfig(model.modelId)?.isDeprecated !== true,
+      ) ?? allowedModels[0]
     );
   }
 


### PR DESCRIPTION
## What

`twenty-server` does not typecheck on main:

```
src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service.ts(452,43):
error TS2339: Property 'isDeprecated' does not exist on type 'RegisteredAiModel'.
```

This blocks `server-lint-typecheck` for every pull request that touches the server. It went unnoticed because that job is changed-files gated, so pushes to main that touch no server file skip it and the run reports green.

## How

`findDefaultModelForTier` falls back to the first allowed model that is not deprecated, and read the flag straight off the registered model. `RegisteredAiModel` does not carry it: the registry entries are built with `modelId`, `sdkPackage`, `model`, `supportsReasoning`, `providerName` and `modelsDevName`, while `isDeprecated` belongs to `AiModelConfig`, which is where the catalog writes it.

The flag is now read from the config, which is what the transcription path a hundred lines above already does:

```ts
this.getTranscriptionModelConfig(model.modelId)?.isDeprecated !== true
```

Adding `isDeprecated` to `RegisteredAiModel` would have silenced the compiler and left the behaviour broken: nothing populates that property on a registered model, so the predicate would read `undefined !== true` for every candidate and the fallback would always return the first allowed model, deprecated or not. Reading the config makes the filter do what it says.

`getModelConfig` refreshes the catalog and registers a variant before reading its cache, so it resolves both the composite identifiers and the configured variant identifiers that appear in this list.

## Verification

- `npx tsgo -p tsconfig.json --noEmit` no longer reports anything for this file.
- The ai-models suites pass, 11 files and 76 tests.
- Lint and prettier on the changed file.

No test is added: the service has no spec today, and the repository prefers integration tests over unit tests with a mocked dependency graph for services. The behaviour this restores was never exercised, since the predicate silently matched every model.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

