### PR TITLE
Fix CLAUDE.md guard import sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Where this repo differs from your defaults:
 - Named exports only. Functional components only.
 - Prefer event handlers over `useEffect` for state updates.
 - No abbreviations in names (`fieldMetadata`, not `fm`); constants in SCREAMING_SNAKE_CASE; component props types suffixed `Props`.
-- Use `twenty-shared/utils` guards (`isDefined`, `isNonEmptyString`, …) and other existing helpers before writing your own — reimplementing an existing util is the most common AI-authored defect here.
+- Use existing guards and helpers before writing your own: `isDefined`, `isNonEmptyArray`, `isPlainObject`, … from `twenty-shared/utils`; `isNonEmptyString`, `isString`, `isNull`, `isObject`, … from `@sniptt/guards`. Reimplementing an existing util is the most common AI-authored defect here.
 - Lingui for user-facing strings; Linaria (zero-runtime, styled-components pattern) for twenty-front styling.
 - For Twenty product concepts, consult `packages/twenty-ui/src/icon/icon-dictionary.md` and use the canonical icon.
 - Import icons from `twenty-ui/icon`, never directly from `@tabler/icons-react`; action and status concepts should use their action or status icons.


### PR DESCRIPTION
The house rules pointed to `twenty-shared/utils` for `isNonEmptyString`, but it isn't exported there. All imports come from `@sniptt/guards` (254 in twenty-server, 274 in twenty-front, 23 in twenty-shared).

The bullet now names the source for each set of guards:
- `twenty-shared/utils`: `isDefined`, `isNonEmptyArray`, `isPlainObject`, ...
- `@sniptt/guards`: `isNonEmptyString`, `isString`, `isNull`, `isObject`, ...

`isNonEmptyArray` is exported by both; `twenty-shared/utils` is the majority import (101 vs 45), so it's listed there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

