### PR TITLE
fix(front): open the view picker on the id its dropdown listens to

### DIFF
--- a/packages/twenty-front/src/modules/views/hooks/useOpenCreateViewDropown.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useOpenCreateViewDropown.ts
@@ -24,9 +24,8 @@ export const useOpenCreateViewDropdown = (viewBardId?: string) => {
       setViewPickerReferenceViewId(referenceView.id);
       setViewPickerMode('create-empty');
       openDropdown({
-        dropdownComponentInstanceIdFromProps: getViewPickerDropdownId(
-          viewBardId ?? recordIndexId,
-        ),
+        dropdownComponentInstanceIdFromProps:
+          getViewPickerDropdownId(recordIndexId),
       });
     }
   };


### PR DESCRIPTION
Follow-up to a review nit on #25790.

`useOpenCreateViewDropdown` built the dropdown id from its optional `viewBardId` argument, while `ViewPickerDropdown` builds it from `recordIndexId`. A caller passing a `viewBardId` that differs from `recordIndexId` would open an id no dropdown is listening on — the same read/write divergence #25790 removed everywhere else.

Both sides now derive the id from `recordIndexId`. Latent today: the two callers pass either nothing or `recordIndexId`, so behaviour is unchanged.

Checked in a browser against a local stack on this commit: the view picker's "Add view" button and the options dropdown's "Create custom view" entry both still open the create-view form.

[Review in cubic](https://cubic.dev/pr/twentyhq/twenty/pull/25799?utm_source=github)

https://claude.ai/code/session_015hjgTjDmBnCsTdnozEQSgp
