### PR TITLE
Give each Sentry cron monitor its own max runtime

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/cron/sentry-cron-monitor.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/cron/sentry-cron-monitor.decorator.ts
@@ -1,6 +1,14 @@
 import * as Sentry from '@sentry/node';
 
-export function SentryCronMonitor(monitorSlug: string, schedule: string) {
+const DEFAULT_MAX_RUNTIME_IN_MINUTES = 5;
+
+export function SentryCronMonitor(
+  monitorSlug: string,
+  schedule: string,
+  {
+    maxRuntimeInMinutes = DEFAULT_MAX_RUNTIME_IN_MINUTES,
+  }: { maxRuntimeInMinutes?: number } = {},
+) {
   return function (
     // oxlint-disable-next-line typescript/no-explicit-any
     _target: any,
@@ -29,7 +37,7 @@ export function SentryCronMonitor(monitorSlug: string, schedule: string) {
               value: schedule,
             },
             checkinMargin: 1,
-            maxRuntime: 5,
+            maxRuntime: maxRuntimeInMinutes,
             timezone: 'UTC',
           },
         );

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-suspended-workspaces.job.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-suspended-workspaces.job.ts
@@ -35,6 +35,7 @@ export class CleanSuspendedWorkspacesJob {
   @SentryCronMonitor(
     CleanSuspendedWorkspacesJob.name,
     cleanSuspendedWorkspaceCronPattern,
+    { maxRuntimeInMinutes: 15 },
   )
   async handle(): Promise<void> {
     const advisoryLockResult =


### PR DESCRIPTION
## Problem

`SentryCronMonitor` hardcodes `maxRuntime: 5` minutes for all 35 cron monitors, so a job that drops workspace schemas shares a budget with one that rotates a signing key.

`CleanSuspendedWorkspacesJob` runs hourly and took between 1 and 10 minutes on prod-eu over the last 24h, measured from the `processed on queue cron-queue in Xms` worker logs. It sits right on the 5 minute threshold, so it reports a timeout check-in most hours and its monitor flaps between resolved and regression. The Sentry issue is at 3471 occurrences.

## Change

Make the runtime an option on the decorator, keeping 5 minutes as the default so no other monitor changes, and give `CleanSuspendedWorkspacesJob` 15 minutes: above its worst observed run, still well inside its hourly period so a real hang alerts within the hour.

#25800 separately removes the work that makes that job slow. This one stops the monitor lying about a job that is simply heavier than the default budget assumes.
