### PR TITLE
feat(ai): generate every deployment catalog from the model catalog and a spec

### DIFF
--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -38,7 +38,7 @@ jobs:
         id: changes
         run: |
           catalog_dir=packages/twenty-server/src/engine/metadata-modules/ai/ai-models
-          if git diff --quiet "$catalog_dir/ai-providers.json" "$catalog_dir/ai-model-benchmarks.json"; then
+          if git diff --quiet "$catalog_dir"; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/packages/twenty-server/scripts/ai-catalog-sync/README.md
+++ b/packages/twenty-server/scripts/ai-catalog-sync/README.md
@@ -64,9 +64,9 @@ A spec looks like this:
 ```
 
 A spec can rename a model for the route that deploys it (`as`) and override the
-prices it negotiated, its label and its deprecation. It cannot restate what a
-model is: context window, modalities, efforts and benchmarks always come from
-the catalog, which is what keeps a deployment from drifting away from the
+prices it negotiated, the limits its route caps, its label and its deprecation.
+It cannot restate what a model is: modalities, reasoning support, efforts and
+benchmarks always come from the catalog, which is what keeps a deployment from drifting away from the
 measured truth. Naming a model the catalog does not carry fails the run rather
 than publishing a route to nothing.
 

--- a/packages/twenty-server/scripts/ai-catalog-sync/README.md
+++ b/packages/twenty-server/scripts/ai-catalog-sync/README.md
@@ -1,14 +1,24 @@
 # AI catalog
 
-Two entry points over the same committed data.
+Three files in `src/engine/metadata-modules/ai/ai-models`, and two entry points
+over them.
 
-## `index.ts` — sync the canonical catalog
+| File | What it is |
+| --- | --- |
+| `ai-models.json` | What every model is: identity, pricing, limits, modalities, efforts, benchmarks. No routes, no credentials. Synced daily. |
+| `ai-self-host-spec.json` | What a self-hosted deployment serves: the five direct routes and their key templates. Hand-maintained. |
+| `ai-providers.json` | The catalog the server bundles. Generated from the two above; a test fails if it is hand-edited. |
+
+Cloud works the same way, from a private spec in twenty-infra, so a deployment
+catalog is always a projection rather than a second copy of the truth.
+
+## `index.ts` — sync the model catalog
 
 Run daily by `.github/workflows/ci-ai-catalog-sync.yaml`. Reads models.dev for
 model identity, pricing, context windows and availability, overlays Artificial
-Analysis for intelligence, speed and cost per task, and writes
-`src/engine/metadata-modules/ai/ai-models/ai-providers.json` plus
-`ai-model-benchmarks.json`. Hand-maintained fields (`efforts`,
+Analysis for intelligence, speed and cost per task, and writes `ai-models.json`
+and `ai-model-benchmarks.json`, then projects the self-host spec over the first
+to write `ai-providers.json`. Hand-maintained fields (`efforts`,
 `dataResidency`, `zeroDataRetention`) survive the rebuild.
 
 ```bash
@@ -29,7 +39,7 @@ npx tsx ./scripts/ai-catalog-sync/project.ts \
   --out ./ai-catalog.json
 ```
 
-`--catalog` points at a different `ai-providers.json`; it defaults to the
+`--catalog` points at a different `ai-models.json`; it defaults to the
 committed one. The output has the same shape, so a server loads it through
 `AI_CATALOG_STORAGE_PATH` with no further processing.
 
@@ -61,6 +71,13 @@ A spec looks like this:
     }
   ]
 }
+```
+
+A route that serves a whole vendor says so instead of listing its models, which
+is how self-host picks up new models with the daily sync:
+
+```json
+{ "name": "openai", "npm": "@ai-sdk/openai", "models": { "vendor": "openai" } }
 ```
 
 A spec can rename a model for the route that deploys it (`as`) and override the

--- a/packages/twenty-server/scripts/ai-catalog-sync/README.md
+++ b/packages/twenty-server/scripts/ai-catalog-sync/README.md
@@ -70,6 +70,7 @@ benchmarks always come from the catalog, which is what keeps a deployment from d
 measured truth. Naming a model the catalog does not carry fails the run rather
 than publishing a route to nothing.
 
-`project.ts` imports nothing from the workspace, so a repository holding a
-private spec can run it from a sparse checkout of these files without
-installing the monorepo and without any API key.
+`project.ts` resolves everything it needs by source path, so a repository
+holding a private spec can run it from a sparse checkout of these files and
+`packages/twenty-shared/src/ai` without installing the monorepo and without any
+API key.

--- a/packages/twenty-server/scripts/ai-catalog-sync/README.md
+++ b/packages/twenty-server/scripts/ai-catalog-sync/README.md
@@ -1,0 +1,75 @@
+# AI catalog
+
+Two entry points over the same committed data.
+
+## `index.ts` — sync the canonical catalog
+
+Run daily by `.github/workflows/ci-ai-catalog-sync.yaml`. Reads models.dev for
+model identity, pricing, context windows and availability, overlays Artificial
+Analysis for intelligence, speed and cost per task, and writes
+`src/engine/metadata-modules/ai/ai-models/ai-providers.json` plus
+`ai-model-benchmarks.json`. Hand-maintained fields (`efforts`,
+`dataResidency`, `zeroDataRetention`) survive the rebuild.
+
+```bash
+npx nx run twenty-server:ts-node-no-deps-transpile-only -- \
+  ./scripts/ai-catalog-sync/index.ts --dry-run
+```
+
+## `project.ts` — derive a deployment catalog
+
+A deployment serves a subset of the catalog through its own routes: Azure, a
+Bedrock region, a gateway, or a first-party key. It declares only what is its
+own — which routes exist, their credentials, and which catalog models each one
+serves — and this projects the catalog through that spec.
+
+```bash
+npx tsx ./scripts/ai-catalog-sync/project.ts \
+  --spec ./my-deployment.json \
+  --out ./ai-catalog.json
+```
+
+`--catalog` points at a different `ai-providers.json`; it defaults to the
+committed one. The output has the same shape, so a server loads it through
+`AI_CATALOG_STORAGE_PATH` with no further processing.
+
+A spec looks like this:
+
+```json
+{
+  "providers": [
+    {
+      "name": "azure-foundry",
+      "npm": "@ai-sdk/azure",
+      "label": "Azure AI Foundry",
+      "apiKey": "{{AZURE_FOUNDRY_API_KEY}}",
+      "baseUrl": "{{AZURE_FOUNDRY_BASE_URL}}",
+      "dataResidency": "eu",
+      "labelSuffix": " (Azure)",
+      "models": [
+        "gpt-5.6-luna",
+        { "model": "gpt-5.6-sol", "cachedInputCostPerMillionTokens": 0.5 }
+      ]
+    },
+    {
+      "name": "amazon-bedrock",
+      "npm": "@ai-sdk/amazon-bedrock",
+      "region": "eu-central-1",
+      "models": [
+        { "model": "claude-opus-4-7", "as": "eu.anthropic.claude-opus-4-7" }
+      ]
+    }
+  ]
+}
+```
+
+A spec can rename a model for the route that deploys it (`as`) and override the
+prices it negotiated, its label and its deprecation. It cannot restate what a
+model is: context window, modalities, efforts and benchmarks always come from
+the catalog, which is what keeps a deployment from drifting away from the
+measured truth. Naming a model the catalog does not carry fails the run rather
+than publishing a route to nothing.
+
+`project.ts` imports nothing from the workspace, so a repository holding a
+private spec can run it from a sparse checkout of these files without
+installing the monorepo and without any API key.

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/carry-over-committed-fields.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/carry-over-committed-fields.spec.ts
@@ -3,12 +3,7 @@ import { type GeneratedModel } from '../types/generated-model.type';
 import { carryOverCommittedFields } from '../utils/carry-over-committed-fields.util';
 
 const openai = (models: GeneratedModel[]): GeneratedCatalog => ({
-  openai: {
-    npm: '@ai-sdk/openai',
-    label: 'OpenAI',
-    apiKey: '{{OPENAI_API_KEY}}',
-    models,
-  },
+  openai: { models },
 });
 
 describe('carryOverCommittedFields', () => {

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/enrich-catalog.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/enrich-catalog.spec.ts
@@ -6,15 +6,9 @@ import { type GeneratedCatalog } from '../types/generated-catalog.type';
 
 const MEASURED_AT = '2026-09-09';
 
-const catalogOf = (...modelNames: string[]): GeneratedCatalog =>
-  ({
-    openai: {
-      npm: '@ai-sdk/openai',
-      label: 'OpenAI',
-      apiKey: '',
-      models: modelNames.map((name) => ({ name, label: name })),
-    },
-  }) as GeneratedCatalog;
+const catalogOf = (...modelNames: string[]): GeneratedCatalog => ({
+  openai: { models: modelNames.map((name) => ({ name, label: name })) },
+});
 
 const enrich = (catalog: GeneratedCatalog, benchmarkIndex: BenchmarkIndex) =>
   enrichCatalog({

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
@@ -1,11 +1,7 @@
-import { AI_SDK_PACKAGES, DATA_RESIDENCY_KEYS } from 'twenty-shared/ai';
-
 import { type CatalogSpec } from '../types/catalog-spec.type';
 import {
   type CanonicalCatalog,
   projectCatalog,
-  SUPPORTED_DATA_RESIDENCIES,
-  SUPPORTED_SDK_PACKAGES,
 } from '../utils/project-catalog.util';
 
 const canonicalCatalog: CanonicalCatalog = {
@@ -254,21 +250,5 @@ describe('projectCatalog', () => {
     const projected = projectCatalog({ canonicalCatalog, spec });
 
     expect(projected['azure-foundry'].models?.[0]?.label).toBe('Luna (Azure)');
-  });
-});
-
-// The projector cannot import these and stay runnable outside the monorepo, so
-// the copies are held in step here instead.
-describe('the vocabularies the projector copies', () => {
-  it('lists every SDK package the server accepts', () => {
-    expect([...SUPPORTED_SDK_PACKAGES].sort()).toEqual(
-      [...AI_SDK_PACKAGES].sort(),
-    );
-  });
-
-  it('lists every data residency the server accepts', () => {
-    expect([...SUPPORTED_DATA_RESIDENCIES].sort()).toEqual(
-      [...DATA_RESIDENCY_KEYS].sort(),
-    );
   });
 });

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
@@ -120,6 +120,24 @@ describe('projectCatalog', () => {
     });
   });
 
+  it('takes a limit the route caps below the one the model allows', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'amazon-bedrock',
+          npm: '@ai-sdk/amazon-bedrock',
+          models: [{ model: 'gpt-5.6-luna', maxOutputTokens: 64000 }],
+        },
+      ],
+    };
+
+    const projected = projectCatalog({ canonicalCatalog, spec });
+
+    expect(projected['amazon-bedrock'].models?.[0]).toMatchObject({
+      maxOutputTokens: 64000,
+    });
+  });
+
   it('refuses a spec naming a model the catalog does not carry', () => {
     const spec: CatalogSpec = {
       providers: [

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
@@ -1,7 +1,11 @@
+import { AI_SDK_PACKAGES, DATA_RESIDENCY_KEYS } from 'twenty-shared/ai';
+
 import { type CatalogSpec } from '../types/catalog-spec.type';
 import {
   type CanonicalCatalog,
   projectCatalog,
+  SUPPORTED_DATA_RESIDENCIES,
+  SUPPORTED_SDK_PACKAGES,
 } from '../utils/project-catalog.util';
 
 const canonicalCatalog: CanonicalCatalog = {
@@ -170,5 +174,101 @@ describe('projectCatalog', () => {
     expect(projected['azure-foundry'].models?.[0]).toMatchObject({
       modalities: ['image', 'pdf'],
     });
+  });
+
+  it('refuses a repeated provider, which would drop the first one silently', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'azure-foundry',
+          npm: '@ai-sdk/azure',
+          models: ['gpt-5.6-luna'],
+        },
+        {
+          name: 'azure-foundry',
+          npm: '@ai-sdk/azure',
+          models: ['claude-opus-4-7'],
+        },
+      ],
+    };
+
+    expect(() => projectCatalog({ canonicalCatalog, spec })).toThrow(
+      'repeated or reserved',
+    );
+  });
+
+  it('refuses an SDK package or residency the server would not parse', () => {
+    const withNpm = (npm: string): CatalogSpec => ({
+      providers: [{ name: 'gateway', npm, models: ['gpt-5.6-luna'] }],
+    });
+
+    expect(() =>
+      projectCatalog({ canonicalCatalog, spec: withNpm('@ai-sdk/imaginary') }),
+    ).toThrow('unsupported SDK package');
+
+    expect(() =>
+      projectCatalog({
+        canonicalCatalog,
+        spec: {
+          providers: [
+            {
+              name: 'gateway',
+              npm: '@ai-sdk/openai',
+              dataResidency: 'mars',
+              models: ['gpt-5.6-luna'],
+            },
+          ],
+        },
+      }),
+    ).toThrow('unsupported data residency');
+  });
+
+  it('refuses a negotiated price that is not a usable number', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'azure-foundry',
+          npm: '@ai-sdk/azure',
+          models: [{ model: 'gpt-5.6-luna', inputCostPerMillionTokens: -1 }],
+        },
+      ],
+    };
+
+    expect(() => projectCatalog({ canonicalCatalog, spec })).toThrow(
+      'which is not a usable number',
+    );
+  });
+
+  it('marks the route on a label the spec overrides', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'azure-foundry',
+          npm: '@ai-sdk/azure',
+          labelSuffix: ' (Azure)',
+          models: [{ model: 'gpt-5.6-luna', label: 'Luna' }],
+        },
+      ],
+    };
+
+    const projected = projectCatalog({ canonicalCatalog, spec });
+
+    expect(projected['azure-foundry'].models?.[0]?.label).toBe('Luna (Azure)');
+  });
+});
+
+// The projector cannot import these and stay runnable outside the monorepo, so
+// the copies are held in step here instead.
+describe('the vocabularies the projector copies', () => {
+  it('lists every SDK package the server accepts', () => {
+    expect([...SUPPORTED_SDK_PACKAGES].sort()).toEqual(
+      [...AI_SDK_PACKAGES].sort(),
+    );
+  });
+
+  it('lists every data residency the server accepts', () => {
+    expect([...SUPPORTED_DATA_RESIDENCIES].sort()).toEqual(
+      [...DATA_RESIDENCY_KEYS].sort(),
+    );
   });
 });

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
@@ -1,0 +1,156 @@
+import { type CatalogSpec } from '../types/catalog-spec.type';
+import {
+  type CanonicalCatalog,
+  projectCatalog,
+} from '../utils/project-catalog.util';
+
+const canonicalCatalog: CanonicalCatalog = {
+  openai: {
+    npm: '@ai-sdk/openai',
+    label: 'OpenAI',
+    apiKey: '{{OPENAI_API_KEY}}',
+    models: [
+      {
+        name: 'gpt-5.6-luna',
+        label: 'GPT-5.6 Luna',
+        inputCostPerMillionTokens: 0.2,
+        outputCostPerMillionTokens: 1.2,
+        cachedInputCostPerMillionTokens: 0.02,
+        modalities: ['image', 'pdf'],
+        efforts: ['low', 'medium', 'high'],
+        benchmark: { intelligenceIndex: 37.5, measuredAt: '2026-09-11' },
+        benchmarkByEffort: {
+          high: { intelligenceIndex: 32.4, measuredAt: '2026-09-11' },
+        },
+      },
+    ],
+  },
+  anthropic: {
+    npm: '@ai-sdk/anthropic',
+    label: 'Anthropic',
+    apiKey: '{{ANTHROPIC_API_KEY}}',
+    models: [{ name: 'claude-opus-4-7', label: 'Claude Opus 4.7' }],
+  },
+};
+
+describe('projectCatalog', () => {
+  it('describes a route from the catalog while keeping the route its own credentials', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'azure-foundry',
+          npm: '@ai-sdk/azure',
+          label: 'Azure AI Foundry',
+          apiKey: '{{AZURE_FOUNDRY_API_KEY}}',
+          baseUrl: '{{AZURE_FOUNDRY_BASE_URL}}',
+          dataResidency: 'eu',
+          labelSuffix: ' (Azure)',
+          models: ['gpt-5.6-luna'],
+        },
+      ],
+    };
+
+    const projected = projectCatalog({ canonicalCatalog, spec });
+
+    expect(Object.keys(projected)).toEqual(['azure-foundry']);
+    expect(projected['azure-foundry']).toMatchObject({
+      npm: '@ai-sdk/azure',
+      label: 'Azure AI Foundry',
+      apiKey: '{{AZURE_FOUNDRY_API_KEY}}',
+      baseUrl: '{{AZURE_FOUNDRY_BASE_URL}}',
+    });
+    expect(projected['azure-foundry'].models?.[0]).toEqual({
+      name: 'gpt-5.6-luna',
+      label: 'GPT-5.6 Luna (Azure)',
+      inputCostPerMillionTokens: 0.2,
+      outputCostPerMillionTokens: 1.2,
+      cachedInputCostPerMillionTokens: 0.02,
+      modalities: ['image', 'pdf'],
+      efforts: ['low', 'medium', 'high'],
+      benchmark: { intelligenceIndex: 37.5, measuredAt: '2026-09-11' },
+      benchmarkByEffort: {
+        high: { intelligenceIndex: 32.4, measuredAt: '2026-09-11' },
+      },
+      dataResidency: 'eu',
+    });
+  });
+
+  it('serves a model under the id the route deploys it as', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'amazon-bedrock',
+          npm: '@ai-sdk/amazon-bedrock',
+          region: 'eu-central-1',
+          models: [
+            { model: 'claude-opus-4-7', as: 'eu.anthropic.claude-opus-4-7' },
+          ],
+        },
+      ],
+    };
+
+    const projected = projectCatalog({ canonicalCatalog, spec });
+
+    expect(projected['amazon-bedrock'].models?.[0]).toMatchObject({
+      name: 'eu.anthropic.claude-opus-4-7',
+      label: 'Claude Opus 4.7',
+    });
+    expect(projected['amazon-bedrock'].region).toBe('eu-central-1');
+  });
+
+  it('takes a price the route negotiated and leaves the rest of the reading alone', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'azure-foundry',
+          npm: '@ai-sdk/azure',
+          models: [
+            { model: 'gpt-5.6-luna', cachedInputCostPerMillionTokens: 0.5 },
+          ],
+        },
+      ],
+    };
+
+    const projected = projectCatalog({ canonicalCatalog, spec });
+
+    expect(projected['azure-foundry'].models?.[0]).toMatchObject({
+      cachedInputCostPerMillionTokens: 0.5,
+      inputCostPerMillionTokens: 0.2,
+      efforts: ['low', 'medium', 'high'],
+    });
+  });
+
+  it('refuses a spec naming a model the catalog does not carry', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'azure-foundry',
+          npm: '@ai-sdk/azure',
+          models: ['gpt-5.6-luna', 'gpt-9-imaginary'],
+        },
+      ],
+    };
+
+    expect(() => projectCatalog({ canonicalCatalog, spec })).toThrow(
+      'azure-foundry/gpt-9-imaginary',
+    );
+  });
+
+  it('cannot restate what a model is, only which models a route serves', () => {
+    const spec = {
+      providers: [
+        {
+          name: 'azure-foundry',
+          npm: '@ai-sdk/azure',
+          models: [{ model: 'gpt-5.6-luna', modalities: ['image'] }],
+        },
+      ],
+    } as unknown as CatalogSpec;
+
+    const projected = projectCatalog({ canonicalCatalog, spec });
+
+    expect(projected['azure-foundry'].models?.[0]).toMatchObject({
+      modalities: ['image', 'pdf'],
+    });
+  });
+});

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/project-catalog.spec.ts
@@ -138,6 +138,44 @@ describe('projectCatalog', () => {
     });
   });
 
+  it('serves every model a vendor publishes when the spec names the vendor', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'openai',
+          npm: '@ai-sdk/openai',
+          apiKey: '{{OPENAI_API_KEY}}',
+          models: { vendor: 'openai' },
+        },
+      ],
+    };
+
+    const projected = projectCatalog({ canonicalCatalog, spec });
+
+    expect(projected['openai'].models?.map((model) => model.name)).toEqual([
+      'gpt-5.6-luna',
+    ]);
+    expect(projected['openai'].models?.[0]).toMatchObject({
+      efforts: ['low', 'medium', 'high'],
+    });
+  });
+
+  it('refuses a spec naming a vendor the catalog does not carry', () => {
+    const spec: CatalogSpec = {
+      providers: [
+        {
+          name: 'openai',
+          npm: '@ai-sdk/openai',
+          models: { vendor: 'openai-imaginary' },
+        },
+      ],
+    };
+
+    expect(() => projectCatalog({ canonicalCatalog, spec })).toThrow(
+      'which the catalog does not carry',
+    );
+  });
+
   it('refuses a spec naming a model the catalog does not carry', () => {
     const spec: CatalogSpec = {
       providers: [

--- a/packages/twenty-server/scripts/ai-catalog-sync/__tests__/self-host-projection.spec.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/__tests__/self-host-projection.spec.ts
@@ -1,0 +1,22 @@
+import canonicalCatalog from 'src/engine/metadata-modules/ai/ai-models/ai-models.json';
+import shippedCatalog from 'src/engine/metadata-modules/ai/ai-models/ai-providers.json';
+import selfHostSpec from 'src/engine/metadata-modules/ai/ai-models/ai-self-host-spec.json';
+
+import { type CatalogSpec } from '../types/catalog-spec.type';
+import {
+  type CanonicalCatalog,
+  projectCatalog,
+} from '../utils/project-catalog.util';
+
+// The shipped catalog is generated, and a hand edit to it is the drift this
+// pipeline exists to remove, so it has to stay what its spec produces.
+describe('the shipped catalog', () => {
+  it('is what the self-host spec projects from the model catalog', () => {
+    const projected = projectCatalog({
+      canonicalCatalog: canonicalCatalog as CanonicalCatalog,
+      spec: selfHostSpec as CatalogSpec,
+    });
+
+    expect(projected).toEqual(shippedCatalog);
+  });
+});

--- a/packages/twenty-server/scripts/ai-catalog-sync/index.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/index.ts
@@ -12,10 +12,12 @@ import { buildCatalog } from './utils/build-catalog.util';
 import { carryOverCommittedFields } from './utils/carry-over-committed-fields.util';
 import { enrichCatalog } from './utils/enrich-catalog.util';
 import { fetchArtificialAnalysisBenchmarks } from './utils/fetch-artificial-analysis-benchmarks.util';
+import { projectCatalog } from './utils/project-catalog.util';
 import { readCommittedBenchmarks } from './utils/read-committed-benchmarks.util';
 import { buildCoverageReport } from './utils/build-coverage-report.util';
 import { renderCoverageReport } from './utils/render-coverage-report.util';
 import { type BenchmarkIndex } from './types/benchmark-index.type';
+import { type CatalogSpec } from './types/catalog-spec.type';
 import { type GeneratedCatalog } from './types/generated-catalog.type';
 
 const AI_MODELS_DIR = path.resolve(
@@ -29,6 +31,8 @@ const AI_MODELS_DIR = path.resolve(
   'ai-models',
 );
 
+const MODELS_PATH = path.join(AI_MODELS_DIR, 'ai-models.json');
+const SELF_HOST_SPEC_PATH = path.join(AI_MODELS_DIR, 'ai-self-host-spec.json');
 const CATALOG_PATH = path.join(AI_MODELS_DIR, 'ai-providers.json');
 const BENCHMARKS_PATH = path.join(AI_MODELS_DIR, 'ai-model-benchmarks.json');
 
@@ -43,7 +47,7 @@ const readArgument = (flag: string): string | undefined => {
   return index === -1 ? undefined : process.argv[index + 1];
 };
 
-const readCommittedCatalog = (filePath: string): GeneratedCatalog =>
+const readCommittedModels = (filePath: string): GeneratedCatalog =>
   fs.existsSync(filePath)
     ? (JSON.parse(fs.readFileSync(filePath, 'utf-8')) as GeneratedCatalog)
     : {};
@@ -131,7 +135,7 @@ const main = async (): Promise<void> => {
 
   carryOverCommittedFields({
     catalog,
-    committedCatalog: readCommittedCatalog(CATALOG_PATH),
+    committedCatalog: readCommittedModels(MODELS_PATH),
   });
 
   const overlay = enrichCatalog({
@@ -155,7 +159,18 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  await writeJson(CATALOG_PATH, catalog);
+  await writeJson(MODELS_PATH, catalog);
+  // Self-host runs the same projection cloud does, from a spec that names the
+  // five direct routes and lets each serve its whole vendor.
+  await writeJson(
+    CATALOG_PATH,
+    projectCatalog({
+      canonicalCatalog: catalog,
+      spec: JSON.parse(
+        fs.readFileSync(SELF_HOST_SPEC_PATH, 'utf-8'),
+      ) as CatalogSpec,
+    }),
+  );
   await writeJson(BENCHMARKS_PATH, {
     source: 'artificialanalysis.ai',
     measuredAt,

--- a/packages/twenty-server/scripts/ai-catalog-sync/project.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/project.ts
@@ -1,8 +1,8 @@
 // Projects the canonical catalog through a deployment spec. See README.md.
 //
-// This entry point and the files it imports deliberately use nothing from the
-// workspace, so a repository holding a private spec can run them straight from
-// a sparse checkout without installing the monorepo.
+// This entry point and the files it imports resolve through node builtins and
+// source paths only, so a repository holding a private spec can run them
+// straight from a sparse checkout without installing the monorepo.
 
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';

--- a/packages/twenty-server/scripts/ai-catalog-sync/project.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/project.ts
@@ -1,20 +1,8 @@
-// Projects the canonical catalog through a deployment spec.
+// Projects the canonical catalog through a deployment spec. See README.md.
 //
-// `index.ts` keeps one catalog of what every model is, refreshed daily from
-// models.dev and Artificial Analysis. A deployment serves a subset of those
-// models, through its own routes and credentials, and used to restate them:
-// prices, labels and modalities copied by hand into a second file that nothing
-// kept in step. Those copies went stale, and the copies that mattered most —
-// the effort levels a model takes and the readings measured for it — were never
-// made at all, so every deployment served models the product could not compare.
-//
-// So a deployment declares only what is its own: which routes exist, what
-// credentials they use, and which catalog models each one serves. Everything
-// that describes a model is read from the catalog at generation time.
-//
-// This entry point deliberately imports nothing from the workspace, so a
-// repository that only needs to generate a catalog can run it straight from a
-// sparse checkout without installing the monorepo.
+// This entry point and the files it imports deliberately use nothing from the
+// workspace, so a repository holding a private spec can run them straight from
+// a sparse checkout without installing the monorepo.
 
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -37,10 +25,22 @@ const DEFAULT_CATALOG_PATH = resolve(
   'ai-providers.json',
 );
 
+// A flag whose value is missing would otherwise swallow the next flag and write
+// the catalog to a file named after it.
 const readArgument = (flag: string): string | undefined => {
   const index = process.argv.indexOf(flag);
 
-  return index === -1 ? undefined : process.argv[index + 1];
+  if (index === -1) {
+    return undefined;
+  }
+
+  const value = process.argv[index + 1];
+
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`${flag} is missing its value`);
+  }
+
+  return value;
 };
 
 const readJson = <TValue>(path: string): TValue => {
@@ -53,7 +53,13 @@ const readJson = <TValue>(path: string): TValue => {
   }
 };
 
-const assertSpecIsUsable = (spec: CatalogSpec, path: string): void => {
+const assertSpecIsUsable = ({
+  spec,
+  path,
+}: {
+  spec: CatalogSpec;
+  path: string;
+}): void => {
   if (!Array.isArray(spec.providers) || spec.providers.length === 0) {
     throw new Error(`${path} declares no providers`);
   }
@@ -98,7 +104,7 @@ const main = (): void => {
   const catalogPath = readArgument('--catalog') ?? DEFAULT_CATALOG_PATH;
   const spec = readJson<CatalogSpec>(specPath);
 
-  assertSpecIsUsable(spec, specPath);
+  assertSpecIsUsable({ spec, path: specPath });
 
   const projected = projectCatalog({
     canonicalCatalog: readJson<CanonicalCatalog>(catalogPath),

--- a/packages/twenty-server/scripts/ai-catalog-sync/project.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/project.ts
@@ -22,7 +22,7 @@ const DEFAULT_CATALOG_PATH = resolve(
   'metadata-modules',
   'ai',
   'ai-models',
-  'ai-providers.json',
+  'ai-models.json',
 );
 
 // A flag whose value is missing would otherwise swallow the next flag and write
@@ -75,7 +75,12 @@ const assertSpecIsUsable = ({
       );
     }
 
-    if (!Array.isArray(provider.models) || provider.models.length === 0) {
+    const servesModels = Array.isArray(provider.models)
+      ? provider.models.length > 0
+      : typeof provider.models?.vendor === 'string' &&
+        provider.models.vendor.length > 0;
+
+    if (!servesModels) {
       throw new Error(`${path}: provider "${provider.name}" serves no models`);
     }
   }
@@ -97,7 +102,7 @@ const main = (): void => {
 
   if (specPath === undefined || outPath === undefined) {
     throw new Error(
-      'Usage: project.ts --spec <spec.json> --out <catalog.json> [--catalog <ai-providers.json>]',
+      'Usage: project.ts --spec <spec.json> --out <catalog.json> [--catalog <ai-models.json>]',
     );
   }
 

--- a/packages/twenty-server/scripts/ai-catalog-sync/project.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/project.ts
@@ -1,0 +1,123 @@
+// Projects the canonical catalog through a deployment spec.
+//
+// `index.ts` keeps one catalog of what every model is, refreshed daily from
+// models.dev and Artificial Analysis. A deployment serves a subset of those
+// models, through its own routes and credentials, and used to restate them:
+// prices, labels and modalities copied by hand into a second file that nothing
+// kept in step. Those copies went stale, and the copies that mattered most —
+// the effort levels a model takes and the readings measured for it — were never
+// made at all, so every deployment served models the product could not compare.
+//
+// So a deployment declares only what is its own: which routes exist, what
+// credentials they use, and which catalog models each one serves. Everything
+// that describes a model is read from the catalog at generation time.
+//
+// This entry point deliberately imports nothing from the workspace, so a
+// repository that only needs to generate a catalog can run it straight from a
+// sparse checkout without installing the monorepo.
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import { type CatalogSpec } from './types/catalog-spec.type';
+import {
+  type CanonicalCatalog,
+  projectCatalog,
+} from './utils/project-catalog.util';
+
+const DEFAULT_CATALOG_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  'src',
+  'engine',
+  'metadata-modules',
+  'ai',
+  'ai-models',
+  'ai-providers.json',
+);
+
+const readArgument = (flag: string): string | undefined => {
+  const index = process.argv.indexOf(flag);
+
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+const readJson = <TValue>(path: string): TValue => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as TValue;
+  } catch (error) {
+    throw new Error(
+      `Could not read ${path}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+};
+
+const assertSpecIsUsable = (spec: CatalogSpec, path: string): void => {
+  if (!Array.isArray(spec.providers) || spec.providers.length === 0) {
+    throw new Error(`${path} declares no providers`);
+  }
+
+  for (const provider of spec.providers) {
+    if (typeof provider.name !== 'string' || provider.name.length === 0) {
+      throw new Error(`${path} has a provider without a name`);
+    }
+
+    if (typeof provider.npm !== 'string' || provider.npm.length === 0) {
+      throw new Error(
+        `${path}: provider "${provider.name}" has no npm package`,
+      );
+    }
+
+    if (!Array.isArray(provider.models) || provider.models.length === 0) {
+      throw new Error(`${path}: provider "${provider.name}" serves no models`);
+    }
+  }
+};
+
+const describe = (catalog: CanonicalCatalog): string => {
+  const models = Object.values(catalog).flatMap(
+    (provider) => provider.models ?? [],
+  );
+  const withEfforts = models.filter((model) => model.efforts !== undefined);
+  const withBenchmark = models.filter((model) => model.benchmark !== undefined);
+
+  return `${Object.keys(catalog).length} providers, ${models.length} models, ${withEfforts.length} with efforts, ${withBenchmark.length} with a benchmark`;
+};
+
+const main = (): void => {
+  const specPath = readArgument('--spec');
+  const outPath = readArgument('--out');
+
+  if (specPath === undefined || outPath === undefined) {
+    throw new Error(
+      'Usage: project.ts --spec <spec.json> --out <catalog.json> [--catalog <ai-providers.json>]',
+    );
+  }
+
+  const catalogPath = readArgument('--catalog') ?? DEFAULT_CATALOG_PATH;
+  const spec = readJson<CatalogSpec>(specPath);
+
+  assertSpecIsUsable(spec, specPath);
+
+  const projected = projectCatalog({
+    canonicalCatalog: readJson<CanonicalCatalog>(catalogPath),
+    spec,
+  });
+
+  mkdirSync(dirname(resolve(outPath)), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(projected, null, 2)}\n`, 'utf-8');
+
+  // oxlint-disable-next-line no-console
+  console.log(`Wrote ${outPath}: ${describe(projected)}`);
+};
+
+try {
+  main();
+} catch (error) {
+  // oxlint-disable-next-line no-console
+  console.error(
+    `AI catalog projection failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}

--- a/packages/twenty-server/scripts/ai-catalog-sync/types/catalog-spec.type.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/types/catalog-spec.type.ts
@@ -24,6 +24,12 @@ export type CatalogSpecModel = CatalogSpecModelOverrides & {
   as?: string;
 };
 
+// Every model the vendor publishes, so a route that serves a whole vendor
+// picks up new models with the daily sync instead of waiting for an edit here.
+export type CatalogSpecModelSelector = {
+  vendor: string;
+};
+
 export type CatalogSpecProvider = {
   name: string;
   npm: string;
@@ -40,7 +46,7 @@ export type CatalogSpecProvider = {
   // Appended to every inherited label, so one route can read as
   // "GPT-5.6 Luna (Azure)" without restating the name of each model.
   labelSuffix?: string;
-  models: (string | CatalogSpecModel)[];
+  models: (string | CatalogSpecModel)[] | CatalogSpecModelSelector;
 };
 
 export type CatalogSpec = {

--- a/packages/twenty-server/scripts/ai-catalog-sync/types/catalog-spec.type.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/types/catalog-spec.type.ts
@@ -1,12 +1,8 @@
-// What a deployment is allowed to say about a model: the prices it negotiated,
-// the limits its route caps, and how it names the model. Everything else —
-// modalities, reasoning support, efforts, benchmarks — is read from the
-// canonical catalog, so a deployment cannot drift from the measured truth by
-// restating it.
+// Deliberately not extensible: a field a route cannot restate is a field it
+// cannot drift on, which is the property this pipeline is for.
 export type CatalogSpecModelOverrides = {
   label?: string;
   isDeprecated?: boolean;
-  // A route can serve a model under a tighter limit than the model's own.
   contextWindowTokens?: number;
   maxOutputTokens?: number;
   inputCostPerMillionTokens?: number;
@@ -16,11 +12,9 @@ export type CatalogSpecModelOverrides = {
 };
 
 export type CatalogSpecModel = CatalogSpecModelOverrides & {
-  // The model as the canonical catalog names it.
   model: string;
-  // The id this route serves it under, when the route renames it
-  // (`eu.anthropic.claude-opus-4-7` for a Bedrock deployment of
-  // `claude-opus-4-7`). Defaults to the canonical name.
+  // `eu.anthropic.claude-opus-4-7` for a Bedrock deployment of
+  // `claude-opus-4-7`.
   as?: string;
 };
 
@@ -43,8 +37,6 @@ export type CatalogSpecProvider = {
   sessionToken?: string;
   dataResidency?: string;
   zeroDataRetention?: boolean;
-  // Appended to every inherited label, so one route can read as
-  // "GPT-5.6 Luna (Azure)" without restating the name of each model.
   labelSuffix?: string;
   models: (string | CatalogSpecModel)[] | CatalogSpecModelSelector;
 };

--- a/packages/twenty-server/scripts/ai-catalog-sync/types/catalog-spec.type.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/types/catalog-spec.type.ts
@@ -1,0 +1,43 @@
+// What a deployment is allowed to say about a model. Everything else — prices,
+// context window, modalities, efforts, benchmarks — is read from the canonical
+// catalog, so a deployment cannot drift from the measured truth by restating it.
+export type CatalogSpecModelOverrides = {
+  label?: string;
+  isDeprecated?: boolean;
+  inputCostPerMillionTokens?: number;
+  outputCostPerMillionTokens?: number;
+  cachedInputCostPerMillionTokens?: number;
+  cacheCreationCostPerMillionTokens?: number;
+};
+
+export type CatalogSpecModel = CatalogSpecModelOverrides & {
+  // The model as the canonical catalog names it.
+  model: string;
+  // The id this route serves it under, when the route renames it
+  // (`eu.anthropic.claude-opus-4-7` for a Bedrock deployment of
+  // `claude-opus-4-7`). Defaults to the canonical name.
+  as?: string;
+};
+
+export type CatalogSpecProvider = {
+  name: string;
+  npm: string;
+  label?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  region?: string;
+  authType?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  dataResidency?: string;
+  zeroDataRetention?: boolean;
+  // Appended to every inherited label, so one route can read as
+  // "GPT-5.6 Luna (Azure)" without restating the name of each model.
+  labelSuffix?: string;
+  models: (string | CatalogSpecModel)[];
+};
+
+export type CatalogSpec = {
+  providers: CatalogSpecProvider[];
+};

--- a/packages/twenty-server/scripts/ai-catalog-sync/types/catalog-spec.type.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/types/catalog-spec.type.ts
@@ -1,9 +1,14 @@
-// What a deployment is allowed to say about a model. Everything else — prices,
-// context window, modalities, efforts, benchmarks — is read from the canonical
-// catalog, so a deployment cannot drift from the measured truth by restating it.
+// What a deployment is allowed to say about a model: the prices it negotiated,
+// the limits its route caps, and how it names the model. Everything else —
+// modalities, reasoning support, efforts, benchmarks — is read from the
+// canonical catalog, so a deployment cannot drift from the measured truth by
+// restating it.
 export type CatalogSpecModelOverrides = {
   label?: string;
   isDeprecated?: boolean;
+  // A route can serve a model under a tighter limit than the model's own.
+  contextWindowTokens?: number;
+  maxOutputTokens?: number;
   inputCostPerMillionTokens?: number;
   outputCostPerMillionTokens?: number;
   cachedInputCostPerMillionTokens?: number;

--- a/packages/twenty-server/scripts/ai-catalog-sync/types/generated-provider.type.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/types/generated-provider.type.ts
@@ -1,10 +1,5 @@
-import { type AiSdkPackage } from 'twenty-shared/ai';
-
 import { type GeneratedModel } from './generated-model.type';
 
 export type GeneratedProvider = {
-  npm: AiSdkPackage;
-  label: string;
-  apiKey: string;
   models: GeneratedModel[];
 };

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/build-catalog.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/build-catalog.util.ts
@@ -1,7 +1,4 @@
-import {
-  type AiSdkPackage,
-  NATIVE_AI_SDK_PROVIDER_IDS,
-} from 'twenty-shared/ai';
+import { NATIVE_AI_SDK_PROVIDER_IDS } from 'twenty-shared/ai';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type ModelsDevData } from 'src/engine/metadata-modules/ai/ai-models/types/models-dev-data.type';
@@ -36,22 +33,6 @@ const EXCLUDED_MODEL_PREFIXES = [
 const EXCLUDED_MODEL_SUFFIXES = ['-audio-preview', '-realtime-preview'];
 
 const LONG_CONTEXT_THRESHOLD_TOKENS = 200000;
-
-const PROVIDER_LABELS: Record<string, string> = {
-  openai: 'OpenAI',
-  anthropic: 'Anthropic',
-  google: 'Google',
-  mistral: 'Mistral',
-  xai: 'xAI',
-};
-
-const API_KEY_TEMPLATES: Record<string, string> = {
-  openai: '{{OPENAI_API_KEY}}',
-  anthropic: '{{ANTHROPIC_API_KEY}}',
-  google: '{{GOOGLE_API_KEY}}',
-  mistral: '{{MISTRAL_API_KEY}}',
-  xai: '{{XAI_API_KEY}}',
-};
 
 const isLanguageModel = (modelId: string): boolean => {
   const lowerId = modelId.toLowerCase();
@@ -169,12 +150,7 @@ export const buildCatalog = (data: ModelsDevData): GeneratedCatalog => {
       continue;
     }
 
-    catalog[providerName] = {
-      npm: `@ai-sdk/${providerName}` as AiSdkPackage,
-      label: PROVIDER_LABELS[providerName] ?? providerName,
-      apiKey: API_KEY_TEMPLATES[providerName] ?? '',
-      models,
-    };
+    catalog[providerName] = { models };
   }
 
   return catalog;

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
@@ -1,3 +1,9 @@
+// twenty-shared by source path rather than by package name: the consuming
+// repository runs this from a sparse checkout with no workspace install, so
+// 'twenty-shared/ai' would not resolve there.
+import { isAiSdkPackage } from '../../../../twenty-shared/src/ai/utils/is-ai-sdk-package.util';
+import { isDataResidency } from '../../../../twenty-shared/src/ai/utils/is-data-residency.util';
+
 import {
   type CatalogSpec,
   type CatalogSpecModel,
@@ -5,7 +11,7 @@ import {
   type CatalogSpecProvider,
 } from '../types/catalog-spec.type';
 
-// Structural, so this file stays free of workspace imports and can run from a
+// Structural, so the catalog needs no schema here and this file can run from a
 // checkout that has not installed the monorepo.
 type CanonicalModel = { name: string; label?: string } & Record<
   string,
@@ -47,34 +53,6 @@ const PROVIDER_CREDENTIAL_FIELDS = [
   'secretAccessKey',
   'sessionToken',
 ] as const;
-
-// Mirrors AI_SDK_PACKAGES and DATA_RESIDENCY_KEYS in twenty-shared, which this
-// file cannot import and stay runnable outside the monorepo. A spec test holds
-// the two in step; a value the server's schema rejects would otherwise leave a
-// deployment with no catalog at all.
-export const SUPPORTED_SDK_PACKAGES = [
-  '@ai-sdk/openai',
-  '@ai-sdk/openai-compatible',
-  '@ai-sdk/anthropic',
-  '@ai-sdk/google',
-  '@ai-sdk/mistral',
-  '@ai-sdk/xai',
-  '@ai-sdk/azure',
-  '@ai-sdk/amazon-bedrock',
-];
-
-export const SUPPORTED_DATA_RESIDENCIES = [
-  'us',
-  'eu',
-  'global',
-  'uk',
-  'ap',
-  'jp',
-  'au',
-  'ca',
-  'de',
-  'fr',
-];
 
 const asSpecModel = (entry: string | CatalogSpecModel): CatalogSpecModel =>
   typeof entry === 'string' ? { model: entry } : entry;
@@ -141,7 +119,7 @@ const assertProviderIsUsable = ({
     throw new Error(`Provider "${provider.name}" is repeated or reserved`);
   }
 
-  if (!SUPPORTED_SDK_PACKAGES.includes(provider.npm)) {
+  if (!isAiSdkPackage(provider.npm)) {
     throw new Error(
       `Provider "${provider.name}" names an unsupported SDK package: ${provider.npm}`,
     );
@@ -149,7 +127,7 @@ const assertProviderIsUsable = ({
 
   if (
     provider.dataResidency !== undefined &&
-    !SUPPORTED_DATA_RESIDENCIES.includes(provider.dataResidency)
+    !isDataResidency(provider.dataResidency)
   ) {
     throw new Error(
       `Provider "${provider.name}" names an unsupported data residency: ${provider.dataResidency}`,

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
@@ -158,11 +158,29 @@ const assertNumbersAreUsable = ({
 // chains then fall through to a neighbouring rung in silence.
 const resolveModels = ({
   provider,
+  canonicalCatalog,
   canonicalModels,
 }: {
   provider: CatalogSpecProvider;
+  canonicalCatalog: CanonicalCatalog;
   canonicalModels: Map<string, CanonicalModel>;
 }): { canonicalModel: CanonicalModel; specModel: CatalogSpecModel }[] => {
+  if (!Array.isArray(provider.models)) {
+    const { vendor } = provider.models;
+    const vendorModels = canonicalCatalog[vendor]?.models ?? [];
+
+    if (vendorModels.length === 0) {
+      throw new Error(
+        `Provider "${provider.name}" serves every model from "${vendor}", which the catalog does not carry`,
+      );
+    }
+
+    return vendorModels.map((canonicalModel) => ({
+      canonicalModel,
+      specModel: { model: canonicalModel.name },
+    }));
+  }
+
   const specModels = provider.models.map(asSpecModel);
   const unknown = specModels
     .filter(({ model }) => !canonicalModels.has(model))
@@ -212,9 +230,11 @@ export const projectCatalog = ({
       npm: provider.npm,
       label: provider.label ?? provider.name,
       ...credentials,
-      models: resolveModels({ provider, canonicalModels }).map((resolved) =>
-        projectModel({ ...resolved, provider }),
-      ),
+      models: resolveModels({
+        provider,
+        canonicalCatalog,
+        canonicalModels,
+      }).map((resolved) => projectModel({ ...resolved, provider })),
     };
   }
 

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
@@ -28,6 +28,15 @@ const OVERRIDABLE_FIELDS = [
   'cacheCreationCostPerMillionTokens',
 ] as const satisfies readonly (keyof CatalogSpecModelOverrides)[];
 
+const NUMERIC_FIELDS = [
+  'contextWindowTokens',
+  'maxOutputTokens',
+  'inputCostPerMillionTokens',
+  'outputCostPerMillionTokens',
+  'cachedInputCostPerMillionTokens',
+  'cacheCreationCostPerMillionTokens',
+] as const satisfies readonly (keyof CatalogSpecModelOverrides)[];
+
 const PROVIDER_CREDENTIAL_FIELDS = [
   'label',
   'apiKey',
@@ -38,6 +47,34 @@ const PROVIDER_CREDENTIAL_FIELDS = [
   'secretAccessKey',
   'sessionToken',
 ] as const;
+
+// Mirrors AI_SDK_PACKAGES and DATA_RESIDENCY_KEYS in twenty-shared, which this
+// file cannot import and stay runnable outside the monorepo. A spec test holds
+// the two in step; a value the server's schema rejects would otherwise leave a
+// deployment with no catalog at all.
+export const SUPPORTED_SDK_PACKAGES = [
+  '@ai-sdk/openai',
+  '@ai-sdk/openai-compatible',
+  '@ai-sdk/anthropic',
+  '@ai-sdk/google',
+  '@ai-sdk/mistral',
+  '@ai-sdk/xai',
+  '@ai-sdk/azure',
+  '@ai-sdk/amazon-bedrock',
+];
+
+export const SUPPORTED_DATA_RESIDENCIES = [
+  'us',
+  'eu',
+  'global',
+  'uk',
+  'ap',
+  'jp',
+  'au',
+  'ca',
+  'de',
+  'fr',
+];
 
 const asSpecModel = (entry: string | CatalogSpecModel): CatalogSpecModel =>
   typeof entry === 'string' ? { model: entry } : entry;
@@ -65,7 +102,11 @@ const projectModel = ({
   specModel: CatalogSpecModel;
   provider: CatalogSpecProvider;
 }): CanonicalModel => {
-  const label = `${canonicalModel.label ?? canonicalModel.name}${provider.labelSuffix ?? ''}`;
+  const overrides = Object.fromEntries(
+    OVERRIDABLE_FIELDS.filter((field) => specModel[field] !== undefined).map(
+      (field) => [field, specModel[field]],
+    ),
+  );
 
   const routeFields = {
     ...(provider.dataResidency === undefined
@@ -76,37 +117,97 @@ const projectModel = ({
       : { zeroDataRetention: provider.zeroDataRetention }),
   };
 
-  const overrides = Object.fromEntries(
-    OVERRIDABLE_FIELDS.filter((field) => specModel[field] !== undefined).map(
-      (field) => [field, specModel[field]],
-    ),
-  );
-
   return {
     ...canonicalModel,
-    name: specModel.as ?? canonicalModel.name,
-    label,
     ...routeFields,
     ...overrides,
+    name: specModel.as ?? canonicalModel.name,
+    // The suffix marks the route, so it is appended to whichever name the model
+    // ends up with rather than to the catalog's.
+    label: `${specModel.label ?? canonicalModel.label ?? canonicalModel.name}${provider.labelSuffix ?? ''}`,
   };
+};
+
+const assertProviderIsUsable = ({
+  provider,
+  seenNames,
+}: {
+  provider: CatalogSpecProvider;
+  seenNames: Set<string>;
+}): void => {
+  // Providers key an object, so a repeat would drop the first one's credentials
+  // and models on the floor, and `__proto__` would drop its own.
+  if (seenNames.has(provider.name) || provider.name === '__proto__') {
+    throw new Error(`Provider "${provider.name}" is repeated or reserved`);
+  }
+
+  if (!SUPPORTED_SDK_PACKAGES.includes(provider.npm)) {
+    throw new Error(
+      `Provider "${provider.name}" names an unsupported SDK package: ${provider.npm}`,
+    );
+  }
+
+  if (
+    provider.dataResidency !== undefined &&
+    !SUPPORTED_DATA_RESIDENCIES.includes(provider.dataResidency)
+  ) {
+    throw new Error(
+      `Provider "${provider.name}" names an unsupported data residency: ${provider.dataResidency}`,
+    );
+  }
+};
+
+const assertNumbersAreUsable = ({
+  provider,
+  specModel,
+}: {
+  provider: CatalogSpecProvider;
+  specModel: CatalogSpecModel;
+}): void => {
+  for (const field of NUMERIC_FIELDS) {
+    const value = specModel[field];
+
+    if (value !== undefined && (!Number.isFinite(value) || value < 0)) {
+      throw new Error(
+        `${provider.name}/${specModel.model} sets ${field} to ${value}, which is not a usable number`,
+      );
+    }
+  }
 };
 
 // A spec naming a model the catalog does not carry is the failure this whole
 // pipeline exists to prevent: it publishes a route to nothing, and the tier
 // chains then fall through to a neighbouring rung in silence.
-const findUnknownModels = ({
-  spec,
+const resolveModels = ({
+  provider,
   canonicalModels,
 }: {
-  spec: CatalogSpec;
+  provider: CatalogSpecProvider;
   canonicalModels: Map<string, CanonicalModel>;
-}): string[] =>
-  spec.providers.flatMap((provider) =>
-    provider.models
-      .map(asSpecModel)
-      .filter(({ model }) => !canonicalModels.has(model))
-      .map(({ model }) => `${provider.name}/${model}`),
-  );
+}): { canonicalModel: CanonicalModel; specModel: CatalogSpecModel }[] => {
+  const specModels = provider.models.map(asSpecModel);
+  const unknown = specModels
+    .filter(({ model }) => !canonicalModels.has(model))
+    .map(({ model }) => `${provider.name}/${model}`);
+
+  if (unknown.length > 0) {
+    throw new Error(
+      `The catalog does not carry: ${unknown.join(', ')}. Check the model names, or wait for the catalog sync to pick them up.`,
+    );
+  }
+
+  return specModels.map((specModel) => {
+    assertNumbersAreUsable({ provider, specModel });
+
+    const canonicalModel = canonicalModels.get(specModel.model);
+
+    if (canonicalModel === undefined) {
+      throw new Error(`The catalog does not carry ${specModel.model}`);
+    }
+
+    return { canonicalModel, specModel };
+  });
+};
 
 export const projectCatalog = ({
   canonicalCatalog,
@@ -116,17 +217,13 @@ export const projectCatalog = ({
   spec: CatalogSpec;
 }): CanonicalCatalog => {
   const canonicalModels = indexCanonicalModels(canonicalCatalog);
-  const unknownModels = findUnknownModels({ spec, canonicalModels });
-
-  if (unknownModels.length > 0) {
-    throw new Error(
-      `The catalog does not carry: ${unknownModels.join(', ')}. Check the model names, or wait for the catalog sync to pick them up.`,
-    );
-  }
-
   const projected: CanonicalCatalog = {};
+  const seenNames = new Set<string>();
 
   for (const provider of spec.providers) {
+    assertProviderIsUsable({ provider, seenNames });
+    seenNames.add(provider.name);
+
     const credentials = Object.fromEntries(
       PROVIDER_CREDENTIAL_FIELDS.filter(
         (field) => provider[field] !== undefined,
@@ -137,15 +234,8 @@ export const projectCatalog = ({
       npm: provider.npm,
       label: provider.label ?? provider.name,
       ...credentials,
-      models: provider.models.map(asSpecModel).map((specModel) =>
-        projectModel({
-          // Checked above, so the lookup cannot miss.
-          canonicalModel: canonicalModels.get(
-            specModel.model,
-          ) as CanonicalModel,
-          specModel,
-          provider,
-        }),
+      models: resolveModels({ provider, canonicalModels }).map((resolved) =>
+        projectModel({ ...resolved, provider }),
       ),
     };
   }

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
@@ -20,6 +20,8 @@ export type CanonicalCatalog = Record<string, CanonicalProvider>;
 const OVERRIDABLE_FIELDS = [
   'label',
   'isDeprecated',
+  'contextWindowTokens',
+  'maxOutputTokens',
   'inputCostPerMillionTokens',
   'outputCostPerMillionTokens',
   'cachedInputCostPerMillionTokens',

--- a/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
+++ b/packages/twenty-server/scripts/ai-catalog-sync/utils/project-catalog.util.ts
@@ -1,0 +1,152 @@
+import {
+  type CatalogSpec,
+  type CatalogSpecModel,
+  type CatalogSpecModelOverrides,
+  type CatalogSpecProvider,
+} from '../types/catalog-spec.type';
+
+// Structural, so this file stays free of workspace imports and can run from a
+// checkout that has not installed the monorepo.
+type CanonicalModel = { name: string; label?: string } & Record<
+  string,
+  unknown
+>;
+type CanonicalProvider = { models?: CanonicalModel[] } & Record<
+  string,
+  unknown
+>;
+export type CanonicalCatalog = Record<string, CanonicalProvider>;
+
+const OVERRIDABLE_FIELDS = [
+  'label',
+  'isDeprecated',
+  'inputCostPerMillionTokens',
+  'outputCostPerMillionTokens',
+  'cachedInputCostPerMillionTokens',
+  'cacheCreationCostPerMillionTokens',
+] as const satisfies readonly (keyof CatalogSpecModelOverrides)[];
+
+const PROVIDER_CREDENTIAL_FIELDS = [
+  'label',
+  'apiKey',
+  'baseUrl',
+  'region',
+  'authType',
+  'accessKeyId',
+  'secretAccessKey',
+  'sessionToken',
+] as const;
+
+const asSpecModel = (entry: string | CatalogSpecModel): CatalogSpecModel =>
+  typeof entry === 'string' ? { model: entry } : entry;
+
+const indexCanonicalModels = (
+  catalog: CanonicalCatalog,
+): Map<string, CanonicalModel> => {
+  const models = new Map<string, CanonicalModel>();
+
+  for (const provider of Object.values(catalog)) {
+    for (const model of provider.models ?? []) {
+      models.set(model.name, model);
+    }
+  }
+
+  return models;
+};
+
+const projectModel = ({
+  canonicalModel,
+  specModel,
+  provider,
+}: {
+  canonicalModel: CanonicalModel;
+  specModel: CatalogSpecModel;
+  provider: CatalogSpecProvider;
+}): CanonicalModel => {
+  const label = `${canonicalModel.label ?? canonicalModel.name}${provider.labelSuffix ?? ''}`;
+
+  const routeFields = {
+    ...(provider.dataResidency === undefined
+      ? {}
+      : { dataResidency: provider.dataResidency }),
+    ...(provider.zeroDataRetention === undefined
+      ? {}
+      : { zeroDataRetention: provider.zeroDataRetention }),
+  };
+
+  const overrides = Object.fromEntries(
+    OVERRIDABLE_FIELDS.filter((field) => specModel[field] !== undefined).map(
+      (field) => [field, specModel[field]],
+    ),
+  );
+
+  return {
+    ...canonicalModel,
+    name: specModel.as ?? canonicalModel.name,
+    label,
+    ...routeFields,
+    ...overrides,
+  };
+};
+
+// A spec naming a model the catalog does not carry is the failure this whole
+// pipeline exists to prevent: it publishes a route to nothing, and the tier
+// chains then fall through to a neighbouring rung in silence.
+const findUnknownModels = ({
+  spec,
+  canonicalModels,
+}: {
+  spec: CatalogSpec;
+  canonicalModels: Map<string, CanonicalModel>;
+}): string[] =>
+  spec.providers.flatMap((provider) =>
+    provider.models
+      .map(asSpecModel)
+      .filter(({ model }) => !canonicalModels.has(model))
+      .map(({ model }) => `${provider.name}/${model}`),
+  );
+
+export const projectCatalog = ({
+  canonicalCatalog,
+  spec,
+}: {
+  canonicalCatalog: CanonicalCatalog;
+  spec: CatalogSpec;
+}): CanonicalCatalog => {
+  const canonicalModels = indexCanonicalModels(canonicalCatalog);
+  const unknownModels = findUnknownModels({ spec, canonicalModels });
+
+  if (unknownModels.length > 0) {
+    throw new Error(
+      `The catalog does not carry: ${unknownModels.join(', ')}. Check the model names, or wait for the catalog sync to pick them up.`,
+    );
+  }
+
+  const projected: CanonicalCatalog = {};
+
+  for (const provider of spec.providers) {
+    const credentials = Object.fromEntries(
+      PROVIDER_CREDENTIAL_FIELDS.filter(
+        (field) => provider[field] !== undefined,
+      ).map((field) => [field, provider[field]]),
+    );
+
+    projected[provider.name] = {
+      npm: provider.npm,
+      label: provider.label ?? provider.name,
+      ...credentials,
+      models: provider.models.map(asSpecModel).map((specModel) =>
+        projectModel({
+          // Checked above, so the lookup cannot miss.
+          canonicalModel: canonicalModels.get(
+            specModel.model,
+          ) as CanonicalModel,
+          specModel,
+          provider,
+        }),
+      ),
+    };
+  }
+
+  return projected;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/ai-models.json
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/ai-models.json
@@ -1,0 +1,2290 @@
+{
+  "openai": {
+    "models": [
+      {
+        "name": "gpt-5-nano",
+        "label": "GPT-5 Nano",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 0.05,
+        "outputCostPerMillionTokens": 0.4,
+        "cachedInputCostPerMillionTokens": 0.005,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 13,
+          "outputTokensPerSecond": 143.09,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-4.1-nano",
+        "label": "GPT-4.1 nano",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 0.1,
+        "outputCostPerMillionTokens": 0.4,
+        "cachedInputCostPerMillionTokens": 0.025,
+        "contextWindowTokens": 1047576,
+        "maxOutputTokens": 32768,
+        "modalities": ["image"],
+        "benchmark": {
+          "intelligenceIndex": 7.8,
+          "outputTokensPerSecond": 116.69,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "gpt-4o-2024-05-13",
+        "label": "GPT-4o (2024-05-13)",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 5,
+        "outputCostPerMillionTokens": 15,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 4096,
+        "modalities": ["image"],
+        "benchmark": {
+          "intelligenceIndex": 7.3,
+          "outputTokensPerSecond": 85.36,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "gpt-5-pro",
+        "label": "GPT-5 Pro",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 15,
+        "outputCostPerMillionTokens": 120,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 272000,
+        "modalities": ["image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gpt-5.6-sol",
+        "label": "GPT-5.6 Sol",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 4,
+        "outputCostPerMillionTokens": 20,
+        "cachedInputCostPerMillionTokens": 0.4,
+        "cacheCreationCostPerMillionTokens": 5,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 8,
+          "outputCostPerMillionTokens": 30,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.8,
+          "cacheCreationCostPerMillionTokens": 10
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 47.1,
+          "outputTokensPerSecond": 59.58,
+          "costPerTask": 1.9885,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "none": {
+            "intelligenceIndex": 28.3,
+            "outputTokensPerSecond": 61.66,
+            "effort": "none",
+            "measuredAt": "2026-09-12"
+          },
+          "low": {
+            "intelligenceIndex": 33.8,
+            "outputTokensPerSecond": 52.9,
+            "costPerTask": 0.2606,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 39.5,
+            "outputTokensPerSecond": 56.62,
+            "costPerTask": 0.505,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 42.5,
+            "outputTokensPerSecond": 60.67,
+            "costPerTask": 0.808,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 44.1,
+            "outputTokensPerSecond": 61.12,
+            "costPerTask": 1.1844,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 47.1,
+            "outputTokensPerSecond": 59.58,
+            "costPerTask": 1.9885,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gpt-4o-2024-08-06",
+        "label": "GPT-4o (2024-08-06)",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 2.5,
+        "outputCostPerMillionTokens": 10,
+        "cachedInputCostPerMillionTokens": 1.25,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 16384,
+        "modalities": ["image"],
+        "benchmark": {
+          "intelligenceIndex": 7.7,
+          "outputTokensPerSecond": 88.48,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-6-astra",
+        "label": "GPT-6 Astra",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 10,
+        "outputCostPerMillionTokens": 50,
+        "cachedInputCostPerMillionTokens": 1,
+        "cacheCreationCostPerMillionTokens": 12.5,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 20,
+          "outputCostPerMillionTokens": 75,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 2,
+          "cacheCreationCostPerMillionTokens": 25
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 52.8,
+          "outputTokensPerSecond": 54.41,
+          "costPerTask": 3.2575,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "low": {
+            "intelligenceIndex": 46,
+            "outputTokensPerSecond": 51.23,
+            "costPerTask": 0.8175,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 49.7,
+            "outputTokensPerSecond": 49.88,
+            "costPerTask": 1.5406,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 51,
+            "outputTokensPerSecond": 49.81,
+            "costPerTask": 1.7214,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 52.5,
+            "outputTokensPerSecond": 51.44,
+            "costPerTask": 2.3088,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 52.8,
+            "outputTokensPerSecond": 54.41,
+            "costPerTask": 3.2575,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gpt-5.2-pro",
+        "label": "GPT-5.2 Pro",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 21,
+        "outputCostPerMillionTokens": 168,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gpt-5.3-codex-spark",
+        "label": "GPT-5.3 Codex Spark",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.75,
+        "outputCostPerMillionTokens": 14,
+        "cachedInputCostPerMillionTokens": 0.175,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 32000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gpt-4.1-mini",
+        "label": "GPT-4.1 mini",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 0.4,
+        "outputCostPerMillionTokens": 1.6,
+        "cachedInputCostPerMillionTokens": 0.1,
+        "contextWindowTokens": 1047576,
+        "maxOutputTokens": 32768,
+        "modalities": ["image", "pdf"],
+        "benchmark": {
+          "intelligenceIndex": 10.2,
+          "outputTokensPerSecond": 107.07,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5.4",
+        "label": "GPT-5.4",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 2.5,
+        "outputCostPerMillionTokens": 15,
+        "cachedInputCostPerMillionTokens": 0.25,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 5,
+          "outputCostPerMillionTokens": 22.5,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.5
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["none", "low", "medium", "high", "xhigh"],
+        "benchmark": {
+          "intelligenceIndex": 39,
+          "outputTokensPerSecond": 132.23,
+          "effort": "xhigh",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "none": {
+            "intelligenceIndex": 18.2,
+            "outputTokensPerSecond": 91.22,
+            "effort": "none",
+            "measuredAt": "2026-09-12"
+          },
+          "low": {
+            "intelligenceIndex": 27.6,
+            "outputTokensPerSecond": 90.64,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 39,
+            "outputTokensPerSecond": 132.23,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gpt-4-turbo",
+        "label": "GPT-4 Turbo",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 10,
+        "outputCostPerMillionTokens": 30,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 4096,
+        "modalities": ["image"],
+        "benchmark": {
+          "intelligenceIndex": 7,
+          "outputTokensPerSecond": 31.1,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "gpt-5.1",
+        "label": "GPT-5.1",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.25,
+        "outputCostPerMillionTokens": 10,
+        "cachedInputCostPerMillionTokens": 0.125,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 24.7,
+          "outputTokensPerSecond": 99.46,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "o1",
+        "label": "o1",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 15,
+        "outputCostPerMillionTokens": 60,
+        "cachedInputCostPerMillionTokens": 7.5,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 100000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 15.2,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "gpt-4o",
+        "label": "GPT-4o",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 2.5,
+        "outputCostPerMillionTokens": 10,
+        "cachedInputCostPerMillionTokens": 1.25,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 16384,
+        "modalities": ["image", "pdf"],
+        "benchmark": {
+          "intelligenceIndex": 9,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5.6-luna",
+        "label": "GPT-5.6 Luna",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 0.2,
+        "outputCostPerMillionTokens": 1.2,
+        "cachedInputCostPerMillionTokens": 0.02,
+        "cacheCreationCostPerMillionTokens": 0.25,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 0.4,
+          "outputCostPerMillionTokens": 1.8,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.04,
+          "cacheCreationCostPerMillionTokens": 0.5
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 37.5,
+          "outputTokensPerSecond": 111.93,
+          "costPerTask": 0.1783,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "none": {
+            "intelligenceIndex": 16.8,
+            "outputTokensPerSecond": 109.79,
+            "effort": "none",
+            "measuredAt": "2026-09-12"
+          },
+          "low": {
+            "intelligenceIndex": 21.5,
+            "outputTokensPerSecond": 104.61,
+            "costPerTask": 0.0098,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 25.5,
+            "outputTokensPerSecond": 104.37,
+            "costPerTask": 0.0156,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 32.4,
+            "outputTokensPerSecond": 108.19,
+            "costPerTask": 0.044,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 34.8,
+            "outputTokensPerSecond": 108.33,
+            "costPerTask": 0.0853,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 37.5,
+            "outputTokensPerSecond": 111.93,
+            "costPerTask": 0.1783,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gpt-5.3-codex",
+        "label": "GPT-5.3 Codex",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.75,
+        "outputCostPerMillionTokens": 14,
+        "cachedInputCostPerMillionTokens": 0.175,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 32.5,
+          "outputTokensPerSecond": 127.21,
+          "effort": "xhigh",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-4o-mini",
+        "label": "GPT-4o mini",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 0.15,
+        "outputCostPerMillionTokens": 0.6,
+        "cachedInputCostPerMillionTokens": 0.075,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 16384,
+        "modalities": ["image", "pdf"],
+        "benchmark": {
+          "intelligenceIndex": 6.7,
+          "outputTokensPerSecond": 149.59,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "o1-pro",
+        "label": "o1-pro",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 150,
+        "outputCostPerMillionTokens": 600,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 100000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 12.4,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "gpt-4.1",
+        "label": "GPT-4.1",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 8,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "contextWindowTokens": 1047576,
+        "maxOutputTokens": 32768,
+        "modalities": ["image", "pdf"],
+        "benchmark": {
+          "intelligenceIndex": 12.7,
+          "outputTokensPerSecond": 162.59,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5.4-nano",
+        "label": "GPT-5.4 nano",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 0.2,
+        "outputCostPerMillionTokens": 1.25,
+        "cachedInputCostPerMillionTokens": 0.02,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 21.2,
+          "outputTokensPerSecond": 153.71,
+          "costPerTask": 0.1831,
+          "effort": "xhigh",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5.5-pro",
+        "label": "GPT-5.5 Pro",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 30,
+        "outputCostPerMillionTokens": 180,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 60,
+          "outputCostPerMillionTokens": 270,
+          "thresholdTokens": 200000
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gpt-5.4-mini",
+        "label": "GPT-5.4 mini",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 0.75,
+        "outputCostPerMillionTokens": 4.5,
+        "cachedInputCostPerMillionTokens": 0.075,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 24.6,
+          "outputTokensPerSecond": 173.66,
+          "costPerTask": 0.4097,
+          "effort": "xhigh",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5.6",
+        "label": "GPT-5.6",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 4,
+        "outputCostPerMillionTokens": 20,
+        "cachedInputCostPerMillionTokens": 0.4,
+        "cacheCreationCostPerMillionTokens": 5,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 8,
+          "outputCostPerMillionTokens": 30,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.8,
+          "cacheCreationCostPerMillionTokens": 10
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gpt-5-mini",
+        "label": "GPT-5 Mini",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 0.25,
+        "outputCostPerMillionTokens": 2,
+        "cachedInputCostPerMillionTokens": 0.025,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 20.6,
+          "outputTokensPerSecond": 93.42,
+          "effort": "medium",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5.4-pro",
+        "label": "GPT-5.4 Pro",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 30,
+        "outputCostPerMillionTokens": 180,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 60,
+          "outputCostPerMillionTokens": 270,
+          "thresholdTokens": 200000
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gpt-5.6-terra",
+        "label": "GPT-5.6 Terra",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 12,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "cacheCreationCostPerMillionTokens": 2.5,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 4,
+          "outputCostPerMillionTokens": 18,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4,
+          "cacheCreationCostPerMillionTokens": 5
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 42.3,
+          "outputTokensPerSecond": 87.05,
+          "costPerTask": 1.3987,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "none": {
+            "intelligenceIndex": 22.3,
+            "outputTokensPerSecond": 74.84,
+            "effort": "none",
+            "measuredAt": "2026-09-12"
+          },
+          "low": {
+            "intelligenceIndex": 27.9,
+            "outputTokensPerSecond": 75.27,
+            "costPerTask": 0.1445,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 30.4,
+            "outputTokensPerSecond": 76.41,
+            "costPerTask": 0.1834,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 34.5,
+            "outputTokensPerSecond": 79.06,
+            "costPerTask": 0.3379,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 38.2,
+            "outputTokensPerSecond": 76.14,
+            "costPerTask": 0.6318,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 42.3,
+            "outputTokensPerSecond": 87.05,
+            "costPerTask": 1.3987,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gpt-4",
+        "label": "GPT-4",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 30,
+        "outputCostPerMillionTokens": 60,
+        "contextWindowTokens": 8192,
+        "maxOutputTokens": 8192,
+        "benchmark": {
+          "intelligenceIndex": 6.7,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "gpt-5.2",
+        "label": "GPT-5.2",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.75,
+        "outputCostPerMillionTokens": 14,
+        "cachedInputCostPerMillionTokens": 0.175,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 30.4,
+          "outputTokensPerSecond": 70.17,
+          "effort": "xhigh",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5",
+        "label": "GPT-5",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.25,
+        "outputCostPerMillionTokens": 10,
+        "cachedInputCostPerMillionTokens": 0.125,
+        "contextWindowTokens": 400000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 23,
+          "outputTokensPerSecond": 75.68,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5.2-chat-latest",
+        "label": "GPT-5.2 Chat",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.75,
+        "outputCostPerMillionTokens": 14,
+        "cachedInputCostPerMillionTokens": 0.175,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 16384,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "isDeprecated": true
+      },
+      {
+        "name": "o4-mini",
+        "label": "o4-mini",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.1,
+        "outputCostPerMillionTokens": 4.4,
+        "cachedInputCostPerMillionTokens": 0.275,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 100000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 16.7,
+          "outputTokensPerSecond": 135.62,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "gpt-realtime-2.1",
+        "label": "GPT-Realtime-2.1",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 4,
+        "outputCostPerMillionTokens": 24,
+        "cachedInputCostPerMillionTokens": 0.4,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 32000,
+        "modalities": ["audio", "image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "o3-mini",
+        "label": "o3-mini",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.1,
+        "outputCostPerMillionTokens": 4.4,
+        "cachedInputCostPerMillionTokens": 0.55,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 100000,
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 12.5,
+          "outputTokensPerSecond": 219.12,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "o3",
+        "label": "o3",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 8,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 100000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 20.2,
+          "outputTokensPerSecond": 107.06,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "o3-pro",
+        "label": "o3-pro",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 20,
+        "outputCostPerMillionTokens": 80,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 100000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 21.9,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gpt-5.3-chat-latest",
+        "label": "GPT-5.3 Chat (latest)",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 1.75,
+        "outputCostPerMillionTokens": 14,
+        "cachedInputCostPerMillionTokens": 0.175,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 16384,
+        "modalities": ["image"],
+        "isDeprecated": true
+      },
+      {
+        "name": "gpt-5.5",
+        "label": "GPT-5.5",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 5,
+        "outputCostPerMillionTokens": 30,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 10,
+          "outputCostPerMillionTokens": 45,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 1
+        },
+        "contextWindowTokens": 1050000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 38.6,
+          "outputTokensPerSecond": 85.03,
+          "costPerTask": 2.634,
+          "effort": "xhigh",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "none": {
+            "intelligenceIndex": 23.2,
+            "outputTokensPerSecond": 77.88,
+            "effort": "none",
+            "measuredAt": "2026-09-12"
+          },
+          "low": {
+            "intelligenceIndex": 30.7,
+            "outputTokensPerSecond": 75.57,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 34.2,
+            "outputTokensPerSecond": 73.12,
+            "costPerTask": 0.9017,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 37.3,
+            "outputTokensPerSecond": 80.46,
+            "costPerTask": 1.5413,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 38.6,
+            "outputTokensPerSecond": 85.03,
+            "costPerTask": 2.634,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gpt-4o-2024-11-20",
+        "label": "GPT-4o (2024-11-20)",
+        "modelFamily": "GPT",
+        "inputCostPerMillionTokens": 2.5,
+        "outputCostPerMillionTokens": 10,
+        "cachedInputCostPerMillionTokens": 1.25,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 16384,
+        "modalities": ["image"],
+        "benchmark": {
+          "intelligenceIndex": 9,
+          "measuredAt": "2026-09-12"
+        }
+      }
+    ]
+  },
+  "anthropic": {
+    "models": [
+      {
+        "name": "claude-sonnet-4-6",
+        "label": "Claude Sonnet 4.6",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 3,
+        "outputCostPerMillionTokens": 15,
+        "cachedInputCostPerMillionTokens": 0.3,
+        "cacheCreationCostPerMillionTokens": 3.75,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "max"],
+        "benchmark": {
+          "intelligenceIndex": 30.5,
+          "outputTokensPerSecond": 55.74,
+          "costPerTask": 2.4859,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "low": {
+            "intelligenceIndex": 23.3,
+            "outputTokensPerSecond": 42.24,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 24.7,
+            "outputTokensPerSecond": 42.38,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 30.5,
+            "outputTokensPerSecond": 55.74,
+            "costPerTask": 2.4859,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "claude-opus-5",
+        "label": "Claude Opus 5",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 5,
+        "outputCostPerMillionTokens": 25,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "cacheCreationCostPerMillionTokens": 6.25,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 50.7,
+          "outputTokensPerSecond": 51.5,
+          "costPerTask": 5.8584,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "low": {
+            "intelligenceIndex": 39.8,
+            "outputTokensPerSecond": 47.77,
+            "costPerTask": 1.0983,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 45.1,
+            "outputTokensPerSecond": 48.27,
+            "costPerTask": 2.1895,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 48.2,
+            "outputTokensPerSecond": 50.34,
+            "costPerTask": 3.6133,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 49.7,
+            "outputTokensPerSecond": 50.56,
+            "costPerTask": 4.8778,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 50.7,
+            "outputTokensPerSecond": 51.5,
+            "costPerTask": 5.8584,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "claude-opus-4-5",
+        "label": "Claude Opus 4.5 (latest)",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 5,
+        "outputCostPerMillionTokens": 25,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "cacheCreationCostPerMillionTokens": 6.25,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 64000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 29.1,
+          "outputTokensPerSecond": 45.22,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "claude-fable-5-1",
+        "label": "Claude Fable 5.1",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 10,
+        "outputCostPerMillionTokens": 50,
+        "cachedInputCostPerMillionTokens": 0.25,
+        "cacheCreationCostPerMillionTokens": 12.5,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 53.4,
+          "outputTokensPerSecond": 66.72,
+          "costPerTask": 7.6297,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "low": {
+            "intelligenceIndex": 47,
+            "outputTokensPerSecond": 46.62,
+            "costPerTask": 2.371,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 49.1,
+            "outputTokensPerSecond": 49.63,
+            "costPerTask": 2.9826,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 51.2,
+            "outputTokensPerSecond": 49.2,
+            "costPerTask": 3.9125,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 53.2,
+            "outputTokensPerSecond": 59.54,
+            "costPerTask": 5.9783,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 53.4,
+            "outputTokensPerSecond": 66.72,
+            "costPerTask": 7.6297,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "claude-opus-4-6",
+        "label": "Claude Opus 4.6",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 5,
+        "outputCostPerMillionTokens": 25,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "cacheCreationCostPerMillionTokens": 6.25,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "max"],
+        "benchmark": {
+          "intelligenceIndex": 31.9,
+          "outputTokensPerSecond": 39.11,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "high": {
+            "intelligenceIndex": 26.4,
+            "outputTokensPerSecond": 36.56,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 31.9,
+            "outputTokensPerSecond": 39.11,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "claude-sonnet-4-5-20250929",
+        "label": "Claude Sonnet 4.5",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 3,
+        "outputCostPerMillionTokens": 15,
+        "cachedInputCostPerMillionTokens": 0.3,
+        "cacheCreationCostPerMillionTokens": 3.75,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 64000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "claude-opus-4-7",
+        "label": "Claude Opus 4.7",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 5,
+        "outputCostPerMillionTokens": 25,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "cacheCreationCostPerMillionTokens": 6.25,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 40.7,
+          "outputTokensPerSecond": 43.55,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "high": {
+            "intelligenceIndex": 30.9,
+            "outputTokensPerSecond": 43.22,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 40.7,
+            "outputTokensPerSecond": 43.55,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "claude-haiku-4-5-20251001",
+        "label": "Claude Haiku 4.5",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 1,
+        "outputCostPerMillionTokens": 5,
+        "cachedInputCostPerMillionTokens": 0.1,
+        "cacheCreationCostPerMillionTokens": 1.25,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 64000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "claude-fable-5",
+        "label": "Claude Fable 5",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 10,
+        "outputCostPerMillionTokens": 50,
+        "cachedInputCostPerMillionTokens": 1,
+        "cacheCreationCostPerMillionTokens": 12.5,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 49.7,
+          "outputTokensPerSecond": 66.38,
+          "costPerTask": 8.746,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "max": {
+            "intelligenceIndex": 49.7,
+            "outputTokensPerSecond": 66.38,
+            "costPerTask": 8.746,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "claude-haiku-4-5",
+        "label": "Claude Haiku 4.5 (latest)",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 1,
+        "outputCostPerMillionTokens": 5,
+        "cachedInputCostPerMillionTokens": 0.1,
+        "cacheCreationCostPerMillionTokens": 1.25,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 64000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "claude-sonnet-4-5",
+        "label": "Claude Sonnet 4.5 (latest)",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 3,
+        "outputCostPerMillionTokens": 15,
+        "cachedInputCostPerMillionTokens": 0.3,
+        "cacheCreationCostPerMillionTokens": 3.75,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 64000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "claude-opus-4-8",
+        "label": "Claude Opus 4.8",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 5,
+        "outputCostPerMillionTokens": 25,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "cacheCreationCostPerMillionTokens": 6.25,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 42,
+          "outputTokensPerSecond": 57.66,
+          "costPerTask": 4.081,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "max": {
+            "intelligenceIndex": 42,
+            "outputTokensPerSecond": 57.66,
+            "costPerTask": 4.081,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "claude-sonnet-5",
+        "label": "Claude Sonnet 5",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 10,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "cacheCreationCostPerMillionTokens": 2.5,
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "benchmark": {
+          "intelligenceIndex": 38.4,
+          "outputTokensPerSecond": 74.17,
+          "costPerTask": 5.0912,
+          "effort": "max",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "low": {
+            "intelligenceIndex": 24.7,
+            "outputTokensPerSecond": 56.19,
+            "costPerTask": 0.5088,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 28.4,
+            "outputTokensPerSecond": 57.81,
+            "costPerTask": 0.9991,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 32,
+            "outputTokensPerSecond": 60.86,
+            "costPerTask": 1.7925,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 34.7,
+            "outputTokensPerSecond": 64.98,
+            "costPerTask": 2.872,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          },
+          "max": {
+            "intelligenceIndex": 38.4,
+            "outputTokensPerSecond": 74.17,
+            "costPerTask": 5.0912,
+            "effort": "max",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "claude-opus-4-5-20251101",
+        "label": "Claude Opus 4.5",
+        "modelFamily": "CLAUDE",
+        "inputCostPerMillionTokens": 5,
+        "outputCostPerMillionTokens": 25,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "cacheCreationCostPerMillionTokens": 6.25,
+        "contextWindowTokens": 200000,
+        "maxOutputTokens": 64000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 29.1,
+          "outputTokensPerSecond": 45.22,
+          "measuredAt": "2026-09-12"
+        }
+      }
+    ]
+  },
+  "google": {
+    "models": [
+      {
+        "name": "gemini-3.1-pro-preview-customtools",
+        "label": "Gemini 3.1 Pro Preview Custom Tools",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 12,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 4,
+          "outputCostPerMillionTokens": 18,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4
+        },
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gemini-3.1-flash-lite-image",
+        "label": "Nano Banana 2 Lite",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.25,
+        "outputCostPerMillionTokens": 30,
+        "contextWindowTokens": 65536,
+        "maxOutputTokens": 65536,
+        "modalities": ["image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "deep-research-max-preview-04-2026",
+        "label": "Deep Research Max Preview (Apr-21-2026)",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 12,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 4,
+          "outputCostPerMillionTokens": 18,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4
+        },
+        "contextWindowTokens": 131072,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gemini-3.1-pro-preview",
+        "label": "Gemini 3.1 Pro Preview",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 12,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 4,
+          "outputCostPerMillionTokens": 18,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4
+        },
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 30.4,
+          "outputTokensPerSecond": 107.99,
+          "costPerTask": 0.6747,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "deep-research-preview-04-2026",
+        "label": "Deep Research Preview (Apr-21-2026)",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 12,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 4,
+          "outputCostPerMillionTokens": 18,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4
+        },
+        "contextWindowTokens": 131072,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gemini-2.5-flash-lite",
+        "label": "Gemini 2.5 Flash-Lite",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.1,
+        "outputCostPerMillionTokens": 0.4,
+        "cachedInputCostPerMillionTokens": 0.01,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "audio", "video", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 8.5,
+          "outputTokensPerSecond": 334,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gemini-2.5-computer-use-preview-10-2025",
+        "label": "Gemini 2.5 Computer Use Preview 10-2025",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 1.25,
+        "outputCostPerMillionTokens": 10,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 2.5,
+          "outputCostPerMillionTokens": 15,
+          "thresholdTokens": 200000
+        },
+        "contextWindowTokens": 131072,
+        "maxOutputTokens": 65536,
+        "modalities": ["image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gemini-3.6-flash",
+        "label": "Gemini 3.6 Flash",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.75,
+        "outputCostPerMillionTokens": 3.75,
+        "cachedInputCostPerMillionTokens": 0.075,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["minimal", "low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 34.3,
+          "outputTokensPerSecond": 195.28,
+          "costPerTask": 0.9288,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "high": {
+            "intelligenceIndex": 34.3,
+            "outputTokensPerSecond": 195.28,
+            "costPerTask": 0.9288,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gemini-3.1-flash-lite",
+        "label": "Gemini 3.1 Flash Lite",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.25,
+        "outputCostPerMillionTokens": 1.5,
+        "cachedInputCostPerMillionTokens": 0.025,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 16,
+          "outputTokensPerSecond": 287.6,
+          "costPerTask": 0.0394,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gemini-3.1-flash-live-preview",
+        "label": "Gemini 3.1 Flash Live Preview",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.75,
+        "outputCostPerMillionTokens": 4.5,
+        "contextWindowTokens": 131072,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "gemini-3.5-flash",
+        "label": "Gemini 3.5 Flash",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 1.5,
+        "outputCostPerMillionTokens": 9,
+        "cachedInputCostPerMillionTokens": 0.15,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["minimal", "low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 33.6,
+          "outputTokensPerSecond": 223.96,
+          "effort": "medium",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "minimal": {
+            "intelligenceIndex": 23.8,
+            "outputTokensPerSecond": 199.42,
+            "effort": "minimal",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 33.6,
+            "outputTokensPerSecond": 223.96,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 33,
+            "outputTokensPerSecond": 213.87,
+            "costPerTask": 1.5625,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gemini-3.1-flash-lite-preview",
+        "label": "Gemini 3.1 Flash Lite Preview",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.25,
+        "outputCostPerMillionTokens": 1.5,
+        "cachedInputCostPerMillionTokens": 0.025,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 16,
+          "outputTokensPerSecond": 287.6,
+          "costPerTask": 0.0394,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "gemini-3.5-flash-lite",
+        "label": "Gemini 3.5 Flash Lite",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.3,
+        "outputCostPerMillionTokens": 2.5,
+        "cachedInputCostPerMillionTokens": 0.03,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["minimal", "low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 22.7,
+          "outputTokensPerSecond": 372.37,
+          "costPerTask": 0.1235,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gemini-flash-lite-latest",
+        "label": "Gemini Flash-Lite Latest",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.3,
+        "outputCostPerMillionTokens": 2.5,
+        "cachedInputCostPerMillionTokens": 0.03,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 22.7,
+          "outputTokensPerSecond": 372.37,
+          "costPerTask": 0.1235,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gemini-3-flash-preview",
+        "label": "Gemini 3 Flash Preview",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.5,
+        "outputCostPerMillionTokens": 3,
+        "cachedInputCostPerMillionTokens": 0.05,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["minimal", "low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 26.3,
+          "outputTokensPerSecond": 184.98,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gemini-3.8-flash",
+        "label": "Gemini 3.8 Flash",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.75,
+        "outputCostPerMillionTokens": 3.75,
+        "cachedInputCostPerMillionTokens": 0.075,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 41.2,
+          "outputTokensPerSecond": 261.3,
+          "costPerTask": 1.2428,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "low": {
+            "intelligenceIndex": 33.8,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 40,
+            "costPerTask": 0.931,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 41.2,
+            "outputTokensPerSecond": 261.3,
+            "costPerTask": 1.2428,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gemini-3.7-flash",
+        "label": "Gemini 3.7 Flash",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.75,
+        "outputCostPerMillionTokens": 3.75,
+        "cachedInputCostPerMillionTokens": 0.075,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 39.6,
+          "outputTokensPerSecond": 272.47,
+          "effort": "medium",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "low": {
+            "intelligenceIndex": 36.9,
+            "outputTokensPerSecond": 287.13,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 39.6,
+            "outputTokensPerSecond": 272.47,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 39.4,
+            "outputTokensPerSecond": 294.7,
+            "costPerTask": 0.9253,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "gemini-2.5-pro",
+        "label": "Gemini 2.5 Pro",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 1.25,
+        "outputCostPerMillionTokens": 10,
+        "cachedInputCostPerMillionTokens": 0.125,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 2.5,
+          "outputCostPerMillionTokens": 15,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.25
+        },
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "audio", "video", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 16.7,
+          "outputTokensPerSecond": 120.75,
+          "costPerTask": 0.2317,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gemini-flash-latest",
+        "label": "Gemini Flash Latest",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.75,
+        "outputCostPerMillionTokens": 3.75,
+        "cachedInputCostPerMillionTokens": 0.075,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "video", "audio", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 41.2,
+          "outputTokensPerSecond": 261.3,
+          "costPerTask": 1.2428,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "gemini-2.5-flash",
+        "label": "Gemini 2.5 Flash",
+        "modelFamily": "GEMINI",
+        "inputCostPerMillionTokens": 0.3,
+        "outputCostPerMillionTokens": 2.5,
+        "cachedInputCostPerMillionTokens": 0.03,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 65536,
+        "modalities": ["image", "audio", "video", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 13.1,
+          "outputTokensPerSecond": 209.6,
+          "measuredAt": "2026-09-12"
+        }
+      }
+    ]
+  },
+  "mistral": {
+    "models": [
+      {
+        "name": "pixtral-12b",
+        "label": "Pixtral 12B",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.15,
+        "outputCostPerMillionTokens": 0.15,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"]
+      },
+      {
+        "name": "devstral-small-2507",
+        "label": "Devstral Small",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.1,
+        "outputCostPerMillionTokens": 0.3,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000,
+        "isDeprecated": true
+      },
+      {
+        "name": "mistral-small-2506",
+        "label": "Mistral Small 3.2",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.1,
+        "outputCostPerMillionTokens": 0.3,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 16384,
+        "modalities": ["image"]
+      },
+      {
+        "name": "magistral-small",
+        "label": "Magistral Small",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.5,
+        "outputCostPerMillionTokens": 1.5,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000,
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 8.2,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "devstral-2512",
+        "label": "Devstral 2",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.4,
+        "outputCostPerMillionTokens": 2,
+        "contextWindowTokens": 262144,
+        "maxOutputTokens": 262144,
+        "isDeprecated": true
+      },
+      {
+        "name": "devstral-small-2505",
+        "label": "Devstral Small 2505",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.1,
+        "outputCostPerMillionTokens": 0.3,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000,
+        "benchmark": {
+          "intelligenceIndex": 8.7,
+          "measuredAt": "2026-09-12"
+        },
+        "isDeprecated": true
+      },
+      {
+        "name": "labs-devstral-small-2512",
+        "label": "Devstral Small 2",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0,
+        "outputCostPerMillionTokens": 0,
+        "contextWindowTokens": 256000,
+        "maxOutputTokens": 256000,
+        "modalities": ["image"],
+        "isDeprecated": true
+      },
+      {
+        "name": "magistral-medium-latest",
+        "label": "Magistral Medium (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 5,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 16384,
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 9.1,
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "open-mixtral-8x22b",
+        "label": "Mixtral 8x22B",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 6,
+        "contextWindowTokens": 64000,
+        "maxOutputTokens": 64000
+      },
+      {
+        "name": "open-mixtral-8x7b",
+        "label": "Mixtral 8x7B",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.7,
+        "outputCostPerMillionTokens": 0.7,
+        "contextWindowTokens": 32000,
+        "maxOutputTokens": 32000
+      },
+      {
+        "name": "open-mistral-7b",
+        "label": "Mistral 7B",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.25,
+        "outputCostPerMillionTokens": 0.25,
+        "contextWindowTokens": 8000,
+        "maxOutputTokens": 8000
+      },
+      {
+        "name": "mistral-medium-latest",
+        "label": "Mistral Medium (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 1.5,
+        "outputCostPerMillionTokens": 7.5,
+        "contextWindowTokens": 262144,
+        "maxOutputTokens": 262144,
+        "modalities": ["image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "devstral-medium-2507",
+        "label": "Devstral Medium",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.4,
+        "outputCostPerMillionTokens": 2,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000,
+        "isDeprecated": true
+      },
+      {
+        "name": "mistral-medium-2604",
+        "label": "Mistral Medium 3.5",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 1.5,
+        "outputCostPerMillionTokens": 7.5,
+        "contextWindowTokens": 262144,
+        "maxOutputTokens": 262144,
+        "modalities": ["image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "mistral-large-2512",
+        "label": "Mistral Large 3",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.5,
+        "outputCostPerMillionTokens": 1.5,
+        "contextWindowTokens": 262144,
+        "maxOutputTokens": 262144,
+        "modalities": ["image"]
+      },
+      {
+        "name": "devstral-medium-latest",
+        "label": "Devstral 2 (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.4,
+        "outputCostPerMillionTokens": 2,
+        "contextWindowTokens": 262144,
+        "maxOutputTokens": 262144,
+        "isDeprecated": true
+      },
+      {
+        "name": "voxtral-small-latest",
+        "label": "Voxtral Small (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.1,
+        "outputCostPerMillionTokens": 0.3,
+        "contextWindowTokens": 32000,
+        "maxOutputTokens": 32000,
+        "modalities": ["audio"]
+      },
+      {
+        "name": "ministral-8b-latest",
+        "label": "Ministral 8B (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.1,
+        "outputCostPerMillionTokens": 0.1,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000
+      },
+      {
+        "name": "mistral-nemo",
+        "label": "Mistral Nemo",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.15,
+        "outputCostPerMillionTokens": 0.15,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000
+      },
+      {
+        "name": "mistral-small-latest",
+        "label": "Mistral Small (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.15,
+        "outputCostPerMillionTokens": 0.6,
+        "contextWindowTokens": 256000,
+        "maxOutputTokens": 256000,
+        "modalities": ["image"],
+        "supportsReasoning": true,
+        "efforts": ["none", "high"]
+      },
+      {
+        "name": "open-mistral-nemo",
+        "label": "Open Mistral Nemo",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.15,
+        "outputCostPerMillionTokens": 0.15,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000,
+        "isDeprecated": true
+      },
+      {
+        "name": "mistral-large-latest",
+        "label": "Mistral Large (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.5,
+        "outputCostPerMillionTokens": 1.5,
+        "contextWindowTokens": 262144,
+        "maxOutputTokens": 262144,
+        "modalities": ["image"]
+      },
+      {
+        "name": "mistral-large-2411",
+        "label": "Mistral Large 2.1",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 6,
+        "contextWindowTokens": 131072,
+        "maxOutputTokens": 16384
+      },
+      {
+        "name": "devstral-latest",
+        "label": "Devstral 2",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.4,
+        "outputCostPerMillionTokens": 2,
+        "contextWindowTokens": 262144,
+        "maxOutputTokens": 262144,
+        "isDeprecated": true
+      },
+      {
+        "name": "mistral-small-2603",
+        "label": "Mistral Small 4",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.15,
+        "outputCostPerMillionTokens": 0.6,
+        "contextWindowTokens": 256000,
+        "maxOutputTokens": 256000,
+        "modalities": ["image"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "mistral-medium-2505",
+        "label": "Mistral Medium 3",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.4,
+        "outputCostPerMillionTokens": 2,
+        "contextWindowTokens": 131072,
+        "maxOutputTokens": 131072,
+        "modalities": ["image"]
+      },
+      {
+        "name": "codestral-latest",
+        "label": "Codestral (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.3,
+        "outputCostPerMillionTokens": 0.9,
+        "contextWindowTokens": 256000,
+        "maxOutputTokens": 4096
+      },
+      {
+        "name": "ministral-3b-latest",
+        "label": "Ministral 3B (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.04,
+        "outputCostPerMillionTokens": 0.04,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000
+      },
+      {
+        "name": "mistral-medium-2508",
+        "label": "Mistral Medium 3.1",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 0.4,
+        "outputCostPerMillionTokens": 2,
+        "contextWindowTokens": 262144,
+        "maxOutputTokens": 262144,
+        "modalities": ["image"]
+      },
+      {
+        "name": "pixtral-large-latest",
+        "label": "Pixtral Large (latest)",
+        "modelFamily": "MISTRAL",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 6,
+        "contextWindowTokens": 128000,
+        "maxOutputTokens": 128000,
+        "modalities": ["image"],
+        "benchmark": {
+          "intelligenceIndex": 7.1,
+          "measuredAt": "2026-09-12"
+        }
+      }
+    ]
+  },
+  "xai": {
+    "models": [
+      {
+        "name": "grok-4.3",
+        "label": "Grok 4.3",
+        "modelFamily": "GROK",
+        "inputCostPerMillionTokens": 1.25,
+        "outputCostPerMillionTokens": 2.5,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 2.5,
+          "outputCostPerMillionTokens": 5,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4
+        },
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 30000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "benchmark": {
+          "intelligenceIndex": 25.4,
+          "outputTokensPerSecond": 119.35,
+          "costPerTask": 0.1653,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        }
+      },
+      {
+        "name": "grok-4.20-0309-reasoning",
+        "label": "Grok 4.20 (Reasoning)",
+        "modelFamily": "GROK",
+        "inputCostPerMillionTokens": 1.25,
+        "outputCostPerMillionTokens": 2.5,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 2.5,
+          "outputCostPerMillionTokens": 5,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4
+        },
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 30000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "grok-4.5",
+        "label": "Grok 4.5",
+        "modelFamily": "GROK",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 6,
+        "cachedInputCostPerMillionTokens": 0.3,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 4,
+          "outputCostPerMillionTokens": 12,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.6
+        },
+        "contextWindowTokens": 500000,
+        "maxOutputTokens": 500000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high"],
+        "benchmark": {
+          "intelligenceIndex": 39.1,
+          "outputTokensPerSecond": 54.84,
+          "costPerTask": 1.0365,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "high": {
+            "intelligenceIndex": 39.1,
+            "outputTokensPerSecond": 54.84,
+            "costPerTask": 1.0365,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "grok-build-0.1",
+        "label": "Grok Build 0.1",
+        "modelFamily": "GROK",
+        "inputCostPerMillionTokens": 1,
+        "outputCostPerMillionTokens": 2,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 2,
+          "outputCostPerMillionTokens": 4,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4
+        },
+        "contextWindowTokens": 256000,
+        "maxOutputTokens": 256000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true
+      },
+      {
+        "name": "grok-4.6",
+        "label": "Grok 4.6",
+        "modelFamily": "GROK",
+        "inputCostPerMillionTokens": 2,
+        "outputCostPerMillionTokens": 6,
+        "cachedInputCostPerMillionTokens": 0.5,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 4,
+          "outputCostPerMillionTokens": 12,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 1
+        },
+        "contextWindowTokens": 500000,
+        "maxOutputTokens": 500000,
+        "modalities": ["image", "pdf"],
+        "supportsReasoning": true,
+        "efforts": ["low", "medium", "high", "xhigh"],
+        "benchmark": {
+          "intelligenceIndex": 44.4,
+          "outputTokensPerSecond": 55.41,
+          "costPerTask": 1.8589,
+          "effort": "high",
+          "measuredAt": "2026-09-12"
+        },
+        "benchmarkByEffort": {
+          "low": {
+            "intelligenceIndex": 35.4,
+            "outputTokensPerSecond": 49.15,
+            "costPerTask": 0.4753,
+            "effort": "low",
+            "measuredAt": "2026-09-12"
+          },
+          "medium": {
+            "intelligenceIndex": 43,
+            "outputTokensPerSecond": 52.18,
+            "costPerTask": 1.4963,
+            "effort": "medium",
+            "measuredAt": "2026-09-12"
+          },
+          "high": {
+            "intelligenceIndex": 44.4,
+            "outputTokensPerSecond": 55.41,
+            "costPerTask": 1.8589,
+            "effort": "high",
+            "measuredAt": "2026-09-12"
+          },
+          "xhigh": {
+            "intelligenceIndex": 44.3,
+            "outputTokensPerSecond": 52.58,
+            "costPerTask": 2.3237,
+            "effort": "xhigh",
+            "measuredAt": "2026-09-12"
+          }
+        }
+      },
+      {
+        "name": "grok-4.20-0309-non-reasoning",
+        "label": "Grok 4.20 (Non-Reasoning)",
+        "modelFamily": "GROK",
+        "inputCostPerMillionTokens": 1.25,
+        "outputCostPerMillionTokens": 2.5,
+        "cachedInputCostPerMillionTokens": 0.2,
+        "longContextCost": {
+          "inputCostPerMillionTokens": 2.5,
+          "outputCostPerMillionTokens": 5,
+          "thresholdTokens": 200000,
+          "cachedInputCostPerMillionTokens": 0.4
+        },
+        "contextWindowTokens": 1000000,
+        "maxOutputTokens": 30000,
+        "modalities": ["image", "pdf"],
+        "benchmark": {
+          "intelligenceIndex": 14.6,
+          "effort": "none",
+          "measuredAt": "2026-09-12"
+        }
+      }
+    ]
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/ai-models.json
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/ai-models.json
@@ -14,9 +14,9 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 13,
-          "outputTokensPerSecond": 143.09,
+          "outputTokensPerSecond": 150.72,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -32,7 +32,7 @@
         "benchmark": {
           "intelligenceIndex": 7.8,
           "outputTokensPerSecond": 116.69,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -47,8 +47,8 @@
         "modalities": ["image"],
         "benchmark": {
           "intelligenceIndex": 7.3,
-          "outputTokensPerSecond": 85.36,
-          "measuredAt": "2026-09-12"
+          "outputTokensPerSecond": 100.41,
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -85,52 +85,52 @@
         "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 47.1,
-          "outputTokensPerSecond": 59.58,
+          "outputTokensPerSecond": 57.38,
           "costPerTask": 1.9885,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "none": {
             "intelligenceIndex": 28.3,
             "outputTokensPerSecond": 61.66,
             "effort": "none",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "low": {
             "intelligenceIndex": 33.8,
-            "outputTokensPerSecond": 52.9,
+            "outputTokensPerSecond": 56.34,
             "costPerTask": 0.2606,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 39.5,
             "outputTokensPerSecond": 56.62,
             "costPerTask": 0.505,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 42.5,
             "outputTokensPerSecond": 60.67,
             "costPerTask": 0.808,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 44.1,
             "outputTokensPerSecond": 61.12,
             "costPerTask": 1.1844,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 47.1,
-            "outputTokensPerSecond": 59.58,
+            "outputTokensPerSecond": 57.38,
             "costPerTask": 1.9885,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -147,7 +147,7 @@
         "benchmark": {
           "intelligenceIndex": 7.7,
           "outputTokensPerSecond": 88.48,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -172,46 +172,46 @@
         "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 52.8,
-          "outputTokensPerSecond": 54.41,
+          "outputTokensPerSecond": 56,
           "costPerTask": 3.2575,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "low": {
             "intelligenceIndex": 46,
-            "outputTokensPerSecond": 51.23,
+            "outputTokensPerSecond": 52.11,
             "costPerTask": 0.8175,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 49.7,
-            "outputTokensPerSecond": 49.88,
+            "outputTokensPerSecond": 49.98,
             "costPerTask": 1.5406,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 51,
             "outputTokensPerSecond": 49.81,
             "costPerTask": 1.7214,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 52.5,
-            "outputTokensPerSecond": 51.44,
+            "outputTokensPerSecond": 51.14,
             "costPerTask": 2.3088,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 52.8,
-            "outputTokensPerSecond": 54.41,
+            "outputTokensPerSecond": 56,
             "costPerTask": 3.2575,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -250,8 +250,8 @@
         "modalities": ["image", "pdf"],
         "benchmark": {
           "intelligenceIndex": 10.2,
-          "outputTokensPerSecond": 107.07,
-          "measuredAt": "2026-09-12"
+          "outputTokensPerSecond": 106.21,
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -274,28 +274,28 @@
         "efforts": ["none", "low", "medium", "high", "xhigh"],
         "benchmark": {
           "intelligenceIndex": 39,
-          "outputTokensPerSecond": 132.23,
+          "outputTokensPerSecond": 131.5,
           "effort": "xhigh",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "none": {
             "intelligenceIndex": 18.2,
-            "outputTokensPerSecond": 91.22,
+            "outputTokensPerSecond": 92.12,
             "effort": "none",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "low": {
             "intelligenceIndex": 27.6,
             "outputTokensPerSecond": 90.64,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 39,
-            "outputTokensPerSecond": 132.23,
+            "outputTokensPerSecond": 131.5,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -311,7 +311,7 @@
         "benchmark": {
           "intelligenceIndex": 7,
           "outputTokensPerSecond": 31.1,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -330,7 +330,7 @@
           "intelligenceIndex": 24.7,
           "outputTokensPerSecond": 99.46,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -346,7 +346,7 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 15.2,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -362,7 +362,7 @@
         "modalities": ["image", "pdf"],
         "benchmark": {
           "intelligenceIndex": 9,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -387,52 +387,52 @@
         "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 37.5,
-          "outputTokensPerSecond": 111.93,
+          "outputTokensPerSecond": 119.03,
           "costPerTask": 0.1783,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "none": {
             "intelligenceIndex": 16.8,
-            "outputTokensPerSecond": 109.79,
+            "outputTokensPerSecond": 104.26,
             "effort": "none",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "low": {
             "intelligenceIndex": 21.5,
-            "outputTokensPerSecond": 104.61,
+            "outputTokensPerSecond": 105.4,
             "costPerTask": 0.0098,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 25.5,
             "outputTokensPerSecond": 104.37,
             "costPerTask": 0.0156,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 32.4,
-            "outputTokensPerSecond": 108.19,
+            "outputTokensPerSecond": 101.18,
             "costPerTask": 0.044,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 34.8,
             "outputTokensPerSecond": 108.33,
             "costPerTask": 0.0853,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 37.5,
-            "outputTokensPerSecond": 111.93,
+            "outputTokensPerSecond": 119.03,
             "costPerTask": 0.1783,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -451,7 +451,7 @@
           "intelligenceIndex": 32.5,
           "outputTokensPerSecond": 127.21,
           "effort": "xhigh",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -466,8 +466,8 @@
         "modalities": ["image", "pdf"],
         "benchmark": {
           "intelligenceIndex": 6.7,
-          "outputTokensPerSecond": 149.59,
-          "measuredAt": "2026-09-12"
+          "outputTokensPerSecond": 150.95,
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -482,7 +482,7 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 12.4,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -498,8 +498,8 @@
         "modalities": ["image", "pdf"],
         "benchmark": {
           "intelligenceIndex": 12.7,
-          "outputTokensPerSecond": 162.59,
-          "measuredAt": "2026-09-12"
+          "outputTokensPerSecond": 151.06,
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -515,10 +515,10 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 21.2,
-          "outputTokensPerSecond": 153.71,
+          "outputTokensPerSecond": 154.16,
           "costPerTask": 0.1831,
           "effort": "xhigh",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -550,10 +550,10 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 24.6,
-          "outputTokensPerSecond": 173.66,
+          "outputTokensPerSecond": 186.25,
           "costPerTask": 0.4097,
           "effort": "xhigh",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -589,9 +589,9 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 20.6,
-          "outputTokensPerSecond": 93.42,
+          "outputTokensPerSecond": 86.09,
           "effort": "medium",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -632,52 +632,52 @@
         "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 42.3,
-          "outputTokensPerSecond": 87.05,
+          "outputTokensPerSecond": 97.3,
           "costPerTask": 1.3987,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "none": {
             "intelligenceIndex": 22.3,
-            "outputTokensPerSecond": 74.84,
+            "outputTokensPerSecond": 85.24,
             "effort": "none",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "low": {
             "intelligenceIndex": 27.9,
-            "outputTokensPerSecond": 75.27,
+            "outputTokensPerSecond": 81.07,
             "costPerTask": 0.1445,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 30.4,
-            "outputTokensPerSecond": 76.41,
+            "outputTokensPerSecond": 85.38,
             "costPerTask": 0.1834,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 34.5,
             "outputTokensPerSecond": 79.06,
             "costPerTask": 0.3379,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 38.2,
-            "outputTokensPerSecond": 76.14,
+            "outputTokensPerSecond": 82.58,
             "costPerTask": 0.6318,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 42.3,
-            "outputTokensPerSecond": 87.05,
+            "outputTokensPerSecond": 97.3,
             "costPerTask": 1.3987,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -691,7 +691,7 @@
         "maxOutputTokens": 8192,
         "benchmark": {
           "intelligenceIndex": 6.7,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -708,9 +708,9 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 30.4,
-          "outputTokensPerSecond": 70.17,
+          "outputTokensPerSecond": 64.67,
           "effort": "xhigh",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -726,9 +726,9 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 23,
-          "outputTokensPerSecond": 75.68,
+          "outputTokensPerSecond": 90.91,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -759,7 +759,7 @@
           "intelligenceIndex": 16.7,
           "outputTokensPerSecond": 135.62,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -788,7 +788,7 @@
         "benchmark": {
           "intelligenceIndex": 12.5,
           "outputTokensPerSecond": 219.12,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -805,8 +805,8 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 20.2,
-          "outputTokensPerSecond": 107.06,
-          "measuredAt": "2026-09-12"
+          "outputTokensPerSecond": 107.03,
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -821,7 +821,7 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 21.9,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -856,44 +856,44 @@
         "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 38.6,
-          "outputTokensPerSecond": 85.03,
+          "outputTokensPerSecond": 79.68,
           "costPerTask": 2.634,
           "effort": "xhigh",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "none": {
             "intelligenceIndex": 23.2,
             "outputTokensPerSecond": 77.88,
             "effort": "none",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "low": {
             "intelligenceIndex": 30.7,
-            "outputTokensPerSecond": 75.57,
+            "outputTokensPerSecond": 82.33,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 34.2,
             "outputTokensPerSecond": 73.12,
             "costPerTask": 0.9017,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 37.3,
             "outputTokensPerSecond": 80.46,
             "costPerTask": 1.5413,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 38.6,
-            "outputTokensPerSecond": 85.03,
+            "outputTokensPerSecond": 79.68,
             "costPerTask": 2.634,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -909,7 +909,7 @@
         "modalities": ["image"],
         "benchmark": {
           "intelligenceIndex": 9,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       }
     ]
@@ -931,30 +931,30 @@
         "efforts": ["low", "medium", "high", "max"],
         "benchmark": {
           "intelligenceIndex": 30.5,
-          "outputTokensPerSecond": 55.74,
+          "outputTokensPerSecond": 53.65,
           "costPerTask": 2.4859,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "low": {
             "intelligenceIndex": 23.3,
             "outputTokensPerSecond": 42.24,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 24.7,
-            "outputTokensPerSecond": 42.38,
+            "outputTokensPerSecond": 42,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 30.5,
-            "outputTokensPerSecond": 55.74,
+            "outputTokensPerSecond": 53.65,
             "costPerTask": 2.4859,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -973,46 +973,46 @@
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 50.7,
-          "outputTokensPerSecond": 51.5,
+          "outputTokensPerSecond": 50.41,
           "costPerTask": 5.8584,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "low": {
             "intelligenceIndex": 39.8,
-            "outputTokensPerSecond": 47.77,
+            "outputTokensPerSecond": 47.63,
             "costPerTask": 1.0983,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 45.1,
             "outputTokensPerSecond": 48.27,
             "costPerTask": 2.1895,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 48.2,
             "outputTokensPerSecond": 50.34,
             "costPerTask": 3.6133,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 49.7,
-            "outputTokensPerSecond": 50.56,
+            "outputTokensPerSecond": 49.3,
             "costPerTask": 4.8778,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 50.7,
-            "outputTokensPerSecond": 51.5,
+            "outputTokensPerSecond": 50.41,
             "costPerTask": 5.8584,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1031,8 +1031,8 @@
         "efforts": ["low", "medium", "high"],
         "benchmark": {
           "intelligenceIndex": 29.1,
-          "outputTokensPerSecond": 45.22,
-          "measuredAt": "2026-09-12"
+          "outputTokensPerSecond": 44.74,
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1050,46 +1050,46 @@
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 53.4,
-          "outputTokensPerSecond": 66.72,
+          "outputTokensPerSecond": 65.8,
           "costPerTask": 7.6297,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "low": {
             "intelligenceIndex": 47,
-            "outputTokensPerSecond": 46.62,
+            "outputTokensPerSecond": 47.44,
             "costPerTask": 2.371,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 49.1,
             "outputTokensPerSecond": 49.63,
             "costPerTask": 2.9826,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 51.2,
             "outputTokensPerSecond": 49.2,
             "costPerTask": 3.9125,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 53.2,
-            "outputTokensPerSecond": 59.54,
+            "outputTokensPerSecond": 57.28,
             "costPerTask": 5.9783,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 53.4,
-            "outputTokensPerSecond": 66.72,
+            "outputTokensPerSecond": 65.8,
             "costPerTask": 7.6297,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1110,20 +1110,20 @@
           "intelligenceIndex": 31.9,
           "outputTokensPerSecond": 39.11,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "high": {
             "intelligenceIndex": 26.4,
             "outputTokensPerSecond": 36.56,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 31.9,
             "outputTokensPerSecond": 39.11,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1155,22 +1155,22 @@
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 40.7,
-          "outputTokensPerSecond": 43.55,
+          "outputTokensPerSecond": 44.18,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "high": {
             "intelligenceIndex": 30.9,
-            "outputTokensPerSecond": 43.22,
+            "outputTokensPerSecond": 43.39,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 40.7,
-            "outputTokensPerSecond": 43.55,
+            "outputTokensPerSecond": 44.18,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1202,18 +1202,18 @@
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 49.7,
-          "outputTokensPerSecond": 66.38,
+          "outputTokensPerSecond": 66.79,
           "costPerTask": 8.746,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "max": {
             "intelligenceIndex": 49.7,
-            "outputTokensPerSecond": 66.38,
+            "outputTokensPerSecond": 66.79,
             "costPerTask": 8.746,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1255,23 +1255,7 @@
         "maxOutputTokens": 128000,
         "modalities": ["image", "pdf"],
         "supportsReasoning": true,
-        "efforts": ["low", "medium", "high", "xhigh", "max"],
-        "benchmark": {
-          "intelligenceIndex": 42,
-          "outputTokensPerSecond": 57.66,
-          "costPerTask": 4.081,
-          "effort": "max",
-          "measuredAt": "2026-09-12"
-        },
-        "benchmarkByEffort": {
-          "max": {
-            "intelligenceIndex": 42,
-            "outputTokensPerSecond": 57.66,
-            "costPerTask": 4.081,
-            "effort": "max",
-            "measuredAt": "2026-09-12"
-          }
-        }
+        "efforts": ["low", "medium", "high", "xhigh", "max"]
       },
       {
         "name": "claude-sonnet-5",
@@ -1288,46 +1272,46 @@
         "efforts": ["low", "medium", "high", "xhigh", "max"],
         "benchmark": {
           "intelligenceIndex": 38.4,
-          "outputTokensPerSecond": 74.17,
+          "outputTokensPerSecond": 72.97,
           "costPerTask": 5.0912,
           "effort": "max",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "low": {
             "intelligenceIndex": 24.7,
-            "outputTokensPerSecond": 56.19,
+            "outputTokensPerSecond": 55.84,
             "costPerTask": 0.5088,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 28.4,
             "outputTokensPerSecond": 57.81,
             "costPerTask": 0.9991,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 32,
-            "outputTokensPerSecond": 60.86,
+            "outputTokensPerSecond": 58.18,
             "costPerTask": 1.7925,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 34.7,
-            "outputTokensPerSecond": 64.98,
+            "outputTokensPerSecond": 62.4,
             "costPerTask": 2.872,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "max": {
             "intelligenceIndex": 38.4,
-            "outputTokensPerSecond": 74.17,
+            "outputTokensPerSecond": 72.97,
             "costPerTask": 5.0912,
             "effort": "max",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1346,8 +1330,8 @@
         "efforts": ["low", "medium", "high"],
         "benchmark": {
           "intelligenceIndex": 29.1,
-          "outputTokensPerSecond": 45.22,
-          "measuredAt": "2026-09-12"
+          "outputTokensPerSecond": 44.74,
+          "measuredAt": "2026-09-13"
         }
       }
     ]
@@ -1421,9 +1405,9 @@
         "efforts": ["low", "medium", "high"],
         "benchmark": {
           "intelligenceIndex": 30.4,
-          "outputTokensPerSecond": 107.99,
+          "outputTokensPerSecond": 109.62,
           "costPerTask": 0.6747,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1458,7 +1442,7 @@
         "benchmark": {
           "intelligenceIndex": 8.5,
           "outputTokensPerSecond": 334,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1494,7 +1478,7 @@
           "outputTokensPerSecond": 195.28,
           "costPerTask": 0.9288,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "high": {
@@ -1502,7 +1486,7 @@
             "outputTokensPerSecond": 195.28,
             "costPerTask": 0.9288,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1521,7 +1505,7 @@
           "intelligenceIndex": 16,
           "outputTokensPerSecond": 287.6,
           "costPerTask": 0.0394,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1551,27 +1535,27 @@
           "intelligenceIndex": 33.6,
           "outputTokensPerSecond": 223.96,
           "effort": "medium",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "minimal": {
             "intelligenceIndex": 23.8,
-            "outputTokensPerSecond": 199.42,
+            "outputTokensPerSecond": 205.07,
             "effort": "minimal",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 33.6,
             "outputTokensPerSecond": 223.96,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 33,
-            "outputTokensPerSecond": 213.87,
+            "outputTokensPerSecond": 211.91,
             "costPerTask": 1.5625,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1590,7 +1574,7 @@
           "intelligenceIndex": 16,
           "outputTokensPerSecond": 287.6,
           "costPerTask": 0.0394,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -1608,9 +1592,9 @@
         "efforts": ["minimal", "low", "medium", "high"],
         "benchmark": {
           "intelligenceIndex": 22.7,
-          "outputTokensPerSecond": 372.37,
+          "outputTokensPerSecond": 320.2,
           "costPerTask": 0.1235,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1626,9 +1610,9 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 22.7,
-          "outputTokensPerSecond": 372.37,
+          "outputTokensPerSecond": 320.2,
           "costPerTask": 0.1235,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1646,7 +1630,7 @@
         "benchmark": {
           "intelligenceIndex": 26.3,
           "outputTokensPerSecond": 184.98,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1666,26 +1650,26 @@
           "outputTokensPerSecond": 261.3,
           "costPerTask": 1.2428,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "low": {
             "intelligenceIndex": 33.8,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 40,
             "costPerTask": 0.931,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 41.2,
             "outputTokensPerSecond": 261.3,
             "costPerTask": 1.2428,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1705,27 +1689,27 @@
           "intelligenceIndex": 39.6,
           "outputTokensPerSecond": 272.47,
           "effort": "medium",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "low": {
             "intelligenceIndex": 36.9,
-            "outputTokensPerSecond": 287.13,
+            "outputTokensPerSecond": 273.31,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 39.6,
             "outputTokensPerSecond": 272.47,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 39.4,
-            "outputTokensPerSecond": 294.7,
+            "outputTokensPerSecond": 287.8,
             "costPerTask": 0.9253,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -1748,9 +1732,9 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 16.7,
-          "outputTokensPerSecond": 120.75,
+          "outputTokensPerSecond": 122.73,
           "costPerTask": 0.2317,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1769,7 +1753,7 @@
           "outputTokensPerSecond": 261.3,
           "costPerTask": 1.2428,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1785,8 +1769,8 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 13.1,
-          "outputTokensPerSecond": 209.6,
-          "measuredAt": "2026-09-12"
+          "outputTokensPerSecond": 211.65,
+          "measuredAt": "2026-09-13"
         }
       }
     ]
@@ -1834,7 +1818,7 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 8.2,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -1857,7 +1841,7 @@
         "maxOutputTokens": 128000,
         "benchmark": {
           "intelligenceIndex": 8.7,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "isDeprecated": true
       },
@@ -1883,7 +1867,7 @@
         "supportsReasoning": true,
         "benchmark": {
           "intelligenceIndex": 9.1,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -2104,7 +2088,7 @@
         "modalities": ["image"],
         "benchmark": {
           "intelligenceIndex": 7.1,
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       }
     ]
@@ -2133,7 +2117,7 @@
           "outputTokensPerSecond": 119.35,
           "costPerTask": 0.1653,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       },
       {
@@ -2177,7 +2161,7 @@
           "outputTokensPerSecond": 54.84,
           "costPerTask": 1.0365,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "high": {
@@ -2185,7 +2169,7 @@
             "outputTokensPerSecond": 54.84,
             "costPerTask": 1.0365,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -2227,39 +2211,39 @@
         "efforts": ["low", "medium", "high", "xhigh"],
         "benchmark": {
           "intelligenceIndex": 44.4,
-          "outputTokensPerSecond": 55.41,
+          "outputTokensPerSecond": 53.59,
           "costPerTask": 1.8589,
           "effort": "high",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         },
         "benchmarkByEffort": {
           "low": {
             "intelligenceIndex": 35.4,
-            "outputTokensPerSecond": 49.15,
+            "outputTokensPerSecond": 48.56,
             "costPerTask": 0.4753,
             "effort": "low",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "medium": {
             "intelligenceIndex": 43,
-            "outputTokensPerSecond": 52.18,
+            "outputTokensPerSecond": 49.99,
             "costPerTask": 1.4963,
             "effort": "medium",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "high": {
             "intelligenceIndex": 44.4,
-            "outputTokensPerSecond": 55.41,
+            "outputTokensPerSecond": 53.59,
             "costPerTask": 1.8589,
             "effort": "high",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           },
           "xhigh": {
             "intelligenceIndex": 44.3,
-            "outputTokensPerSecond": 52.58,
+            "outputTokensPerSecond": 54.05,
             "costPerTask": 2.3237,
             "effort": "xhigh",
-            "measuredAt": "2026-09-12"
+            "measuredAt": "2026-09-13"
           }
         }
       },
@@ -2282,7 +2266,7 @@
         "benchmark": {
           "intelligenceIndex": 14.6,
           "effort": "none",
-          "measuredAt": "2026-09-12"
+          "measuredAt": "2026-09-13"
         }
       }
     ]

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/ai-self-host-spec.json
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/ai-self-host-spec.json
@@ -1,0 +1,49 @@
+{
+  "providers": [
+    {
+      "name": "openai",
+      "npm": "@ai-sdk/openai",
+      "label": "OpenAI",
+      "apiKey": "{{OPENAI_API_KEY}}",
+      "models": {
+        "vendor": "openai"
+      }
+    },
+    {
+      "name": "anthropic",
+      "npm": "@ai-sdk/anthropic",
+      "label": "Anthropic",
+      "apiKey": "{{ANTHROPIC_API_KEY}}",
+      "models": {
+        "vendor": "anthropic"
+      }
+    },
+    {
+      "name": "google",
+      "npm": "@ai-sdk/google",
+      "label": "Google",
+      "apiKey": "{{GOOGLE_API_KEY}}",
+      "models": {
+        "vendor": "google"
+      }
+    },
+    {
+      "name": "mistral",
+      "npm": "@ai-sdk/mistral",
+      "label": "Mistral",
+      "apiKey": "{{MISTRAL_API_KEY}}",
+      "models": {
+        "vendor": "mistral"
+      }
+    },
+    {
+      "name": "xai",
+      "npm": "@ai-sdk/xai",
+      "label": "xAI",
+      "apiKey": "{{XAI_API_KEY}}",
+      "models": {
+        "vendor": "xai"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
First of two. This one adds the generator and puts self-host on it; the second gives twenty-infra its private specs.

## Why

The daily sync keeps one record of what every model is: identity and pricing from models.dev, intelligence, speed and cost per task from Artificial Analysis, effort levels carried over by hand. That is the truth about models.

A deployment serves a subset of those models through its own routes, and until now it restated them. Each cloud environment carried a second catalog with its own copy of prices, labels, context windows and modalities, written by hand and kept in step by nothing. Diffing those files against the catalog showed the result: almost every model was a verbatim copy, and where they differed it was a stale copy rather than a deliberate change. prod-eu lists the OpenAI models with `modalities: ["image"]` against the catalog's `["image", "pdf"]`, so it is quietly refusing PDFs.

The fields never copied at all are the ones that mattered. A deployment catalog carries no `efforts`, so no effort variant is registered and every tier chain entry pinned at an effort is unreachable. It carries no `benchmark`, so the product has nothing to compare models with.

## The shape

`ai-providers.json` used to be two things at once: the truth about models, and one deployment's view of it. That is why only cloud could get a spec. Splitting the two makes self-host and cloud the same mechanism:

| File | What it is |
| --- | --- |
| `ai-models.json` | What every model is. No routes, no credentials. Synced daily. |
| `ai-self-host-spec.json` | What a self-hosted deployment serves: the five direct routes and their key templates. |
| `ai-providers.json` | What the server bundles. Generated from the two above. |

Cloud is the same projection over a private spec. There is one generator and two callers.

## What a spec says

Only what belongs to the deployment: which routes exist, their credentials, and which catalog models each route serves.

```json
{
  "providers": [
    {
      "name": "azure-foundry",
      "npm": "@ai-sdk/azure",
      "apiKey": "{{AZURE_FOUNDRY_API_KEY}}",
      "dataResidency": "eu",
      "labelSuffix": " (Azure)",
      "models": ["gpt-5.6-luna", { "model": "gpt-5.6-sol", "cachedInputCostPerMillionTokens": 0.5 }]
    },
    { "name": "openai", "npm": "@ai-sdk/openai", "models": { "vendor": "openai" } }
  ]
}
```

A route may rename a model it deploys under another id, and override the prices it negotiated, the label and the deprecation flag. It cannot restate what a model is: context window, modalities, efforts, benchmark and per-effort benchmarks always come from the catalog. That is the property that makes the drift above impossible rather than merely fixed. Naming a model the catalog does not carry fails the run instead of publishing a route to nothing, which is the failure that put every tier on one model.

The second form is how self-host works: a route serving a whole vendor picks up new models with the daily sync instead of waiting for an edit. The provider labels and key templates that were hardcoded in `build-catalog.util.ts` now live in the spec.

## Nothing changes for self-hosters

`ai-providers.json` is unmodified in this PR: the projection of `ai-self-host-spec.json` over `ai-models.json` reproduces the committed file exactly, key order included, so the diff is zero. A new test fails if it ever stops matching, which is what stops the shipped catalog being hand-edited back into a second copy.

## Runnable from a sparse checkout

`project.ts` resolves everything by source path, node builtins and `packages/twenty-shared/src/ai` for the two guards. A repository holding a private spec runs it with `npx tsx` against a sparse checkout, no monorepo install and no API key. Verified in a bare directory holding only the script, that shared directory and `ai-models.json`: twenty-infra's prod-eu spec produces its committed catalog byte for byte.

## Scope

The daily sync now writes `ai-models.json` and projects self-host from it. 153 tests pass across the sync scripts and the ai-models module.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5ctWwYtKiq5VdfDG7ZvNy)_