### PR TITLE
fix iCal parsing: bare CR (0x0D) line breaks instead of the CRLF that…

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/parse-ical-event.util.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/parse-ical-event.util.spec.ts
@@ -239,6 +239,42 @@ describe('parseICalEvents', () => {
     expect(parseICalEvents('not a calendar', HREF)).toEqual([]);
   });
 
+  it('parses calendar data with bare CR line breaks as served by Kerio Connect', () => {
+    const ics = buildVEvent([
+      'UID:abc',
+      'SUMMARY:Kerio event',
+      'DTSTART:20260901T100000Z',
+      'DTEND:20260901T110000Z',
+    ]).replace(/\r\n/g, '\r');
+
+    const [event] = parseICalEvents(ics, HREF);
+
+    expect(event).toMatchObject({
+      iCalUid: 'abc',
+      title: 'Kerio event',
+      startsAt: '2026-09-01T10:00:00.000Z',
+      endsAt: '2026-09-01T11:00:00.000Z',
+    });
+  });
+
+  it('parses calendar data with bare LF line breaks', () => {
+    const ics = buildVEvent([
+      'UID:abc',
+      'SUMMARY:LF event',
+      'DTSTART:20260901T100000Z',
+      'DTEND:20260901T110000Z',
+    ]).replace(/\r\n/g, '\n');
+
+    const [event] = parseICalEvents(ics, HREF);
+
+    expect(event).toMatchObject({
+      iCalUid: 'abc',
+      title: 'LF event',
+      startsAt: '2026-09-01T10:00:00.000Z',
+      endsAt: '2026-09-01T11:00:00.000Z',
+    });
+  });
+
   it('skips a VEVENT missing DTSTART without dropping its siblings', () => {
     const ics = buildVCalendar([
       ['UID:no-start', 'SUMMARY:Broken'],

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-ical-event.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-ical-event.util.ts
@@ -9,8 +9,6 @@ export const parseICalEvents = (
   objectUrl: string,
 ): FetchedCalendarEvent[] => {
   try {
-    // iCal mandates CRLF line breaks; servers like Kerio Connect serve
-    // calendar-data with bare CR (or LF) breaks, which node-ical parses as {}
     const normalizedRawData = rawData.replace(/\r\n|\r|\n/g, '\r\n');
 
     const events = Object.values(ical.parseICS(normalizedRawData))

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-ical-event.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-ical-event.util.ts
@@ -9,7 +9,11 @@ export const parseICalEvents = (
   objectUrl: string,
 ): FetchedCalendarEvent[] => {
   try {
-    const events = Object.values(ical.parseICS(rawData))
+    // iCal mandates CRLF line breaks; servers like Kerio Connect serve
+    // calendar-data with bare CR (or LF) breaks, which node-ical parses as {}
+    const normalizedRawData = rawData.replace(/\r\n|\r|\n/g, '\r\n');
+
+    const events = Object.values(ical.parseICS(normalizedRawData))
       .filter(
         (calendarComponent): calendarComponent is ical.VEvent =>
           calendarComponent.type === 'VEVENT',


### PR DESCRIPTION
fix https://github.com/twentyhq/twenty/issues/25781

/closes https://github.com/twentyhq/twenty/issues/25781


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

