### PR TITLE
fix(ai): keep catalog efforts and benchmarks under a stored AI catalog

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AiModelTierSlider.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiModelTierSlider.tsx
@@ -3,7 +3,12 @@ import { useLingui } from '@lingui/react/macro';
 import { type ChangeEvent, useContext, useId } from 'react';
 import { AI_MODEL_TIERS, type AiModelTier } from 'twenty-shared/ai';
 import { isDefined } from 'twenty-shared/utils';
-import { IconBolt, IconBrain, IconCoins } from 'twenty-ui/icon';
+import {
+  IconBolt,
+  IconBrain,
+  IconCoins,
+  type IconComponent,
+} from 'twenty-ui/icon';
 import { AppTooltip, TooltipDelay } from 'twenty-ui/surfaces';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 
@@ -138,6 +143,21 @@ const StyledInput = styled.input`
   width: 100%;
 `;
 
+type TierMetric = {
+  key: string;
+  Icon: IconComponent;
+  deltaPercent: number | undefined;
+  description: string;
+};
+
+// A tier backed by the same model as Balanced, or by one the sync has no
+// reading for, has nothing to compare: showing "0%" would read as a measured
+// tie rather than as a missing benchmark.
+const hasDeltaToShow = (
+  metric: TierMetric,
+): metric is TierMetric & { deltaPercent: number } =>
+  isDefined(metric.deltaPercent) && metric.deltaPercent !== 0;
+
 type AiModelTierSliderProps = {
   selectedTier: AiModelTier;
   onTierChange: (tier: AiModelTier) => void;
@@ -169,7 +189,7 @@ export const AiModelTierSlider = ({
 
   // Below Balanced the gain is speed, above it intelligence; cost moves with
   // both, so each side shows the two figures that explain the trade.
-  const metrics = [
+  const candidateMetrics: TierMetric[] = [
     ...(selectedStep < BALANCED_STEP
       ? [
           {
@@ -200,7 +220,9 @@ export const AiModelTierSlider = ({
           },
         ]
       : []),
-  ].filter((metric) => isDefined(metric.deltaPercent));
+  ];
+
+  const metrics = candidateMetrics.filter(hasDeltaToShow);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const tier = AI_MODEL_TIERS[Number(event.target.value)];
@@ -224,7 +246,7 @@ export const AiModelTierSlider = ({
               isInherited={isBenchmarkInherited}
             >
               <Icon size={theme.icon.size.md} />
-              {formatPercentDelta(deltaPercent ?? 0)}
+              {formatPercentDelta(deltaPercent)}
             </StyledMetric>
           ))}
         </StyledMetrics>

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/default-ai-catalog.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/services/default-ai-catalog.service.ts
@@ -5,15 +5,17 @@ import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twent
 import defaultAiProviders from 'src/engine/metadata-modules/ai/ai-models/ai-providers.json';
 import { aiProvidersConfigSchema } from 'src/engine/metadata-modules/ai/ai-models/types/ai-providers-config.schema';
 import { type AiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-providers-config.type';
+import { inheritCatalogReadings } from 'src/engine/metadata-modules/ai/ai-models/utils/merge-custom-providers-into-catalog.util';
 import { normalizeAiProviders } from 'src/engine/metadata-modules/ai/ai-models/utils/normalize-ai-providers.util';
 import { streamToBuffer } from 'src/utils/stream-to-buffer';
 
 @Injectable()
 export class DefaultAiCatalogService implements OnModuleInit {
   private readonly logger = new Logger(DefaultAiCatalogService.name);
-  private catalog: AiProvidersConfig = normalizeAiProviders(
+  private readonly builtInCatalog: AiProvidersConfig = normalizeAiProviders(
     defaultAiProviders as AiProvidersConfig,
   );
+  private catalog: AiProvidersConfig = this.builtInCatalog;
 
   constructor(
     private readonly twentyConfigService: TwentyConfigService,
@@ -34,7 +36,13 @@ export class DefaultAiCatalogService implements OnModuleInit {
     try {
       const raw = await this.fetchCatalog(catalogPath);
 
-      this.catalog = normalizeAiProviders(raw);
+      // A stored catalog carries the credentials, labels and prices of one
+      // deployment, not the efforts and benchmarks the sync measures, so it
+      // lists the models and the built-in catalog describes the ones it knows.
+      this.catalog = inheritCatalogReadings({
+        catalog: this.builtInCatalog,
+        providers: normalizeAiProviders(raw),
+      });
       this.logger.log(`Loaded AI catalog from storage: ${catalogPath}`);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/__tests__/merge-custom-providers-into-catalog.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/__tests__/merge-custom-providers-into-catalog.util.spec.ts
@@ -1,5 +1,8 @@
 import { type AiProvidersConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-providers-config.type';
-import { mergeCustomProvidersIntoCatalog } from 'src/engine/metadata-modules/ai/ai-models/utils/merge-custom-providers-into-catalog.util';
+import {
+  inheritCatalogReadings,
+  mergeCustomProvidersIntoCatalog,
+} from 'src/engine/metadata-modules/ai/ai-models/utils/merge-custom-providers-into-catalog.util';
 
 const catalog: AiProvidersConfig = {
   openai: {
@@ -192,6 +195,37 @@ describe('mergeCustomProvidersIntoCatalog', () => {
 
     expect(merged['azure-foundry'].models?.[0]?.benchmark).toEqual({
       intelligenceIndex: 12.7,
+    });
+  });
+});
+
+describe('inheritCatalogReadings', () => {
+  it('keeps only the providers it is given, with the catalog readings', () => {
+    const providers = inheritCatalogReadings({
+      catalog,
+      providers: {
+        'azure-foundry': {
+          npm: '@ai-sdk/azure',
+          label: 'Azure',
+          apiKey: 'azure-key',
+          models: [
+            {
+              name: 'gpt-5.6-luna',
+              label: 'Luna on Azure',
+              inputCostPerMillionTokens: 0.25,
+              outputCostPerMillionTokens: 1.4,
+            },
+          ],
+        },
+      } as unknown as AiProvidersConfig,
+    });
+
+    expect(Object.keys(providers)).toEqual(['azure-foundry']);
+    expect(providers['azure-foundry'].models?.[0]).toMatchObject({
+      label: 'Luna on Azure',
+      efforts: ['low', 'medium', 'high'],
+      benchmark: { intelligenceIndex: 37.5 },
+      inputCostPerMillionTokens: 0.25,
     });
   });
 });

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/merge-custom-providers-into-catalog.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/merge-custom-providers-into-catalog.util.ts
@@ -36,7 +36,7 @@ const routeCandidates = (modelName: string): string[] => {
   return segments.map((_, index) => segments.slice(index).join('.'));
 };
 
-const withCatalogReadings = ({
+const withCatalogModelReadings = ({
   catalogModel,
   customModel,
 }: {
@@ -68,7 +68,7 @@ const mergeModels = ({
     );
 
     return isDefined(catalogModel)
-      ? withCatalogReadings({
+      ? withCatalogModelReadings({
           catalogModel,
           customModel: { ...catalogModel, ...customModel },
         })
@@ -102,46 +102,58 @@ const withReadingsFromAnyProvider = ({
       .find(isDefined);
 
     return isDefined(catalogModel)
-      ? withCatalogReadings({ catalogModel, customModel })
+      ? withCatalogModelReadings({ catalogModel, customModel })
       : customModel;
   });
 };
 
-// A custom entry replaces the catalog provider of the same name, but an entry
-// written before the catalog carried efforts and benchmarks would then strip
-// both from every model it lists, and the tier chains could no longer name
-// an effort on it. A model the catalog knows keeps the catalog fields it does
-// not set itself; the custom entry still decides which models exist.
+// A provider written before the catalog carried efforts and benchmarks would
+// strip both from every model it lists, and the tier chains could no longer
+// name an effort on it. A model the catalog knows keeps the catalog fields the
+// entry does not set itself; the entry still decides which models exist.
+export const inheritCatalogReadings = ({
+  catalog,
+  providers,
+}: {
+  catalog: AiProvidersConfig;
+  providers: AiProvidersConfig;
+}): AiProvidersConfig => {
+  const result: AiProvidersConfig = {};
+
+  for (const [providerName, provider] of Object.entries(providers)) {
+    const catalogProvider: AiProviderConfig | undefined = catalog[providerName];
+
+    if (!isDefined(provider.models)) {
+      result[providerName] = provider;
+      continue;
+    }
+
+    result[providerName] = {
+      ...provider,
+      models: isDefined(catalogProvider)
+        ? mergeModels({
+            catalogModels: catalogProvider.models ?? [],
+            customModels: provider.models,
+          })
+        : withReadingsFromAnyProvider({
+            catalog,
+            customModels: provider.models,
+          }),
+    };
+  }
+
+  return result;
+};
+
+// A custom entry replaces the catalog provider of the same name; providers it
+// does not name stay as the catalog has them.
 export const mergeCustomProvidersIntoCatalog = ({
   catalog,
   custom,
 }: {
   catalog: AiProvidersConfig;
   custom: AiProvidersConfig;
-}): AiProvidersConfig => {
-  const merged: AiProvidersConfig = { ...catalog };
-
-  for (const [providerName, customProvider] of Object.entries(custom)) {
-    const catalogProvider: AiProviderConfig | undefined = catalog[providerName];
-
-    if (!isDefined(customProvider.models)) {
-      merged[providerName] = customProvider;
-      continue;
-    }
-
-    merged[providerName] = {
-      ...customProvider,
-      models: isDefined(catalogProvider)
-        ? mergeModels({
-            catalogModels: catalogProvider.models ?? [],
-            customModels: customProvider.models,
-          })
-        : withReadingsFromAnyProvider({
-            catalog,
-            customModels: customProvider.models,
-          }),
-    };
-  }
-
-  return merged;
-};
+}): AiProvidersConfig => ({
+  ...catalog,
+  ...inheritCatalogReadings({ catalog, providers: custom }),
+});


### PR DESCRIPTION
## What is broken on the cloud instances

twenty-main, twenty-staging and prod-eu do not use an `AI_PROVIDERS` override. They set `AI_CATALOG_STORAGE_PATH`, and a twenty-infra workflow uploads `ai-models-config/<env>.json` to S3 as the whole catalog. That file carries the credentials, labels, prices and context windows of one deployment. It carries no efforts and no benchmarks, because those are measured by the sync and belong to the model, not to the deployment.

The stored catalog replaced the built-in one wholesale, so every model lost `efforts`, `benchmark` and `benchmarkByEffort`. Live `/client-config` on twenty-main returns 26 models with `efforts: []`, no intelligence index, no cost per task and no tokens per second. Every tier chain entry pinned at an effort (`openai/gpt-5.6-luna@low` and so on) is unreachable, so all five tiers resolve to the same bare model, and the tier slider compares that model with itself and prints "0%".

This is the same failure #25753 fixed for `AI_PROVIDERS`, one layer down: the merge was never reached, because these instances have no custom providers.

## Now time-sensitive

twentyhq/twenty-infra#936 has merged, so all three environments now name effort-pinned ids in every tier chain. Until this PR ships, none of those ids resolve and each chain falls through to its bare fallback leg, which puts every tier on the `gpt-5.4` family instead of `gpt-5.6`:

| Tier | dev | staging | prod-eu |
| --- | --- | --- | --- |
| Extra Fast | `azure-foundry/gpt-5.4-nano` | `openai/gpt-5.4-nano` | `azure-foundry/gpt-5.4-nano` |
| Fast | `azure-foundry/gpt-5.4-mini` | `openai/gpt-5.4-mini` | `azure-foundry/gpt-5.4-mini` |
| Balanced | `azure-foundry/gpt-5.4` | `azure-foundry/gpt-5.4` | `azure-foundry/gpt-5.4` |
| Smart | `azure-foundry/gpt-5.4` | `azure-foundry/gpt-5.4` | `azure-foundry/gpt-5.4` |
| Extra Smart | `azure-foundry/gpt-5.4` | `azure-foundry/gpt-5.4` | `azure-foundry-us/gpt-5.5` |

Balanced is the tier most traffic runs on, and `gpt-5.4` costs $2.50 per million input tokens against `gpt-5.6-luna`'s $0.20.

## Changes

- **Stored catalog inherits the built-in readings.** `inheritCatalogReadings` is the existing merge body, split out so it can run on its own: a provider entry still decides which models exist and keeps its own credentials, labels and prices, while a model the built-in catalog knows inherits the fields that describe the model itself. `mergeCustomProvidersIntoCatalog` is now that function layered over the catalog, so `AI_PROVIDERS` behaviour is unchanged, including keeping a catalog provider the override does not name.
- **`DefaultAiCatalogService` runs a stored catalog through it.** Providers the stored file does not list stay out, so a deployment still serves exactly the models it configured. Azure and Bedrock routes match by name with route segments and deployment stamps dropped, so `azure-foundry/gpt-5.6-luna` picks up the readings of the model it serves.
- Hide a tier metric whose delta is zero. A tier backed by the same model as Balanced has nothing to compare, and "0%" reads as a measured tie rather than as a missing benchmark.

## Effect, simulated against the real config files

Replaying the resolution with each environment's catalog file and its `values.yaml` chains:

| Environment | Registered model ids before | After |
| --- | --- | --- |
| dev | 26 | 108 |
| staging | 26 | 85 |
| prod-eu | 26 | 119 |

With the merged infra chains, every tier then resolves to an effort variant with a benchmark: Extra Fast `gpt-5.6-luna@low`, Fast `@medium`, Balanced `@high`, Smart `gpt-5.6-sol@high`, Extra Smart `gpt-5.6-sol@xhigh`, on `azure-foundry` throughout for prod-eu.

## Tests

`merge-custom-providers-into-catalog.util.spec.ts` covers the new entry point: given providers keep only themselves, with the catalog readings applied. Existing cases for the `AI_PROVIDERS` path pass unchanged.