### PR TITLE
Resolve dropdown and modal identities through their owner hooks on every surface

### DIFF
--- a/packages/twenty-front/.oxlintrc.json
+++ b/packages/twenty-front/.oxlintrc.json
@@ -127,6 +127,28 @@
     "twenty/no-jotai-store-in-selector": "error",
     "twenty/no-direct-atom-family-in-selector": "error",
     "twenty/folder-structure": "error",
+    "twenty/no-surface-scoped-state-outside-owner": [
+      "error",
+      {
+        "restrictedStates": [
+          {
+            "importPath": "@/ui/layout/dropdown/states/isDropdownOpenComponentState",
+            "ownerModulePath": "src/modules/ui/layout/dropdown/",
+            "useInstead": "useIsDropdownOpen"
+          },
+          {
+            "importPath": "@/ui/layout/dropdown/states/dropdownPlacementComponentState",
+            "ownerModulePath": "src/modules/ui/layout/dropdown/",
+            "useInstead": "useDropdownPlacement"
+          },
+          {
+            "importPath": "@/ui/layout/modal/states/isModalOpenedComponentState",
+            "ownerModulePath": "src/modules/ui/layout/modal/",
+            "useInstead": "useIsModalOpened"
+          }
+        ]
+      }
+    ],
     "twenty/enforce-module-boundaries": [
       "error",
       {

--- a/packages/twenty-front/src/modules/activities/calendar/components/CalendarEventComposerTargetsInput.tsx
+++ b/packages/twenty-front/src/modules/activities/calendar/components/CalendarEventComposerTargetsInput.tsx
@@ -13,6 +13,7 @@ import { t } from '@lingui/core/macro';
 import { useId } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 const StyledClickableContainer = styled.div`
   align-items: center;
@@ -41,6 +42,8 @@ export const CalendarEventComposerTargetsInput = ({
 }: CalendarEventComposerTargetsInputProps) => {
   const componentId = useId();
   const dropdownId = `calendar-event-composer-targets-${componentId}`;
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
 
   const { closeDropdown } = useCloseDropdown();
   const { openCalendarEventTargetsPicker } =
@@ -100,7 +103,7 @@ export const CalendarEventComposerTargetsInput = ({
       dropdownComponents={
         <MultipleRecordPicker
           componentInstanceId={dropdownId}
-          focusId={dropdownId}
+          focusId={scopedDropdownId}
           onChange={onTargetChange}
           onSubmit={() => closeDropdown(dropdownId)}
           onClickOutside={() => closeDropdown(dropdownId)}

--- a/packages/twenty-front/src/modules/activities/emails/recipients/components/EmailRecipientsFieldInput.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/recipients/components/EmailRecipientsFieldInput.tsx
@@ -42,7 +42,6 @@ import { FORM_FIELD_PLACEHOLDER_STYLES } from '@/ui/input/constants/FormFieldPla
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { useOpenDropdown } from '@/ui/layout/dropdown/hooks/useOpenDropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectableList';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { DND_KIT_COLLISION_PRIORITY } from '@/ui/utilities/drag-and-drop/constants/DndKitCollisionPriority';
@@ -52,8 +51,8 @@ import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 const SUGGESTIONS_SEARCH_DEBOUNCE_MS = 300;
 
@@ -147,10 +146,7 @@ export const EmailRecipientsFieldInput = ({
     suggestionsDropdownId,
   );
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    suggestionsDropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(suggestionsDropdownId);
 
   const {
     inputValue,

--- a/packages/twenty-front/src/modules/ai/components/AiChatThreadListItem.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatThreadListItem.tsx
@@ -11,9 +11,8 @@ import { useAiChatThreadClick } from '@/ai/hooks/useAiChatThreadClick';
 import { useAiChatThreadRename } from '@/ai/hooks/useAiChatThreadRename';
 import { getAiChatThreadItemMenuDropdownId } from '@/ai/utils/getAiChatThreadItemMenuDropdownId';
 import { TextInput } from '@/ui/input/components/TextInput';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { type AgentChatThread } from '~/generated-metadata/graphql';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 const StyledThreadItem = styled.div`
   align-items: center;
@@ -104,10 +103,7 @@ export const AiChatThreadListItem = ({ thread }: AiChatThreadListItemProps) => {
     thread.id,
     AI_CHAT_THREAD_ACTIONS_SURFACE.SIDE_PANEL,
   );
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    itemMenuDropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(itemMenuDropdownId);
 
   return (
     <StyledThreadItem

--- a/packages/twenty-front/src/modules/ai/components/NavigationDrawerAiChatThreadItem.tsx
+++ b/packages/twenty-front/src/modules/ai/components/NavigationDrawerAiChatThreadItem.tsx
@@ -4,11 +4,10 @@ import { AiChatThreadItemMenu } from '@/ai/components/AiChatThreadItemMenu';
 import { AI_CHAT_THREAD_ACTIONS_SURFACE } from '@/ai/constants/AiChatThreadActionsSurface';
 import { useAiChatThreadRename } from '@/ai/hooks/useAiChatThreadRename';
 import { getAiChatThreadItemMenuDropdownId } from '@/ai/utils/getAiChatThreadItemMenuDropdownId';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { NavigationDrawerInput } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerInput';
 import { NavigationDrawerItem } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerItem';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { type AgentChatThread } from '~/generated-metadata/graphql';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 type NavigationDrawerAiChatThreadItemProps = {
   thread: AgentChatThread;
@@ -37,10 +36,7 @@ export const NavigationDrawerAiChatThreadItem = ({
     thread.id,
     AI_CHAT_THREAD_ACTIONS_SURFACE.NAV_DRAWER,
   );
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    itemMenuDropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(itemMenuDropdownId);
 
   if (isRenaming) {
     return (

--- a/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/components/RecordIndexCommandMenuDropdown.tsx
@@ -88,9 +88,9 @@ export const RecordIndexCommandMenuDropdown = () => {
           >
             <DropdownMenuItemsContainer>
               <SelectableList
-                focusId={dropdownId}
+                focusId={scopedDropdownId}
                 selectableItemIdArray={selectedItemIdArray}
-                selectableListInstanceId={dropdownId}
+                selectableListInstanceId={scopedDropdownId}
               >
                 {recordIndexCommandMenuItems.map((item) => (
                   <CommandMenuItemRenderer item={item} key={item.id} />

--- a/packages/twenty-front/src/modules/command-menu-item/confirmation-modal/components/CommandMenuConfirmationModalManager.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/confirmation-modal/components/CommandMenuConfirmationModalManager.tsx
@@ -9,8 +9,7 @@ import {
   ConfirmationModal,
   StyledCenteredButton,
 } from '@/ui/layout/modal/components/ConfirmationModal';
-import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useIsModalOpened } from '@/ui/layout/modal/hooks/useIsModalOpened';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { isDefined } from 'twenty-shared/utils';
@@ -19,8 +18,7 @@ export const CommandMenuConfirmationModalManager = () => {
   const commandMenuItemConfirmationModalConfig = useAtomStateValue(
     commandMenuItemConfirmationModalConfigState,
   );
-  const isModalOpened = useAtomComponentStateValue(
-    isModalOpenedComponentState,
+  const isModalOpened = useIsModalOpened(
     COMMAND_MENU_CONFIRMATION_MODAL_INSTANCE_ID,
   );
   const setCommandMenuItemConfirmationModalConfig = useSetAtomState(

--- a/packages/twenty-front/src/modules/command-menu-item/confirmation-modal/hooks/useCommandMenuConfirmationModal.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/confirmation-modal/hooks/useCommandMenuConfirmationModal.ts
@@ -7,7 +7,6 @@ import {
   commandMenuItemConfirmationModalConfigState,
 } from '@/command-menu-item/confirmation-modal/states/commandMenuItemConfirmationModalState';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
-import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 
 export const useCommandMenuConfirmationModal = () => {
@@ -15,17 +14,15 @@ export const useCommandMenuConfirmationModal = () => {
   const setCommandMenuItemConfirmationModalConfig = useSetAtomState(
     commandMenuItemConfirmationModalConfigState,
   );
-  const { openModal } = useModal();
+  const { openModal, isModalOpened } = useModal();
 
   const openConfirmationModal = useCallback(
     (config: CommandMenuItemConfirmationModalConfig) => {
       const existingCommandMenuItemConfirmationModalConfig = store.get(
         commandMenuItemConfirmationModalConfigState.atom,
       );
-      const isCommandMenuItemConfirmationModalOpened = store.get(
-        isModalOpenedComponentState.atomFamily({
-          instanceId: COMMAND_MENU_CONFIRMATION_MODAL_INSTANCE_ID,
-        }),
+      const isCommandMenuItemConfirmationModalOpened = isModalOpened(
+        COMMAND_MENU_CONFIRMATION_MODAL_INSTANCE_ID,
       );
 
       if (
@@ -41,7 +38,12 @@ export const useCommandMenuConfirmationModal = () => {
 
       openModal(COMMAND_MENU_CONFIRMATION_MODAL_INSTANCE_ID);
     },
-    [store, setCommandMenuItemConfirmationModalConfig, openModal],
+    [
+      store,
+      setCommandMenuItemConfirmationModalConfig,
+      openModal,
+      isModalOpened,
+    ],
   );
 
   return { openConfirmationModal };

--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuItemDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuItemDropdown.tsx
@@ -7,9 +7,8 @@ import {
   Dropdown,
   type DropdownProps,
 } from '@/ui/layout/dropdown/components/Dropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectableList';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 export type CommandMenuItemDropdownProps = CommandMenuItemProps &
   Pick<
@@ -31,10 +30,7 @@ export const CommandMenuItemDropdown = ({
   dropdownId,
   disabled = false,
 }: CommandMenuItemDropdownProps) => {
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   const { setSelectedItemId } = useSelectableList(
     SIDE_PANEL_SELECTABLE_LIST_ID,

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/folder/hooks/useFavoritesFolderEdit.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/folder/hooks/useFavoritesFolderEdit.ts
@@ -5,10 +5,9 @@ import { NAVIGATION_MENU_ITEM_FOLDER_DELETE_MODAL_ID } from '@/navigation-menu-i
 import { useDeleteNavigationMenuItemFolder } from '@/navigation-menu-item/edit/folder/hooks/useDeleteNavigationMenuItemFolder';
 import { useRenameNavigationMenuItemFolder } from '@/navigation-menu-item/edit/folder/hooks/useRenameNavigationMenuItemFolder';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
-import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
+import { useIsModalOpened } from '@/ui/layout/modal/hooks/useIsModalOpened';
 
 type UseFavoritesFolderEditParams = {
   folderId: string;
@@ -31,17 +30,11 @@ export const useFavoritesFolderEdit = ({
   const { openModal } = useModal();
 
   const dropdownId = `navigation-menu-item-folder-edit-${folderId}`;
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
   const { closeDropdown } = useCloseDropdown();
 
   const modalId = `${NAVIGATION_MENU_ITEM_FOLDER_DELETE_MODAL_ID}-${folderId}`;
-  const isModalOpened = useAtomComponentStateValue(
-    isModalOpenedComponentState,
-    modalId,
-  );
+  const isModalOpened = useIsModalOpened(modalId);
 
   const handleSubmitRename = async (value: string) => {
     if (value === '') return;

--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterRecordFilterOperandSelectContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterRecordFilterOperandSelectContent.tsx
@@ -94,11 +94,11 @@ export const AdvancedFilterRecordFilterOperandSelectContent = ({
         <DropdownContent widthInPixels={GenericDropdownContentWidth.Narrow}>
           <DropdownMenuItemsContainer>
             <SelectableList
-              focusId={dropdownId}
+              focusId={scopedDropdownId}
               selectableItemIdArray={operandsForFilterType.map(
                 (operand) => operand,
               )}
-              selectableListInstanceId={dropdownId}
+              selectableListInstanceId={scopedDropdownId}
             >
               {operandsForFilterType.map((filterOperand, index) => (
                 <SelectableListItem

--- a/packages/twenty-front/src/modules/object-record/advanced-filter/hooks/useAdvancedFilterFieldSelectDropdown.ts
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/hooks/useAdvancedFilterFieldSelectDropdown.ts
@@ -1,7 +1,13 @@
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 export const useAdvancedFilterFieldSelectDropdown = (viewFilterId?: string) => {
-  const advancedFilterFieldSelectDropdownId = `advanced-filter-view-filter-field-${viewFilterId}`;
+  // Resolved once here so the Dropdown, its hotkeys and its selectable list
+  // all share the surface-scoped identity the Dropdown registers under.
+  const advancedFilterFieldSelectDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(
+      `advanced-filter-view-filter-field-${viewFilterId}`,
+    );
 
   const { closeDropdown } = useCloseDropdown();
 

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownActorSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownActorSelect.tsx
@@ -16,6 +16,7 @@ import {
   jsonRelationFilterValueSchema,
 } from 'twenty-shared/utils';
 import { IconUserCircle } from 'twenty-ui/icon';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 export const EMPTY_ACTOR_FILTER_VALUE: string = JSON.stringify({
   isCurrentWorkspaceMemberSelected: false,
@@ -31,6 +32,9 @@ type ObjectFilterDropdownActorSelectProps = {
 export const ObjectFilterDropdownActorSelect = ({
   dropdownId,
 }: ObjectFilterDropdownActorSelectProps) => {
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const { objectFilterDropdownFilterValue } =
     useObjectFilterDropdownFilterValue();
 
@@ -160,7 +164,7 @@ export const ObjectFilterDropdownActorSelect = ({
       )}
       <MultipleSelectDropdown
         selectableListId="object-filter-actor-select-id"
-        focusId={dropdownId}
+        focusId={scopedDropdownId}
         itemsToSelect={recordsToSelect}
         filteredSelectedItems={filteredSelectedRecords}
         selectedItems={selectedRecords}

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOptionSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOptionSelect.tsx
@@ -77,6 +77,8 @@ export const ObjectFilterDropdownOptionSelect = ({
   const scopedComponentInstanceId =
     useWorkspaceSurfaceScopedComponentInstanceId(componentInstanceId);
 
+  const scopedFocusId = useWorkspaceSurfaceScopedComponentInstanceId(focusId);
+
   const selectedItemId = useAtomComponentStateValue(
     selectedItemIdComponentState,
     scopedComponentInstanceId,
@@ -123,7 +125,7 @@ export const ObjectFilterDropdownOptionSelect = ({
       closeDropdown();
       resetSelectedItem();
     },
-    focusId,
+    focusId: scopedFocusId,
     dependencies: [closeDropdown, resetSelectedItem],
   });
 
@@ -174,7 +176,7 @@ export const ObjectFilterDropdownOptionSelect = ({
     <SelectableList
       selectableListInstanceId={componentInstanceId}
       selectableItemIdArray={objectRecordsIds}
-      focusId={focusId}
+      focusId={scopedFocusId}
     >
       <DropdownMenuItemsContainer hasMaxHeight>
         {showNoResult ? (

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownRecordSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownRecordSelect.tsx
@@ -26,6 +26,7 @@ import {
 import { IconUserCircle } from 'twenty-ui/icon';
 import { allowRequestsToTwentyIconsState } from '@/client-config/states/allowRequestsToTwentyIcons';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 export const EMPTY_FILTER_VALUE: string = JSON.stringify({
   isCurrentWorkspaceMemberSelected: false,
@@ -52,6 +53,9 @@ const ObjectFilterDropdownRecordSelectContent = ({
   recordFilterId,
   dropdownId,
 }: ObjectFilterDropdownRecordSelectContentProps) => {
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const fieldMetadataItemUsedInFilterDropdown = useAtomComponentSelectorValue(
     fieldMetadataItemUsedInDropdownComponentSelector,
   );
@@ -227,7 +231,7 @@ const ObjectFilterDropdownRecordSelectContent = ({
       )}
       <MultipleSelectDropdown
         selectableListId="object-filter-record-select-id"
-        focusId={dropdownId}
+        focusId={scopedDropdownId}
         itemsToSelect={recordsToSelect}
         filteredSelectedItems={filteredSelectedRecords}
         selectedItems={selectedRecords}

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownSourceSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownSourceSelect.tsx
@@ -13,6 +13,7 @@ import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { isDefined, parseJson } from 'twenty-shared/utils';
 import { z } from 'zod';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 export const EMPTY_FILTER_VALUE = '[]';
 export const MAX_ITEMS_TO_DISPLAY = 3;
@@ -22,6 +23,9 @@ export const ObjectFilterDropdownSourceSelect = ({
 }: {
   dropdownId: string;
 }) => {
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const objectFilterDropdownSearchInput = useAtomComponentStateValue(
     objectFilterDropdownSearchInputComponentState,
   );
@@ -88,7 +92,7 @@ export const ObjectFilterDropdownSourceSelect = ({
     <DropdownContent widthInPixels={GenericDropdownContentWidth.ExtraLarge}>
       <MultipleSelectDropdown
         selectableListId="object-filter-source-select-id"
-        focusId={dropdownId}
+        focusId={scopedDropdownId}
         itemsToSelect={sourceTypes.filter(
           (item) =>
             !filteredSelectedItems.some((selected) => selected.id === item.id),

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdown.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdown.tsx
@@ -9,10 +9,9 @@ import { useRecordGroupReorderConfirmationModal } from '@/object-record/record-g
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { StyledHeaderDropdownButton } from '@/ui/layout/dropdown/components/StyledHeaderDropdownButton';
 import { DROPDOWN_OFFSET_Y } from '@/ui/layout/dropdown/constants/DropdownOffsetY';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { type ViewType } from '@/views/types/ViewType';
 import { Trans } from '@lingui/react/macro';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 type ObjectOptionsDropdownProps = {
   viewType: ViewType;
@@ -28,10 +27,7 @@ export const ObjectOptionsDropdown = ({
   const { currentContentId, handleContentChange, handleResetContent } =
     useDropdownContextCurrentContentId<ObjectOptionsContentId>();
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    OBJECT_OPTIONS_DROPDOWN_ID,
-  );
+  const isDropdownOpen = useIsDropdownOpen(OBJECT_OPTIONS_DROPDOWN_ID);
 
   const {
     handleRecordGroupOrderChangeWithModal,

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
@@ -80,8 +80,8 @@ export const ObjectOptionsDropdownCalendarViewContent = () => {
       </DropdownMenuHeader>
       <DropdownMenuItemsContainer>
         <SelectableList
-          selectableListInstanceId={OBJECT_OPTIONS_DROPDOWN_ID}
-          focusId={OBJECT_OPTIONS_DROPDOWN_ID}
+          selectableListInstanceId={scopedObjectOptionsDropdownId}
+          focusId={scopedObjectOptionsDropdownId}
           selectableItemIdArray={selectableItemIdArray}
         >
           <SelectableListItem

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCustomView.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCustomView.tsx
@@ -138,8 +138,8 @@ export const ObjectOptionsDropdownCustomView = ({
       <ObjectOptionsDropdownMenuViewName currentView={customViewData} />
       <DropdownMenuSeparator />
       <SelectableList
-        selectableListInstanceId={OBJECT_OPTIONS_DROPDOWN_ID}
-        focusId={OBJECT_OPTIONS_DROPDOWN_ID}
+        selectableListInstanceId={scopedObjectOptionsDropdownId}
+        focusId={scopedObjectOptionsDropdownId}
         selectableItemIdArray={selectableItemIdArray}
       >
         <DropdownMenuItemsContainer scrollable={false}>

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownDefaultView.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownDefaultView.tsx
@@ -77,8 +77,8 @@ export const ObjectOptionsDropdownDefaultView = () => {
       </DropdownMenuItemsContainer>
       <DropdownMenuSeparator />
       <SelectableList
-        selectableListInstanceId={OBJECT_OPTIONS_DROPDOWN_ID}
-        focusId={OBJECT_OPTIONS_DROPDOWN_ID}
+        selectableListInstanceId={scopedObjectOptionsDropdownId}
+        focusId={scopedObjectOptionsDropdownId}
         selectableItemIdArray={selectableItemIdArray}
       >
         <DropdownMenuItemsContainer scrollable={false}>

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
@@ -149,8 +149,8 @@ export const ObjectOptionsDropdownLayoutContent = () => {
 
       {!!currentView && (
         <SelectableList
-          selectableListInstanceId={OBJECT_OPTIONS_DROPDOWN_ID}
-          focusId={OBJECT_OPTIONS_DROPDOWN_ID}
+          selectableListInstanceId={scopedObjectOptionsDropdownId}
+          focusId={scopedObjectOptionsDropdownId}
           selectableItemIdArray={selectableItemIdArray}
         >
           <DropdownMenuItemsContainer scrollable={false}>

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupSortContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupSortContent.tsx
@@ -89,8 +89,8 @@ export const ObjectOptionsDropdownRecordGroupSortContent = () => {
       </DropdownMenuHeader>
       <DropdownMenuItemsContainer>
         <SelectableList
-          selectableListInstanceId={OBJECT_OPTIONS_DROPDOWN_ID}
-          focusId={OBJECT_OPTIONS_DROPDOWN_ID}
+          selectableListInstanceId={scopedObjectOptionsDropdownId}
+          focusId={scopedObjectOptionsDropdownId}
           selectableItemIdArray={selectableItemIdArray}
         >
           <SelectableListItem

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupsContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupsContent.tsx
@@ -133,8 +133,8 @@ export const ObjectOptionsDropdownRecordGroupsContent = () => {
       </DropdownMenuHeader>
       <DropdownMenuItemsContainer>
         <SelectableList
-          selectableListInstanceId={OBJECT_OPTIONS_DROPDOWN_ID}
-          focusId={OBJECT_OPTIONS_DROPDOWN_ID}
+          selectableListInstanceId={scopedObjectOptionsDropdownId}
+          focusId={scopedObjectOptionsDropdownId}
           selectableItemIdArray={selectableItemIdArray}
         >
           {currentView?.key !== 'INDEX' && (

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownVisibilityContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownVisibilityContent.tsx
@@ -87,8 +87,8 @@ export const ObjectOptionsDropdownVisibilityContent = () => {
       </DropdownMenuHeader>
       <DropdownMenuItemsContainer>
         <SelectableList
-          selectableListInstanceId={OBJECT_OPTIONS_DROPDOWN_ID}
-          focusId={OBJECT_OPTIONS_DROPDOWN_ID}
+          selectableListInstanceId={scopedObjectOptionsDropdownId}
+          focusId={scopedObjectOptionsDropdownId}
           selectableItemIdArray={selectableItemIdArray}
         >
           <SelectableListItem

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -21,7 +21,6 @@ import { DropdownMenuSectionLabel } from '@/ui/layout/dropdown/components/Dropdo
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { StyledHeaderDropdownButton } from '@/ui/layout/dropdown/components/StyledHeaderDropdownButton';
 import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
 import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
@@ -37,6 +36,7 @@ import { IconX, useIcons } from 'twenty-ui/icon';
 import { MenuItem } from 'twenty-ui/navigation';
 import { v4 } from 'uuid';
 import { ViewSortDirection } from '~/generated-metadata/graphql';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 export const ObjectSortDropdownButton = () => {
   const { resetRecordSortDropdownSearchInput } =
@@ -141,10 +141,7 @@ export const ObjectSortDropdownButton = () => {
     setIsRecordSortDirectionDropdownMenuUnfolded(false);
   };
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    OBJECT_SORT_DROPDOWN_ID,
-  );
+  const isDropdownOpen = useIsDropdownOpen(OBJECT_SORT_DROPDOWN_ID);
 
   const { t } = useLingui();
 
@@ -224,9 +221,9 @@ export const ObjectSortDropdownButton = () => {
             }
           />
           <SelectableList
-            selectableListInstanceId={OBJECT_SORT_DROPDOWN_ID}
+            selectableListInstanceId={scopedObjectSortDropdownId}
             selectableItemIdArray={selectableItemIdArray}
-            focusId={OBJECT_SORT_DROPDOWN_ID}
+            focusId={scopedObjectSortDropdownId}
           >
             {shouldShowVisibleFields && (
               <>

--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardContainer.tsx
@@ -13,9 +13,9 @@ import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record
 import { RecordIndexRemoveSortingModal } from '@/object-record/record-index/components/RecordIndexRemoveSortingModal';
 import { RECORD_INDEX_REMOVE_SORTING_MODAL_ID } from '@/object-record/record-index/constants/RecordIndexRemoveSortingModalId';
 
-import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { isDefined } from 'twenty-shared/utils';
+import { useIsModalOpened } from '@/ui/layout/modal/hooks/useIsModalOpened';
 
 type RecordBoardContainerProps = {
   recordBoardId: string;
@@ -55,10 +55,7 @@ export const RecordBoardContainer = ({
       ...args,
     });
 
-  const isModalOpened = useAtomComponentStateValue(
-    isModalOpenedComponentState,
-    RECORD_INDEX_REMOVE_SORTING_MODAL_ID,
-  );
+  const isModalOpened = useIsModalOpened(RECORD_INDEX_REMOVE_SORTING_MODAL_ID);
 
   if (!isDefined(recordIndexGroupFieldMetadataItem)) {
     return null;

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeader.tsx
@@ -26,13 +26,13 @@ import { canCreateRecordsForObjectMetadataItem } from '@/object-record/utils/can
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { useDisableDragSelectOnPointerDown } from '@/ui/utilities/drag-select/hooks/useDisableDragSelectOnPointerDown';
 import { useToggleDropdown } from '@/ui/layout/dropdown/hooks/useToggleDropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { isDefined } from 'twenty-shared/utils';
 import { IconDotsVertical, IconPlus } from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 const StyledHeader = styled.div<{ isReadOnly: boolean }>`
   align-items: center;
@@ -197,10 +197,7 @@ export const RecordBoardColumnHeader = () => {
 
   const dropdownId = `record-board-column-dropdown-${columnDefinition.id}`;
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   const handleCreateNewRecordClick = async () => {
     await createNewIndexRecord({

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSection.tsx
@@ -10,15 +10,14 @@ import {
 } from '@/object-record/record-field/ui/contexts/FieldInputEventContext';
 import { type FieldMorphRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { getRecordFieldCardRelationPickerDropdownId } from '@/object-record/record-show/utils/getRecordFieldCardRelationPickerDropdownId';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 
 import { RecordDetailMorphRelationSectionDropdown } from '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSectionDropdown';
 import { RecordDetailRelationRecordsList } from '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsList';
 import { useGetMorphRelationRelatedRecordsWithObjectNameSingular } from '@/object-record/record-field-list/record-detail-section/relation/components/hooks/useGetMorphRelationRelatedRecordsWithObjectNameSingular';
 import { useMorphPersistManyToOne } from '@/object-record/record-field/ui/meta-types/input/hooks/useMorphPersistManyToOne';
 import { CustomError, isDefined } from 'twenty-shared/utils';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 type RecordDetailMorphRelationSectionProps = {
   loading: boolean;
@@ -49,10 +48,7 @@ export const RecordDetailMorphRelationSection = ({
     instanceId: scopeInstanceId,
   });
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   const { objectMetadataItems } = useObjectMetadataItems();
 

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSectionDropdownManyToOne.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSectionDropdownManyToOne.tsx
@@ -15,13 +15,13 @@ import { type RecordPickerPickableMorphItem } from '@/object-record/record-picke
 import { getRecordFieldCardRelationPickerDropdownId } from '@/object-record/record-show/utils/getRecordFieldCardRelationPickerDropdownId';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { dropdownPlacementComponentState } from '@/ui/layout/dropdown/states/dropdownPlacementComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { IconForbid, IconPencil } from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
+import { useDropdownPlacement } from '@/ui/layout/dropdown/hooks/useDropdownPlacement';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type RecordDetailMorphRelationSectionDropdownManyToOneProps = {
   dropdownTriggerClickableComponent?: ReactNode;
@@ -63,12 +63,12 @@ export const RecordDetailMorphRelationSectionDropdownManyToOne = ({
     instanceId: scopeInstanceId,
   });
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const { closeDropdown } = useCloseDropdown();
 
-  const dropdownPlacement = useAtomComponentStateValue(
-    dropdownPlacementComponentState,
-    dropdownId,
-  );
+  const dropdownPlacement = useDropdownPlacement(dropdownId);
 
   const setSingleRecordPickerSearchFilter = useSetAtomComponentState(
     singleRecordPickerSearchFilterComponentState,
@@ -134,7 +134,7 @@ export const RecordDetailMorphRelationSectionDropdownManyToOne = ({
       }
       dropdownComponents={
         <SingleRecordPicker
-          focusId={dropdownId}
+          focusId={scopedDropdownId}
           componentInstanceId={dropdownId}
           EmptyIcon={IconForbid}
           onMorphItemSelected={handleRelationPickerEntitySelected}

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSectionDropdownOneToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailMorphRelationSectionDropdownOneToMany.tsx
@@ -17,13 +17,13 @@ import { getRecordFieldCardRelationPickerDropdownId } from '@/object-record/reco
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { dropdownPlacementComponentState } from '@/ui/layout/dropdown/states/dropdownPlacementComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { CustomError, isDefined } from 'twenty-shared/utils';
 import { IconPlus } from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
+import { useDropdownPlacement } from '@/ui/layout/dropdown/hooks/useDropdownPlacement';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type RecordDetailMorphRelationSectionDropdownOneToManyProps = {
   dropdownTriggerClickableComponent?: ReactNode;
@@ -66,12 +66,12 @@ export const RecordDetailMorphRelationSectionDropdownOneToMany = ({
     instanceId: scopeInstanceId,
   });
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const { closeDropdown } = useCloseDropdown();
 
-  const dropdownPlacement = useAtomComponentStateValue(
-    dropdownPlacementComponentState,
-    dropdownId,
-  );
+  const dropdownPlacement = useDropdownPlacement(dropdownId);
 
   const setMultipleRecordPickerSearchFilter = useSetAtomComponentState(
     multipleRecordPickerSearchFilterComponentState,
@@ -169,7 +169,7 @@ export const RecordDetailMorphRelationSectionDropdownOneToMany = ({
       }
       dropdownComponents={
         <MultipleRecordPicker
-          focusId={dropdownId}
+          focusId={scopedDropdownId}
           componentInstanceId={dropdownId}
           onChange={(morphItem) => {
             updateMorphRelationOneToMany(morphItem);

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsListItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsListItem.tsx
@@ -23,10 +23,8 @@ import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
@@ -46,6 +44,7 @@ import { LightIconButton } from 'twenty-ui/input';
 import { MenuItem } from 'twenty-ui/navigation';
 import { AnimatedEaseInOut } from 'twenty-ui/layout';
 import { FieldMetadataType, RelationType } from '~/generated-metadata/graphql';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 const StyledClickableZone = styled.div`
   align-items: center;
@@ -127,10 +126,7 @@ export const RecordDetailRelationRecordsListItem = ({
   const dropdownInstanceId = `record-field-card-menu:${scopeInstanceId}:${relationFieldMetadataId}:${relationRecord.id}`;
 
   const { closeDropdown } = useCloseDropdown();
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownInstanceId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownInstanceId);
 
   const dropdownId = getRecordFieldCardRelationPickerDropdownId({
     fieldDefinition,

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
@@ -18,10 +18,8 @@ import { getRecordFieldCardRelationPickerDropdownId } from '@/object-record/reco
 import { recordStoreFamilySelector } from '@/object-record/record-store/states/selectors/recordStoreFamilySelector';
 import { AggregateOperations } from '@/object-record/record-table/constants/AggregateOperations';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { indexViewIdFromObjectMetadataItemFamilySelector } from '@/views/states/selectors/indexViewIdFromObjectMetadataItemFamilySelector';
 import { useLingui } from '@lingui/react/macro';
 import {
@@ -37,6 +35,7 @@ import {
   isDefined,
 } from 'twenty-shared/utils';
 import { RelationType } from '~/generated-metadata/graphql';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 type RecordDetailRelationSectionProps = {
   loading: boolean;
@@ -101,10 +100,7 @@ export const RecordDetailRelationSection = ({
     instanceId: scopeInstanceId,
   });
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   const indexViewId = useAtomFamilySelectorValue(
     indexViewIdFromObjectMetadataItemFamilySelector,

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -24,13 +24,13 @@ import { recordStoreFamilySelector } from '@/object-record/record-store/states/s
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { dropdownPlacementComponentState } from '@/ui/layout/dropdown/states/dropdownPlacementComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { CustomError, isDefined } from 'twenty-shared/utils';
 import { IconPlus } from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
+import { useDropdownPlacement } from '@/ui/layout/dropdown/hooks/useDropdownPlacement';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type RecordDetailRelationSectionDropdownToManyProps = {
   dropdownTriggerClickableComponent?: ReactNode;
@@ -121,12 +121,12 @@ export const RecordDetailRelationSectionDropdownToMany = ({
     instanceId: scopeInstanceId,
   });
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const { closeDropdown } = useCloseDropdown();
 
-  const dropdownPlacement = useAtomComponentStateValue(
-    dropdownPlacementComponentState,
-    dropdownId,
-  );
+  const dropdownPlacement = useDropdownPlacement(dropdownId);
 
   const setMultipleRecordPickerSearchFilter = useSetAtomComponentState(
     multipleRecordPickerSearchFilterComponentState,
@@ -252,7 +252,7 @@ export const RecordDetailRelationSectionDropdownToMany = ({
       }
       dropdownComponents={
         <MultipleRecordPicker
-          focusId={dropdownId}
+          focusId={scopedDropdownId}
           componentInstanceId={dropdownId}
           onCreate={
             isJunctionRelation || isDefined(createNewRecordAndOpenSidePanel)

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToOne.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToOne.tsx
@@ -16,9 +16,7 @@ import { recordStoreFamilySelector } from '@/object-record/record-store/states/s
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { dropdownPlacementComponentState } from '@/ui/layout/dropdown/states/dropdownPlacementComponentState';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
@@ -28,6 +26,8 @@ import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/is
 import { CustomError, isDefined } from 'twenty-shared/utils';
 import { IconForbid, IconPencil } from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
+import { useDropdownPlacement } from '@/ui/layout/dropdown/hooks/useDropdownPlacement';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type RecordDetailRelationSectionDropdownToOneProps = {
   dropdownTriggerClickableComponent?: ReactNode;
@@ -94,12 +94,12 @@ export const RecordDetailRelationSectionDropdownToOne = ({
     instanceId: scopeInstanceId,
   });
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const { closeDropdown } = useCloseDropdown();
 
-  const dropdownPlacement = useAtomComponentStateValue(
-    dropdownPlacementComponentState,
-    dropdownId,
-  );
+  const dropdownPlacement = useDropdownPlacement(dropdownId);
 
   const setSingleRecordPickerSearchFilter = useSetAtomComponentState(
     singleRecordPickerSearchFilterComponentState,
@@ -175,7 +175,7 @@ export const RecordDetailRelationSectionDropdownToOne = ({
       }
       dropdownComponents={
         <SingleRecordPicker
-          focusId={dropdownId}
+          focusId={scopedDropdownId}
           componentInstanceId={dropdownId}
           EmptyIcon={IconForbid}
           onMorphItemSelected={handleRelationPickerEntitySelected}

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -16,11 +16,9 @@ import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/Drop
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { useOpenDropdown } from '@/ui/layout/dropdown/hooks/useOpenDropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { isStandaloneVariableString } from 'twenty-shared/workflow';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
@@ -31,6 +29,7 @@ import { IconPlus } from 'twenty-ui/icon';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 import { MenuItem } from 'twenty-ui/navigation';
 import { toSpliced } from '~/utils/array/toSpliced';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 type FormArrayFieldInputProps = {
   label?: string;
@@ -134,10 +133,7 @@ export const FormArrayFieldInput = ({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const dropdownId = `dropdown-${instanceId}`;
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   const preventContainerFocusStackUpdate =
     draftValue.type === 'static' && draftValue.value.length >= 1;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormMultiRecordPicker.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormMultiRecordPicker.tsx
@@ -29,6 +29,7 @@ import { isDefined, isValidUuid } from 'twenty-shared/utils';
 import { mapArrayToObject } from '~/utils/array/mapArrayToObject';
 import { IconChevronDown } from 'twenty-ui/icon';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 const StyledFormSelectContainerWrapper = styled.div<{ readonly?: boolean }>`
   cursor: ${({ readonly }) => (readonly ? 'default' : 'pointer')};
@@ -81,6 +82,8 @@ export const FormMultiRecordPicker = ({
 
   const componentId = useId();
   const dropdownId = `form-multi-record-picker-${componentId}`;
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
   const variablesDropdownId = `form-multi-record-picker-${componentId}-variables`;
 
   const { closeDropdown } = useCloseDropdown();
@@ -230,7 +233,7 @@ export const FormMultiRecordPicker = ({
               dropdownComponents={
                 <MultipleRecordPicker
                   componentInstanceId={dropdownId}
-                  focusId={dropdownId}
+                  focusId={scopedDropdownId}
                   onChange={handleMorphItemChange}
                   onSubmit={() => closeDropdown(dropdownId)}
                   onClickOutside={() => closeDropdown(dropdownId)}

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormSingleRecordPicker.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormSingleRecordPicker.tsx
@@ -24,6 +24,7 @@ import { useCallback, useContext, useId } from 'react';
 import { CustomError, isDefined, isValidUuid } from 'twenty-shared/utils';
 import { IconChevronDown, IconForbid } from 'twenty-ui/icon';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 const StyledFormSelectContainerWrapper = styled.div<{ readonly?: boolean }>`
   cursor: ${({ readonly }) => (readonly ? 'default' : 'pointer')};
@@ -125,6 +126,8 @@ export const FormSingleRecordPicker = ({
 
   const componentId = useId();
   const dropdownId = `form-record-picker-${componentId}`;
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
   const variablesDropdownId = `form-record-picker-${componentId}-variables`;
 
   const { closeDropdown } = useCloseDropdown();
@@ -251,7 +254,7 @@ export const FormSingleRecordPicker = ({
               }
               dropdownComponents={
                 <SingleRecordPicker
-                  focusId={dropdownId}
+                  focusId={scopedDropdownId}
                   componentInstanceId={dropdownId}
                   EmptyIcon={IconForbid}
                   emptyLabel={t`No record`}

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormWorkspaceMemberFilterValueInputDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormWorkspaceMemberFilterValueInputDropdownContent.tsx
@@ -7,6 +7,7 @@ import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent
 import { DropdownMenuSearchInput } from '@/ui/layout/dropdown/components/DropdownMenuSearchInput';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type FormWorkspaceMemberFilterValueInputDropdownContentProps = {
   dropdownId: string;
@@ -32,33 +33,38 @@ export const FormWorkspaceMemberFilterValueInputDropdownContent = ({
   selectedRecords,
   loading,
   onSelectChange,
-}: FormWorkspaceMemberFilterValueInputDropdownContentProps) => (
-  <DropdownContent widthInPixels={GenericDropdownContentWidth.ExtraLarge}>
-    <DropdownMenuSearchInput
-      autoFocus
-      type="text"
-      value={searchFilter}
-      onChange={onSearchChange}
-    />
-    <DropdownMenuSeparator />
-    {pinnedSelectableItems.length > 0 && (
-      <>
-        <ObjectFilterDropdownRecordPinnedItems
-          selectableItems={pinnedSelectableItems}
-          onChange={onSelectChange}
-        />
-        <DropdownMenuSeparator />
-      </>
-    )}
-    <MultipleSelectDropdown
-      selectableListId={selectableListId}
-      focusId={dropdownId}
-      itemsToSelect={recordsToSelect}
-      filteredSelectedItems={filteredSelectedRecords}
-      selectedItems={selectedRecords}
-      onChange={onSelectChange}
-      searchFilter={searchFilter}
-      loadingItems={loading}
-    />
-  </DropdownContent>
-);
+}: FormWorkspaceMemberFilterValueInputDropdownContentProps) => {
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
+  return (
+    <DropdownContent widthInPixels={GenericDropdownContentWidth.ExtraLarge}>
+      <DropdownMenuSearchInput
+        autoFocus
+        type="text"
+        value={searchFilter}
+        onChange={onSearchChange}
+      />
+      <DropdownMenuSeparator />
+      {pinnedSelectableItems.length > 0 && (
+        <>
+          <ObjectFilterDropdownRecordPinnedItems
+            selectableItems={pinnedSelectableItems}
+            onChange={onSelectChange}
+          />
+          <DropdownMenuSeparator />
+        </>
+      )}
+      <MultipleSelectDropdown
+        selectableListId={selectableListId}
+        focusId={scopedDropdownId}
+        itemsToSelect={recordsToSelect}
+        filteredSelectedItems={filteredSelectedRecords}
+        selectedItems={selectedRecords}
+        onChange={onSelectChange}
+        searchFilter={searchFilter}
+        loadingItems={loading}
+      />
+    </DropdownContent>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -2,9 +2,7 @@ import { t } from '@lingui/core/macro';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { MenuItemWithOptionDropdown } from '@/ui/navigation/menu-item/components/MenuItemWithOptionDropdown';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import React, { useState } from 'react';
 import {
   IconBookmark,
@@ -14,6 +12,7 @@ import {
   IconTrash,
 } from 'twenty-ui/icon';
 import { MenuItem } from 'twenty-ui/navigation';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 type MultiItemFieldMenuItemProps<T> = {
   dropdownId: string;
@@ -44,10 +43,7 @@ export const MultiItemFieldMenuItem = <T,>({
 }: MultiItemFieldMenuItemProps<T>) => {
   const [isHovered, setIsHovered] = useState(false);
   const { closeDropdown } = useCloseDropdown();
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   const handleMouseEnter = () => setIsHovered(true);
   const handleMouseLeave = () => {

--- a/packages/twenty-front/src/modules/object-record/record-group/components/AddRecordGroupButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-group/components/AddRecordGroupButton.tsx
@@ -12,6 +12,7 @@ import { isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
 import { IconPlus } from 'twenty-ui/icon';
 import { LightButton } from 'twenty-ui/input';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type AddRecordGroupButtonProps = {
   fieldMetadataItem: FieldMetadataItem;
@@ -27,6 +28,8 @@ export const AddRecordGroupButton = ({
   const { currentView } = useGetCurrentViewOnly();
   const { addRecordGroup } = useAddRecordGroup();
   const { closeDropdown } = useCloseDropdown();
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
 
   const targetObjectNameSingular =
     fieldMetadataItem.relation?.targetObjectMetadata.nameSingular;
@@ -62,7 +65,7 @@ export const AddRecordGroupButton = ({
       }
       dropdownComponents={
         <SingleRecordPicker
-          focusId={dropdownId}
+          focusId={scopedDropdownId}
           componentInstanceId={dropdownId}
           onCancel={() => closeDropdown(dropdownId)}
           onMorphItemSelected={handleRecordSelected}

--- a/packages/twenty-front/src/modules/object-record/record-group/components/RecordGroupAggregateDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-group/components/RecordGroupAggregateDropdownButton.tsx
@@ -1,11 +1,10 @@
 import { StyledHeaderDropdownButton } from '@/ui/layout/dropdown/components/StyledHeaderDropdownButton';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { styled } from '@linaria/react';
 import { type Nullable } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { Tag } from 'twenty-ui/data-display';
 import { AppTooltip, TooltipDelay } from 'twenty-ui/surfaces';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 const StyledTagContainer = styled.div`
   width: 100%;
@@ -26,10 +25,7 @@ export const RecordGroupAggregateDropdownButton = ({
   value?: Nullable<string | number>;
   tooltip?: Nullable<string>;
 }) => {
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   return (
     <StyledHeaderContainer>

--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexTableContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexTableContainer.tsx
@@ -3,8 +3,7 @@ import { RecordIndexTableContainerEffect } from '@/object-record/record-index/co
 import { RECORD_INDEX_REMOVE_SORTING_MODAL_ID } from '@/object-record/record-index/constants/RecordIndexRemoveSortingModalId';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { RecordTableWithWrappers } from '@/object-record/record-table/components/RecordTableWithWrappers';
-import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useIsModalOpened } from '@/ui/layout/modal/hooks/useIsModalOpened';
 
 type RecordIndexTableContainerProps = {
   recordTableId: string;
@@ -16,10 +15,7 @@ export const RecordIndexTableContainer = ({
   const { objectNameSingular, viewBarInstanceId } =
     useRecordIndexContextOrThrow();
 
-  const isModalOpened = useAtomComponentStateValue(
-    isModalOpenedComponentState,
-    RECORD_INDEX_REMOVE_SORTING_MODAL_ID,
-  );
+  const isModalOpened = useIsModalOpened(RECORD_INDEX_REMOVE_SORTING_MODAL_ID);
 
   return (
     <>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterValueCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterValueCell.tsx
@@ -4,14 +4,13 @@ import { RECORD_TABLE_COLUMN_CHECKBOX_WIDTH } from '@/object-record/record-table
 import { RecordTableColumnAggregateFooterCellContext } from '@/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterCellContext';
 import { RecordTableColumnAggregateFooterValue } from '@/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterValue';
 import { hasAggregateOperationForViewFieldFamilySelector } from '@/object-record/record-table/record-table-footer/states/hasAggregateOperationForViewFieldFamilySelector';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { styled } from '@linaria/react';
 import { useContext, useState } from 'react';
 import { IconChevronDown } from 'twenty-ui/icon';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 const StyledCell = styled.div<{ isUnfolded: boolean; isFirstCell: boolean }>`
   align-items: center;
@@ -57,10 +56,7 @@ export const RecordTableColumnAggregateFooterValueCell = ({
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   const { theme } = useContext(ThemeContext);
   const { viewFieldId, fieldMetadataId } = useContext(

--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsConfigurationGroupRenameInput.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsConfigurationGroupRenameInput.tsx
@@ -6,6 +6,7 @@ import { TextInput } from '@/ui/input/components/TextInput';
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { Button } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 const StyledContainer = styled.div`
   align-items: center;
@@ -32,6 +33,7 @@ export const FieldsConfigurationGroupRenameInput = ({
   onCancel,
 }: FieldsConfigurationGroupRenameInputProps) => {
   const { t } = useLingui();
+  const focusId = useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
 
   const handleSave = () => {
     if (renameValue.trim().length > 0) {
@@ -43,14 +45,14 @@ export const FieldsConfigurationGroupRenameInput = ({
   useHotkeysOnFocusedElement({
     keys: [Key.Enter],
     callback: handleSave,
-    focusId: dropdownId,
+    focusId,
     dependencies: [handleSave],
   });
 
   useHotkeysOnFocusedElement({
     keys: [Key.Escape],
     callback: onCancel,
-    focusId: dropdownId,
+    focusId,
     dependencies: [onCancel],
   });
 

--- a/packages/twenty-front/src/modules/settings/components/__tests__/SettingsRoutedFlowStateScope.test.tsx
+++ b/packages/twenty-front/src/modules/settings/components/__tests__/SettingsRoutedFlowStateScope.test.tsx
@@ -8,17 +8,16 @@ import { settingsDraftRoleFamilyState } from '@/settings/roles/states/settingsDr
 import { settingsPersistedRoleFamilyState } from '@/settings/roles/states/settingsPersistedRoleFamilyState';
 import { type RoleWithPartialMembers } from '@/settings/roles/types/RoleWithPartialMembers';
 import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 import { useOpenDropdown } from '@/ui/layout/dropdown/hooks/useOpenDropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
+import { useIsModalOpened } from '@/ui/layout/modal/hooks/useIsModalOpened';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
-import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
 import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { sortedFieldByTableFamilyState } from '@/ui/layout/table/states/sortedFieldByTableFamilyState';
 import {
   RoutedFlowStateScopeContext,
   useRoutedFlowStateScopeId,
 } from '@/ui/utilities/state/contexts/RoutedFlowStateScopeContext';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomFamilyState } from '@/ui/utilities/state/jotai/hooks/useSetAtomFamilyState';
@@ -41,8 +40,6 @@ const ScopedStateProbe = ({
 }: {
   name: 'main' | 'panel' | 'panel-second';
 }) => {
-  const modalId = useWorkspaceSurfaceScopedComponentInstanceId(MODAL_ID);
-  const dropdownId = useWorkspaceSurfaceScopedComponentInstanceId(DROPDOWN_ID);
   const tableId = useWorkspaceSurfaceScopedComponentInstanceId('role-table');
   const settingsDraftRole = useAtomFamilyStateValue(
     settingsDraftRoleFamilyState,
@@ -60,15 +57,9 @@ const ScopedStateProbe = ({
     settingsPersistedRoleFamilyState,
     ROLE_ID,
   );
-  const isModalOpened = useAtomComponentStateValue(
-    isModalOpenedComponentState,
-    modalId,
-  );
+  const isModalOpened = useIsModalOpened(MODAL_ID);
   const { openModal, toggleModal } = useModal();
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(DROPDOWN_ID);
   const { openDropdown } = useOpenDropdown();
   const sortedFieldByTable = useAtomFamilyStateValue(
     sortedFieldByTableFamilyState,

--- a/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignment.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignment.tsx
@@ -10,10 +10,8 @@ import { type SettingsRoleAssignmentConfirmationModalSelectedRoleTarget } from '
 import { useSettingsAllRoles } from '@/settings/roles/hooks/useSettingsAllRoles';
 import { settingsDraftRoleFamilyState } from '@/settings/roles/states/settingsDraftRoleFamilyState';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
-import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
 import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useState } from 'react';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { SettingsPath } from 'twenty-shared/types';
@@ -29,6 +27,7 @@ import { type PartialWorkspaceMember } from '@/settings/roles/types/RoleWithPart
 import { ROLE_ASSIGNMENT_CONFIRMATION_MODAL_ID } from '@/settings/roles/role-assignment/constants/RoleAssignmentConfirmationModalId';
 import { ROLE_TARGET_CONFIG } from '@/settings/roles/role-assignment/constants/RoleTargetConfig';
 import { buildRoleMaps } from '@/settings/roles/role-assignment/utils/buildRoleMaps';
+import { useIsModalOpened } from '@/ui/layout/modal/hooks/useIsModalOpened';
 
 type SettingsRoleAssignmentProps = {
   roleId: string;
@@ -91,10 +90,7 @@ export const SettingsRoleAssignment = ({
     setSelectRoleTarget(null);
   };
 
-  const isModalOpened = useAtomComponentStateValue(
-    isModalOpenedComponentState,
-    modalInstanceId,
-  );
+  const isModalOpened = useIsModalOpened(modalInstanceId);
 
   const handleConfirm = async () => {
     if (!selectedRoleTarget || !isModalOpened) return;

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelObjectFilterDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelObjectFilterDropdownContent.tsx
@@ -86,8 +86,8 @@ export const SidePanelObjectFilterDropdownContent = ({
       />
       <DropdownMenuSeparator />
       <SelectableList
-        selectableListInstanceId={OBJECT_FILTER_DROPDOWN_ID}
-        focusId={OBJECT_FILTER_DROPDOWN_ID}
+        selectableListInstanceId={scopedSelectableListId}
+        focusId={scopedSelectableListId}
         selectableItemIdArray={selectableItemIdArray}
       >
         <DropdownMenuItemsContainer hasMaxHeight>

--- a/packages/twenty-front/src/modules/ui/field/input/components/AddressInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/AddressInput.tsx
@@ -11,9 +11,8 @@ import { TEXT_INPUT_CLICK_OUTSIDE_ID } from '@/ui/input/components/constants/Tex
 import { CountrySelect } from '@/ui/input/components/internal/country/components/CountrySelect';
 import { SELECT_COUNTRY_DROPDOWN_ID } from '@/ui/input/components/internal/country/constants/SelectCountryDropdownId';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
-import { activeDropdownFocusIdState } from '@/ui/layout/dropdown/states/activeDropdownFocusIdState';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 import { MOBILE_VIEWPORT } from 'twenty-ui/theme-constants';
 
@@ -22,6 +21,7 @@ import { type AllowedAddressSubField } from 'twenty-shared/types';
 import { useAddressAutocomplete } from '@/ui/field/input/hooks/useAddressAutocomplete';
 import { useCountryUtils } from '@/ui/field/input/hooks/useCountryUtils';
 import { useFocusManagement } from '@/ui/field/input/hooks/useFocusManagement';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 const StyledAddressContainer = styled.div`
   padding: 4px 8px;
@@ -227,15 +227,20 @@ export const AddressInput = ({
     onShiftTab: handleShiftTab,
   });
 
-  const activeDropdownFocusId = useAtomStateValue(activeDropdownFocusIdState);
+  const autocompleteDropdownId = useWorkspaceSurfaceScopedComponentInstanceId(
+    SELECT_AUTOCOMPLETE_LIST_DROPDOWN_ID,
+  );
+
+  const isCountryDropdownOpen = useIsDropdownOpen(SELECT_COUNTRY_DROPDOWN_ID);
+  const isAutocompleteDropdownOpen = useIsDropdownOpen(autocompleteDropdownId);
 
   useListenClickOutside({
     refs: [wrapperRef],
     callback: (event) => {
-      if (
-        activeDropdownFocusId === SELECT_COUNTRY_DROPDOWN_ID ||
-        activeDropdownFocusId === SELECT_AUTOCOMPLETE_LIST_DROPDOWN_ID
-      ) {
+      // A click on an option of one of our own dropdowns lands in a portal,
+      // outside wrapperRef, and must reach the option rather than close the
+      // whole address input.
+      if (isCountryDropdownOpen || isAutocompleteDropdownOpen) {
         return;
       }
 
@@ -270,7 +275,7 @@ export const AddressInput = ({
     return (
       <StyledInputWithDropdownContainer>
         <Dropdown
-          dropdownId={SELECT_AUTOCOMPLETE_LIST_DROPDOWN_ID}
+          dropdownId={autocompleteDropdownId}
           dropdownPlacement="bottom-start"
           excludedClickOutsideIds={[
             TEXT_INPUT_CLICK_OUTSIDE_ID,
@@ -283,7 +288,7 @@ export const AddressInput = ({
             <PlaceAutocompleteSelect
               list={validAutocompleteData}
               onChange={handlePlaceSelection}
-              dropdownId={SELECT_AUTOCOMPLETE_LIST_DROPDOWN_ID}
+              dropdownId={autocompleteDropdownId}
             />
           }
         />

--- a/packages/twenty-front/src/modules/ui/field/input/components/__tests__/AddressInput.surfaceScope.test.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/__tests__/AddressInput.surfaceScope.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { type ReactNode } from 'react';
+
+import { AddressInput } from '@/ui/field/input/components/AddressInput';
+import {
+  WorkspaceSurfaceContext,
+  type WorkspaceSurfaceContextValue,
+} from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+const SIDE_PANEL_SURFACE: WorkspaceSurfaceContextValue = {
+  type: 'side-panel',
+  instanceId: 'side-panel-page',
+  ownsRouteLocation: true,
+};
+
+const EMPTY_ADDRESS = {
+  addressStreet1: '',
+  addressStreet2: null,
+  addressCity: null,
+  addressState: null,
+  addressCountry: null,
+  addressPostcode: null,
+  addressLat: null,
+  addressLng: null,
+};
+
+const renderAddressInput = (surface?: WorkspaceSurfaceContextValue) => {
+  const onChange = jest.fn();
+  const onClickOutside = jest.fn();
+  const BaseWrapper = getJestMetadataAndApolloMocksWrapper({});
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <I18nProvider i18n={i18n}>
+      <BaseWrapper>
+        {surface ? (
+          <WorkspaceSurfaceContext.Provider value={surface}>
+            {children}
+          </WorkspaceSurfaceContext.Provider>
+        ) : (
+          children
+        )}
+      </BaseWrapper>
+    </I18nProvider>
+  );
+
+  render(
+    <AddressInput
+      instanceId="address-input"
+      value={EMPTY_ADDRESS}
+      onTab={jest.fn()}
+      onShiftTab={jest.fn()}
+      onEnter={jest.fn()}
+      onEscape={jest.fn()}
+      onClickOutside={onClickOutside}
+      onChange={onChange}
+    />,
+    { wrapper: Wrapper },
+  );
+
+  return { onChange, onClickOutside };
+};
+
+describe('AddressInput country picker on a side panel surface', () => {
+  it.each([
+    ['main', undefined],
+    ['side-panel', SIDE_PANEL_SURFACE],
+  ])('selects a country with a click on %s', async (_, surface) => {
+    const user = userEvent.setup();
+    const { onChange, onClickOutside } = renderAddressInput(surface);
+
+    await user.click(screen.getByText('No country'));
+    await user.type(screen.getByPlaceholderText('Search'), 'France');
+    await user.click(await screen.findByText('France'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ addressCountry: 'France' }),
+    );
+    expect(onClickOutside).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front/src/modules/ui/input/components/IconPicker.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/IconPicker.tsx
@@ -413,6 +413,9 @@ export const IconPicker = ({
 
   const iconColorPickerDropdownId = `${dropdownId}-icon-color-picker`;
 
+  const scopedDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownId);
+
   const selectableListInstanceId =
     useWorkspaceSurfaceScopedComponentInstanceId('icon-list');
 
@@ -459,7 +462,7 @@ export const IconPicker = ({
               <SelectableList
                 selectableListInstanceId={selectableListInstanceId}
                 selectableItemIdMatrix={iconKeys2d}
-                focusId={dropdownId}
+                focusId={scopedDropdownId}
               >
                 <IconPickerSearchRow
                   closeDropdown={closeDropdown}

--- a/packages/twenty-front/src/modules/ui/input/components/Select.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/Select.tsx
@@ -170,7 +170,7 @@ export const Select = <Value extends SelectValue>({
     scopedDropdownId,
   );
 
-  const { setSelectedItemId } = useSelectableList(dropdownId);
+  const { setSelectedItemId } = useSelectableList(scopedDropdownId);
 
   const controlSelectedOption = useMemo(() => {
     if (!isDefined(selectedOption) || showContextualTextInControl) {
@@ -214,7 +214,7 @@ export const Select = <Value extends SelectValue>({
         />
       ) : (
         <Dropdown
-          dropdownId={dropdownId}
+          dropdownId={scopedDropdownId}
           dropdownPlacement="bottom-start"
           dropdownOffset={dropdownOffset}
           isDropdownInModal={isDropdownInModal}
@@ -254,7 +254,7 @@ export const Select = <Value extends SelectValue>({
                     onClick={() => {
                       onChange?.(pinnedOption.value);
                       onBlur?.();
-                      closeDropdown(dropdownId);
+                      closeDropdown(scopedDropdownId);
                     }}
                   />
                 </DropdownMenuItemsContainer>
@@ -265,8 +265,8 @@ export const Select = <Value extends SelectValue>({
               {isNonEmptyArray(filteredOptions) && (
                 <DropdownMenuItemsContainer hasMaxHeight>
                   <SelectableList
-                    selectableListInstanceId={dropdownId}
-                    focusId={dropdownId}
+                    selectableListInstanceId={scopedDropdownId}
+                    focusId={scopedDropdownId}
                     selectableItemIdArray={selectableItemIdArray}
                   >
                     {filteredOptions.map((option) => (
@@ -276,7 +276,7 @@ export const Select = <Value extends SelectValue>({
                         onEnter={() => {
                           onChange?.(option.value);
                           onBlur?.();
-                          closeDropdown(dropdownId);
+                          closeDropdown(scopedDropdownId);
                         }}
                       >
                         <MenuItemSelect
@@ -292,7 +292,7 @@ export const Select = <Value extends SelectValue>({
                           onClick={() => {
                             onChange?.(option.value);
                             onBlur?.();
-                            closeDropdown(dropdownId);
+                            closeDropdown(scopedDropdownId);
                           }}
                         />
                       </SelectableListItem>

--- a/packages/twenty-front/src/modules/ui/input/components/__tests__/Select.surfaceScope.test.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/__tests__/Select.surfaceScope.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { Select } from '@/ui/input/components/Select';
+import {
+  WorkspaceSurfaceContext,
+  type WorkspaceSurfaceContextValue,
+} from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+
+const SIDE_PANEL_SURFACE: WorkspaceSurfaceContextValue = {
+  type: 'side-panel',
+  instanceId: 'side-panel-page',
+  ownsRouteLocation: true,
+};
+
+const renderSelect = (surface?: WorkspaceSurfaceContextValue) => {
+  const onChange = jest.fn();
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={createStore()}>
+      {surface ? (
+        <WorkspaceSurfaceContext.Provider value={surface}>
+          {children}
+        </WorkspaceSurfaceContext.Provider>
+      ) : (
+        children
+      )}
+    </JotaiProvider>
+  );
+
+  render(
+    <Select
+      dropdownId="select-dropdown"
+      options={[
+        { label: 'Option A', value: 'a' },
+        { label: 'Option B', value: 'b' },
+      ]}
+      value="a"
+      onChange={onChange}
+    />,
+    { wrapper: Wrapper },
+  );
+
+  return { onChange };
+};
+
+describe('Select on a side panel surface', () => {
+  it.each([
+    ['main', undefined],
+    ['side-panel', SIDE_PANEL_SURFACE],
+  ])('selects an option with the keyboard on %s', async (_, surface) => {
+    const user = userEvent.setup();
+    const { onChange } = renderSelect(surface);
+
+    await user.click(screen.getByText('Option A'));
+    expect(await screen.findByText('Option B')).toBeInTheDocument();
+
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it.each([
+    ['main', undefined],
+    ['side-panel', SIDE_PANEL_SURFACE],
+  ])('selects an option with a click on %s', async (_, surface) => {
+    const user = userEvent.setup();
+    const { onChange } = renderSelect(surface);
+
+    await user.click(screen.getByText('Option A'));
+    await user.click(await screen.findByText('Option B'));
+
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+});

--- a/packages/twenty-front/src/modules/ui/input/components/internal/phone/components/PhoneCountryPickerDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/phone/components/PhoneCountryPickerDropdownButton.tsx
@@ -8,12 +8,11 @@ import { PhoneCountryPickerDropdownSelect } from './PhoneCountryPickerDropdownSe
 
 import { PHONE_COUNTRY_CODE_PICKER_DROPDOWN_ID } from '@/ui/input/components/internal/phone/constants/PhoneCountryCodePickerDropdownId';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import 'react-phone-number-input/style.css';
 import { isDefined } from 'twenty-shared/utils';
 import { IconChevronDown, IconWorld } from 'twenty-ui/icon';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 type StyledDropdownButtonProps = {
   isUnfolded: boolean;
@@ -76,8 +75,7 @@ export const PhoneCountryPickerDropdownButton = ({
 }) => {
   const [selectedCountry, setSelectedCountry] = useState<Country>();
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
+  const isDropdownOpen = useIsDropdownOpen(
     PHONE_COUNTRY_CODE_PICKER_DROPDOWN_ID,
   );
 

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx
@@ -13,6 +13,7 @@ import { useLingui } from '@lingui/react/macro';
 import { type ReactNode, useId } from 'react';
 import { IconDotsVertical } from 'twenty-ui/icon';
 import { IconButton } from 'twenty-ui/input';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 type OptionsDropdownMenuProps = {
   dropdownId?: string;
@@ -70,7 +71,9 @@ export const OptionsDropdownMenu = ({
   children,
 }: OptionsDropdownMenuProps) => {
   const generatedDropdownId = useId();
-  const dropdownId = dropdownIdFromProps ?? generatedDropdownId;
+  const dropdownId = useWorkspaceSurfaceScopedComponentInstanceId(
+    dropdownIdFromProps ?? generatedDropdownId,
+  );
   const { t } = useLingui();
 
   const listId = selectableListId ?? dropdownId;

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/__tests__/useIsDropdownOpen.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/__tests__/useIsDropdownOpen.test.tsx
@@ -1,0 +1,59 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
+import { useOpenDropdown } from '@/ui/layout/dropdown/hooks/useOpenDropdown';
+import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+
+const DROPDOWN_ID = 'country-select-dropdown';
+
+const buildWrapper =
+  (store: ReturnType<typeof createStore>) =>
+  ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={store}>
+      <WorkspaceSurfaceContext.Provider
+        value={{
+          type: 'side-panel',
+          instanceId: 'side-panel-page',
+          ownsRouteLocation: true,
+        }}
+      >
+        {children}
+      </WorkspaceSurfaceContext.Provider>
+    </JotaiProvider>
+  );
+
+// The dropdown hooks store the open state under a surface-scoped id. A reader
+// holding the raw id it passed to <Dropdown> must resolve it the same way,
+// which is what useIsDropdownOpen does and a direct atom read does not.
+describe('useIsDropdownOpen', () => {
+  it('sees a dropdown opened by its raw id inside a side panel', () => {
+    const store = createStore();
+    const wrapper = buildWrapper(store);
+
+    const { result: open } = renderHook(() => useOpenDropdown(), { wrapper });
+
+    act(() => {
+      open.current.openDropdown({
+        dropdownComponentInstanceIdFromProps: DROPDOWN_ID,
+      });
+    });
+
+    const { result: isDropdownOpen } = renderHook(
+      () => useIsDropdownOpen(DROPDOWN_ID),
+      { wrapper },
+    );
+
+    const { result: rawRead } = renderHook(
+      () =>
+        useAtomComponentStateValue(isDropdownOpenComponentState, DROPDOWN_ID),
+      { wrapper },
+    );
+
+    expect(isDropdownOpen.current).toBe(true);
+    expect(rawRead.current).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/useDropdownPlacement.ts
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/useDropdownPlacement.ts
@@ -1,0 +1,22 @@
+import { DropdownComponentInstanceContext } from '@/ui/layout/dropdown/contexts/DropdownComponentInstanceContext';
+import { dropdownPlacementComponentState } from '@/ui/layout/dropdown/states/dropdownPlacementComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+
+// Same contract as useIsDropdownOpen: the placement is written under the
+// dropdown's surface-scoped id, so readers resolve the id the same way.
+export const useDropdownPlacement = (dropdownId?: string) => {
+  const dropdownComponentInstanceId = useAvailableComponentInstanceIdOrThrow(
+    DropdownComponentInstanceContext,
+    dropdownId,
+  );
+
+  const scopedDropdownComponentInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownComponentInstanceId);
+
+  return useAtomComponentStateValue(
+    dropdownPlacementComponentState,
+    scopedDropdownComponentInstanceId,
+  );
+};

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/useIsDropdownOpen.ts
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/useIsDropdownOpen.ts
@@ -1,0 +1,23 @@
+import { DropdownComponentInstanceContext } from '@/ui/layout/dropdown/contexts/DropdownComponentInstanceContext';
+import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+
+// Dropdown keeps its state under a surface-scoped id, so a raw dropdownId
+// read through the atom directly misses inside a side panel. Resolve it the
+// same way useOpenDropdown and useCloseDropdown do.
+export const useIsDropdownOpen = (dropdownId?: string) => {
+  const dropdownComponentInstanceId = useAvailableComponentInstanceIdOrThrow(
+    DropdownComponentInstanceContext,
+    dropdownId,
+  );
+
+  const scopedDropdownComponentInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId(dropdownComponentInstanceId);
+
+  return useAtomComponentStateValue(
+    isDropdownOpenComponentState,
+    scopedDropdownComponentInstanceId,
+  );
+};

--- a/packages/twenty-front/src/modules/ui/layout/modal/hooks/__tests__/useIsModalOpened.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/hooks/__tests__/useIsModalOpened.test.tsx
@@ -1,0 +1,55 @@
+import { act, renderHook } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
+import { type ReactNode } from 'react';
+
+import { WorkspaceSurfaceContext } from '@/ui/layout/contexts/WorkspaceSurfaceContext';
+import { useIsModalOpened } from '@/ui/layout/modal/hooks/useIsModalOpened';
+import { useModal } from '@/ui/layout/modal/hooks/useModal';
+import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+
+const MODAL_ID = 'remove-sorting-modal';
+
+const buildWrapper =
+  (store: ReturnType<typeof createStore>) =>
+  ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={store}>
+      <WorkspaceSurfaceContext.Provider
+        value={{
+          type: 'side-panel',
+          instanceId: 'side-panel-page',
+          ownsRouteLocation: true,
+        }}
+      >
+        {children}
+      </WorkspaceSurfaceContext.Provider>
+    </JotaiProvider>
+  );
+
+// Same contract as useIsDropdownOpen: useModal writes under a surface-scoped
+// id, so a reader holding the raw modal id has to resolve it the same way.
+describe('useIsModalOpened', () => {
+  it('sees a modal opened by its raw id inside a side panel', () => {
+    const store = createStore();
+    const wrapper = buildWrapper(store);
+
+    const { result: modal } = renderHook(() => useModal(), { wrapper });
+
+    act(() => {
+      modal.current.openModal(MODAL_ID);
+    });
+
+    const { result: isModalOpened } = renderHook(
+      () => useIsModalOpened(MODAL_ID),
+      { wrapper },
+    );
+
+    const { result: rawRead } = renderHook(
+      () => useAtomComponentStateValue(isModalOpenedComponentState, MODAL_ID),
+      { wrapper },
+    );
+
+    expect(isModalOpened.current).toBe(true);
+    expect(rawRead.current).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/ui/layout/modal/hooks/useIsModalOpened.ts
+++ b/packages/twenty-front/src/modules/ui/layout/modal/hooks/useIsModalOpened.ts
@@ -1,0 +1,23 @@
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
+import { ModalComponentInstanceContext } from '@/ui/layout/modal/contexts/ModalComponentInstanceContext';
+import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpenedComponentState';
+import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+
+// ModalStatefulWrapper keeps its state under a surface-scoped id, so a raw
+// modalId read through the atom directly misses inside a side panel. Resolve
+// it the same way useModal does.
+export const useIsModalOpened = (modalId?: string) => {
+  const modalComponentInstanceId = useAvailableComponentInstanceIdOrThrow(
+    ModalComponentInstanceContext,
+    modalId,
+  );
+
+  const scopedModalComponentInstanceId =
+    useWorkspaceSurfaceScopedComponentInstanceId(modalComponentInstanceId);
+
+  return useAtomComponentStateValue(
+    isModalOpenedComponentState,
+    scopedModalComponentInstanceId,
+  );
+};

--- a/packages/twenty-front/src/modules/ui/layout/modal/hooks/useModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/hooks/useModal.tsx
@@ -16,6 +16,18 @@ export const useModal = () => {
   const resolveComponentInstanceId =
     useWorkspaceSurfaceScopedComponentInstanceIdResolver();
 
+  // Imperative counterpart of useIsModalOpened, for callbacks that cannot
+  // subscribe: resolves the id the same way open, close and toggle do.
+  const isModalOpened = useCallback(
+    (modalInstanceId: string) =>
+      store.get(
+        isModalOpenedComponentState.atomFamily({
+          instanceId: resolveComponentInstanceId(modalInstanceId),
+        }),
+      ),
+    [store, resolveComponentInstanceId],
+  );
+
   const closeModal = useCallback(
     (modalInstanceId: string) => {
       const scopedModalInstanceId = resolveComponentInstanceId(modalInstanceId);
@@ -100,5 +112,6 @@ export const useModal = () => {
     closeModal,
     openModal,
     toggleModal,
+    isModalOpened,
   };
 };

--- a/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
@@ -20,7 +20,6 @@ import { useAreViewSortsDifferentFromRecordSorts } from '@/views/hooks/useAreVie
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useCheckIsSoftDeleteFilter } from '@/object-record/record-filter/hooks/useCheckIsSoftDeleteFilter';
 import { anyFieldFilterValueComponentState } from '@/object-record/record-filter/states/anyFieldFilterValueComponentState';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { AnyFieldSearchDropdownButton } from '@/views/components/AnyFieldSearchDropdownButton';
 import { ANY_FIELD_SEARCH_DROPDOWN_ID } from '@/views/constants/AnyFieldSearchDropdownId';
@@ -37,6 +36,7 @@ import { isNonEmptyArray, isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
 import { LightButton } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 export type ViewBarDetailsProps = {
   hasFilterButton?: boolean;
@@ -188,10 +188,7 @@ export const ViewBarDetails = ({
   const shouldShowAdvancedFilterDropdownButton =
     currentRecordFilterGroups.length > 0;
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    ANY_FIELD_SEARCH_DROPDOWN_ID,
-  );
+  const isDropdownOpen = useIsDropdownOpen(ANY_FIELD_SEARCH_DROPDOWN_ID);
 
   const canResetView =
     (viewFiltersAreDifferentFromRecordFilters ||

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterButton.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterButton.tsx
@@ -1,14 +1,10 @@
 import { StyledHeaderDropdownButton } from '@/ui/layout/dropdown/components/StyledHeaderDropdownButton';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { ViewBarFilterDropdownIds } from '@/views/constants/ViewBarFilterDropdownIds';
 import { Trans } from '@lingui/react/macro';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 export const ViewBarFilterButton = () => {
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    ViewBarFilterDropdownIds.MAIN,
-  );
+  const isDropdownOpen = useIsDropdownOpen(ViewBarFilterDropdownIds.MAIN);
 
   return (
     <StyledHeaderDropdownButton isUnfolded={isDropdownOpen}>

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
@@ -25,6 +25,7 @@ import { ViewBarFilterDropdownIds } from '@/views/constants/ViewBarFilterDropdow
 import { useLingui } from '@lingui/react/macro';
 import { IconX } from 'twenty-ui/icon';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 export const StyledInput = styled.input`
   background: transparent;
@@ -62,6 +63,9 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
   } = useFilterDropdownSelectableFieldMetadataItems();
 
   const { closeDropdown } = useCloseDropdown();
+
+  const scopedViewBarFilterDropdownId =
+    useWorkspaceSurfaceScopedComponentInstanceId(ViewBarFilterDropdownIds.MAIN);
 
   const selectableFieldMetadataItemIds = [
     ...selectableVisibleFieldMetadataItems.map(
@@ -112,7 +116,7 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
         <SelectableList
           selectableItemIdArray={selectableFieldMetadataItemIds}
           selectableListInstanceId={FILTER_FIELD_LIST_ID}
-          focusId={ViewBarFilterDropdownIds.MAIN}
+          focusId={scopedViewBarFilterDropdownId}
         >
           {shouldShowVisibleFields && (
             <>

--- a/packages/twenty-front/src/modules/views/hooks/useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown.ts
@@ -20,6 +20,7 @@ import { useStore } from 'jotai';
 import { useCallback } from 'react';
 import { getFilterTypeFromFieldType, isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
+import { useWorkspaceSurfaceScopedComponentInstanceId } from '@/ui/layout/hooks/useWorkspaceSurfaceScopedComponentInstanceId';
 
 export const useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown =
   () => {
@@ -55,6 +56,10 @@ export const useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown =
       useUpsertObjectFilterDropdownCurrentFilter();
 
     const { pushFocusItemToFocusStack } = usePushFocusItemToFocusStack();
+    const scopedViewBarFilterDropdownId =
+      useWorkspaceSurfaceScopedComponentInstanceId(
+        ViewBarFilterDropdownIds.MAIN,
+      );
     const { getInitialFilterValue } = useGetInitialFilterValue();
 
     const store = useStore();
@@ -75,7 +80,7 @@ export const useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown =
 
           if (filterType === 'RELATION' || filterType === 'SELECT') {
             pushFocusItemToFocusStack({
-              focusId: ViewBarFilterDropdownIds.MAIN,
+              focusId: scopedViewBarFilterDropdownId,
               component: {
                 type: FocusComponentType.DROPDOWN,
                 instanceId: fieldMetadataItem.id,
@@ -144,6 +149,7 @@ export const useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown =
         },
         [
           store,
+          scopedViewBarFilterDropdownId,
           fieldMetadataItemUsedInDropdownCallbackState,
           currentRecordFiltersCallbackState,
           objectFilterDropdownFilterIsSelectedCallbackState,

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
@@ -3,8 +3,6 @@ import { t } from '@lingui/core/macro';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { StyledDropdownButtonContainer } from '@/ui/layout/dropdown/components/StyledDropdownButtonContainer';
 import { useNumberFormat } from '@/localization/hooks/useNumberFormat';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useGetRecordIndexTotalCount } from '@/views/hooks/internal/useGetRecordIndexTotalCount';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { ViewPickerContentCreateMode } from '@/views/view-picker/components/ViewPickerContentCreateMode';
@@ -23,6 +21,7 @@ import {
   ThemeContext,
   themeCssVariables,
 } from 'twenty-ui/theme-constants';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 const StyledIconContainer = styled.span`
   display: flex;
@@ -61,10 +60,7 @@ export const ViewPickerDropdown = () => {
 
   const { formatNumber } = useNumberFormat();
 
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    VIEW_PICKER_DROPDOWN_ID,
-  );
+  const isDropdownOpen = useIsDropdownOpen(VIEW_PICKER_DROPDOWN_ID);
 
   const { viewPickerMode, setViewPickerMode } = useViewPickerMode();
 

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowObjectDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowObjectDropdownContent.tsx
@@ -98,8 +98,8 @@ export const WorkflowObjectDropdownContent = ({
       <DropdownMenuSeparator />
       <DropdownMenuItemsContainer hasMaxHeight>
         <SelectableList
-          selectableListInstanceId={dropdownId}
-          focusId={dropdownId}
+          selectableListInstanceId={scopedDropdownId}
+          focusId={scopedDropdownId}
           selectableItemIdArray={selectableItemIdArray}
         >
           {filteredObjects.map((objectMetadataItem) => (

--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerDatabaseEventForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerDatabaseEventForm.tsx
@@ -236,8 +236,8 @@ export const WorkflowEditTriggerDatabaseEventForm = ({
                     <DropdownMenuSeparator />
                     <DropdownMenuItemsContainer hasMaxHeight>
                       <SelectableList
-                        selectableListInstanceId={dropdownId}
-                        focusId={dropdownId}
+                        selectableListInstanceId={scopedDropdownId}
+                        focusId={scopedDropdownId}
                         selectableItemIdArray={selectableItemIdArray}
                       >
                         {filteredObjects.map((option) => (

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablePicker.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablePicker.tsx
@@ -1,10 +1,9 @@
 import { type VariablePickerComponent } from '@/object-record/record-field/ui/form-types/types/VariablePickerComponent';
-import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
-import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { WorkflowVariablesDropdown } from '@/workflow/workflow-variables/components/WorkflowVariablesDropdown';
 import { SEARCH_VARIABLES_DROPDOWN_ID } from '@/workflow/workflow-variables/constants/SearchVariablesDropdownId';
 import { styled } from '@linaria/react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';
 
 const StyledSearchVariablesDropdownContainer = styled.div<{
   isReadonly?: boolean;
@@ -66,10 +65,7 @@ export const WorkflowVariablePicker: VariablePickerComponent = ({
   objectNameSingularsToSelect,
 }) => {
   const dropdownId = `${SEARCH_VARIABLES_DROPDOWN_ID}-${instanceId}`;
-  const isDropdownOpen = useAtomComponentStateValue(
-    isDropdownOpenComponentState,
-    dropdownId,
-  );
+  const isDropdownOpen = useIsDropdownOpen(dropdownId);
 
   return (
     <StyledSearchVariablesDropdownContainer

--- a/packages/twenty-oxlint-rules/oxlint-plugin.ts
+++ b/packages/twenty-oxlint-rules/oxlint-plugin.ts
@@ -61,6 +61,10 @@ import {
   RULE_NAME as noStorybookA11yDisableName,
 } from './rules/no-storybook-a11y-disable';
 import {
+  rule as noSurfaceScopedStateOutsideOwner,
+  RULE_NAME as noSurfaceScopedStateOutsideOwnerName,
+} from './rules/no-surface-scoped-state-outside-owner';
+import {
   rule as preferWorkspaceScopedRepository,
   RULE_NAME as preferWorkspaceScopedRepositoryName,
 } from './rules/prefer-workspace-scoped-repository';
@@ -100,6 +104,7 @@ export default definePlugin({
     [noNavigatePreferLinkName]: noNavigatePreferLink,
     [noStateUserefName]: noStateUseref,
     [noStorybookA11yDisableName]: noStorybookA11yDisable,
+    [noSurfaceScopedStateOutsideOwnerName]: noSurfaceScopedStateOutsideOwner,
     [preferWorkspaceScopedRepositoryName]: preferWorkspaceScopedRepository,
     [restApiMethodsShouldBeGuardedName]: restApiMethodsShouldBeGuarded,
     [sortCssPropertiesAlphabeticallyName]: sortCssPropertiesAlphabetically,

--- a/packages/twenty-oxlint-rules/rules/no-surface-scoped-state-outside-owner.spec.ts
+++ b/packages/twenty-oxlint-rules/rules/no-surface-scoped-state-outside-owner.spec.ts
@@ -1,0 +1,59 @@
+import { RuleTester } from 'oxlint/plugins-dev';
+
+import { rule, RULE_NAME } from './no-surface-scoped-state-outside-owner';
+
+const ruleTester = new RuleTester();
+
+const OPTIONS = [
+  {
+    restrictedStates: [
+      {
+        importPath: '@/ui/layout/dropdown/states/isDropdownOpenComponentState',
+        ownerModulePath: 'src/modules/ui/layout/dropdown/',
+        useInstead: 'useIsDropdownOpen',
+      },
+    ],
+  },
+];
+
+const IMPORT_STATE =
+  "import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';";
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      code: IMPORT_STATE,
+      filename:
+        '/project/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/useIsDropdownOpen.ts',
+      options: OPTIONS,
+    },
+    {
+      code: "import { useIsDropdownOpen } from '@/ui/layout/dropdown/hooks/useIsDropdownOpen';",
+      filename:
+        '/project/packages/twenty-front/src/modules/views/components/ViewBarFilterButton.tsx',
+      options: OPTIONS,
+    },
+    {
+      code: IMPORT_STATE,
+      filename:
+        '/project/packages/twenty-front/src/modules/views/components/ViewBarFilterButton.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: IMPORT_STATE,
+      filename:
+        '/project/packages/twenty-front/src/modules/views/components/ViewBarFilterButton.tsx',
+      options: OPTIONS,
+      errors: [
+        {
+          messageId: 'useOwnerHook',
+          data: {
+            stateName: 'isDropdownOpenComponentState',
+            useInstead: 'useIsDropdownOpen',
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/twenty-oxlint-rules/rules/no-surface-scoped-state-outside-owner.ts
+++ b/packages/twenty-oxlint-rules/rules/no-surface-scoped-state-outside-owner.ts
@@ -1,0 +1,84 @@
+import { defineRule } from '@oxlint/plugins';
+
+export const RULE_NAME = 'no-surface-scoped-state-outside-owner';
+
+type RestrictedState = {
+  importPath: string;
+  ownerModulePath: string;
+  useInstead: string;
+};
+
+type RuleOptions = {
+  restrictedStates?: RestrictedState[];
+};
+
+// Some component states (dropdown, modal) are keyed by an id their owner
+// module rewrites per workspace surface. Reading such a state with the raw id
+// compiles, is correct on the main surface, and silently returns the default
+// inside a side panel. The owner module exposes a hook that resolves the id,
+// so every other module has to go through it.
+export const rule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow importing a surface-scoped component state outside the module that owns it; read it through the owner hook instead.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          restrictedStates: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                importPath: { type: 'string' },
+                ownerModulePath: { type: 'string' },
+                useInstead: { type: 'string' },
+              },
+              required: ['importPath', 'ownerModulePath', 'useInstead'],
+              additionalProperties: false,
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      useOwnerHook:
+        "'{{ stateName }}' is keyed by a surface-scoped id that only its owner module resolves, so a direct read misses inside a side panel. Use {{ useInstead }} instead.",
+    },
+  },
+  create: (context) => {
+    const [options] = context.options as [RuleOptions | undefined];
+    const restrictedStates = options?.restrictedStates ?? [];
+    const filename = context.filename.replace(/\\/g, '/');
+
+    return {
+      ImportDeclaration: (node: any) => {
+        const importPath = node.source.value;
+
+        const restrictedState = restrictedStates.find(
+          (state) => state.importPath === importPath,
+        );
+
+        if (
+          restrictedState === undefined ||
+          filename.includes(restrictedState.ownerModulePath)
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'useOwnerHook',
+          data: {
+            stateName: importPath.split('/').pop() ?? importPath,
+            useInstead: restrictedState.useInstead,
+          },
+        });
+      },
+    };
+  },
+});


### PR DESCRIPTION
Fixes #25755.

## The mechanism

`Dropdown`, `ModalStatefulWrapper` and `SelectableList` register everything they own under a surface-scoped instance id: the jotai atoms, the focus-stack entry, `activeDropdownFocusIdState`, the DOM ids and the click-outside listener. `useOpenDropdown`, `useCloseDropdown`, `useToggleDropdown` and `useModal` resolve a raw id the same way, which is why `closeDropdown(RAW_ID)` works everywhere.

Three consumer paths did not go through that resolution and kept the raw id. All three compile, all three are correct on `main` (where scoping is the identity), and all three silently miss inside a routed side panel:

1. **Reads.** ~20 components read `isDropdownOpenComponentState` (and 4 read `dropdownPlacementComponentState`, 4 read `isModalOpenedComponentState`) with the raw id. In the panel they always read the default: header buttons never show as unfolded, relation-section adornments hide while their picker is open, `ViewPickerDropdown`'s edit-mode effect never runs, the record index never mounts `RecordIndexRemoveSortingModal`, and so on.
2. **Active-dropdown comparison.** `AddressInput` compared `activeDropdownFocusIdState` against `SELECT_COUNTRY_DROPDOWN_ID`. In the panel the active id is `select-country-dropdown-id-<page>`, so a click on a country option was treated as a click outside the address input: the document-capture listener called `stopImmediatePropagation()` and the option never received the click. That is #25755.
3. **Hotkey focus ids.** `Dropdown` pushes its scoped id on the focus stack, but `Select`, `OptionsDropdownMenu`, `IconPicker`, the record and relation pickers, the filter, sort and options dropdowns and the workflow trigger form registered their `useHotkeysOnFocusedElement` / `SelectableList` under the raw id. `currentFocusId !== focusId` for every one of them in the panel, so arrow keys and Enter did nothing in any side-panel dropdown. #25225 aligned the *selectable-list reads* at these sites but left the focus ids raw, which is why each of them already carried a `scopedXxxId` used for one purpose and the raw id for the other.

The view bar filter flow also pushed `ViewBarFilterDropdownIds.MAIN` raw onto the focus stack after the Dropdown had pushed the scoped id; in the panel that left an orphan focus entry behind when the dropdown closed.

## The fix

One rule, applied everywhere: **the dropdown's identity is `useWorkspaceSurfaceScopedComponentInstanceId(dropdownId)`; resolve it once where the id is created and use it for every handle, and never touch the owner module's atoms from outside.**

- `useIsDropdownOpen`, `useDropdownPlacement`, `useIsModalOpened`: read hooks that resolve the id exactly like `useCloseDropdown` / `useModal`, with the same context fallback. Every reader outside the two owner modules now uses them (28 files).
- `AddressInput` asks `useIsDropdownOpen` whether its country or autocomplete dropdown is open instead of comparing focus ids by hand, and resolves the autocomplete dropdown id once for `Dropdown` and `PlaceAutocompleteSelect`.
- Hotkey focus ids and selectable-list ids use the scoped identity at 33 sites. `useAdvancedFilterFieldSelectDropdown` and `OptionsDropdownMenu` resolve at the source so all their consumers are covered at once; `ObjectFilterDropdown{Option,Record,Source,Actor}Select` resolve the `filterDropdownId` they are handed, since that id is also the filter state instance id and must stay raw upstream.
- `twenty/no-surface-scoped-state-outside-owner`: a new oxlint rule that rejects importing `isDropdownOpenComponentState`, `dropdownPlacementComponentState` or `isModalOpenedComponentState` outside `ui/layout/dropdown` / `ui/layout/modal`, with the hook to use in the message. This is the part that stops the read-side class from coming back: a missed site fails CI instead of failing in a side panel. Focus ids cannot be linted the same way, so those rely on the per-site rule above.

Nothing about `Dropdown`, `SelectableList` or the scoping helper changes; ids that were already scoped resolve to themselves.

## Not in this PR

- `activeTabIdComponentState` raw readers (the `TabList` class). That is the subject of #25346 and its open design question about page-layout tab lists edited across surfaces; it is a different owner module and I did not want to pre-empt that decision here.
- Settings-only pages (`WebhookEntitySelect`, `SettingsMorphRelationMultiSelect`, `MultiSelectAddressFields`) still pass raw focus ids. Settings routes are `main`-only so they cannot hit the bug today; the `Select`-based ones are fixed through `Select` anyway.
- `hiddenGroupsSelectableListId` and `ADD_RECORD_GROUP_PICKER_INSTANCE_ID` as focus ids in the object options dropdown: nothing pushes those on any surface, which predates the side panel and is unrelated to scoping.

## Tests

- `AddressInput.surfaceScope.test.tsx`: opens the country picker, types, clicks "France", on `main` and in a side panel. **Fails on `main` for the side-panel case with exactly the issue's symptom** (no `onChange`), passes with this PR.
- `Select.surfaceScope.test.tsx`: ArrowDown + Enter and a click, on both surfaces. The side-panel keyboard case fails on `main`, proving the focus-id class.
- `useIsDropdownOpen.test.tsx`, `useIsModalOpened.test.tsx`: opened by raw id in a side panel, the hook sees it and a direct atom read does not.
- `no-surface-scoped-state-outside-owner.spec.ts` plus the plugin registry spec.

## Verification

- `tsgo --noEmit` on `twenty-front`: only the pre-existing `front-components` errors from the missing `twenty-front-component-renderer` build (same baseline as #25346).
- oxlint (type-aware, rebuilt plugin) and oxfmt clean on all changed files; the new rule confirmed to fire on a probe file.
- jest: 147 suites / 902 tests across every touched module.
- Storybook was not run.

Session: https://claude.ai/code/session_015hjgTjDmBnCsTdnozEQSgp