### PR TITLE
Wait for workflow status updates in If/Else integration test

### DIFF
--- a/packages/twenty-server/test/integration/graphql/suites/workflow/if-else-workflow.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/if-else-workflow.integration-spec.ts
@@ -10,6 +10,7 @@ import { v4 } from 'uuid';
 
 import { type WorkflowIfElseAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
 import { updateWorkflowVersionTrigger } from 'test/integration/graphql/suites/workflow/utils/update-workflow-version-trigger.util';
+import { waitForAllJobsToFinish } from 'test/integration/utils/wait-for-all-jobs-to-finish.util';
 
 const client = request(`http://localhost:${APP_PORT}`);
 
@@ -408,6 +409,9 @@ describe('If/Else Workflow (e2e)', () => {
 
   describe('Workflow structure', () => {
     it('should verify If/Else workflow exists and is active', async () => {
+      // Activation updates the workflow's aggregate status through a background job.
+      await waitForAllJobsToFinish();
+
       const response = await client
         .post('/graphql')
         .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)


### PR DESCRIPTION
## Summary
- Wait for background jobs before asserting the activated workflow status.
- Reuse the existing queue-drain helper to avoid racing the asynchronous aggregate-status update.
- Split this unrelated test-stability fix out of #25810.

## Validation
- Formatting and git diff checks passed.
- Database-backed integration test not run locally; CI will validate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

