### PR TITLE
fix(apps): require reverse relation when targeting standard objects

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/data/relations.mdx
+++ b/packages/twenty-docs/developers/extend/apps/data/relations.mdx
@@ -125,9 +125,9 @@ import {
 } from 'twenty-sdk/define';
 import { SELF_HOSTING_USER_UNIVERSAL_IDENTIFIER } from '../objects/self-hosting-user.object';
 
+// Both identifiers live here so imports stay one-way (the reverse field imports from this file)
 export const PERSON_FIELD_ID = 'c3333333-3333-3333-3333-333333333333';
-// Imported from the reverse field below
-import { SELF_HOSTING_USER_REVERSE_FIELD_ID } from './self-hosting-users-on-person.field';
+export const SELF_HOSTING_USER_REVERSE_FIELD_ID = 'd4444444-4444-4444-4444-444444444444';
 
 export default defineField({
   universalIdentifier: PERSON_FIELD_ID,
@@ -158,9 +158,10 @@ import {
   STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
 } from 'twenty-sdk/define';
 import { SELF_HOSTING_USER_UNIVERSAL_IDENTIFIER } from '../objects/self-hosting-user.object';
-import { PERSON_FIELD_ID } from './person-on-self-hosting-user.field';
-
-export const SELF_HOSTING_USER_REVERSE_FIELD_ID = 'd4444444-4444-4444-4444-444444444444';
+import {
+  PERSON_FIELD_ID,
+  SELF_HOSTING_USER_REVERSE_FIELD_ID,
+} from './person-on-self-hosting-user.field';
 
 export default defineField({
   universalIdentifier: SELF_HOSTING_USER_REVERSE_FIELD_ID,

--- a/packages/twenty-docs/developers/extend/apps/data/relations.mdx
+++ b/packages/twenty-docs/developers/extend/apps/data/relations.mdx
@@ -162,6 +162,7 @@ import {
   PERSON_FIELD_ID,
   SELF_HOSTING_USER_REVERSE_FIELD_ID,
 } from './person-on-self-hosting-user.field';
+// Keep imports one-way: field manifests execute eagerly, so mutual imports can read an uninitialized identifier.
 
 export default defineField({
   universalIdentifier: SELF_HOSTING_USER_REVERSE_FIELD_ID,

--- a/packages/twenty-docs/developers/extend/apps/data/relations.mdx
+++ b/packages/twenty-docs/developers/extend/apps/data/relations.mdx
@@ -109,7 +109,11 @@ export default defineField({
 
 ## Relating to standard objects
 
-To create a relation with a built-in Twenty object (Person, Company, etc.), use `STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS`:
+To create a relation with a built-in Twenty object (Person, Company, Opportunity, etc.), use `STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS`.
+
+Relations are always bidirectional, even when the target is a standard object. You must declare **both sides** and cross-reference their `universalIdentifier`s. The reverse `ONE_TO_MANY` side lives on the standard object itself and is declared as a top-level `defineField`:
+
+**Step 1: Define the MANY_TO_ONE side on your custom object** (holds the foreign key):
 
 ```ts src/fields/person-on-self-hosting-user.field.ts
 import {
@@ -122,7 +126,8 @@ import {
 import { SELF_HOSTING_USER_UNIVERSAL_IDENTIFIER } from '../objects/self-hosting-user.object';
 
 export const PERSON_FIELD_ID = 'c3333333-3333-3333-3333-333333333333';
-export const SELF_HOSTING_USER_REVERSE_FIELD_ID = 'd4444444-4444-4444-4444-444444444444';
+// Imported from the reverse field below
+import { SELF_HOSTING_USER_REVERSE_FIELD_ID } from './self-hosting-users-on-person.field';
 
 export default defineField({
   universalIdentifier: PERSON_FIELD_ID,
@@ -142,6 +147,40 @@ export default defineField({
   },
 });
 ```
+
+**Step 2: Define the ONE_TO_MANY reverse side on the standard object:**
+
+```ts src/fields/self-hosting-users-on-person.field.ts
+import {
+  defineField,
+  FieldType,
+  RelationType,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
+} from 'twenty-sdk/define';
+import { SELF_HOSTING_USER_UNIVERSAL_IDENTIFIER } from '../objects/self-hosting-user.object';
+import { PERSON_FIELD_ID } from './person-on-self-hosting-user.field';
+
+export const SELF_HOSTING_USER_REVERSE_FIELD_ID = 'd4444444-4444-4444-4444-444444444444';
+
+export default defineField({
+  universalIdentifier: SELF_HOSTING_USER_REVERSE_FIELD_ID,
+  objectUniversalIdentifier:
+    STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person.universalIdentifier,
+  type: FieldType.RELATION,
+  name: 'selfHostingUsers',
+  label: 'Self Hosting Users',
+  relationTargetObjectMetadataUniversalIdentifier:
+    SELF_HOSTING_USER_UNIVERSAL_IDENTIFIER,
+  relationTargetFieldMetadataUniversalIdentifier: PERSON_FIELD_ID,
+  universalSettings: {
+    relationType: RelationType.ONE_TO_MANY,
+  },
+});
+```
+
+<Note>
+If you only declare the `MANY_TO_ONE` side, sync fails with `FIELD_METADATA_NOT_FOUND: Relation field target metadata not found`. Declare the reverse `ONE_TO_MANY` field on the standard object (Person, Company, Opportunity, …) as shown above so both sides resolve.
+</Note>
 
 ## Relation field properties
 

--- a/packages/twenty-sdk/src/cli/utilities/error/__tests__/get-sync-error-recovery-hint.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/error/__tests__/get-sync-error-recovery-hint.spec.ts
@@ -46,6 +46,14 @@ describe('getSyncErrorRecoveryHint', () => {
     expect(hint).toContain('bidirectional');
   });
 
+  it('does not suggest a missing reverse field when the target exists but has the wrong type', () => {
+    expect(
+      getSyncErrorRecoveryHint(
+        'INVALID_FIELD_INPUT: Relation target field must be a RELATION field',
+      ),
+    ).toBeUndefined();
+  });
+
   it('returns undefined for an unrecognized error', () => {
     expect(getSyncErrorRecoveryHint('Network request failed')).toBeUndefined();
     expect(getSyncErrorRecoveryHint(undefined)).toBeUndefined();

--- a/packages/twenty-sdk/src/cli/utilities/error/__tests__/get-sync-error-recovery-hint.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/error/__tests__/get-sync-error-recovery-hint.spec.ts
@@ -29,6 +29,23 @@ describe('getSyncErrorRecoveryHint', () => {
     expect(hint).toContain('yarn twenty dev --once --dry-run');
   });
 
+  it('suggests declaring the reverse field when a relation target is missing', () => {
+    const hint = getSyncErrorRecoveryHint(
+      'FIELD_METADATA_NOT_FOUND: Relation field target metadata not found in both existing and about to be created field metadatas',
+    );
+
+    expect(hint).toContain('bidirectional');
+    expect(hint).toContain('reverse');
+  });
+
+  it('suggests declaring the reverse field for the improved validator message', () => {
+    const hint = getSyncErrorRecoveryHint(
+      'Relation target field d4444444-4444-4444-4444-444444444444 not found in both existing and about to be created field metadatas.',
+    );
+
+    expect(hint).toContain('bidirectional');
+  });
+
   it('returns undefined for an unrecognized error', () => {
     expect(getSyncErrorRecoveryHint('Network request failed')).toBeUndefined();
     expect(getSyncErrorRecoveryHint(undefined)).toBeUndefined();

--- a/packages/twenty-sdk/src/cli/utilities/error/get-sync-error-recovery-hint.ts
+++ b/packages/twenty-sdk/src/cli/utilities/error/get-sync-error-recovery-hint.ts
@@ -9,7 +9,8 @@ export const getSyncErrorRecoveryHint = (
 
   if (
     normalizedMessage.includes('relation field target metadata not found') ||
-    normalizedMessage.includes('relation target field')
+    (normalizedMessage.includes('relation target field') &&
+      normalizedMessage.includes('not found'))
   ) {
     return 'Hint: relations are bidirectional. Declare the reverse relation field (ONE_TO_MANY on the target object, including standard objects) and cross-reference both universal identifiers. See developers/extend/apps/data/relations.';
   }

--- a/packages/twenty-sdk/src/cli/utilities/error/get-sync-error-recovery-hint.ts
+++ b/packages/twenty-sdk/src/cli/utilities/error/get-sync-error-recovery-hint.ts
@@ -8,6 +8,13 @@ export const getSyncErrorRecoveryHint = (
   }
 
   if (
+    normalizedMessage.includes('relation field target metadata not found') ||
+    normalizedMessage.includes('relation target field')
+  ) {
+    return 'Hint: relations are bidirectional. Declare the reverse relation field (ONE_TO_MANY on the target object, including standard objects) and cross-reference both universal identifiers. See developers/extend/apps/data/relations.';
+  }
+
+  if (
     normalizedMessage.includes('already exists') ||
     normalizedMessage.includes('universalidentifier') ||
     /migration action .* failed/.test(normalizedMessage)

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/__tests__/validate-morph-or-relation-flat-field-metadata.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/__tests__/validate-morph-or-relation-flat-field-metadata.util.spec.ts
@@ -1,0 +1,117 @@
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { FieldMetadataExceptionCode } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
+import { validateMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+import { type UniversalFlatObjectMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-object-metadata.type';
+
+const CUSTOM_OBJECT_ID = '11111111-1111-4111-8111-111111111111';
+const OPPORTUNITY_OBJECT_ID = '20202020-9549-49dd-b2b2-883999db8938';
+const FORWARD_FIELD_ID = '22222222-2222-4222-8222-222222222222';
+const REVERSE_FIELD_ID = 'b642fa8b-5943-4022-ba07-300ea94fa78e';
+
+const createObject = (
+  universalIdentifier: string,
+): UniversalFlatObjectMetadata =>
+  ({
+    universalIdentifier,
+  }) as UniversalFlatObjectMetadata;
+
+const createManyToOneField = (): UniversalFlatFieldMetadata<FieldMetadataType.RELATION> =>
+  ({
+    universalIdentifier: FORWARD_FIELD_ID,
+    objectMetadataUniversalIdentifier: CUSTOM_OBJECT_ID,
+    type: FieldMetadataType.RELATION,
+    name: 'opportunity',
+    relationTargetObjectMetadataUniversalIdentifier: OPPORTUNITY_OBJECT_ID,
+    relationTargetFieldMetadataUniversalIdentifier: REVERSE_FIELD_ID,
+    universalSettings: {
+      relationType: RelationType.MANY_TO_ONE,
+      joinColumnName: 'opportunityId',
+    },
+  }) as UniversalFlatFieldMetadata<FieldMetadataType.RELATION>;
+
+const createReverseOneToManyField =
+  (): UniversalFlatFieldMetadata<FieldMetadataType.RELATION> =>
+    ({
+      universalIdentifier: REVERSE_FIELD_ID,
+      objectMetadataUniversalIdentifier: OPPORTUNITY_OBJECT_ID,
+      type: FieldMetadataType.RELATION,
+      name: 'customObjects',
+      relationTargetObjectMetadataUniversalIdentifier: CUSTOM_OBJECT_ID,
+      relationTargetFieldMetadataUniversalIdentifier: FORWARD_FIELD_ID,
+      universalSettings: {
+        relationType: RelationType.ONE_TO_MANY,
+      },
+    }) as UniversalFlatFieldMetadata<FieldMetadataType.RELATION>;
+
+const baseArgs = {
+  workspaceId: 'workspace-id',
+  buildOptions: {
+    isSystemBuild: false,
+    applicationUniversalIdentifier: 'app-id',
+  },
+  additionalCacheDataMaps: {},
+} as const;
+
+describe('validateMorphOrRelationFlatFieldMetadata missing reverse (issue #25820)', () => {
+  it('reports FIELD_METADATA_NOT_FOUND with the missing target identifier when the reverse field is not declared', () => {
+    const errors = validateMorphOrRelationFlatFieldMetadata({
+      flatEntityToValidate: createManyToOneField(),
+      optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
+        flatObjectMetadataMaps: {
+          byUniversalIdentifier: {
+            [CUSTOM_OBJECT_ID]: createObject(CUSTOM_OBJECT_ID),
+            [OPPORTUNITY_OBJECT_ID]: createObject(OPPORTUNITY_OBJECT_ID),
+          },
+        },
+        flatFieldMetadataMaps: {
+          byUniversalIdentifier: {},
+        },
+      },
+      remainingFlatEntityMapsToValidate: {
+        byUniversalIdentifier: {},
+      },
+      ...baseArgs,
+    } as never);
+
+    const missingTargetError = errors.find(
+      (error) => error.code === FieldMetadataExceptionCode.FIELD_METADATA_NOT_FOUND,
+    );
+
+    expect(missingTargetError).toBeDefined();
+    expect(missingTargetError?.value).toBe(REVERSE_FIELD_ID);
+    expect(missingTargetError?.message).toContain(REVERSE_FIELD_ID);
+    expect(missingTargetError?.message).toContain('bidirectional');
+  });
+
+  it('does not report FIELD_METADATA_NOT_FOUND when the reverse field is declared in the same manifest', () => {
+    const errors = validateMorphOrRelationFlatFieldMetadata({
+      flatEntityToValidate: createManyToOneField(),
+      optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
+        flatObjectMetadataMaps: {
+          byUniversalIdentifier: {
+            [CUSTOM_OBJECT_ID]: createObject(CUSTOM_OBJECT_ID),
+            [OPPORTUNITY_OBJECT_ID]: createObject(OPPORTUNITY_OBJECT_ID),
+          },
+        },
+        flatFieldMetadataMaps: {
+          byUniversalIdentifier: {},
+        },
+      },
+      remainingFlatEntityMapsToValidate: {
+        byUniversalIdentifier: {
+          [REVERSE_FIELD_ID]: createReverseOneToManyField(),
+        },
+      },
+      ...baseArgs,
+    } as never);
+
+    expect(
+      errors.filter(
+        (error) =>
+          error.code === FieldMetadataExceptionCode.FIELD_METADATA_NOT_FOUND,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/__tests__/validate-morph-or-relation-flat-field-metadata.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/__tests__/validate-morph-or-relation-flat-field-metadata.util.spec.ts
@@ -17,19 +17,20 @@ const createObject = (
     universalIdentifier,
   }) as UniversalFlatObjectMetadata;
 
-const createManyToOneField = (): UniversalFlatFieldMetadata<FieldMetadataType.RELATION> =>
-  ({
-    universalIdentifier: FORWARD_FIELD_ID,
-    objectMetadataUniversalIdentifier: CUSTOM_OBJECT_ID,
-    type: FieldMetadataType.RELATION,
-    name: 'opportunity',
-    relationTargetObjectMetadataUniversalIdentifier: OPPORTUNITY_OBJECT_ID,
-    relationTargetFieldMetadataUniversalIdentifier: REVERSE_FIELD_ID,
-    universalSettings: {
-      relationType: RelationType.MANY_TO_ONE,
-      joinColumnName: 'opportunityId',
-    },
-  }) as UniversalFlatFieldMetadata<FieldMetadataType.RELATION>;
+const createManyToOneField =
+  (): UniversalFlatFieldMetadata<FieldMetadataType.RELATION> =>
+    ({
+      universalIdentifier: FORWARD_FIELD_ID,
+      objectMetadataUniversalIdentifier: CUSTOM_OBJECT_ID,
+      type: FieldMetadataType.RELATION,
+      name: 'opportunity',
+      relationTargetObjectMetadataUniversalIdentifier: OPPORTUNITY_OBJECT_ID,
+      relationTargetFieldMetadataUniversalIdentifier: REVERSE_FIELD_ID,
+      universalSettings: {
+        relationType: RelationType.MANY_TO_ONE,
+        joinColumnName: 'opportunityId',
+      },
+    }) as UniversalFlatFieldMetadata<FieldMetadataType.RELATION>;
 
 const createReverseOneToManyField =
   (): UniversalFlatFieldMetadata<FieldMetadataType.RELATION> =>
@@ -76,7 +77,8 @@ describe('validateMorphOrRelationFlatFieldMetadata missing reverse (issue #25820
     } as never);
 
     const missingTargetError = errors.find(
-      (error) => error.code === FieldMetadataExceptionCode.FIELD_METADATA_NOT_FOUND,
+      (error) =>
+        error.code === FieldMetadataExceptionCode.FIELD_METADATA_NOT_FOUND,
     );
 
     expect(missingTargetError).toBeDefined();

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util.ts
@@ -156,9 +156,10 @@ export const validateMorphOrRelationFlatFieldMetadata = ({
     errors.push({
       code: FieldMetadataExceptionCode.FIELD_METADATA_NOT_FOUND,
       message: isDefined(remainingFlatEntityMapsToValidate)
-        ? 'Relation field target metadata not found in both existing and about to be created field metadatas'
-        : 'Relation field target metadata not found',
+        ? `Relation field target metadata not found in both existing and about to be created field metadatas (target: ${relationTargetFieldMetadataUniversalIdentifier}). Relations are bidirectional: declare the reverse field and cross-reference both universal identifiers`
+        : `Relation field target metadata not found (target: ${relationTargetFieldMetadataUniversalIdentifier})`,
       userFriendlyMessage: msg`Relation field target metadata not found`,
+      value: relationTargetFieldMetadataUniversalIdentifier,
     });
   } else {
     if (!isMorphOrRelationUniversalFlatFieldMetadata(targetFlatFieldMetadata)) {


### PR DESCRIPTION
Closes #25820.

## Root cause
Relations are bidirectional, including app relations targeting standard objects (Person, Company, Opportunity). The Relations docs showed only the MANY_TO_ONE side for standard-object targets, so following it produced:

- fieldMetadata: FIELD_METADATA_NOT_FOUND - Relation field target metadata not found in both existing and about to be created field metadatas
- viewField: INVALID_VIEW_DATA cascade for the field that never got created

Person/Company appeared to work when the reverse field already existed in the workspace (e.g. created earlier via UI); Opportunity had no such pre-existing reverse, so it failed consistently.

## Changes
- docs(relations.mdx): show both sides for standard-object relations - MANY_TO_ONE on the custom object plus top-level ONE_TO_MANY reverse defineField on the standard object - and note the sync error when the reverse side is omitted.
- server(validate-morph-or-relation): include missing target universalIdentifier in value/message and hint that the reverse field must be declared. Preserves the original message substring for log grepping.
- sdk(getSyncErrorRecoveryHint): surface a bidirectional-relations recovery hint for this sync error.

## Tests
- new: validate-morph-or-relation-flat-field-metadata.util.spec.ts - missing reverse reports FIELD_METADATA_NOT_FOUND with value/message hint; declared reverse clears it.
- updated: get-sync-error-recovery-hint.spec.ts - covers both legacy and improved validator messages.
- manual: verified SDK hint branches and validator message formatting with node; docs code fences checked.