### PR TITLE
fix: LOCAL logic function runner environment

### DIFF
--- a/packages/twenty-docs/developers/self-host/capabilities/setup.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/setup.mdx
@@ -344,7 +344,7 @@ Twenty supports logic functions for workflows and the code interpreter for AI da
 **In development (NODE_ENV=development):** Both default to **LOCAL** for convenience when running locally.
 
 <Warning>
-**Security Notice:** The local driver (`LOGIC_FUNCTION_TYPE=LOCAL` or `CODE_INTERPRETER_TYPE=LOCAL`) runs code directly on the host in a Node.js process with no sandboxing. It should only be used for trusted code in development. For production deployments handling untrusted code, use `LOGIC_FUNCTION_TYPE=LAMBDA` or `CODE_INTERPRETER_TYPE=E2B` (with sandboxing), or keep them disabled.
+**Security Notice:** The local driver (`LOGIC_FUNCTION_TYPE=LOCAL` or `CODE_INTERPRETER_TYPE=LOCAL`) runs code directly on the host in a Node.js process with no sandboxing. It should only be used for trusted code in development. Setting `LOGIC_FUNCTION_TYPE=LOCAL` or `CODE_INTERPRETER_TYPE=LOCAL` when `NODE_ENV=production` is refused. For production, use `LOGIC_FUNCTION_TYPE=LAMBDA` or `CODE_INTERPRETER_TYPE=E2B`, or keep them disabled.
 </Warning>
 
 ### Logic Functions - Available Drivers
@@ -352,7 +352,7 @@ Twenty supports logic functions for workflows and the code interpreter for AI da
 | Driver | Environment Variable | Use Case | Security Level |
 |--------|---------------------|----------|----------------|
 | Disabled | `LOGIC_FUNCTION_TYPE=DISABLED` | Disable logic functions entirely | N/A |
-| Local | `LOGIC_FUNCTION_TYPE=LOCAL` | Development and trusted environments | Low (no sandboxing) |
+| Local | `LOGIC_FUNCTION_TYPE=LOCAL` | Development only | Low (no sandboxing) |
 | Lambda | `LOGIC_FUNCTION_TYPE=LAMBDA` | Production with untrusted code | High (hardware-level isolation) |
 
 ### Logic Functions - Recommended Configuration

--- a/packages/twenty-docs/developers/self-host/capabilities/troubleshooting.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/troubleshooting.mdx
@@ -160,7 +160,7 @@ Run `UPDATE core."user" SET "canAccessFullAdminPanel" = TRUE WHERE email = 'you@
 
 #### When running workflow, workflow run fails with "Logic function execution is disabled. Set LOGIC_FUNCTION_TYPE to LOCAL or LAMBDA to enable."
 
-In production, logic functions are disabled by default. Set the `LOGIC_FUNCTION_TYPE` environment variable to `LOCAL` or `LAMBDA` to enable them. This can be configured via environment variables or through the admin panel database variables. See the [Logic Functions setup guide](/developers/self-host/capabilities/setup#logic-functions-available-drivers) for details.
+In production, logic functions are disabled by default. Set `LOGIC_FUNCTION_TYPE=LAMBDA` to run them on AWS Lambda. `LOCAL` is refused when `NODE_ENV=production`. This can be configured via environment variables or through the admin panel database variables. See the [Logic Functions setup guide](/developers/self-host/capabilities/setup#logic-functions-available-drivers) for details.
 
 #### When I type a message in AI chat, it doesn't answer immediately and I must refresh the page to see the answer
 

--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -33,8 +33,8 @@ FRONTEND_URL=http://localhost:3001
 # AUTH_GOOGLE_CLIENT_SECRET=replace_me_with_google_client_secret
 # AUTH_GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/redirect
 # AUTH_GOOGLE_APIS_CALLBACK_URL=http://localhost:3000/auth/google-apis/get-access-token
-# CODE_INTERPRETER_TYPE=LOCAL
-# LOGIC_FUNCTION_TYPE=LOCAL
+# CODE_INTERPRETER_TYPE=LOCAL  # development only; refused when NODE_ENV=production
+# LOGIC_FUNCTION_TYPE=LOCAL    # development only; refused when NODE_ENV=production
 # STORAGE_TYPE=local
 # STORAGE_LOCAL_PATH=.local-storage
 # SUPPORT_DRIVER=front

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/__tests__/logic-function-driver.factory.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/__tests__/logic-function-driver.factory.spec.ts
@@ -1,0 +1,108 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
+import { DisabledDriver } from 'src/engine/core-modules/logic-function/logic-function-drivers/drivers/disabled.driver';
+import { LocalDriver } from 'src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver';
+import { LogicFunctionDriverType } from 'src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface';
+import { LogicFunctionDriverFactory } from 'src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory';
+import { LogicFunctionResourceService } from 'src/engine/core-modules/logic-function/logic-function-resource/logic-function-resource.service';
+import { SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
+import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
+import { ConfigGroupHashService } from 'src/engine/core-modules/twenty-config/services/config-group-hash.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { LogicFunctionException } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+
+describe('LogicFunctionDriverFactory', () => {
+  let factory: LogicFunctionDriverFactory;
+  let twentyConfigService: TwentyConfigService;
+
+  const mockTwentyConfigService = {
+    get: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LogicFunctionDriverFactory,
+        {
+          provide: TwentyConfigService,
+          useValue: mockTwentyConfigService,
+        },
+        {
+          provide: ConfigGroupHashService,
+          useValue: { computeHash: jest.fn().mockReturnValue('') },
+        },
+        {
+          provide: LogicFunctionResourceService,
+          useValue: {},
+        },
+        {
+          provide: SdkClientArchiveService,
+          useValue: {},
+        },
+        {
+          provide: CacheLockService,
+          useValue: {},
+        },
+        {
+          provide: WorkspaceCacheService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    factory = module.get(LogicFunctionDriverFactory);
+    twentyConfigService = module.get(TwentyConfigService);
+
+    jest.clearAllMocks();
+  });
+
+  describe('createDriver', () => {
+    it('refuses LOCAL when NODE_ENV is production', async () => {
+      jest
+        .spyOn(twentyConfigService, 'get')
+        .mockImplementation((key: string) => {
+          if (key === 'LOGIC_FUNCTION_TYPE') {
+            return LogicFunctionDriverType.LOCAL;
+          }
+
+          if (key === 'NODE_ENV') {
+            return NodeEnvironment.PRODUCTION;
+          }
+
+          return undefined;
+        });
+
+      const driver = factory['createDriver']() as DisabledDriver;
+
+      expect(driver).toBeInstanceOf(DisabledDriver);
+      await expect(driver.execute()).rejects.toBeInstanceOf(
+        LogicFunctionException,
+      );
+      await expect(driver.execute()).rejects.toThrow(
+        'LOCAL logic function driver is not allowed in production',
+      );
+    });
+
+    it('creates LocalDriver when NODE_ENV is development', () => {
+      jest
+        .spyOn(twentyConfigService, 'get')
+        .mockImplementation((key: string) => {
+          if (key === 'LOGIC_FUNCTION_TYPE') {
+            return LogicFunctionDriverType.LOCAL;
+          }
+
+          if (key === 'NODE_ENV') {
+            return NodeEnvironment.DEVELOPMENT;
+          }
+
+          return undefined;
+        });
+
+      const driver = factory['createDriver']();
+
+      expect(driver).toBeInstanceOf(LocalDriver);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/disabled.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/disabled.driver.ts
@@ -10,6 +10,8 @@ import {
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 
 export class DisabledDriver implements LogicFunctionDriver {
+  constructor(private readonly reason?: string) {}
+
   async delete(): Promise<void> {
     // No-op when disabled
   }
@@ -20,21 +22,24 @@ export class DisabledDriver implements LogicFunctionDriver {
 
   async execute(): Promise<LogicFunctionExecuteResult> {
     throw new LogicFunctionException(
-      'Logic function execution is disabled. Set LOGIC_FUNCTION_TYPE to LOCAL or LAMBDA to enable.',
+      this.reason ??
+        'Logic function execution is disabled. Set LOGIC_FUNCTION_TYPE to LOCAL or LAMBDA to enable.',
       LogicFunctionExceptionCode.LOGIC_FUNCTION_DISABLED,
     );
   }
 
   async transpile(): Promise<LogicFunctionTranspileResult> {
     throw new LogicFunctionException(
-      'Logic function transpilation is disabled. Set LOGIC_FUNCTION_TYPE to LOCAL or LAMBDA to enable.',
+      this.reason ??
+        'Logic function transpilation is disabled. Set LOGIC_FUNCTION_TYPE to LOCAL or LAMBDA to enable.',
       LogicFunctionExceptionCode.LOGIC_FUNCTION_DISABLED,
     );
   }
 
   async installPrebuiltBundle(): Promise<void> {
     throw new LogicFunctionException(
-      'Logic function prebuilt install is disabled. Set LOGIC_FUNCTION_TYPE to LOCAL or LAMBDA to enable.',
+      this.reason ??
+        'Logic function prebuilt install is disabled. Set LOGIC_FUNCTION_TYPE to LOCAL or LAMBDA to enable.',
       LogicFunctionExceptionCode.LOGIC_FUNCTION_DISABLED,
     );
   }

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.spec.ts
@@ -62,4 +62,79 @@ describe('LocalChildProcessRunnerService', () => {
       jest.useFakeTimers();
     }
   });
+
+  it('does not copy host process.env into the child', async () => {
+    jest.useRealTimers();
+
+    const hostCanaryKey = 'TWENTY_HOST_ENV_CANARY';
+    const previousCanary = process.env[hostCanaryKey];
+
+    process.env[hostCanaryKey] = 'should-not-leak';
+
+    const logicFunctionDirectory = await mkdtemp(
+      join(tmpdir(), 'twenty-logic-function-env-'),
+    );
+
+    try {
+      const builtLogicFunctionPath = join(
+        logicFunctionDirectory,
+        'logic-function.mjs',
+      );
+
+      await writeFile(
+        builtLogicFunctionPath,
+        `export const main = async () => ({
+          hasHostCanary: process.env.${hostCanaryKey} === 'should-not-leak',
+          callerMark: process.env.TWENTY_FUNCTION_MARK ?? null,
+          nodeOptions: process.env.NODE_OPTIONS ?? null,
+        });`,
+        'utf8',
+      );
+
+      const localChildProcessRunnerService =
+        new LocalChildProcessRunnerService();
+      const runnerPath =
+        await localChildProcessRunnerService.writeBootstrapRunner({
+          dir: logicFunctionDirectory,
+          builtFileAbsPath: builtLogicFunctionPath,
+          handlerName: 'main',
+        });
+
+      const executionResult =
+        await localChildProcessRunnerService.runChildWithEnv({
+          runnerPath,
+          env: {
+            TWENTY_FUNCTION_MARK: 'from-caller',
+            NODE_OPTIONS: '--require ./should-not-run.js',
+          },
+          payload: {},
+          context: {
+            retryCount: 0,
+            maxRetries: 0,
+            workspaceId: 'workspace-1',
+            userWorkspaceId: null,
+            workspaceMemberId: null,
+          },
+          timeoutMs: 5_000,
+        });
+
+      expect(executionResult).toMatchObject({
+        ok: true,
+        result: {
+          hasHostCanary: false,
+          callerMark: 'from-caller',
+          nodeOptions: null,
+        },
+      });
+    } finally {
+      if (previousCanary === undefined) {
+        delete process.env[hostCanaryKey];
+      } else {
+        process.env[hostCanaryKey] = previousCanary;
+      }
+
+      await rm(logicFunctionDirectory, { recursive: true, force: true });
+      jest.useFakeTimers();
+    }
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.ts
@@ -163,12 +163,14 @@ export class LocalChildProcessRunnerService {
       stdout: string;
       stderr: string;
     }>((resolve) => {
-      // Strip NODE_OPTIONS to prevent tsx loader from being inherited
-      const { NODE_OPTIONS: _n1, ...cleanProcessEnv } = process.env;
-      const { NODE_OPTIONS: _n2, ...cleanUserEnv } = env;
+      // Only the caller-supplied env is passed through. Spreading
+      // process.env used to hand the child APP_SECRET, database URLs,
+      // and the rest of the host environment. NODE_OPTIONS is still
+      // stripped so a function cannot re-enable the tsx loader.
+      const { NODE_OPTIONS: _ignored, ...cleanUserEnv } = env;
 
       const child = spawn(process.execPath, [runnerPath], {
-        env: { ...cleanProcessEnv, ...cleanUserEnv },
+        env: cleanUserEnv,
         stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
       });
 

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory.ts
@@ -16,6 +16,7 @@ import { LogicFunctionResourceService } from 'src/engine/core-modules/logic-func
 import { SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
 import { DriverFactoryBase } from 'src/engine/core-modules/twenty-config/dynamic-factory.base';
 import { ConfigVariablesGroup } from 'src/engine/core-modules/twenty-config/enums/config-variables-group.enum';
+import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 import { ConfigGroupHashService } from 'src/engine/core-modules/twenty-config/services/config-group-hash.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
@@ -50,13 +51,22 @@ export class LogicFunctionDriverFactory extends DriverFactoryBase<LogicFunctionD
       case LogicFunctionDriverType.DISABLED:
         return new DisabledDriver();
 
-      case LogicFunctionDriverType.LOCAL:
+      case LogicFunctionDriverType.LOCAL: {
+        const nodeEnv = this.twentyConfigService.get('NODE_ENV');
+
+        if (nodeEnv === NodeEnvironment.PRODUCTION) {
+          return new DisabledDriver(
+            'LOCAL logic function driver is not allowed in production. Use LAMBDA, or keep LOGIC_FUNCTION_TYPE=DISABLED.',
+          );
+        }
+
         return new LocalDriver({
           logicFunctionResourceService: this.logicFunctionResourceService,
           sdkClientArchiveService: this.sdkClientArchiveService,
           cacheLockService: this.cacheLockService,
           workspaceCacheService: this.workspaceCacheService,
         });
+      }
 
       case LogicFunctionDriverType.LAMBDA: {
         const region = this.twentyConfigService.get(


### PR DESCRIPTION
## What

LOCAL logic functions start a child Node process. That process currently copies the parent environment and then overlays the caller `env`. This change passes only the caller `env`.

When `NODE_ENV=production`, LOCAL is treated the same way as the code interpreter: the factory returns the disabled driver. Docs and `.env.example` comments match that.

## Why

The code interpreter already disables LOCAL in production. The logic-function factory did not. The runner also forwarded the full parent environment into the child.

## How

- Spawn the child with the caller `env` only. `NODE_OPTIONS` is still dropped.
- Return a disabled driver for `LOGIC_FUNCTION_TYPE=LOCAL` when `NODE_ENV=production`.
- Update setup and troubleshooting so LOCAL is described as development-only.

## Testing

```
npx nx jest twenty-server --testPathPattern=local-child-process-runner.service.spec
npx nx jest twenty-server --testPathPattern=logic-function-driver.factory.spec
```
