### PR TITLE
fix(twenty-orm): add withDeleted() to before-fetch in soft-delete restore path

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
@@ -100,9 +100,11 @@ export class WorkspaceSoftDeleteQueryBuilder<
 
       const tableName = computeObjectTargetTable(objectMetadata);
 
-      const before = await beforeEventSelectQueryBuilder.getMany({
-        noFormatting: true,
-      });
+      const before = await beforeEventSelectQueryBuilder
+        .withDeleted()
+        .getMany({
+          noFormatting: true,
+        });
 
       this.expressionMap.wheres = applyTableAliasOnWhereCondition({
         condition: this.expressionMap.wheres,


### PR DESCRIPTION
## Summary

When restoring a soft-deleted record, the before-fetch used a plain `getMany()` which TypeORM implicitly filters to `WHERE deletedAt IS NULL`. The record being restored has `deletedAt` set, so `before` returned `[]` and `formatTwentyOrmEventToDatabaseBatchEvent` threw a *Record mismatch* error for the `RESTORED` action — causing a 500 and no webhook being fired.

PR #23725 fixed the same pattern for the after-fetch (DELETE path) but missed the before-fetch (RESTORE path). Adding `withDeleted()` makes the query include soft-deleted rows and matches how the delete path works.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/26240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

