### PR TITLE
Stop re-checking already-warned workspaces every hour in CleanSuspendedWorkspacesJob

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/jobs/clean-workspace-deletion-warning-user-vars.job.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/jobs/clean-workspace-deletion-warning-user-vars.job.ts
@@ -1,15 +1,9 @@
 import { Logger, Scope } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-
-import chunk from 'lodash.chunk';
-import { Repository } from 'typeorm';
 
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { UserService } from 'src/engine/core-modules/user/services/user.service';
 import { UserVarsService } from 'src/engine/core-modules/user/user-vars/services/user-vars.service';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { USER_WORKSPACE_DELETION_WARNING_SENT_KEY } from 'src/engine/workspace-manager/workspace-cleaner/constants/user-workspace-deletion-warning-sent-key.constant';
 
 export type CleanWorkspaceDeletionWarningUserVarsJobData = {
@@ -25,46 +19,22 @@ export class CleanWorkspaceDeletionWarningUserVarsJob {
     CleanWorkspaceDeletionWarningUserVarsJob.name,
   );
 
-  constructor(
-    private readonly userService: UserService,
-    private readonly userVarsService: UserVarsService,
-    @InjectRepository(WorkspaceEntity)
-    private readonly workspaceRepository: Repository<WorkspaceEntity>,
-  ) {}
+  constructor(private readonly userVarsService: UserVarsService) {}
 
   @Process(CleanWorkspaceDeletionWarningUserVarsJob.name)
   async handle(
     data: CleanWorkspaceDeletionWarningUserVarsJobData,
   ): Promise<void> {
-    this.logger.log(`Job running...`);
-
     const { workspaceId } = data;
 
     try {
-      const workspace = await this.workspaceRepository.findOneOrFail({
-        where: { id: workspaceId },
+      await this.userVarsService.delete({
+        workspaceId,
+        key: USER_WORKSPACE_DELETION_WARNING_SENT_KEY,
       });
-
-      const workspaceMembers =
-        await this.userService.loadWorkspaceMembers(workspace);
-
-      const workspaceMembersChunks = chunk(workspaceMembers, 5);
-
-      for (const workspaceMembersChunk of workspaceMembersChunks) {
-        await Promise.all(
-          workspaceMembersChunk.map(async (workspaceMember) => {
-            await this.userVarsService.delete({
-              userId: workspaceMember.userId,
-              workspaceId: workspace.id,
-              key: USER_WORKSPACE_DELETION_WARNING_SENT_KEY,
-            });
-            this.logger.log(
-              `Successfully cleaned user vars for ${workspaceMember.userId} user in ${workspace.id} workspace`,
-            );
-          }),
-        );
-      }
-      this.logger.log(`Job done!`);
+      this.logger.log(
+        `Successfully cleaned deletion warning user vars for ${workspaceId} workspace`,
+      );
     } catch (error) {
       this.logger.error(
         `Failed to clean ${workspaceId} workspace users deletion warning user vars: ${error.message}`,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
@@ -16,6 +16,10 @@ import { In, Repository } from 'typeorm';
 import { BillingSubscriptionEntity } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
 import { SubscriptionStatus } from 'src/engine/core-modules/billing/enums/billing-subscription-status.enum';
 import { BillingSubscriptionService } from 'src/engine/core-modules/billing/services/billing-subscription.service';
+import {
+  KeyValuePairEntity,
+  KeyValuePairType,
+} from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { EmailService } from 'src/engine/core-modules/email/email.service';
 import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
@@ -62,6 +66,8 @@ export class CleanerWorkspaceService {
     private readonly emailService: EmailService,
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
+    @InjectRepository(KeyValuePairEntity)
+    private readonly keyValuePairRepository: Repository<KeyValuePairEntity>,
     @InjectWorkspaceScopedRepository(BillingSubscriptionEntity)
     private readonly billingSubscriptionRepository: WorkspaceScopedRepository<BillingSubscriptionEntity>,
     private readonly billingSubscriptionService: BillingSubscriptionService,
@@ -94,25 +100,6 @@ export class CleanerWorkspaceService {
     }
 
     return null;
-  }
-
-  async checkIfAtLeastOneWorkspaceMemberWarned(
-    workspaceMembers: WorkspaceMemberWorkspaceEntity[],
-    workspaceId: string,
-  ) {
-    for (const workspaceMember of workspaceMembers) {
-      const workspaceMemberWarned = await this.userVarsService.get({
-        userId: workspaceMember.userId,
-        workspaceId: workspaceId,
-        key: USER_WORKSPACE_DELETION_WARNING_SENT_KEY,
-      });
-
-      if (workspaceMemberWarned) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   async sendWarningEmail(
@@ -159,20 +146,6 @@ export class CleanerWorkspaceService {
   ) {
     const workspaceMembers =
       await this.userService.loadWorkspaceMembers(workspace);
-
-    const workspaceMembersWarned =
-      await this.checkIfAtLeastOneWorkspaceMemberWarned(
-        workspaceMembers,
-        workspace.id,
-      );
-
-    if (workspaceMembersWarned) {
-      this.logger.log(
-        `${dryRun ? 'DRY RUN - ' : ''}Workspace ${workspace.id} ${workspace.displayName} already warned`,
-      );
-
-      return;
-    }
 
     this.logger.log(
       `${dryRun ? 'DRY RUN - ' : ''}Sending ${workspace.id} ${
@@ -420,6 +393,18 @@ export class CleanerWorkspaceService {
       withDeleted: true,
     });
 
+    const warnedUserVars = await this.keyValuePairRepository.find({
+      select: ['workspaceId'],
+      where: {
+        workspaceId: In(workspaces.map((workspace) => workspace.id)),
+        type: KeyValuePairType.USER_VARIABLE,
+        key: USER_WORKSPACE_DELETION_WARNING_SENT_KEY,
+      },
+    });
+    const alreadyWarnedWorkspaceIds = new Set(
+      warnedUserVars.map((userVar) => userVar.workspaceId),
+    );
+
     let deletedWorkspacesCount = 0;
 
     for (const [index, workspace] of workspaces.entries()) {
@@ -475,6 +460,7 @@ export class CleanerWorkspaceService {
 
         if (
           (!isDefined(onlyOperation) || onlyOperation === 'warn') &&
+          !alreadyWarnedWorkspaceIds.has(workspace.id) &&
           inactiveDaysSinceSuspended > this.inactiveDaysBeforeWarn &&
           inactiveDaysSinceSuspended <= this.inactiveDaysBeforeSoftDelete
         ) {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module.ts
@@ -5,6 +5,7 @@ import { BillingModule } from 'src/engine/core-modules/billing/billing.module';
 import { BillingSubscriptionEntity } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
 import { WorkspaceDomainsModule } from 'src/engine/core-modules/domain/workspace-domains/workspace-domains.module';
 import { EmailModule } from 'src/engine/core-modules/email/email.module';
+import { KeyValuePairEntity } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { UserVarsModule } from 'src/engine/core-modules/user/user-vars/user-vars.module';
@@ -25,6 +26,7 @@ import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-
       WorkspaceEntity,
       UserWorkspaceEntity,
       BillingSubscriptionEntity,
+      KeyValuePairEntity,
     ]),
     WorkspaceModule,
     UserVarsModule,


### PR DESCRIPTION
## Problem

`CleanSuspendedWorkspacesJob` runs hourly over ~2850 suspended workspaces on prod-eu and takes **1 to 10 minutes** (median ~5 min). The Sentry cron monitor budgets 5 minutes, so the monitor sits right on its threshold and flips between resolved and regression nearly every hour. The issue is at 3471 occurrences.

Runtimes from the worker logs over 24h:

```
09-10 20:00  605s      09-11 04:00  509s
09-10 22:00  538s      09-11 08:00  312s
09-10 23:00  436s      09-11 10:00  602s
09-11 00:00  322s      09-11 11:00  475s
```

Almost all of that time is spent on workspaces that were already warned. `warnWorkspaceMembers` loaded the full workspace ORM context via `loadWorkspaceMembers`, then read one user var per member (each `userVarsService.get` fans out to 3 core queries), and only then discovered the workspace was already warned, logged `already warned`, and returned.

Prod logs show **~986 of those per run**, against ~8 workspaces that actually get a new warning. The job also stalls the worker event loop for 10-95s at a time while doing it, which is enough for BullMQ to declare the job stalled and hand it to a second pod.

## Change

Resolve the already-warned workspaces up front with a single query on `keyValuePair`, and skip them before touching the workspace ORM. ~986 workspace ORM loads per run become 0.

That check is now keyed on the workspace rather than on its current members. So reactivation has to clear every warn var of the workspace instead of only those belonging to members it can still load, otherwise a departed member's stale row would suppress a later warning. That also collapses `CleanWorkspaceDeletionWarningUserVarsJob` to a single delete.
