### PR TITLE
Complete call recordings whose Recall transcript is empty

### DIFF
--- a/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
@@ -14,6 +14,7 @@ import {
 import { CALL_RECORDER_CALENDAR_BOT_SCHEDULING_ENABLED_ENV_VAR_NAME } from 'src/logic-functions/constants/call-recorder-calendar-bot-scheduling-enabled-env-var-name';
 import { CALENDAR_EVENT_UPDATE_BATCH_SIZE } from 'src/logic-functions/constants/calendar-event-update-batch-size';
 import { cancelCallRecordingRequest } from 'src/logic-functions/flows/cancel-call-recording-request.util';
+import { handleCallRecordingArtifactsImportJob } from 'src/logic-functions/flows/handle-call-recording-artifacts-import-job.util';
 import { reconcileCallRecorderForCalendarEventIds } from 'src/logic-functions/flows/reconcile-call-recorder.util';
 import { retryFailedRecallCancellations } from 'src/logic-functions/flows/retry-failed-recall-cancellations.util';
 import { scheduleRecallBotsForPendingCallRecordings } from 'src/logic-functions/flows/schedule-recall-bots-for-pending-call-recordings.util';
@@ -165,9 +166,30 @@ type FakeRecallBot = {
   statusCode: string;
 };
 
+type FakeRecallTranscript = {
+  id: string;
+  statusCode: string;
+  content: unknown;
+};
+
+const FAKE_RECALL_DOWNLOAD_BASE_URL = `${RECALL_BASE_URL}/fake-downloads`;
+
+const MP4_FILE_HEADER_BYTES = Uint8Array.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00,
+  0x00, 0x02, 0x00, 0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32,
+]);
+const MP3_FRAME_HEADER_BYTES = Uint8Array.from([
+  0xff,
+  0xfb,
+  0x90,
+  0x64,
+  ...new Array(412).fill(0),
+]);
+
 class FakeRecallApi {
   bots = new Map<string, FakeRecallBot>();
   botIdByIdempotencyKey = new Map<string, string>();
+  transcripts = new Map<string, FakeRecallTranscript>();
   deletedBotIds: string[] = [];
   listRequestCount = 0;
   artifactImportRequests: object[] = [];
@@ -177,6 +199,13 @@ class FakeRecallApi {
 
   seedBot(bot: FakeRecallBot): void {
     this.bots.set(bot.id, bot);
+  }
+
+  completeTranscripts(content: unknown): void {
+    for (const transcript of this.transcripts.values()) {
+      transcript.statusCode = 'done';
+      transcript.content = content;
+    }
   }
 
   botForCallRecording(callRecordingId: string): FakeRecallBot | undefined {
@@ -268,6 +297,95 @@ class FakeRecallApi {
       this.deletedBotIds.push(botIdMatch[1]);
 
       return new Response(null, { status: 204 });
+    }
+
+    if (
+      method === 'POST' &&
+      /\/recording\/[^/]+\/create_transcript\/$/.test(requestUrl)
+    ) {
+      const transcript: FakeRecallTranscript = {
+        id: `recall-transcript-${this.transcripts.size + 1}`,
+        statusCode: 'processing',
+        content: undefined,
+      };
+
+      this.transcripts.set(transcript.id, transcript);
+
+      return jsonResponse(200, { id: transcript.id });
+    }
+
+    if (
+      method === 'GET' &&
+      requestUrl.startsWith(`${RECALL_BASE_URL}/transcript/?`)
+    ) {
+      return jsonResponse(200, {
+        next: null,
+        results: [...this.transcripts.values()].map((transcript) => ({
+          id: transcript.id,
+          status: { code: transcript.statusCode },
+        })),
+      });
+    }
+
+    const transcriptIdMatch = requestUrl.match(/\/transcript\/([^/?]+)\/$/);
+
+    if (method === 'GET' && transcriptIdMatch !== null) {
+      const transcript = this.transcripts.get(transcriptIdMatch[1]);
+
+      if (transcript === undefined) {
+        return jsonResponse(404, {});
+      }
+
+      return jsonResponse(200, {
+        id: transcript.id,
+        status: { code: transcript.statusCode },
+        data: {
+          download_url:
+            transcript.statusCode === 'done'
+              ? `${FAKE_RECALL_DOWNLOAD_BASE_URL}/transcripts/${transcript.id}.json`
+              : null,
+        },
+      });
+    }
+
+    const transcriptDownloadMatch = requestUrl.match(
+      /\/fake-downloads\/transcripts\/([^/]+)\.json$/,
+    );
+
+    if (method === 'GET' && transcriptDownloadMatch !== null) {
+      const transcript = this.transcripts.get(transcriptDownloadMatch[1]);
+
+      return new Response(JSON.stringify(transcript?.content ?? null), {
+        status: 200,
+      });
+    }
+
+    if (method === 'GET' && /\/recording\/[^/]+\/$/.test(requestUrl)) {
+      return jsonResponse(200, {
+        media_shortcuts: {
+          video_mixed: {
+            download_url: `${FAKE_RECALL_DOWNLOAD_BASE_URL}/media/video.mp4`,
+          },
+          audio_mixed: {
+            download_url: `${FAKE_RECALL_DOWNLOAD_BASE_URL}/media/audio.mp3`,
+          },
+        },
+      });
+    }
+
+    if (
+      method === 'GET' &&
+      requestUrl.startsWith(`${FAKE_RECALL_DOWNLOAD_BASE_URL}/media/`)
+    ) {
+      // Twenty checks uploads by magic bytes, so the fake media needs real headers.
+      const mediaBytes = requestUrl.endsWith('.mp4')
+        ? MP4_FILE_HEADER_BYTES
+        : MP3_FRAME_HEADER_BYTES;
+
+      return new Response(mediaBytes, {
+        status: 200,
+        headers: { 'content-length': String(mediaBytes.byteLength) },
+      });
     }
 
     throw new Error(`Unhandled Recall API request: ${method} ${requestUrl}`);
@@ -409,6 +527,7 @@ describe('call recorder app lifecycle (integration)', () => {
 
   beforeEach(() => {
     recall = new FakeRecallApi();
+    nextArtifactImportRequestIndex = 0;
 
     const realFetch = globalThis.fetch;
 
@@ -593,6 +712,7 @@ describe('call recorder app lifecycle (integration)', () => {
             callRecorderFailureReason: true,
             startedAt: true,
             endedAt: true,
+            transcript: true,
           },
         },
       },
@@ -691,6 +811,23 @@ describe('call recorder app lifecycle (integration)', () => {
   // the payload Recall would have delivered.
   const deliverRecallWebhook = (body: object) =>
     processRecallWebhookHandler(body);
+
+  // Mocked job queue: runs the artifact imports the webhooks enqueued since
+  // the last call, in order.
+  let nextArtifactImportRequestIndex = 0;
+
+  const runQueuedArtifactImports = async (): Promise<void> => {
+    while (
+      nextArtifactImportRequestIndex < recall.artifactImportRequests.length
+    ) {
+      const artifactImportRequest =
+        recall.artifactImportRequests[nextArtifactImportRequestIndex];
+
+      nextArtifactImportRequestIndex += 1;
+
+      await handleCallRecordingArtifactsImportJob(artifactImportRequest);
+    }
+  };
 
   // Mocked cron trigger: runs the flows the recovery cron dispatches.
   const runPendingRecoveryCron = () =>
@@ -802,6 +939,40 @@ describe('call recorder app lifecycle (integration)', () => {
       expect(recall.artifactImportRequests).toHaveLength(3);
       expect(recall.artifactImportRequests[2]).toMatchObject({
         callRecordingId,
+      });
+    });
+
+    it('completes a recording whose transcript came back empty', async () => {
+      const { callRecordingId, botId, metadata } =
+        await scheduleRecordingThroughCalendarReconciliation();
+
+      await deliverRecallWebhook(
+        buildRecordingDoneWebhook({
+          botId,
+          metadata,
+          startedAt: hoursAgo(1),
+          completedAt: new Date().toISOString(),
+        }),
+      );
+      await runQueuedArtifactImports();
+
+      expect((await fetchCallRecording(callRecordingId)).status).toBe(
+        'PROCESSING',
+      );
+
+      recall.completeTranscripts([]);
+
+      await deliverRecallWebhook(
+        buildTranscriptDoneWebhook({ botId, metadata }),
+      );
+      await runQueuedArtifactImports();
+
+      const callRecording = await fetchCallRecording(callRecordingId);
+
+      expect(callRecording.status).toBe('COMPLETED');
+      expect(callRecording.transcript).toEqual({
+        recallTranscriptId: 'recall-transcript-1',
+        status: 'EMPTY',
       });
     });
 

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/__tests__/is-call-recording-import-complete.test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/__tests__/is-call-recording-import-complete.test.ts
@@ -32,6 +32,34 @@ describe('isCallRecordingImportComplete', () => {
     ).toBe(false);
   });
 
+  it('is complete when the transcript came back empty', () => {
+    expect(
+      isCallRecordingImportComplete({
+        transcript: {
+          recallTranscriptId: 'recall-transcript-1',
+          status: 'EMPTY',
+        },
+        audio: AUDIO_VALUE,
+        video: VIDEO_VALUE,
+        callRecorderFailureReason: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it('is incomplete when the transcript failed', () => {
+    expect(
+      isCallRecordingImportComplete({
+        transcript: {
+          recallTranscriptId: 'recall-transcript-1',
+          status: 'FAILED',
+        },
+        audio: AUDIO_VALUE,
+        video: VIDEO_VALUE,
+        callRecorderFailureReason: undefined,
+      }),
+    ).toBe(false);
+  });
+
   it('is incomplete when the transcript is unset', () => {
     expect(
       isCallRecordingImportComplete({

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/build-empty-transcript-marker.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/build-empty-transcript-marker.util.ts
@@ -1,0 +1,10 @@
+import { type TranscriptMarker } from 'src/logic-functions/types/transcript-marker.type';
+
+export const buildEmptyTranscriptMarker = ({
+  recallTranscriptId,
+}: {
+  recallTranscriptId: string;
+}): TranscriptMarker => ({
+  recallTranscriptId,
+  status: 'EMPTY',
+});

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/is-call-recording-import-complete.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/is-call-recording-import-complete.util.ts
@@ -17,11 +17,12 @@ export const isCallRecordingImportComplete = ({
 }): boolean => {
   const { audioFileTooLarge, videoFileTooLarge } =
     parseMediaFileTooLargeMarkers(callRecorderFailureReason);
+  const transcriptMarker = parseTranscriptMarker(transcript);
 
   return (
     !isNull(transcript) &&
     !isUndefined(transcript) &&
-    isUndefined(parseTranscriptMarker(transcript)) &&
+    (isUndefined(transcriptMarker) || transcriptMarker.status === 'EMPTY') &&
     (isNonEmptyArray(audio) || audioFileTooLarge) &&
     (isNonEmptyArray(video) || videoFileTooLarge)
   );

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/parse-transcript-marker.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/parse-transcript-marker.util.ts
@@ -12,7 +12,11 @@ export const parseTranscriptMarker = (
     return undefined;
   }
 
-  if (candidate.status !== 'PENDING' && candidate.status !== 'FAILED') {
+  if (
+    candidate.status !== 'PENDING' &&
+    candidate.status !== 'FAILED' &&
+    candidate.status !== 'EMPTY'
+  ) {
     return undefined;
   }
 

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/import-call-recording-transcript.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/import-call-recording-transcript.util.ts
@@ -1,6 +1,7 @@
-import { isNull, isUndefined } from '@sniptt/guards';
+import { isArray, isNull, isUndefined } from '@sniptt/guards';
 
 import { CallRecordingStatus } from 'src/logic-functions/constants/call-recording-status';
+import { buildEmptyTranscriptMarker } from 'src/logic-functions/domain/build-empty-transcript-marker.util';
 import { buildFailedTranscriptMarker } from 'src/logic-functions/domain/build-failed-transcript-marker.util';
 import { buildPendingTranscriptMarker } from 'src/logic-functions/domain/build-pending-transcript-marker.util';
 import { buildTranscriptFailureReason } from 'src/logic-functions/domain/build-transcript-failure-reason.util';
@@ -39,7 +40,10 @@ export const importCallRecordingTranscript = async ({
     return buildEmptyTranscriptArtifactResult();
   }
 
-  if (existingTranscriptMarker?.status === 'FAILED') {
+  if (
+    existingTranscriptMarker?.status === 'FAILED' ||
+    existingTranscriptMarker?.status === 'EMPTY'
+  ) {
     return buildEmptyTranscriptArtifactResult();
   }
 
@@ -131,9 +135,17 @@ export const importCallRecordingTranscript = async ({
   });
 
   if (downloadResult.outcome === 'filled') {
+    // Twenty stores an empty JSON array as null, which would read as never imported.
+    const isEmptyTranscript =
+      isArray(downloadResult.content) && downloadResult.content.length === 0;
+
     return {
       updateData: {
-        transcript: downloadResult.content as Record<string, unknown>,
+        transcript: isEmptyTranscript
+          ? buildEmptyTranscriptMarker({
+              recallTranscriptId: transcriptIdToDownload,
+            })
+          : (downloadResult.content as Record<string, unknown>),
       },
       requestedTranscript: false,
       hasRetryableFailure: false,

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/sync-call-recording.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/sync-call-recording.util.ts
@@ -252,7 +252,7 @@ const hasReachableTranscript = (transcript: unknown): boolean => {
 
   const transcriptMarker = parseTranscriptMarker(transcript);
 
-  return isUndefined(transcriptMarker) || transcriptMarker.status === 'PENDING';
+  return isUndefined(transcriptMarker) || transcriptMarker.status !== 'FAILED';
 };
 
 // A media size marker must not overwrite the failure reason of a FAILED recording.

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/types/transcript-marker.type.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/types/transcript-marker.type.ts
@@ -1,6 +1,6 @@
 export type TranscriptMarker = {
   recallTranscriptId: string | null;
-  status: 'PENDING' | 'FAILED';
+  status: 'PENDING' | 'FAILED' | 'EMPTY';
   requestedAt?: string;
   subCode?: string | null;
 };


### PR DESCRIPTION
Recall can finish a transcript with no content. Twenty stores an empty JSON array as null, so the recording read as never imported and stayed in PROCESSING forever. The import now stores an \`EMPTY\` transcript marker and the recording completes.

Deferred: twenty-shared's transcript marker type and guard still only know \`PENDING\` and \`FAILED\`; the transcript tab falls through to the COMPLETED copy for an empty marker.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

