### PR TITLE
fix(links): write only the subfields a partial LINKS update sends

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-links-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-links-value.util.spec.ts
@@ -1,14 +1,11 @@
+import { RecordTransformerExceptionCode } from 'src/engine/core-modules/record-transformer/record-transformer.exception';
 import { transformLinksValue } from 'src/engine/core-modules/record-transformer/utils/transform-links-value.util';
 
 describe('transformLinksValue', () => {
   it('should handle null/undefined/empty object values', () => {
     expect(transformLinksValue({ input: null })).toBeNull();
     expect(transformLinksValue({ input: undefined })).toBeUndefined();
-    expect(transformLinksValue({ input: {} })).toEqual({
-      primaryLinkLabel: null,
-      primaryLinkUrl: null,
-      secondaryLinks: null,
-    });
+    expect(transformLinksValue({ input: {} })).toEqual({});
   });
 
   describe('primary link', () => {
@@ -102,6 +99,105 @@ describe('transformLinksValue', () => {
       };
 
       expect(transformLinksValue({ input })).toEqual(expected);
+    });
+  });
+
+  // A subfield left out of the input keeps its stored value, so every
+  // assertion here is about which keys come back, not only their values.
+  describe('partial update', () => {
+    it('should leave the url and the secondary links alone when only the label is sent', () => {
+      expect(
+        transformLinksValue({ input: { primaryLinkLabel: 'Example' } }),
+      ).toEqual({ primaryLinkLabel: 'Example' });
+    });
+
+    it('should leave the label and the secondary links alone when only the url is sent', () => {
+      expect(
+        transformLinksValue({
+          input: { primaryLinkUrl: 'HTTPS://EXAMPLE.COM/' },
+        }),
+      ).toEqual({ primaryLinkUrl: 'https://example.com' });
+    });
+
+    it('should not promote a secondary link to primary when only the secondary links are sent', () => {
+      expect(
+        transformLinksValue({
+          input: {
+            secondaryLinks: JSON.stringify([
+              { url: 'https://docs.twenty.com', label: 'Documentation' },
+            ]),
+          },
+        }),
+      ).toEqual({
+        secondaryLinks: JSON.stringify([
+          { url: 'https://docs.twenty.com', label: 'Documentation' },
+        ]),
+      });
+    });
+
+    it('should clear the label along with the url, and still leave the secondary links alone', () => {
+      expect(transformLinksValue({ input: { primaryLinkUrl: '' } })).toEqual({
+        primaryLinkUrl: null,
+        primaryLinkLabel: null,
+      });
+    });
+
+    it('should drop a label that was sent together with an emptied url', () => {
+      expect(
+        transformLinksValue({
+          input: { primaryLinkUrl: null, primaryLinkLabel: 'Example' },
+        }),
+      ).toEqual({
+        primaryLinkUrl: null,
+        primaryLinkLabel: null,
+      });
+    });
+
+    it('should null the secondary links when the only ones sent are empty', () => {
+      expect(
+        transformLinksValue({
+          input: {
+            secondaryLinks: JSON.stringify([{ url: '', label: 'Empty' }]),
+          },
+        }),
+      ).toEqual({ secondaryLinks: null });
+    });
+
+    it('should still reject an invalid url', () => {
+      expect(() =>
+        transformLinksValue({ input: { primaryLinkUrl: 'lydia,com' } }),
+      ).toThrow(
+        expect.objectContaining({
+          code: RecordTransformerExceptionCode.INVALID_URL,
+        }),
+      );
+
+      expect(() =>
+        transformLinksValue({
+          input: { secondaryLinks: JSON.stringify([{ url: 'wikipedia' }]) },
+        }),
+      ).toThrow(
+        expect.objectContaining({
+          code: RecordTransformerExceptionCode.INVALID_URL,
+        }),
+      );
+    });
+
+    it('should normalize with the field variant', () => {
+      expect(
+        transformLinksValue({
+          input: {
+            secondaryLinks: JSON.stringify([
+              { url: 'https://www.example-old.com/about', label: 'Old domain' },
+            ]),
+          },
+          settings: { type: 'domain' },
+        }),
+      ).toEqual({
+        secondaryLinks: JSON.stringify([
+          { url: 'example-old.com', label: 'Old domain' },
+        ]),
+      });
     });
   });
 

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/remove-empty-links.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/remove-empty-links.ts
@@ -7,24 +7,10 @@ import {
   RecordTransformerExceptionCode,
 } from 'src/engine/core-modules/record-transformer/record-transformer.exception';
 
-export const removeEmptyLinks = ({
-  primaryLinkUrl,
-  secondaryLinks,
-  primaryLinkLabel,
-}: {
-  secondaryLinks: LinkMetadataNullable[] | null;
-  primaryLinkUrl: string | null;
-  primaryLinkLabel: string | null;
-}) => {
-  const filteredLinks = [
-    isNonEmptyString(primaryLinkUrl)
-      ? {
-          url: primaryLinkUrl,
-          label: primaryLinkLabel,
-        }
-      : null,
-    ...(secondaryLinks ?? []),
-  ]
+export const removeEmptyAndValidateLinks = (
+  links: (LinkMetadataNullable | null)[],
+) => {
+  const filteredLinks = links
     .filter(isDefined)
     .map((link) => {
       if (!isNonEmptyString(link.url)) {
@@ -46,6 +32,28 @@ export const removeEmptyLinks = ({
       );
     }
   }
+
+  return filteredLinks;
+};
+
+export const removeEmptyLinks = ({
+  primaryLinkUrl,
+  secondaryLinks,
+  primaryLinkLabel,
+}: {
+  secondaryLinks: LinkMetadataNullable[] | null;
+  primaryLinkUrl: string | null;
+  primaryLinkLabel: string | null;
+}) => {
+  const filteredLinks = removeEmptyAndValidateLinks([
+    isNonEmptyString(primaryLinkUrl)
+      ? {
+          url: primaryLinkUrl,
+          label: primaryLinkLabel,
+        }
+      : null,
+    ...(secondaryLinks ?? []),
+  ]);
 
   const firstLink = filteredLinks[0];
   const otherLinks = filteredLinks.slice(1);

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-links-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-links-value.util.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString } from '@sniptt/guards';
+import { isNonEmptyString, isUndefined } from '@sniptt/guards';
 import isEmpty from 'lodash.isempty';
 import {
   type FieldMetadataSettings,
@@ -11,7 +11,10 @@ import {
   parseJson,
 } from 'twenty-shared/utils';
 
-import { removeEmptyLinks } from 'src/engine/core-modules/record-transformer/utils/remove-empty-links';
+import {
+  removeEmptyAndValidateLinks,
+  removeEmptyLinks,
+} from 'src/engine/core-modules/record-transformer/utils/remove-empty-links';
 
 export type LinksFieldGraphQLInput =
   | {
@@ -22,7 +25,99 @@ export type LinksFieldGraphQLInput =
   | null
   | undefined;
 
-// TODO refactor this function handle partial composite field update
+type LinkUrlNormalizer = (url: string) => string;
+
+const parseSecondaryLinks = (
+  secondaryLinks: string | LinkMetadataNullable[] | null | undefined,
+): LinkMetadataNullable[] | null =>
+  isNonEmptyString(secondaryLinks)
+    ? parseJson<LinkMetadataNullable[]>(secondaryLinks)
+    : ((secondaryLinks as LinkMetadataNullable[] | null | undefined) ?? null);
+
+const serializeSecondaryLinks = (
+  secondaryLinks: LinkMetadataNullable[],
+  normalizeLinkUrl: LinkUrlNormalizer,
+): string | null => {
+  const normalizedSecondaryLinks = secondaryLinks.map((link) => ({
+    ...link,
+    url: isDefined(link.url) ? normalizeLinkUrl(link.url) : link.url,
+  }));
+
+  return isEmpty(normalizedSecondaryLinks)
+    ? null
+    : JSON.stringify(normalizedSecondaryLinks);
+};
+
+// Rewriting the whole field is what lets an empty primary link be back-filled
+// from the secondary ones: the caller told us about every link there is.
+const transformWholeLinksValue = ({
+  input,
+  normalizeLinkUrl,
+}: {
+  input: NonNullable<LinksFieldGraphQLInput>;
+  normalizeLinkUrl: LinkUrlNormalizer;
+}): LinksFieldGraphQLInput => {
+  const { primaryLinkUrl, primaryLinkLabel, secondaryLinks } = removeEmptyLinks(
+    {
+      primaryLinkUrl: input.primaryLinkUrl ?? null,
+      primaryLinkLabel: input.primaryLinkLabel ?? null,
+      secondaryLinks: parseSecondaryLinks(input.secondaryLinks),
+    },
+  );
+
+  return {
+    primaryLinkUrl: isDefined(primaryLinkUrl)
+      ? normalizeLinkUrl(primaryLinkUrl)
+      : primaryLinkUrl,
+    primaryLinkLabel,
+    secondaryLinks: serializeSecondaryLinks(secondaryLinks, normalizeLinkUrl),
+  };
+};
+
+// A subfield the caller left out keeps whatever the row already holds, so this
+// branch only emits the subfields it was given. Back-filling the primary link
+// from the secondary ones is off the table here: the links it would draw from
+// are the stored ones, which this input does not describe.
+const transformPartialLinksValue = ({
+  input,
+  normalizeLinkUrl,
+}: {
+  input: NonNullable<LinksFieldGraphQLInput>;
+  normalizeLinkUrl: LinkUrlNormalizer;
+}): LinksFieldGraphQLInput => {
+  const transformedValue: NonNullable<LinksFieldGraphQLInput> = {};
+
+  if (!isUndefined(input.primaryLinkLabel)) {
+    transformedValue.primaryLinkLabel = input.primaryLinkLabel;
+  }
+
+  if (!isUndefined(input.primaryLinkUrl)) {
+    const [primaryLink] = removeEmptyAndValidateLinks([
+      { url: input.primaryLinkUrl, label: null },
+    ]);
+
+    transformedValue.primaryLinkUrl = isDefined(primaryLink)
+      ? normalizeLinkUrl(primaryLink.url)
+      : null;
+
+    // A label on its own is not a link, so clearing the url clears it too.
+    if (!isDefined(primaryLink)) {
+      transformedValue.primaryLinkLabel = null;
+    }
+  }
+
+  if (!isUndefined(input.secondaryLinks)) {
+    transformedValue.secondaryLinks = serializeSecondaryLinks(
+      removeEmptyAndValidateLinks(
+        parseSecondaryLinks(input.secondaryLinks) ?? [],
+      ),
+      normalizeLinkUrl,
+    );
+  }
+
+  return transformedValue;
+};
+
 export const transformLinksValue = ({
   input,
   settings,
@@ -36,35 +131,12 @@ export const transformLinksValue = ({
 
   const normalizeLinkUrl = getLinkUrlNormalizer(settings?.type);
 
-  const primaryLinkUrlRaw = input.primaryLinkUrl as string | null;
-  const primaryLinkLabelRaw = input.primaryLinkLabel as string | null;
-  const secondaryLinksRaw = input.secondaryLinks as string | null;
+  const isWholeFieldWrite =
+    !isUndefined(input.primaryLinkUrl) &&
+    !isUndefined(input.primaryLinkLabel) &&
+    !isUndefined(input.secondaryLinks);
 
-  const secondaryLinksArray = isNonEmptyString(secondaryLinksRaw)
-    ? parseJson<LinkMetadataNullable[]>(secondaryLinksRaw)
-    : secondaryLinksRaw;
-
-  const { primaryLinkLabel, primaryLinkUrl, secondaryLinks } = removeEmptyLinks(
-    {
-      primaryLinkUrl: primaryLinkUrlRaw,
-      primaryLinkLabel: primaryLinkLabelRaw,
-      secondaryLinks: secondaryLinksArray,
-    },
-  );
-
-  const processedSecondaryLinks = secondaryLinks?.map((link) => ({
-    ...link,
-    url: isDefined(link.url) ? normalizeLinkUrl(link.url) : link.url,
-  }));
-
-  return {
-    ...input,
-    primaryLinkUrl: isDefined(primaryLinkUrl)
-      ? normalizeLinkUrl(primaryLinkUrl)
-      : primaryLinkUrl,
-    primaryLinkLabel,
-    secondaryLinks: isEmpty(processedSecondaryLinks)
-      ? null
-      : JSON.stringify(processedSecondaryLinks),
-  };
+  return isWholeFieldWrite
+    ? transformWholeLinksValue({ input, normalizeLinkUrl })
+    : transformPartialLinksValue({ input, normalizeLinkUrl });
 };


### PR DESCRIPTION
Closes #13211

## Problem

`transformLinksValue` always returned all three LINKS subfields, whatever the input named. `formatCompositeField` writes a column for every subfield that is not `undefined` ([format-data.util.ts:98](https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts#L98)), so the two subfields the caller never mentioned were overwritten with whatever `removeEmptyLinks` produced from an input that did not describe them:

| update sent | what got written |
| --- | --- |
| `{ primaryLinkLabel: 'Docs' }` | label nulled (no url to hang it on), url nulled, secondary links nulled |
| `{ primaryLinkUrl: 'twenty.com' }` | secondary links nulled, label nulled |
| `{ secondaryLinks: '[{"url":"docs.twenty.com"}]' }` | the first secondary link promoted to primary and removed from the list, overwriting the stored primary |

The last one is the sharpest: `removeEmptyLinks` back-fills the primary link from the secondary ones when the primary is empty, and a partial input makes the primary *look* empty when it is only absent.

This is reachable from any caller that sends one subfield: the REST/GraphQL APIs, and `RecordInputTransformerService` on the workflow and tool paths. `validateLinksFieldOrThrow` returns the input untouched, so the absent keys really are absent by the time they reach the transformer.

## Fix

Split the two cases the one function was conflating.

**Whole-field write** (all three subfields present, which is what the front-end sends) is unchanged, `removeEmptyLinks` and all. Rewriting the whole field is precisely what makes the back-fill sound: the caller has told us about every link there is.

**Partial write** emits only the subfields it was given, so the rest keep their stored value. The back-fill is off the table here, since the links it would draw from are the stored ones this input does not describe. Url validation and variant normalization (`url` vs `domain`) still run on whatever the input does carry.

One deliberate cross-subfield write survives on the partial path: emptying `primaryLinkUrl` also nulls `primaryLinkLabel`, since a label with no url is not a link.

`removeEmptyLinks` keeps its behaviour and its spec; the per-link cleaning and url validation it did inline is now `removeEmptyAndValidateLinks`, which the partial path reuses so both paths reject the same urls.

### Behaviour change worth flagging

`transformLinksValue({ input: {} })` used to clear the field and is now a no-op, which is what "write only what you were sent" means for an empty input. `null` remains the way to clear a LINKS field, and the whole-field write still clears it subfield by subfield. The existing test that asserted the old result is updated.

## Tests

Seven cases under `partial update` in `transform-links-value.util.spec.ts`, covering each single-subfield update, the label-clears-with-the-url rule, empty secondary links, url rejection on both subfields, and domain normalization. Against the pre-fix transformer 8 of the suite's cases fail (the seven new ones plus the changed empty-object assertion) and the 9 whole-write cases pass, so the existing behaviour is pinned rather than rewritten.

```
Test Suites: 42 passed, 42 total
Tests:       415 passed, 415 total
```
(`record-transformer`, `data-arg-processor`, `record-crud`; every `link`-matching suite passes too.)

`oxlint --type-aware` and `oxfmt` clean on the changed files. `tsgo --noEmit` on twenty-server reports the same 41 pre-existing errors as clean `main` (AI SDK version drift and a missing `sanitize-html` type package), none in the touched paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

