### PR TITLE
Canonicalize internationalized email domains for storage and exact matching

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/2-41-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/2-41-upgrade-version-command.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { CanonicalizeEmailDomainsCommand } from 'src/database/commands/upgrade-version-command/2-41/2-41-workspace-command-1789154318369-canonicalize-email-domains.command';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+
+@Module({
+  imports: [WorkspaceCacheModule, WorkspaceIteratorModule],
+  providers: [CanonicalizeEmailDomainsCommand],
+})
+export class V2_41_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/2-41-workspace-command-1789154318369-canonicalize-email-domains.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/2-41-workspace-command-1789154318369-canonicalize-email-domains.command.ts
@@ -1,0 +1,353 @@
+import { Command } from 'nest-commander';
+import {
+  emailsCompositeType,
+  FieldMetadataType,
+} from 'twenty-shared/types';
+import { findOrThrow, isDefined } from 'twenty-shared/utils';
+import { QueryFailedError, type QueryRunner } from 'typeorm';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { canonicalizeEmailColumnsValue } from 'src/database/commands/upgrade-version-command/2-41/utils/canonicalize-email-columns-value.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { escapeIdentifier } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+
+const EMAIL_MIGRATION_BATCH_SIZE = 500;
+const UNIQUE_VIOLATION_POSTGRES_CODE = '23505';
+const TEMPORARY_TABLE_NAME = 'emailDomainCanonicalization';
+
+const PRIMARY_EMAIL_PROPERTY = findOrThrow(
+  emailsCompositeType.properties,
+  (property) => property.name === 'primaryEmail',
+);
+const ADDITIONAL_EMAILS_PROPERTY = findOrThrow(
+  emailsCompositeType.properties,
+  (property) => property.name === 'additionalEmails',
+);
+
+type EmailRow = {
+  id: string;
+  primaryEmail: unknown;
+  additionalEmails: unknown;
+};
+
+type EmailFieldTarget = {
+  fieldMetadata: FlatFieldMetadata;
+  tableName: string;
+  primaryEmailColumnName: string;
+  additionalEmailsColumnName: string;
+  hasStandaloneUniqueIndex: boolean;
+};
+
+const serializeJsonValue = (value: unknown): string | null =>
+  value === null || value === undefined ? null : JSON.stringify(value);
+
+@RegisteredWorkspaceCommand('2.41.0', 1789154318369)
+@Command({
+  name: 'upgrade:2-41:canonicalize-email-domains',
+  description:
+    'Canonicalize domains in every workspace EMAILS field to their ASCII IDNA form.',
+})
+export class CanonicalizeEmailDomainsCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    dataSource,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    if (!isDefined(dataSource)) {
+      this.logger.log(`No data source for workspace ${workspaceId}, skipping`);
+
+      return;
+    }
+
+    const { flatFieldMetadataMaps, flatIndexMaps, flatObjectMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatFieldMetadataMaps',
+        'flatIndexMaps',
+        'flatObjectMetadataMaps',
+      ]);
+
+    const emailFields = Object.values(
+      flatFieldMetadataMaps.byUniversalIdentifier,
+    )
+      .filter(isDefined)
+      .filter((field) => field.type === FieldMetadataType.EMAILS);
+
+    const targets = emailFields.flatMap((fieldMetadata) => {
+      const objectMetadata =
+        flatObjectMetadataMaps.byUniversalIdentifier[
+          fieldMetadata.objectMetadataUniversalIdentifier
+        ];
+
+      if (!isDefined(objectMetadata)) {
+        this.logger.warn(
+          `Object metadata not found for EMAILS field ${fieldMetadata.name} (${fieldMetadata.id}), skipping`,
+        );
+
+        return [];
+      }
+
+      const hasStandaloneUniqueIndex = Object.values(
+        flatIndexMaps.byUniversalIdentifier,
+      )
+        .filter(isDefined)
+        .some(
+          (indexMetadata) =>
+            indexMetadata.isUnique &&
+            indexMetadata.indexWhereClause === null &&
+            indexMetadata.flatIndexFieldMetadatas.length === 1 &&
+            indexMetadata.flatIndexFieldMetadatas[0]?.fieldMetadataId ===
+              fieldMetadata.id &&
+            [null, 'primaryEmail'].includes(
+              indexMetadata.flatIndexFieldMetadatas[0]?.subFieldName ?? null,
+            ),
+        );
+
+      return [
+        {
+          fieldMetadata,
+          tableName: computeObjectTargetTable(objectMetadata),
+          primaryEmailColumnName: computeCompositeColumnName(
+            fieldMetadata.name,
+            PRIMARY_EMAIL_PROPERTY,
+          ),
+          additionalEmailsColumnName: computeCompositeColumnName(
+            fieldMetadata.name,
+            ADDITIONAL_EMAILS_PROPERTY,
+          ),
+          hasStandaloneUniqueIndex,
+        },
+      ];
+    });
+
+    if (targets.length === 0) {
+      this.logger.log(
+        `No EMAILS fields found for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    const queryRunner = dataSource.createQueryRunner();
+
+    await queryRunner.connect();
+
+    try {
+      await this.createTemporaryTable(queryRunner);
+
+      for (const target of targets) {
+        await this.canonicalizeField({
+          isDryRun: options.dryRun ?? false,
+          queryRunner,
+          schemaName: getWorkspaceSchemaName(workspaceId),
+          target,
+          workspaceId,
+        });
+      }
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  private async createTemporaryTable(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TEMPORARY TABLE IF NOT EXISTS ${escapeIdentifier(TEMPORARY_TABLE_NAME)} (
+        "recordId" uuid PRIMARY KEY,
+        "primaryEmail" text,
+        "additionalEmails" jsonb,
+        "originalPrimaryEmail" text,
+        "originalAdditionalEmails" jsonb
+      ) ON COMMIT PRESERVE ROWS`,
+    );
+  }
+
+  private async canonicalizeField({
+    isDryRun,
+    queryRunner,
+    schemaName,
+    target,
+    workspaceId,
+  }: {
+    isDryRun: boolean;
+    queryRunner: QueryRunner;
+    schemaName: string;
+    target: EmailFieldTarget;
+    workspaceId: string;
+  }): Promise<void> {
+    await queryRunner.query(
+      `TRUNCATE ${escapeIdentifier(TEMPORARY_TABLE_NAME)}`,
+    );
+
+    const tableReference = `${escapeIdentifier(schemaName)}.${escapeIdentifier(target.tableName)}`;
+    const primaryEmailColumn = escapeIdentifier(
+      target.primaryEmailColumnName,
+    );
+    const additionalEmailsColumn = escapeIdentifier(
+      target.additionalEmailsColumnName,
+    );
+    let cursor: string | null = null;
+    let changedRowCount = 0;
+
+    while (true) {
+      const rows = (await queryRunner.query(
+        `SELECT "id",
+                ${primaryEmailColumn} AS "primaryEmail",
+                ${additionalEmailsColumn} AS "additionalEmails"
+         FROM ${tableReference}
+         WHERE ($1::uuid IS NULL OR "id" > $1)
+           AND (${primaryEmailColumn} IS NOT NULL OR ${additionalEmailsColumn} IS NOT NULL)
+         ORDER BY "id"
+         LIMIT $2`,
+        [cursor, EMAIL_MIGRATION_BATCH_SIZE],
+      )) as EmailRow[];
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      const changedRows = rows.flatMap((row) => {
+        const canonicalValue = canonicalizeEmailColumnsValue(row);
+
+        return canonicalValue.hasChanges
+          ? [
+              {
+                ...canonicalValue,
+                id: row.id,
+                originalAdditionalEmails: row.additionalEmails,
+                originalPrimaryEmail: row.primaryEmail,
+              },
+            ]
+          : [];
+      });
+
+      if (changedRows.length > 0) {
+        await this.stageRows(queryRunner, changedRows);
+        changedRowCount += changedRows.length;
+      }
+
+      cursor = rows[rows.length - 1]?.id ?? null;
+    }
+
+    const fieldLabel = `${target.tableName}.${target.fieldMetadata.name}`;
+
+    if (changedRowCount === 0) {
+      this.logger.log(
+        `Email domains already canonical for ${fieldLabel} in workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    if (target.hasStandaloneUniqueIndex) {
+      const [{ collisionCount }] = (await queryRunner.query(
+        `SELECT count(*)::int AS "collisionCount"
+         FROM (
+           SELECT "primaryEmail"
+           FROM ${escapeIdentifier(TEMPORARY_TABLE_NAME)}
+           WHERE "primaryEmail" IS NOT NULL
+           GROUP BY "primaryEmail"
+           HAVING count(*) > 1
+
+           UNION ALL
+
+           SELECT staged."primaryEmail"
+           FROM ${escapeIdentifier(TEMPORARY_TABLE_NAME)} staged
+           JOIN ${tableReference} existing
+             ON existing.${primaryEmailColumn} = staged."primaryEmail"
+            AND existing."id" <> staged."recordId"
+           LIMIT 1
+         ) collisions`,
+      )) as Array<{ collisionCount: number }>;
+
+      if (collisionCount > 0) {
+        throw new Error(
+          `Cannot canonicalize ${fieldLabel} in workspace ${workspaceId}: equivalent email values would collide under its unique index`,
+        );
+      }
+    }
+
+    if (isDryRun) {
+      this.logger.log(
+        `[DRY RUN] Would canonicalize ${changedRowCount} row(s) in ${fieldLabel} for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    try {
+      const result = await queryRunner.query(
+        `UPDATE ${tableReference} target
+         SET ${primaryEmailColumn} = staged."primaryEmail",
+             ${additionalEmailsColumn} = staged."additionalEmails"
+         FROM ${escapeIdentifier(TEMPORARY_TABLE_NAME)} staged
+         WHERE target."id" = staged."recordId"
+           AND target.${primaryEmailColumn} IS NOT DISTINCT FROM staged."originalPrimaryEmail"
+           AND target.${additionalEmailsColumn} IS NOT DISTINCT FROM staged."originalAdditionalEmails"`,
+        undefined,
+        true,
+      );
+
+      this.logger.log(
+        `Canonicalized ${result.affected ?? 0} row(s) in ${fieldLabel} for workspace ${workspaceId}`,
+      );
+    } catch (error) {
+      const postgresCode =
+        error instanceof QueryFailedError
+          ? (error.driverError as { code?: string } | undefined)?.code
+          : undefined;
+
+      if (postgresCode === UNIQUE_VIOLATION_POSTGRES_CODE) {
+        throw new Error(
+          `Cannot canonicalize ${fieldLabel} in workspace ${workspaceId}: equivalent email values conflict with an existing unique index`,
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  private async stageRows(
+    queryRunner: QueryRunner,
+    rows: Array<
+      EmailRow & {
+        originalPrimaryEmail: unknown;
+        originalAdditionalEmails: unknown;
+      }
+    >,
+  ): Promise<void> {
+    const parameters: unknown[] = [];
+    const valuePlaceholders = rows.map((row, rowIndex) => {
+      const parameterOffset = rowIndex * 5;
+
+      parameters.push(
+        row.id,
+        row.primaryEmail,
+        serializeJsonValue(row.additionalEmails),
+        row.originalPrimaryEmail,
+        serializeJsonValue(row.originalAdditionalEmails),
+      );
+
+      return `($${parameterOffset + 1}, $${parameterOffset + 2}, $${parameterOffset + 3}::jsonb, $${parameterOffset + 4}, $${parameterOffset + 5}::jsonb)`;
+    });
+
+    await queryRunner.query(
+      `INSERT INTO ${escapeIdentifier(TEMPORARY_TABLE_NAME)}
+        ("recordId", "primaryEmail", "additionalEmails", "originalPrimaryEmail", "originalAdditionalEmails")
+       VALUES ${valuePlaceholders.join(', ')}`,
+      parameters,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/__tests__/2-41-workspace-command-1789154318369-canonicalize-email-domains.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/__tests__/2-41-workspace-command-1789154318369-canonicalize-email-domains.command.spec.ts
@@ -1,0 +1,164 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+import { type DataSource, type QueryRunner } from 'typeorm';
+
+import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { CanonicalizeEmailDomainsCommand } from 'src/database/commands/upgrade-version-command/2-41/2-41-workspace-command-1789154318369-canonicalize-email-domains.command';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
+
+const WORKSPACE_ID = '20202020-0000-0000-0000-000000000001';
+const FIELD_ID = '20202020-0000-0000-0000-000000000002';
+
+const buildCache = (isUnique = false) => ({
+  flatFieldMetadataMaps: {
+    byUniversalIdentifier: {
+      emailField: {
+        id: FIELD_ID,
+        name: 'emails',
+        type: FieldMetadataType.EMAILS,
+        objectMetadataUniversalIdentifier: 'personObject',
+      },
+    },
+  },
+  flatIndexMaps: {
+    byUniversalIdentifier: isUnique
+      ? {
+          emailIndex: {
+            isUnique: true,
+            indexWhereClause: null,
+            flatIndexFieldMetadatas: [
+              {
+                fieldMetadataId: FIELD_ID,
+                subFieldName: null,
+              },
+            ],
+          },
+        }
+      : {},
+  },
+  flatObjectMetadataMaps: {
+    byUniversalIdentifier: {
+      personObject: {
+        nameSingular: 'person',
+        applicationUniversalIdentifier:
+          TWENTY_STANDARD_APPLICATION.universalIdentifier,
+      },
+    },
+  },
+});
+
+const createCommand = ({
+  collisionCount = 0,
+  dryRun = false,
+  isUnique = false,
+}: {
+  collisionCount?: number;
+  dryRun?: boolean;
+  isUnique?: boolean;
+} = {}) => {
+  let recordSelectCount = 0;
+  const query = jest.fn(
+    async (sql: string, _parameters?: unknown[], structured?: boolean) => {
+      if (sql.includes('SELECT "id"')) {
+        recordSelectCount++;
+
+        return recordSelectCount === 1
+          ? [
+              {
+                id: '20202020-0000-0000-0000-000000000003',
+                primaryEmail: 'admin@💩.la',
+                additionalEmails: ['user@例え.テスト'],
+              },
+            ]
+          : [];
+      }
+
+      if (sql.includes('SELECT count(*)')) {
+        return [{ collisionCount }];
+      }
+
+      if (structured && sql.includes('UPDATE')) {
+        return { affected: 1 };
+      }
+
+      return [];
+    },
+  );
+  const queryRunner = {
+    connect: jest.fn(),
+    query,
+    release: jest.fn(),
+  } as unknown as QueryRunner;
+  const dataSource = {
+    createQueryRunner: jest.fn(() => queryRunner),
+  } as unknown as DataSource;
+  const workspaceCacheService = {
+    getOrRecompute: jest.fn().mockResolvedValue(buildCache(isUnique)),
+  } as unknown as WorkspaceCacheService;
+  const command = new CanonicalizeEmailDomainsCommand(
+    {} as WorkspaceIteratorService,
+    workspaceCacheService,
+  );
+  const run = () =>
+    command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      dataSource,
+      options: { dryRun },
+      index: 0,
+      total: 1,
+    });
+
+  return { query, queryRunner, run };
+};
+
+describe('CanonicalizeEmailDomainsCommand', () => {
+  it('stages canonical values and updates the EMAILS field', async () => {
+    const { query, queryRunner, run } = createCommand();
+
+    await run();
+
+    const insertCall = query.mock.calls.find(([sql]) =>
+      sql.includes('INSERT INTO'),
+    );
+
+    expect(insertCall?.[1]).toEqual([
+      '20202020-0000-0000-0000-000000000003',
+      'admin@xn--ls8h.la',
+      '["user@xn--r8jz45g.xn--zckzah"]',
+      'admin@💩.la',
+      '["user@例え.テスト"]',
+    ]);
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE'))).toBe(
+      true,
+    );
+    expect(queryRunner.release).toHaveBeenCalled();
+  });
+
+  it('scans and stages values without updating in dry-run mode', async () => {
+    const { query, run } = createCommand({ dryRun: true });
+
+    await run();
+
+    expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO'))).toBe(
+      true,
+    );
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE'))).toBe(
+      false,
+    );
+  });
+
+  it('stops before updating when canonical values collide', async () => {
+    const { query, queryRunner, run } = createCommand({
+      collisionCount: 1,
+      isUnique: true,
+    });
+
+    await expect(run()).rejects.toThrow(
+      'equivalent email values would collide under its unique index',
+    );
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE'))).toBe(
+      false,
+    );
+    expect(queryRunner.release).toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/utils/__tests__/canonicalize-email-columns-value.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/utils/__tests__/canonicalize-email-columns-value.util.spec.ts
@@ -1,0 +1,45 @@
+import { canonicalizeEmailColumnsValue } from 'src/database/commands/upgrade-version-command/2-41/utils/canonicalize-email-columns-value.util';
+
+describe('canonicalizeEmailColumnsValue', () => {
+  it('canonicalizes primary and additional internationalized domains', () => {
+    expect(
+      canonicalizeEmailColumnsValue({
+        primaryEmail: 'admin@💩.la',
+        additionalEmails: ['user@例え.テスト', 'user@пример.рф'],
+      }),
+    ).toEqual({
+      primaryEmail: 'admin@xn--ls8h.la',
+      additionalEmails: [
+        'user@xn--r8jz45g.xn--zckzah',
+        'user@xn--e1afmkfd.xn--p1ai',
+      ],
+      hasChanges: true,
+    });
+  });
+
+  it('leaves canonical values unchanged', () => {
+    expect(
+      canonicalizeEmailColumnsValue({
+        primaryEmail: 'admin@example.com',
+        additionalEmails: ['user@xn--mgbh0fb.xn--kgbechtv'],
+      }),
+    ).toEqual({
+      primaryEmail: 'admin@example.com',
+      additionalEmails: ['user@xn--mgbh0fb.xn--kgbechtv'],
+      hasChanges: false,
+    });
+  });
+
+  it('preserves malformed non-string JSON values', () => {
+    expect(
+      canonicalizeEmailColumnsValue({
+        primaryEmail: null,
+        additionalEmails: ['admin@💩.la', { legacy: true }],
+      }),
+    ).toEqual({
+      primaryEmail: null,
+      additionalEmails: ['admin@xn--ls8h.la', { legacy: true }],
+      hasChanges: true,
+    });
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/utils/canonicalize-email-columns-value.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-41/utils/canonicalize-email-columns-value.util.ts
@@ -1,0 +1,37 @@
+import { canonicalizeEmail } from 'twenty-shared/utils';
+
+export type EmailColumnsValue = {
+  primaryEmail: unknown;
+  additionalEmails: unknown;
+};
+
+export type CanonicalEmailColumnsValue = EmailColumnsValue & {
+  hasChanges: boolean;
+};
+
+const areJsonValuesEqual = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+export const canonicalizeEmailColumnsValue = ({
+  primaryEmail,
+  additionalEmails,
+}: EmailColumnsValue): CanonicalEmailColumnsValue => {
+  const canonicalPrimaryEmail =
+    typeof primaryEmail === 'string'
+      ? canonicalizeEmail(primaryEmail)
+      : primaryEmail;
+
+  const canonicalAdditionalEmails = Array.isArray(additionalEmails)
+    ? additionalEmails.map((email) =>
+        typeof email === 'string' ? canonicalizeEmail(email) : email,
+      )
+    : additionalEmails;
+
+  return {
+    primaryEmail: canonicalPrimaryEmail,
+    additionalEmails: canonicalAdditionalEmails,
+    hasChanges:
+      canonicalPrimaryEmail !== primaryEmail ||
+      !areJsonValuesEqual(canonicalAdditionalEmails, additionalEmails),
+  };
+};

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -33,6 +33,7 @@ import { V2_37_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
 import { V2_38_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-38/2-38-upgrade-version-command.module';
 import { V2_39_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-39/2-39-upgrade-version-command.module';
 import { V2_40_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-40/2-40-upgrade-version-command.module';
+import { V2_41_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-41/2-41-upgrade-version-command.module';
 import { V2_4_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-4/2-4-upgrade-version-command.module';
 import { V2_5_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-5/2-5-upgrade-version-command.module';
 import { V2_7_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-7/2-7-upgrade-version-command.module';
@@ -79,6 +80,7 @@ import { V2_9_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-
     V2_38_UpgradeVersionCommandModule,
     V2_39_UpgradeVersionCommandModule,
     V2_40_UpgradeVersionCommandModule,
+    V2_41_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service.ts
@@ -12,6 +12,7 @@ import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-m
 import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { MAX_RELATION_FILTER_DEPTH } from 'src/engine/api/common/common-args-processors/filter-arg-processor/constants/max-relation-filter-depth.constant';
+import { canonicalizeEmailFilter } from 'src/engine/api/common/common-args-processors/filter-arg-processor/utils/canonicalize-email-filter.util';
 import { validateAndTransformOperatorAndValue } from 'src/engine/api/common/common-args-processors/filter-arg-processor/utils/validate-and-transform-operator-and-value.util';
 import {
   CommonQueryRunnerException,
@@ -348,7 +349,7 @@ export class FilterArgProcessorService {
         );
       }
 
-      transformedFilter[subFieldKey] = validateAndTransformOperatorAndValue(
+      const transformedSubFieldFilter = validateAndTransformOperatorAndValue(
         `${fieldMetadata.name}.${subFieldKey}`,
         subFieldFilter as Record<string, unknown>,
         {
@@ -356,6 +357,12 @@ export class FilterArgProcessorService {
           type: subFieldMetadata.type as FieldMetadataType,
         },
       );
+
+      transformedFilter[subFieldKey] =
+        fieldMetadata.type === FieldMetadataType.EMAILS &&
+        subFieldKey === 'primaryEmail'
+          ? canonicalizeEmailFilter(transformedSubFieldFilter)
+          : transformedSubFieldFilter;
     }
 
     return transformedFilter;

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/filter-arg-processor/utils/__tests__/canonicalize-email-filter.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/filter-arg-processor/utils/__tests__/canonicalize-email-filter.util.spec.ts
@@ -1,0 +1,44 @@
+import { canonicalizeEmailFilter } from 'src/engine/api/common/common-args-processors/filter-arg-processor/utils/canonicalize-email-filter.util';
+
+describe('canonicalizeEmailFilter', () => {
+  it('canonicalizes an exact email filter', () => {
+    expect(canonicalizeEmailFilter({ eq: 'Admin@💩.la' })).toEqual({
+      in: ['admin@💩.la', 'admin@xn--ls8h.la'],
+    });
+  });
+
+  it('canonicalizes every email in a bulk exact filter', () => {
+    expect(
+      canonicalizeEmailFilter({
+        in: [
+          'Admin@EXAMPLE.COM',
+          'user@münchen.de',
+          'user@пример.рф',
+          'user@例え.テスト',
+          'user@مثال.إختبار',
+          'admin@💩.la',
+        ],
+      }),
+    ).toEqual({
+      in: [
+        'admin@example.com',
+        'user@münchen.de',
+        'user@xn--mnchen-3ya.de',
+        'user@пример.рф',
+        'user@xn--e1afmkfd.xn--p1ai',
+        'user@例え.テスト',
+        'user@xn--r8jz45g.xn--zckzah',
+        'user@مثال.إختبار',
+        'user@xn--mgbh0fb.xn--kgbechtv',
+        'admin@💩.la',
+        'admin@xn--ls8h.la',
+      ],
+    });
+  });
+
+  it('does not rewrite partial-match filters', () => {
+    const filter = { ilike: '%💩.la%' };
+
+    expect(canonicalizeEmailFilter(filter)).toBe(filter);
+  });
+});

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/filter-arg-processor/utils/canonicalize-email-filter.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/filter-arg-processor/utils/canonicalize-email-filter.util.ts
@@ -1,0 +1,38 @@
+import {
+  canonicalizeEmail,
+  getEmailMatchCandidates,
+} from 'twenty-shared/utils';
+
+const CANONICAL_EMAIL_FILTER_OPERATORS = new Set(['eq', 'neq', 'in']);
+
+export const canonicalizeEmailFilter = (
+  filter: Record<string, unknown>,
+): Record<string, unknown> => {
+  const [[operator, value]] = Object.entries(filter);
+
+  if (!CANONICAL_EMAIL_FILTER_OPERATORS.has(operator)) {
+    return filter;
+  }
+
+  if (Array.isArray(value)) {
+    return {
+      [operator]: [
+        ...new Set(
+          value.flatMap((item) =>
+            typeof item === 'string' ? getEmailMatchCandidates(item) : [item],
+          ),
+        ),
+      ],
+    };
+  }
+
+  if (operator === 'eq' && typeof value === 'string') {
+    const candidates = getEmailMatchCandidates(value);
+
+    return candidates.length === 1 ? { eq: candidates[0] } : { in: candidates };
+  }
+
+  return {
+    [operator]: typeof value === 'string' ? canonicalizeEmail(value) : value,
+  };
+};

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-emails-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-emails-value.util.spec.ts
@@ -24,6 +24,15 @@ describe('transformEmailsValue', () => {
     expect(result.primaryEmail).toBe('test@example.com');
   });
 
+  it('should canonicalize an internationalized primary email domain', () => {
+    const result = transformEmailsValue({
+      primaryEmail: 'Admin@💩.la',
+      additionalEmails: null,
+    });
+
+    expect(result.primaryEmail).toBe('admin@xn--ls8h.la');
+  });
+
   it('should return null for primaryEmail when it is empty string', () => {
     const value = {
       primaryEmail: '',
@@ -66,6 +75,17 @@ describe('transformEmailsValue', () => {
 
     expect(result.additionalEmails).toBe(
       '["user1@example.com","user2@example.com"]',
+    );
+  });
+
+  it('should canonicalize internationalized additional email domains', () => {
+    const result = transformEmailsValue({
+      primaryEmail: 'test@example.com',
+      additionalEmails: ['user@例え.テスト', 'user@пример.рф'],
+    });
+
+    expect(result.additionalEmails).toBe(
+      '["user@xn--r8jz45g.xn--zckzah","user@xn--e1afmkfd.xn--p1ai"]',
     );
   });
 

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-emails-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-emails-value.util.ts
@@ -1,5 +1,6 @@
 import { isNonEmptyArray, isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'class-validator';
+import { canonicalizeEmail } from 'twenty-shared/utils';
 
 export const transformEmailsValue = (
   // oxlint-disable-next-line typescript/no-explicit-any
@@ -12,7 +13,7 @@ export const transformEmailsValue = (
 
   let additionalEmails: string | null = value?.additionalEmails;
   const primaryEmail = isNonEmptyString(value?.primaryEmail)
-    ? value.primaryEmail.toLowerCase()
+    ? canonicalizeEmail(value.primaryEmail)
     : null;
 
   if (additionalEmails) {
@@ -24,7 +25,7 @@ export const transformEmailsValue = (
       ) as string[];
 
       additionalEmails = isNonEmptyArray(emailArray)
-        ? JSON.stringify(emailArray.map((email) => email.toLowerCase()))
+        ? JSON.stringify(emailArray.map(canonicalizeEmail))
         : null;
     } catch {
       /* empty */

--- a/packages/twenty-server/src/modules/match-participant/utils/__tests__/__snapshots__/add-person-email-filters-to-query-builder.util.spec.ts.snap
+++ b/packages/twenty-server/src/modules/match-participant/utils/__tests__/__snapshots__/add-person-email-filters-to-query-builder.util.spec.ts.snap
@@ -98,6 +98,69 @@ exports[`addPersonEmailFiltersToQueryBuilder empty emails array: should handle e
 ]
 `;
 
+exports[`addPersonEmailFiltersToQueryBuilder internationalized email domain normalization: should normalize internationalized domains to punycode - query builder calls 1`] = `
+[
+  {
+    "args": [
+      "LOWER("person"."emailsPrimaryEmail") IN (:...emails)",
+      {
+        "emails": [
+          "admin@💩.la",
+          "admin@xn--ls8h.la",
+          "user@例え.テスト",
+          "user@xn--r8jz45g.xn--zckzah",
+        ],
+      },
+    ],
+    "method": "where",
+  },
+  {
+    "args": [],
+    "method": "withDeleted",
+  },
+  {
+    "args": [
+      ""person"."emailsAdditionalEmails" @> :email0::jsonb",
+      {
+        "email0": "["admin@💩.la"]",
+      },
+    ],
+    "method": "orWhere",
+  },
+  {
+    "args": [
+      ""person"."emailsAdditionalEmails" @> :email1::jsonb",
+      {
+        "email1": "["admin@xn--ls8h.la"]",
+      },
+    ],
+    "method": "orWhere",
+  },
+  {
+    "args": [
+      ""person"."emailsAdditionalEmails" @> :email2::jsonb",
+      {
+        "email2": "["user@例え.テスト"]",
+      },
+    ],
+    "method": "orWhere",
+  },
+  {
+    "args": [
+      ""person"."emailsAdditionalEmails" @> :email3::jsonb",
+      {
+        "email3": "["user@xn--r8jz45g.xn--zckzah"]",
+      },
+    ],
+    "method": "orWhere",
+  },
+  {
+    "args": [],
+    "method": "withDeleted",
+  },
+]
+`;
+
 exports[`addPersonEmailFiltersToQueryBuilder multiple emails with exclusions: should handle exclusions with multiple emails - query builder calls 1`] = `
 [
   {

--- a/packages/twenty-server/src/modules/match-participant/utils/__tests__/add-person-email-filters-to-query-builder.util.spec.ts
+++ b/packages/twenty-server/src/modules/match-participant/utils/__tests__/add-person-email-filters-to-query-builder.util.spec.ts
@@ -72,6 +72,13 @@ const testCases: AddPersonEmailFiltersToQueryBuilderTestCase[] = [
       description: 'should normalize emails to lowercase',
     },
   },
+  {
+    title: 'internationalized email domain normalization',
+    context: {
+      emails: ['admin@💩.la', 'user@例え.テスト'],
+      description: 'should normalize internationalized domains to punycode',
+    },
+  },
 ];
 
 interface QueryBuilderCall {

--- a/packages/twenty-server/src/modules/match-participant/utils/__tests__/find-person-by-primary-or-additional-email.spec.ts
+++ b/packages/twenty-server/src/modules/match-participant/utils/__tests__/find-person-by-primary-or-additional-email.spec.ts
@@ -156,6 +156,44 @@ describe('findPersonByPrimaryOrAdditionalEmail', () => {
     expect(result).toEqual(mockPeople[2]);
   });
 
+  it('should match Unicode and punycode primary email domains', () => {
+    const people = [
+      {
+        id: 'person-idn',
+        emails: {
+          primaryEmail: 'admin@xn--ls8h.la',
+          additionalEmails: null,
+        },
+      },
+    ] as PersonWorkspaceEntity[];
+
+    const result = findPersonByPrimaryOrAdditionalEmail({
+      people,
+      email: 'admin@💩.la',
+    });
+
+    expect(result).toEqual(people[0]);
+  });
+
+  it('should match Unicode and punycode additional email domains', () => {
+    const people = [
+      {
+        id: 'person-idn',
+        emails: {
+          primaryEmail: 'other@example.com',
+          additionalEmails: ['admin@xn--ls8h.la'],
+        },
+      },
+    ] as PersonWorkspaceEntity[];
+
+    const result = findPersonByPrimaryOrAdditionalEmail({
+      people,
+      email: 'admin@💩.la',
+    });
+
+    expect(result).toEqual(people[0]);
+  });
+
   it('should handle people with non-array additional emails', () => {
     const peopleWithInvalidAdditionalEmail = [
       {

--- a/packages/twenty-server/src/modules/match-participant/utils/add-person-email-filters-to-query-builder.ts
+++ b/packages/twenty-server/src/modules/match-participant/utils/add-person-email-filters-to-query-builder.ts
@@ -1,3 +1,5 @@
+import { getEmailMatchCandidates } from 'twenty-shared/utils';
+
 import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/query-builder/workspace-select-query-builder';
 
 export interface AddPersonEmailFiltersToQueryBuilderOptions {
@@ -12,7 +14,9 @@ export function addPersonEmailFiltersToQueryBuilder({
   emails,
   excludePersonIds = [],
 }: AddPersonEmailFiltersToQueryBuilderOptions): WorkspaceSelectQueryBuilder {
-  const normalizedEmails = emails.map((email) => email.toLowerCase());
+  const normalizedEmails = [
+    ...new Set(emails.flatMap(getEmailMatchCandidates)),
+  ];
 
   queryBuilder = queryBuilder
     .where('LOWER("person"."emailsPrimaryEmail") IN (:...emails)', {

--- a/packages/twenty-server/src/modules/match-participant/utils/find-person-by-primary-or-additional-email.ts
+++ b/packages/twenty-server/src/modules/match-participant/utils/find-person-by-primary-or-additional-email.ts
@@ -1,3 +1,5 @@
+import { canonicalizeEmail } from 'twenty-shared/utils';
+
 import { type PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
 
 export const findPersonByPrimaryOrAdditionalEmail = ({
@@ -7,10 +9,12 @@ export const findPersonByPrimaryOrAdditionalEmail = ({
   people: PersonWorkspaceEntity[];
   email: string;
 }): PersonWorkspaceEntity | undefined => {
-  const lowercaseEmail = email.toLowerCase();
+  const canonicalEmail = canonicalizeEmail(email);
 
   const personWithPrimaryEmail = people.find(
-    (person) => person.emails?.primaryEmail?.toLowerCase() === lowercaseEmail,
+    (person) =>
+      person.emails?.primaryEmail &&
+      canonicalizeEmail(person.emails.primaryEmail) === canonicalEmail,
   );
 
   if (personWithPrimaryEmail) {
@@ -25,7 +29,8 @@ export const findPersonByPrimaryOrAdditionalEmail = ({
     }
 
     return additionalEmails.some(
-      (additionalEmail) => additionalEmail.toLowerCase() === lowercaseEmail,
+      (additionalEmail) =>
+        canonicalizeEmail(additionalEmail) === canonicalEmail,
     );
   });
 

--- a/packages/twenty-shared/src/utils/email/__tests__/canonicalizeEmail.test.ts
+++ b/packages/twenty-shared/src/utils/email/__tests__/canonicalizeEmail.test.ts
@@ -1,0 +1,97 @@
+import {
+  canonicalizeEmail,
+  getEmailMatchCandidates,
+} from '@/utils/email/canonicalizeEmail';
+
+describe('canonicalizeEmail', () => {
+  it.each([
+    {
+      category: 'ASCII',
+      input: 'Admin@EXAMPLE.COM',
+      expected: 'admin@example.com',
+    },
+    {
+      category: 'international Latin',
+      input: 'user@münchen.de',
+      expected: 'user@xn--mnchen-3ya.de',
+    },
+    {
+      category: 'Cyrillic',
+      input: 'user@пример.рф',
+      expected: 'user@xn--e1afmkfd.xn--p1ai',
+    },
+    {
+      category: 'Turkish casing',
+      input: 'user@İSTANBUL.example',
+      expected: 'user@xn--istanbul-o0e.example',
+    },
+    {
+      category: 'CJK',
+      input: 'user@例え.テスト',
+      expected: 'user@xn--r8jz45g.xn--zckzah',
+    },
+    {
+      category: 'right-to-left Arabic',
+      input: 'user@مثال.إختبار',
+      expected: 'user@xn--mgbh0fb.xn--kgbechtv',
+    },
+    {
+      category: 'emoji',
+      input: 'admin@💩.la',
+      expected: 'admin@xn--ls8h.la',
+    },
+  ])('canonicalizes a $category domain', ({ input, expected }) => {
+    expect(canonicalizeEmail(input)).toBe(expected);
+  });
+
+  it('canonicalizes Unicode and punycode spellings to the same value', () => {
+    expect(canonicalizeEmail('admin@💩.la')).toBe(
+      canonicalizeEmail('admin@xn--ls8h.la'),
+    );
+  });
+
+  it('normalizes Unicode dot variants and trailing dots', () => {
+    expect(canonicalizeEmail('user@例え。テスト.')).toBe(
+      'user@xn--r8jz45g.xn--zckzah',
+    );
+  });
+
+  it('normalizes canonically equivalent domain labels', () => {
+    expect(canonicalizeEmail('user@mu\u0308nchen.de')).toBe(
+      canonicalizeEmail('user@münchen.de'),
+    );
+  });
+
+  it('preserves local-part punctuation while retaining existing lowercase behavior', () => {
+    expect(canonicalizeEmail('Admin+Tag.With.Dots@💩.la')).toBe(
+      'admin+tag.with.dots@xn--ls8h.la',
+    );
+  });
+
+  it('does not strip a meaningful www domain label', () => {
+    expect(canonicalizeEmail('admin@www.example.com')).toBe(
+      'admin@www.example.com',
+    );
+  });
+
+  it('does not interpret URL structural characters in a malformed domain', () => {
+    expect(canonicalizeEmail('admin@example.com/path')).toBe(
+      'admin@example.com/path',
+    );
+  });
+});
+
+describe('getEmailMatchCandidates', () => {
+  it('returns both legacy Unicode and canonical IDNA spellings', () => {
+    expect(getEmailMatchCandidates('Admin@💩.LA')).toEqual([
+      'admin@💩.la',
+      'admin@xn--ls8h.la',
+    ]);
+  });
+
+  it('deduplicates an already canonical address', () => {
+    expect(getEmailMatchCandidates('Admin@EXAMPLE.COM')).toEqual([
+      'admin@example.com',
+    ]);
+  });
+});

--- a/packages/twenty-shared/src/utils/email/canonicalizeEmail.ts
+++ b/packages/twenty-shared/src/utils/email/canonicalizeEmail.ts
@@ -1,0 +1,37 @@
+const UNSAFE_DOMAIN_CHARACTERS = /[\s/\\?#@:[\]]/;
+
+const canonicalizeEmailDomain = (domain: string): string => {
+  const normalizedDomain = domain.normalize('NFKC').toLowerCase();
+
+  if (UNSAFE_DOMAIN_CHARACTERS.test(normalizedDomain)) {
+    return normalizedDomain;
+  }
+
+  try {
+    return new URL(`https://${normalizedDomain}`).hostname.replace(/\.+$/, '');
+  } catch {
+    return normalizedDomain;
+  }
+};
+
+// Email values have historically been lowercased by Twenty. Keep that product
+// behavior while also giving internationalized domains one stable IDNA form.
+// URL is used instead of node:url so this shared utility works in the browser.
+export const canonicalizeEmail = (email: string): string => {
+  const atIndex = email.lastIndexOf('@');
+
+  if (atIndex <= 0 || atIndex === email.length - 1) {
+    return email.toLowerCase();
+  }
+
+  const localPart = email.slice(0, atIndex).toLowerCase();
+  const domain = canonicalizeEmailDomain(email.slice(atIndex + 1));
+
+  return `${localPart}@${domain}`;
+};
+
+// Keep the pre-IDNA lowercase spelling as a read candidate so a rollout does
+// not make existing Unicode-domain records unreachable before data migration.
+export const getEmailMatchCandidates = (email: string): string[] => [
+  ...new Set([email.toLowerCase(), canonicalizeEmail(email)]),
+];

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -50,6 +50,10 @@ export { turnJSDateToPlainDate } from './date/turnJSDateToPlainDate';
 export { turnPlainDateIntoUserTimeZoneInstantString } from './date/turnPlainDateIntoUserTimeZoneInstantString';
 export { turnPlainDateToShiftedDateInSystemTimeZone } from './date/turnPlainDateToShiftedDateInSystemTimeZone';
 export { deepMerge } from './deepMerge';
+export {
+  canonicalizeEmail,
+  getEmailMatchCandidates,
+} from './email/canonicalizeEmail';
 export { formatEmailAddress } from './email/formatEmailAddress';
 export { getSendableEmailHandles } from './email/getSendableEmailHandles';
 export type { ParsedEmailAddress } from './email/parseEmailAddressList';


### PR DESCRIPTION
Closes https://github.com/twentyhq/twenty/issues/25815

## Problem

Twenty currently lowercases complete email values, but it does not canonicalize internationalized domain names. Unicode and ASCII IDNA spellings of the same mailbox can therefore be stored and queried as different values.

For example, `admin@💩.la` and `admin@xn--ls8h.la` identify the same mailbox, but exact filters and participant matching do not currently treat them as equivalent. The same issue affects accented Latin, Cyrillic, CJK, right-to-left, and other internationalized domains. Besides missed lookups, equivalent spellings can bypass raw-value uniqueness checks.

Full-text or partial matching is not a reliable identity mechanism here because punctuation and emoji may be tokenized or omitted. Storage, existing data, and exact-match inputs need the same domain canonicalization.

## Change

- canonicalize domains to their lowercase ASCII IDNA form when `EMAILS` values are stored
- apply the same canonicalization to exact primary-email filters and person matching
- retain Twenty’s historical lowercase Unicode spelling as a read candidate during rollout
- migrate existing primary and additional email values in every standard and custom workspace `EMAILS` field
- leave partial/`ILIKE` search behavior unchanged

This preserves Twenty’s existing behavior of lowercasing the complete email value while adding one stable representation for its domain.

## Migration behavior

The registered `2.41.0` workspace upgrade command runs once for each provisioned workspace. It discovers `EMAILS` fields from workspace metadata, so it covers standard fields such as `person.emails` as well as custom objects and custom email fields.

For example:

- `admin@💩.la` becomes `admin@xn--ls8h.la`
- `user@例え.テスト` becomes `user@xn--r8jz45g.xn--zckzah`
- already-canonical ASCII and IDNA values remain unchanged

For each field, the command:

1. Scans non-null rows using 500-row keyset batches.
2. Canonicalizes both the primary email and every additional email.
3. Stages only rows whose stored value would change in a temporary table.
4. In dry-run mode, reports the affected row count without updating workspace data.
5. Preflights equivalent primary-email values for standalone unique indexes.
6. Applies all staged changes for that field in one atomic update.
7. Uses the original column values as update guards, so a concurrent edit is not overwritten.
8. Converts any remaining PostgreSQL unique violation into a field- and workspace-specific migration failure.

If canonicalization would create a uniqueness collision, the affected field is not updated. The command does not choose a winning record, merge records, or discard an email value. An operator resolves the conflicting records and reruns the upgrade. Previously canonicalized fields are no-ops on rerun, making the command idempotent and safe to resume.

## Test coverage

The tests cover:

- ASCII domains
- accented Latin and canonically equivalent Unicode spellings
- Cyrillic domains
- Turkish dotted-I casing
- CJK domains
- right-to-left Arabic domains
- emoji domains, including `admin@💩.la`
- Unicode dot separators and trailing dots
- Unicode and punycode equivalence
- bulk exact filters
- primary and additional-email participant matching
- migration of primary and additional values
- migration dry-run behavior
- refusal of unique-index collisions before updates

## Local validation

- 61 focused tests pass across `twenty-shared` and `twenty-server`
- targeted migration typecheck passes
- `twenty-shared` typecheck passes
- `twenty-shared` lint passes
- `twenty-server` lint passes with two unrelated pre-existing warnings
- `twenty-shared` Vite build passes