### PR TITLE
Point pull users at the apply flag that protects what it could not write

### DIFF
--- a/packages/twenty-sdk/src/cli/commands/dev/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/dev-once.ts
@@ -3,6 +3,7 @@ import { APP_ERROR_CODES } from '@/cli/types';
 import { ConfigService } from '@/cli/utilities/config/config-service';
 import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/utilities/config/current-execution-directory';
 import { confirmDestructiveApply } from '@/cli/utilities/dev/confirm-destructive-apply';
+import { hasPullBaseFile } from '@/cli/utilities/pull/pull-base-file';
 import { checkSdkVersionCompatibility } from '@/cli/utilities/version/check-sdk-version-compatibility';
 import chalk from 'chalk';
 
@@ -12,6 +13,26 @@ export type AppDevOnceCommandOptions = {
   apply?: boolean;
   force?: boolean;
   inferDeletionFromMissingEntities?: boolean;
+};
+
+const warnWhenDeletingFromAPulledProject = async (
+  appPath: string,
+): Promise<void> => {
+  if (!(await hasPullBaseFile({ appPath }))) {
+    return;
+  }
+
+  console.log(
+    chalk.yellow(
+      'This project was written by `twenty pull`, which is experimental and cannot export every entity yet.',
+    ),
+  );
+  console.log(
+    chalk.yellow(
+      'Entities it could not write are missing from your source, so applying will destroy them in the workspace.',
+    ),
+  );
+  console.log(chalk.yellow('Re-run with --no-delete to keep them.\n'));
 };
 
 export class AppDevOnceCommand {
@@ -29,6 +50,10 @@ export class AppDevOnceCommand {
       ),
     );
     console.log(chalk.gray(`App path: ${appPath}\n`));
+
+    if (apply && options.inferDeletionFromMissingEntities !== false) {
+      await warnWhenDeletingFromAPulledProject(appPath);
+    }
 
     const result = await appDevOnce({
       appPath,

--- a/packages/twenty-sdk/src/cli/commands/dev/pull.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/pull.ts
@@ -64,7 +64,7 @@ export class AppPullCommand {
     console.log(chalk.gray(`Base recorded in ${PULL_BASE_FILE_PATH}`));
 
     if (result.data.isSdkResolvable) {
-      console.log(chalk.gray('Next: yarn twenty plan --no-delete'));
+      console.log(chalk.gray('Next: yarn twenty apply --no-delete'));
     } else {
       console.log(
         chalk.yellow(
@@ -73,7 +73,7 @@ export class AppPullCommand {
       );
       console.log(
         chalk.gray(
-          'Next: install your dependencies, then yarn twenty plan --no-delete',
+          'Next: install your dependencies, then yarn twenty apply --no-delete',
         ),
       );
     }

--- a/packages/twenty-sdk/src/cli/utilities/pull/__tests__/has-pull-base-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/__tests__/has-pull-base-file.spec.ts
@@ -1,0 +1,42 @@
+import {
+  hasPullBaseFile,
+  PULL_BASE_FILE_PATH,
+} from '@/cli/utilities/pull/pull-base-file';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('hasPullBaseFile', () => {
+  let appPath: string;
+
+  beforeEach(async () => {
+    appPath = await mkdtemp(join(tmpdir(), 'has-pull-base-file-'));
+  });
+
+  afterEach(async () => {
+    await rm(appPath, { recursive: true, force: true });
+  });
+
+  it('should report no base in a project that was never pulled into', async () => {
+    expect(await hasPullBaseFile({ appPath })).toBe(false);
+  });
+
+  it('should report a base in a project that was pulled into', async () => {
+    const baseFilePath = join(appPath, PULL_BASE_FILE_PATH);
+
+    await mkdir(dirname(baseFilePath), { recursive: true });
+    await writeFile(baseFilePath, '{}');
+
+    expect(await hasPullBaseFile({ appPath })).toBe(true);
+  });
+
+  it('should report a base even when its content cannot be parsed', async () => {
+    const baseFilePath = join(appPath, PULL_BASE_FILE_PATH);
+
+    await mkdir(dirname(baseFilePath), { recursive: true });
+    await writeFile(baseFilePath, '{ "version": 1, ');
+
+    expect(await hasPullBaseFile({ appPath })).toBe(true);
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/pull/pull-base-file.ts
+++ b/packages/twenty-sdk/src/cli/utilities/pull/pull-base-file.ts
@@ -68,6 +68,12 @@ const isUsableBaseManifest = (manifest: unknown): manifest is Manifest => {
   );
 };
 
+export const hasPullBaseFile = async ({
+  appPath,
+}: {
+  appPath: string;
+}): Promise<boolean> => pathExists(join(appPath, PULL_BASE_FILE_PATH));
+
 export const readPullBaseManifest = async ({
   appPath,
   applicationUniversalIdentifier,


### PR DESCRIPTION
## What

`pull` signs off with `Next: yarn twenty plan --no-delete`. `plan` is read-only, so the flag does nothing there. The command that acts on the pulled tree is `apply`, and a user following the printed guidance runs it without the flag.

`pull` is experimental and says so. It reports the rows it could not export, and then writes a manifest that omits them. Applying that tree with deletion inference on, which is the default, reads those rows as entities the developer removed and destroys them.

Measured on a seeded dev workspace, pulling the Custom application and applying the result:

```
Plan: 0 to add, 0 to change, 19 to destroy.
```

Those 19 are exactly the rows the pull report had just listed as "not written, unsupported by this version": 4 roles, 4 command menu items, 3 front components, 3 logic functions, 2 object permissions, 2 field permissions, 1 role permission flag. Destroying the 4 roles cascades, because `core."roleTarget"."roleId"` is `ON DELETE CASCADE` and six tables hang off `core.role`:

```
roleTarget   1012 -> 8     (member-bound 1005 -> 1)
role            5 -> 1
objectPermission / fieldPermission / rolePermissionFlag  -> 0
```

1004 of 1005 workspace members were left with no role. Nothing prompted, because `DESTRUCTIVE_METADATA_NAMES` covers only `objectMetadata` and `fieldMetadata`, so `hasDestructiveActions` was false and the run exited 0.

The same tree applied with `--no-delete` is a true fixpoint: nothing destroyed, every count unchanged, and a fresh pull afterwards is byte-identical in both source and coverage report.

## How

- The two `Next:` hints name `apply --no-delete` instead of `plan --no-delete`.
- `apply` warns before it acts when the tree carries a `.twenty/pull-base.json` and deletion inference is on. It is silent under `--no-delete`, and silent for a project that was never pulled into, so a hand-authored app that genuinely drops a role still deletes it with no new noise.
- `hasPullBaseFile` is deliberately existence-only rather than reusing `readPullBaseManifest`, which returns null for a base it cannot parse or whose application does not match. A project pulled into by an older version still deserves the warning.

## What this does not do

It does not stop the deletion, and it is not the fix. The underlying defect is that deletion inference treats "our exporter could not write this" as "the user deleted this", and no rule reading the manifest alone can tell an empty section apart from an unexpressed one. Fixing that needs the producer to declare its coverage on the sync input, so it also covers install and upgrade paths where no CLI is in the loop. That belongs with the export work that removes the trigger.

Scope of the exposure, for whoever picks that up: the exported manifest hardcodes `logicFunctions`, `frontComponents`, `permissionFlags`, `roles`, `skills`, `agents`, `publicAssets`, `commandMenuItems` and `timelineActivityTypes` to `[]`, and omits `connectionProviders` and `application.applicationVariables` entirely. The 19 rows above are what this particular workspace happened to contain, not a ceiling. A workspace with connection providers would also lose them, and `connectedAccount.connectionProviderId` is `ON DELETE CASCADE`.

## Verification

- Unit spec on `hasPullBaseFile`: absent base, present base, and an unparseable base that must still count as present.
- Verified live against a dev workspace on the measured state above: the hint now reads `Next: yarn twenty apply --no-delete`; a bare `apply` prints the warning before touching the server; `apply --no-delete` prints nothing, reports "No changes", and leaves all 1005 member assignments, 5 roles and 2 object permissions intact.
- Full SDK unit suite (118 files, 854 tests), tsgo, oxlint and prettier clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

