### PR TITLE
Slide the side panel with transform instead of animating its width

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelForDesktop.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelForDesktop.tsx
@@ -24,17 +24,14 @@ import { useStore } from 'jotai';
 import { type AnimationEvent, useCallback, useState } from 'react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
-const StyledSidePanelWrapper = styled.div<{
-  isOpen: boolean;
-  isResizing: boolean;
-}>`
+// Width is not transitioned: the main content is a flex sibling, so animating
+// it lays out the whole page on every frame. The background hides the reserved
+// room until the panel has slid over it.
+const StyledSidePanelWrapper = styled.div<{ isOpen: boolean }>`
+  background: ${themeCssVariables.background.primary};
   flex-shrink: 0;
   min-width: 0;
-  overflow: hidden;
-  transition: ${({ isResizing }) =>
-    isResizing
-      ? 'none'
-      : `width calc(${themeCssVariables.animation.duration.normal} * 1s)`};
+  position: relative;
   width: ${({ isOpen }) => (isOpen ? `var(${SIDE_PANEL_WIDTH_VAR})` : '0px')};
 
   @keyframes sidePanelShrinkFromFullWidth {
@@ -49,7 +46,12 @@ const StyledSidePanelWrapper = styled.div<{
   }
 `;
 
-const StyledSidePanel = styled.aside<{ isShrinkingFromFullWidth: boolean }>`
+// Pinned to the right edge of the row and slid with `transform`, which needs no
+// layout. When closed it is clipped by the main container's `overflow: hidden`.
+const StyledSidePanel = styled.aside<{
+  isOpen: boolean;
+  isShrinkingFromFullWidth: boolean;
+}>`
   background: ${themeCssVariables.background.primary};
   border-left: 1px solid ${themeCssVariables.border.color.medium};
   box-sizing: border-box;
@@ -57,7 +59,12 @@ const StyledSidePanel = styled.aside<{ isShrinkingFromFullWidth: boolean }>`
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  position: relative;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transform: ${({ isOpen }) => (isOpen ? 'none' : 'translateX(100%)')};
+  transition: transform
+    calc(${themeCssVariables.animation.duration.normal} * 1s);
   width: ${({ isShrinkingFromFullWidth }) =>
     isShrinkingFromFullWidth ? '100%' : `var(${SIDE_PANEL_WIDTH_VAR})`};
 `;
@@ -84,7 +91,6 @@ export const SidePanelForDesktop = () => {
   const [modalContainer, setModalContainer] = useState<HTMLDivElement | null>(
     null,
   );
-  const [isResizing, setIsResizing] = useState(false);
   const [shouldRenderContent, setShouldRenderContent] =
     useState(isSidePanelOpened);
   const [isShrinkingFromFullWidth, setIsShrinkingFromFullWidth] =
@@ -139,20 +145,17 @@ export const SidePanelForDesktop = () => {
   const handleWidthChange = useCallback(
     (width: number) => {
       setSidePanelWidth(width);
-      setIsResizing(false);
       setTableWidthResizeIsActive(true);
     },
     [setSidePanelWidth, setTableWidthResizeIsActive],
   );
 
   const handleResizeStart = useCallback(() => {
-    setIsResizing(true);
     setTableWidthResizeIsActive(false);
   }, [setTableWidthResizeIsActive]);
 
   const handleCollapse = useCallback(() => {
     closeSidePanelMenu();
-    setIsResizing(false);
     setTableWidthResizeIsActive(true);
   }, [closeSidePanelMenu, setTableWidthResizeIsActive]);
 
@@ -175,14 +178,16 @@ export const SidePanelForDesktop = () => {
 
       <StyledSidePanelWrapper
         isOpen={isSidePanelOpened}
-        isResizing={isResizing}
         onTransitionEnd={handleTransitionEnd}
         onAnimationEnd={handleAnimationEnd}
         data-shrink-from-full-width={isShrinkingFromFullWidth}
         data-side-panel=""
         data-click-outside-id={SIDE_PANEL_CLICK_OUTSIDE_ID}
       >
-        <StyledSidePanel isShrinkingFromFullWidth={isShrinkingFromFullWidth}>
+        <StyledSidePanel
+          isOpen={isSidePanelOpened}
+          isShrinkingFromFullWidth={isShrinkingFromFullWidth}
+        >
           <StyledModalContainer ref={handleModalContainerRef} />
           <ModalContainerContext.Provider value={{ container: modalContainer }}>
             <ParentClickOutsideIdContext.Provider


### PR DESCRIPTION
## Problem

Opening or closing the side panel on desktop (e.g. opening a record from a table) lags on heavy pages.

`StyledSidePanelWrapper` in `SidePanelForDesktop.tsx` animates `width`:

```css
transition: width calc(var(--t-animation-duration-normal) * 1s);
width: var(--side-panel-width) | 0px;
```

The page content sits next to it in the same flex row (`StyledContent`, `flex: 1 1 0` in `MainAppLayoutWithSidePanel`). Each frame of the transition changes the wrapper's width, which changes the content's width, so the browser recomputes layout for the whole page (table, record show page…) on every frame of the animation.

## History

The panel has animated its width since the framer-motion version (`animate={{ width }}`), then as a CSS transition in #16612. The Linaria migration (#18342) accidentally made the value invalid (`var(...)s`), so the panel opened instantly for a few weeks, until #19556 restored it with `calc(... * 1s)`. The per-frame layout cost is therefore inherent to animating the width, and became noticeable again once the animation was restored.

## Fix

- The wrapper still reserves the panel's room, but its width changes in one step (a single layout) instead of being transitioned. It carries the panel background so the reserved room does not flash before the panel covers it.
- The panel is `position: absolute; right: 0` inside the wrapper and slides with `transform: translateX(100%)` ↔ `none`, which is composited and triggers no layout. When closed, it is clipped by `StyledMainContainer`'s `overflow: hidden` in `DefaultLayout`.
- The `isResizing` state is removed: it only disabled the width transition during a resize, and resizing changes the width, never the transform.
- The close cleanup is unchanged: the panel's `transform` transition bubbles to the wrapper's `onTransitionEnd`, as the width transition did.

Visible trade-off: the page content now snaps to its new width instead of shrinking/growing smoothly, while the panel slides in and out as before.

## How to verify

1. Open a record list with many rows, Chrome DevTools > Performance, start recording.
2. Click a record to open the side panel, then close it.
3. Before: a "Layout" block on every frame for the duration of the animation, covering the page content. After: one layout when the panel opens or closes; the slide itself is compositor-only.

Existing `SidePanelForDesktop` tests pass unchanged.
