### PR TITLE
fix(workflow): ensure SELECT filter IS/IS_NOT performs exact equality match (#25827)

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-filter-conditions.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-filter-conditions.util.spec.ts
@@ -361,6 +361,79 @@ describe('evaluateFilterConditions', () => {
 
         expect(evaluateFilterConditions({ filters: [filter] })).toBe(true);
       });
+    describe('Select filter operands', () => {
+      it('should return true for IS when select values match exactly', () => {
+        const filter = createFilter(
+          ViewFilterOperand.IS,
+          'ACTIVE',
+          'ACTIVE',
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filter] })).toBe(true);
+      });
+
+      it('should return false for IS when select value is a substring of filter value', () => {
+        const filter = createFilter(
+          ViewFilterOperand.IS,
+          'ACTIVE',
+          'INACTIVE',
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filter] })).toBe(false);
+      });
+
+      it('should return false for IS when filter value is a substring of select value', () => {
+        const filter = createFilter(
+          ViewFilterOperand.IS,
+          'INACTIVE',
+          'ACTIVE',
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filter] })).toBe(false);
+      });
+
+      it('should return true for IS_NOT when select values differ even if substrings overlap', () => {
+        const filter = createFilter(
+          ViewFilterOperand.IS_NOT,
+          'INACTIVE',
+          'ACTIVE',
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filter] })).toBe(true);
+      });
+
+      it('should return false for IS_NOT when select values match exactly', () => {
+        const filter = createFilter(
+          ViewFilterOperand.IS_NOT,
+          'ACTIVE',
+          'ACTIVE',
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filter] })).toBe(false);
+      });
+
+      it('should support array rightOperand for IS', () => {
+        const filterMatch = createFilter(
+          ViewFilterOperand.IS,
+          'ACTIVE',
+          ['PENDING', 'ACTIVE'],
+          'SELECT',
+        );
+        const filterNoMatch = createFilter(
+          ViewFilterOperand.IS,
+          'ARCHIVED',
+          ['PENDING', 'ACTIVE'],
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filterMatch] })).toBe(true);
+        expect(evaluateFilterConditions({ filters: [filterNoMatch] })).toBe(false);
+      });
     });
 
     describe('Rating filter operands', () => {

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-filter-conditions.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-filter-conditions.util.spec.ts
@@ -395,11 +395,44 @@ describe('evaluateFilterConditions', () => {
         expect(evaluateFilterConditions({ filters: [filter] })).toBe(false);
       });
 
+      it('should return false for IS when select value is substring in JSON-stringified array', () => {
+        const filter = createFilter(
+          ViewFilterOperand.IS,
+          'CUSTOMER_SUCCESS',
+          '["CUSTOMER"]',
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filter] })).toBe(false);
+      });
+
+      it('should return true for IS when select value matches element in JSON-stringified array', () => {
+        const filter = createFilter(
+          ViewFilterOperand.IS,
+          'CUSTOMER',
+          '["CUSTOMER", "LEAD"]',
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filter] })).toBe(true);
+      });
+
       it('should return true for IS_NOT when select values differ even if substrings overlap', () => {
         const filter = createFilter(
           ViewFilterOperand.IS_NOT,
           'INACTIVE',
           'ACTIVE',
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filter] })).toBe(true);
+      });
+
+      it('should return true for IS_NOT when select value is substring of JSON-stringified array element', () => {
+        const filter = createFilter(
+          ViewFilterOperand.IS_NOT,
+          'CUSTOMER_SUCCESS',
+          '["CUSTOMER"]',
           'SELECT',
         );
 
@@ -417,7 +450,7 @@ describe('evaluateFilterConditions', () => {
         expect(evaluateFilterConditions({ filters: [filter] })).toBe(false);
       });
 
-      it('should support array rightOperand for IS', () => {
+      it('should support array rightOperand for IS and IS_NOT', () => {
         const filterMatch = createFilter(
           ViewFilterOperand.IS,
           'ACTIVE',
@@ -430,9 +463,62 @@ describe('evaluateFilterConditions', () => {
           ['PENDING', 'ACTIVE'],
           'SELECT',
         );
+        const filterIsNotMatch = createFilter(
+          ViewFilterOperand.IS_NOT,
+          'ARCHIVED',
+          ['PENDING', 'ACTIVE'],
+          'SELECT',
+        );
+        const filterIsNotNoMatch = createFilter(
+          ViewFilterOperand.IS_NOT,
+          'ACTIVE',
+          ['PENDING', 'ACTIVE'],
+          'SELECT',
+        );
 
         expect(evaluateFilterConditions({ filters: [filterMatch] })).toBe(true);
         expect(evaluateFilterConditions({ filters: [filterNoMatch] })).toBe(false);
+        expect(evaluateFilterConditions({ filters: [filterIsNotMatch] })).toBe(true);
+        expect(evaluateFilterConditions({ filters: [filterIsNotNoMatch] })).toBe(false);
+      });
+
+      it('should handle IS_EMPTY and IS_NOT_EMPTY for select filter', () => {
+        const filterEmptyNull = createFilter(
+          ViewFilterOperand.IS_EMPTY,
+          null,
+          null,
+          'SELECT',
+        );
+        const filterEmptyEmptyString = createFilter(
+          ViewFilterOperand.IS_EMPTY,
+          '',
+          null,
+          'SELECT',
+        );
+        const filterEmptyWithValue = createFilter(
+          ViewFilterOperand.IS_EMPTY,
+          'ACTIVE',
+          null,
+          'SELECT',
+        );
+        const filterNotEmptyWithValue = createFilter(
+          ViewFilterOperand.IS_NOT_EMPTY,
+          'ACTIVE',
+          null,
+          'SELECT',
+        );
+        const filterNotEmptyNull = createFilter(
+          ViewFilterOperand.IS_NOT_EMPTY,
+          null,
+          null,
+          'SELECT',
+        );
+
+        expect(evaluateFilterConditions({ filters: [filterEmptyNull] })).toBe(true);
+        expect(evaluateFilterConditions({ filters: [filterEmptyEmptyString] })).toBe(true);
+        expect(evaluateFilterConditions({ filters: [filterEmptyWithValue] })).toBe(false);
+        expect(evaluateFilterConditions({ filters: [filterNotEmptyWithValue] })).toBe(true);
+        expect(evaluateFilterConditions({ filters: [filterNotEmptyNull] })).toBe(false);
       });
     });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-filter-conditions.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-filter-conditions.util.spec.ts
@@ -2175,3 +2175,5 @@ describe('evaluateFilterConditions', () => {
     });
   });
 });
+});
+

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-step-filters.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-step-filters.util.spec.ts
@@ -216,4 +216,40 @@ describe('evaluateStepFilters', () => {
       }),
     ).toBe(false);
   });
+
+  it('performs exact value match for SELECT filters and does not match substrings', () => {
+    const selectFilterExactMatch: StepFilter = {
+      id: 'filter-select-match',
+      type: 'SELECT',
+      operand: ViewFilterOperand.IS,
+      value: JSON.stringify(['Acme']),
+      stepOutputKey: '{{trigger.properties.after.name}}',
+      stepFilterGroupId: group.id,
+    };
+
+    const selectFilterSubstringNoMatch: StepFilter = {
+      id: 'filter-select-no-match',
+      type: 'SELECT',
+      operand: ViewFilterOperand.IS,
+      value: JSON.stringify(['Ac']),
+      stepOutputKey: '{{trigger.properties.after.name}}',
+      stepFilterGroupId: group.id,
+    };
+
+    expect(
+      evaluateStepFilters({
+        stepFilterGroups: [group],
+        stepFilters: [selectFilterExactMatch],
+        context,
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateStepFilters({
+        stepFilterGroups: [group],
+        stepFilters: [selectFilterSubstringNoMatch],
+        context,
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
@@ -485,33 +485,46 @@ function evaluateDefaultFilter(filter: ResolvedFilter): boolean {
   }
 }
 
-function evaluateSelectFilter(filter: ResolvedFilter): boolean {
-  const leftValue = filter.leftOperand;
-  const rightValue = filter.rightOperand;
+function isSelectMatch(leftValue: unknown, rightValue: unknown): boolean {
+  if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
+    return leftValue.some((item) => rightValue.includes(item));
+  }
 
+  if (Array.isArray(rightValue)) {
+    return rightValue.includes(leftValue);
+  }
+
+  if (Array.isArray(leftValue)) {
+    return leftValue.includes(rightValue);
+  }
+
+  if (isString(rightValue)) {
+    try {
+      const parsedRightValue = JSON.parse(rightValue);
+
+      if (Array.isArray(parsedRightValue)) {
+        if (Array.isArray(leftValue)) {
+          return leftValue.some((item) => parsedRightValue.includes(item));
+        }
+
+        return parsedRightValue.includes(leftValue);
+      } else {
+        return leftValue === parsedRightValue;
+      }
+    } catch {
+      return leftValue === rightValue;
+    }
+  }
+
+  return leftValue === rightValue;
+}
+
+function evaluateSelectFilter(filter: ResolvedFilter): boolean {
   switch (filter.operand) {
     case ViewFilterOperand.IS:
-      if (Array.isArray(rightValue)) {
-        return rightValue.some((item) => String(item) === String(leftValue));
-      }
-      if (Array.isArray(leftValue)) {
-        return leftValue.some((item) => String(item) === String(rightValue));
-      }
-      if (isDefined(leftValue) && isDefined(rightValue)) {
-        return String(leftValue) === String(rightValue);
-      }
-      return leftValue === rightValue;
+      return isSelectMatch(filter.leftOperand, filter.rightOperand);
     case ViewFilterOperand.IS_NOT:
-      if (Array.isArray(rightValue)) {
-        return !rightValue.some((item) => String(item) === String(leftValue));
-      }
-      if (Array.isArray(leftValue)) {
-        return !leftValue.some((item) => String(item) === String(rightValue));
-      }
-      if (isDefined(leftValue) && isDefined(rightValue)) {
-        return String(leftValue) !== String(rightValue);
-      }
-      return leftValue !== rightValue;
+      return !isSelectMatch(filter.leftOperand, filter.rightOperand);
     case ViewFilterOperand.IS_EMPTY:
       return !isNotEmptyTextOrArray(filter.leftOperand);
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
@@ -486,11 +486,32 @@ function evaluateDefaultFilter(filter: ResolvedFilter): boolean {
 }
 
 function evaluateSelectFilter(filter: ResolvedFilter): boolean {
+  const leftValue = filter.leftOperand;
+  const rightValue = filter.rightOperand;
+
   switch (filter.operand) {
     case ViewFilterOperand.IS:
-      return contains(filter.leftOperand, filter.rightOperand);
+      if (Array.isArray(rightValue)) {
+        return rightValue.some((item) => String(item) === String(leftValue));
+      }
+      if (Array.isArray(leftValue)) {
+        return leftValue.some((item) => String(item) === String(rightValue));
+      }
+      if (isDefined(leftValue) && isDefined(rightValue)) {
+        return String(leftValue) === String(rightValue);
+      }
+      return leftValue === rightValue;
     case ViewFilterOperand.IS_NOT:
-      return !contains(filter.leftOperand, filter.rightOperand);
+      if (Array.isArray(rightValue)) {
+        return !rightValue.some((item) => String(item) === String(leftValue));
+      }
+      if (Array.isArray(leftValue)) {
+        return !leftValue.some((item) => String(item) === String(rightValue));
+      }
+      if (isDefined(leftValue) && isDefined(rightValue)) {
+        return String(leftValue) !== String(rightValue);
+      }
+      return leftValue !== rightValue;
     case ViewFilterOperand.IS_EMPTY:
       return !isNotEmptyTextOrArray(filter.leftOperand);
 


### PR DESCRIPTION
### Summary
In workflow trigger and filter / IF_ELSE step evaluation, evaluating `SELECT` attribute filters with `IS` and `IS_NOT` operands previously called `contains(leftOperand, rightOperand)`. This caused substring matches (e.g. matching `"ACTIVE"` when the value is `"INACTIVE"`) instead of strict equality checks.

### Solution
- Updated `evaluateSelectFilter` in `packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts` to perform exact equality comparisons for `IS` and `IS_NOT`, with support for array operands.
- Added comprehensive unit test coverage for `SELECT` filter operand matching in `evaluate-filter-conditions.util.spec.ts`.

Closes #25827


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

