### PR TITLE
Migrate Status to the new twenty-ui API

### DIFF
--- a/packages/twenty-front-component-renderer/src/__stories__/TwentyUiGallery.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/TwentyUiGallery.stories.tsx
@@ -13,6 +13,7 @@ import {
   sliderTest,
   toastTest,
 } from '@/__stories__/twenty-ui-gallery/utils/componentInteractionTests';
+import { statusControlsTest } from '@/__stories__/twenty-ui-gallery/utils/displayControlTests';
 import { createGalleryStory } from '@/__stories__/twenty-ui-gallery/utils/createGalleryStory';
 import {
   codeEditorTest,
@@ -353,4 +354,16 @@ export const CardPickerPreact: Story = createGalleryStory({
   frontComponentBundleName: 'twenty-ui-radio-group',
   runtime: 'preact',
   play: createRadioGroupPreactTest({ optionName: 'Pro plan' }),
+});
+
+export const StatusControlsReact: Story = createGalleryStory({
+  frontComponentBundleName: 'twenty-ui-status-controls',
+  runtime: 'react',
+  play: statusControlsTest,
+});
+
+export const StatusControlsPreact: Story = createGalleryStory({
+  frontComponentBundleName: 'twenty-ui-status-controls',
+  runtime: 'preact',
+  play: statusControlsTest,
 });

--- a/packages/twenty-front-component-renderer/src/__stories__/showcase/twenty-ui-example.front-component.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/showcase/twenty-ui-example.front-component.tsx
@@ -40,9 +40,9 @@ const TwentyUiComponent = () => {
           <Tag color="blue" text="Themed" variant="outline" />
         </div>
         <div style={ROW_STYLE}>
-          <Status color="green" text="Online" />
-          <Status color="red" text="Offline" />
-          <Status color="orange" text="Away" />
+          <Status color="green">Online</Status>
+          <Status color="red">Offline</Status>
+          <Status color="orange">Away</Status>
         </div>
         <div style={ROW_STYLE}>
           <Chip label="Highlighted" variant={ChipVariant.Highlighted} />

--- a/packages/twenty-front-component-renderer/src/__stories__/twenty-ui-gallery/twenty-ui-data-display-gallery.front-component.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/twenty-ui-gallery/twenty-ui-data-display-gallery.front-component.tsx
@@ -81,7 +81,7 @@ const DATA_DISPLAY_ENTRIES: GalleryEntry[] = [
   },
   {
     name: 'Status',
-    node: <Status color="green" text="Active" />,
+    node: <Status color="green">Active</Status>,
   },
   {
     name: 'StyledTintedIconTileContainer',

--- a/packages/twenty-front-component-renderer/src/__stories__/twenty-ui-gallery/twenty-ui-status-controls.front-component.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/twenty-ui-gallery/twenty-ui-status-controls.front-component.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { defineFrontComponent } from 'twenty-sdk/define';
+import { Status } from 'twenty-ui/data-display';
+import { ThemeProvider } from 'twenty-ui/theme-constants';
+import 'twenty-ui/style.css';
+
+import { ComponentGallery } from '../shared/front-components/component-gallery';
+
+const StatusControls = () => {
+  const [activations, setActivations] = useState(0);
+  const handleClick = () => setActivations((count) => count + 1);
+  return (
+    <ThemeProvider colorScheme="light">
+      <ComponentGallery
+        title="Status controls"
+        entries={[
+          {
+            name: 'Status',
+            node: (
+              <>
+                <Status color="green" onClick={handleClick}>
+                  Open status
+                </Status>
+                <Status color="green" onClick={handleClick} disabled>
+                  Disabled status
+                </Status>
+                <Status color="blue" loading>
+                  Loading status
+                </Status>
+              </>
+            ),
+          },
+        ]}
+      />
+      <output aria-label="Activations">{activations}</output>
+    </ThemeProvider>
+  );
+};
+
+export default defineFrontComponent({
+  universalIdentifier: '5b533ab1-e117-4644-a22f-b00b095fd81e',
+  name: 'twenty-ui-status-controls',
+  description: 'Status APIs and interactions in the sandbox',
+  component: StatusControls,
+});

--- a/packages/twenty-front-component-renderer/src/__stories__/twenty-ui-gallery/utils/displayControlTests.ts
+++ b/packages/twenty-front-component-renderer/src/__stories__/twenty-ui-gallery/utils/displayControlTests.ts
@@ -1,0 +1,43 @@
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { type TwentyUiGalleryPlayFunction } from '@/__stories__/twenty-ui-gallery/types/TwentyUiGalleryPlayFunction';
+import { galleryRenderTest } from '@/__stories__/twenty-ui-gallery/utils/galleryRenderTests';
+
+const createDisplayControlTest =
+  (
+    buttonName: string,
+    disabledButtonName: string,
+    staticContent: string,
+    checkGallery: TwentyUiGalleryPlayFunction = galleryRenderTest,
+  ): TwentyUiGalleryPlayFunction =>
+  async (context) => {
+    await checkGallery(context);
+    const canvas = within(context.canvasElement);
+    await expect(canvas.getByText(staticContent)).toBeVisible();
+    const button = canvas.getByRole('button', { name: buttonName });
+    await userEvent.click(button);
+    await waitFor(() =>
+      expect(canvas.getByLabelText('Activations')).toHaveTextContent('1'),
+    );
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() =>
+      expect(canvas.getByLabelText('Activations')).toHaveTextContent('2'),
+    );
+    await userEvent.keyboard(' ');
+    await waitFor(() =>
+      expect(canvas.getByLabelText('Activations')).toHaveTextContent('3'),
+    );
+    await expect(button).toHaveFocus();
+    const disabledButton = canvas.getByRole('button', {
+      name: disabledButtonName,
+    });
+    await expect(disabledButton).toBeDisabled();
+    await userEvent.click(disabledButton);
+    await expect(canvas.getByLabelText('Activations')).toHaveTextContent('3');
+  };
+
+export const statusControlsTest = createDisplayControlTest(
+  'Open status',
+  'Disabled status',
+  'Loading status',
+);

--- a/packages/twenty-front-component-renderer/src/__stories__/twenty-ui-gallery/utils/displayControlTests.ts
+++ b/packages/twenty-front-component-renderer/src/__stories__/twenty-ui-gallery/utils/displayControlTests.ts
@@ -3,13 +3,20 @@ import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { type TwentyUiGalleryPlayFunction } from '@/__stories__/twenty-ui-gallery/types/TwentyUiGalleryPlayFunction';
 import { galleryRenderTest } from '@/__stories__/twenty-ui-gallery/utils/galleryRenderTests';
 
+type CreateDisplayControlTestOptions = {
+  buttonName: string;
+  disabledButtonName: string;
+  staticContent: string;
+  checkGallery?: TwentyUiGalleryPlayFunction;
+};
+
 const createDisplayControlTest =
-  (
-    buttonName: string,
-    disabledButtonName: string,
-    staticContent: string,
-    checkGallery: TwentyUiGalleryPlayFunction = galleryRenderTest,
-  ): TwentyUiGalleryPlayFunction =>
+  ({
+    buttonName,
+    disabledButtonName,
+    staticContent,
+    checkGallery = galleryRenderTest,
+  }: CreateDisplayControlTestOptions): TwentyUiGalleryPlayFunction =>
   async (context) => {
     await checkGallery(context);
     const canvas = within(context.canvasElement);
@@ -36,8 +43,8 @@ const createDisplayControlTest =
     await expect(canvas.getByLabelText('Activations')).toHaveTextContent('3');
   };
 
-export const statusControlsTest = createDisplayControlTest(
-  'Open status',
-  'Disabled status',
-  'Loading status',
-);
+export const statusControlsTest = createDisplayControlTest({
+  buttonName: 'Open status',
+  disabledButtonName: 'Disabled status',
+  staticContent: 'Loading status',
+});

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/PageLayoutWidgetInvalidConfigDisplay.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/PageLayoutWidgetInvalidConfigDisplay.tsx
@@ -26,7 +26,7 @@ export const PageLayoutWidgetInvalidConfigDisplay = ({
   return (
     <StyledInvalidConfigContainer>
       <div id={tooltipId}>
-        <Status color="red" text={text} />
+        <Status color="red">{text}</Status>
       </div>
       <AppTooltip
         anchorSelect={`#${tooltipId}`}

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/PageLayoutWidgetStatusDisplay.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/PageLayoutWidgetStatusDisplay.tsx
@@ -25,7 +25,7 @@ export const PageLayoutWidgetStatusDisplay = ({
   return (
     <StyledContainer>
       <div id={tooltipId}>
-        <Status color={color} text={text} />
+        <Status color={color}>{text}</Status>
       </div>
       <AppTooltip
         anchorSelect={`#${tooltipId}`}

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsConnectedAccountsRowRightContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsConnectedAccountsRowRightContainer.tsx
@@ -31,7 +31,7 @@ export const SettingsAccountsConnectedAccountsRowRightContainer = ({
   if (isArchived) {
     return (
       <StyledRowRightContainer>
-        <Status color="gray" text={t`Archived`} weight="medium" />
+        <Status color="gray" weight="medium">{t`Archived`}</Status>
         <SettingsAccountsRowDropdownMenu account={account} />
       </StyledRowRightContainer>
     );
@@ -40,24 +40,23 @@ export const SettingsAccountsConnectedAccountsRowRightContainer = ({
   return (
     <StyledRowRightContainer>
       {status === SyncStatus.FAILED && (
-        <Status color="red" text={t`Sync failed`} weight="medium" />
+        <Status color="red" weight="medium">{t`Sync failed`}</Status>
       )}
       {status === SyncStatus.SYNCED && (
-        <Status color="green" text={t`Synced`} weight="medium" />
+        <Status color="green" weight="medium">{t`Synced`}</Status>
       )}
       {status === SyncStatus.NOT_SYNCED && (
-        <Status color="orange" text={t`Not synced`} weight="medium" />
+        <Status color="orange" weight="medium">{t`Not synced`}</Status>
       )}
       {status === SyncStatus.IMPORTING && (
         <Status
           color="turquoise"
-          text={t`Importing`}
           weight="medium"
-          isLoaderVisible
-        />
+          loading
+        >{t`Importing`}</Status>
       )}
       {status === SyncStatus.PENDING_CONFIGURATION && (
-        <Status color="orange" text={t`Setup incomplete`} weight="medium" />
+        <Status color="orange" weight="medium">{t`Setup incomplete`}</Status>
       )}
       <SettingsAccountsRowDropdownMenu account={account} />
     </StyledRowRightContainer>

--- a/packages/twenty-front/src/modules/settings/accounts/components/message-folders/SettingsMessageFoldersTreeItem.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/message-folders/SettingsMessageFoldersTreeItem.tsx
@@ -182,7 +182,7 @@ export const SettingsMessageFoldersTreeItem = ({
           <StyledRightSection>
             {folder.pendingSyncAction ===
               MessageFolderPendingSyncAction.FOLDER_IMPORT && (
-              <Status color="turquoise" text={t`Importing`} isLoaderVisible />
+              <Status color="turquoise" loading>{t`Importing`}</Status>
             )}
 
             {hasChildren && (

--- a/packages/twenty-front/src/modules/settings/admin-panel/ai/components/SettingsAdminAiProviderListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/ai/components/SettingsAdminAiProviderListCard.tsx
@@ -77,9 +77,9 @@ export const SettingsAdminAiProviderListCard = ({
       getItemDescription={getProviderDescription}
       RowRightComponent={({ item: provider }) =>
         isProviderConfigured(provider) ? (
-          <Status color="green" text={t`Configured`} weight="medium" />
+          <Status color="green" weight="medium">{t`Configured`}</Status>
         ) : (
-          <Status color="orange" text={t`No credentials`} weight="medium" />
+          <Status color="orange" weight="medium">{t`No credentials`}</Status>
         )
       }
       to={(provider) =>

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminServerAdminAccess.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminServerAdminAccess.tsx
@@ -148,10 +148,10 @@ export const SettingsAdminServerAdminAccess = ({
         {hasAnyAccess ? (
           <StyledChips>
             {canAccessFullAdminPanel && (
-              <Status color="green" text={t`Admin panel`} weight="medium" />
+              <Status color="green" weight="medium">{t`Admin panel`}</Status>
             )}
             {canImpersonate && (
-              <Status color="blue" text={t`Impersonation`} weight="medium" />
+              <Status color="blue" weight="medium">{t`Impersonation`}</Status>
             )}
           </StyledChips>
         ) : (

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
@@ -164,9 +164,10 @@ export const SettingsAdminWorkspaceContent = ({
                 value: (
                   <Status
                     color={upgradeHealthStatusBadge.color}
-                    text={upgradeHealthStatusBadge.label}
                     weight="medium"
-                  />
+                  >
+                    {upgradeHealthStatusBadge.label}
+                  </Status>
                 ),
               },
               {

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatusRightContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatusRightContainer.tsx
@@ -10,10 +10,10 @@ export const SettingsAdminHealthStatusRightContainer = ({
   return (
     <>
       {status === AdminPanelHealthServiceStatus.OPERATIONAL && (
-        <Status color="green" text={t`Operational`} weight="medium" />
+        <Status color="green" weight="medium">{t`Operational`}</Status>
       )}
       {status === AdminPanelHealthServiceStatus.OUTAGE && (
-        <Status color="red" text={t`Outage`} weight="medium" />
+        <Status color="red" weight="medium">{t`Outage`}</Status>
       )}
     </>
   );

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminUpgradeStatusRightContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminUpgradeStatusRightContainer.tsx
@@ -12,18 +12,20 @@ export const SettingsAdminUpgradeStatusRightContainer = ({
 }) => {
   if (item.kind === 'inferred-version') {
     return (
-      <Status
-        color="gray"
-        text={item.inferredVersion ?? t`Unknown`}
-        weight="medium"
-      />
+      <Status color="gray" weight="medium">
+        {item.inferredVersion ?? t`Unknown`}
+      </Status>
     );
   }
 
   if (item.kind === 'instance-status') {
     const badge = getUpgradeHealthStatusBadge(item.instanceHealth);
 
-    return <Status color={badge.color} text={badge.label} weight="medium" />;
+    return (
+      <Status color={badge.color} weight="medium">
+        {badge.label}
+      </Status>
+    );
   }
 
   const workspacesUpgradeHealth = getWorkspacesUpgradeHealth(
@@ -40,10 +42,8 @@ export const SettingsAdminUpgradeStatusRightContainer = ({
   );
 
   return (
-    <Status
-      color={workspacesUpgradeHealthBadge.color}
-      text={workspacesUpgradeHealthText}
-      weight="medium"
-    />
+    <Status color={workspacesUpgradeHealthBadge.color} weight="medium">
+      {workspacesUpgradeHealthText}
+    </Status>
   );
 };

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkspacesStatusSummaryCard.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkspacesStatusSummaryCard.tsx
@@ -50,11 +50,9 @@ export const SettingsAdminWorkspacesStatusSummaryCard = ({
           Icon: IconStatusChange,
           label: t`Upgrade health`,
           value: (
-            <Status
-              color={workspacesUpgradeHealthBadge.color}
-              text={workspacesUpgradeHealthText}
-              weight="medium"
-            />
+            <Status color={workspacesUpgradeHealthBadge.color} weight="medium">
+              {workspacesUpgradeHealthText}
+            </Status>
           ),
         },
         {

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
@@ -241,10 +241,7 @@ export const SettingsAdminMaintenanceMode = () => {
               </div>
               {isScheduled && (
                 <StyledStatusRow>
-                  <Status
-                    color="orange"
-                    text={t`Planned for ${formattedStartDate}`}
-                  />
+                  <Status color="orange">{t`Planned for ${formattedStartDate}`}</Status>
                 </StyledStatusRow>
               )}
             </StyledFormContainer>

--- a/packages/twenty-front/src/modules/settings/components/SettingsDnsRecordsTable.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsDnsRecordsTable.tsx
@@ -140,10 +140,9 @@ export const SettingsDnsRecordsTable = ({
           {hasStatusColumn && (
             <TableCell align="right">
               {isDefined(record.status) && isDefined(record.statusColor) && (
-                <Status
-                  color={record.statusColor}
-                  text={capitalize(record.status)}
-                />
+                <Status color={record.statusColor}>
+                  {capitalize(record.status)}
+                </Status>
               )}
             </TableCell>
           )}

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsPublicDomainsListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsPublicDomainsListCard.tsx
@@ -74,7 +74,7 @@ export const SettingsPublicDomainsListCard = ({
       RowRightComponent={({ item: publicDomain }) => (
         <>
           {!publicDomain.isValidated && (
-            <Status color="orange" text={t`Pending`} />
+            <Status color="orange">{t`Pending`}</Status>
           )}
           <SettingPublicDomainRowDropdownMenu publicDomain={publicDomain} />
         </>

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsWorkspaceDomainCard.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsWorkspaceDomainCard.tsx
@@ -52,9 +52,9 @@ export const SettingsWorkspaceDomainCard = () => {
             Status={
               currentWorkspace?.customDomain &&
               currentWorkspace?.isCustomDomainEnabled ? (
-                <Status text={t`Active`} color="turquoise" />
+                <Status color="turquoise">{t`Active`}</Status>
               ) : currentWorkspace?.customDomain ? (
-                <Status text={t`Inactive`} color="orange" />
+                <Status color="orange">{t`Inactive`}</Status>
               ) : undefined
             }
           />

--- a/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowRightComponent.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/devices/components/SettingsDeviceSessionRowRightComponent.tsx
@@ -17,10 +17,10 @@ export const SettingsDeviceSessionRowRightComponent = ({
   return (
     <>
       {session.isImpersonating && (
-        <Status color="orange" text={t`Impersonation`} />
+        <Status color="orange">{t`Impersonation`}</Status>
       )}
       {session.isCurrent ? (
-        <Status color="turquoise" text={t`This device`} />
+        <Status color="turquoise">{t`This device`}</Status>
       ) : (
         <SettingsDeviceSessionRowDropdownMenu userSessionId={session.id} />
       )}

--- a/packages/twenty-front/src/modules/settings/security/components/approvedAccessDomains/SettingsApprovedAccessDomainsListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/approvedAccessDomains/SettingsApprovedAccessDomainsListCard.tsx
@@ -73,7 +73,7 @@ export const SettingsApprovedAccessDomainsListCard = () => {
         RowRightComponent={({ item: approvedAccessDomain }) => (
           <>
             {!approvedAccessDomain.isValidated && (
-              <Status color="orange" text={t`Pending`} />
+              <Status color="orange">{t`Pending`}</Status>
             )}
             <SettingsSecurityApprovedAccessDomainRowDropdownMenu
               approvedAccessDomain={approvedAccessDomain}

--- a/packages/twenty-front/src/modules/settings/security/components/sso/SettingsSsoIdentityProviderRowRightContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/sso/SettingsSsoIdentityProviderRowRightContainer.tsx
@@ -22,9 +22,10 @@ export const SettingsSsoIdentityProviderRowRightContainer = ({
     <StyledRowRightContainer>
       <Status
         color={getColorBySsoIdentityProviderStatus[ssoIdp.status]}
-        text={ssoIdp.status}
         weight="medium"
-      />
+      >
+        {ssoIdp.status}
+      </Status>
       <SettingsSecuritySsoRowDropdownMenu ssoIdp={ssoIdp} />
     </StyledRowRightContainer>
   );

--- a/packages/twenty-front/src/modules/settings/unsubscribe-topics/components/SettingsWorkspaceUnsubscribeTopicSection.tsx
+++ b/packages/twenty-front/src/modules/settings/unsubscribe-topics/components/SettingsWorkspaceUnsubscribeTopicSection.tsx
@@ -35,9 +35,9 @@ export const SettingsWorkspaceUnsubscribeTopicSection = () => {
           align: 'right',
           Cell: ({ item }) =>
             item.visibility === UnsubscribeTopicVisibility.PUBLIC ? (
-              <Status color="blue" text={t`Public`} />
+              <Status color="blue">{t`Public`}</Status>
             ) : (
-              <Status color="gray" text={t`Private`} />
+              <Status color="gray">{t`Private`}</Status>
             ),
         },
       ]}

--- a/packages/twenty-front/src/modules/settings/unsubscribers/components/SettingsUnsubscribersList.tsx
+++ b/packages/twenty-front/src/modules/settings/unsubscribers/components/SettingsUnsubscribersList.tsx
@@ -159,11 +159,9 @@ export const SettingsUnsubscribersList = () => {
               const badge = getMessageSuppressionReasonBadge(item.reason);
 
               return (
-                <Status
-                  color={badge.color}
-                  text={badge.label}
-                  weight="medium"
-                />
+                <Status color={badge.color} weight="medium">
+                  {badge.label}
+                </Status>
               );
             },
           },

--- a/packages/twenty-front/src/modules/settings/workspace/components/SettingsWorkspaceEmailChannelDomainStatusCell.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace/components/SettingsWorkspaceEmailChannelDomainStatusCell.tsx
@@ -27,9 +27,8 @@ export const SettingsWorkspaceEmailChannelDomainStatusCell = ({
   }
 
   return (
-    <Status
-      color={getColorByEmailingDomainStatus(emailingDomain.status)}
-      text={getTextByEmailingDomainStatus(emailingDomain.status)}
-    />
+    <Status color={getColorByEmailingDomainStatus(emailingDomain.status)}>
+      {getTextByEmailingDomainStatus(emailingDomain.status)}
+    </Status>
   );
 };

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
@@ -121,11 +121,9 @@ export const SettingsAdminInstanceStatus = () => {
                 Icon: IconProgressCheck,
                 label: t`Status`,
                 value: (
-                  <Status
-                    color={instanceHealthBadge.color}
-                    text={instanceHealthBadge.label}
-                    weight="medium"
-                  />
+                  <Status color={instanceHealthBadge.color} weight="medium">
+                    {instanceHealthBadge.label}
+                  </Status>
                 ),
               },
               {

--- a/packages/twenty-front/src/pages/settings/ai/SettingsAgentTurnDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/ai/SettingsAgentTurnDetail.tsx
@@ -227,8 +227,7 @@ export const SettingsAgentTurnDetail = () => {
                       <TableCell gap={themeCssVariables.spacing[2]}>
                         <Status
                           color={getScoreColor(evaluation.score)}
-                          text={`${evaluation.score}`}
-                        />
+                        >{`${evaluation.score}`}</Status>
                       </TableCell>
                       <TableCell
                         overflow="hidden"

--- a/packages/twenty-front/src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
+++ b/packages/twenty-front/src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
@@ -212,11 +212,10 @@ export const SettingsAgentLogsTab = ({
                 {latestEvaluation ? (
                   <Status
                     color={getScoreColor(latestEvaluation.score)}
-                    text={`${latestEvaluation.score}`}
-                  />
+                  >{`${latestEvaluation.score}`}</Status>
                 ) : evaluatingTurnIds.has(turn.id) ||
                   backgroundEvaluatingTurnIds.has(turn.id) ? (
-                  <Status color="blue" text={t`Evaluating`} isLoaderVisible />
+                  <Status color="blue" loading>{t`Evaluating`}</Status>
                 ) : (
                   <Button
                     size="small"

--- a/packages/twenty-front/src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
@@ -220,21 +220,20 @@ export const SettingsApplicationConnectionDetail = () => {
         value: (
           <Status
             color={connection.visibility === 'workspace' ? 'blue' : 'gray'}
-            text={
-              connection.visibility === 'workspace'
-                ? t`Workspace shared`
-                : t`Just for me`
-            }
-          />
+          >
+            {connection.visibility === 'workspace'
+              ? t`Workspace shared`
+              : t`Just for me`}
+          </Status>
         ),
       },
       {
         key: 'status',
         label: t`Status`,
         value: connection.authFailedAt ? (
-          <Status color="red" text={t`Reconnect needed`} />
+          <Status color="red">{t`Reconnect needed`}</Status>
         ) : (
-          <Status color="green" text={t`Connected`} />
+          <Status color="green">{t`Connected`}</Status>
         ),
       },
       {

--- a/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
@@ -119,9 +119,9 @@ export const SettingsApplicationConnectionsSection = ({
                       </TableCell>
                       <TableCell clickable>
                         {connection.authFailedAt ? (
-                          <Status color="red" text={t`Reconnect needed`} />
+                          <Status color="red">{t`Reconnect needed`}</Status>
                         ) : (
-                          <Status color="green" text={t`Connected`} />
+                          <Status color="green">{t`Connected`}</Status>
                         )}
                       </TableCell>
                       <TableCell clickable>
@@ -131,12 +131,11 @@ export const SettingsApplicationConnectionsSection = ({
                               ? 'blue'
                               : 'gray'
                           }
-                          text={
-                            connection.visibility === 'workspace'
-                              ? t`Workspace shared`
-                              : t`Just for me`
-                          }
-                        />
+                        >
+                          {connection.visibility === 'workspace'
+                            ? t`Workspace shared`
+                            : t`Just for me`}
+                        </Status>
                       </TableCell>
                       <TableCell
                         align="right"

--- a/packages/twenty-front/src/pages/settings/communications/SettingsWorkspaceCommunicationGroupChannelDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/communications/SettingsWorkspaceCommunicationGroupChannelDetail.tsx
@@ -251,10 +251,9 @@ export const SettingsWorkspaceCommunicationGroupChannelDetail = () => {
               description={t`Outbound mail from this channel is sent through this domain. It must be verified before email can be delivered.`}
               adornment={
                 <StyledSendingDomainAdornment>
-                  <Status
-                    color={getColorByEmailingDomainStatus(domainStatus)}
-                    text={getTextByEmailingDomainStatus(domainStatus)}
-                  />
+                  <Status color={getColorByEmailingDomainStatus(domainStatus)}>
+                    {getTextByEmailingDomainStatus(domainStatus)}
+                  </Status>
                   {!isDomainVerified && (
                     <SettingsEmailingDomainVerifyButton
                       emailingDomainId={emailingDomain.id}

--- a/packages/twenty-front/src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
+++ b/packages/twenty-front/src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
@@ -199,10 +199,9 @@ export const SettingsWorkspaceMembersInviteTab = () => {
                       </StyledTextContainerWithEllipsis>
                     </TableCell>
                     <TableCell align="center">
-                      <Status
-                        color="gray"
-                        text={getExpiresAtText(workspaceInvitation.expiresAt)}
-                      />
+                      <Status color="gray">
+                        {getExpiresAtText(workspaceInvitation.expiresAt)}
+                      </Status>
                     </TableCell>
                     <TableCell align="right">
                       <StyledButtonContainer>

--- a/packages/twenty-front/src/pages/settings/profile/SettingsProfile.tsx
+++ b/packages/twenty-front/src/pages/settings/profile/SettingsProfile.tsx
@@ -85,9 +85,9 @@ export const SettingsProfile = () => {
               Icon={<IconShield />}
               Status={
                 has2FAMethod ? (
-                  <Status text={t`Active`} color="turquoise" />
+                  <Status color="turquoise">{t`Active`}</Status>
                 ) : (
-                  <Status text={t`Deactivated`} color="gray" />
+                  <Status color="gray">{t`Deactivated`}</Status>
                 )
               }
             />

--- a/packages/twenty-ui/src/data-display/Status/Status.module.scss
+++ b/packages/twenty-ui/src/data-display/Status/Status.module.scss
@@ -1,40 +1,46 @@
 .status {
+  @include focus-ring;
+  border: none;
+  font-family: inherit;
+  font-weight: var(--t-font-weight-regular);
+  &[data-weight='medium'] {
+    font-weight: var(--t-font-weight-medium);
+  }
+  &[data-interactive] {
+    cursor: pointer;
+  }
+  &[data-disabled] {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
   align-items: center;
-  background: var(--status-background);
+  background: var(--tw-status-background);
   border-radius: var(--t-border-radius-pill);
   corner-shape: round;
-  color: var(--status-text-color);
+  color: var(--tw-status-text-color);
   display: inline-flex;
   font-size: var(--t-font-size-md);
   font-style: normal;
   gap: var(--t-spacing-1);
-  height: var(--t-spacing-5);
+  block-size: var(--t-spacing-5);
   margin: 0;
   overflow: hidden;
   padding: 0 var(--t-spacing-2) 0 var(--t-spacing-2);
 
-  &[data-loader-visible] {
-    padding-right: var(--t-spacing-1);
+  &[data-loading] {
+    padding-inline-end: var(--t-spacing-1);
   }
 
   &:before {
-    background-color: var(--status-text-color);
+    background-color: var(--tw-status-text-color);
     border-radius: var(--t-border-radius-rounded);
     corner-shape: round;
     content: '';
     display: block;
     flex-shrink: 0;
-    height: var(--t-spacing-1);
-    width: var(--t-spacing-1);
+    block-size: var(--t-spacing-1);
+    inline-size: var(--t-spacing-1);
   }
-}
-
-.regular {
-  font-weight: var(--t-font-weight-regular);
-}
-
-.medium {
-  font-weight: var(--t-font-weight-medium);
 }
 
 .content {

--- a/packages/twenty-ui/src/data-display/Status/Status.module.scss.d.ts
+++ b/packages/twenty-ui/src/data-display/Status/Status.module.scss.d.ts
@@ -1,7 +1,5 @@
-declare const classNames: {
+declare const styles: {
   readonly status: 'status';
-  readonly regular: 'regular';
-  readonly medium: 'medium';
   readonly content: 'content';
 };
-export default classNames;
+export default styles;

--- a/packages/twenty-ui/src/data-display/Status/Status.tsx
+++ b/packages/twenty-ui/src/data-display/Status/Status.tsx
@@ -1,49 +1,60 @@
+import { Button as ButtonPrimitive } from '@base-ui/react/button';
+import { useRender } from '@base-ui/react/use-render';
 import { clsx } from 'clsx';
+import { type CSSProperties } from 'react';
 
-import { handleClickableElementKeyDown } from '@ui/accessibility/utils/handleClickableElementKeyDown';
 import { Loader } from '@ui/feedback/Loader/Loader';
-import { type ThemeColor } from '@ui/theme';
 import { themeCssVariables } from '@ui/theme-constants';
 import { parseThemeColor } from '@ui/utilities';
 import { isDefined } from '@ui/utilities/utils/isDefined';
 
 import styles from './Status.module.scss';
-
-type StatusProps = {
-  className?: string;
-  color: ThemeColor;
-  isLoaderVisible?: boolean;
-  text: string;
-  onClick?: () => void;
-  weight?: 'regular' | 'medium';
-};
+import { type StatusProps } from './types/StatusProps';
 
 export const Status = ({
-  className,
+  children,
   color,
-  isLoaderVisible = false,
-  text,
-  onClick,
+  loading = false,
   weight = 'regular',
+  disabled = false,
+  nativeButton = true,
+  onClick,
+  className,
+  style,
+  render,
+  ref,
+  ...props
 }: StatusProps) => {
   const parsedColor = parseThemeColor(color);
 
-  return (
-    <h3
-      className={clsx(styles.status, styles[weight], className)}
-      onClick={onClick}
-      tabIndex={isDefined(onClick) ? 0 : undefined}
-      onKeyDown={handleClickableElementKeyDown}
-      data-loader-visible={isLoaderVisible || undefined}
-      style={
-        {
-          '--status-background': themeCssVariables.tag.background[parsedColor],
-          '--status-text-color': themeCssVariables.tag.text[parsedColor],
-        } as React.CSSProperties
-      }
-    >
-      <span className={styles.content}>{text}</span>
-      {isLoaderVisible ? <Loader color={color} /> : null}
-    </h3>
-  );
+  return useRender({
+    defaultTagName: 'span',
+    render: isDefined(onClick) ? (
+      <ButtonPrimitive
+        render={render}
+        disabled={disabled}
+        nativeButton={nativeButton}
+      />
+    ) : (
+      render
+    ),
+    ref,
+    state: { loading, weight, disabled, interactive: isDefined(onClick) },
+    props: {
+      ...props,
+      onClick,
+      className: clsx(styles.status, className),
+      style: {
+        '--tw-status-background': themeCssVariables.tag.background[parsedColor],
+        '--tw-status-text-color': themeCssVariables.tag.text[parsedColor],
+        ...style,
+      } as CSSProperties,
+      children: (
+        <>
+          <span className={styles.content}>{children}</span>
+          {loading && <Loader color={color} />}
+        </>
+      ),
+    },
+  });
 };

--- a/packages/twenty-ui/src/data-display/Status/__stories__/Status.stories.tsx
+++ b/packages/twenty-ui/src/data-display/Status/__stories__/Status.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Status> = {
   title: 'UI/Data Display/Status',
   component: Status,
   args: {
-    text: 'Urgent',
+    children: 'Urgent',
     weight: 'medium',
   },
 };
@@ -31,7 +31,7 @@ export const Default: Story = {
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
-    const status = canvas.getByRole('heading', { level: 3 });
+    const status = canvas.getByRole('button', { name: 'Urgent' });
 
     await userEvent.click(status);
     expect(args.onClick).toHaveBeenCalled();
@@ -42,7 +42,7 @@ export const WithLongText: Story = {
   decorators: [ComponentDecorator],
   args: {
     color: 'green',
-    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    children: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
   },
   parameters: {
     a11y: A11Y_DEFER_COLOR_CONTRAST,
@@ -59,6 +59,11 @@ export const Catalog: CatalogStory<Story, typeof Status> = {
     catalog: {
       dimensions: [
         {
+          name: 'state',
+          values: ['default', 'loading'],
+          props: (state: string) => ({ loading: state === 'loading' }),
+        },
+        {
           name: 'colors',
           values: MAIN_COLOR_NAMES,
           props: (color: ThemeColor) => ({ color }),
@@ -67,4 +72,46 @@ export const Catalog: CatalogStory<Story, typeof Status> = {
     },
   },
   decorators: [CatalogDecorator],
+};
+
+export const CatalogDark: typeof Catalog = {
+  ...Catalog,
+  tags: ['!autodocs'],
+  globals: { colorScheme: 'dark' },
+};
+
+export const PointerAndKeyboard: Story = {
+  decorators: [ComponentDecorator],
+  args: { children: 'Open details', onClick: fn(), color: 'blue' },
+  play: async ({ canvasElement, args }) => {
+    const control = within(canvasElement).getByRole('button', {
+      name: 'Open details',
+    });
+    await userEvent.click(control);
+    await userEvent.keyboard('{Enter}');
+    await userEvent.keyboard(' ');
+    await expect(args.onClick).toHaveBeenCalledTimes(3);
+    await expect(control).toHaveFocus();
+    await expect(args.onClick).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'click' }),
+    );
+  },
+};
+
+export const Disabled: Story = {
+  decorators: [ComponentDecorator],
+  args: {
+    children: 'Unavailable',
+    disabled: true,
+    onClick: fn(),
+    color: 'blue',
+  },
+  play: async ({ canvasElement, args }) => {
+    const control = within(canvasElement).getByRole('button', {
+      name: 'Unavailable',
+    });
+    await expect(control).toBeDisabled();
+    await userEvent.click(control);
+    await expect(args.onClick).not.toHaveBeenCalled();
+  },
 };

--- a/packages/twenty-ui/src/data-display/Status/__tests__/Status.test.tsx
+++ b/packages/twenty-ui/src/data-display/Status/__tests__/Status.test.tsx
@@ -1,0 +1,11 @@
+import { runComponentConformance } from '@test-utilities/conformance/runComponentConformance';
+
+import { Status } from '../Status';
+import styles from '../Status.module.scss';
+
+runComponentConformance({
+  name: 'Status',
+  element: <Status color="blue">Label</Status>,
+  ownClassName: styles.status,
+  refInstanceOf: HTMLSpanElement,
+});

--- a/packages/twenty-ui/src/data-display/Status/__tests__/Status.test.tsx
+++ b/packages/twenty-ui/src/data-display/Status/__tests__/Status.test.tsx
@@ -1,4 +1,10 @@
 import { runComponentConformance } from '@test-utilities/conformance/runComponentConformance';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { expectTypeOf, it, expect, vi } from 'vitest';
+
+import { ThemeProvider } from '@ui/theme-constants/ThemeProvider';
 
 import { Status } from '../Status';
 import styles from '../Status.module.scss';
@@ -8,4 +14,64 @@ runComponentConformance({
   element: <Status color="blue">Label</Status>,
   ownClassName: styles.status,
   refInstanceOf: HTMLSpanElement,
+});
+
+it('forwards native button props, refs, and click event targets', async () => {
+  const buttonRef = createRef<HTMLButtonElement>();
+  const handleClick = vi.fn();
+
+  render(
+    <ThemeProvider colorScheme="light">
+      <Status
+        color="blue"
+        name="connection"
+        type="button"
+        ref={buttonRef}
+        onClick={(event) => {
+          expectTypeOf(event.currentTarget).toEqualTypeOf<
+            EventTarget & HTMLButtonElement
+          >();
+          handleClick(event.currentTarget.name);
+        }}
+      >
+        Connection details
+      </Status>
+    </ThemeProvider>,
+  );
+
+  const button = screen.getByRole('button', { name: 'Connection details' });
+  expect(buttonRef.current).toBe(button);
+  expect(buttonRef.current).toBeInstanceOf(HTMLButtonElement);
+  await userEvent.click(button);
+  expect(handleClick).toHaveBeenCalledWith('connection');
+});
+
+it('uses an HTMLElement contract for a custom non-native button', async () => {
+  const elementRef = createRef<HTMLElement>();
+  const handleClick = vi.fn();
+
+  render(
+    <ThemeProvider colorScheme="light">
+      <Status
+        color="blue"
+        nativeButton={false}
+        render={<div />}
+        ref={elementRef}
+        onClick={(event) => {
+          expectTypeOf(event.currentTarget).toEqualTypeOf<
+            EventTarget & HTMLElement
+          >();
+          handleClick(event.currentTarget.tagName);
+        }}
+      >
+        Custom details
+      </Status>
+    </ThemeProvider>,
+  );
+
+  const button = screen.getByRole('button', { name: 'Custom details' });
+  expect(elementRef.current).toBe(button);
+  expect(elementRef.current).toBeInstanceOf(HTMLDivElement);
+  await userEvent.click(button);
+  expect(handleClick).toHaveBeenCalledWith('DIV');
 });

--- a/packages/twenty-ui/src/data-display/Status/types/StatusProps.ts
+++ b/packages/twenty-ui/src/data-display/Status/types/StatusProps.ts
@@ -1,0 +1,11 @@
+import { type useRender } from '@base-ui/react/use-render';
+
+import { type ThemeColor } from '@ui/theme';
+
+export type StatusProps = Omit<useRender.ComponentProps<'span'>, 'color'> & {
+  color: ThemeColor;
+  weight?: 'regular' | 'medium';
+  disabled?: boolean;
+  nativeButton?: boolean;
+  loading?: boolean;
+};

--- a/packages/twenty-ui/src/data-display/Status/types/StatusProps.ts
+++ b/packages/twenty-ui/src/data-display/Status/types/StatusProps.ts
@@ -1,11 +1,40 @@
 import { type useRender } from '@base-ui/react/use-render';
+import {
+  type HTMLAttributes,
+  type MouseEventHandler,
+  type RefAttributes,
+} from 'react';
 
 import { type ThemeColor } from '@ui/theme';
 
-export type StatusProps = Omit<useRender.ComponentProps<'span'>, 'color'> & {
+type StatusOwnProps = {
   color: ThemeColor;
   weight?: 'regular' | 'medium';
   disabled?: boolean;
-  nativeButton?: boolean;
   loading?: boolean;
 };
+
+type StatusStaticProps = Omit<
+  useRender.ComponentProps<'span'>,
+  'color' | 'onClick'
+> & {
+  onClick?: undefined;
+  nativeButton?: true;
+};
+
+type StatusButtonProps = Omit<
+  useRender.ComponentProps<'button'>,
+  'color' | 'onClick'
+> & {
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  nativeButton?: true;
+};
+
+type StatusCustomProps = Omit<HTMLAttributes<HTMLElement>, 'color'> &
+  RefAttributes<HTMLElement> & {
+    nativeButton: false;
+    render: NonNullable<useRender.ComponentProps<'span'>['render']>;
+  };
+
+export type StatusProps = StatusOwnProps &
+  (StatusStaticProps | StatusButtonProps | StatusCustomProps);

--- a/packages/twenty-ui/src/data-display/index.ts
+++ b/packages/twenty-ui/src/data-display/index.ts
@@ -38,6 +38,7 @@ export { NumberDisplay } from './NumberDisplay/NumberDisplay';
 export { Pill } from './Pill/Pill';
 export { SelectDisplay } from './SelectDisplay/SelectDisplay';
 export { Status } from './Status/Status';
+export type { StatusProps } from './Status/types/StatusProps';
 export { StyledTintedIconTileContainer } from './StyledTintedIconTileContainer/StyledTintedIconTileContainer';
 export type { TagColor } from './Tag/Tag';
 export { Tag } from './Tag/Tag';


### PR DESCRIPTION
Status used heading markup and custom keyboard handling for interactive content. Migrate it to children/loading, native props and refs, and Base UI button behavior when onClick is provided. Update consumers and add conformance, light/dark catalog, and React/Preact renderer coverage.

Validation: 11 unit tests, 6 UI browser stories, and 4 renderer checks pass. UI, frontend, and renderer direct typechecks, regular/individual UI builds, lint, and formatting pass.

Part 1 of 4. Review against `main` and merge in this order:

[Status #25785](https://github.com/twentyhq/twenty/pull/25785) → [Tag #25786](https://github.com/twentyhq/twenty/pull/25786) → [Avatar #25787](https://github.com/twentyhq/twenty/pull/25787) → [Chip #25788](https://github.com/twentyhq/twenty/pull/25788)
