### PR TITLE
Finish call recordings without a transcript when Recall rejects the transcript request

### DIFF
--- a/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
@@ -985,7 +985,7 @@ describe('call recorder app lifecycle (integration)', () => {
       const { callRecordingId, botId, metadata } =
         await scheduleRecordingThroughCalendarReconciliation();
 
-      recall.transcriptRequestFailureStatus = 402;
+      recall.transcriptRequestFailureStatus = 400;
 
       await deliverRecallWebhook(
         buildRecordingDoneWebhook({
@@ -1003,8 +1003,30 @@ describe('call recorder app lifecycle (integration)', () => {
       expect(callRecording.transcript).toEqual({
         recallTranscriptId: null,
         status: 'EMPTY',
-        subCode: 'transcript_request_rejected:402',
+        subCode: 'transcript_request_rejected:400',
       });
+    });
+
+    it('keeps a recording processing when the Recall account rejects the transcript request', async () => {
+      const { callRecordingId, botId, metadata } =
+        await scheduleRecordingThroughCalendarReconciliation();
+
+      recall.transcriptRequestFailureStatus = 402;
+
+      await deliverRecallWebhook(
+        buildRecordingDoneWebhook({
+          botId,
+          metadata,
+          startedAt: hoursAgo(1),
+          completedAt: new Date().toISOString(),
+        }),
+      );
+      await runQueuedArtifactImports();
+
+      const callRecording = await fetchCallRecording(callRecordingId);
+
+      expect(callRecording.status).toBe('PROCESSING');
+      expect(callRecording.transcript).toBeNull();
     });
 
     it('keeps a recording processing while the transcript request fails temporarily', async () => {

--- a/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/__tests__/call-recorder-lifecycle.integration-test.ts
@@ -190,6 +190,7 @@ class FakeRecallApi {
   bots = new Map<string, FakeRecallBot>();
   botIdByIdempotencyKey = new Map<string, string>();
   transcripts = new Map<string, FakeRecallTranscript>();
+  transcriptRequestFailureStatus: number | undefined = undefined;
   deletedBotIds: string[] = [];
   listRequestCount = 0;
   artifactImportRequests: object[] = [];
@@ -303,6 +304,10 @@ class FakeRecallApi {
       method === 'POST' &&
       /\/recording\/[^/]+\/create_transcript\/$/.test(requestUrl)
     ) {
+      if (this.transcriptRequestFailureStatus !== undefined) {
+        return jsonResponse(this.transcriptRequestFailureStatus, {});
+      }
+
       const transcript: FakeRecallTranscript = {
         id: `recall-transcript-${this.transcripts.size + 1}`,
         statusCode: 'processing',
@@ -974,6 +979,57 @@ describe('call recorder app lifecycle (integration)', () => {
         recallTranscriptId: 'recall-transcript-1',
         status: 'EMPTY',
       });
+    });
+
+    it('completes a recording without a transcript when Recall rejects the transcript request', async () => {
+      const { callRecordingId, botId, metadata } =
+        await scheduleRecordingThroughCalendarReconciliation();
+
+      recall.transcriptRequestFailureStatus = 402;
+
+      await deliverRecallWebhook(
+        buildRecordingDoneWebhook({
+          botId,
+          metadata,
+          startedAt: hoursAgo(1),
+          completedAt: new Date().toISOString(),
+        }),
+      );
+      await runQueuedArtifactImports();
+
+      const callRecording = await fetchCallRecording(callRecordingId);
+
+      expect(callRecording.status).toBe('COMPLETED');
+      expect(callRecording.transcript).toEqual({
+        recallTranscriptId: null,
+        status: 'EMPTY',
+        subCode: 'transcript_request_rejected:402',
+      });
+    });
+
+    it('keeps a recording processing while the transcript request fails temporarily', async () => {
+      const { callRecordingId, botId, metadata } =
+        await scheduleRecordingThroughCalendarReconciliation();
+
+      recall.transcriptRequestFailureStatus = 503;
+
+      await deliverRecallWebhook(
+        buildRecordingDoneWebhook({
+          botId,
+          metadata,
+          startedAt: hoursAgo(1),
+          completedAt: new Date().toISOString(),
+        }),
+      );
+
+      await expect(runQueuedArtifactImports()).rejects.toMatchObject({
+        name: 'RetryableLogicFunctionError',
+      });
+
+      const callRecording = await fetchCallRecording(callRecordingId);
+
+      expect(callRecording.status).toBe('PROCESSING');
+      expect(callRecording.transcript).toBeNull();
     });
 
     it('never moves the status backwards on late webhook deliveries', async () => {

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/build-empty-transcript-marker.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/domain/build-empty-transcript-marker.util.ts
@@ -1,10 +1,15 @@
+import { isUndefined } from '@sniptt/guards';
+
 import { type TranscriptMarker } from 'src/logic-functions/types/transcript-marker.type';
 
 export const buildEmptyTranscriptMarker = ({
   recallTranscriptId,
+  subCode,
 }: {
-  recallTranscriptId: string;
+  recallTranscriptId: string | null;
+  subCode?: string;
 }): TranscriptMarker => ({
   recallTranscriptId,
   status: 'EMPTY',
+  ...(isUndefined(subCode) ? {} : { subCode }),
 });

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/import-call-recording-transcript.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/import-call-recording-transcript.util.ts
@@ -84,11 +84,30 @@ export const importCallRecordingTranscript = async ({
         `[call-recorder] failed to request transcript for Recall recording ${externalRecordingId}: ${createResult.errorMessage}`,
       );
 
-      return buildEmptyTranscriptArtifactResult({
-        hasRetryableFailure:
-          !isNull(createResult.status) &&
-          isRetryableRecallApiStatus(createResult.status),
-      });
+      // A lost response may still have created the transcript, and the next
+      // run lists transcripts before requesting a new one.
+      if (isNull(createResult.status)) {
+        return buildEmptyTranscriptArtifactResult();
+      }
+
+      if (isRetryableRecallApiStatus(createResult.status)) {
+        return buildEmptyTranscriptArtifactResult({
+          hasRetryableFailure: true,
+        });
+      }
+
+      // Recall rejected the request, so finish the recording without a
+      // transcript instead of leaving it processing.
+      return {
+        updateData: {
+          transcript: buildEmptyTranscriptMarker({
+            recallTranscriptId: null,
+            subCode: `transcript_request_rejected:${createResult.status}`,
+          }),
+        },
+        requestedTranscript: false,
+        hasRetryableFailure: false,
+      };
     }
 
     return {

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/import-call-recording-transcript.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/import-call-recording-transcript.util.ts
@@ -9,7 +9,10 @@ import { isCallRecordingStatusDowngrade } from 'src/logic-functions/domain/is-ca
 import { parseTranscriptMarker } from 'src/logic-functions/domain/parse-transcript-marker.util';
 import { createAsyncRecallTranscript } from 'src/logic-functions/recall-api/create-async-recall-transcript.util';
 import { listRecallTranscripts } from 'src/logic-functions/recall-api/list-recall-transcripts.util';
-import { isRetryableRecallApiStatus } from 'src/logic-functions/recall-api/recall-api-retry-policy.util';
+import {
+  isRecallAccountStatus,
+  isRetryableRecallApiStatus,
+} from 'src/logic-functions/recall-api/recall-api-retry-policy.util';
 import { type RecallTranscriptSummary } from 'src/logic-functions/recall-api/recall-transcript-summary.type';
 import { downloadTranscript } from 'src/logic-functions/flows/download-transcript.util';
 import { type ImportCallRecordingTranscriptResult } from 'src/logic-functions/flows/import-call-recording-transcript-result.type';
@@ -96,8 +99,10 @@ export const importCallRecordingTranscript = async ({
         });
       }
 
-      // Recall rejected the request, so finish the recording without a
-      // transcript instead of leaving it processing.
+      if (isRecallAccountStatus(createResult.status)) {
+        return buildEmptyTranscriptArtifactResult();
+      }
+
       return {
         updateData: {
           transcript: buildEmptyTranscriptMarker({

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/recall-api/__tests__/recall-api-retry-policy.test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/recall-api/__tests__/recall-api-retry-policy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isRecallAccountStatus,
+  isRetryableRecallApiStatus,
+} from 'src/logic-functions/recall-api/recall-api-retry-policy.util';
+
+describe('recall api retry policy', () => {
+  it('retries rate limits, conflicts and server errors', () => {
+    expect(isRetryableRecallApiStatus(429)).toBe(true);
+    expect(isRetryableRecallApiStatus(409)).toBe(true);
+    expect(isRetryableRecallApiStatus(503)).toBe(true);
+    expect(isRetryableRecallApiStatus(400)).toBe(false);
+  });
+
+  it('separates account statuses from request rejections', () => {
+    expect(isRecallAccountStatus(401)).toBe(true);
+    expect(isRecallAccountStatus(402)).toBe(true);
+    expect(isRecallAccountStatus(403)).toBe(true);
+    expect(isRecallAccountStatus(400)).toBe(false);
+    expect(isRecallAccountStatus(404)).toBe(false);
+  });
+});

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/recall-api/recall-api-retry-policy.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/recall-api/recall-api-retry-policy.util.ts
@@ -1,6 +1,9 @@
 import { RECALL_API_ADHOC_POOL_RETRY_DELAY_MS } from 'src/logic-functions/constants/recall-api-adhoc-pool-retry-delay-ms';
 import { RECALL_API_RETRY_DELAY_MS } from 'src/logic-functions/constants/recall-api-retry-delay-ms';
 
+const RECALL_STATUS_UNAUTHORIZED = 401;
+const RECALL_STATUS_PAYMENT_REQUIRED = 402;
+const RECALL_STATUS_FORBIDDEN = 403;
 const RECALL_STATUS_RATE_LIMITED = 429;
 const RECALL_STATUS_CONFLICT = 409;
 const RECALL_STATUS_ADHOC_POOL_EXHAUSTED = 507;
@@ -11,6 +14,11 @@ export const isRetryableRecallApiStatus = (status: number): boolean =>
   status === RECALL_STATUS_RATE_LIMITED ||
   status === RECALL_STATUS_CONFLICT ||
   isRecallServerError(status);
+
+export const isRecallAccountStatus = (status: number): boolean =>
+  status === RECALL_STATUS_UNAUTHORIZED ||
+  status === RECALL_STATUS_PAYMENT_REQUIRED ||
+  status === RECALL_STATUS_FORBIDDEN;
 
 export const resolveRecallApiRetryDelayMs = ({
   retryAfterMs,


### PR DESCRIPTION
Stacked on #25793.

When Recall rejects the transcript request with a non-retryable status, the recording finishes without a transcript (an \`EMPTY\` marker carrying the status as sub code) instead of staying in PROCESSING. Retryable and lost-response failures behave as before.

Deferred: 401, 402 and 403 are Twenty-side and transient (key or Recall balance); narrowing the terminal set so those stay in PROCESSING for the daily reconciler to retry.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

