### PR TITLE
fix(metadata): allow editing display format of system date fields

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/date/components/SettingsDataModelFieldDateForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/date/components/SettingsDataModelFieldDateForm.tsx
@@ -123,7 +123,7 @@ export const SettingsDataModelFieldDateForm = ({
                 placeholder={t`Format e.g. d-MMM-y (qqq''yy)`}
                 value={value}
                 onChange={(value) => onChange(value)}
-                disabled={false}
+                disabled={disabled ?? false}
                 fullWidth
               />
             </StyledTextInputContainer>

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/sanitize-raw-update-field-input.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/sanitize-raw-update-field-input.spec.ts
@@ -1,0 +1,374 @@
+import {
+  DateDisplayFormat,
+  FieldMetadataType,
+  RelationType,
+} from 'twenty-shared/types';
+
+import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
+
+import { FieldMetadataException } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
+import { type UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { sanitizeRawUpdateFieldInput } from 'src/engine/metadata-modules/flat-field-metadata/utils/sanitize-raw-update-field-input';
+
+const buildFlatFieldMetadata = (
+  overrides: Partial<FlatFieldMetadata>,
+): FlatFieldMetadata =>
+  ({
+    id: 'field-id',
+    universalIdentifier: 'field-uid',
+    applicationUniversalIdentifier:
+      TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+    objectMetadataId: 'object-id',
+    objectMetadataUniversalIdentifier: 'object-uid',
+    type: FieldMetadataType.DATE_TIME,
+    name: 'createdAt',
+    label: 'Creation date',
+    description: '',
+    icon: 'IconCalendar',
+    isActive: true,
+    isSystem: true,
+    isSystemSideEffect: true,
+    isNullable: false,
+    isUnique: false,
+    isSearchable: false,
+    isAuditLogged: true,
+    isUIEditable: false,
+    isLabelSyncedWithName: false,
+    writability: 'OPEN',
+    overrides: null,
+    defaultValue: 'now',
+    settings: { displayFormat: DateDisplayFormat.RELATIVE },
+    options: null,
+    relationTargetFieldMetadataId: null,
+    relationTargetObjectMetadataId: null,
+    morphId: null,
+    viewFieldIds: [],
+    viewFilterIds: [],
+    fieldPermissionIds: [],
+    kanbanAggregateOperationViewIds: [],
+    calendarViewIds: [],
+    calendarEndViewIds: [],
+    mainGroupByFieldMetadataViewIds: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    applicationId: 'application-id',
+    workspaceId: 'workspace-id',
+    relationTargetObjectMetadataUniversalIdentifier: null,
+    relationTargetFieldMetadataUniversalIdentifier: null,
+    viewFilterUniversalIdentifiers: [],
+    viewFieldUniversalIdentifiers: [],
+    fieldPermissionUniversalIdentifiers: [],
+    kanbanAggregateOperationViewUniversalIdentifiers: [],
+    calendarViewUniversalIdentifiers: [],
+    calendarEndViewUniversalIdentifiers: [],
+    mainGroupByFieldMetadataViewUniversalIdentifiers: [],
+    viewSortIds: [],
+    viewSortUniversalIdentifiers: [],
+    searchFieldMetadataIds: [],
+    searchFieldMetadataUniversalIdentifiers: [],
+    universalSettings: { displayFormat: DateDisplayFormat.RELATIVE },
+    ...overrides,
+  }) as FlatFieldMetadata;
+
+const buildUpdateInput = (
+  overrides: Partial<UpdateFieldInput>,
+): UpdateFieldInput =>
+  ({
+    id: 'field-id',
+    workspaceId: 'workspace-id',
+    ...overrides,
+  }) as UpdateFieldInput;
+
+describe('sanitizeRawUpdateFieldInput', () => {
+  describe('system side-effect DATE_TIME field (e.g. createdAt)', () => {
+    it('should allow updating settings.displayFormat', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.DATE_TIME,
+          name: 'createdAt',
+        }),
+        rawUpdateFieldInput: buildUpdateInput({
+          settings: { displayFormat: DateDisplayFormat.USER_SETTINGS },
+        }),
+        isSystemBuild: false,
+      });
+
+      expect(result.updatedEditableFieldProperties.settings).toEqual({
+        displayFormat: DateDisplayFormat.USER_SETTINGS,
+      });
+    });
+
+    it('should allow updating settings.customUnicodeDateFormat alongside displayFormat', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.DATE_TIME,
+          name: 'updatedAt',
+        }),
+        rawUpdateFieldInput: buildUpdateInput({
+          settings: {
+            displayFormat: DateDisplayFormat.CUSTOM,
+            customUnicodeDateFormat: 'dd/MM/yyyy HH:mm',
+          },
+        }),
+        isSystemBuild: false,
+      });
+
+      expect(result.updatedEditableFieldProperties.settings).toEqual({
+        displayFormat: DateDisplayFormat.CUSTOM,
+        customUnicodeDateFormat: 'dd/MM/yyyy HH:mm',
+      });
+    });
+
+    it('should allow updating settings on DATE (not DATE_TIME) system side-effect fields', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.DATE,
+          name: 'birthdate',
+        }),
+        rawUpdateFieldInput: buildUpdateInput({
+          settings: { displayFormat: DateDisplayFormat.USER_SETTINGS },
+        }),
+        isSystemBuild: false,
+      });
+
+      expect(result.updatedEditableFieldProperties.settings).toEqual({
+        displayFormat: DateDisplayFormat.USER_SETTINGS,
+      });
+    });
+
+    it('should merge a partial update with the existing settings instead of overwriting them', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.DATE_TIME,
+          name: 'createdAt',
+          settings: {
+            displayFormat: DateDisplayFormat.CUSTOM,
+            customUnicodeDateFormat: 'dd/MM/yyyy HH:mm',
+          },
+        }),
+        rawUpdateFieldInput: buildUpdateInput({
+          settings: { displayFormat: DateDisplayFormat.USER_SETTINGS },
+        }),
+        isSystemBuild: false,
+      });
+
+      expect(result.updatedEditableFieldProperties.settings).toEqual({
+        displayFormat: DateDisplayFormat.USER_SETTINGS,
+        customUnicodeDateFormat: 'dd/MM/yyyy HH:mm',
+      });
+    });
+
+    it('should drop the settings update entirely when it matches the existing value', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.DATE_TIME,
+          name: 'createdAt',
+        }),
+        rawUpdateFieldInput: buildUpdateInput({
+          settings: { displayFormat: DateDisplayFormat.RELATIVE },
+        }),
+        isSystemBuild: false,
+      });
+
+      expect(
+        result.updatedEditableFieldProperties.settings,
+      ).toBeUndefined();
+      expect(result.updatedEditableFieldProperties).not.toHaveProperty(
+        'settings',
+      );
+    });
+
+    it('should clear customUnicodeDateFormat when set to null', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.DATE_TIME,
+          name: 'createdAt',
+          settings: {
+            displayFormat: DateDisplayFormat.CUSTOM,
+            customUnicodeDateFormat: 'dd/MM/yyyy',
+          },
+        }),
+        rawUpdateFieldInput: buildUpdateInput({
+          settings: { customUnicodeDateFormat: null as unknown as string },
+        }),
+        isSystemBuild: false,
+      });
+
+      expect(result.updatedEditableFieldProperties.settings).toEqual({
+        displayFormat: DateDisplayFormat.CUSTOM,
+      });
+    });
+
+    it('should reject settings with unknown keys', () => {
+      expect(() =>
+        sanitizeRawUpdateFieldInput({
+          existingFlatFieldMetadata: buildFlatFieldMetadata({
+            type: FieldMetadataType.DATE_TIME,
+            name: 'createdAt',
+          }),
+          rawUpdateFieldInput: buildUpdateInput({
+            settings: {
+              displayFormat: DateDisplayFormat.USER_SETTINGS,
+              relationType: RelationType.ONE_TO_MANY,
+            },
+          }),
+          isSystemBuild: false,
+        }),
+      ).toThrow(FieldMetadataException);
+    });
+
+    it('should reject an unknown displayFormat value', () => {
+      expect(() =>
+        sanitizeRawUpdateFieldInput({
+          existingFlatFieldMetadata: buildFlatFieldMetadata({
+            type: FieldMetadataType.DATE_TIME,
+            name: 'createdAt',
+          }),
+          rawUpdateFieldInput: buildUpdateInput({
+            settings: {
+              displayFormat: 'NOPE' as unknown as DateDisplayFormat,
+            },
+          }),
+          isSystemBuild: false,
+        }),
+      ).toThrow(FieldMetadataException);
+    });
+
+    it('should reject an invalid customUnicodeDateFormat value', () => {
+      expect(() =>
+        sanitizeRawUpdateFieldInput({
+          existingFlatFieldMetadata: buildFlatFieldMetadata({
+            type: FieldMetadataType.DATE_TIME,
+            name: 'createdAt',
+          }),
+          rawUpdateFieldInput: buildUpdateInput({
+            settings: {
+              displayFormat: DateDisplayFormat.CUSTOM,
+              customUnicodeDateFormat: 'this is not a format',
+            },
+          }),
+          isSystemBuild: false,
+        }),
+      ).toThrow(FieldMetadataException);
+    });
+
+    it('should reject a non-string customUnicodeDateFormat value', () => {
+      expect(() =>
+        sanitizeRawUpdateFieldInput({
+          existingFlatFieldMetadata: buildFlatFieldMetadata({
+            type: FieldMetadataType.DATE_TIME,
+            name: 'createdAt',
+          }),
+          rawUpdateFieldInput: buildUpdateInput({
+            settings: {
+              displayFormat: DateDisplayFormat.CUSTOM,
+              customUnicodeDateFormat: 42 as unknown as string,
+            },
+          }),
+          isSystemBuild: false,
+        }),
+      ).toThrow(FieldMetadataException);
+    });
+
+    it('should still allow updating isActive', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.DATE_TIME,
+          name: 'createdAt',
+        }),
+        rawUpdateFieldInput: buildUpdateInput({ isActive: false }),
+        isSystemBuild: false,
+      });
+
+      expect(result.updatedEditableFieldProperties.isActive).toBe(false);
+    });
+
+    it('should still reject non-display property updates like label', () => {
+      expect(() =>
+        sanitizeRawUpdateFieldInput({
+          existingFlatFieldMetadata: buildFlatFieldMetadata({
+            type: FieldMetadataType.DATE_TIME,
+            name: 'createdAt',
+          }),
+          rawUpdateFieldInput: buildUpdateInput({ label: 'New Label' }),
+          isSystemBuild: false,
+        }),
+      ).toThrow(FieldMetadataException);
+    });
+  });
+
+  describe('system side-effect non-date field (e.g. position)', () => {
+    it('should reject settings updates', () => {
+      expect(() =>
+        sanitizeRawUpdateFieldInput({
+          existingFlatFieldMetadata: buildFlatFieldMetadata({
+            type: FieldMetadataType.POSITION,
+            name: 'position',
+            settings: null,
+          }),
+          rawUpdateFieldInput: buildUpdateInput({
+            settings: { displayFormat: DateDisplayFormat.USER_SETTINGS },
+          }),
+          isSystemBuild: false,
+        }),
+      ).toThrow(FieldMetadataException);
+    });
+
+    it('should still allow updating isActive', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.POSITION,
+          name: 'position',
+          settings: null,
+        }),
+        rawUpdateFieldInput: buildUpdateInput({ isActive: false }),
+        isSystemBuild: false,
+      });
+
+      expect(result.updatedEditableFieldProperties.isActive).toBe(false);
+    });
+  });
+
+  describe('non-system-side-effect fields', () => {
+    it('should not enforce the system side-effect rules on a regular field', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.TEXT,
+          name: 'name',
+          isSystem: false,
+          isSystemSideEffect: false,
+        }),
+        rawUpdateFieldInput: buildUpdateInput({ label: 'New label' }),
+        isSystemBuild: false,
+      });
+
+      // Label is overridable for standard fields, so it lands in overrides
+      expect(result.overrides).toEqual({ label: 'New label' });
+      expect(result.updatedEditableFieldProperties).not.toHaveProperty('label');
+    });
+  });
+
+  describe('system build', () => {
+    it('should not enforce the system side-effect rules during a system build', () => {
+      const result = sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata: buildFlatFieldMetadata({
+          type: FieldMetadataType.DATE_TIME,
+          name: 'createdAt',
+        }),
+        rawUpdateFieldInput: buildUpdateInput({
+          settings: {
+            displayFormat: DateDisplayFormat.RELATIVE,
+            relationType: RelationType.ONE_TO_MANY,
+          },
+        }),
+        isSystemBuild: true,
+      });
+
+      expect(result.updatedEditableFieldProperties.settings).toEqual({
+        displayFormat: DateDisplayFormat.RELATIVE,
+        relationType: RelationType.ONE_TO_MANY,
+      });
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/sanitize-raw-update-field-input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/sanitize-raw-update-field-input.ts
@@ -1,5 +1,11 @@
+import { format as formatDate } from 'date-fns';
+import {
+  DateDisplayFormat,
+  FieldMetadataType,
+} from 'twenty-shared/types';
 import {
   extractAndSanitizeObjectStringFields,
+  fastDeepEqual,
   isDefined,
 } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
@@ -45,23 +51,43 @@ export const sanitizeRawUpdateFieldInput = ({
   );
 
   if (existingFlatFieldMetadata.isSystemSideEffect === true && !isSystemBuild) {
+    const isSystemSideEffectDateField =
+      existingFlatFieldMetadata.type === FieldMetadataType.DATE ||
+      existingFlatFieldMetadata.type === FieldMetadataType.DATE_TIME;
+
+    const allowedSystemSideEffectProperties: string[] = isSystemSideEffectDateField
+      ? [...FLAT_FIELD_METADATA_SYSTEM_SIDE_EFFECT_EDITABLE_PROPERTIES, 'settings']
+      : [...FLAT_FIELD_METADATA_SYSTEM_SIDE_EFFECT_EDITABLE_PROPERTIES];
+
     const forbiddenUpdatedProperties = [
       ...Object.keys(updatedEditableFieldProperties),
       ...(isDefined(rawUpdateFieldInput.morphRelationsUpdatePayload)
         ? ['morphRelationsUpdatePayload']
         : []),
-    ].filter(
-      (property) =>
-        !FLAT_FIELD_METADATA_SYSTEM_SIDE_EFFECT_EDITABLE_PROPERTIES.includes(
-          property as (typeof FLAT_FIELD_METADATA_SYSTEM_SIDE_EFFECT_EDITABLE_PROPERTIES)[number],
-        ),
-    );
+    ].filter((property) => !allowedSystemSideEffectProperties.includes(property));
 
     if (forbiddenUpdatedProperties.length > 0) {
       throw new FieldMetadataException(
         `Cannot edit system-managed field "${existingFlatFieldMetadata.name}" properties: ${forbiddenUpdatedProperties.join(', ')}`,
         FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
       );
+    }
+
+    if (
+      isSystemSideEffectDateField &&
+      isDefined(updatedEditableFieldProperties.settings)
+    ) {
+      const mergedSettings = mergeSystemSideEffectDateFieldSettings({
+        existingSettings: existingFlatFieldMetadata.settings,
+        incomingSettings: updatedEditableFieldProperties.settings,
+      });
+
+      if (mergedSettings === undefined) {
+        // No-op update: merged value matches the existing settings
+        delete updatedEditableFieldProperties.settings;
+      } else {
+        updatedEditableFieldProperties.settings = mergedSettings;
+      }
     }
   }
 
@@ -145,4 +171,96 @@ export const sanitizeRawUpdateFieldInput = ({
     }),
     updatedEditableFieldProperties: remainingProperties,
   };
+};
+
+const SYSTEM_SIDE_EFFECT_DATE_FIELD_SETTINGS_KEYS = [
+  'displayFormat',
+  'customUnicodeDateFormat',
+] as const;
+
+const DATE_DISPLAY_FORMAT_VALUES = new Set<string>([
+  DateDisplayFormat.RELATIVE,
+  DateDisplayFormat.USER_SETTINGS,
+  DateDisplayFormat.CUSTOM,
+]);
+
+const isDateDisplayFormatValue = (value: unknown): value is DateDisplayFormat =>
+  typeof value === 'string' && DATE_DISPLAY_FORMAT_VALUES.has(value);
+
+const isValidCustomDateFormat = (value: unknown): value is string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false;
+  }
+
+  try {
+    formatDate(new Date(), value);
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const mergeSystemSideEffectDateFieldSettings = ({
+  existingSettings,
+  incomingSettings,
+}: {
+  existingSettings: FlatFieldMetadata['settings'];
+  incomingSettings: unknown;
+}): Record<string, unknown> | undefined => {
+  const rawIncoming = (incomingSettings ?? {}) as Record<string, unknown>;
+
+  const knownKeys = new Set<string>(
+    SYSTEM_SIDE_EFFECT_DATE_FIELD_SETTINGS_KEYS,
+  );
+
+  const unknownKeys = Object.keys(rawIncoming).filter(
+    (key) => !knownKeys.has(key),
+  );
+
+  if (unknownKeys.length > 0) {
+    throw new FieldMetadataException(
+      `Cannot edit system-managed date field settings: only ${SYSTEM_SIDE_EFFECT_DATE_FIELD_SETTINGS_KEYS.join(', ')} are allowed`,
+      FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+    );
+  }
+
+  const existingRecord = (existingSettings ?? {}) as Record<string, unknown>;
+
+  const merged: Record<string, unknown> = { ...existingRecord };
+
+  if ('displayFormat' in rawIncoming) {
+    const value = rawIncoming.displayFormat;
+
+    if (!isDateDisplayFormatValue(value)) {
+      throw new FieldMetadataException(
+        `Invalid displayFormat for system-managed date field: expected one of ${DateDisplayFormat.RELATIVE}, ${DateDisplayFormat.USER_SETTINGS}, or ${DateDisplayFormat.CUSTOM}`,
+        FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+      );
+    }
+
+    merged.displayFormat = value;
+  }
+
+  if ('customUnicodeDateFormat' in rawIncoming) {
+    const value = rawIncoming.customUnicodeDateFormat;
+
+    if (value === null) {
+      delete merged.customUnicodeDateFormat;
+    } else if (!isValidCustomDateFormat(value)) {
+      throw new FieldMetadataException(
+        `Invalid customUnicodeDateFormat for system-managed date field: not a valid date-fns format string`,
+        FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+      );
+    } else {
+      merged.customUnicodeDateFormat = value;
+    }
+  }
+
+  // Drop the no-op case: the request produced the same settings object as the current value
+  if (fastDeepEqual(merged, existingRecord)) {
+    return undefined;
+  }
+
+  return merged;
 };

--- a/packages/twenty-shared/src/types/FieldMetadataSettings.ts
+++ b/packages/twenty-shared/src/types/FieldMetadataSettings.ts
@@ -43,10 +43,12 @@ type FieldMetadataTextSettings = {
 
 type FieldMetadataDateSettings = {
   displayFormat?: DateDisplayFormat;
+  customUnicodeDateFormat?: string;
 };
 
 type FieldMetadataDateTimeSettings = {
   displayFormat?: DateDisplayFormat;
+  customUnicodeDateFormat?: string;
 };
 
 type FieldMetadataRelationSettings = {


### PR DESCRIPTION
Allow presentation-only metadata overrides for system date fields (createdAt and updatedAt). Users can now switch between RELATIVE, USER_SETTINGS, and CUSTOM display formats from Settings → Data Model without duplicating the field.

The sanitizer now permits settings updates on isSystemSideEffect DATE and DATE_TIME fields but restricts the settings payload to the display-only keys (displayFormat, customUnicodeDateFormat) so that the underlying timestamp behavior stays system-managed.

Fixes #25819

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/25839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

