### PR TITLE
List every kind pull does not export yet

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
+++ b/packages/twenty-docs/developers/extend/apps/operations/sync-and-recovery.mdx
@@ -127,7 +127,7 @@ Each entity goes to the file that already defines it, so a second pull rewrites 
 
 **What it does not write:**
 
-- **Not exported yet** — roles and permissions, command menu items, logic functions and front components, and the stored source of your functions.
+- **Not exported yet** — roles and permissions, command menu items, logic functions and front components, skills and agents, connection providers, application variables, public assets, timeline activity types, and the stored source of your functions.
 - **Derived by the engine** — system fields, default relations, default views and backing indexes, and the default page layouts of each object. The server rebuilds them on apply. An object may still point its label identifier at one of them, as junction objects created in the UI do; the pointer is written and the build resolves it without adding a field.
 - **Placed on a default or foreign view** — filters, filter groups, sorts, groups and field groups added to an engine default view, or to a view owned by another application, have no source form yet and are reported. View fields added there are written as standalone files, since the view's identifier is known.
 - **Placed on a default or foreign page layout** — tabs and widgets added to an engine default page layout, or to one owned by another application, are written as standalone `definePageLayoutTab()` and `definePageLayoutWidget()` files, since the identifier they attach to is known.


### PR DESCRIPTION
## What

The sync and recovery page tells a developer what `yarn twenty pull` does not write, and the "Not exported yet" bullet is incomplete. It names roles and permissions, command menu items, logic functions and front components. Seven more kinds are also not exported.

That page is the contract someone reads before deciding whether a pulled tree is safe to apply, so a partial list reads as a promise that everything else round-trips.

## How

Completed the bullet against what `application-manifest-export.service.ts` actually assembles. The exporter hardcodes nine sections to `[]`:

```ts
logicFunctions: [],   frontComponents: [],  permissionFlags: [],
roles: [],            skills: [],           agents: [],
publicAssets: [],     commandMenuItems: [], timelineActivityTypes: [],
```

and two more never reach the manifest at all: `connectionProviders` is an optional key the export never sets, and `application.applicationVariables` is not emitted by `fromFlatApplicationToApplicationManifest`.

So the bullet gains skills and agents, connection providers, application variables, public assets and timeline activity types. Permission flags stay folded into the existing "roles and permissions".

Nothing else on the page changes. The advice immediately below it is already correct and unchanged:

> push a pulled tree back with `yarn twenty apply --no-delete` until the missing kinds are covered. A pruning `yarn twenty apply` would delete them

## Why it matters

Deletion inference destroys any row of the application that the incoming manifest does not mention, so every kind on that list is destroyed by a pruning apply of a pulled tree. Measured on a seeded dev workspace, pulling the Custom application and applying without `--no-delete` destroyed 19 rows, and because `core."roleTarget"."roleId"` is `ON DELETE CASCADE` it left 1004 of 1005 members with no role.

Connection providers are the reason this is worth correcting rather than leaving to the export work. `core."connectedAccount"."connectionProviderId"` is `ON DELETE CASCADE` and is the only inbound cascade on that table, so losing a provider takes its connected accounts with it, along with their encrypted access and refresh tokens. A developer who read the old list would have no reason to expect that.

The list shrinks again as each kind gets exported.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

