### PR TITLE
bump call recorder app version to 1.14.0

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/call-recorder",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",


### PR DESCRIPTION
Bumps the call-recorder app to 1.14.0 to release the changes merged since 1.13.0:

- Complete call recordings whose Recall transcript is empty (#25793)
- Finish call recordings without a transcript when Recall rejects the transcript request (#25794)

#25795 (settling stuck recordings from the stale-state cron) is still in review and is not part of this release unless it merges first.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

